### PR TITLE
feat: Pokemon GO style CP system with Battle Power display

### DIFF
--- a/src/Ankimon/__init__.py
+++ b/src/Ankimon/__init__.py
@@ -201,7 +201,7 @@ if not _collection_loaded:  # If the collection hasn't already been loaded
 with open(sound_list_path, "r", encoding="utf-8") as json_file:
     sound_list = json.load(json_file)
 
-ankimon_tracker_obj.pokemon_encouter = 0
+ankimon_tracker_obj.pokemon_encounter = 0
 
 """
 get web exports ready for special reviewer look
@@ -526,11 +526,11 @@ def on_review_card(*args):
             ankimon_tracker_obj.cards_battle_round = 0
             ankimon_tracker_obj.attack_counter = 0
             slp_counter = 0
-            ankimon_tracker_obj.pokemon_encouter += 1
+            ankimon_tracker_obj.pokemon_encounter += 1
             multiplier = ankimon_tracker_obj.multiplier
 
             if (
-                ankimon_tracker_obj.pokemon_encouter > 0
+                ankimon_tracker_obj.pokemon_encounter > 0
                 and enemy_pokemon.hp > 0
                 and multiplier < 1
             ):
@@ -551,7 +551,7 @@ def on_review_card(*args):
             category = move.get("category")
 
             if (
-                ankimon_tracker_obj.pokemon_encouter > 0
+                ankimon_tracker_obj.pokemon_encounter > 0
                 and main_pokemon.hp > 0
                 and enemy_pokemon.hp > 0
             ):
@@ -669,7 +669,7 @@ def on_review_card(*args):
                 user_hp_after=main_pokemon.hp,  # Use the already updated HP
                 opponent_hp_after=enemy_pokemon.hp,  # Use the already updated HP
                 battle_status=main_pokemon.battle_status,
-                pokemon_encounter=ankimon_tracker_obj.pokemon_encouter,
+                pokemon_encounter=ankimon_tracker_obj.pokemon_encounter,
                 translator=translator,
                 changes=current_battle_info_changes,
             )

--- a/src/Ankimon/business.py
+++ b/src/Ankimon/business.py
@@ -184,26 +184,66 @@ def type_compatibility_multiplier(attacker_types, defender_types) -> float:
         return 1.0
     if best == 0:
         return 0.2
-    if best > 1:
+    elif best > 1:
         return 1.5
-    if best < 1:
+    elif best < 1:
         return 0.8
     return 1.0
 
 
 def calculate_present_power(
-    cp: int, current_hp: int, compatibility_multiplier: float = 1.0
+    cp: int,
+    current_hp: int,
+    compatibility_multiplier: float = 1.0,
+    atk_stage: int = 0,
+    spa_stage: int = 0,
 ) -> int:
-    """Present Power = CP × current HP × type compatibility multiplier.
+    """Present Power = CP × current HP × type multiplier × avg(atk, spa) stage.
 
-    A matchup-aware indicator of a Pokemon's threat level right now,
-    factoring in how beaten-up it is and how well its types match the
-    opponent. Rounded down to an int.
+    A live threat indicator: baseline power (CP), durability remaining
+    (current HP), type matchup, and in-battle attack-stage changes
+    (Swords Dance, Intimidate, etc.). Atk and Spa stages are averaged
+    to match the CP formula's averaging of physical and special. Drops
+    below neutral shrink BP; boosts grow it. Rounded down to an int.
     """
     cp = max(int(cp if cp is not None else 0), 0)
     current_hp = max(int(current_hp if current_hp is not None else 0), 0)
     compat = float(compatibility_multiplier if compatibility_multiplier is not None else 1.0)
-    return int(math.floor(cp * current_hp * compat))
+
+    def _stage_mult(stage) -> float:
+        if stage is None:
+            return 1.0
+        try:
+            val = get_multiplier_stats(int(stage))
+        except (TypeError, ValueError):
+            return 1.0
+        return float(val) if isinstance(val, (int, float)) else 1.0
+
+    stage_factor = (_stage_mult(atk_stage) + _stage_mult(spa_stage)) / 2
+    return int(math.floor(cp * current_hp * compat * stage_factor))
+
+
+def cp_breakdown_tooltip(pokemon_dict: dict) -> str:
+    """Human-readable CP breakdown for Qt tooltips.
+
+    Shows the formula, this Pokemon's substituted values, and the CP
+    projected at level 100 (useful for planning evolutions/training).
+    Accepts either the caught-Pokemon dict shape ("stats" = base_stats)
+    or the to_dict shape ("base_stats" = bases).
+    """
+    base_stats = pokemon_dict.get("base_stats") or pokemon_dict.get("stats") or {}
+    iv = pokemon_dict.get("iv") or {}
+    ev = pokemon_dict.get("ev") or {}
+    level = int(pokemon_dict.get("level", 1) or 1)
+    attack, defense, stamina = pokemon_go_raw_stats(base_stats, iv, ev)
+    cpm = calculate_cpm(level)
+    cp_at_100 = calculate_pokemon_go_cp(attack, defense, stamina, 100)
+    return (
+        "CP = floor(Atk × √Def × √Sta × CPM² ÷ 10)\n"
+        f"    = floor({attack:.0f} × √{defense:.0f} × √{stamina:.0f}"
+        f" × {cpm:.4f}² ÷ 10)\n"
+        f"CP at Level 100: {cp_at_100:,}"
+    )
 
 
 def calculate_cp_from_dict(pokemon_dict):

--- a/src/Ankimon/business.py
+++ b/src/Ankimon/business.py
@@ -1,7 +1,11 @@
 import base64
 import csv
+import functools
+import json
+import math
+from typing import Optional
 
-from .resources import csv_file_items, csv_file_descriptions
+from .resources import csv_file_items, csv_file_descriptions, effectiveness_chart_file_path
 
 def get_image_as_base64(path):
     with open(path, 'rb') as image_file:
@@ -75,6 +79,152 @@ def get_multiplier_acc_eva(stage):
 
     # Return the corresponding factor or a default value if the stage is out of range
     return stage_to_factor_new.get(stage, "Invalid stage")
+
+def calculate_cpm(level: int) -> float:
+    """CP Multiplier — exponential (saturating) function of level.
+
+    Models the Pokemon GO idea of a level-scaling multiplier that grows
+    quickly at low levels and tapers off as the Pokemon approaches its
+    level ceiling. Asymptotes just below ``0.84`` — the approximate max
+    CPM in Pokemon GO — but is smooth and defined for any Anki level.
+    """
+    return 0.84 * (1 - math.exp(-max(level, 1) / 20))
+
+
+def pokemon_go_raw_stats(base_stats: dict, iv: dict, ev: dict):
+    """Derive Pokemon GO-style Attack/Defense/Stamina from main-series stats.
+
+    Uses *raw* stat values (base + IV + floor(EV/4)) — **not** the
+    level-scaled values from ``calc_stat`` — so that ``CPM`` is the sole
+    level multiplier in the CP formula.  Physical and special variants are
+    averaged to adapt the 6-stat model to Pokemon GO's 3-stat model.
+
+    Returns ``(attack, defense, stamina)`` as floats.
+    """
+    def _raw(key):
+        return max(1, int(base_stats.get(key, 1)) + max(0, int(iv.get(key, 0))) + max(0, int(ev.get(key, 0))) // 4)
+
+    attack = (_raw("atk") + _raw("spa")) / 2
+    defense = (_raw("def") + _raw("spd")) / 2
+    stamina = _raw("hp")
+    return attack, defense, stamina
+
+
+def calculate_pokemon_go_cp(
+    attack: float, defense: float, stamina: float, level: int
+) -> int:
+    """Pokemon GO style Combat Power.
+
+    ``CP = floor(Attack × √Defense × √Stamina × CPM² / 10)``
+
+    ``Attack``, ``Defense``, and ``Stamina`` should be *raw* values
+    (base + IV + EV/4, **not** level-scaled ``calc_stat`` output).
+    ``CPM`` provides all level scaling.  CP is clamped to a minimum of 10
+    so sort keys remain well-defined for under-leveled or stub Pokemon.
+    """
+    cpm = calculate_cpm(level)
+    cp = math.floor(
+        attack * math.sqrt(max(defense, 1)) * math.sqrt(max(stamina, 1)) * (cpm ** 2) / 10
+    )
+    return max(10, int(cp))
+
+
+@functools.lru_cache(maxsize=1)
+def _load_type_chart() -> dict:
+    """Load ``eff_chart.json`` once and cache the result.
+
+    Returns a nested dict ``{AttackingType: {DefendingType: multiplier}}``
+    where keys are capitalised type names (e.g. ``"Fire"``, ``"Water"``).
+    Returns an empty dict if the file cannot be read so callers fall back
+    to a neutral multiplier.
+    """
+    try:
+        with open(effectiveness_chart_file_path, "r", encoding="utf-8") as f:
+            return json.load(f)
+    except (OSError, json.JSONDecodeError):
+        return {}
+
+
+def type_compatibility_multiplier(attacker_types, defender_types) -> float:
+    """Return a simplified Present Power multiplier for a matchup.
+
+    Uses the maximum per-pair effectiveness from ``eff_chart.json``:
+
+    - ``== 0`` → immune → ``0.2``
+    - ``> 1``  → super-effective → ``1.5``
+    - ``< 1``  → not-very-effective → ``0.8``
+    - otherwise → ``1.0``
+
+    Type arguments may be either strings or iterables of strings. Unknown
+    types are silently ignored; if no valid pairings exist, a neutral
+    ``1.0`` is returned.
+    """
+    chart = _load_type_chart()
+    if not chart or not attacker_types or not defender_types:
+        return 1.0
+
+    if isinstance(attacker_types, str):
+        attacker_types = [attacker_types]
+    if isinstance(defender_types, str):
+        defender_types = [defender_types]
+
+    best: Optional[float] = None
+    for atk in attacker_types:
+        atk_row = chart.get(str(atk).capitalize())
+        if not atk_row:
+            continue
+        for dfn in defender_types:
+            mult = atk_row.get(str(dfn).capitalize())
+            if mult is None:
+                continue
+            if best is None or mult > best:
+                best = mult
+
+    if best is None:
+        return 1.0
+    if best == 0:
+        return 0.2
+    if best > 1:
+        return 1.5
+    if best < 1:
+        return 0.8
+    return 1.0
+
+
+def calculate_present_power(
+    cp: int, current_hp: int, compatibility_multiplier: float = 1.0
+) -> int:
+    """Present Power = CP × current HP × type compatibility multiplier.
+
+    A matchup-aware indicator of a Pokemon's threat level right now,
+    factoring in how beaten-up it is and how well its types match the
+    opponent. Rounded down to an int.
+    """
+    cp = max(int(cp if cp is not None else 0), 0)
+    current_hp = max(int(current_hp if current_hp is not None else 0), 0)
+    compat = float(compatibility_multiplier if compatibility_multiplier is not None else 1.0)
+    return int(math.floor(cp * current_hp * compat))
+
+
+def calculate_cp_from_dict(pokemon_dict):
+    """Calculate Combat Power from a raw Pokemon dict using the
+    Pokemon GO style formula.
+
+    Handles both data formats:
+    - Caught Pokemon: "stats" field contains base_stats
+    - to_dict() Pokemon: "base_stats" field contains base_stats
+    """
+    if "base_stats" in pokemon_dict:
+        base_stats = pokemon_dict["base_stats"]
+    else:
+        base_stats = pokemon_dict.get("stats", {})
+
+    level = pokemon_dict.get("level", 1)
+    iv = pokemon_dict.get("iv") or {}
+    ev = pokemon_dict.get("ev") or {}
+
+    attack, defense, stamina = pokemon_go_raw_stats(base_stats, iv, ev)
+    return calculate_pokemon_go_cp(attack, defense, stamina, level)
 
 def bP_none_moves(move):
     target =  move.get("target", None)

--- a/src/Ankimon/functions/encounter_functions.py
+++ b/src/Ankimon/functions/encounter_functions.py
@@ -39,7 +39,7 @@ from ..functions.trainer_functions import xp_share_gain_exp
 from ..functions.badges_functions import check_for_badge, receive_badge
 from ..functions.drawing_utils import tooltipWithColour
 from ..utils import limit_ev_yield, play_effect_sound, get_ev_spread
-from ..business import calc_experience
+from ..business import calc_experience, calculate_cp_from_dict
 from ..const import gen_ids
 from ..singletons import (
     main_pokemon,
@@ -571,9 +571,11 @@ def save_main_pokemon_progress(
     if settings_obj.get("gui.pop_up_dialog_message_on_defeat") is True:
         logger.log_and_showinfo("info", f"{msg}")
 
-    # Load existing Pokémon data if it exists
+    # Update in-place, then persist both main and mypokemon files. Base
+    # stats intentionally not overwritten here — "stats" in the legacy main
+    # record was level-scaled and confused downstream readers that expect
+    # "stats" to mean base stats.
     for mainpkmndata in main_pokemon_data:
-        mainpkmndata["stats"] = main_pokemon.stats
         mainpkmndata["xp"] = int(main_pokemon.xp)
         mainpkmndata["level"] = int(main_pokemon.level)
         ev_yield = limit_ev_yield(mainpkmndata["ev"], enemy_pokemon.ev_yield)
@@ -583,7 +585,18 @@ def save_main_pokemon_progress(
         mainpkmndata["ev"]["spa"] += ev_yield["special-attack"]
         mainpkmndata["ev"]["spd"] += ev_yield["special-defense"]
         mainpkmndata["ev"]["spe"] += ev_yield["speed"]
-        mainpkmndata["current_hp"] = int(main_pokemon.current_hp)
+        # Mirror EV gain onto the in-memory object so CP/stats reads
+        # stay consistent with the persisted dict until next restart.
+        # Dict-item mutation doesn't fire __setattr__, so invalidate
+        # the CP cache explicitly.
+        main_pokemon.ev["hp"] += ev_yield["hp"]
+        main_pokemon.ev["atk"] += ev_yield["attack"]
+        main_pokemon.ev["def"] += ev_yield["defense"]
+        main_pokemon.ev["spa"] += ev_yield["special-attack"]
+        main_pokemon.ev["spd"] += ev_yield["special-defense"]
+        main_pokemon.ev["spe"] += ev_yield["speed"]
+        main_pokemon.invalidate_cp_cache()
+        mainpkmndata["current_hp"] = int(main_pokemon.hp)
         main_pokemon.friendship += random.randint(5, 9)
         if main_pokemon.friendship > 255:
             main_pokemon.friendship = 255
@@ -595,6 +608,9 @@ def save_main_pokemon_progress(
         if hasattr(main_pokemon, "is_favorite"):
             mainpkmndata["is_favorite"] = main_pokemon.is_favorite
     mainpkmndata = [mainpkmndata]
+    # Refresh cached CP so Collection Dialog / PC Box readers don't
+    # short-circuit to a stale pre-level-up value on the next render.
+    mainpkmndata[0]["cp"] = calculate_cp_from_dict(mainpkmndata[0])
     # Save the caught Pokémon's data to a JSON file
     try:
         with open(str(mainpokemon_path), "w") as json_file:
@@ -609,14 +625,13 @@ def save_main_pokemon_progress(
                 if (
                     pokemon_data.get("individual_id") == main_pokemon.individual_id
                 ):  # Match by individual_id
-                    mypokemondata[index] = mypkmndata  # Replace with new data
+                    mypokemondata[index] = mainpkmndata[0]
                     break
 
             # Save the modified data to the output JSON file
             with open(str(mypokemon_path), "w") as output_file:
                 json.dump(mypokemondata, output_file, indent=2)
 
-        sync_mainpokemon_to_mypokemon(main_pokemon, mainpokemon_path, mypokemon_path)
         mw.logger.log("info", f"Successfully saved progress for {main_pokemon.name}")
     except Exception as e:
         mw.logger.log("error", f"Failed to save pokemon progress: {str(e)}")
@@ -702,34 +717,30 @@ def save_caught_pokemon(
 
     # enemy_pokemon.stats["xp"] = 0
     enemy_pokemon.xp = 0
-    caught_pokemon = {
+    # Use to_dict() so the caught record shares the canonical shape with
+    # saved main Pokemon (includes base_stats, level-scaled stats, cp,
+    # nature). Then override caught-only fields.
+    _max_hp = enemy_pokemon.calculate_max_hp()
+    caught_pokemon = enemy_pokemon.to_dict()
+    caught_pokemon.update({
         "name": enemy_pokemon.name.capitalize(),
         "nickname": "",
-        "level": enemy_pokemon.level,
-        "gender": enemy_pokemon.gender,
-        "id": enemy_pokemon.id,
-        "ability": enemy_pokemon.ability,
-        "type": enemy_pokemon.type,
-        "stats": enemy_pokemon.base_stats,
         "ev": {"hp": 0, "atk": 0, "def": 0, "spa": 0, "spd": 0, "spe": 0},
-        "iv": enemy_pokemon.iv,
-        "attacks": enemy_pokemon.attacks,
-        "base_experience": enemy_pokemon.base_experience,
-        "current_hp": enemy_pokemon.calculate_max_hp(),
-        "growth_rate": enemy_pokemon.growth_rate,
         "friendship": 0,
         "pokemon_defeated": 0,
         "xp": 0,
         "everstone": False,
-        "shiny": enemy_pokemon.shiny,
         "captured_date": datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
         "individual_id": str(uuid.uuid4()),
         "mega": False,
         "special_form": None,
-        "tier": enemy_pokemon.tier,
         "is_favorite": False,
         "held_item": None,
-    }
+        "hp": _max_hp,
+        "current_hp": _max_hp,
+    })
+    # Recompute CP against the overridden (zeroed) EVs.
+    caught_pokemon["cp"] = calculate_cp_from_dict(caught_pokemon)
 
     # Load existing Pokémon data if it exists
     caught_pokemon_data = []

--- a/src/Ankimon/functions/pokemon_functions.py
+++ b/src/Ankimon/functions/pokemon_functions.py
@@ -71,6 +71,9 @@ def find_experience_for_level(group_growth_rate, level, remove_levelcap=True):
     if level < 100:
         # Open the CSV file
         csv_file_path = str(next_lvl_file_path)  # Replace 'your_file_path.csv' with the actual path to your CSV file
+        # Default if no row matches or the growth_rate column is unknown —
+        # prevents UnboundLocalError from breaking the level-up path.
+        experience = 0
         with open(csv_file_path, 'r', encoding='utf-8') as file:
             # Create a CSV reader
             csv_reader = csv.DictReader(file, delimiter=';')
@@ -81,10 +84,10 @@ def find_experience_for_level(group_growth_rate, level, remove_levelcap=True):
             # Iterate through rows and find the experience for the specified growth rate and level
             for row in csv_reader:
                 if row[fieldnames[0]] == str(level):  # Use the first fieldname to access the 'Level' column
-                    experience = row[growth_rate]
+                    experience = row.get(growth_rate, 0)
                     break
 
-            return experience
+        return experience
     elif level > 99:
         if group_growth_rate == "erratic":
             if level + 1 < 50: # +1 was added to prevent -ve amounts of xp to come up (even though it wouldn't since the loop only takes in levels above 99)
@@ -209,7 +212,10 @@ def save_fossil_pokemon(pokemon_id):
         "id": id,
         "ability": ability,
         "type": type,
+        # Keep legacy "stats" key AND add canonical "base_stats" so both
+        # dict-shape readers (caught vs to_dict) work.
         "stats": stats,
+        "base_stats": stats,
         "ev": ev,
         "iv": iv,
         "attacks": attacks,
@@ -218,6 +224,7 @@ def save_fossil_pokemon(pokemon_id):
         "growth_rate": growth_rate,
         "friendship": 0,
         "pokemon_defeated": 0,
+        "xp": 0,
         "everstone": False,
         "shiny": shiny_chance(),
         "captured_date": datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
@@ -225,7 +232,14 @@ def save_fossil_pokemon(pokemon_id):
         "mega": False,
         "special_form": None,
         "tier": "Fossil",
+        "nature": "serious",
+        "held_item": None,
+        "is_favorite": False,
     }
+    # Refresh CP after dict is fully assembled so the record matches
+    # the shape produced by save_caught_pokemon.
+    from ..business import calculate_cp_from_dict as _calc_cp
+    caught_pokemon["cp"] = _calc_cp(caught_pokemon)
     # Load existing Pokémon data if it exists
     if mypokemon_path.is_file():
         with open(mypokemon_path, "r", encoding="utf-8") as json_file:

--- a/src/Ankimon/functions/pokemon_showdown_functions.py
+++ b/src/Ankimon/functions/pokemon_showdown_functions.py
@@ -18,6 +18,9 @@ def export_to_pkmn_showdown():
     for stat, value in main_pokemon.ev.items():
         if value == 0:
             main_pokemon.ev[stat] += 1
+    # EV dict was mutated in place; __setattr__ doesn't catch dict-item
+    # changes, so drop the cached CP manually.
+    main_pokemon.invalidate_cp_cache()
     # Format the Pokemon info
     pokemon_info = "{} ({})\nAbility: {}\nLevel: {}\nType: {}\nEVs: {} HP / {} Atk / {} Def / {} SpA / {} SpD / {} Spe\n IVs: {} HP / {} Atk / {} Def / {} SpA / {} SpD / {} Spe ".format(
         main_pokemon.name,

--- a/src/Ankimon/gui_classes/overview_team.py
+++ b/src/Ankimon/gui_classes/overview_team.py
@@ -30,6 +30,7 @@ from typing import Any
 
 from aqt import gui_hooks, mw
 
+from ..business import calculate_cp_from_dict
 from ..functions.sprite_functions import get_sprite_path
 from ..resources import mypokemon_path, icon_path as pokeball_path, team_pokemon_path
 from ..utils import png_to_base64
@@ -136,6 +137,7 @@ _GRID_CSS = """\
 }
 .poke-level { font-weight: 700; color: #0066cc; }
 .poke-hp    { color: #cc0000; }
+.poke-cp    { font-weight: 700; color: #6a4dac; }
 .poke-types { font-style: italic; color: #006600; }
 
 @media (max-width: 800px) {
@@ -237,6 +239,8 @@ def _build_card_html(pokemon: dict[str, Any], id_prefix: str) -> str:
     style_attr = f' style="{bg_style}"' if bg_style else ""
     pokeball_style = _build_pokeball_style()
 
+    cp_value = pokemon.get("cp") or calculate_cp_from_dict(pokemon)
+
     return (
         f'<div id="{safe_id}" class="poke-item"{style_attr}>'
         f'  <div class="poke-sprite-wrap"{pokeball_style}>'
@@ -245,6 +249,7 @@ def _build_card_html(pokemon: dict[str, Any], id_prefix: str) -> str:
         f'  <div class="poke-desc">'
         f"    <h3>{display_name}</h3>"
         f'    <p class="poke-level">Level {level}</p>'
+        f'    <p class="poke-cp">CP {cp_value:,}</p>'
         f'    <p class="poke-hp">HP: {current_hp}</p>'
         f'    <p class="poke-types">{type_str}</p>'
         f"  </div>"
@@ -312,8 +317,9 @@ def load_pokemon_team() -> list[dict[str, Any]]:
         return []
     except Exception as e:
         # Unexpected errors are logged but not allowed to crash Anki's UI.
-        if mw:
-            mw.progress.chrome_logger.log(f"Ankimon Team Overview Error: {e}")
+        # mw.progress has no chrome_logger attribute — the previous call
+        # would raise AttributeError and mask the original exception.
+        print(f"Ankimon Team Overview Error: {e}")
         return []
 
 

--- a/src/Ankimon/gui_classes/pokemon_details.py
+++ b/src/Ankimon/gui_classes/pokemon_details.py
@@ -23,6 +23,7 @@ from PyQt6.QtWidgets import (
     QSizePolicy,
 )
 
+from ..business import calculate_pokemon_go_cp, pokemon_go_raw_stats
 from ..pyobj.attack_dialog import AttackDialog
 from ..pyobj.pokemon_trade import PokemonTrade
 from ..pyobj.error_handler import show_warning_with_traceback
@@ -97,6 +98,7 @@ def PokemonCollectionDetails(
     initial_tab_index: int = 0,
     tab_changed_callback=None,
     nature: str = "serious",
+    base_stats: dict = None,
 ):
     # Create a layout for the details panel
     try:
@@ -221,10 +223,16 @@ def PokemonCollectionDetails(
         else:
             gender_symbol = ""
 
+        _cp_stats = base_stats if base_stats is not None else detail_stats
+        _attack, _defense, _stamina = pokemon_go_raw_stats(_cp_stats, iv, ev)
+        cp_value = calculate_pokemon_go_cp(_attack, _defense, _stamina, level)
+        cp_txt = f" CP: {cp_value}"
+
         name_label = QLabel(f"{capitalized_name} - {gender_symbol}")
         name_label.setFont(namefont)
         description_label = QLabel(description_txt)
         level_label = QLabel(lvl)
+        cp_label = QLabel(cp_txt)
         ability_label = QLabel(ability_txt)
         attacks_label = QLabel(attacks_txt)
         pokemon_defeated_label = QLabel(f"Pokemon Defeated: {pokemon_defeated}")
@@ -234,6 +242,7 @@ def PokemonCollectionDetails(
             captured_date_label = QLabel(f"Captured: N/A")
 
         level_label.setFont(custom_font)
+        cp_label.setFont(custom_font)
         type_label = QLabel("Type:")
         type_label.setFont(custom_font)
         ability_label.setFont(custom_font)
@@ -249,6 +258,7 @@ def PokemonCollectionDetails(
         pkmnimage_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
         name_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
         level_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        cp_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
         type_label.setAlignment(
             Qt.AlignmentFlag.AlignLeft | Qt.AlignmentFlag.AlignCenter
         )
@@ -268,6 +278,7 @@ def PokemonCollectionDetails(
         TopR_layout_Box = QVBoxLayout()
         typelayout_widget = QWidget()
         TopL_layout_Box.addWidget(level_label)
+        TopL_layout_Box.addWidget(cp_label)
         TopL_layout_Box.addWidget(pkmnimage_label)
 
         typelayout.addWidget(type_label)

--- a/src/Ankimon/gui_classes/pokemon_details.py
+++ b/src/Ankimon/gui_classes/pokemon_details.py
@@ -96,6 +96,7 @@ def PokemonCollectionDetails(
     refresh_callback,
     initial_tab_index: int = 0,
     tab_changed_callback=None,
+    nature: str = "serious",
 ):
     # Create a layout for the details panel
     try:
@@ -190,7 +191,7 @@ def PokemonCollectionDetails(
         for key, val in detail_stats.items():
             if key not in ("hp", "atk", "def", "spa", "spd", "spe"):
                 continue
-            stat = PokemonObject.calc_stat(key, val, level, iv[key], ev[key], "serious")
+            stat = PokemonObject.calc_stat(key, val, level, iv[key], ev[key], nature)
             stats_list.append(stat)
         stats_list.append(detail_stats.get("xp", 0))
         stats_txt = f"Stats:\n Hp: {stats_list[0]}\n Attack: {stats_list[1]}\n Defense: {stats_list[2]}\n Special-attack: {stats_list[3]}\n Special-defense: {stats_list[4]}\n Speed: {stats_list[5]}\n XP: {stats_list[6]}"

--- a/src/Ankimon/gui_classes/pokemon_details.py
+++ b/src/Ankimon/gui_classes/pokemon_details.py
@@ -23,7 +23,12 @@ from PyQt6.QtWidgets import (
     QSizePolicy,
 )
 
-from ..business import calculate_pokemon_go_cp, pokemon_go_raw_stats
+from ..business import (
+    calculate_pokemon_go_cp,
+    pokemon_go_raw_stats,
+    calculate_cpm,
+    cp_breakdown_tooltip,
+)
 from ..pyobj.attack_dialog import AttackDialog
 from ..pyobj.pokemon_trade import PokemonTrade
 from ..pyobj.error_handler import show_warning_with_traceback
@@ -226,13 +231,17 @@ def PokemonCollectionDetails(
         _cp_stats = base_stats if base_stats is not None else detail_stats
         _attack, _defense, _stamina = pokemon_go_raw_stats(_cp_stats, iv, ev)
         cp_value = calculate_pokemon_go_cp(_attack, _defense, _stamina, level)
-        cp_txt = f" CP: {cp_value}"
+        cp_txt = f"CP {cp_value:,}"
+        cp_tooltip = cp_breakdown_tooltip(
+            {"base_stats": _cp_stats, "iv": iv, "ev": ev, "level": level}
+        )
 
         name_label = QLabel(f"{capitalized_name} - {gender_symbol}")
         name_label.setFont(namefont)
         description_label = QLabel(description_txt)
         level_label = QLabel(lvl)
         cp_label = QLabel(cp_txt)
+        cp_label.setToolTip(cp_tooltip)
         ability_label = QLabel(ability_txt)
         attacks_label = QLabel(attacks_txt)
         pokemon_defeated_label = QLabel(f"Pokemon Defeated: {pokemon_defeated}")

--- a/src/Ankimon/lang/en_text.json
+++ b/src/Ankimon/lang/en_text.json
@@ -453,5 +453,9 @@
   "futuresight_hits": "The foreseen attack strikes {side}!",
   "futuresight_fails": "Future Sight failed!",
   "wish_started": "{pokemon_name} made a wish! It will heal {heal_amount} HP soon.",
-  "pc_box_label": "Box {current}/{total}"
+  "pc_box_label": "Box {current}/{total}",
+  "cp_label": "CP",
+  "bp_label": "BP",
+  "combat_power": "Combat Power",
+  "battle_power": "Battle Power"
 }

--- a/src/Ankimon/pokedex/pokedex_obj.py
+++ b/src/Ankimon/pokedex/pokedex_obj.py
@@ -84,7 +84,7 @@ class Pokedex(QDialog):
                     defeated_count += defeated_num
                     #print(f"POKEDEX_DEBUG: Pokemon ID {pokemon.get('id', 'unknown')}: pokemon_defeated = {defeated_num}")
                 except (TypeError, ValueError):
-                    mw.logger.log(f"POKEDEX_DEBUG: Invalid pokemon_defeated for ID {pokemon.get('id', 'unknown')}: {defeated}")
+                    mw.logger.log("warning", f"POKEDEX_DEBUG: Invalid pokemon_defeated for ID {pokemon.get('id', 'unknown')}: {defeated}")
                 
                 # Check if Pokémon is shiny
                 if pokemon.get("shiny") is True:
@@ -92,7 +92,7 @@ class Pokedex(QDialog):
                     if pokemon_id and pokemon_id not in shiny_pokemon_ids:
                         shiny_pokemon_ids.append(pokemon_id)
         else:
-            mw.logger.log("POKEDEX_DEBUG: No valid mypokemon.json found")
+            mw.logger.log("info", "POKEDEX_DEBUG: No valid mypokemon.json found")
             total_caught_count = 0
 
         # Also count defeated Pokémon from released Pokémon history

--- a/src/Ankimon/pyobj/ankimon_tracker.py
+++ b/src/Ankimon/pyobj/ankimon_tracker.py
@@ -75,9 +75,12 @@ class AnkimonTracker:
     def get_total_reviews(self):
         if mw.col is None:
             return 0
-        else:
-            studied_today_num = re.search(r'Studied\s+[^\d]*(\d+)(?=[^\n]*card)', mw.col.studied_today())
-            return int(studied_today_num.group(1))
+        match = re.search(r'Studied\s+[^\d]*(\d+)(?=[^\n]*card)', mw.col.studied_today())
+        if match is None:
+            # Empty-study session or localized Anki whose "Studied N cards"
+            # text doesn't match the English regex.
+            return 0
+        return int(match.group(1))
 
     def set_main_pokemon(self, pokemon):
         """Set the main Pokémon being used."""

--- a/src/Ankimon/pyobj/collection_dialog.py
+++ b/src/Ankimon/pyobj/collection_dialog.py
@@ -27,6 +27,7 @@ from ..functions.pokedex_functions import (
 from ..gui_classes.pokemon_details import PokemonCollectionDetails
 from ..gui_entities import MovieSplashLabel
 from ..resources import mypokemon_path, frontdefault, frontdefault, mainpokemon_path
+from ..business import calculate_cp_from_dict
 
 
 class PokemonCollectionDialog(QDialog):
@@ -71,28 +72,17 @@ class PokemonCollectionDialog(QDialog):
         self.setMinimumHeight(400)
         self.layout = QVBoxLayout(self)
 
-        # add Widget to sort by ID
-        self.sort_checkbox = QCheckBox("Sort by ID")
-        self.sort_checkbox.stateChanged.connect(
-            lambda: (
-                self.sort_pokemon()
-                if self.sort_checkbox.isChecked()
-                else self.filter_pokemon()
-            )
-        )
+        # Sort dropdown
+        self.sort_combo = QComboBox()
+        self.sort_combo.addItems(["Capture Order", "ID", "CP", "Level", "Name"])
+        self.sort_combo.currentIndexChanged.connect(self.apply_sort_and_filter)
 
         # Search Filter
         self.search_edit = QLineEdit()
         self.search_edit.setPlaceholderText("Search Pokémon (by nickname, name)")
         # self.search_edit.textChanged.connect(self.filter_pokemon)
         self.search_button = QPushButton("Search")
-        self.search_button.clicked.connect(
-            lambda: (
-                self.sort_pokemon()
-                if self.sort_checkbox.isChecked()
-                else self.filter_pokemon()
-            )
-        )
+        self.search_button.clicked.connect(self.apply_sort_and_filter)
 
         # Add dropdown menu for generation filtering
         self.generation_combo = QComboBox()
@@ -109,13 +99,7 @@ class PokemonCollectionDialog(QDialog):
                 "Generation 8",
             ]
         )
-        self.generation_combo.currentIndexChanged.connect(
-            lambda: (
-                self.sort_pokemon()
-                if self.sort_checkbox.isChecked()
-                else self.filter_pokemon()
-            )
-        )
+        self.generation_combo.currentIndexChanged.connect(self.apply_sort_and_filter)
 
         # Add dropdown menu for generation filtering
         self.type_combo = QComboBox()
@@ -142,13 +126,7 @@ class PokemonCollectionDialog(QDialog):
                 "Fairy",
             ]
         )
-        self.type_combo.currentIndexChanged.connect(
-            lambda: (
-                self.sort_pokemon()
-                if self.sort_checkbox.isChecked()
-                else self.filter_pokemon()
-            )
-        )
+        self.type_combo.currentIndexChanged.connect(self.apply_sort_and_filter)
 
         # Add widgets to layout
         filter_layout = QHBoxLayout()
@@ -156,7 +134,8 @@ class PokemonCollectionDialog(QDialog):
         filter_layout.addWidget(self.search_button)
         filter_layout.addWidget(self.generation_combo)
         filter_layout.addWidget(self.type_combo)
-        filter_layout.addWidget(self.sort_checkbox)
+        filter_layout.addWidget(QLabel("Sort:"))
+        filter_layout.addWidget(self.sort_combo)
         self.layout.addLayout(filter_layout)
 
         self.scroll_area = QScrollArea()
@@ -295,6 +274,9 @@ class PokemonCollectionDialog(QDialog):
                 ability_label = self.create_label(
                     f"Ability: {pokemon_ability.capitalize()}", 8
                 )
+                cp_label = self.create_label(
+                    f"CP: {pokemon.get('cp') or calculate_cp_from_dict(pokemon)}", 8
+                )
 
                 image_label = QLabel()
                 image_label.setPixmap(pixmap)
@@ -316,6 +298,7 @@ class PokemonCollectionDialog(QDialog):
 
                 container_layout.addWidget(name_label)
                 container_layout.addWidget(level_label)
+                container_layout.addWidget(cp_label)
                 container_layout.addWidget(type_label)
                 container_layout.addWidget(ability_label)
                 container_layout.addWidget(pokemon_button)
@@ -416,6 +399,7 @@ class PokemonCollectionDialog(QDialog):
             logger=self.logger,
             refresh_callback=self.refresh_collection,
             nature=pokemon.get("nature", "serious"),
+            base_stats=pokemon.get("base_stats"),
         )
 
     def get_gender_symbol(self, gender):
@@ -426,113 +410,65 @@ class PokemonCollectionDialog(QDialog):
         else:
             return ""
 
-    def filter_pokemon(self):
-        filtered_pokemon = []
-        pokemon_list = self.pokemon_list
-        if not self.sort_checkbox.isChecked():
-            type_index = self.type_combo.currentIndex()
-            type_text = self.type_combo.currentText()
-            search_text = self.search_edit.text().lower()
-            generation_index = self.generation_combo.currentIndex()
-
-            try:
-                if pokemon_list:
-                    for position, pokemon in enumerate(pokemon_list):
-                        pokemon_id = pokemon["id"]
-                        pokemon_name = pokemon["name"].lower()
-                        if pokemon.get("shiny", False):
-                            pokemon_name += " (shiny) "
-                        pokemon_nickname = pokemon.get("nickname") or ""
-                        if pokemon.get("shiny", False):
-                            pokemon_nickname += " (shiny) "
-                        pokemon_type = pokemon.get("type", " ")
-
-                        # Check if the Pokémon matches the search text and generation filter
-                        if (
-                            (
-                                search_text.lower() in pokemon_name.lower()
-                                or (
-                                    pokemon_nickname is not None
-                                    and search_text.lower() in pokemon_nickname.lower()
-                                )
-                            )
-                            and 0 <= generation_index <= 8
-                            and (
-                                generation_index == 0
-                                or (1 <= pokemon_id <= 151 and generation_index == 1)
-                                or (152 <= pokemon_id <= 251 and generation_index == 2)
-                                or (252 <= pokemon_id <= 386 and generation_index == 3)
-                                or (387 <= pokemon_id <= 493 and generation_index == 4)
-                                or (494 <= pokemon_id <= 649 and generation_index == 5)
-                                or (650 <= pokemon_id <= 721 and generation_index == 6)
-                                or (722 <= pokemon_id <= 809 and generation_index == 7)
-                                or (810 <= pokemon_id <= 898 and generation_index == 8)
-                            )
-                            and (type_index == 0 or type_text in pokemon_type)
-                        ):
-                            filtered_pokemon.append(pokemon)
-                    self.refresh_collection(filtered_pokemon)
-                    if not filtered_pokemon:
-                        showInfo("No Pokemon for the desired filter options!")
-                    self.current_page = 0
-            except FileNotFoundError:
-                self.layout.addWidget(
-                    QLabel(f"Can't open the Saving File. {mypokemon_path}")
-                )
-        else:
-            self.sort_pokemon()
-
-    def sort_pokemon(self):
-        filtered_pokemon = []
+    def apply_sort_and_filter(self):
         pokemon_list = self.pokemon_list
         search_text = self.search_edit.text().lower()
         generation_index = self.generation_combo.currentIndex()
         type_index = self.type_combo.currentIndex()
         type_text = self.type_combo.currentText()
-        sorted_pokemon_list = sorted(pokemon_list, key=lambda x: x["id"])
-        for i in reversed(range(self.scroll_layout.count())):
-            widget = self.scroll_layout.itemAt(i).widget()
-            if widget is not None:
-                widget.deleteLater()
+        sort_key = self.sort_combo.currentText()
+
         try:
-            if sorted_pokemon_list:
-                for position, pokemon in enumerate(sorted_pokemon_list):
-                    pokemon_id = pokemon["id"]
-                    pokemon_name = pokemon["name"].lower()
-                    if pokemon.get("shiny", False):
-                        pokemon_name += " (shiny) "
-                    pokemon_nickname = pokemon.get("nickname") or ""
-                    if pokemon.get("shiny", False):
-                        pokemon_nickname += " (shiny) "
-                    pokemon_type = pokemon.get("type", " ")
-                    # Check if the Pokémon matches the search text and generation filter
-                    if (
-                        (
-                            search_text.lower() in pokemon_name.lower()
-                            or (
-                                pokemon_nickname is not None
-                                and search_text.lower() in pokemon_nickname.lower()
-                            )
-                        )
-                        and 0 <= generation_index <= 8
-                        and (
-                            generation_index == 0
-                            or (1 <= pokemon_id <= 151 and generation_index == 1)
-                            or (152 <= pokemon_id <= 251 and generation_index == 2)
-                            or (252 <= pokemon_id <= 386 and generation_index == 3)
-                            or (387 <= pokemon_id <= 493 and generation_index == 4)
-                            or (494 <= pokemon_id <= 649 and generation_index == 5)
-                            or (650 <= pokemon_id <= 721 and generation_index == 6)
-                            or (722 <= pokemon_id <= 809 and generation_index == 7)
-                            or (810 <= pokemon_id <= 898 and generation_index == 8)
-                        )
-                        and (type_index == 0 or type_text in pokemon_type)
-                    ):
-                        filtered_pokemon.append(pokemon)
-                self.refresh_collection(filtered_pokemon)
-                if not filtered_pokemon:
-                    showInfo("No Pokemon for the desired filter options!")
-                self.current_page = 0
+            if not pokemon_list:
+                return
+
+            # Filter
+            filtered_pokemon = []
+            for pokemon in pokemon_list:
+                pokemon_id = pokemon["id"]
+                pokemon_name = pokemon["name"].lower()
+                if pokemon.get("shiny", False):
+                    pokemon_name += " (shiny) "
+                pokemon_nickname = pokemon.get("nickname") or ""
+                if pokemon.get("shiny", False):
+                    pokemon_nickname += " (shiny) "
+                pokemon_type = pokemon.get("type", " ")
+
+                if (
+                    (
+                        search_text in pokemon_name.lower()
+                        or search_text in pokemon_nickname.lower()
+                    )
+                    and 0 <= generation_index <= 8
+                    and (
+                        generation_index == 0
+                        or (1 <= pokemon_id <= 151 and generation_index == 1)
+                        or (152 <= pokemon_id <= 251 and generation_index == 2)
+                        or (252 <= pokemon_id <= 386 and generation_index == 3)
+                        or (387 <= pokemon_id <= 493 and generation_index == 4)
+                        or (494 <= pokemon_id <= 649 and generation_index == 5)
+                        or (650 <= pokemon_id <= 721 and generation_index == 6)
+                        or (722 <= pokemon_id <= 809 and generation_index == 7)
+                        or (810 <= pokemon_id <= 898 and generation_index == 8)
+                    )
+                    and (type_index == 0 or type_text in pokemon_type)
+                ):
+                    filtered_pokemon.append(pokemon)
+
+            # Sort
+            if sort_key == "ID":
+                filtered_pokemon.sort(key=lambda x: x["id"])
+            elif sort_key == "CP":
+                filtered_pokemon.sort(key=lambda x: x.get("cp") or calculate_cp_from_dict(x), reverse=True)
+            elif sort_key == "Level":
+                filtered_pokemon.sort(key=lambda x: x.get("level", 0), reverse=True)
+            elif sort_key == "Name":
+                filtered_pokemon.sort(key=lambda x: x.get("name", "").lower())
+
+            self.current_page = 0
+            self.refresh_collection(filtered_pokemon)
+            if not filtered_pokemon:
+                showInfo("No Pokemon for the desired filter options!")
         except FileNotFoundError:
             self.layout.addWidget(
                 QLabel(f"Can't open the Saving File. {mypokemon_path}")

--- a/src/Ankimon/pyobj/collection_dialog.py
+++ b/src/Ankimon/pyobj/collection_dialog.py
@@ -227,10 +227,15 @@ class PokemonCollectionDialog(QDialog):
         # Add the paginator layout at the bottom
         self.layout.addLayout(self.paginator_layout)
 
-    def refresh_collection(self, pokemon_list=[]):
-        if not pokemon_list:  # If pokemon_list is empty or None
+    def refresh_collection(self, pokemon_list=None):
+        """Refresh the Pokémon collection and pagination layout.
+
+        ``pokemon_list`` may be an empty list to explicitly render an empty
+        collection (e.g. a filter returning no matches). Only fall back to
+        the full collection when the caller passes ``None``.
+        """
+        if pokemon_list is None:
             pokemon_list = self.pokemon_list
-        """Refresh the Pokémon collection and pagination layout."""
         # Clear existing Pokémon and paginator
         self.refresh_pokemon_collection()
         self.refresh_paginator_layout()
@@ -410,6 +415,7 @@ class PokemonCollectionDialog(QDialog):
             remove_levelcap=self.remove_levelcap,
             logger=self.logger,
             refresh_callback=self.refresh_collection,
+            nature=pokemon.get("nature", "serious"),
         )
 
     def get_gender_symbol(self, gender):

--- a/src/Ankimon/pyobj/collection_dialog.py
+++ b/src/Ankimon/pyobj/collection_dialog.py
@@ -27,7 +27,7 @@ from ..functions.pokedex_functions import (
 from ..gui_classes.pokemon_details import PokemonCollectionDetails
 from ..gui_entities import MovieSplashLabel
 from ..resources import mypokemon_path, frontdefault, frontdefault, mainpokemon_path
-from ..business import calculate_cp_from_dict
+from ..business import calculate_cp_from_dict, cp_breakdown_tooltip
 
 
 class PokemonCollectionDialog(QDialog):
@@ -76,6 +76,13 @@ class PokemonCollectionDialog(QDialog):
         self.sort_combo = QComboBox()
         self.sort_combo.addItems(["Capture Order", "ID", "CP", "Level", "Name"])
         self.sort_combo.currentIndexChanged.connect(self.apply_sort_and_filter)
+
+        # Descending toggle — matches PC Box convention. Default ON so
+        # the common "strongest/highest first" CP and Level sorts keep
+        # their pre-existing behaviour.
+        self.desc_sort = QCheckBox("Descending")
+        self.desc_sort.setChecked(True)
+        self.desc_sort.stateChanged.connect(self.apply_sort_and_filter)
 
         # Search Filter
         self.search_edit = QLineEdit()
@@ -136,6 +143,7 @@ class PokemonCollectionDialog(QDialog):
         filter_layout.addWidget(self.type_combo)
         filter_layout.addWidget(QLabel("Sort:"))
         filter_layout.addWidget(self.sort_combo)
+        filter_layout.addWidget(self.desc_sort)
         self.layout.addLayout(filter_layout)
 
         self.scroll_area = QScrollArea()
@@ -211,16 +219,16 @@ class PokemonCollectionDialog(QDialog):
 
         ``pokemon_list`` may be an empty list to explicitly render an empty
         collection (e.g. a filter returning no matches). Only fall back to
-        the full collection when the caller passes ``None``.
+        the full collection when the caller passes ``None`` — and in that
+        case reload from disk so the UI picks up any recent
+        rename/release/trade persisted by another code path.
         """
         if pokemon_list is None:
-            pokemon_list = self.pokemon_list
+            pokemon_list = self.load_pokemon_data() or []
         # Clear existing Pokémon and paginator
         self.refresh_pokemon_collection()
         self.refresh_paginator_layout()
 
-        # Reload Pokémon data and setup the UI
-        self.load_pokemon_data()
         self.setup_ui(pokemon_list)
 
     def setup_ui(self, pokemon_list=[]):
@@ -274,9 +282,9 @@ class PokemonCollectionDialog(QDialog):
                 ability_label = self.create_label(
                     f"Ability: {pokemon_ability.capitalize()}", 8
                 )
-                cp_label = self.create_label(
-                    f"CP: {pokemon.get('cp') or calculate_cp_from_dict(pokemon)}", 8
-                )
+                cp_value = pokemon.get("cp") or calculate_cp_from_dict(pokemon)
+                cp_label = self.create_label(f"CP {cp_value:,}", 8)
+                cp_label.setToolTip(cp_breakdown_tooltip(pokemon))
 
                 image_label = QLabel()
                 image_label.setPixmap(pixmap)
@@ -381,7 +389,7 @@ class PokemonCollectionDialog(QDialog):
             shiny=pokemon.get("shiny", False),
             ability=pokemon["ability"],
             type=pokemon["type"],
-            detail_stats={**pokemon["stats"], "xp": pokemon.get("xp", 0)},
+            detail_stats={**(pokemon.get("base_stats") or pokemon["stats"]), "xp": pokemon.get("xp", 0)},
             attacks=pokemon["attacks"],
             base_experience=pokemon["base_experience"],
             growth_rate=pokemon["growth_rate"],
@@ -455,15 +463,16 @@ class PokemonCollectionDialog(QDialog):
                 ):
                     filtered_pokemon.append(pokemon)
 
-            # Sort
+            # Sort — direction controlled by the Descending checkbox
+            reverse = self.desc_sort.isChecked()
             if sort_key == "ID":
-                filtered_pokemon.sort(key=lambda x: x["id"])
+                filtered_pokemon.sort(key=lambda x: x["id"], reverse=reverse)
             elif sort_key == "CP":
-                filtered_pokemon.sort(key=lambda x: x.get("cp") or calculate_cp_from_dict(x), reverse=True)
+                filtered_pokemon.sort(key=lambda x: x.get("cp") or calculate_cp_from_dict(x), reverse=reverse)
             elif sort_key == "Level":
-                filtered_pokemon.sort(key=lambda x: x.get("level", 0), reverse=True)
+                filtered_pokemon.sort(key=lambda x: x.get("level", 0), reverse=reverse)
             elif sort_key == "Name":
-                filtered_pokemon.sort(key=lambda x: x.get("name", "").lower())
+                filtered_pokemon.sort(key=lambda x: x.get("name", "").lower(), reverse=reverse)
 
             self.current_page = 0
             self.refresh_collection(filtered_pokemon)

--- a/src/Ankimon/pyobj/evolution_window.py
+++ b/src/Ankimon/pyobj/evolution_window.py
@@ -384,8 +384,22 @@ class EvoWindow(QWidget):
                         pokemon["attacks"] = attacks
                         base_stats = search_pokedex(evo_name.lower(), "baseStats")
                         pokemon["base_stats"] = base_stats
-                        pokemon["stats"] = base_stats
+                        # Refresh level-scaled "stats" against new species
+                        # bases; previously we wrote base_stats here, which
+                        # collided with to_dict semantics (stats = scaled).
+                        _iv = pokemon.get("iv") or {}
+                        _ev = pokemon.get("ev") or {}
+                        _level = pokemon.get("level", 1)
+                        _nature = pokemon.get("nature", "serious")
+                        from ..pyobj.pokemon_obj import PokemonObject as _PO
+                        pokemon["stats"] = {
+                            k: _PO.calc_stat(k, base_stats[k], _level, _iv.get(k, 0), _ev.get(k, 0), _nature)
+                            for k in ("hp", "atk", "def", "spa", "spd", "spe")
+                        }
                         pokemon["xp"] = 0
+                        # Refresh CP against the new species' base stats.
+                        from ..business import calculate_cp_from_dict as _recalc_cp
+                        pokemon["cp"] = _recalc_cp(pokemon)
                         hp_stat = int(base_stats["hp"])
                         iv = pokemon["iv"]
                         ev = pokemon["ev"]

--- a/src/Ankimon/pyobj/pc_box.py
+++ b/src/Ankimon/pyobj/pc_box.py
@@ -1018,6 +1018,7 @@ class PokemonPC(QDialog):
             refresh_callback=self.refresh_gui,
             initial_tab_index=self.current_stats_tab_index,
             tab_changed_callback=self.on_stats_tab_changed,
+            nature=pokemon.get("nature", "serious"),
         )
         self.refresh_gui()
 

--- a/src/Ankimon/pyobj/pc_box.py
+++ b/src/Ankimon/pyobj/pc_box.py
@@ -1177,6 +1177,7 @@ class PokemonPC(QDialog):
             "tier",
             "is_favorite",
             "held_item",
+            "cp",
         }
 
         is_migration_needed = any(
@@ -1211,6 +1212,7 @@ class PokemonPC(QDialog):
             "tier": lambda p: get_tier_by_id(p.get("id", 0)) or "Normal",
             "is_favorite": False,
             "held_item": None,
+            "cp": lambda p: calculate_cp_from_dict(p),
         }
 
         for i, pokemon in enumerate(pokemon_list):

--- a/src/Ankimon/pyobj/pc_box.py
+++ b/src/Ankimon/pyobj/pc_box.py
@@ -42,6 +42,7 @@ from ..pyobj.settings import Settings
 from ..functions.sprite_functions import get_sprite_path
 from ..utils import load_custom_font, get_tier_by_id
 from ..resources import mypokemon_path, itembag_path
+from ..business import calculate_cp_from_dict
 
 
 def format_item_name(item_name: str) -> str:
@@ -477,6 +478,7 @@ class PokemonPC(QDialog):
         self.sort_by_id = QRadioButton("ID")
         self.sort_by_name = QRadioButton("Name")
         self.sort_by_level = QRadioButton("Level")
+        self.sort_by_cp = QRadioButton("CP")
         self.sort_by_iv = QRadioButton("IV")
         self.sort_by_ev = QRadioButton("EV")
         self.sort_by_date = QRadioButton("Date")
@@ -484,6 +486,7 @@ class PokemonPC(QDialog):
         self.sort_group.addButton(self.sort_by_id)
         self.sort_group.addButton(self.sort_by_name)
         self.sort_group.addButton(self.sort_by_level)
+        self.sort_group.addButton(self.sort_by_cp)
         self.sort_group.addButton(self.sort_by_iv)
         self.sort_group.addButton(self.sort_by_ev)
         self.sort_group.addButton(self.sort_by_date)
@@ -494,6 +497,8 @@ class PokemonPC(QDialog):
             self.sort_by_name.setChecked(True)
         elif self.selected_sort_key == "Level":
             self.sort_by_level.setChecked(True)
+        elif self.selected_sort_key == "CP":
+            self.sort_by_cp.setChecked(True)
         elif self.selected_sort_key == "IV":
             self.sort_by_iv.setChecked(True)
         elif self.selected_sort_key == "EV":
@@ -509,6 +514,7 @@ class PokemonPC(QDialog):
         sort_radio_layout.addWidget(self.sort_by_id)
         sort_radio_layout.addWidget(self.sort_by_name)
         sort_radio_layout.addWidget(self.sort_by_level)
+        sort_radio_layout.addWidget(self.sort_by_cp)
         sort_radio_layout.addWidget(self.sort_by_iv)
         sort_radio_layout.addWidget(self.sort_by_ev)
         sort_radio_layout.addWidget(self.sort_by_date)
@@ -882,6 +888,8 @@ class PokemonPC(QDialog):
                 # Sum all IV values for total IV score
                 iv_dict = p.get("iv", {})
                 return sum(iv_dict.values()) if iv_dict else 0
+            elif sort_key_str == "cp":
+                return p.get("cp") or calculate_cp_from_dict(p)
             elif sort_key_str == "ev":
                 # Sum all EV values for total EV score
                 ev_dict = p.get("ev", {})
@@ -1019,6 +1027,7 @@ class PokemonPC(QDialog):
             initial_tab_index=self.current_stats_tab_index,
             tab_changed_callback=self.on_stats_tab_changed,
             nature=pokemon.get("nature", "serious"),
+            base_stats=pokemon.get("base_stats"),
         )
         self.refresh_gui()
 

--- a/src/Ankimon/pyobj/pokemon_obj.py
+++ b/src/Ankimon/pyobj/pokemon_obj.py
@@ -133,6 +133,23 @@ class PokemonObject:
     def stats(self, value):
         raise AttributeError("Setting the value of the stats of a Pokemon is forbidden as they are automatically calculated using their base stats. You can instead set the base_stats of the Pokemon.")
 
+    @property
+    def cp(self) -> int:
+        """Combat Power — Pokemon GO style formula.
+
+        ``CP = floor(Attack × √Defense × √Stamina × CPM² / 10)``
+
+        Uses raw stats (base + IV + EV/4) so CPM is the sole level
+        multiplier.  See :func:`business.calculate_pokemon_go_cp`.
+        """
+        # Local import to avoid a circular dependency with ``business``.
+        from ..business import calculate_pokemon_go_cp, pokemon_go_raw_stats
+
+        attack, defense, stamina = pokemon_go_raw_stats(
+            self.base_stats, self.iv, self.ev
+        )
+        return calculate_pokemon_go_cp(attack, defense, stamina, self.level)
+
     @classmethod
     def get_nature_stat_mult(cls, stat_name: str, nature: str) -> float:
         if stat_name == "atk":
@@ -173,6 +190,8 @@ class PokemonObject:
             "type": self.type,
             "base_stats": self.base_stats,
             "stats": self.stats,  # Calculated stats
+            "cp": self.cp,
+            "nature": self.nature,
             "ev": self.ev,
             "iv": self.iv,
             "attacks": self.attacks,

--- a/src/Ankimon/pyobj/pokemon_obj.py
+++ b/src/Ankimon/pyobj/pokemon_obj.py
@@ -141,14 +141,38 @@ class PokemonObject:
 
         Uses raw stats (base + IV + EV/4) so CPM is the sole level
         multiplier.  See :func:`business.calculate_pokemon_go_cp`.
+
+        Memoized: attribute assignment to ``level``, ``ev``, ``iv``, or
+        ``base_stats`` invalidates the cache via ``__setattr__``. Mutating
+        those containers in-place (e.g. ``self.ev["atk"] += 1``) does not,
+        so call :meth:`invalidate_cp_cache` explicitly at those sites.
         """
+        cached = getattr(self, "_cached_cp", None)
+        if cached is not None:
+            return cached
         # Local import to avoid a circular dependency with ``business``.
         from ..business import calculate_pokemon_go_cp, pokemon_go_raw_stats
 
         attack, defense, stamina = pokemon_go_raw_stats(
             self.base_stats, self.iv, self.ev
         )
-        return calculate_pokemon_go_cp(attack, defense, stamina, self.level)
+        cp_val = calculate_pokemon_go_cp(attack, defense, stamina, self.level)
+        object.__setattr__(self, "_cached_cp", cp_val)
+        return cp_val
+
+    def invalidate_cp_cache(self) -> None:
+        """Drop memoized CP so the next ``cp`` access recomputes.
+
+        Call after mutating ``ev``/``iv``/``base_stats`` dict contents
+        in place (attribute reassignment is caught automatically by
+        ``__setattr__``).
+        """
+        object.__setattr__(self, "_cached_cp", None)
+
+    def __setattr__(self, name, value):
+        super().__setattr__(name, value)
+        if name in ("level", "ev", "iv", "base_stats"):
+            object.__setattr__(self, "_cached_cp", None)
 
     @classmethod
     def get_nature_stat_mult(cls, stat_name: str, nature: str) -> float:
@@ -210,7 +234,7 @@ class PokemonObject:
             "tier": self.tier,  # Added tier
             "is_favorite": getattr(self, "is_favorite", False),  # Added with default
             # Additional fields from your example
-            "current_hp": getattr(self, "current_hp", "hp"),  # For backward compatibility
+            "current_hp": getattr(self, "current_hp", self.hp),
             "held_item": self.held_item,
         }
 
@@ -222,11 +246,25 @@ class PokemonObject:
         """Return the stats of the Pokémon."""
         return vars(self)
 
+    # Derived/read-only attributes to skip in update_stats. ``cp`` and
+    # ``stats`` are @property getters whose setattr raises
+    # AttributeError (silently swallowed by the caller's bare
+    # `except Exception`). ``max_hp`` is a plain cache field — setattr
+    # would succeed, but the splatted value is almost certainly stale
+    # relative to the new ``level``/``base_stats``, so we skip it and
+    # recompute it ourselves below.
+    _READONLY_ATTRS = frozenset({"cp", "stats", "max_hp"})
+
     def update_stats(self, **kwargs):
         """Update the attributes of the Pokémon object with keyword arguments."""
         for key, value in kwargs.items():
+            if key in self._READONLY_ATTRS:
+                continue
             if hasattr(self, key):
                 setattr(self, key, value)
+        # Derived caches — recompute from the (possibly updated)
+        # base_stats/level/iv/ev so they don't go stale.
+        self.max_hp = self.calculate_max_hp()
         self._update_battle_stats()  # Update battle stats
 
     def reset_stats(self):

--- a/src/Ankimon/pyobj/test_window.py
+++ b/src/Ankimon/pyobj/test_window.py
@@ -169,7 +169,7 @@ class TestWindow(QWidget):
 
         Battle Power = CP * current_HP * type-matchup multiplier.
         """
-        cp_font = load_custom_font(14, int(self.settings_obj.get("misc.language")))
+        cp_font = load_custom_font(18, int(self.settings_obj.get("misc.language")))
         painter.setFont(cp_font)
         painter.setPen(QColor(31, 31, 39))
         try:
@@ -189,17 +189,29 @@ class TestWindow(QWidget):
             getattr(self.main_pokemon, "type", None),
             getattr(self.enemy_pokemon, "type", None),
         )
+        enemy_stages = getattr(self.enemy_pokemon, "stat_stages", None) or {}
+        main_stages = getattr(self.main_pokemon, "stat_stages", None) or {}
         enemy_bp = calculate_present_power(
-            enemy_cp, getattr(self.enemy_pokemon, "hp", 0), enemy_vs_main
+            enemy_cp,
+            getattr(self.enemy_pokemon, "hp", 0),
+            enemy_vs_main,
+            enemy_stages.get("atk", 0),
+            enemy_stages.get("spa", 0),
         )
         main_bp = calculate_present_power(
-            main_cp, getattr(self.main_pokemon, "hp", 0), main_vs_enemy
+            main_cp,
+            getattr(self.main_pokemon, "hp", 0),
+            main_vs_enemy,
+            main_stages.get("atk", 0),
+            main_stages.get("spa", 0),
         )
 
-        painter.drawText(48, 104, f"CP {enemy_cp:,}")
-        painter.drawText(48, 118, f"BP {enemy_bp:,}")
-        painter.drawText(326, 216, f"CP {main_cp:,}")
-        painter.drawText(326, 230, f"BP {main_bp:,}")
+        cp_lbl = self.translator.translate("cp_label")
+        bp_lbl = self.translator.translate("bp_label")
+        painter.drawText(48, 104, f"{cp_lbl} {enemy_cp:,}")
+        painter.drawText(48, 118, f"{bp_lbl} {enemy_bp:,}")
+        painter.drawText(326, 216, f"{cp_lbl} {main_cp:,}")
+        painter.drawText(326, 230, f"{bp_lbl} {main_bp:,}")
 
     def pokemon_display_first_encounter(self):
         # Main window layout
@@ -219,7 +231,7 @@ class TestWindow(QWidget):
 
         bckgimage_path = battlescene_path / self.ankimon_tracker_obj.battlescene_file
 
-        if self.ankimon_tracker_obj.pokemon_encouter > 0:
+        if self.ankimon_tracker_obj.pokemon_encounter > 0:
             bckgimage_path = battlescene_path_without_dialog / self.ankimon_tracker_obj.battlescene_file
 
         msg_font = load_custom_font(32, int(self.settings_obj.get("misc.language")))
@@ -290,7 +302,7 @@ class TestWindow(QWidget):
         # draw background to a specific pixel
         painter.drawPixmap(0, 0, pixmap_bckg)
 
-        painter = self.draw_hp_bar(118, 76, 8, 116, self.enemy_pokemon.current_hp, self.enemy_pokemon.max_hp, painter)  # enemy pokemon hp_bar
+        painter = self.draw_hp_bar(118, 76, 8, 116, self.enemy_pokemon.hp, self.enemy_pokemon.max_hp, painter)  # enemy pokemon hp_bar
 
         painter = self.draw_hp_bar(401, 208, 8, 116, self.main_pokemon.hp, self.main_pokemon.max_hp, painter)  # main pokemon hp_bar
 
@@ -395,11 +407,11 @@ class TestWindow(QWidget):
         return painter
 
     def pokemon_display_battle(self):
-        self.ankimon_tracker_obj.pokemon_encouter += 1
+        self.ankimon_tracker_obj.pokemon_encounter += 1
 
         bckgimage_path = battlescene_path / self.ankimon_tracker_obj.battlescene_file
 
-        if self.ankimon_tracker_obj.pokemon_encouter > 1:
+        if self.ankimon_tracker_obj.pokemon_encounter > 1:
             bckgimage_path = battlescene_path_without_dialog / self.ankimon_tracker_obj.battlescene_file
 
         ui_path = battle_ui_path

--- a/src/Ankimon/pyobj/test_window.py
+++ b/src/Ankimon/pyobj/test_window.py
@@ -43,6 +43,8 @@ from ..pyobj.translator import Translator
 
 from .error_handler import show_warning_with_traceback
 
+from ..business import calculate_present_power, type_compatibility_multiplier
+
 from ..resources import (
     pkmnimgfolder,
     addon_dir,
@@ -161,6 +163,43 @@ class TestWindow(QWidget):
 
             self.first_start = True
             self.pkmn_window = True
+
+    def _draw_cp_pp(self, painter):
+        """Draw CP and Battle Power labels for both Pokemon.
+
+        Battle Power = CP * current_HP * type-matchup multiplier.
+        """
+        cp_font = load_custom_font(14, int(self.settings_obj.get("misc.language")))
+        painter.setFont(cp_font)
+        painter.setPen(QColor(31, 31, 39))
+        try:
+            enemy_cp = int(self.enemy_pokemon.cp)
+        except (AttributeError, TypeError, ValueError):
+            enemy_cp = 0
+        try:
+            main_cp = int(self.main_pokemon.cp)
+        except (AttributeError, TypeError, ValueError):
+            main_cp = 0
+
+        enemy_vs_main = type_compatibility_multiplier(
+            getattr(self.enemy_pokemon, "type", None),
+            getattr(self.main_pokemon, "type", None),
+        )
+        main_vs_enemy = type_compatibility_multiplier(
+            getattr(self.main_pokemon, "type", None),
+            getattr(self.enemy_pokemon, "type", None),
+        )
+        enemy_bp = calculate_present_power(
+            enemy_cp, getattr(self.enemy_pokemon, "hp", 0), enemy_vs_main
+        )
+        main_bp = calculate_present_power(
+            main_cp, getattr(self.main_pokemon, "hp", 0), main_vs_enemy
+        )
+
+        painter.drawText(48, 104, f"CP {enemy_cp:,}")
+        painter.drawText(48, 118, f"BP {enemy_bp:,}")
+        painter.drawText(326, 216, f"CP {main_cp:,}")
+        painter.drawText(326, 230, f"BP {main_bp:,}")
 
     def pokemon_display_first_encounter(self):
         # Main window layout
@@ -326,6 +365,8 @@ class TestWindow(QWidget):
         enemy_max_hp_x = 64 if int(self.enemy_pokemon.max_hp) < 100 else 56  # Shift left if 3 digits
         painter.drawText(enemy_hp_x, 84 if int(self.enemy_pokemon.max_hp) < 100 else 80 , str(int(self.enemy_pokemon.hp)) + "/")
         painter.drawText(enemy_max_hp_x, 84 if int(self.enemy_pokemon.max_hp) < 100 else 88, str(int(self.enemy_pokemon.max_hp)))
+
+        self._draw_cp_pp(painter)
 
         painter.end()
 
@@ -496,6 +537,8 @@ class TestWindow(QWidget):
         enemy_max_hp_x = 64 if int(self.enemy_pokemon.max_hp) < 100 else 56  # Shift left if 3 digits
         painter.drawText(enemy_hp_x, 84 if int(self.enemy_pokemon.max_hp) < 100 else 80 , str(int(self.enemy_pokemon.hp)) + "/")
         painter.drawText(enemy_max_hp_x, 84 if int(self.enemy_pokemon.max_hp) < 100 else 88, str(int(self.enemy_pokemon.max_hp)))
+
+        self._draw_cp_pp(painter)
 
         painter.end()
 

--- a/src/Ankimon/pyobj/trainer_card.py
+++ b/src/Ankimon/pyobj/trainer_card.py
@@ -1,7 +1,7 @@
 from ..resources import trainer_sprites_path, mypokemon_path, team_pokemon_path
 from ..functions.trainer_functions import find_trainer_rank
 from ..functions.badges_functions import get_achieved_badges
-from aqt.utils import showWarning, showInfo
+from aqt.utils import showWarning
 import math
 import json
 from .ankimon_leaderboard import (

--- a/src/Ankimon/pyobj/trainer_card.py
+++ b/src/Ankimon/pyobj/trainer_card.py
@@ -105,11 +105,12 @@ class TrainerCard:
             # Find the Pokémon with the highest level and return its name
             highest_pokemon = max(pokemon_data, key=lambda p: p.get("level", 0))
             return f"{highest_pokemon.get('name', 'None')} (Level {highest_pokemon.get('level', 0)})"
-        except FileNotFoundError:
-            showInfo(f"File not found: {mypokemon_path}")
-            return "None"
-        except json.JSONDecodeError:
-            showInfo(f"Error decoding JSON from file: {mypokemon_path}")
+        except (FileNotFoundError, json.JSONDecodeError):
+            # Missing / malformed mypokemon.json is expected on first run and
+            # also in integrity tests. Surface it via the logger instead of a
+            # modal so the constructor stays importable without an Anki UI.
+            if getattr(self, "logger", None) is not None:
+                self.logger.log("debug", f"Could not read {mypokemon_path}")
             return "None"
 
     def highest_pokemon_level(self):
@@ -125,11 +126,9 @@ class TrainerCard:
             # Find the Pokémon with the highest level and return its name
             highest_pokemon = max(pokemon_data, key=lambda p: p.get("level", 0))
             return int(highest_pokemon.get("level", 0))
-        except FileNotFoundError:
-            showInfo(f"File not found: {mypokemon_path}")
-            return 0
-        except json.JSONDecodeError:
-            showInfo(f"Error decoding JSON from file: {mypokemon_path}")
+        except (FileNotFoundError, json.JSONDecodeError):
+            if getattr(self, "logger", None) is not None:
+                self.logger.log("debug", f"Could not read {mypokemon_path}")
             return 0
 
     def add_achievement(self, achievement):

--- a/tests/test_addon_integrity.py
+++ b/tests/test_addon_integrity.py
@@ -28,8 +28,19 @@ def test_ankimon_initialization(qapp):
     `qapp` is a pytest-qt fixture that provides a QApplication instance, allowing
     real PyQt6 widgets to be instantiated without crashing.
     """
-    import aqt
     from PyQt6.QtWidgets import QMainWindow
+
+    # Other tests (e.g. test_encounter_functions) may install MagicMock stubs
+    # for aqt and Ankimon packages in sys.modules.  conftest.py also installs
+    # lightweight stubs for Ankimon and Ankimon.functions.
+    # This test needs the *real* packages, so purge all stubs first.
+    for _stub in [k for k in list(sys.modules) if k.startswith("Ankimon")]:
+        del sys.modules[_stub]
+    for _aqt_key in [k for k in list(sys.modules) if k.startswith("aqt")]:
+        if isinstance(sys.modules[_aqt_key], MagicMock):
+            del sys.modules[_aqt_key]
+    import aqt
+    import aqt.qt
 
     # Instead of a MagicMock which Qt rejects for parent classes, use a real QWidget
     # as the mock main window.
@@ -40,6 +51,15 @@ def test_ankimon_initialization(qapp):
             self.pm.name = "test_profile"
             self.form = MagicMock()
             self.addonManager = MagicMock()
+            # settings_obj is accessed at import time by modules like
+            # gui_classes/overview_team.py. Return False for all settings
+            # so hook-registration code paths short-circuit.
+            self.settings_obj = MagicMock()
+            self.settings_obj.get = MagicMock(return_value=False)
+            # col is accessed by ankimon_tracker.get_total_reviews() which
+            # calls re.search on mw.col.studied_today() — needs a string.
+            self.col = MagicMock()
+            self.col.studied_today.return_value = "Studied 0 cards today"
 
         def _increase_background_ops(self):
             pass
@@ -82,14 +102,6 @@ def test_ankimon_initialization(qapp):
             except Exception as e:
                 error_msg = f"Failed to dynamically import module {modname}:\n{traceback.format_exc()}"
                 errors.append(error_msg)
-
-    # Ignore the known bug in __init__.py until it is fixed in a separate PR
-    errors = [
-        e
-        for e in errors
-        if "module 'Ankimon.gui_classes.overview_team' has no attribute 'init_hooks'"
-        not in e
-    ]
 
     if errors:
         error_text = "\n".join(errors)

--- a/tests/test_cp_formula.py
+++ b/tests/test_cp_formula.py
@@ -1,0 +1,160 @@
+"""Unit tests for the CP formula and related business functions."""
+import sys
+import types
+from pathlib import Path
+
+# Stub Ankimon packages so we can import business.py without triggering __init__.py
+_src = Path(__file__).parent.parent / "src"
+for _pkg in ("Ankimon", "Ankimon.functions", "Ankimon.pyobj"):
+    if _pkg not in sys.modules:
+        _mod = types.ModuleType(_pkg)
+        _mod.__path__ = [str(_src / _pkg.replace(".", "/"))]
+        _mod.__package__ = _pkg
+        sys.modules[_pkg] = _mod
+
+# Stub modules that business.py imports at module level, but give
+# resources the real effectiveness_chart_file_path so type chart tests work.
+from unittest.mock import MagicMock
+
+_resources_mock = MagicMock()
+_resources_mock.effectiveness_chart_file_path = (
+    _src / "Ankimon" / "addon_files" / "eff_chart.json"
+)
+for _dep in ("Ankimon.resources", "Ankimon.const"):
+    if _dep not in sys.modules:
+        sys.modules[_dep] = (
+            _resources_mock if _dep == "Ankimon.resources" else MagicMock()
+        )
+
+# Now import the functions under test
+from Ankimon.business import (
+    calculate_cpm,
+    calculate_pokemon_go_cp,
+    calculate_present_power,
+    pokemon_go_raw_stats,
+    type_compatibility_multiplier,
+    _load_type_chart,
+)
+
+
+class TestCalculateCPM:
+    def test_level_1_is_small(self):
+        cpm = calculate_cpm(1)
+        assert 0 < cpm < 0.1
+
+    def test_level_100_near_cap(self):
+        cpm = calculate_cpm(100)
+        assert 0.8 < cpm <= 0.84
+
+    def test_monotonically_increasing(self):
+        values = [calculate_cpm(lv) for lv in range(1, 101)]
+        for a, b in zip(values, values[1:]):
+            assert b > a
+
+    def test_level_0_treated_as_1(self):
+        assert calculate_cpm(0) == calculate_cpm(1)
+
+
+class TestPokemonGoRawStats:
+    def test_basic(self):
+        base = {"hp": 50, "atk": 80, "def": 60, "spa": 100, "spd": 70, "spe": 90}
+        iv = {"hp": 10, "atk": 15, "def": 10, "spa": 15, "spd": 10, "spe": 15}
+        ev = {"hp": 0, "atk": 0, "def": 0, "spa": 0, "spd": 0, "spe": 0}
+        attack, defense, stamina = pokemon_go_raw_stats(base, iv, ev)
+        # attack = ((80+15) + (100+15)) / 2 = 105
+        assert attack == 105.0
+        # defense = ((60+10) + (70+10)) / 2 = 75
+        assert defense == 75.0
+        # stamina = 50 + 10 = 60
+        assert stamina == 60
+
+    def test_ev_contribution(self):
+        base = {"hp": 50, "atk": 80, "def": 60, "spa": 100, "spd": 70, "spe": 90}
+        iv = {"hp": 0, "atk": 0, "def": 0, "spa": 0, "spd": 0, "spe": 0}
+        ev = {"hp": 252, "atk": 252, "def": 0, "spa": 0, "spd": 0, "spe": 0}
+        attack, defense, stamina = pokemon_go_raw_stats(base, iv, ev)
+        # EV/4: atk gets 63, hp gets 63
+        assert attack == (80 + 63 + 100) / 2  # 121.5
+        assert stamina == 50 + 63  # 113
+
+    def test_missing_keys_default_to_1_and_0(self):
+        attack, defense, stamina = pokemon_go_raw_stats({}, {}, {})
+        # base defaults to 1, iv/ev to 0 → raw = 1 each
+        assert attack == 1.0
+        assert defense == 1.0
+        assert stamina == 1
+
+
+class TestCalculatePokemonGoCP:
+    def test_minimum_clamp(self):
+        # Very low stats should clamp to 10
+        cp = calculate_pokemon_go_cp(1, 1, 1, 1)
+        assert cp == 10
+
+    def test_reasonable_mid_level(self):
+        # Moderate stats at level 50 should give a sensible number
+        cp = calculate_pokemon_go_cp(100, 80, 70, 50)
+        assert cp > 10
+        assert cp < 10000
+
+    def test_higher_level_gives_higher_cp(self):
+        cp_low = calculate_pokemon_go_cp(100, 80, 70, 10)
+        cp_high = calculate_pokemon_go_cp(100, 80, 70, 50)
+        assert cp_high > cp_low
+
+    def test_higher_attack_gives_higher_cp(self):
+        cp_weak = calculate_pokemon_go_cp(50, 80, 70, 50)
+        cp_strong = calculate_pokemon_go_cp(150, 80, 70, 50)
+        assert cp_strong > cp_weak
+
+    def test_low_level_pokemon_not_all_same(self):
+        # With raw stats, even level-5 Pokemon should differentiate
+        cp_weak = calculate_pokemon_go_cp(30, 30, 30, 5)
+        cp_strong = calculate_pokemon_go_cp(120, 100, 100, 5)
+        assert cp_strong > cp_weak
+
+
+class TestTypeCompatibilityMultiplier:
+    def test_neutral_matchup(self):
+        assert type_compatibility_multiplier("Normal", "Normal") == 1.0
+
+    def test_super_effective(self):
+        assert type_compatibility_multiplier("Fire", "Grass") == 1.5
+
+    def test_not_very_effective(self):
+        assert type_compatibility_multiplier("Grass", "Fire") == 0.8
+
+    def test_immunity_returns_low(self):
+        # Ghost vs Normal is immune (0x) → should return 0.2, not 0.8
+        mult = type_compatibility_multiplier("Normal", "Ghost")
+        assert mult == 0.2
+
+    def test_unknown_types_return_neutral(self):
+        assert type_compatibility_multiplier("FakeType", "Water") == 1.0
+
+    def test_empty_types_return_neutral(self):
+        assert type_compatibility_multiplier([], ["Fire"]) == 1.0
+        assert type_compatibility_multiplier(None, None) == 1.0
+
+    def test_accepts_list_of_types(self):
+        # Fire/Flying vs Grass — at least one pair is super-effective
+        mult = type_compatibility_multiplier(["Fire", "Flying"], ["Grass"])
+        assert mult == 1.5
+
+
+class TestCalculatePresentPower:
+    def test_basic(self):
+        pp = calculate_present_power(100, 50, 1.0)
+        assert pp == 5000
+
+    def test_with_multiplier(self):
+        pp = calculate_present_power(100, 50, 1.5)
+        assert pp == 7500
+
+    def test_zero_hp(self):
+        pp = calculate_present_power(100, 0, 1.5)
+        assert pp == 0
+
+    def test_none_values(self):
+        pp = calculate_present_power(None, None, None)
+        assert pp == 0

--- a/tests/test_cp_formula.py
+++ b/tests/test_cp_formula.py
@@ -33,6 +33,7 @@ from Ankimon.business import (
     calculate_present_power,
     pokemon_go_raw_stats,
     type_compatibility_multiplier,
+    calculate_cp_from_dict,
     _load_type_chart,
 )
 
@@ -158,3 +159,52 @@ class TestCalculatePresentPower:
     def test_none_values(self):
         pp = calculate_present_power(None, None, None)
         assert pp == 0
+
+
+class TestCalculateCPFromDict:
+    """Tests for the dict-based CP entry point used by collection/PC box."""
+
+    BASE = {"hp": 35, "atk": 55, "def": 40, "spa": 50, "spd": 50, "spe": 90}
+
+    def test_with_base_stats_key(self):
+        pokemon = {
+            "base_stats": self.BASE,
+            "stats": {k: v * 3 for k, v in self.BASE.items()},  # inflated
+            "level": 50,
+            "iv": {"hp": 15, "atk": 15, "def": 15, "spa": 15, "spd": 15, "spe": 15},
+            "ev": {},
+        }
+        cp = calculate_cp_from_dict(pokemon)
+        # Should use base_stats, not the inflated stats
+        expected = calculate_pokemon_go_cp(
+            *pokemon_go_raw_stats(self.BASE, pokemon["iv"], {}), 50
+        )
+        assert cp == expected
+
+    def test_falls_back_to_stats_key(self):
+        pokemon = {
+            "stats": self.BASE,
+            "level": 25,
+            "iv": {"hp": 0, "atk": 0, "def": 0, "spa": 0, "spd": 0, "spe": 0},
+            "ev": {},
+        }
+        cp = calculate_cp_from_dict(pokemon)
+        expected = calculate_pokemon_go_cp(
+            *pokemon_go_raw_stats(self.BASE, pokemon["iv"], {}), 25
+        )
+        assert cp == expected
+
+    def test_missing_iv_ev_default_to_empty(self):
+        pokemon = {"base_stats": self.BASE, "level": 10}
+        cp = calculate_cp_from_dict(pokemon)
+        assert cp >= 10  # minimum clamp
+
+    def test_none_iv_ev_coerced(self):
+        pokemon = {"base_stats": self.BASE, "level": 10, "iv": None, "ev": None}
+        cp = calculate_cp_from_dict(pokemon)
+        assert cp >= 10
+
+    def test_empty_stats_returns_minimum(self):
+        pokemon = {"stats": {}, "level": 1}
+        cp = calculate_cp_from_dict(pokemon)
+        assert cp == 10  # minimum clamp with all defaults

--- a/tests/test_cp_formula.py
+++ b/tests/test_cp_formula.py
@@ -34,6 +34,7 @@ from Ankimon.business import (
     pokemon_go_raw_stats,
     type_compatibility_multiplier,
     calculate_cp_from_dict,
+    cp_breakdown_tooltip,
     _load_type_chart,
 )
 
@@ -160,6 +161,25 @@ class TestCalculatePresentPower:
         pp = calculate_present_power(None, None, None)
         assert pp == 0
 
+    def test_atk_boost_increases_bp(self):
+        # +2 stage = 5/3, BP = 100 × 50 × 1 × 5/3 = 8333.33 → floor 8333
+        assert calculate_present_power(100, 50, 1.0, atk_stage=2, spa_stage=2) == 8333
+
+    def test_atk_drop_decreases_bp(self):
+        # -2 stage = 3/5 = 0.6, BP = 100 × 50 × 1 × 0.6 = 3000
+        assert calculate_present_power(100, 50, 1.0, atk_stage=-2, spa_stage=-2) == 3000
+
+    def test_mixed_atk_spa_stages_averaged(self):
+        # atk +2 (5/3), spa -2 (3/5), avg = 17/15, BP = 5000 × 17/15 = 5666.66 → floor 5666
+        assert calculate_present_power(100, 50, 1.0, atk_stage=2, spa_stage=-2) == 5666
+
+    def test_out_of_range_stage_neutral(self):
+        # Stage 7 is invalid per get_multiplier_stats — should fall back to 1.0
+        assert calculate_present_power(100, 50, 1.0, atk_stage=7, spa_stage=7) == 5000
+
+    def test_none_stage_neutral(self):
+        assert calculate_present_power(100, 50, 1.0, atk_stage=None, spa_stage=None) == 5000
+
 
 class TestCalculateCPFromDict:
     """Tests for the dict-based CP entry point used by collection/PC box."""
@@ -208,3 +228,77 @@ class TestCalculateCPFromDict:
         pokemon = {"stats": {}, "level": 1}
         cp = calculate_cp_from_dict(pokemon)
         assert cp == 10  # minimum clamp with all defaults
+
+
+class TestDictShapeEquivalence:
+    """Sentinel: caught-Pokemon dicts ('stats' = base_stats, no 'base_stats')
+    and to_dict dicts ('base_stats' = bases, 'stats' = level-scaled) must
+    produce the same CP. Regression guard for the pokemon-persistence fix
+    that routed save_caught_pokemon through PokemonObject.to_dict().
+    """
+
+    BASE = {"hp": 100, "atk": 80, "def": 90, "spa": 70, "spd": 85, "spe": 95}
+    LEVEL = 50
+    IV = {"hp": 20, "atk": 25, "def": 30, "spa": 15, "spd": 28, "spe": 31}
+    EV = {"hp": 100, "atk": 200, "def": 150, "spa": 80, "spd": 100, "spe": 80}
+
+    def _caught_shape(self):
+        return {
+            "level": self.LEVEL,
+            "stats": self.BASE,
+            "iv": self.IV,
+            "ev": self.EV,
+        }
+
+    def _to_dict_shape(self):
+        return {
+            "level": self.LEVEL,
+            "base_stats": self.BASE,
+            "stats": {k: 999 for k in self.BASE},
+            "iv": self.IV,
+            "ev": self.EV,
+            "cp": 42,
+            "nature": "adamant",
+        }
+
+    def test_both_shapes_give_same_cp(self):
+        assert calculate_cp_from_dict(self._caught_shape()) == calculate_cp_from_dict(
+            self._to_dict_shape()
+        )
+
+    def test_to_dict_shape_ignores_level_scaled_stats(self):
+        direct = calculate_pokemon_go_cp(
+            *pokemon_go_raw_stats(self.BASE, self.IV, self.EV), self.LEVEL
+        )
+        assert calculate_cp_from_dict(self._to_dict_shape()) == direct
+
+
+class TestCPBreakdownTooltip:
+    BASE = {"hp": 100, "atk": 80, "def": 90, "spa": 70, "spd": 85, "spe": 95}
+
+    def test_contains_formula(self):
+        tip = cp_breakdown_tooltip(
+            {"base_stats": self.BASE, "iv": {}, "ev": {}, "level": 50}
+        )
+        assert "CP = floor(" in tip
+        assert "CPM²" in tip or "CPM^2" in tip or "CPM" in tip
+
+    def test_contains_level_100_projection(self):
+        tip = cp_breakdown_tooltip(
+            {"base_stats": self.BASE, "iv": {}, "ev": {}, "level": 50}
+        )
+        expected_max = calculate_pokemon_go_cp(
+            *pokemon_go_raw_stats(self.BASE, {}, {}), 100
+        )
+        assert f"{expected_max:,}" in tip
+
+    def test_handles_caught_shape(self):
+        # caught dicts have "stats"=base_stats, no "base_stats"
+        tip = cp_breakdown_tooltip(
+            {"stats": self.BASE, "iv": {}, "ev": {}, "level": 25}
+        )
+        assert "CP at Level 100" in tip
+
+    def test_handles_missing_level(self):
+        tip = cp_breakdown_tooltip({"base_stats": self.BASE})
+        assert "CP at Level 100" in tip


### PR DESCRIPTION
## Summary

Closes #324

Implements a **Combat Power (CP)** system using the Pokemon GO formula, plus a **Battle Power (BP)** stat that factors in HP and type matchups. Also fixes several bugs found during development.

### CP Formula
```
CP = floor(Attack × √Defense × √Stamina × CPM² / 10)
```
- **Attack/Defense** average physical and special stats to adapt the 6-stat model to Pokemon GO's 3-stat model
- Uses **raw stats** (base + IV + EV/4) so CPM is the sole level multiplier — no double-counting
- **CPM** = `0.84 × (1 - e^(-level/20))` — exponential curve that saturates near Pokemon GO's ~0.84 cap

### Battle Power (BP)
```
BP = CP × current_HP × type_compatibility_multiplier
```
- Type matchup multipliers: **1.5** (super-effective), **1.0** (neutral), **0.8** (not very effective), **0.2** (immune)
- Displayed in the battle scene alongside CP for both Pokemon

### What changed
- **Collection Dialog**: CP shown on every Pokemon card, sort dropdown with Capture Order / ID / CP / Level / Name
- **PC Box**: CP sort with descending toggle, CP in details panel
- **Battle scene**: CP and BP displayed under both Pokemon with comma-formatted numbers
- **Formula**: `pokemon_go_raw_stats()` centralizes the stat averaging, `calculate_pokemon_go_cp()` implements the formula
- **23 new unit tests** for CPM, CP formula, raw stats, type compatibility, and present power
- **Bug fixes**: empty filtered list sentinel, nature threading to details panel, integrity test robustness

### Reviewer feedback addressed
All inline comments from Copilot and Gemini have been addressed:
- ✅ Nature no longer hardcoded as "serious" — uses `pokemon_dict.get("nature", "serious")`
- ✅ Nature included in `to_dict()` output
- ✅ Stored CP used with recalculation fallback for sort performance
- ✅ `current_page` reset before `refresh_collection()`
- ✅ Case-insensitive nickname search

## Test plan
- [ ] Open Collection Dialog — each Pokemon card shows a "CP: xxx" label
- [ ] Use the sort dropdown to sort by CP — strongest Pokemon appear first
- [ ] Open PC Box — click "CP" radio button to sort by CP
- [ ] Click a Pokemon in PC Box — CP shows in the details panel
- [ ] Verify descending toggle works with CP sort in PC Box
- [ ] Start a battle — CP and BP display under both Pokemon
- [ ] Fight a type-advantaged matchup — BP should show higher multiplier
- [ ] Check that old Pokemon (caught before this update) still display CP correctly

🤖 Generated with [Claude Code](https://claude.ai/claude-code)