### PR TITLE
Pokedex search function handles unexpected suffixes

### DIFF
--- a/src/Ankimon/functions/encounter_functions.py
+++ b/src/Ankimon/functions/encounter_functions.py
@@ -172,13 +172,10 @@ def choose_random_pkmn_from_tier():
 def check_min_generate_level(name):
     evoType = search_pokedex(name.lower(), "evoType")
     evoLevel = search_pokedex(name.lower(), "evoLevel")
-    if evoLevel is not None:
+    if isinstance(evoLevel, (int, str)) and str(evoLevel).isdigit():
         return int(evoLevel)
     elif evoType is not None:
         min_level = 100
-        return int(min_level)
-    elif evoType and evoLevel is None:
-        min_level = 1
         return int(min_level)
     else:
         min_level = 1

--- a/src/Ankimon/functions/pokedex_functions.py
+++ b/src/Ankimon/functions/pokedex_functions.py
@@ -58,16 +58,43 @@ def special_pokemon_names_for_min_level(name):
     else:
         return name
 
-def search_pokedex(pokemon_name,variable):
-    pokemon_name = special_pokemon_names_for_min_level(pokemon_name)
-    with open(str(pokedex_path), "r", encoding="utf-8") as json_file:
+def search_pokedex(pokemon_name, variable):
+    try:
+        pokemon_name = special_pokemon_names_for_min_level(pokemon_name)
+        with open(str(pokedex_path), "r", encoding="utf-8") as json_file:
             pokedex_data = json.load(json_file)
-            if pokemon_name in pokedex_data:
-                pokemon_info = pokedex_data[pokemon_name]
-                var = pokemon_info.get(variable, None)
+
+        # 1. Try a direct match first
+        if pokemon_name in pokedex_data:
+            pokemon_info = pokedex_data[pokemon_name]
+            var = pokemon_info.get(variable)
+            if var is not None:
                 return var
-            else:
-                return []
+
+        # 2. If no direct match, try stripping known suffixes in a prioritized order
+        # The order is important to handle names with multiple suffixes correctly.
+        suffixes_to_strip = [
+            "-standard", "-altered", "-land", "-incarnate", "-ordinary", "-aria", 
+            "-shield", "-average", "-50", "-baile", "-midday", "-solo", 
+            "-red-meteor", "-disguised", "-amped", "-ice", "-male", 
+            "-full-belly", "-single-strike", "-therian", "-origin", "-zen", 
+            "-blade", "-mega", "-gmax", "-alola", "-galar", "-hisui"
+        ]
+
+        for suffix in suffixes_to_strip:
+            if pokemon_name.endswith(suffix):
+                base_name = pokemon_name[:-len(suffix)]
+                if base_name in pokedex_data:
+                    pokemon_info = pokedex_data[base_name]
+                    var = pokemon_info.get(variable)
+                    if var is not None:
+                        return var
+
+        # 3. If still no match, return an empty list to be handled by the calling function
+        return []
+    except Exception as e:
+        show_warning_with_traceback(parent=mw, exception=e, message=f"Error searching for pokemon '{pokemon_name}'")
+        return []
 
 def search_pokedex_by_name_for_id(pokemon_name, variable):
     pokemon_name = special_pokemon_names_for_min_level(pokemon_name)

--- a/src/Ankimon/functions/pokedex_functions.py
+++ b/src/Ankimon/functions/pokedex_functions.py
@@ -64,34 +64,30 @@ def search_pokedex(pokemon_name, variable):
         with open(str(pokedex_path), "r", encoding="utf-8") as json_file:
             pokedex_data = json.load(json_file)
 
-        # 1. Try a direct match first
-        if pokemon_name in pokedex_data:
-            pokemon_info = pokedex_data[pokemon_name]
-            var = pokemon_info.get(variable)
-            if var is not None:
-                return var
+        # Create a copy of the name to modify
+        current_name = pokemon_name
 
-        # 2. If no direct match, try stripping known suffixes in a prioritized order
-        # The order is important to handle names with multiple suffixes correctly.
-        suffixes_to_strip = [
-            "-standard", "-altered", "-land", "-incarnate", "-ordinary", "-aria", 
-            "-shield", "-average", "-50", "-baile", "-midday", "-solo", 
-            "-red-meteor", "-disguised", "-amped", "-ice", "-male", 
-            "-full-belly", "-single-strike", "-therian", "-origin", "-zen", 
-            "-blade", "-mega", "-gmax", "-alola", "-galar", "-hisui"
-        ]
+        while True:
+            # 1. Try to find a match with the current name
+            if current_name in pokedex_data:
+                pokemon_info = pokedex_data[current_name]
+                var = pokemon_info.get(variable)
+                if var is not None:
+                    return var
 
-        for suffix in suffixes_to_strip:
-            if pokemon_name.endswith(suffix):
-                base_name = pokemon_name[:-len(suffix)]
-                if base_name in pokedex_data:
-                    pokemon_info = pokedex_data[base_name]
-                    var = pokemon_info.get(variable)
-                    if var is not None:
-                        return var
+            # 2. If no match, find the last hyphen
+            last_hyphen_index = current_name.rfind('-')
 
-        # 3. If still no match, return an empty list to be handled by the calling function
+            # 3. If no hyphen is found, we can't shorten the name anymore.
+            if last_hyphen_index == -1:
+                break
+
+            # 4. Remove the suffix and try again in the next iteration
+            current_name = current_name[:last_hyphen_index]
+
+        # 5. If no match was ever found, return an empty list
         return []
+
     except Exception as e:
         show_warning_with_traceback(parent=mw, exception=e, message=f"Error searching for pokemon '{pokemon_name}'")
         return []


### PR DESCRIPTION
  This PR fixes a bug that caused an error during the evolution of Pokémon with special forms, such as Darumaka.

  The root cause of the issue was an inconsistency in the naming convention for Pokémon forms between pokemon.csv and pokedex.json. This led to a failure in retrieving the
  base stats for the evolved Pokémon, causing a TypeError.

  This PR resolves the issue by patching the search_pokedex function to be more resilient to these inconsistencies. The function now intelligently strips the string alongwith the rightmost suffix from Pokémon names to find the correct base form in pokedex.json. This ensures that the correct data is retrieved for all Pokémon, including their different forms. This triggers ONLY if the base stat fetching fails, so pokemons that are correctly defined like Porygon-Z for example will work just fine, and problematic names like Darmanitar-Standard get shortened to Darmanitar.

  This change fixes the reported bug and improves the overall robustness of the application.