### PR TITLE
FIX: Error if tooltip closes before lab.hide()

### DIFF
--- a/src/Ankimon/functions/drawing_utils.py
+++ b/src/Ankimon/functions/drawing_utils.py
@@ -1,7 +1,7 @@
 from typing import Optional
 
 from aqt import mw
-from aqt.qt import QPainter, QLabel, Qt
+from aqt.qt import QPainter, QLabel, Qt, sip
 from PyQt6.QtGui import QColor, QFont, QColor, QPalette
 from PyQt6.QtCore import Qt, QRect, QPoint, QSize, QPoint, QTimer
 from PyQt6.QtWidgets import QApplication, QLabel, QFrame
@@ -52,9 +52,9 @@ def tooltipWithColour(msg, color, x=0, y=20, xref=1, parent=None, width=0, heigh
         lab.show()
         lab.move(QPoint(x - round(lab.width() * 0.5 * xref), y))
         try:
-            QTimer.singleShot(period, lambda: lab.hide())
+            QTimer.singleShot(period, lambda: lab.hide() if lab and not sip.isdeleted(lab) else None)
         except:
-            QTimer.singleShot(3000, lambda: lab.hide())
+            QTimer.singleShot(3000, lambda: lab.hide() if lab and not sip.isdeleted(lab) else None)
         mw.logger.log_and_showinfo("game", msg)
 
 def draw_gender_symbols(


### PR DESCRIPTION
I've had this error pop up on occasion, it seems to happen if the tooltip box closes from something else before `lab.hide()` closes it. 
```python
Traceback (most recent call last):
  File "/home/gjgress/.local/share/Anki2/addons21/1908235722/functions/drawing_utils.py", line 55, in <lambda>
    QTimer.singleShot(period, lambda: lab.hide())
                                      ~~~~~~~~^^
RuntimeError: wrapped C/C++ object of type CustomLabel has been deleted

Traceback (most recent call last):
  File "/home/gjgress/.local/share/Anki2/addons21/1908235722/functions/drawing_utils.py", line 55, in <lambda>
    QTimer.singleShot(period, lambda: lab.hide())
                                      ~~~~~~~~^^
RuntimeError: wrapped C/C++ object of type CustomLabel has been deleted
Qt warning: QObject::disconnect: wildcard call disconnects from destroyed signal of QPushButton::unnamed
Qt warning: QObject::disconnect: wildcard call disconnects from destroyed signal of QPushButton::unnamed
```
This fix adds a check to see if it's already closed; it requires a small import (sip from aqt.qt), if this is not preferable it should be fixable with a small auxiliary function.