### PR TITLE
Tip of the day error fix on first install

### DIFF
--- a/src/Ankimon/pyobj/tip_of_the_day.py
+++ b/src/Ankimon/pyobj/tip_of_the_day.py
@@ -87,6 +87,9 @@ def show_tip_of_the_day():
         return
 
     last_tip_index = settings.get("misc.last_tip_index")
+    if last_tip_index is None:
+        last_tip_index = 0
+
     next_tip_index = (last_tip_index + 1) % len(tips)
 
     dialog = TipOfTheDayDialog(tips[next_tip_index], next_tip_index, len(tips), mw)


### PR DESCRIPTION
Error:

```python
Ankimon v1.51-E | Anki 25.09.2 | Python 3.13.5 | macOS-26.2-arm64-arm-64bit-Mach-O

Traceback (most recent call last):
  File "/home/USER/Library/Application Support/Anki2/addons21/Ankimon/__init__.py", line 715, in on_profile_did_open
    show_tip_of_the_day()
    ~~~~~~~~~~~~~~~~~~~^^
  File "/home/USER/Library/Application Support/Anki2/addons21/Ankimon/pyobj/tip_of_the_day.py", line 90, in show_tip_of_the_day
    next_tip_index = (last_tip_index + 1) % len(tips)
                      ~~~~~~~~~~~~~~~^~~
TypeError: unsupported operand type(s) for +: 'NoneType' and 'int'

```