### PR TITLE
Fix: Crash when sorting pokemon PC by name

### DIFF
--- a/src/Ankimon/pyobj/pc_box.py
+++ b/src/Ankimon/pyobj/pc_box.py
@@ -600,9 +600,14 @@ class PokemonPC(QDialog):
 
         def sort_key(p):
             if sort_key_str == "name":
-                return (p.get("name", ""), p.get("nickname", ""))
+                name = p.get("name") or ""
+                nickname = p.get("nickname") or ""
+                return (name.lower(), nickname.lower())
             else:
-                return p.get(sort_key_str, 0)
+                val = p.get(sort_key_str)
+                if val is None:
+                    return 0 if sort_key_str in ["id", "level", "original_index"] else ""
+                return val
 
         return sorted(
             pokemon_list,


### PR DESCRIPTION
This pull request fixes #257 by updating the sorting logic in `pc_box.py`
Current Bugs:
Sorting could crash when a sortable field existed but had a value of `None`, causing python to compare incompatible types
Name sorting is case-sensitive, resulting in unintuitive alphabetical ordering
Solution:
Explicitly handle `None` values to use default values
Perform case-insensitive comparisons when sorting by name