### PR TITLE
fix: missing closing brace in pokedex file

### DIFF
--- a/src/Ankimon/pokedex/pokedex.html
+++ b/src/Ankimon/pokedex/pokedex.html
@@ -386,6 +386,8 @@
         const caughtTotalParam = params.get("caught_total");
         const caughtTotal = parseInt(caughtTotalParam, 10);
         return isNaN(caughtTotal) ? 0 : Math.max(0, caughtTotal);
+      }
+      
       function getShinyNumbersFromURL() {
         const params = new URLSearchParams(window.location.search);
         const shiniesParam = params.get("shinies");


### PR DESCRIPTION
Fixes error `Qt critical: Uncaught SyntaxError: Identifier 'caughtTotal' has already been declared` that prevents pokedex from loading
Resolves #303 