### PR TITLE
FIX: No more duplicate catching of pokemon, and adds Pokemon PC GUI refresh after capture

### DIFF
--- a/src/Ankimon/functions/encounter_functions.py
+++ b/src/Ankimon/functions/encounter_functions.py
@@ -729,8 +729,6 @@ def catch_pokemon(
         if logger is not None:
             show_warning_with_traceback(parent=mw, exception=e, message="Error while catching Pokemon:") # Display a message when the Pokémon is caught
 
-    pokemon_pc.refresh_gui()
-
 def handle_enemy_faint(
         main_pokemon: PokemonObject,
         enemy_pokemon: PokemonObject,


### PR DESCRIPTION
Two bugs here:

If somehow the user already caught the pokemon, and tries to catch it again (this occurred on my side when the window didn't close for some reason), a warning is supposed to show to let the user know they already caught it. But it doesn't actually exit the function, so it continues and catches the pokemon again anyway.

Adding the return will exit the function instead of catching it again

I also added a refresh_gui() call from pokemon_pc after the pokemon is caught. If the user has their Pokemon PC window open, it will immediately refresh and the caught pokemon will appear immediately, instead of on a manual refresh.

This call can probably be used in all sorts of places to resolve PC visual bugs (learned/forgotten moves not reflecting, level-up not reflecting), but I didn't look deep enough to figure out where it should go.