### PR TITLE
Discord RPC does not occupy main thread

### DIFF
--- a/src/Ankimon/functions/discord_function.py
+++ b/src/Ankimon/functions/discord_function.py
@@ -99,7 +99,7 @@ class DiscordPresence:
         try:
             self.loop = False
             if hasattr(self, 'thread') and self.thread and self.thread.is_alive():
-                self.thread.join() # Wait for the thread to finish
+                # self.thread.join() # Removed to prevent blocking
                 self.thread = None  # Reset the thread
             self.RPC.clear()
         except Exception as e:


### PR DESCRIPTION
Fixes h0tp's issue of 30s lag spikes every time sync/close was triggered. Now, Discord RPC logic will not occupy the main thread, preventing the 30s sleep in update() from causing a main thread freeze.