### PR TITLE
Fix tip of the day index / nonetype issue

### DIFF
--- a/src/Ankimon/pyobj/tip_of_the_day.py
+++ b/src/Ankimon/pyobj/tip_of_the_day.py
@@ -85,12 +85,12 @@ def show_tip_of_the_day():
 
     if not tips:
         return
-    
-    last_tip_index = int(settings.get("misc.last_tip_index"))
-    if last_tip_index is not None:
-        next_tip_index = (last_tip_index + 1) % len(tips)
-    else:
+
+    last_tip_index = settings.get("misc.last_tip_index")
+    if last_tip_index is None:
         next_tip_index = 0
+    else:
+        next_tip_index = (last_tip_index + 1) % len(tips)
 
     dialog = TipOfTheDayDialog(tips[next_tip_index], next_tip_index, len(tips), mw)
     dialog.exec()


### PR DESCRIPTION
Unfortunately #231 does not provide a valid fix for #233 as the cast to `int` is done before the check for `None`, resulting in an error.
<img width="910" height="247" alt="image" src="https://github.com/user-attachments/assets/eb5adce2-3d42-4c03-ad62-20978629b27e" />

#241 works but starts by showing the second tip instead of the first tip.

This PR fixes #233  and attributes both of these authors.