### PR TITLE
Save trade pokemon data

### DIFF
--- a/src/Ankimon/gui_classes/pokemon_details.py
+++ b/src/Ankimon/gui_classes/pokemon_details.py
@@ -908,13 +908,22 @@ def PokemonFree(
         # Save important stats to history before release
         from datetime import datetime
         history_data = {
-            "id": pokemon_to_release.get("id"),
             "name": pokemon_to_release.get("name"),
+            "nickname": pokemon_to_release.get("nickname", ""),
             "level": pokemon_to_release.get("level"),
-            "tier": pokemon_to_release.get("tier", "Normal"),
+            "gender": pokemon_to_release.get("gender"),
+            "id": pokemon_to_release.get("id"),
+            "ability": pokemon_to_release.get("ability"),
+            "ev": pokemon_to_release.get("ev"),
+            "iv": pokemon_to_release.get("iv"),
+            "attacks": pokemon_to_release.get("attacks", []),
             "shiny": pokemon_to_release.get("shiny", False),
-            "pokemon_defeated": pokemon_to_release.get("pokemon_defeated", 0),
+            "captured_date": pokemon_to_release.get("captured_date"),
             "individual_id": pokemon_to_release.get("individual_id"),
+            "mega": pokemon_to_release.get("mega", False),
+            "special_form": pokemon_to_release.get("special_form", None),
+            "pokemon_defeated": pokemon_to_release.get("pokemon_defeated", 0),
+            "tier": pokemon_to_release.get("tier", "Normal"),
             "released_date": datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
             "action": "release"
         }

--- a/src/Ankimon/pyobj/pokemon_trade.py
+++ b/src/Ankimon/pyobj/pokemon_trade.py
@@ -609,15 +609,34 @@ class PokemonTrade:
                         # Save to history before replacing
                         try:
                             history_data = {
-                                "id": pokemon.get("id"),
                                 "name": pokemon.get("name"),
+                                "nickname": pokemon.get("nickname", ""),
                                 "level": pokemon.get("level"),
-                                "tier": pokemon.get("tier", "Normal"),
+                                "gender": pokemon.get("gender"),
+                                "id": pokemon.get("id"),
+                                "ability": pokemon.get("ability"),
+                                "ev": pokemon.get("ev"),
+                                "iv": pokemon.get("iv"),
+                                "attacks": pokemon.get("attacks", []),
                                 "shiny": pokemon.get("shiny", False),
-                                "pokemon_defeated": pokemon.get("pokemon_defeated", 0),
+                                "captured_date": pokemon.get("captured_date"),
                                 "individual_id": pokemon.get("individual_id"),
+                                "mega": pokemon.get("mega", False),
+                                "special_form": pokemon.get("special_form", None),
+                                "pokemon_defeated": pokemon.get("pokemon_defeated", 0),
+                                "tier": pokemon.get("tier", "Normal"),
                                 "released_date": datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
-                                "action": "trade"
+                                "action": "trade",
+                                "traded_for_name": new_pokemon.get("name"),
+                                "traded_for_level": new_pokemon.get("level"),
+                                "traded_for_gender": new_pokemon.get("gender"),
+                                "traded_for_id": new_pokemon.get("id"),
+                                "traded_for_ev": new_pokemon.get("ev"),
+                                "traded_for_iv": new_pokemon.get("iv"),
+                                "traded_for_attacks": new_pokemon.get("attacks", []),
+                                "traded_for_shiny": new_pokemon.get("shiny", False),
+                                "traded_for_mega": new_pokemon.get("mega", False),
+                                "traded_for_special_form": new_pokemon.get("special_form", None),
                             }
                             
                             history_list = []


### PR DESCRIPTION
This is a follow-up to the PR where I added `pokemon_history.json`.  
Now, I also save the traded Pokémon data to have an accurate `pokemon seen` counter and not lose data that can be helpful. 

Maybe in the future with this I’ll make a history of traded Pokémon, including which Pokémon they were traded for, with stats comparisons or something like that. 

I save all the data that cannot be retrieved from the Pokémon ID
