### PR TITLE
bugfix: reset the window title to 'Ankimon Window' after every catch/defeat

### DIFF
--- a/src/Ankimon/pyobj/test_window.py
+++ b/src/Ankimon/pyobj/test_window.py
@@ -741,7 +741,7 @@ class TestWindow(QWidget):
         catch_button.setFont(QFont("Arial", 12))  # Adjust the font size and style as needed
         catch_button.setStyleSheet("background-color: rgb(44,44,44);")
         #catch_button.setFixedWidth(150)
-        qconnect(catch_button.clicked, lambda: self._reset_window_title(mw.catchpokemon()))
+        qconnect(catch_button.clicked, lambda: self._reset_window_title(mw.catchpokemon))
 
         kill_button = QPushButton(self.translator.translate("defeat_button"))
         kill_button.setFixedSize(175, 30)  # Adjust the size as needed


### PR DESCRIPTION
After catching or defeating a pokemon the "Ankimon Window" title is not being reset.

Current state:
<img width="597" height="345" alt="Screenshot 2026-02-23 111449" src="https://github.com/user-attachments/assets/8b489e83-deac-4de3-b0db-91b8f522ae62" />

State with the PR:
<img width="574" height="424" alt="Screenshot 2026-02-23 111701" src="https://github.com/user-attachments/assets/c69f266e-f417-483b-a5b4-9fdf9b4b4b94" />