### PR TITLE
CRITICAL - Generate blank personal files on startup

### DIFF
--- a/src/Ankimon/__init__.py
+++ b/src/Ankimon/__init__.py
@@ -33,6 +33,10 @@ from PyQt6.QtWidgets import QDialog
 from aqt.gui_hooks import webview_will_set_content
 from aqt.webview import WebContent
 
+from .resources import generate_startup_files, user_path
+
+generate_startup_files(user_path)
+
 from .config_var import (
     dmg_in_reviewer,
     no_more_news,

--- a/src/Ankimon/functions/rate_addon_functions.py
+++ b/src/Ankimon/functions/rate_addon_functions.py
@@ -23,15 +23,6 @@ from ..singletons import logger, test_window
 
 def rate_this_addon():
     
-    # Default data for the file
-    default_data = {"rate_this": False}
-
-    # Create the file with default contents if it doesn't exist
-    if not os.path.exists(rate_path):
-        os.makedirs(os.path.dirname(rate_path), exist_ok=True)
-        with open(rate_path, "w", encoding="utf-8") as f:
-            json.dump(default_data, f, indent=4)
-
     # Load rate data
     try:
         with open(rate_path, "r", encoding="utf-8") as file:

--- a/src/Ankimon/resources.py
+++ b/src/Ankimon/resources.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 import os
+import json
 
 addon_dir = Path(__file__).parents[0]
 
@@ -98,3 +99,20 @@ backup_root = addon_dir / "user_files" / "backups"
 backup_folder_1 = backup_root / "backup_1"
 backup_folder_2 = backup_root / "backup_2"
 backup_folders = [os.path.join(backup_root, f"backup_{i}") for i in range(1, 4)]
+
+def generate_startup_files(base_path):  # Add base_path parameter
+    """
+    Generates blank personal files at startup with the value [].
+    Introduced as a workaround to gitignore personal files.
+    """
+    files = ['mypokemon.json', 'mainpokemon.json', 'items.json', 
+             'team.json', 'data.json', 'badges.json']
+    
+    for file in files:
+        file_path = os.path.join(base_path, file)  # Use base_path parameter
+        # Create parent directory if needed
+        os.makedirs(os.path.dirname(file_path), exist_ok=True)
+        
+        if not os.path.exists(file_path):
+            with open(file_path, 'w', encoding='utf-8') as f:
+                json.dump([], f, indent=2)

--- a/src/Ankimon/resources.py
+++ b/src/Ankimon/resources.py
@@ -116,3 +116,14 @@ def generate_startup_files(base_path):  # Add base_path parameter
         if not os.path.exists(file_path):
             with open(file_path, 'w', encoding='utf-8') as f:
                 json.dump([], f, indent=2)
+
+    # Default data for the file
+    default_rating_data = {"rate_this": False}
+    rate_path = os.path.join(base_path, 'rate_this.json')
+
+    # Create the file with default contents if it doesn't exist
+    if not os.path.exists(rate_path):
+        os.makedirs(os.path.dirname(rate_path), exist_ok=True)
+        with open(rate_path, "w", encoding="utf-8") as f:
+            json.dump(default_rating_data, f, indent=4)
+


### PR DESCRIPTION
Previously new installations would instantly crash because of missing files.
Now, a file generation function is run before any other Ankimon function imports (it ignores the file if it is empty)