### PR TITLE
fix: tooltip RuntimeError from deleted Qt object

### DIFF
--- a/src/Ankimon/functions/drawing_utils.py
+++ b/src/Ankimon/functions/drawing_utils.py
@@ -58,7 +58,7 @@ def tooltipWithColour(msg, color, x=0, y=20, xref=1, parent=None, width=0, heigh
             except RuntimeError:
                 pass
 
-        QTimer.singleShot(period, lambda: hide_lab())
+        QTimer.singleShot(period, hide_lab)
         mw.logger.log_and_showinfo("game", msg)
 
 def draw_gender_symbols(


### PR DESCRIPTION
Should resolve issue #337 
This fixes the `RuntimeError: wrapped C/C++ object of type CustomLabel has been deleted`  error that could occur when the tooltip label is destroyed before the `QTimer` callback runs.
Changes:
Replace the `lab.hide()` with a safe callback using `try/except`
Remove the `try/except` around `QTimer.singleShot` 

Fixes: #337 