### PR TITLE
FIX: Multiplier display text no longer typecast to int

### DIFF
--- a/src/Ankimon/__init__.py
+++ b/src/Ankimon/__init__.py
@@ -424,7 +424,7 @@ def on_review_card(*args):
             ankimon_tracker_obj.attack_counter = 0
             slp_counter = 0
             ankimon_tracker_obj.pokemon_encouter += 1
-            multiplier = int(ankimon_tracker_obj.multiplier)
+            multiplier = ankimon_tracker_obj.multiplier
 
             if ankimon_tracker_obj.pokemon_encouter > 0 and enemy_pokemon.hp > 0 and multiplier < 1:
                 enemy_move = safe_get_random_move(enemy_pokemon.attacks, logger=logger)


### PR DESCRIPTION
When pop-up text boxes are enabled, the multiplier is displayed incorrectly. Any multiplier less than 1.0x is displayed as 0.0x for example.

I discovered that multiplier was being cast to int (after the damage was calculated, so this is purely visual).

I thought at first there may have been some other error that required this be cast to int, but as far as I can tell after removing the typecasting, no errors occurred. 