### PR TITLE
Closing of Anki is automatically triggered when needed

### DIFF
--- a/src/Ankimon/pyobj/ankimon_sync.py
+++ b/src/Ankimon/pyobj/ankimon_sync.py
@@ -11,6 +11,7 @@ from aqt.utils import showWarning, showInfo, tooltip
 
 from ..resources import user_path, addon_dir
 from ..config_var import ankiweb_sync
+from ..utils import close_anki
 
 from PyQt6.QtGui import QTextOption
 from PyQt6.QtWidgets import QLabel, QVBoxLayout, QTextEdit, QPushButton, QDialog, QHBoxLayout, QScrollArea, QWidget
@@ -567,6 +568,7 @@ class ImprovedPokemonDataSync(QDialog):
                 
                 tooltip("Data imported from AnkiWeb successfully! Automatic sync is now enabled.")
                 self.close()
+                close_anki
             else:
                 showWarning("Failed to import data from AnkiWeb.")
         except Exception as e:
@@ -886,7 +888,7 @@ class AnkimonDataSync:
                     shutil.copy2(media_file, source_file)
                     updated_files.append(filename)
             
-            showInfo(f"Imported {len(updated_files)} files from AnkiWeb: {', '.join(updated_files)}\n\nPlease restart Anki to apply changes, otherwise Ankimon may get corrupted.")
+            showInfo(f"Imported {len(updated_files)} files from AnkiWeb: {', '.join(updated_files)}\n\nAnki will now close. Please reopen Anki to apply changes!")
             return True
         except Exception as e:
             showWarning(f"Failed to import from AnkiWeb: {str(e)}")

--- a/src/Ankimon/utils.py
+++ b/src/Ankimon/utils.py
@@ -9,6 +9,7 @@ import csv
 from collections import Counter
 from typing import Union
 
+from aqt import mw
 from aqt.utils import showWarning, showInfo
 from PyQt6.QtGui import QFontDatabase, QFont
 
@@ -907,3 +908,6 @@ def substract_item_from_itembag(item: str, quantity: int=1) -> None:
         with open(str(itembag_path), "w") as f:
             json.dump(items_list, f, indent=2)
         return
+    
+def close_anki():
+    mw.close()


### PR DESCRIPTION
Issue was that many times, people would not restart their Anki after picking their starter, or in Ankiweb sync when getting from Ankiweb. In these moments, not restarting can remove and corrupt your progress.

This does NOT CAUSE A RESTART, but it does close Anki, prompting user to restart it for it to work!