### PR TITLE
feat: add learnset retrieval module with generation-aware move lookup

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,19 @@
+"""Shared test configuration.
+
+Stub the Ankimon package in sys.modules so that individual submodules can be
+imported without triggering Ankimon/__init__.py, which depends on Anki internals.
+"""
+
+import sys
+import types
+from pathlib import Path
+
+_src = Path(__file__).parent.parent / "src"
+
+# Stub parent packages so relative imports resolve without loading __init__.py
+for _pkg in ("Ankimon", "Ankimon.functions"):
+    if _pkg not in sys.modules:
+        _mod = types.ModuleType(_pkg)
+        _mod.__path__ = [str(_src / _pkg.replace(".", "/"))]
+        _mod.__package__ = _pkg
+        sys.modules[_pkg] = _mod

--- a/tests/test_learnset_retrieval.py
+++ b/tests/test_learnset_retrieval.py
@@ -7,27 +7,13 @@ from unittest.mock import mock_open, patch
 
 import pytest
 
-# We need to import learnset_retrieval without triggering Ankimon/__init__.py
-# (which depends on Anki internals). We do this by:
-# 1. Creating stub parent packages in sys.modules
-# 2. Loading only the target module from its file path.
-
-_src = Path(__file__).parent.parent / "src"
-
-# Stub parent packages so relative imports resolve without loading __init__.py
-for _pkg in ("Ankimon", "Ankimon.functions"):
-    if _pkg not in sys.modules:
-        _mod = types.ModuleType(_pkg)
-        _mod.__path__ = [str(_src / _pkg.replace(".", "/"))]
-        _mod.__package__ = _pkg
-        sys.modules[_pkg] = _mod
-
-# Stub the resources module with a fake learnset_path
+# Stub resources module with a fake learnset_path
 _resources = types.ModuleType("Ankimon.resources")
 _resources.learnset_path = "/fake/learnsets.json"
 sys.modules["Ankimon.resources"] = _resources
 
 # Now load learnset_retrieval from its file
+_src = Path(__file__).parent.parent / "src"
 _spec = importlib.util.spec_from_file_location(
     "Ankimon.functions.learnset_retrieval",
     _src / "Ankimon" / "functions" / "learnset_retrieval.py",
@@ -36,10 +22,12 @@ _lr = importlib.util.module_from_spec(_spec)
 sys.modules[_spec.name] = _lr
 _spec.loader.exec_module(_lr)
 
-_get_learnset_moves = _lr._get_learnset_moves
-get_all_pokemon_moves = _lr.get_all_pokemon_moves
-get_levelup_move_for_pokemon = _lr.get_levelup_move_for_pokemon
-get_random_moves_for_pokemon = _lr.get_random_moves_for_pokemon
+from Ankimon.functions.learnset_retrieval import (
+    _get_learnset_moves,
+    get_all_pokemon_moves,
+    get_levelup_move_for_pokemon,
+    get_random_moves_for_pokemon,
+)
 
 
 FAKE_LEARNSET = {


### PR DESCRIPTION
- New module responsible for learnset retrieval
- Fix cross-generation bug where moves from other generations could pollute level up checks (gen 3 level 17 entry blocking gen 9 level 12 entry)
- units covering generation filtering, level boundaries, TM exclusion and case insensitivity