### PR TITLE
Fix de-evolution data corruption in PC box logic

### DIFF
--- a/src/Ankimon/pyobj/collection_dialog.py
+++ b/src/Ankimon/pyobj/collection_dialog.py
@@ -760,27 +760,41 @@ def MainPokemon(
     migrate_starter_individual_id()
     # --- Save the existing mainpokemon to mypokemon before replacing ---
     try:
-        # Load the current mainpokemon
-        with open(mainpokemon_path, "r", encoding="utf-8") as f:
-            current_main_list = json.load(f)
-        if current_main_list:
-            current_main = current_main_list[0]
-            # Load mypokemon
-            with open(mypokemon_path, "r", encoding="utf-8") as f:
-                mypokemondata = json.load(f)
-            # Update or append the current mainpokemon in mypokemon
-            found = False
-            for idx, pkmn in enumerate(mypokemondata):
-                if pkmn.get("individual_id") == current_main.get("individual_id"):
-                    mypokemondata[idx] = current_main
-                    found = True
-                    break
-            if not found:
-                mypokemondata.append(current_main)
-            with open(mypokemon_path, "w", encoding="utf-8") as f:
-                json.dump(mypokemondata, f, indent=2)
-    except Exception:
-        pass  # If files don't exist, just continue
+        # Load mypokemon
+        with open(mypokemon_path, "r", encoding="utf-8") as f:
+            mypokemondata = json.load(f)
+
+        # The outgoing active Pokémon is currently in memory as `main_pokemon`.
+        # We update its dynamic progress in mypokemon.json without overwriting
+        # static attributes (like name and id) which might be stale in mainpokemon.json.
+        outgoing_id = main_pokemon.individual_id
+
+        found = False
+        for idx, pkmn in enumerate(mypokemondata):
+            if pkmn.get("individual_id") == outgoing_id:
+                # Update only the dynamic attributes to preserve any evolutions
+                # that were saved to mypokemon.json but not properly synced to main_pokemon.
+                pkmn["level"] = main_pokemon.level
+                pkmn["xp"] = main_pokemon.xp
+                pkmn["current_hp"] = main_pokemon.hp
+                pkmn["ev"] = main_pokemon.ev
+                pkmn["iv"] = main_pokemon.iv
+                pkmn["attacks"] = main_pokemon.attacks
+                pkmn["friendship"] = main_pokemon.friendship
+                pkmn["pokemon_defeated"] = main_pokemon.pokemon_defeated
+                pkmn["held_item"] = main_pokemon.held_item
+
+                found = True
+                break
+
+        if not found:
+            # If it wasn't in mypokemon.json for some reason, append it entirely
+            mypokemondata.append(main_pokemon.to_dict() if hasattr(main_pokemon, "to_dict") else main_pokemon.__dict__)
+
+        with open(mypokemon_path, "w", encoding="utf-8") as f:
+            json.dump(mypokemondata, f, indent=2)
+    except Exception as e:
+        logger.log("error", f"Error saving outgoing main pokemon: {e}")
 
     # --- Now proceed to set the new mainpokemon as before ---
     pokemon_id = pokemon_data.get("id")

--- a/tests/test_deevolution.py
+++ b/tests/test_deevolution.py
@@ -1,0 +1,192 @@
+import pytest
+import json
+import uuid
+import os
+import sys
+
+from unittest.mock import patch, MagicMock
+
+# Create a mock for Anki/AQT to avoid complex imports
+class MockPackage(MagicMock):
+    __path__ = []
+
+mock_aqt = MockPackage()
+mock_aqt.__spec__ = MagicMock()
+mock_anki = MockPackage()
+mock_anki.__spec__ = MagicMock()
+sys.modules['aqt'] = mock_aqt
+sys.modules['aqt.operations'] = MagicMock()
+sys.modules['aqt.operations.QueryOp'] = MagicMock()
+sys.modules['aqt.reviewer'] = MagicMock()
+sys.modules['aqt.main'] = MagicMock()
+sys.modules['aqt.theme'] = MagicMock()
+sys.modules['aqt.webview'] = MagicMock()
+sys.modules['aqt.editor'] = MagicMock()
+sys.modules['aqt.gui_hooks'] = MagicMock()
+sys.modules['anki'] = mock_anki
+sys.modules['anki.hooks'] = MagicMock()
+sys.modules['anki.cards'] = MagicMock()
+sys.modules['anki.collection'] = MagicMock()
+sys.modules['anki.utils'] = MagicMock()
+sys.modules['anki.decks'] = MagicMock()
+sys.modules['anki.buildinfo'] = MagicMock()
+sys.modules['anki.buildinfo.version'] = "24.04"
+sys.modules['aqt.qt'] = MagicMock()
+sys.modules['aqt.utils'] = MagicMock()
+sys.modules['PyQt6'] = MockPackage()
+sys.modules['PyQt6'].__spec__ = MagicMock()
+sys.modules['PyQt6.QtCore'] = MagicMock()
+class MockQDialog:
+    pass
+
+class MockQtWidgets(MagicMock):
+    QDialog = MockQDialog
+    QWidget = MockQDialog
+    QMainWindow = MockQDialog
+
+# To make 'from PyQt6.QtWidgets import QDialog' work
+mock_qtwidgets = MockQtWidgets()
+mock_qtwidgets.QDialog = MockQDialog
+sys.modules['PyQt6.QtWidgets'] = mock_qtwidgets
+sys.modules['PyQt6.QtGui'] = MagicMock()
+sys.modules['PyQt6.QtMultimedia'] = MagicMock()
+sys.modules['PyQt6.QtWebEngineCore'] = MagicMock()
+sys.modules['PyQt6.QtWebEngineWidgets'] = MagicMock()
+sys.modules['PyQt6.QtWebChannel'] = MagicMock()
+sys.modules['PyQt6.QtNetwork'] = MagicMock()
+sys.modules['markdown'] = MagicMock()
+sys.modules['requests'] = MagicMock()
+
+# Mock out complex singletons before they load
+sys.modules['src.Ankimon.singletons'] = MagicMock()
+
+# Now we can safely import Ankimon objects
+import importlib.util
+
+# Stop triggering complex __init__.py stuff from src/Ankimon/__init__.py
+# We can bypass __init__.py by directly importing from the file.
+import importlib.util
+
+# Use normal import, but mock the __init__ correctly.
+import sys
+mock_pkg = MockPackage()
+mock_pkg.__path__ = ['src/Ankimon']
+mock_pkg.__spec__ = MagicMock()
+sys.modules['src.Ankimon'] = mock_pkg
+
+import src.Ankimon
+from src.Ankimon.pyobj.pokemon_obj import PokemonObject
+
+
+@pytest.fixture
+def mock_paths(tmp_path):
+    main_path = tmp_path / "mainpokemon.json"
+    my_path = tmp_path / "mypokemon.json"
+
+    with patch('src.Ankimon.pyobj.collection_dialog.mainpokemon_path', main_path), \
+         patch('src.Ankimon.pyobj.collection_dialog.mypokemon_path', my_path), \
+         patch('src.Ankimon.pyobj.pokemon_obj.mypokemon_path', my_path), \
+         patch('src.Ankimon.pyobj.pokemon_obj.mainpokemon_path', main_path), \
+         patch('src.Ankimon.resources.mypokemon_path', my_path), \
+         patch('src.Ankimon.resources.mainpokemon_path', main_path):
+        yield main_path, my_path
+
+def test_pick_main_pokemon_does_not_deevolve(mock_paths):
+    main_path, my_path = mock_paths
+
+    # 1. Setup the scenario
+    # An evolved Pokemon (Golduck) is in mypokemon.json
+    # But the stale active data in mainpokemon.json (and in-memory main_pokemon) is still Psyduck.
+
+    ind_id_1 = str(uuid.uuid4())
+    ind_id_2 = str(uuid.uuid4())
+
+    # mypokemon.json has the correct evolved data
+    mypokemon_data = [
+        {
+            "id": 55,
+            "name": "Golduck",
+            "level": 34,
+            "individual_id": ind_id_1,
+            "attacks": ["Water Gun", "Confusion"],
+            "base_stats": {"hp": 80, "atk": 82, "def": 78, "spa": 95, "spd": 80, "spe": 85},
+            "xp": 1000,
+            "ev": {"hp": 0, "atk": 0, "def": 0, "spa": 0, "spd": 0, "spe": 0},
+            "iv": {"hp": 0, "atk": 0, "def": 0, "spa": 0, "spd": 0, "spe": 0}
+        },
+        {
+            "id": 1,
+            "name": "Bulbasaur",
+            "level": 5,
+            "individual_id": ind_id_2,
+            "attacks": ["Tackle"],
+            "base_stats": {"hp": 45, "atk": 49, "def": 49, "spa": 65, "spd": 65, "spe": 45},
+            "ev": {"hp": 0, "atk": 0, "def": 0, "spa": 0, "spd": 0, "spe": 0},
+            "iv": {"hp": 0, "atk": 0, "def": 0, "spa": 0, "spd": 0, "spe": 0}
+        }
+    ]
+
+    with open(my_path, "w") as f:
+        json.dump(mypokemon_data, f)
+
+    # stale main_pokemon in memory (still Psyduck)
+    stale_main_pokemon = PokemonObject(
+        id=54,
+        name="Psyduck",
+        level=34,
+        ability=["Damp"],
+        type=["Water"],
+        base_stats={"hp": 50, "atk": 52, "def": 48, "spa": 65, "spd": 50, "spe": 55},
+        individual_id=ind_id_1,
+        attacks=["Water Gun", "Confusion"],
+        xp=1050,  # Note: XP has increased slightly since evolution
+        hp=50,
+        gender="M",
+        shiny=False,
+        tier="Normal",
+        growth_rate="medium",
+        captured_date="2024-01-01"
+    )
+
+    # We want to pick Bulbasaur as the new main Pokemon
+    new_pokemon_data = mypokemon_data[1]
+
+    # Mock the required dependencies for MainPokemon
+    logger = MagicMock()
+    translator = MagicMock()
+    reviewer_obj = MagicMock()
+    test_window = MagicMock()
+
+    # Patch external calls inside MainPokemon
+    with patch('src.Ankimon.pyobj.collection_dialog.search_pokedex_by_id', return_value="Bulbasaur"), \
+         patch('src.Ankimon.pyobj.collection_dialog.search_pokedex', return_value={"hp": 45, "atk": 49, "def": 49, "spa": 65, "spd": 65, "spe": 45}), \
+         patch('src.Ankimon.pyobj.collection_dialog.PokemonObject.calc_stat', return_value=20), \
+         patch('src.Ankimon.pyobj.collection_dialog.uuid.uuid4', return_value=uuid.uuid4()), \
+         patch('src.Ankimon.functions.migration.migrate_starter_individual_id'), \
+         patch('src.Ankimon.singletons.pokemon_pc'):
+
+        from src.Ankimon.pyobj.collection_dialog import MainPokemon
+
+        # Execute the function
+        MainPokemon(
+            pokemon_data=new_pokemon_data,
+            main_pokemon=stale_main_pokemon,
+            logger=logger,
+            translator=translator,
+            reviewer_obj=reviewer_obj,
+            test_window=test_window
+        )
+
+    # Verify the results
+    with open(my_path, "r") as f:
+        updated_mypokemon = json.load(f)
+
+    # Find our first Pokemon (which was Golduck)
+    first_pokemon = next((p for p in updated_mypokemon if p["individual_id"] == ind_id_1), None)
+
+    assert first_pokemon is not None
+    # Crucial assertion: The Pokemon should still be Golduck, NOT Psyduck
+    assert first_pokemon["name"] == "Golduck"
+    assert first_pokemon["id"] == 55
+    # The progress (XP) should have been updated from the stale memory object
+    assert first_pokemon["xp"] == 1050

--- a/tests/test_deevolution.py
+++ b/tests/test_deevolution.py
@@ -1,81 +1,108 @@
 import pytest
 import json
 import uuid
-import os
 import sys
+from pathlib import Path
+import importlib.util
 
+import unittest.mock as mock
 from unittest.mock import patch, MagicMock
 
-# Create a mock for Anki/AQT to avoid complex imports
-class MockPackage(MagicMock):
-    __path__ = []
+_src = Path(__file__).parent.parent / "src"
 
-mock_aqt = MockPackage()
-mock_aqt.__spec__ = MagicMock()
-mock_anki = MockPackage()
-mock_anki.__spec__ = MagicMock()
-sys.modules['aqt'] = mock_aqt
-sys.modules['aqt.operations'] = MagicMock()
-sys.modules['aqt.operations.QueryOp'] = MagicMock()
-sys.modules['aqt.reviewer'] = MagicMock()
-sys.modules['aqt.main'] = MagicMock()
-sys.modules['aqt.theme'] = MagicMock()
-sys.modules['aqt.webview'] = MagicMock()
-sys.modules['aqt.editor'] = MagicMock()
-sys.modules['aqt.gui_hooks'] = MagicMock()
-sys.modules['anki'] = mock_anki
-sys.modules['anki.hooks'] = MagicMock()
-sys.modules['anki.cards'] = MagicMock()
-sys.modules['anki.collection'] = MagicMock()
-sys.modules['anki.utils'] = MagicMock()
-sys.modules['anki.decks'] = MagicMock()
-sys.modules['anki.buildinfo'] = MagicMock()
-sys.modules['anki.buildinfo.version'] = "24.04"
-sys.modules['aqt.qt'] = MagicMock()
-sys.modules['aqt.utils'] = MagicMock()
-sys.modules['PyQt6'] = MockPackage()
-sys.modules['PyQt6'].__spec__ = MagicMock()
-sys.modules['PyQt6.QtCore'] = MagicMock()
-class MockQDialog:
-    pass
+@pytest.fixture(autouse=True)
+def patch_sys_modules():
+    original_modules = dict(sys.modules)
 
-class MockQtWidgets(MagicMock):
-    QDialog = MockQDialog
-    QWidget = MockQDialog
-    QMainWindow = MockQDialog
+    # Mock necessary modules
+    sys.modules["aqt"] = mock.MagicMock()
+    sys.modules["aqt.qt"] = mock.MagicMock()
+    sys.modules["aqt.utils"] = mock.MagicMock()
 
-# To make 'from PyQt6.QtWidgets import QDialog' work
-mock_qtwidgets = MockQtWidgets()
-mock_qtwidgets.QDialog = MockQDialog
-sys.modules['PyQt6.QtWidgets'] = mock_qtwidgets
-sys.modules['PyQt6.QtGui'] = MagicMock()
-sys.modules['PyQt6.QtMultimedia'] = MagicMock()
-sys.modules['PyQt6.QtWebEngineCore'] = MagicMock()
-sys.modules['PyQt6.QtWebEngineWidgets'] = MagicMock()
-sys.modules['PyQt6.QtWebChannel'] = MagicMock()
-sys.modules['PyQt6.QtNetwork'] = MagicMock()
-sys.modules['markdown'] = MagicMock()
-sys.modules['requests'] = MagicMock()
+    for module in [
+        "Ankimon.pyobj",
+        "Ankimon.pyobj.settings",
+        "Ankimon.pyobj.pokemon_obj",
+        "Ankimon.pyobj.reviewer_obj",
+        "Ankimon.pyobj.test_window",
+        "Ankimon.pyobj.trainer_card",
+        "Ankimon.pyobj.InfoLogger",
+        "Ankimon.pyobj.evolution_window",
+        "Ankimon.pyobj.attack_dialog",
+        "Ankimon.pyobj.translator",
+        "Ankimon.pyobj.error_handler",
+        "Ankimon.functions.pokemon_functions",
+        "Ankimon.functions.pokedex_functions",
+        "Ankimon.functions.trainer_functions",
+        "Ankimon.functions.badges_functions",
+        "Ankimon.functions.drawing_utils",
+        "Ankimon.functions.migration",
+        "Ankimon.utils",
+        "Ankimon.business",
+        "Ankimon.const",
+        "Ankimon.singletons",
+        "Ankimon.resources",
+        "Ankimon.gui_classes.pokemon_details",
+        "Ankimon.gui_entities"
+    ]:
+        sys.modules[module] = mock.MagicMock()
 
-# Mock out complex singletons before they load
-sys.modules['Ankimon.singletons'] = MagicMock()
+    class MockQDialog:
+        pass
 
-# Now we can safely import Ankimon objects
-import importlib.util
+    class MockQtWidgets(mock.MagicMock):
+        QDialog = MockQDialog
+        QWidget = MockQDialog
+        QMainWindow = MockQDialog
 
-# Stop triggering complex __init__.py stuff from src/Ankimon/__init__.py
-# We can bypass __init__.py by directly importing from the file.
-import importlib.util
+    mock_qtwidgets = MockQtWidgets()
+    mock_qtwidgets.QDialog = MockQDialog
+    mock_qtwidgets.QWidget = MockQDialog
+    mock_qtwidgets.QMainWindow = MockQDialog
 
-# Use normal import, but mock the __init__ correctly.
-import sys
-mock_pkg = MockPackage()
-mock_pkg.__path__ = ['src/Ankimon']
-mock_pkg.__spec__ = MagicMock()
-sys.modules['Ankimon'] = mock_pkg
+    class MockPackage(mock.MagicMock):
+        __path__ = []
 
-import Ankimon
-from Ankimon.pyobj.pokemon_obj import PokemonObject
+    sys.modules['PyQt6'] = MockPackage()
+    sys.modules['PyQt6'].__spec__ = mock.MagicMock()
+    sys.modules['PyQt6.QtWidgets'] = mock_qtwidgets
+    sys.modules['PyQt6.QtCore'] = mock.MagicMock()
+    sys.modules['PyQt6.QtGui'] = mock.MagicMock()
+    sys.modules['PyQt6.QtMultimedia'] = mock.MagicMock()
+    sys.modules['PyQt6.QtWebEngineCore'] = mock.MagicMock()
+    sys.modules['PyQt6.QtWebEngineWidgets'] = mock.MagicMock()
+    sys.modules['PyQt6.QtWebChannel'] = mock.MagicMock()
+    sys.modules['PyQt6.QtNetwork'] = mock.MagicMock()
+
+    import PyQt6
+    import PyQt6.QtWidgets
+    PyQt6.QtWidgets.QDialog = MockQDialog
+    PyQt6.QtWidgets.QWidget = MockQDialog
+    PyQt6.QtWidgets.QMainWindow = MockQDialog
+
+    for module in [
+        "requests",
+        "Ankimon.poke_engine",
+        "Ankimon.poke_engine.objects",
+        "Ankimon.poke_engine.helpers"
+    ]:
+        sys.modules[module] = mock.MagicMock()
+
+    yield
+
+    sys.modules.clear()
+    sys.modules.update(original_modules)
+
+
+def load_pokemon_obj():
+    spec_pokemon_obj = importlib.util.spec_from_file_location(
+        "Ankimon.pyobj.pokemon_obj",
+        _src / "Ankimon" / "pyobj" / "pokemon_obj.py",
+    )
+    pokemon_obj = importlib.util.module_from_spec(spec_pokemon_obj)
+    sys.modules["Ankimon.pyobj.pokemon_obj"] = pokemon_obj
+    spec_pokemon_obj.loader.exec_module(pokemon_obj)
+    return pokemon_obj.PokemonObject
 
 
 @pytest.fixture
@@ -129,6 +156,7 @@ def test_pick_main_pokemon_does_not_deevolve(mock_paths):
     with open(my_path, "w") as f:
         json.dump(mypokemon_data, f)
 
+        PokemonObject = load_pokemon_obj()
     # stale main_pokemon in memory (still Psyduck)
     stale_main_pokemon = PokemonObject(
         id=54,
@@ -157,18 +185,27 @@ def test_pick_main_pokemon_does_not_deevolve(mock_paths):
     reviewer_obj = MagicMock()
     test_window = MagicMock()
 
-    # Patch external calls inside MainPokemon
-    with patch('Ankimon.pyobj.collection_dialog.search_pokedex_by_id', return_value="Bulbasaur"), \
-         patch('Ankimon.pyobj.collection_dialog.search_pokedex', return_value={"hp": 45, "atk": 49, "def": 49, "spa": 65, "spd": 65, "spe": 45}), \
-         patch('Ankimon.pyobj.collection_dialog.PokemonObject.calc_stat', return_value=20), \
-         patch('Ankimon.pyobj.collection_dialog.uuid.uuid4', return_value=uuid.uuid4()), \
-         patch('Ankimon.functions.migration.migrate_starter_individual_id'), \
-         patch('Ankimon.singletons.pokemon_pc'):
+    # Load collection_dialog isolated FIRST before patching it
+    spec_collection_dialog = importlib.util.spec_from_file_location(
+        "Ankimon.pyobj.collection_dialog",
+        _src / "Ankimon" / "pyobj" / "collection_dialog.py",
+    )
+    collection_dialog = importlib.util.module_from_spec(spec_collection_dialog)
+    sys.modules["Ankimon.pyobj.collection_dialog"] = collection_dialog
+    spec_collection_dialog.loader.exec_module(collection_dialog)
 
-        from Ankimon.pyobj.collection_dialog import MainPokemon
+    # Patch external calls inside MainPokemon using patch.object to avoid JSON serialization issues with mock modules
+    with patch.object(collection_dialog, 'search_pokedex_by_id', return_value="Bulbasaur"), \
+         patch.object(collection_dialog, 'search_pokedex', return_value={"hp": 45, "atk": 49, "def": 49, "spa": 65, "spd": 65, "spe": 45}), \
+         patch.object(collection_dialog.PokemonObject, 'calc_stat', return_value=20), \
+         patch.object(collection_dialog.uuid, 'uuid4', return_value=uuid.uuid4()), \
+         patch('Ankimon.functions.migration.migrate_starter_individual_id'), \
+             patch('Ankimon.singletons.pokemon_pc'), \
+             patch.object(collection_dialog, 'mainpokemon_path', main_path), \
+             patch.object(collection_dialog, 'mypokemon_path', my_path):
 
         # Execute the function
-        MainPokemon(
+        collection_dialog.MainPokemon(
             pokemon_data=new_pokemon_data,
             main_pokemon=stale_main_pokemon,
             logger=logger,

--- a/tests/test_deevolution.py
+++ b/tests/test_deevolution.py
@@ -58,7 +58,7 @@ sys.modules['markdown'] = MagicMock()
 sys.modules['requests'] = MagicMock()
 
 # Mock out complex singletons before they load
-sys.modules['src.Ankimon.singletons'] = MagicMock()
+sys.modules['Ankimon.singletons'] = MagicMock()
 
 # Now we can safely import Ankimon objects
 import importlib.util
@@ -72,10 +72,10 @@ import sys
 mock_pkg = MockPackage()
 mock_pkg.__path__ = ['src/Ankimon']
 mock_pkg.__spec__ = MagicMock()
-sys.modules['src.Ankimon'] = mock_pkg
+sys.modules['Ankimon'] = mock_pkg
 
-import src.Ankimon
-from src.Ankimon.pyobj.pokemon_obj import PokemonObject
+import Ankimon
+from Ankimon.pyobj.pokemon_obj import PokemonObject
 
 
 @pytest.fixture
@@ -83,12 +83,12 @@ def mock_paths(tmp_path):
     main_path = tmp_path / "mainpokemon.json"
     my_path = tmp_path / "mypokemon.json"
 
-    with patch('src.Ankimon.pyobj.collection_dialog.mainpokemon_path', main_path), \
-         patch('src.Ankimon.pyobj.collection_dialog.mypokemon_path', my_path), \
-         patch('src.Ankimon.pyobj.pokemon_obj.mypokemon_path', my_path), \
-         patch('src.Ankimon.pyobj.pokemon_obj.mainpokemon_path', main_path), \
-         patch('src.Ankimon.resources.mypokemon_path', my_path), \
-         patch('src.Ankimon.resources.mainpokemon_path', main_path):
+    with patch('Ankimon.pyobj.collection_dialog.mainpokemon_path', main_path), \
+         patch('Ankimon.pyobj.collection_dialog.mypokemon_path', my_path), \
+         patch('Ankimon.pyobj.pokemon_obj.mypokemon_path', my_path), \
+         patch('Ankimon.pyobj.pokemon_obj.mainpokemon_path', main_path), \
+         patch('Ankimon.resources.mypokemon_path', my_path), \
+         patch('Ankimon.resources.mainpokemon_path', main_path):
         yield main_path, my_path
 
 def test_pick_main_pokemon_does_not_deevolve(mock_paths):
@@ -158,14 +158,14 @@ def test_pick_main_pokemon_does_not_deevolve(mock_paths):
     test_window = MagicMock()
 
     # Patch external calls inside MainPokemon
-    with patch('src.Ankimon.pyobj.collection_dialog.search_pokedex_by_id', return_value="Bulbasaur"), \
-         patch('src.Ankimon.pyobj.collection_dialog.search_pokedex', return_value={"hp": 45, "atk": 49, "def": 49, "spa": 65, "spd": 65, "spe": 45}), \
-         patch('src.Ankimon.pyobj.collection_dialog.PokemonObject.calc_stat', return_value=20), \
-         patch('src.Ankimon.pyobj.collection_dialog.uuid.uuid4', return_value=uuid.uuid4()), \
-         patch('src.Ankimon.functions.migration.migrate_starter_individual_id'), \
-         patch('src.Ankimon.singletons.pokemon_pc'):
+    with patch('Ankimon.pyobj.collection_dialog.search_pokedex_by_id', return_value="Bulbasaur"), \
+         patch('Ankimon.pyobj.collection_dialog.search_pokedex', return_value={"hp": 45, "atk": 49, "def": 49, "spa": 65, "spd": 65, "spe": 45}), \
+         patch('Ankimon.pyobj.collection_dialog.PokemonObject.calc_stat', return_value=20), \
+         patch('Ankimon.pyobj.collection_dialog.uuid.uuid4', return_value=uuid.uuid4()), \
+         patch('Ankimon.functions.migration.migrate_starter_individual_id'), \
+         patch('Ankimon.singletons.pokemon_pc'):
 
-        from src.Ankimon.pyobj.collection_dialog import MainPokemon
+        from Ankimon.pyobj.collection_dialog import MainPokemon
 
         # Execute the function
         MainPokemon(

--- a/tests/test_deevolution.py
+++ b/tests/test_deevolution.py
@@ -10,16 +10,10 @@ from unittest.mock import patch, MagicMock
 
 _src = Path(__file__).parent.parent / "src"
 
-@pytest.fixture(autouse=True)
-def patch_sys_modules():
-    original_modules = dict(sys.modules)
-
-    # Mock necessary modules
-    sys.modules["aqt"] = mock.MagicMock()
-    sys.modules["aqt.qt"] = mock.MagicMock()
-    sys.modules["aqt.utils"] = mock.MagicMock()
-
-    for module in [
+def setup_mock_modules():
+    mocks = {}
+    modules_to_mock = [
+        "aqt", "aqt.qt", "aqt.utils",
         "Ankimon.pyobj",
         "Ankimon.pyobj.settings",
         "Ankimon.pyobj.pokemon_obj",
@@ -44,8 +38,11 @@ def patch_sys_modules():
         "Ankimon.resources",
         "Ankimon.gui_classes.pokemon_details",
         "Ankimon.gui_entities"
-    ]:
-        sys.modules[module] = mock.MagicMock()
+    ]
+    for module in modules_to_mock:
+        if module not in sys.modules:
+            mocks[module] = mock.MagicMock()
+            sys.modules[module] = mocks[module]
 
     class MockQDialog:
         pass
@@ -86,13 +83,22 @@ def patch_sys_modules():
         "Ankimon.poke_engine.objects",
         "Ankimon.poke_engine.helpers"
     ]:
-        sys.modules[module] = mock.MagicMock()
+        if module not in sys.modules:
+            mocks[module] = mock.MagicMock()
+            sys.modules[module] = mocks[module]
 
+    return mocks
+
+def teardown_mock_modules(mocks):
+    for module in mocks:
+        if module in sys.modules:
+            del sys.modules[module]
+
+@pytest.fixture(autouse=True)
+def patch_sys_modules():
+    mocks = setup_mock_modules()
     yield
-
-    sys.modules.clear()
-    sys.modules.update(original_modules)
-
+    teardown_mock_modules(mocks)
 
 def load_pokemon_obj():
     spec_pokemon_obj = importlib.util.spec_from_file_location(


### PR DESCRIPTION
Fixes the critical de-evolution bug reported where a Pokémon's evolution would be lost and replaced with stale active-party data from `mainpokemon.json` when returning it to the PC Box.

Instead of overwriting the full dictionary in `mypokemon.json` with the active data (which is often missing the latest evolution `id` and `name`), the logic now safely merges *only* the dynamic properties (`xp`, `level`, `hp`, etc.) from the active session into the single-source-of-truth record in `mypokemon.json`.

Adds a regression test to replicate and prevent this data flow failure in the future.

---
*PR created automatically by Jules for task [5141504812763708752](https://jules.google.com/task/5141504812763708752) started by @h0tp-ftw*