### PR TITLE
fix: prevent crash on macOS when .DS_Store appears in ankimon_backups

### DIFF
--- a/src/Ankimon/pyobj/backup_manager.py
+++ b/src/Ankimon/pyobj/backup_manager.py
@@ -217,6 +217,9 @@ class BackupManager:
         
         backups_to_keep = []
         for backup_dir in backups:
+            # Skip hidden files like .DS_Store
+            if backup_dir.name.startswith("."):
+                continue
             backup_time = datetime.datetime.fromtimestamp(os.path.getmtime(backup_dir))
             if (datetime.datetime.now() - backup_time).days > self.MAX_BACKUP_AGE_DAYS:
                 shutil.rmtree(backup_dir)


### PR DESCRIPTION
### Summary
This PR fixes a crash that occurs on macOS when a `.DS_Store` file exists in the `ankimon_backups` directory.

### Root Cause
macOS automatically creates `.DS_Store` metadata files when users open folders in Finder.
Ankimon’s `cleanup_backups()` assumed all entries were directories and used `shutil.rmtree()` on them, which raises `NotADirectoryError` for `.DS_Store`.

### Fix
Added a simple guard in `cleanup_backups()` to skip hidden files or folders whose names start with "." (e.g., `.DS_Store`).

### Verification
- Reproduced crash by opening backup folder in Finder, then quitting Anki.
- After patch, Anki exits cleanly, backups still work as expected.

### Notes
This only affects macOS users who open the backup directory via Finder.