### PR TITLE
Ankimon window updates when enemy pokemon hp < 1

### DIFF
--- a/src/Ankimon/__init__.py
+++ b/src/Ankimon/__init__.py
@@ -583,6 +583,7 @@ def on_review_card(*args):
             # if enemy pokemon faints, this handles AUTOMATIC BATTLE
             if enemy_pokemon.hp < 1:
                 enemy_pokemon.hp = 0
+                test_window.display_battle()
                 handle_enemy_faint(
                     main_pokemon,
                     enemy_pokemon,

--- a/src/Ankimon/functions/encounter_functions.py
+++ b/src/Ankimon/functions/encounter_functions.py
@@ -761,7 +761,7 @@ def handle_enemy_faint(
         new_pokemon(enemy_pokemon, test_window, ankimon_tracker_obj, reviewer_obj)  # Show a new random Pokémon
 
     # For Manual mode (auto_battle_setting == 0): no need to show window or do actions automatically
-
+    test_window.display_pokemon_death()
     main_pokemon.reset_bonuses()
     ankimon_tracker_obj.general_card_count_for_battle = 0
 


### PR DESCRIPTION
Missing Triggers lead to Ankimon Window not being updated upon reaching enemy pokemon hp < 1