### PR TITLE
TEST PR TO SEE GITHUB ACTIONS

### DIFF
--- a/src/Ankimon/__init__.py
+++ b/src/Ankimon/__init__.py
@@ -17,7 +17,7 @@ except ModuleNotFoundError:
     # Debug console should not be available to non devs, so it's fine if this import doesn't succeed
     pass
 
-import json
+import orjson
 import random
 import copy
 from pathlib import Path
@@ -149,11 +149,11 @@ from .pyobj.error_handler import show_warning_with_traceback
 from .functions.drawing_utils import draw_gender_symbols, draw_stat_boosts
 
 # Load move and pokemon name mapping at startup
-with open(pokemon_names_file_path, "r", encoding="utf-8") as f:
-    POKEMON_NAME_LOOKUP = json.load(f)
+with open(pokemon_names_file_path, "rb") as f:
+    POKEMON_NAME_LOOKUP = orjson.loads(f.read())
 
-with open(move_names_file_path, "r", encoding="utf-8") as f:
-    MOVE_NAME_LOOKUP = json.load(f)
+with open(move_names_file_path, "rb") as f:
+    MOVE_NAME_LOOKUP = orjson.loads(f.read())
 
 mw.settings_ankimon = settings_window
 mw.logger = logger
@@ -194,11 +194,11 @@ if not _collection_loaded: # If the collection hasn't already been loaded
 
 
 items_list = []
-with open(items_list_path, "r", encoding="utf-8") as file:
-    items_list = json.load(file)
+with open(items_list_path, "rb") as file:
+    items_list = orjson.loads(file.read())
 
-with open(sound_list_path, "r", encoding="utf-8") as json_file:
-    sound_list = json.load(json_file)
+with open(sound_list_path, "rb") as f:
+    sound_list = orjson.loads(f.read())
 
 ankimon_tracker_obj.pokemon_encouter = 0
 
@@ -239,8 +239,8 @@ if not database_complete:
     dialog.show()
 
 if mainpokemon_path.is_file():
-    with open(mainpokemon_path, "r", encoding="utf-8") as json_file:
-        main_pokemon_data = json.load(json_file)
+    with open(mainpokemon_path, "rb") as f:
+        main_pokemon_data = orjson.loads(f.read())
         if not main_pokemon_data or main_pokemon_data is None:
             mainpokemon_empty = True
         else:
@@ -657,21 +657,21 @@ def on_review_card(*args):
 gui_hooks.reviewer_did_answer_card.append(on_review_card)
 
 if database_complete:
-    with open(badgebag_path, "r", encoding="utf-8") as json_file:
-        badge_list = json.load(json_file)
+    with open(badgebag_path, "rb") as f:
+        badge_list = orjson.loads(f.read())
         if len(badge_list) > 1: # has atleast one badge
             rate_this_addon()
 
 #Badges needed for achievements:
-with open(badges_list_path, "r", encoding="utf-8") as json_file:
-    badges = json.load(json_file)
+with open(badges_list_path, "rb") as f:
+    badges = orjson.loads(f.read())
 
 if database_complete:
     if mypokemon_path.is_file() is False:
         starter_window.display_starter_pokemon()
     else:
-        with open(mypokemon_path, "r", encoding="utf-8") as file:
-            pokemon_list = json.load(file)
+        with open(mypokemon_path, "rb") as file:
+            pokemon_list = orjson.loads(file.read())
             if not pokemon_list :
                 starter_window.display_starter_pokemon()
 

--- a/src/Ankimon/functions/badges_functions.py
+++ b/src/Ankimon/functions/badges_functions.py
@@ -1,15 +1,15 @@
-import json
+import orjson
 
 from ..resources import badgebag_path
 
 def populate_achievements_from_badges(achievements):
     # name change for clarification
     try:
-        with open(badgebag_path, "r", encoding="utf-8") as json_file:
-            badge_list = json.load(json_file)
+        with open(badgebag_path, "rb") as f:
+            badge_list = orjson.loads(f.read())
             for badge_num in badge_list:
                 achievements[str(badge_num)] = True
-    except (FileNotFoundError, json.JSONDecodeError):
+    except (FileNotFoundError, orjson.JSONDecodeError):
         # If file doesn't exist or is empty, just return the initial achievements
         pass
     return achievements
@@ -18,8 +18,8 @@ def check_for_badge(achievements, rec_badge_num):
     return achievements.get(str(rec_badge_num), False)
 
 def save_badges(badges_collection):
-    with open(badgebag_path, 'w') as json_file:
-        json.dump(badges_collection, json_file)
+    with open(badgebag_path, 'wb') as f:
+        f.write(orjson.dumps(badges_collection))
 
 def receive_badge(badge_num,achievements):
     achievements[str(badge_num)] = True

--- a/src/Ankimon/functions/battle_functions.py
+++ b/src/Ankimon/functions/battle_functions.py
@@ -1,11 +1,11 @@
 import copy
-import json
+import orjson
 from ..poke_engine import constants
 from ..resources import move_names_file_path
 from ..pyobj.error_handler import show_warning_with_traceback
 
-with open(move_names_file_path, "r", encoding="utf-8") as f:
-    MOVE_NAME_LOOKUP = json.load(f)
+with open(move_names_file_path, "rb") as f:
+    MOVE_NAME_LOOKUP = orjson.loads(f.read())
 
 def format_move_name(move: str) -> str:
     """

--- a/src/Ankimon/functions/encounter_functions.py
+++ b/src/Ankimon/functions/encounter_functions.py
@@ -1,5 +1,5 @@
 
-import json
+import orjson
 import random
 import math
 from typing import Union
@@ -121,8 +121,8 @@ def get_pokemon_id_by_tier(tier):
     elif tier == "Mythical":
         id_species_path = pokemon_species_mythical_path
 
-    with open(id_species_path, "r", encoding="utf-8") as file:
-        id_data = json.load(file)
+    with open(id_species_path, "rb") as file:
+        id_data = orjson.loads(file.read())
 
     # Select a random Pokemon ID from those in the tier
     random_pokemon_id = random.choice(id_data)
@@ -409,8 +409,8 @@ def save_main_pokemon_progress(
         level_cap = 100
     try:
         if mainpokemon_path.is_file():
-            with open(mainpokemon_path, "r", encoding="utf-8") as json_file:
-                main_pokemon_data = json.load(json_file)
+            with open(mainpokemon_path, "rb") as f:
+                main_pokemon_data = orjson.loads(f.read())
         else:
             showWarning(translator.translate("missing_mainpokemon_data"))
     except Exception as e:
@@ -516,12 +516,12 @@ def save_main_pokemon_progress(
     mypkmndata = mainpkmndata
     mainpkmndata = [mainpkmndata]
     # Save the caught Pokémon's data to a JSON file
-    with open(str(mainpokemon_path), "w") as json_file:
-        json.dump(mainpkmndata, json_file, indent=2)
+    with open(str(mainpokemon_path), "wb") as f:
+        f.write(orjson.dumps(mainpkmndata, option=orjson.OPT_INDENT_2))
 
     # Load data from the output JSON file
-    with open(str(mypokemon_path), "r", encoding="utf-8") as output_file:
-        mypokemondata = json.load(output_file)
+    with open(str(mypokemon_path), "rb") as f:
+        mypokemondata = orjson.loads(f.read())
 
         # Find and replace the specified Pokémon's data in mypokemondata
         for index, pokemon_data in enumerate(mypokemondata):
@@ -530,8 +530,8 @@ def save_main_pokemon_progress(
                 break
 
         # Save the modified data to the output JSON file
-        with open(str(mypokemon_path), "w") as output_file:
-            json.dump(mypokemondata, output_file, indent=2)
+        with open(str(mypokemon_path), "wb") as f:
+            f.write(orjson.dumps(mypokemondata, option=orjson.OPT_INDENT_2))
 
     sync_mainpokemon_to_mypokemon(main_pokemon, mainpokemon_path, mypokemon_path)
 
@@ -546,12 +546,12 @@ def sync_mainpokemon_to_mypokemon(main_pokemon, mainpokemon_path, mypokemon_path
         mainpokemon_path: Path to mainpokemon.json.
         mypokemon_path: Path to mypokemon.json.
     """
-    import json
+    import orjson
     # Load mainpokemon data
     if not mainpokemon_path.is_file():
         return
-    with open(mainpokemon_path, "r", encoding="utf-8") as f:
-        main_data = json.load(f)
+    with open(mainpokemon_path, "rb") as f:
+        main_data = orjson.loads(f.read())
     if not main_data:
         return
     # Use the first (and only) mainpokemon entry
@@ -564,8 +564,8 @@ def sync_mainpokemon_to_mypokemon(main_pokemon, mainpokemon_path, mypokemon_path
     # Load mypokemon data
     if not mypokemon_path.is_file():
         return
-    with open(mypokemon_path, "r", encoding="utf-8") as f:
-        my_data = json.load(f)
+    with open(mypokemon_path, "rb") as f:
+        my_data = orjson.loads(f.read())
     # Find and update the entry with matching individual_id
     updated = False
     for idx, entry in enumerate(my_data):
@@ -577,8 +577,8 @@ def sync_mainpokemon_to_mypokemon(main_pokemon, mainpokemon_path, mypokemon_path
             updated = True
             break
     if updated:
-        with open(mypokemon_path, "w", encoding="utf-8") as f:
-            json.dump(my_data, f, indent=2)
+        with open(mypokemon_path, "wb") as f:
+            f.write(orjson.dumps(my_data, option=orjson.OPT_INDENT_2))
     return
 
 def kill_pokemon(
@@ -680,15 +680,15 @@ def save_caught_pokemon(
     # Load existing Pokémon data if it exists
     caught_pokemon_data = []
     if mypokemon_path.is_file():
-        with open(mypokemon_path, "r", encoding="utf-8") as json_file:
-            caught_pokemon_data = json.load(json_file)
+        with open(mypokemon_path, "rb") as f:
+            caught_pokemon_data = orjson.loads(f.read())
 
     # Append the caught Pokémon's data to the list
     caught_pokemon_data.append(caught_pokemon)
 
     # Save the caught Pokémon's data to a JSON file
-    with open(str(mypokemon_path), "w") as json_file:
-        json.dump(caught_pokemon_data, json_file, indent=2)
+    with open(str(mypokemon_path), "wb") as f:
+        f.write(orjson.dumps(caught_pokemon_data, option=orjson.OPT_INDENT_2))
 
 def catch_pokemon(
         enemy_pokemon: PokemonObject,

--- a/src/Ankimon/functions/pokedex_functions.py
+++ b/src/Ankimon/functions/pokedex_functions.py
@@ -13,7 +13,7 @@ from ..resources import (
 )
 from aqt.utils import showWarning
 from aqt import mw
-import json
+import orjson
 import random
 import csv
 from ..pyobj.error_handler import show_warning_with_traceback
@@ -75,8 +75,8 @@ def special_pokemon_names_for_min_level(name):
 def search_pokedex(pokemon_name, variable):
     try:
         pokemon_name = special_pokemon_names_for_min_level(pokemon_name)
-        with open(str(pokedex_path), "r", encoding="utf-8") as json_file:
-            pokedex_data = json.load(json_file)
+        with open(str(pokedex_path), "rb") as f:
+            pokedex_data = orjson.loads(f.read())
 
         # Create a copy of the name to modify
         current_name = pokemon_name
@@ -113,8 +113,8 @@ def search_pokedex(pokemon_name, variable):
 
 def search_pokedex_by_name_for_id(pokemon_name, variable):
     pokemon_name = special_pokemon_names_for_min_level(pokemon_name)
-    with open(str(pokedex_path), "r", encoding="utf-8") as json_file:
-        pokedex_data = json.load(json_file)
+    with open(str(pokedex_path), "rb") as f:
+        pokedex_data = orjson.loads(f.read())
         if pokemon_name in pokedex_data:
             pokemon_info = pokedex_data[pokemon_name]
             var = pokemon_info.get("num", None)
@@ -124,8 +124,8 @@ def search_pokedex_by_name_for_id(pokemon_name, variable):
 
 
 def search_pokedex_by_id(pokemon_id):
-    with open(str(pokedex_path), "r", encoding="utf-8") as json_file:
-        pokedex_data = json.load(json_file)
+    with open(str(pokedex_path), "rb") as f:
+        pokedex_data = orjson.loads(f.read())
         for entry_name, attributes in pokedex_data.items():
             if attributes["num"] == pokemon_id:
                 return entry_name
@@ -133,8 +133,8 @@ def search_pokedex_by_id(pokemon_id):
 
 
 def get_mainpokemon_evo(pokemon_name):
-    with open(str(pokedex_path), "r", encoding="utf-8") as json_file:
-        pokedex_data = json.load(json_file)
+    with open(str(pokedex_path), "rb") as f:
+        pokedex_data = orjson.loads(f.read())
         if pokemon_name not in pokedex_data:
             return []
         pokemon_info = pokedex_data[pokemon_name]
@@ -143,8 +143,8 @@ def get_mainpokemon_evo(pokemon_name):
 
 
 def search_pokeapi_db(pkmn_name, variable):
-    with open(str(pokeapi_db_path), "r", encoding="utf-8") as json_file:
-        pokedex_data = json.load(json_file)
+    with open(str(pokeapi_db_path), "rb") as f:
+        pokedex_data = orjson.loads(f.read())
         for pokemon_data in pokedex_data:
             name = pokemon_data["name"]
             if pokemon_data["name"] == pkmn_name:
@@ -153,8 +153,8 @@ def search_pokeapi_db(pkmn_name, variable):
 
 
 def search_pokeapi_db_by_id(pkmn_id, variable):
-    with open(str(pokeapi_db_path), "r", encoding="utf-8") as json_file:
-        pokedex_data = json.load(json_file)
+    with open(str(pokeapi_db_path), "rb") as f:
+        pokedex_data = orjson.loads(f.read())
         for pokemon_data in pokedex_data:
             if pokemon_data["id"] == pkmn_id:
                 var = pokemon_data.get(variable, None)
@@ -201,8 +201,8 @@ def get_pokemon_diff_lang_name(pokemon_id: int, language: int):
 def extract_ids_from_file():
     try:
         filename = mypokemon_path
-        with open(filename, "r", encoding="utf-8") as file:
-            data = json.load(file)
+        with open(filename, "rb") as file:
+            data = orjson.loads(file.read())
             ids = [character["id"] for character in data]
             owned_pokemon_ids = ids
             owned_pokemon_ids = sorted(list(set(owned_pokemon_ids)))
@@ -226,8 +226,8 @@ def get_all_pokemon_moves(pk_name, level):
         list: A list of up to 4 random moves and their highest levels.
     """
     # Load the JSON file
-    with open(learnset_path, "r", encoding="utf-8") as file:
-        learnsets = json.load(file)
+    with open(learnset_path, "rb") as file:
+        learnsets = orjson.loads(file.read())
 
     # Normalize the Pokémon name to lowercase for consistency
     pk_name = pk_name.lower()
@@ -279,8 +279,8 @@ def get_all_pokemon_moves(pk_name, level):
 
 def find_details_move(move_name: str):
     try:
-        with open(moves_file_path, "r", encoding="utf-8") as json_file:
-            moves_data = json.load(json_file)
+        with open(moves_file_path, "rb") as f:
+            moves_data = orjson.loads(f.read())
             move = moves_data.get(
                 move_name.lower()
             )  # Use get() to access the move by name

--- a/src/Ankimon/functions/pokemon_functions.py
+++ b/src/Ankimon/functions/pokemon_functions.py
@@ -1,5 +1,5 @@
 import csv
-import json
+import orjson
 import random
 import uuid
 from datetime import datetime
@@ -26,8 +26,8 @@ def pick_random_gender(pokemon_name):
     Returns:
         str: "M" for male, "F" for female, or "Genderless" for genderless Pokémon.
     """
-    with open(pokedex_path, 'r', encoding="utf-8") as file:
-        pokedex_data = json.load(file)
+    with open(pokedex_path, 'rb') as file:
+        pokedex_data = orjson.loads(file.read())
     pokemon_name = pokemon_name.lower()  # Normalize Pokémon name to lowercase
     pokemon = pokedex_data.get(pokemon_name)
     if not pokemon:
@@ -173,8 +173,8 @@ def get_random_moves_for_pokemon(pokemon_name, level):
             list: A list of up to 4 random moves and their highest levels.
         """
         # Load the JSON file
-        with open(learnset_path, "r", encoding="utf-8") as file:
-            learnsets = json.load(file)
+        with open(learnset_path, "rb") as file:
+            learnsets = orjson.loads(file.read())
 
         # Normalize the Pokémon name to lowercase for consistency
         pokemon_name = pokemon_name.lower()
@@ -296,16 +296,16 @@ def save_fossil_pokemon(pokemon_id):
     }
     # Load existing Pokémon data if it exists
     if mypokemon_path.is_file():
-        with open(mypokemon_path, "r", encoding="utf-8") as json_file:
-            caught_pokemon_data = json.load(json_file)
+        with open(mypokemon_path, "rb") as f:
+            caught_pokemon_data = orjson.loads(f.read())
     else:
         caught_pokemon_data = []
 
     # Append the caught Pokémon's data to the list
     caught_pokemon_data.append(caught_pokemon)
     # Save the caught Pokémon's data to a JSON file
-    with open(str(mypokemon_path), "w") as json_file:
-        json.dump(caught_pokemon_data, json_file, indent=2)
+    with open(str(mypokemon_path), "wb") as f:
+        f.write(orjson.dumps(caught_pokemon_data, option=orjson.OPT_INDENT_2))
 
 def get_levelup_move_for_pokemon(pokemon_name, level):
     """
@@ -319,8 +319,8 @@ def get_levelup_move_for_pokemon(pokemon_name, level):
         str: A random move and its highest level.
     """
     # Load the JSON file
-    with open(learnset_path, "r", encoding="utf-8") as file:
-        learnsets = json.load(file)
+    with open(learnset_path, "rb") as file:
+        learnsets = orjson.loads(file.read())
 
     # Normalize the Pokémon name to lowercase for consistency
     pokemon_name = pokemon_name.lower()

--- a/src/Ankimon/functions/pokemon_showdown_functions.py
+++ b/src/Ankimon/functions/pokemon_showdown_functions.py
@@ -1,4 +1,4 @@
-import json
+import orjson
 
 from aqt import mw
 from aqt.qt import QDialog, QLabel,Qt, QVBoxLayout
@@ -85,8 +85,8 @@ def export_all_pkmn_showdown():
     # Get all pokemon data
     pokemon_info_complete_text = ""
     try:
-        with (open(mypokemon_path, "r", encoding="utf-8") as json_file):
-            captured_pokemon_data = json.load(json_file)
+        with (open(mypokemon_path, "rb") as f):
+            captured_pokemon_data = orjson.loads(f.read())
 
             # Check if there are any captured Pokémon
             if captured_pokemon_data:
@@ -184,8 +184,8 @@ def flex_pokemon_collection():
 # Get all pokemon data
     pokemon_info_complete_text = ""
     try:
-        with (open(mypokemon_path, "r", encoding="utf-8") as json_file):
-            captured_pokemon_data = json.load(json_file)
+        with (open(mypokemon_path, "rb") as f):
+            captured_pokemon_data = orjson.loads(f.read())
 
             # Check if there are any captured Pokémon
             if captured_pokemon_data:

--- a/src/Ankimon/functions/trainer_functions.py
+++ b/src/Ankimon/functions/trainer_functions.py
@@ -1,4 +1,4 @@
-import json
+import orjson
 from .pokedex_functions import extract_ids_from_file
 from ..resources import mypokemon_path, badgebag_path
 from .pokemon_functions import find_experience_for_level
@@ -23,13 +23,13 @@ def find_trainer_rank(highest_level, trainer_level):
 
         # Count the number of shiny Pokémon
         shiny_pokemon_count = 0
-        with open(mypokemon_path, 'r', encoding='utf-8') as f:
-            my_pokemon = json.load(f)
+        with open(mypokemon_path, 'rb') as f:
+            my_pokemon = orjson.loads(f.read())
             shiny_pokemon_count = sum(1 for pokemon in my_pokemon if pokemon.get('shiny', False))  # Assuming 'shiny' is a key
 
         # Count badges
-        with open(badgebag_path, 'r', encoding='utf-8') as f:
-            badges = json.load(f)
+        with open(badgebag_path, 'rb') as f:
+            badges = orjson.loads(f.read())
             badge_count = len(badges)
 
         # Determine rank based on achievements
@@ -75,8 +75,8 @@ def xp_share_gain_exp(logger, settings_obj, evo_window, main_pokemon_id, exp, xp
     exp = int(exp * 0.5)  # Convert the experience to an integer
 
     # Open the mypokemon_path JSON file and load the data
-    with open(mypokemon_path, "r", encoding="utf-8") as json_file:
-        mypokemon_data = json.load(json_file)
+    with open(mypokemon_path, "rb") as f:
+        mypokemon_data = orjson.loads(f.read())
 
     msg = ""
     evolution_triggered = False
@@ -123,16 +123,16 @@ def xp_share_gain_exp(logger, settings_obj, evo_window, main_pokemon_id, exp, xp
             evolution_triggered = True
 
             # Write the XP/level changes to file BEFORE calling evolution
-            with open(mypokemon_path, "w", encoding="utf-8") as json_file:
-                json.dump(mypokemon_data, json_file, indent=4)
+            with open(mypokemon_path, "wb") as f:
+                f.write(orjson.dumps(mypokemon_data, option=orjson.OPT_INDENT_2))
 
             # Now call evolution (which will read the updated file and handle the evolution)
             break  # Exit the loop since we found and processed the Pokemon
 
     # Only write to file if no evolution was triggered (since evolution already wrote to file)
     if not evolution_triggered:
-        with open(mypokemon_path, "w", encoding="utf-8") as json_file:
-            json.dump(mypokemon_data, json_file, indent=4)
+        with open(mypokemon_path, "wb") as f:
+            f.write(orjson.dumps(mypokemon_data, option=orjson.OPT_INDENT_2))
 
     logger.log("info", f"{msg}")
     return original_exp  # Return the amount of experience added

--- a/src/Ankimon/gui_classes/check_files.py
+++ b/src/Ankimon/gui_classes/check_files.py
@@ -1,6 +1,6 @@
 import sys
 import os
-import json
+import orjson
 from PyQt6.QtWidgets import (
     QApplication, QMainWindow, QVBoxLayout, QLabel, QPushButton,
     QLineEdit, QFileDialog, QTextEdit, QWidget, QDialog
@@ -37,8 +37,8 @@ def check_files_in_json(json_file=json_file_structure, root_directory=addon_dir)
                     missing_files.append(folder_path)
 
     # Load the JSON file
-    with open(json_file, 'r', encoding='utf-8') as f:
-        folder_structure = json.load(f)
+    with open(json_file, 'rb') as f:
+        folder_structure = orjson.loads(f.read())
 
     missing_files = []
     verify_files(folder_structure, root_directory, missing_files)

--- a/src/Ankimon/gui_classes/pokemon_details.py
+++ b/src/Ankimon/gui_classes/pokemon_details.py
@@ -1,5 +1,5 @@
 from math import exp
-import json
+import orjson
 from typing import Any
 
 from aqt import mw, qconnect
@@ -598,8 +598,8 @@ def remember_attack(
         logger.log_and_showinfo("warning", "Missing Mainpokemon Data !")
         return
 
-    with open(str(mypokemon_path), "r", encoding="utf-8") as output_file:
-        mypokemondata = json.load(output_file)
+    with open(str(mypokemon_path), "rb") as output_file:
+        mypokemondata = orjson.loads(output_file.read())
     for pokemon_data in mypokemondata:
         # Use individual_id for matching
         if pokemon_data["individual_id"] != individual_id:
@@ -632,18 +632,18 @@ def remember_attack(
                         )
         pokemon_data["attacks"] = attacks
 
-        with open(str(mypokemon_path), "w") as output_file:
-            json.dump(mypokemondata, output_file, indent=2)
+        with open(str(mypokemon_path), "wb") as output_file:
+            output_file.write(orjson.dumps(mypokemondata, option=orjson.OPT_INDENT_2))
 
         # Update mainpokemon file if necessary
-        with open(mainpokemon_path, "r", encoding="utf-8") as json_file:
-            main_pokemon_data = json.load(json_file)
+        with open(mainpokemon_path, "rb") as f:
+            main_pokemon_data = orjson.loads(f.read())
         for mainpkmndata in main_pokemon_data:
             if mainpkmndata["individual_id"] == individual_id:
                 mainpkmndata["attacks"] = attacks
                 break
-        with open(str(mainpokemon_path), "w") as json_file:
-            json.dump(main_pokemon_data, json_file, indent=2)
+        with open(str(mainpokemon_path), "wb") as f:
+            f.write(orjson.dumps(main_pokemon_data, option=orjson.OPT_INDENT_2))
 
         break
 
@@ -673,8 +673,8 @@ def forget_attack(
         logger.log_and_showinfo("warning", "Missing Mainpokemon Data !")
         return
 
-    with open(str(mypokemon_path), "r", encoding="utf-8") as output_file:
-        mypokemondata = json.load(output_file)
+    with open(str(mypokemon_path), "rb") as output_file:
+        mypokemondata = orjson.loads(output_file.read())
     for pokemon_data in mypokemondata:
         # Use individual_id for matching
         if pokemon_data["individual_id"] != individual_id:
@@ -694,18 +694,18 @@ def forget_attack(
             logger.log_and_showinfo("info", f"{msg}")
         pokemon_data["attacks"] = attacks
 
-        with open(str(mypokemon_path), "w") as output_file:
-            json.dump(mypokemondata, output_file, indent=2)
+        with open(str(mypokemon_path), "wb") as output_file:
+            output_file.write(orjson.dumps(mypokemondata, option=orjson.OPT_INDENT_2))
 
         # Update mainpokemon file if necessary
-        with open(mainpokemon_path, "r", encoding="utf-8") as json_file:
-            main_pokemon_data = json.load(json_file)
+        with open(mainpokemon_path, "rb") as f:
+            main_pokemon_data = orjson.loads(f.read())
         for mainpkmndata in main_pokemon_data:
             if mainpkmndata["individual_id"] == individual_id:
                 mainpkmndata["attacks"] = attacks
                 break
-        with open(str(mainpokemon_path), "w") as json_file:
-            json.dump(main_pokemon_data, json_file, indent=2)
+        with open(str(mainpokemon_path), "wb") as f:
+            f.write(orjson.dumps(main_pokemon_data, option=orjson.OPT_INDENT_2))
 
         break
 
@@ -747,15 +747,15 @@ def tm_attack_details_window(
     html_content = remember_attack_details_window_template
     from pathlib import Path
 
-    with open(pokemon_tm_learnset_path, "r") as f:
-        pokemon_tm_learnset = json.load(f)
+    with open(pokemon_tm_learnset_path, "rb") as f:
+        pokemon_tm_learnset = orjson.loads(f.read())
 
     pokemon_name = search_pokedex_by_id(id)
     tm_learnset = pokemon_tm_learnset.get(
         pokemon_name, []
     )  # TMs that can be learnt by the Pokemon
-    with open(itembag_path, "r", encoding="utf-8") as json_file:
-        itembag_list = json.load(json_file)
+    with open(itembag_path, "rb") as f:
+        itembag_list = orjson.loads(f.read())
     owned_tms = [item["item"] for item in itembag_list if item.get("type") == "TM"]
     attack_set = [tm for tm in tm_learnset if tm in owned_tms]
 
@@ -823,8 +823,8 @@ def rename_pkmn(
 ):
     try:
         # Load the captured Pokémon data
-        with open(mypokemon_path, "r", encoding="utf-8") as json_file:
-            captured_pokemon_data = json.load(json_file)
+        with open(mypokemon_path, "rb") as f:
+            captured_pokemon_data = orjson.loads(f.read())
             pokemon = None
 
             # Find the Pokémon by individual_id
@@ -837,16 +837,16 @@ def rename_pkmn(
                 # Update the nickname
                 pokemon["nickname"] = nickname
                 # Reflect the change in the output JSON file
-                with open(str(mypokemon_path), "r", encoding="utf-8") as output_file:
-                    mypokemondata = json.load(output_file)
+                with open(str(mypokemon_path), "rb") as output_file:
+                    mypokemondata = orjson.loads(output_file.read())
                     # Update the specified Pokémon's data
                     for idx, data in enumerate(mypokemondata):
                         if data["individual_id"] == individual_id:
                             mypokemondata[idx] = pokemon
                             break
                 # Save the modified data
-                with open(str(mypokemon_path), "w") as output_file:
-                    json.dump(mypokemondata, output_file, indent=2)
+                with open(str(mypokemon_path), "wb") as output_file:
+                    output_file.write(orjson.dumps(mypokemondata, option=orjson.OPT_INDENT_2))
                 # Logging and UI update
                 logger.log_and_showinfo(
                     "info",
@@ -878,8 +878,8 @@ def PokemonFree(
         return
 
     # Check if the Pokémon is in the main Pokémon file
-    with open(mainpokemon_path, "r", encoding="utf-8") as file:
-        pokemon_data = json.load(file)
+    with open(mainpokemon_path, "rb") as file:
+        pokemon_data = orjson.loads(file.read())
 
     for pokemon in pokemon_data:
         if pokemon["individual_id"] == individual_id:
@@ -888,9 +888,9 @@ def PokemonFree(
 
     # Load Pokémon list from 'mypokemon_path' file
     try:
-        with open(mypokemon_path, "r", encoding="utf-8") as file:
-            pokemon_list = json.load(file)
-    except (FileNotFoundError, json.JSONDecodeError):
+        with open(mypokemon_path, "rb") as file:
+            pokemon_list = orjson.loads(file.read())
+    except (FileNotFoundError, orjson.JSONDecodeError):
         logger.log_and_showinfo("info", "Error: Could not load Pokémon data.")
         return
 
@@ -904,8 +904,8 @@ def PokemonFree(
     # If the Pokémon was found, remove it from the list
     if position != -1:
         pokemon_list.pop(position)
-        with open(mypokemon_path, "w") as file:
-            json.dump(pokemon_list, file, indent=2)
+        with open(mypokemon_path, "wb") as file:
+            file.write(orjson.dumps(pokemon_list, option=orjson.OPT_INDENT_2))
         logger.log_and_showinfo("info", f"{name.capitalize()} has been let free.")
     else:
         logger.log_and_showinfo("info", "No Pokémon found with the specified ID.")

--- a/src/Ankimon/gui_classes/pokemon_team_window.py
+++ b/src/Ankimon/gui_classes/pokemon_team_window.py
@@ -2,7 +2,7 @@ from ..functions.sprite_functions import get_sprite_path
 from PyQt6.QtCore import Qt
 from PyQt6.QtWidgets import QApplication, QDialog, QVBoxLayout, QLabel, QPushButton, QScrollArea, QGroupBox, QFrame, QGridLayout, QComboBox, QDialogButtonBox
 from PyQt6.QtGui import QPixmap
-import json
+import orjson
 import os
 from aqt import mw
 from aqt.utils import showInfo, showWarning
@@ -113,14 +113,14 @@ class PokemonTeamDialog(QDialog):
     def load_my_pokemon(self):
         """Load the player's Pokémon data from a JSON string (in this case, hardcoded)"""
         # Replace the following with the actual loading method if from a file:
-        with open(mypokemon_path, "r", encoding="utf-8") as file:
-            pokemon_data = json.load(file)
+        with open(mypokemon_path, "rb") as file:
+            pokemon_data = orjson.loads(file.read())
         return pokemon_data
 
     def load_pokemon_team(self):
         """Load the player's Pokémon Team from a JSON string (in this case, hardcoded)"""
-        with open(team_pokemon_path, "r", encoding="utf-8") as file:
-            team_data = json.load(file)
+        with open(team_pokemon_path, "rb") as file:
+            team_data = orjson.loads(file.read())
 
         # Load the player's Pokémon data (mypokemon_path)
         my_pokemon_data = self.load_my_pokemon()
@@ -300,8 +300,8 @@ class PokemonTeamDialog(QDialog):
         self.settings.set("trainer.xp_share", xp_share_individual_id)  # Save XP Share Pokémon
 
         try:
-            with open(team_pokemon_path, "w") as json_file:
-                json.dump(team_data, json_file, indent=4)
+            with open(team_pokemon_path, "wb") as f:
+                f.write(orjson.dumps(team_data, option=orjson.OPT_INDENT_2))
 
             self.logger.log_and_showinfo("info", f"Trainer settings saved to {team_pokemon_path}.")
             self.logger.log_and_showinfo("info", f"You chose the following team: [{', '.join([pokemon['name'] for pokemon in pokemon_names])}]\nXP Share: {xp_share_pokemon}")

--- a/src/Ankimon/gui_entities.py
+++ b/src/Ankimon/gui_entities.py
@@ -1,5 +1,5 @@
 import markdown
-import json
+import orjson
 from PyQt6.QtGui import QMovie, QIcon
 from PyQt6.QtWidgets import QLabel, QVBoxLayout, QTextEdit, QCheckBox, QPushButton, QMessageBox, QWidget, QScrollArea, QGridLayout, QTextBrowser
 from aqt import mw
@@ -297,8 +297,8 @@ class Pokedex_Widget(QWidget):
         self.initUI()
 
     def read_poke_coll(self):
-        with (open(mypokemon_path, "r", encoding="utf-8") as json_file):
-            self.captured_pokemon_data = json.load(json_file)
+        with (open(mypokemon_path, "rb")) as f:
+            self.captured_pokemon_data = orjson.loads(f.read())
 
     def initUI(self):
         self.setWindowTitle("Pokédex")

--- a/src/Ankimon/poke_engine/battle_modifier.py
+++ b/src/Ankimon/poke_engine/battle_modifier.py
@@ -1,5 +1,5 @@
 import re
-import json
+import orjson
 from copy import deepcopy
 import logging
 
@@ -102,7 +102,7 @@ def request(battle, split_msg):
     """Update the user's team given the battle JSON in split_msg[2]
        Also updates some battle meta-data such as rqid, force_switch, and wait"""
     if len(split_msg) >= 2:
-        battle_json = json.loads(split_msg[2].strip('\''))
+        battle_json = orjson.loads(split_msg[2].strip('\''))
         logger.debug("Received battle JSON from server: {}".format(battle_json))
         battle.rqid = battle_json[constants.RQID]
 

--- a/src/Ankimon/poke_engine/data/__init__.py
+++ b/src/Ankimon/poke_engine/data/__init__.py
@@ -1,5 +1,5 @@
 import os
-import json
+import orjson
 import logging
 
 logger = logging.getLogger(__name__)
@@ -7,16 +7,16 @@ logger = logging.getLogger(__name__)
 PWD = os.path.dirname(os.path.abspath(__file__))
 
 move_json_location = os.path.join(PWD, 'moves.json')
-with open(move_json_location) as f:
-    all_move_json = json.load(f)
+with open(move_json_location, 'rb') as f:
+    all_move_json = orjson.loads(f.read())
 
 pkmn_json_location = os.path.join(PWD, 'pokedex.json')
-with open(pkmn_json_location, 'r') as f:
-    pokedex = json.loads(f.read())
+with open(pkmn_json_location, 'rb') as f:
+    pokedex = orjson.loads(f.read())
 
 random_battle_set_location = os.path.join(PWD, 'random_battle_sets.json')
-with open(random_battle_set_location, 'r') as f:
-    random_battle_sets = json.load(f)
+with open(random_battle_set_location, 'rb') as f:
+    random_battle_sets = orjson.loads(f.read())
 
 
 pokemon_sets = random_battle_sets

--- a/src/Ankimon/poke_engine/data/mods/apply_mods.py
+++ b/src/Ankimon/poke_engine/data/mods/apply_mods.py
@@ -1,5 +1,5 @@
 import os
-import json
+import orjson
 import logging
 import constants
 import data
@@ -37,8 +37,8 @@ PRE_PHYSICAL_SPECIAL_SPLIT_CATEGORY_LOOKUP = {
 def apply_move_mods(gen_number):
     logger.debug("Applying move mod for gen {}".format(gen_number))
     for gen_number in reversed(range(gen_number, CURRENT_GEN)):
-        with open("{}/gen{}_move_mods.json".format(PWD, gen_number), 'r') as f:
-            move_mods = json.load(f)
+        with open("{}/gen{}_move_mods.json".format(PWD, gen_number), 'rb') as f:
+            move_mods = orjson.loads(f.read())
         for move, modifications in move_mods.items():
             all_move_json[move].update(modifications)
 
@@ -46,16 +46,16 @@ def apply_move_mods(gen_number):
 def apply_pokedex_mods(gen_number):
     logger.debug("Applying dex mod for gen {}".format(gen_number))
     for gen_number in reversed(range(gen_number, CURRENT_GEN)):
-        with open("{}/gen{}_pokedex_mods.json".format(PWD, gen_number), 'r') as f:
-            pokedex_mods = json.load(f)
+        with open("{}/gen{}_pokedex_mods.json".format(PWD, gen_number), 'rb') as f:
+            pokedex_mods = orjson.loads(f.read())
         for pokemon, modifications in pokedex_mods.items():
             pokedex[pokemon].update(modifications)
 
 
 def set_random_battle_sets(gen_number):
     logger.debug("Setting random battle sets for gen {}".format(gen_number))
-    with open("{}/random_battle_sets_gen{}.json".format(PWD, gen_number), 'r') as f:
-        data.random_battle_sets = json.load(f)
+    with open("{}/random_battle_sets_gen{}.json".format(PWD, gen_number), 'rb') as f:
+        data.random_battle_sets = orjson.loads(f.read())
 
 
 def apply_gen_3_mods():

--- a/src/Ankimon/poke_engine/data/scripts/parse_random_battle_raw_sets.py
+++ b/src/Ankimon/poke_engine/data/scripts/parse_random_battle_raw_sets.py
@@ -6,7 +6,7 @@ Creates a JSON file with the data arranged in a way that the bot can use to unde
 This was made for the purposes of random battles
 """
 
-import json
+import orjson
 from copy import deepcopy
 import constants
 from showdown.engine.helpers import normalize_name
@@ -25,8 +25,8 @@ def add_thing_to_dict_or_increment(d, second_key, thing):
         d[second_key][thing] = 1
 
 
-with open(pokedex_path, 'r') as f:
-    pokedex = json.load(f)
+with open(pokedex_path, 'rb') as f:
+    pokedex = orjson.loads(f.read())
 
 
 with open(fp, 'r') as f:
@@ -132,5 +132,5 @@ for k, v in deepcopy(final_json).items():
         final_json.pop(k)
 
 
-with open("out.json", 'w') as f:
-    json.dump(final_json, f, indent=4, sort_keys=True)
+with open("out.json", 'wb') as f:
+    f.write(orjson.dumps(final_json, option=orjson.OPT_INDENT_2 | orjson.OPT_SORT_KEYS))

--- a/src/Ankimon/poke_engine/data/scripts/update_moves.py
+++ b/src/Ankimon/poke_engine/data/scripts/update_moves.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 import requests
-import json
+import orjson
 import copy
 import subprocess
 
@@ -52,7 +52,7 @@ stdout = p.stdout.read()
 stderr = p.stderr.read()
 
 # stdout should now be parse-able as JSON
-moves_dict = json.loads(stdout)
+moves_dict = orjson.loads(stdout)
 
 
 # make modifications to some values for the bot
@@ -127,13 +127,13 @@ for k, v in moves_dict.copy().items():
 
 
 # the bot needs these keys to be named differently
-string_json = json.dumps(moves_dict)
+string_json = orjson.dumps(moves_dict).decode('utf-8')
 string_json = string_json.replace('"atk"', '"attack"')
 string_json = string_json.replace('"def"', '"defense"')
 string_json = string_json.replace('"spa"', '"special-attack"')
 string_json = string_json.replace('"spd"', '"special-defense"')
 string_json = string_json.replace('"spe"', '"speed"')
-moves_dict = json.loads(string_json)
+moves_dict = orjson.loads(string_json)
 
 # custom changes for the bot to work
 # some of these are dumb, but here we are
@@ -300,6 +300,6 @@ moves_dict["jumpkick"]["crash"] = [1, 2]
 moves_dict["highjumpkick"]["crash"] = [1, 2]
 moves_dict["axekick"]["crash"] = [1, 2]
 
-with open("data/new_moves.json", "w") as f:
-    json.dump(moves_dict, f, indent=4, sort_keys=True)
+with open("data/new_moves.json", "wb") as f:
+    f.write(orjson.dumps(moves_dict, option=orjson.OPT_INDENT_2 | orjson.OPT_SORT_KEYS))
 a=5

--- a/src/Ankimon/poke_engine/data/scripts/update_pokedex.py
+++ b/src/Ankimon/poke_engine/data/scripts/update_pokedex.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 import requests
 import re
-import json
+import orjson
 
 # Fetch latest version
 data = requests.get(
@@ -37,7 +37,7 @@ data = re.sub(r': ""(.*)":(.*)",', r': "\1:\2",', data)
 data = data.replace("};", "}")
 
 # should be parseable as JSON now
-data_json = json.loads(data)
+data_json = orjson.loads(data)
 
 # some custom changes for this project
 for k, v in data_json.items():
@@ -63,5 +63,5 @@ sorted_dex = [i for i in sorted_dex if i[1]["num"] > 0]
 for k, v in sorted_dex + negative_nums:
     new_dict[k] = v
 
-with open("pokedex_new.json", "w") as f:
-    json.dump(data_json, f, indent=4)
+with open("pokedex_new.json", "wb") as f:
+    f.write(orjson.dumps(data_json, option=orjson.OPT_INDENT_2))

--- a/src/Ankimon/poke_engine/data/team_datasets.py
+++ b/src/Ankimon/poke_engine/data/team_datasets.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 import os
-import json
+import orjson
 import logging
 import typing
 from typing import Tuple
@@ -96,8 +96,8 @@ class _TeamDatasets:
 
     def append_to_team_datasets(self, pkmn_names):
         sets = os.path.join(PWD, 'team_datasets.json')
-        with open(sets, 'r') as f:
-            sets_dict = json.load(f)["pokemon"]
+        with open(sets, 'rb') as f:
+            sets_dict = orjson.loads(f.read())["pokemon"]
 
         for pkmn in pkmn_names:
             try:
@@ -108,8 +108,8 @@ class _TeamDatasets:
     @staticmethod
     def get_exact_team(pkmn_names):
         sets = os.path.join(PWD, 'team_datasets.json')
-        with open(sets, 'r') as f:
-            teams_dict = json.load(f)["teams"]
+        with open(sets, 'rb') as f:
+            teams_dict = orjson.loads(f.read())["teams"]
 
         pkmn_lookup = "|".join(pkmn_names)
         try:

--- a/src/Ankimon/pokedex/pokedex_obj.py
+++ b/src/Ankimon/pokedex/pokedex_obj.py
@@ -1,5 +1,5 @@
 import os
-import json
+import orjson
 from aqt import QDialog, QVBoxLayout, QWebEngineView, mw
 from PyQt6.QtCore import QUrlQuery
 from aqt.qt import Qt, QFile, QUrl, QFrame, QPushButton
@@ -61,11 +61,11 @@ class Pokedex(QDialog):
 
         if os.path.exists(mypokemon_path):
             try:
-                with open(mypokemon_path, "r", encoding="utf-8") as file:
-                    pokemon_list = json.load(file)
+                with open(mypokemon_path, "rb") as file:
+                    pokemon_list = orjson.loads(file.read())
                     print("POKEDEX_DEBUG: Loaded pokemon_list!")
 
-            except json.JSONDecodeError:
+            except orjson.JSONDecodeError:
                 print("POKEDEX_DEBUG: Invalid JSON in mypokemon.json at", mypokemon_path)
             except Exception as e:
                 print("POKEDEX_DEBUG: Error reading mypokemon.json at", mypokemon_path, ":", str(e))

--- a/src/Ankimon/pyobj/achievement_window.py
+++ b/src/Ankimon/pyobj/achievement_window.py
@@ -1,4 +1,4 @@
-import json
+import orjson
 
 from aqt import mw
 from aqt.qt import (
@@ -73,8 +73,8 @@ class AchievementWindow(QWidget):
     def BadgesLabel(self, badge_num):
         badge_path = badges_path / f"{str(badge_num)}.png"
         frame = QVBoxLayout() #itemframe
-        with open(badges_list_path, "r", encoding="utf-8") as json_file:
-            badges = json.load(json_file)
+        with open(badges_list_path, "rb") as f:
+            badges = orjson.loads(f.read())
         achievement_description = f"{(badges[str(badge_num)])}"
         badges_name_label = QLabel(f"{achievement_description}")
         badges_name_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
@@ -114,8 +114,8 @@ class AchievementWindow(QWidget):
 
     def read_item_file(self):
         # Read the list from the JSON file
-        with open(badgebag_path, "r", encoding="utf-8") as json_file:
-            self.badge_list = json.load(json_file)
+        with open(badgebag_path, "rb") as f:
+            self.badge_list = orjson.loads(f.read())
 
     def clear_layout(self, layout):
         while layout.count():

--- a/src/Ankimon/pyobj/achievements_dialog.py
+++ b/src/Ankimon/pyobj/achievements_dialog.py
@@ -1,5 +1,5 @@
 import os
-import json
+import orjson
 from aqt import QDialog, QVBoxLayout, QWebEngineView, mw
 from aqt.qt import QPushButton, QCheckBox, QFrame, Qt
 from PyQt6.QtCore import QUrl, QUrlQuery
@@ -34,8 +34,8 @@ class AchievementsDialog(QDialog):
     def load_html(self):
         # Load badge definitions
         badges_path = self.addon_dir / "addon_files" / "badges.json"
-        with open(badges_path, "r") as f:
-            badge_definitions = json.load(f)
+        with open(badges_path, "rb") as f:
+            badge_definitions = orjson.loads(f.read())
 
         # Load user's unlocked badges
         unlocked_badges = getattr(self.data_handler, "badges", [])
@@ -51,11 +51,11 @@ class AchievementsDialog(QDialog):
         query.addQueryItem("addon_name", mw.addonManager.addonFromModule(__name__))
         query.addQueryItem(
             "unlocked_badges",
-            json.dumps(unlocked_badges)
+            orjson.dumps(unlocked_badges).decode('utf-8')
         )
         query.addQueryItem(
             "badge_definitions",
-            json.dumps(badge_definitions)
+            orjson.dumps(badge_definitions).decode('utf-8')
         )
 
         url.setQuery(query.query(QUrl.ComponentFormattingOption.FullyEncoded))

--- a/src/Ankimon/pyobj/ankimon_leaderboard.py
+++ b/src/Ankimon/pyobj/ankimon_leaderboard.py
@@ -1,9 +1,8 @@
 import sys
-import json
+import orjson
 from PyQt6.QtWidgets import QApplication, QDialog, QVBoxLayout, QLabel, QLineEdit, QPushButton
 from aqt.utils import showInfo
 from ..resources import user_path_credentials, mypokemon_path
-import json
 import requests
 from aqt import mw # import setting values direct from init file
 
@@ -59,8 +58,8 @@ class ApiKeyDialog(QDialog):
     def save_credentials(self, credentials):
         try:
             # Save the new credentials as a single object
-            with open(user_path_credentials, "w", encoding="utf-8") as f:
-                json.dump(credentials, f, indent=4)
+            with open(user_path_credentials, "wb") as f:
+                f.write(orjson.dumps(credentials, option=orjson.OPT_INDENT_2))
             showInfo("Credentials saved successfully!")
         except Exception as e:
             showInfo(f"Error saving credentials: {e}")
@@ -73,8 +72,8 @@ def sync_data_to_leaderboard(data):
 
         try:
             # Load credentials from the file
-            with open(user_path_credentials, "r", encoding="utf-8") as f:
-                credentials = json.load(f)
+            with open(user_path_credentials, "rb") as f:
+                credentials = orjson.loads(f.read())
 
             # Extract username and api_key from the list of dictionaries
             username = credentials.get("username")
@@ -122,8 +121,8 @@ def get_unique_pokemon():
         return
 
     try:
-        with open(mypokemon_path, "r", encoding="utf-8") as file:
-            pokemon_data = json.load(file)
+        with open(mypokemon_path, "rb") as file:
+            pokemon_data = orjson.loads(file.read())
             pokemon_info = {}  # Define as a dictionary
             id_list = []  # Initialize id_list as an empty list
 
@@ -149,8 +148,8 @@ def get_unique_pokemon():
 
 def get_total_pokemon():
     try:
-        with open(mypokemon_path, "r", encoding="utf-8") as file:
-            pokemon_data = json.load(file)
+        with open(mypokemon_path, "rb") as file:
+            pokemon_data = orjson.loads(file.read())
             total_pokemon = len(pokemon_data)
             return total_pokemon
     except:
@@ -159,8 +158,8 @@ def get_total_pokemon():
 
 def get_shinies():
     try:
-        with open(mypokemon_path, "r", encoding="utf-8") as file:
-            pokemon_data = json.load(file)
+        with open(mypokemon_path, "rb") as file:
+            pokemon_data = orjson.loads(file.read())
             shinies = 0
             for pokemon in pokemon_data:
                 if pokemon.get("shiny") is True:

--- a/src/Ankimon/pyobj/ankimon_shop.py
+++ b/src/Ankimon/pyobj/ankimon_shop.py
@@ -1,7 +1,7 @@
 import os
 import random
 from datetime import datetime
-import json
+import orjson
 from typing import Union
 
 from aqt import mw
@@ -395,8 +395,8 @@ class PokemonShopManager:
     def get_daily_items(self):
         """Generate daily items based on the current date."""
         if os.path.isfile(self.shop_save_file):
-            with open(self.shop_save_file, 'r', encoding='utf-8') as f:
-                data = json.load(f)
+            with open(self.shop_save_file, 'rb') as f:
+                data = orjson.loads(f.read())
                 if data.get("items") and data.get("date") == datetime.now().strftime("%Y-%m-%d"):
                     return data.get("items")
 
@@ -407,8 +407,8 @@ class PokemonShopManager:
     def get_daily_tms(self):
         """Works like get_daily_items, but for TMs"""
         if os.path.isfile(self.shop_save_file):
-            with open(self.shop_save_file, 'r', encoding='utf-8') as f:
-                data = json.load(f)
+            with open(self.shop_save_file, 'rb') as f:
+                data = orjson.loads(f.read())
                 if data.get("technical_machines") and data.get("date") == datetime.now().strftime("%Y-%m-%d"):
                     return data.get("technical_machines")
 
@@ -418,8 +418,8 @@ class PokemonShopManager:
         return random.sample(tm_pool, self.number_of_daily_items)
 
     def get_tm_pool(self) -> list[str]:
-        with open(pokemon_tm_learnset_path, "r") as f:
-            pokemon_tm_learnset = json.load(f)
+        with open(pokemon_tm_learnset_path, "rb") as f:
+            pokemon_tm_learnset = orjson.loads(f.read())
 
         def flatten(xss):
             return [x for xs in xss for x in xs]
@@ -527,13 +527,13 @@ class PokemonShopManager:
         self.todays_daily_tms = random.sample(self.get_tm_pool(), self.number_of_daily_items)
 
         # SAVE IMMEDIATELY - before GUI refresh
-        with open(self.shop_save_file, 'w', encoding='utf-8') as f:
+        with open(self.shop_save_file, 'wb') as f:
             data = {
                 "items": self.todays_daily_items,
                 "technical_machines": self.todays_daily_tms,
                 "date": datetime.now().strftime("%Y-%m-%d"),
             }
-            json.dump(data, f, ensure_ascii=False, indent=4)
+            f.write(orjson.dumps(data, option=orjson.OPT_INDENT_2))
 
         # Now refresh the window - it will load from the updated JSON file
         self.toggle_window()

--- a/src/Ankimon/pyobj/backup_files.py
+++ b/src/Ankimon/pyobj/backup_files.py
@@ -1,7 +1,6 @@
 import os
 import shutil
 from datetime import datetime
-import json
 from aqt.utils import showInfo
 from aqt import mw
 from ..resources import mypokemon_path, mainpokemon_path, itembag_path, badgebag_path, user_path_credentials, backup_root

--- a/src/Ankimon/pyobj/backup_manager.py
+++ b/src/Ankimon/pyobj/backup_manager.py
@@ -1,6 +1,6 @@
 
 import base64
-import json
+import orjson
 import os
 import shutil
 import datetime
@@ -58,7 +58,7 @@ class BackupManager:
             key_bytes = self._OBFUSCATION_KEY.encode('utf-8')
             for i, byte in enumerate(obfuscated_bytes):
                 deobfuscated_bytes.append(byte ^ key_bytes[i % len(key_bytes)])
-            return json.loads(deobfuscated_bytes.decode('utf-8'))
+            return orjson.loads(deobfuscated_bytes.decode('utf-8'))
         except Exception as e:
             self.logger.log("error", f"Failed to deobfuscate data: {e}")
             return None
@@ -70,12 +70,12 @@ class BackupManager:
             if backup_dir.is_dir():
                 summary_path = backup_dir / "summary.json"
                 if summary_path.exists():
-                    with open(summary_path, 'r', encoding='utf-8') as f:
+                    with open(summary_path, 'rb') as f:
                         try:
-                            summary = json.load(f)
+                            summary = orjson.loads(f.read())
                             summary['path'] = str(backup_dir)
                             backups.append(summary)
-                        except json.JSONDecodeError:
+                        except orjson.JSONDecodeError:
                             self.logger.log("error", f"Could not read summary for backup: {backup_dir.name}")
         return backups
 
@@ -94,8 +94,8 @@ class BackupManager:
 
             summary = self._generate_summary(backup_dir)
             summary['manual'] = manual
-            with open(backup_dir / "summary.json", 'w', encoding='utf-8') as f:
-                json.dump(summary, f, indent=4)
+            with open(backup_dir / "summary.json", 'wb') as f:
+                f.write(orjson.dumps(summary, option=orjson.OPT_INDENT_2))
             
             if manual:
                 showInfo("Manual backup created successfully.")
@@ -124,33 +124,33 @@ class BackupManager:
         # Read mainpokemon.json for main Pokémon info
         mainpokemon_path = backup_dir / "mainpokemon.json"
         if mainpokemon_path.exists():
-            with open(mainpokemon_path, 'r', encoding='utf-8') as f:
+            with open(mainpokemon_path, 'rb') as f:
                 try:
-                    mainpokemon_data = json.load(f)
+                    mainpokemon_data = orjson.loads(f.read())
                     if mainpokemon_data:
                         summary["main_pokemon_name"] = mainpokemon_data[0].get("name", "N/A")
                         summary["main_pokemon_level"] = mainpokemon_data[0].get("level", "N/A")
-                except (json.JSONDecodeError, IndexError):
+                except (orjson.JSONDecodeError, IndexError):
                     pass
 
         # Read mypokemon.json for total Pokémon count
         mypokemon_path = backup_dir / "mypokemon.json"
         if mypokemon_path.exists():
-            with open(mypokemon_path, 'r', encoding='utf-8') as f:
+            with open(mypokemon_path, 'rb') as f:
                 try:
-                    mypokemon_data = json.load(f)
+                    mypokemon_data = orjson.loads(f.read())
                     summary["pokemon_count"] = len(mypokemon_data)
-                except json.JSONDecodeError:
+                except orjson.JSONDecodeError:
                     pass
 
         # Read items.json for total item count
         items_path = backup_dir / "items.json"
         if items_path.exists():
-            with open(items_path, 'r', encoding='utf-8') as f:
+            with open(items_path, 'rb') as f:
                 try:
-                    items_data = json.load(f)
+                    items_data = orjson.loads(f.read())
                     summary["item_count"] = sum(item.get('quantity', 0) for item in items_data)
-                except json.JSONDecodeError:
+                except orjson.JSONDecodeError:
                     pass
 
         # Read config.obf for trainer info

--- a/src/Ankimon/pyobj/error_handler.py
+++ b/src/Ankimon/pyobj/error_handler.py
@@ -1,6 +1,6 @@
 import os
 import re
-import json
+import orjson
 import random
 import traceback
 import requests
@@ -24,7 +24,7 @@ manifest_path = addon_dir / "manifest.json"
 def get_environment_info() -> str:
     """Collect add-on, Anki, Python, and OS version information."""
     try:
-        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+        manifest = orjson.loads(manifest_path.read_text(encoding="utf-8"))
         addon_ver = manifest.get("version", "unknown")
     except Exception:
         addon_ver = "unknown"
@@ -69,8 +69,8 @@ def load_error_images(json_path: Path) -> Dict[str, str]:
     """Load and select random error image metadata."""
     default_image = {"path": "", "credit": "", "url": ""}
     try:
-        with open(json_path, 'r', encoding='utf-8') as f:
-            error_images = json.load(f)
+        with open(json_path, 'rb') as f:
+            error_images = orjson.loads(f.read())
         return random.choice(error_images)
     except Exception as e:
         mw.logger.log("error", f"Failed to load error images: {str(e)}")

--- a/src/Ankimon/pyobj/evolution_window.py
+++ b/src/Ankimon/pyobj/evolution_window.py
@@ -1,4 +1,4 @@
-import json
+import orjson
 import random
 
 from aqt import mw
@@ -227,8 +227,8 @@ class EvoWindow(QWidget):
     def evolve_pokemon(self, individual_id, prevo_id, prevo_name, evo_id, evo_name, main_pokemon):
         #global achievements
         try:
-            with open(mypokemon_path, "r", encoding="utf-8") as json_file:
-                captured_pokemon_data = json.load(json_file)
+            with open(mypokemon_path, "rb") as f:
+                captured_pokemon_data = orjson.loads(f.read())
                 pokemon = None
                 if captured_pokemon_data:
                     for pokemon_data in captured_pokemon_data:
@@ -288,16 +288,16 @@ class EvoWindow(QWidget):
                                     pokemon["ability"] = random.choice(abilities_list)
                                 else:
                                     pokemon["ability"] = self.translator.translate("no_ability")
-                                with open(str(mypokemon_path), "r", encoding="utf-8") as output_file:
-                                    mypokemondata = json.load(output_file)
+                                with open(str(mypokemon_path), "rb") as output_file:
+                                    mypokemondata = orjson.loads(output_file.read())
                                     # Find and replace the specified Pokémon's data in mypokemondata
                                     for index, pokemon_data in enumerate(mypokemondata):
                                         if pokemon_data["individual_id"] == individual_id:
                                             mypokemondata[index] = pokemon
                                             break
                                             # Save the modified data to the output JSON file
-                                    with open(str(mypokemon_path), "w") as output_file:
-                                        json.dump(mypokemondata, output_file, indent=2)
+                                    with open(str(mypokemon_path), "wb") as output_file:
+                                        output_file.write(orjson.dumps(mypokemondata, option=orjson.OPT_INDENT_2))
                                 self.logger.log_and_showinfo("info", self.translator.translate("mainpokemon_has_evolved", prevo_name=prevo_name, evo_name=evo_name))
         except Exception as e:
             show_warning_with_traceback(parent=mw, exception=e, message=f"Error occured in evolving pokemon")
@@ -324,8 +324,8 @@ class EvoWindow(QWidget):
 
     def cancel_evolution(self, individual_id, prevo_name):
         try:
-            with open(mypokemon_path, "r+", encoding="utf-8") as f:
-                all_pokemon = json.load(f)
+            with open(mypokemon_path, "rb+") as f:
+                all_pokemon = orjson.loads(f.read())
 
                 pokemon_to_update = None
                 for p in all_pokemon:
@@ -367,7 +367,7 @@ class EvoWindow(QWidget):
 
                 # Write the changes back to the file
                 f.seek(0)
-                json.dump(all_pokemon, f, indent=2)
+                f.write(orjson.dumps(all_pokemon, option=orjson.OPT_INDENT_2))
                 f.truncate()
 
             # If the main pokemon was the one, update its object in memory

--- a/src/Ankimon/pyobj/pc_box.py
+++ b/src/Ankimon/pyobj/pc_box.py
@@ -1,4 +1,4 @@
-import json
+import orjson
 import uuid
 from typing import Any, Callable
 
@@ -514,14 +514,14 @@ class PokemonPC(QDialog):
     def load_pokemon_data(self) -> list:
         """Reads the mypokemon.json file and loads Pokémon data into self.pokemon_list."""
         try:
-            with open(mypokemon_path, "r", encoding="utf-8") as file:
-                pokemon_list = json.load(file)
+            with open(mypokemon_path, "rb") as file:
+                pokemon_list = orjson.loads(file.read())
                 for i, pokemon in enumerate(pokemon_list):
                     pokemon['original_index'] = i
                 return pokemon_list
         except FileNotFoundError:
             self.logger.log("error","mypokemon.json file not found.")
-        except json.JSONDecodeError:
+        except orjson.JSONDecodeError:
             self.logger.log("error","mypokemon.json file not found.")
 
         return []
@@ -749,8 +749,8 @@ class PokemonPC(QDialog):
                 is_currently_favorite = pokemon_list[i].get("is_favorite", False)
                 pokemon_list[i]["is_favorite"] = not is_currently_favorite
 
-                with open(str(mypokemon_path), "w", encoding="utf-8") as json_file:
-                    json.dump(pokemon_list, json_file, indent=2)
+                with open(str(mypokemon_path), "wb") as f:
+                    f.write(orjson.dumps(pokemon_list, option=orjson.OPT_INDENT_2))
 
                 self.refresh_gui()
                 return
@@ -779,8 +779,8 @@ class PokemonPC(QDialog):
             - Logs and displays an info message using `ShowInfoLogger`.
             - Refreshes the GUI via `self.refresh_gui()`.
         """
-        with open(itembag_path, "r", encoding="utf-8") as f:
-            items_list = json.load(f)
+        with open(itembag_path, "rb") as f:
+            items_list = orjson.loads(f.read())
         items_names = [item_data["item"] for item_data in items_list if item_data.get("type") is None]
         pokemon_obj = PokemonObject.from_dict(pokemon)
 
@@ -884,8 +884,8 @@ class PokemonPC(QDialog):
                     pokemon_list[i][key] = value
 
         if needs_update:
-            with open(str(mypokemon_path), "w", encoding="utf-8") as json_file:
-                json.dump(pokemon_list, json_file, indent=2)
+            with open(str(mypokemon_path), "wb") as f:
+                f.write(orjson.dumps(pokemon_list, option=orjson.OPT_INDENT_2))
 
     def on_window_close(self):
         if self.pokemon_details_layout is not None:

--- a/src/Ankimon/pyobj/pokemon_obj.py
+++ b/src/Ankimon/pyobj/pokemon_obj.py
@@ -1,6 +1,6 @@
 from typing import Union
 import uuid
-import json
+import orjson
 import os
 
 from ..poke_engine.objects import Pokemon
@@ -419,25 +419,25 @@ class PokemonObject:
 
         # Then, We save that information in the user data
         # First, we save the info in mypokemon_path
-        with open(mypokemon_path, "r", encoding="utf-8") as f:
-            pokemon_list_data = json.load(f)
+        with open(mypokemon_path, "rb") as f:
+            pokemon_list_data = orjson.loads(f.read())
 
         for i in range(len(pokemon_list_data)):
             if pokemon_list_data[i]["individual_id"] == self.individual_id:
                 pokemon_list_data[i]["held_item"] = held_item
                 break
 
-        with open(str(mypokemon_path), "w") as f:
-            json.dump(pokemon_list_data, f, indent=2)
+        with open(str(mypokemon_path), "wb") as f:
+            f.write(orjson.dumps(pokemon_list_data, option=orjson.OPT_INDENT_2))
 
         # Secondly, we save the info in mainpokemon_path, if the pokemon happens to be our main pokemon
-        with open(mainpokemon_path, "r", encoding="utf-8") as f:
-            main_pokemon_data = json.load(f)
+        with open(mainpokemon_path, "rb") as f:
+            main_pokemon_data = orjson.loads(f.read())
 
         if main_pokemon_data[0]["individual_id"] == self.individual_id:
             main_pokemon_data[0]["held_item"] = held_item
-            with open(str(mainpokemon_path), "w") as f:
-                json.dump(main_pokemon_data, f, indent=2)
+            with open(str(mainpokemon_path), "wb") as f:
+                f.write(orjson.dumps(main_pokemon_data, option=orjson.OPT_INDENT_2))
 
     def remove_held_item(self) -> None:
         """
@@ -464,34 +464,22 @@ class PokemonObject:
 
         # Then, We save that information in the user data
         # First, we save the info in mypokemon_path
-        with open(mypokemon_path, "r", encoding="utf-8") as f:
-            pokemon_list_data = json.load(f)
+        with open(mypokemon_path, "rb") as f:
+            pokemon_list_data = orjson.loads(f.read())
 
         for i in range(len(pokemon_list_data)):
             if pokemon_list_data[i]["individual_id"] == self.individual_id:
                 pokemon_list_data[i]["held_item"] = None
                 break
 
-        with open(str(mypokemon_path), "w") as f:
-            json.dump(pokemon_list_data, f, indent=2)
+        with open(str(mypokemon_path), "wb") as f:
+            f.write(orjson.dumps(pokemon_list_data, option=orjson.OPT_INDENT_2))
 
         # Secondly, we save the info in mainpokemon_path, if the pokemon happens to be our main pokemon
-        with open(mainpokemon_path, "r", encoding="utf-8") as f:
-            main_pokemon_data = json.load(f)
+        with open(mainpokemon_path, "rb") as f:
+            main_pokemon_data = orjson.loads(f.read())
 
         if main_pokemon_data[0]["individual_id"] == self.individual_id:
             main_pokemon_data[0]["held_item"] = None
-            with open(str(mainpokemon_path), "w") as f:
-                json.dump(main_pokemon_data, f, indent=2)
-
-
-class PokemonEncoder(json.JSONEncoder):
-    def default(self, obj):
-        if isinstance(obj, PokemonObject):
-            data = obj.__dict__.copy()
-            # Convert complex types to serializable formats
-            data['volatile_status'] = list(data['volatile_status'])
-            data['stat_stages'] = data.get('stat_stages', {})
-            data['moves'] = data.get('attacks', [])
-            return data
-        return super().default(obj)
+            with open(str(mainpokemon_path), "wb") as f:
+                f.write(orjson.dumps(main_pokemon_data, option=orjson.OPT_INDENT_2))

--- a/src/Ankimon/pyobj/pokemon_trade.py
+++ b/src/Ankimon/pyobj/pokemon_trade.py
@@ -1,4 +1,4 @@
-import json
+import orjson
 import hashlib
 import requests
 from PyQt6.QtWidgets import QDialog, QVBoxLayout, QLabel, QLineEdit, QPushButton, QHBoxLayout, QFrame
@@ -50,11 +50,11 @@ def create_monthly_challenge_pokemon(pokemon_data, make_shiny=False):
 def add_pokemon_to_collection(new_pokemon, refresh_callback=None, parent_window=None):
     """Adds a Pokémon to the user's collection file."""
     try:
-        with open(mypokemon_path, "r", encoding="utf-8") as file:
-            pokemon_list = json.load(file)
+        with open(mypokemon_path, "rb") as file:
+            pokemon_list = orjson.loads(file.read())
         pokemon_list.append(new_pokemon)
-        with open(mypokemon_path, "w", encoding="utf-8") as file:
-            json.dump(pokemon_list, file, indent=2)
+        with open(mypokemon_path, "wb") as file:
+            file.write(orjson.dumps(pokemon_list, option=orjson.OPT_INDENT_2))
         if refresh_callback:
             refresh_callback()
     except Exception as e:
@@ -65,8 +65,8 @@ def check_and_award_monthly_pokemon(logger):
     try:
         should_check = False
         if rate_path.is_file():
-            with open(rate_path, "r", encoding="utf-8") as f:
-                if json.load(f).get("rate_this") is True:
+            with open(rate_path, "rb") as f:
+                if orjson.loads(f.read()).get("rate_this") is True:
                     should_check = True
         
         if not should_check:
@@ -104,9 +104,9 @@ def check_and_award_monthly_pokemon(logger):
             return
 
         try:
-            with open(mypokemon_path, "r", encoding="utf-8") as f:
-                my_pokemon = json.load(f)
-        except (FileNotFoundError, json.JSONDecodeError) as e:
+            with open(mypokemon_path, "rb") as f:
+                my_pokemon = orjson.loads(f.read())
+        except (FileNotFoundError, orjson.JSONDecodeError) as e:
             logger.log("error", f"Failed to load or parse mypokemon.json: {e}")
             return
 

--- a/src/Ankimon/pyobj/reviewer_obj.py
+++ b/src/Ankimon/pyobj/reviewer_obj.py
@@ -3,7 +3,7 @@ from aqt.utils import showInfo
 from ..functions.pokemon_functions import find_experience_for_level
 from ..business import get_image_as_base64
 from ..functions.create_css_for_reviewer import create_css_for_reviewer
-import json
+import orjson
 import os
 from ..functions.create_gui_functions import create_status_html
 from ..functions.pokedex_functions import get_pokemon_diff_lang_name
@@ -237,7 +237,7 @@ class Reviewer_Manager:
             if(window.__ankimonHud && window.__ankimonHud.update){{
                 window.__ankimonHud.update(h,c);
             }}
-        }})({json.dumps(hud_html)}, {json.dumps(hud_css)});
+        }})({orjson.dumps(hud_html).decode('utf-8')}, {orjson.dumps(hud_css).decode('utf-8')});
         """
         reviewer.web.eval(js_code)
 

--- a/src/Ankimon/pyobj/settings_window.py
+++ b/src/Ankimon/pyobj/settings_window.py
@@ -1,4 +1,4 @@
-import json
+import orjson
 import os
 from aqt.qt import (
     QWidget, QVBoxLayout, QLabel, QLineEdit, QPushButton,
@@ -166,9 +166,9 @@ class SettingsWindow(QMainWindow):
         descriptions_file = os.path.join(os.path.dirname(os.path.dirname(__file__)), 'lang', 'setting_description.json')
         if os.path.exists(descriptions_file):
             try:
-                with open(descriptions_file, 'r', encoding='utf-8') as f:
-                    return json.load(f)
-            except (json.JSONDecodeError, UnicodeDecodeError) as e:
+                with open(descriptions_file, 'rb') as f:
+                    return orjson.loads(f.read())
+            except (orjson.JSONDecodeError, UnicodeDecodeError) as e:
                 showWarning(f"Error reading descriptions file: {e}")
         return {}
 
@@ -176,9 +176,9 @@ class SettingsWindow(QMainWindow):
         names_file = os.path.join(os.path.dirname(os.path.dirname(__file__)), 'lang', 'setting_name.json')
         if os.path.exists(names_file):
             try:
-                with open(names_file, "r", encoding="utf-8") as f:
-                    return json.load(f)
-            except (json.JSONDecodeError, UnicodeDecodeError) as e:
+                with open(names_file, "rb") as f:
+                    return orjson.loads(f.read())
+            except (orjson.JSONDecodeError, UnicodeDecodeError) as e:
                 showWarning(f"Error reading friendly names file: {e}")
         return {}
 

--- a/src/Ankimon/pyobj/test_window.py
+++ b/src/Ankimon/pyobj/test_window.py
@@ -1,4 +1,4 @@
-import json
+import orjson
 
 from aqt import mw
 
@@ -623,8 +623,8 @@ class TestWindow(QWidget):
 
             message_box_text = self.translator.translate("received_a_badge")
 
-            with open(badges_list_path, "r", encoding="utf-8") as json_file:
-                badges = json.load(json_file)
+            with open(badges_list_path, "rb") as f:
+                badges = orjson.loads(f.read())
 
             message_box_text2 = f"{badges[str(badge_number)]}!"
 

--- a/src/Ankimon/pyobj/tip_of_the_day.py
+++ b/src/Ankimon/pyobj/tip_of_the_day.py
@@ -1,4 +1,4 @@
-import json
+import orjson
 import random
 from pathlib import Path
 
@@ -41,10 +41,10 @@ class TipOfTheDayDialog(QDialog):
         if not tips_path.exists():
             return []
         try:
-            with open(tips_path, "r", encoding="utf-8") as f:
-                data = json.load(f)
+            with open(tips_path, "rb") as f:
+                data = orjson.loads(f.read())
                 return data.get("tips", [])
-        except (json.JSONDecodeError, Exception):
+        except (orjson.JSONDecodeError, Exception):
             return []
 
     def show_new_tip(self):
@@ -67,20 +67,20 @@ def show_tip_of_the_day():
 
     # Check if the addon has been rated
     try:
-        with open(rate_path, "r", encoding="utf-8") as f:
-            rate_data = json.load(f)
+        with open(rate_path, "rb") as f:
+            rate_data = orjson.loads(f.read())
             if not rate_data.get("rate_this", False):
                 return
-    except (FileNotFoundError, json.JSONDecodeError):
+    except (FileNotFoundError, orjson.JSONDecodeError):
         return
 
     tips_path = Path(__file__).parent.parent / "addon_files" / "tips.json"
     if not tips_path.exists():
         return
     try:
-        with open(tips_path, "r", encoding="utf-8") as f:
-            tips = json.load(f).get("tips", [])
-    except (json.JSONDecodeError, Exception):
+        with open(tips_path, "rb") as f:
+            tips = orjson.loads(f.read()).get("tips", [])
+    except (orjson.JSONDecodeError, Exception):
         return
 
     if not tips:

--- a/src/Ankimon/pyobj/trainer_card.py
+++ b/src/Ankimon/pyobj/trainer_card.py
@@ -2,7 +2,7 @@ from ..resources import trainer_sprites_path, mypokemon_path
 from ..functions.trainer_functions import find_trainer_rank
 from aqt.utils import showWarning, showInfo
 import math
-import json
+import orjson
 from .ankimon_leaderboard import sync_data_to_leaderboard, get_unique_pokemon, get_total_pokemon, get_shinies
 
 
@@ -62,8 +62,8 @@ class TrainerCard:
         """Method to find the name of the highest-level Pokémon from the mypokemon_path."""
         try:
             # Read the Pokémon data from the file
-            with open(mypokemon_path, "r", encoding="utf-8") as file:
-                pokemon_data = json.load(file)
+            with open(mypokemon_path, "rb") as file:
+                pokemon_data = orjson.loads(file.read())
 
             if not pokemon_data:
                 return None  # Return None if the data is empty
@@ -82,8 +82,8 @@ class TrainerCard:
         """Method to find the name of the highest-level Pokémon from the mypokemon_path."""
         try:
             # Read the Pokémon data from the file
-            with open(mypokemon_path, "r", encoding="utf-8") as file:
-                pokemon_data = json.load(file)
+            with open(mypokemon_path, "rb") as file:
+                pokemon_data = orjson.loads(file.read())
 
             if not pokemon_data:
                 return int(0)  # Return None if the data is empty

--- a/src/Ankimon/pyobj/translator.py
+++ b/src/Ankimon/pyobj/translator.py
@@ -1,4 +1,4 @@
-import json
+import orjson
 from ..resources import lang_path_de, lang_path_ch, lang_path_en, lang_path_fr, lang_path_jp, lang_path_sp, lang_path_kr, lang_path_it, lang_path_cz, lang_path_po
 
 LANG_PATHS = {
@@ -35,11 +35,11 @@ class Translator:
         short_language = LANG_NUMBERS.get(int(language), 'en')
         self.filepath = LANG_PATHS.get(short_language, lang_path_en)
         try:
-            with open(self.filepath, 'r', encoding='utf-8') as f:
-                self.translations = json.load(f)
+            with open(self.filepath, 'rb') as f:
+                self.translations = orjson.loads(f.read())
         except FileNotFoundError:
             raise Exception(f"Translation file not found: {self.filepath}")
-        except json.JSONDecodeError:
+        except orjson.JSONDecodeError:
             raise Exception(f"Invalid JSON format in translation file: {self.filepath}")
 
     def translate(self, key, **kwargs):
@@ -50,8 +50,8 @@ class Translator:
         # Fallback to English if key not found
         if template is None:
             try:
-                with open(lang_path_en, 'r', encoding='utf-8') as f:
-                    fallback_translations = json.load(f)
+                with open(lang_path_en, 'rb') as f:
+                    fallback_translations = orjson.loads(f.read())
                 template = fallback_translations.get(key, key)
                 source_file = lang_path_en  # Now using fallback file
             except Exception as e:

--- a/src/Ankimon/resources.py
+++ b/src/Ankimon/resources.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 import os
-import json
+import orjson
 
 addon_dir = Path(__file__).parents[0]
 
@@ -103,7 +103,7 @@ backup_folders = [os.path.join(backup_root, f"backup_{i}") for i in range(1, 4)]
 
 #detect add-on version
 try:
-    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    manifest = orjson.loads(manifest_path.read_text(encoding="utf-8"))
     addon_ver = manifest.get("version", "unknown")
 except Exception:
     addon_ver = "unknown"
@@ -288,8 +288,8 @@ def generate_startup_files(base_path, base_user_path):  # Add base_user_path par
         os.makedirs(os.path.dirname(file_path), exist_ok=True)
 
         if not os.path.exists(file_path):
-            with open(file_path, 'w', encoding='utf-8') as f:
-                json.dump([], f, indent=2)
+            with open(file_path, 'wb') as f:
+                f.write(orjson.dumps([], option=orjson.OPT_INDENT_2))
 
     # Default data for the file
     default_rating_data = {"rate_this": False}
@@ -298,8 +298,8 @@ def generate_startup_files(base_path, base_user_path):  # Add base_user_path par
     # Create the file with default contents if it doesn't exist
     if not os.path.exists(rate_path):
         os.makedirs(os.path.dirname(rate_path), exist_ok=True)
-        with open(rate_path, "w", encoding="utf-8") as f:
-            json.dump(default_rating_data, f, indent=4)
+        with open(rate_path, "wb") as f:
+            f.write(orjson.dumps(default_rating_data, option=orjson.OPT_INDENT_2))
 
     # Create blank HelpInfos.html and updateinfos.md at base_path if they don't exist
     helpinfos_path = os.path.join(base_path, 'HelpInfos.html')

--- a/src/Ankimon/singletons.py
+++ b/src/Ankimon/singletons.py
@@ -12,7 +12,7 @@ More detailed explanation if needed:
 Author: Axil
 Created: 2025-06-03 (YYY-MM-DD)
 """
-import json
+import orjson
 import uuid
 
 from aqt import mw

--- a/src/Ankimon/utils.py
+++ b/src/Ankimon/utils.py
@@ -1,7 +1,7 @@
 import os
 from pathlib import Path
 import requests
-import json
+import orjson
 import markdown
 import random
 import csv
@@ -45,10 +45,10 @@ media_player = QMediaPlayer()
 media_player.setAudioOutput(audio_output)
 
 # Load move and pokemon name mapping at startup
-with open(pokemon_names_file_path, "r", encoding="utf-8") as f:
-    POKEMON_NAME_LOOKUP = json.load(f)
-with open(move_names_file_path, "r", encoding="utf-8") as f:
-    MOVE_NAME_LOOKUP = json.load(f)
+with open(pokemon_names_file_path, "rb") as f:
+    POKEMON_NAME_LOOKUP = orjson.loads(f.read())
+with open(move_names_file_path, "rb") as f:
+    MOVE_NAME_LOOKUP = orjson.loads(f.read())
 
 
 def format_pokemon_name(name: str) -> str:
@@ -102,7 +102,7 @@ def addon_config_editor_will_display_json(text: str) -> str:
     """
     try:
         # Parse the JSON text
-        config = json.loads(text)
+        config = orjson.loads(text)
         if "mainpokemon" in config:
             #showInfo(f"{config}")
             showInfo("This Configuration is old and wont be used anymore. \n Please use the Settings Window in the Ankimon Menu => Settings")
@@ -117,10 +117,10 @@ def addon_config_editor_will_display_json(text: str) -> str:
 
 
             # Convert back to JSON string
-            modified_text = json.dumps(config, indent=4)
+            modified_text = orjson.dumps(config, option=orjson.OPT_INDENT_2).decode('utf-8')
             return modified_text
         return text
-    except json.JSONDecodeError:
+    except orjson.JSONDecodeError:
         # Handle JSON parsing error
         return text
 
@@ -383,8 +383,8 @@ def daily_item_list():
 
 # Function to give an item to the player
 def give_item(item_name, item_type: str | None=None):
-    with open(itembag_path, "r", encoding="utf-8") as json_file:
-        itembag_list = json.load(json_file)
+    with open(itembag_path, "rb") as f:
+        itembag_list = orjson.loads(f.read())
         # Check if the item exists and update quantity, otherwise append
         for item in itembag_list:
             if item.get("item") == item_name:
@@ -396,8 +396,8 @@ def give_item(item_name, item_type: str | None=None):
             if item_type is not None:
                 item_dict["type"] = item_type
             itembag_list.append(item_dict)
-    with open(itembag_path, 'w', encoding="utf-8") as json_file:
-        json.dump(itembag_list, json_file, indent=4)
+    with open(itembag_path, 'wb') as f:
+        f.write(orjson.dumps(itembag_list, option=orjson.OPT_INDENT_2))
     #logger.log_and_showinfo('game', f"Player bought item {item_name.capitalize()}")
 
 #Function to return a cost of an item
@@ -479,8 +479,8 @@ def count_items_and_rewrite(file_path):
     sums their quantities, and rewrites the file preserving every other field.
     """
     try:
-        with open(file_path, "r", encoding="utf-8") as f:
-            items = json.load(f)
+        with open(file_path, "rb") as f:
+            items = orjson.loads(f.read())
 
         aggregated = {}  # maps a frozenset of (key,value) pairs to the merged entry
 
@@ -509,8 +509,8 @@ def count_items_and_rewrite(file_path):
 
         updated_items = list(aggregated.values())
 
-        with open(file_path, "w", encoding="utf-8") as f:
-            json.dump(updated_items, f, indent=4, ensure_ascii=False)
+        with open(file_path, "wb") as f:
+            f.write(orjson.dumps(updated_items, option=orjson.OPT_INDENT_2))
 
         print("items.json has been updated with aggregated quantities!")
 
@@ -649,8 +649,8 @@ def save_error_code(error_code, logger=None):
         logger.log_and_showinfo("info",f"{error_fix_msg}")
 
 def get_main_pokemon_data():
-    with (open(str(mainpokemon_path), "r", encoding="utf-8") as json_file):
-        main_pokemon_datalist = json.load(json_file)
+    with (open(str(mainpokemon_path), "rb") as f):
+        main_pokemon_datalist = orjson.loads(f.read())
 
     main_pokemon_data = []
     for main_pokemon_data in main_pokemon_datalist:
@@ -719,8 +719,8 @@ def load_collected_pokemon_ids() -> set:
 
     collected_pokemon_ids = set()
     try:
-        with open(mypokemon_path, "r", encoding="utf-8") as f:
-            collection = json.load(f)
+        with open(mypokemon_path, "rb") as f:
+            collection = orjson.loads(f.read())
             collected_pokemon_ids = {pkmn["id"] for pkmn in collection}
     except Exception as e:
         show_warning_with_traceback(exception=e, message="Error loading collection cache")
@@ -930,8 +930,8 @@ def substract_item_from_itembag(item: str, quantity: int=1) -> None:
             - Item does not have a 'quantity' field.
             - Insufficient quantity to subtract.
     """
-    with open(itembag_path, "r", encoding="utf-8") as f:
-        items_list = json.load(f)
+    with open(itembag_path, "rb") as f:
+        items_list = orjson.loads(f.read())
 
     # First, we check if the item is in the item bag
     if item not in [item_data["item"] for item_data in items_list]:
@@ -956,13 +956,13 @@ def substract_item_from_itembag(item: str, quantity: int=1) -> None:
     # Finally, we substract the given amount
     if items_list[index].get("quantity") == quantity:
         del items_list[index]
-        with open(str(itembag_path), "w") as f:
-            json.dump(items_list, f, indent=2)
+        with open(str(itembag_path), "wb") as f:
+            f.write(orjson.dumps(items_list, option=orjson.OPT_INDENT_2))
         return
     if items_list[index].get("quantity") > quantity:
         items_list[index]["quantity"] -= quantity
-        with open(str(itembag_path), "w") as f:
-            json.dump(items_list, f, indent=2)
+        with open(str(itembag_path), "wb") as f:
+            f.write(orjson.dumps(items_list, option=orjson.OPT_INDENT_2))
         return
 
 def close_anki():

--- a/tests/check_lang_placeholders.py
+++ b/tests/check_lang_placeholders.py
@@ -1,4 +1,4 @@
-import json
+import orjson
 import re
 from pathlib import Path
 
@@ -17,8 +17,8 @@ def check_language_files():
         print(f"Error: Reference file not found at {en_file}")
         return
 
-    with open(en_file, "r", encoding="utf-8") as f:
-        en_data = json.load(f)
+    with open(en_file, "rb") as f:
+        en_data = orjson.loads(f.read())
 
     en_placeholders = {key: find_placeholders(value) for key, value in en_data.items()}
 
@@ -28,9 +28,9 @@ def check_language_files():
             continue
 
         try:
-            with open(lang_file, "r", encoding="utf-8") as f:
-                lang_data = json.load(f)
-        except json.JSONDecodeError:
+            with open(lang_file, "rb") as f:
+                lang_data = orjson.loads(f.read())
+        except orjson.JSONDecodeError:
             print(f"Error: Could not decode JSON from {lang_file}")
             errors_found = True
             continue

--- a/tests/test_addon_integrity.py
+++ b/tests/test_addon_integrity.py
@@ -2,7 +2,7 @@ import os
 import sys
 import importlib
 import pkgutil
-import json
+import orjson
 import ast
 from unittest.mock import patch, MagicMock
 import pytest

--- a/tests/test_ankimon_integrity.py
+++ b/tests/test_ankimon_integrity.py
@@ -1,4 +1,4 @@
-import json
+import orjson
 import os
 import sys
 import ast

--- a/tests/test_code_integrity.py
+++ b/tests/test_code_integrity.py
@@ -1,7 +1,7 @@
 import pytest
 import os
 import sys
-import json
+import orjson
 import ast
 import importlib.util
 import platform


### PR DESCRIPTION
feat: Migrate JSON handling to orjson

Replaced all instances of the standard `json` library with the `orjson` library to improve performance. This change affects all JSON serialization and deserialization operations throughout the codebase.

- Replaced `import json` with `import orjson`.
- Updated `json.load()` and `json.loads()` to `orjson.loads()`.
- Updated `json.dump()` and `json.dumps()` to `orjson.dumps()`.
- Opened files in binary mode (`'rb'` and `'wb'`) as required by `orjson`.
- Removed an unused and incorrect `PokemonEncoder` class that was causing a fatal error.