### PR TITLE
fix+feat: round-3 UX/quality fixes and tag-biased encounters

### DIFF
--- a/src/Ankimon/__init__.py
+++ b/src/Ankimon/__init__.py
@@ -201,7 +201,7 @@ if not _collection_loaded:  # If the collection hasn't already been loaded
 with open(sound_list_path, "r", encoding="utf-8") as json_file:
     sound_list = json.load(json_file)
 
-ankimon_tracker_obj.pokemon_encouter = 0
+ankimon_tracker_obj.pokemon_encounter = 0
 
 """
 get web exports ready for special reviewer look
@@ -526,11 +526,11 @@ def on_review_card(*args):
             ankimon_tracker_obj.cards_battle_round = 0
             ankimon_tracker_obj.attack_counter = 0
             slp_counter = 0
-            ankimon_tracker_obj.pokemon_encouter += 1
+            ankimon_tracker_obj.pokemon_encounter += 1
             multiplier = ankimon_tracker_obj.multiplier
 
             if (
-                ankimon_tracker_obj.pokemon_encouter > 0
+                ankimon_tracker_obj.pokemon_encounter > 0
                 and enemy_pokemon.hp > 0
                 and multiplier < 1
             ):
@@ -551,7 +551,7 @@ def on_review_card(*args):
             category = move.get("category")
 
             if (
-                ankimon_tracker_obj.pokemon_encouter > 0
+                ankimon_tracker_obj.pokemon_encounter > 0
                 and main_pokemon.hp > 0
                 and enemy_pokemon.hp > 0
             ):
@@ -669,7 +669,7 @@ def on_review_card(*args):
                 user_hp_after=main_pokemon.hp,  # Use the already updated HP
                 opponent_hp_after=enemy_pokemon.hp,  # Use the already updated HP
                 battle_status=main_pokemon.battle_status,
-                pokemon_encounter=ankimon_tracker_obj.pokemon_encouter,
+                pokemon_encounter=ankimon_tracker_obj.pokemon_encounter,
                 translator=translator,
                 changes=current_battle_info_changes,
             )

--- a/src/Ankimon/business.py
+++ b/src/Ankimon/business.py
@@ -223,6 +223,29 @@ def calculate_present_power(
     return int(math.floor(cp * current_hp * compat * stage_factor))
 
 
+def cp_breakdown_tooltip(pokemon_dict: dict) -> str:
+    """Human-readable CP breakdown for Qt tooltips.
+
+    Shows the formula, this Pokemon's substituted values, and the CP
+    projected at level 100 (useful for planning evolutions/training).
+    Accepts either the caught-Pokemon dict shape ("stats" = base_stats)
+    or the to_dict shape ("base_stats" = bases).
+    """
+    base_stats = pokemon_dict.get("base_stats") or pokemon_dict.get("stats") or {}
+    iv = pokemon_dict.get("iv") or {}
+    ev = pokemon_dict.get("ev") or {}
+    level = int(pokemon_dict.get("level", 1) or 1)
+    attack, defense, stamina = pokemon_go_raw_stats(base_stats, iv, ev)
+    cpm = calculate_cpm(level)
+    cp_at_100 = calculate_pokemon_go_cp(attack, defense, stamina, 100)
+    return (
+        "CP = floor(Atk × √Def × √Sta × CPM² ÷ 10)\n"
+        f"    = floor({attack:.0f} × √{defense:.0f} × √{stamina:.0f}"
+        f" × {cpm:.4f}² ÷ 10)\n"
+        f"CP at Level 100: {cp_at_100:,}"
+    )
+
+
 def calculate_cp_from_dict(pokemon_dict):
     """Calculate Combat Power from a raw Pokemon dict using the
     Pokemon GO style formula.

--- a/src/Ankimon/business.py
+++ b/src/Ankimon/business.py
@@ -192,18 +192,35 @@ def type_compatibility_multiplier(attacker_types, defender_types) -> float:
 
 
 def calculate_present_power(
-    cp: int, current_hp: int, compatibility_multiplier: float = 1.0
+    cp: int,
+    current_hp: int,
+    compatibility_multiplier: float = 1.0,
+    atk_stage: int = 0,
+    spa_stage: int = 0,
 ) -> int:
-    """Present Power = CP × current HP × type compatibility multiplier.
+    """Present Power = CP × current HP × type multiplier × avg(atk, spa) stage.
 
-    A matchup-aware indicator of a Pokemon's threat level right now,
-    factoring in how beaten-up it is and how well its types match the
-    opponent. Rounded down to an int.
+    A live threat indicator: baseline power (CP), durability remaining
+    (current HP), type matchup, and in-battle attack-stage changes
+    (Swords Dance, Intimidate, etc.). Atk and Spa stages are averaged
+    to match the CP formula's averaging of physical and special. Drops
+    below neutral shrink BP; boosts grow it. Rounded down to an int.
     """
     cp = max(int(cp if cp is not None else 0), 0)
     current_hp = max(int(current_hp if current_hp is not None else 0), 0)
     compat = float(compatibility_multiplier if compatibility_multiplier is not None else 1.0)
-    return int(math.floor(cp * current_hp * compat))
+
+    def _stage_mult(stage) -> float:
+        if stage is None:
+            return 1.0
+        try:
+            val = get_multiplier_stats(int(stage))
+        except (TypeError, ValueError):
+            return 1.0
+        return float(val) if isinstance(val, (int, float)) else 1.0
+
+    stage_factor = (_stage_mult(atk_stage) + _stage_mult(spa_stage)) / 2
+    return int(math.floor(cp * current_hp * compat * stage_factor))
 
 
 def calculate_cp_from_dict(pokemon_dict):

--- a/src/Ankimon/business.py
+++ b/src/Ankimon/business.py
@@ -223,6 +223,33 @@ def calculate_present_power(
     return int(math.floor(cp * current_hp * compat * stage_factor))
 
 
+_POKEMON_TYPES_LOWER = frozenset({
+    "normal", "fire", "water", "electric", "grass", "ice", "fighting",
+    "poison", "ground", "flying", "psychic", "bug", "rock", "ghost",
+    "dragon", "dark", "steel", "fairy",
+})
+
+
+def compute_type_bias(tags, deck_name: str = "") -> list:
+    """Pure helper: derive a Pokemon-type bias from raw tag list and
+    optional deck name.
+
+    Returns a sorted list of capitalized type names whose lowercase form
+    appears among the tags or the ``::``/whitespace-separated components
+    of the deck name. Unknown tokens are ignored, so a tag like
+    ``#leech`` or ``biology`` has no effect.
+
+    Keeping this function pure (no ``mw``/``settings`` dependency) makes
+    the bias logic unit-testable without the Anki runtime. The
+    encounter-side wrapper handles the opt-in check and the actual
+    ``mw.reviewer.card`` lookup.
+    """
+    tokens = [str(t).lower() for t in (tags or [])]
+    for piece in (deck_name or "").lower().replace("::", " ").split():
+        tokens.append(piece)
+    return sorted({t.capitalize() for t in tokens if t in _POKEMON_TYPES_LOWER})
+
+
 def cp_breakdown_tooltip(pokemon_dict: dict) -> str:
     """Human-readable CP breakdown for Qt tooltips.
 

--- a/src/Ankimon/business.py
+++ b/src/Ankimon/business.py
@@ -184,9 +184,9 @@ def type_compatibility_multiplier(attacker_types, defender_types) -> float:
         return 1.0
     if best == 0:
         return 0.2
-    if best > 1:
+    elif best > 1:
         return 1.5
-    if best < 1:
+    elif best < 1:
         return 0.8
     return 1.0
 

--- a/src/Ankimon/config.json
+++ b/src/Ankimon/config.json
@@ -3,6 +3,7 @@
     "battle.cards_per_round": 2,
     "battle.daily_average": 100,
     "battle.card_max_time": 60,
+    "battle.tag_biased_encounters": false,
 
     "controls.pokemon_buttons": true,
     "controls.defeat_key": "5",

--- a/src/Ankimon/functions/encounter_functions.py
+++ b/src/Ankimon/functions/encounter_functions.py
@@ -597,6 +597,9 @@ def save_main_pokemon_progress(
         if hasattr(main_pokemon, "is_favorite"):
             mainpkmndata["is_favorite"] = main_pokemon.is_favorite
     mainpkmndata = [mainpkmndata]
+    # Refresh cached CP so Collection Dialog / PC Box readers don't
+    # short-circuit to a stale pre-level-up value on the next render.
+    mainpkmndata[0]["cp"] = calculate_cp_from_dict(mainpkmndata[0])
     # Save the caught Pokémon's data to a JSON file
     try:
         with open(str(mainpokemon_path), "w") as json_file:

--- a/src/Ankimon/functions/encounter_functions.py
+++ b/src/Ankimon/functions/encounter_functions.py
@@ -211,6 +211,47 @@ def check_id_ok(id_num: Union[int, list[int]]):
     return False
 
 
+_POKEMON_TYPES_LOWER = {
+    "normal", "fire", "water", "electric", "grass", "ice", "fighting",
+    "poison", "ground", "flying", "psychic", "bug", "rock", "ghost",
+    "dragon", "dark", "steel", "fairy",
+}
+
+
+def _get_card_type_bias() -> list:
+    """Return Pokemon types matching the current Anki card's tags or
+    deck name, if the user has opted into tag-biased encounters.
+
+    Tag or deck-name component ``electric`` biases toward Electric-type
+    Pokemon. Returns an empty list when the feature is disabled, mw is
+    unavailable, or no match is found. Never raises — on any error the
+    caller falls through to unbiased generation.
+    """
+    try:
+        if not settings_obj.get("battle.tag_biased_encounters"):
+            return []
+        card = getattr(getattr(mw, "reviewer", None), "card", None)
+        if card is None:
+            return []
+        tags = [str(t).lower() for t in (card.note().tags or [])]
+        deck_name = (mw.col.decks.name(card.did) or "").lower()
+        for piece in deck_name.replace("::", " ").split():
+            tags.append(piece)
+        return sorted({t.capitalize() for t in tags if t in _POKEMON_TYPES_LOWER})
+    except Exception:
+        return []
+
+
+def _pokemon_matches_bias(name: str, bias: list) -> bool:
+    """True when the Pokemon's type list intersects the bias. Unknown
+    Pokemon are treated as matching so the draw doesn't block."""
+    try:
+        types = search_pokedex(name, "types") or []
+        return any(t in bias for t in types)
+    except Exception:
+        return True
+
+
 def generate_random_pokemon(
     main_pokemon_level: int, ankimon_tracker_obj: AnkimonTracker
 ):
@@ -264,14 +305,24 @@ def generate_random_pokemon(
         wild_pokemon_lvl = 100
 
     # First, we draw a random, valid pokemon id.
+    type_bias = _get_card_type_bias()
+    max_bias_attempts = 25  # Bias is a soft preference — fall through if it can't be satisfied quickly.
+    bias_attempts = 0
     pokemon_id, tier = choose_random_pkmn_from_tier()
     name = search_pokedex_by_id(pokemon_id)
     min_allowed_pokemon_lvl = check_min_generate_level(
         str(name.lower())
     )  # Gets the minimum allowed level for that pokemon given its stage of evolution
-    while (not check_id_ok(pokemon_id)) or (
-        wild_pokemon_lvl < min_allowed_pokemon_lvl
+    while (
+        (not check_id_ok(pokemon_id))
+        or (wild_pokemon_lvl < min_allowed_pokemon_lvl)
+        or (
+            type_bias
+            and bias_attempts < max_bias_attempts
+            and not _pokemon_matches_bias(name, type_bias)
+        )
     ):  # We keep drawing a random pokemon until we find a valid one
+        bias_attempts += 1
         pokemon_id, tier = choose_random_pkmn_from_tier()
         name = search_pokedex_by_id(pokemon_id)
         min_allowed_pokemon_lvl = check_min_generate_level(

--- a/src/Ankimon/functions/encounter_functions.py
+++ b/src/Ankimon/functions/encounter_functions.py
@@ -39,7 +39,7 @@ from ..functions.trainer_functions import xp_share_gain_exp
 from ..functions.badges_functions import check_for_badge, receive_badge
 from ..functions.drawing_utils import tooltipWithColour
 from ..utils import limit_ev_yield, play_effect_sound, get_ev_spread
-from ..business import calc_experience
+from ..business import calc_experience, calculate_cp_from_dict
 from ..const import gen_ids
 from ..singletons import (
     main_pokemon,
@@ -571,9 +571,11 @@ def save_main_pokemon_progress(
     if settings_obj.get("gui.pop_up_dialog_message_on_defeat") is True:
         logger.log_and_showinfo("info", f"{msg}")
 
-    # Load existing Pokémon data if it exists
+    # Update in-place, then persist both main and mypokemon files. Base
+    # stats intentionally not overwritten here — "stats" in the legacy main
+    # record was level-scaled and confused downstream readers that expect
+    # "stats" to mean base stats.
     for mainpkmndata in main_pokemon_data:
-        mainpkmndata["stats"] = main_pokemon.stats
         mainpkmndata["xp"] = int(main_pokemon.xp)
         mainpkmndata["level"] = int(main_pokemon.level)
         ev_yield = limit_ev_yield(mainpkmndata["ev"], enemy_pokemon.ev_yield)
@@ -583,7 +585,7 @@ def save_main_pokemon_progress(
         mainpkmndata["ev"]["spa"] += ev_yield["special-attack"]
         mainpkmndata["ev"]["spd"] += ev_yield["special-defense"]
         mainpkmndata["ev"]["spe"] += ev_yield["speed"]
-        mainpkmndata["current_hp"] = int(main_pokemon.current_hp)
+        mainpkmndata["current_hp"] = int(main_pokemon.hp)
         main_pokemon.friendship += random.randint(5, 9)
         if main_pokemon.friendship > 255:
             main_pokemon.friendship = 255
@@ -609,14 +611,13 @@ def save_main_pokemon_progress(
                 if (
                     pokemon_data.get("individual_id") == main_pokemon.individual_id
                 ):  # Match by individual_id
-                    mypokemondata[index] = mypkmndata  # Replace with new data
+                    mypokemondata[index] = mainpkmndata[0]
                     break
 
             # Save the modified data to the output JSON file
             with open(str(mypokemon_path), "w") as output_file:
                 json.dump(mypokemondata, output_file, indent=2)
 
-        sync_mainpokemon_to_mypokemon(main_pokemon, mainpokemon_path, mypokemon_path)
         mw.logger.log("info", f"Successfully saved progress for {main_pokemon.name}")
     except Exception as e:
         mw.logger.log("error", f"Failed to save pokemon progress: {str(e)}")
@@ -702,34 +703,30 @@ def save_caught_pokemon(
 
     # enemy_pokemon.stats["xp"] = 0
     enemy_pokemon.xp = 0
-    caught_pokemon = {
+    # Use to_dict() so the caught record shares the canonical shape with
+    # saved main Pokemon (includes base_stats, level-scaled stats, cp,
+    # nature). Then override caught-only fields.
+    _max_hp = enemy_pokemon.calculate_max_hp()
+    caught_pokemon = enemy_pokemon.to_dict()
+    caught_pokemon.update({
         "name": enemy_pokemon.name.capitalize(),
         "nickname": "",
-        "level": enemy_pokemon.level,
-        "gender": enemy_pokemon.gender,
-        "id": enemy_pokemon.id,
-        "ability": enemy_pokemon.ability,
-        "type": enemy_pokemon.type,
-        "stats": enemy_pokemon.base_stats,
         "ev": {"hp": 0, "atk": 0, "def": 0, "spa": 0, "spd": 0, "spe": 0},
-        "iv": enemy_pokemon.iv,
-        "attacks": enemy_pokemon.attacks,
-        "base_experience": enemy_pokemon.base_experience,
-        "current_hp": enemy_pokemon.calculate_max_hp(),
-        "growth_rate": enemy_pokemon.growth_rate,
         "friendship": 0,
         "pokemon_defeated": 0,
         "xp": 0,
         "everstone": False,
-        "shiny": enemy_pokemon.shiny,
         "captured_date": datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
         "individual_id": str(uuid.uuid4()),
         "mega": False,
         "special_form": None,
-        "tier": enemy_pokemon.tier,
         "is_favorite": False,
         "held_item": None,
-    }
+        "hp": _max_hp,
+        "current_hp": _max_hp,
+    })
+    # Recompute CP against the overridden (zeroed) EVs.
+    caught_pokemon["cp"] = calculate_cp_from_dict(caught_pokemon)
 
     # Load existing Pokémon data if it exists
     caught_pokemon_data = []

--- a/src/Ankimon/functions/encounter_functions.py
+++ b/src/Ankimon/functions/encounter_functions.py
@@ -585,6 +585,17 @@ def save_main_pokemon_progress(
         mainpkmndata["ev"]["spa"] += ev_yield["special-attack"]
         mainpkmndata["ev"]["spd"] += ev_yield["special-defense"]
         mainpkmndata["ev"]["spe"] += ev_yield["speed"]
+        # Mirror EV gain onto the in-memory object so CP/stats reads
+        # stay consistent with the persisted dict until next restart.
+        # Dict-item mutation doesn't fire __setattr__, so invalidate
+        # the CP cache explicitly.
+        main_pokemon.ev["hp"] += ev_yield["hp"]
+        main_pokemon.ev["atk"] += ev_yield["attack"]
+        main_pokemon.ev["def"] += ev_yield["defense"]
+        main_pokemon.ev["spa"] += ev_yield["special-attack"]
+        main_pokemon.ev["spd"] += ev_yield["special-defense"]
+        main_pokemon.ev["spe"] += ev_yield["speed"]
+        main_pokemon.invalidate_cp_cache()
         mainpkmndata["current_hp"] = int(main_pokemon.hp)
         main_pokemon.friendship += random.randint(5, 9)
         if main_pokemon.friendship > 255:

--- a/src/Ankimon/functions/encounter_functions.py
+++ b/src/Ankimon/functions/encounter_functions.py
@@ -211,21 +211,13 @@ def check_id_ok(id_num: Union[int, list[int]]):
     return False
 
 
-_POKEMON_TYPES_LOWER = {
-    "normal", "fire", "water", "electric", "grass", "ice", "fighting",
-    "poison", "ground", "flying", "psychic", "bug", "rock", "ghost",
-    "dragon", "dark", "steel", "fairy",
-}
-
-
 def _get_card_type_bias() -> list:
     """Return Pokemon types matching the current Anki card's tags or
     deck name, if the user has opted into tag-biased encounters.
 
-    Tag or deck-name component ``electric`` biases toward Electric-type
-    Pokemon. Returns an empty list when the feature is disabled, mw is
-    unavailable, or no match is found. Never raises — on any error the
-    caller falls through to unbiased generation.
+    Thin wrapper around :func:`business.compute_type_bias`; handles the
+    opt-in flag and the ``mw.reviewer.card`` lookup. Never raises — on
+    any error the caller falls through to unbiased generation.
     """
     try:
         if not settings_obj.get("battle.tag_biased_encounters"):
@@ -233,11 +225,10 @@ def _get_card_type_bias() -> list:
         card = getattr(getattr(mw, "reviewer", None), "card", None)
         if card is None:
             return []
-        tags = [str(t).lower() for t in (card.note().tags or [])]
-        deck_name = (mw.col.decks.name(card.did) or "").lower()
-        for piece in deck_name.replace("::", " ").split():
-            tags.append(piece)
-        return sorted({t.capitalize() for t in tags if t in _POKEMON_TYPES_LOWER})
+        tags = card.note().tags or []
+        deck_name = mw.col.decks.name(card.did) or ""
+        from ..business import compute_type_bias
+        return compute_type_bias(tags, deck_name)
     except Exception:
         return []
 

--- a/src/Ankimon/functions/pokemon_functions.py
+++ b/src/Ankimon/functions/pokemon_functions.py
@@ -212,7 +212,10 @@ def save_fossil_pokemon(pokemon_id):
         "id": id,
         "ability": ability,
         "type": type,
+        # Keep legacy "stats" key AND add canonical "base_stats" so both
+        # dict-shape readers (caught vs to_dict) work.
         "stats": stats,
+        "base_stats": stats,
         "ev": ev,
         "iv": iv,
         "attacks": attacks,
@@ -221,6 +224,7 @@ def save_fossil_pokemon(pokemon_id):
         "growth_rate": growth_rate,
         "friendship": 0,
         "pokemon_defeated": 0,
+        "xp": 0,
         "everstone": False,
         "shiny": shiny_chance(),
         "captured_date": datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
@@ -228,7 +232,14 @@ def save_fossil_pokemon(pokemon_id):
         "mega": False,
         "special_form": None,
         "tier": "Fossil",
+        "nature": "serious",
+        "held_item": None,
+        "is_favorite": False,
     }
+    # Refresh CP after dict is fully assembled so the record matches
+    # the shape produced by save_caught_pokemon.
+    from ..business import calculate_cp_from_dict as _calc_cp
+    caught_pokemon["cp"] = _calc_cp(caught_pokemon)
     # Load existing Pokémon data if it exists
     if mypokemon_path.is_file():
         with open(mypokemon_path, "r", encoding="utf-8") as json_file:

--- a/src/Ankimon/functions/pokemon_functions.py
+++ b/src/Ankimon/functions/pokemon_functions.py
@@ -71,6 +71,9 @@ def find_experience_for_level(group_growth_rate, level, remove_levelcap=True):
     if level < 100:
         # Open the CSV file
         csv_file_path = str(next_lvl_file_path)  # Replace 'your_file_path.csv' with the actual path to your CSV file
+        # Default if no row matches or the growth_rate column is unknown —
+        # prevents UnboundLocalError from breaking the level-up path.
+        experience = 0
         with open(csv_file_path, 'r', encoding='utf-8') as file:
             # Create a CSV reader
             csv_reader = csv.DictReader(file, delimiter=';')
@@ -81,10 +84,10 @@ def find_experience_for_level(group_growth_rate, level, remove_levelcap=True):
             # Iterate through rows and find the experience for the specified growth rate and level
             for row in csv_reader:
                 if row[fieldnames[0]] == str(level):  # Use the first fieldname to access the 'Level' column
-                    experience = row[growth_rate]
+                    experience = row.get(growth_rate, 0)
                     break
 
-            return experience
+        return experience
     elif level > 99:
         if group_growth_rate == "erratic":
             if level + 1 < 50: # +1 was added to prevent -ve amounts of xp to come up (even though it wouldn't since the loop only takes in levels above 99)

--- a/src/Ankimon/functions/pokemon_showdown_functions.py
+++ b/src/Ankimon/functions/pokemon_showdown_functions.py
@@ -18,6 +18,9 @@ def export_to_pkmn_showdown():
     for stat, value in main_pokemon.ev.items():
         if value == 0:
             main_pokemon.ev[stat] += 1
+    # EV dict was mutated in place; __setattr__ doesn't catch dict-item
+    # changes, so drop the cached CP manually.
+    main_pokemon.invalidate_cp_cache()
     # Format the Pokemon info
     pokemon_info = "{} ({})\nAbility: {}\nLevel: {}\nType: {}\nEVs: {} HP / {} Atk / {} Def / {} SpA / {} SpD / {} Spe\n IVs: {} HP / {} Atk / {} Def / {} SpA / {} SpD / {} Spe ".format(
         main_pokemon.name,

--- a/src/Ankimon/functions/update_main_pokemon.py
+++ b/src/Ankimon/functions/update_main_pokemon.py
@@ -91,7 +91,13 @@ def update_main_pokemon(main_pokemon: Optional[PokemonObject] = None):
                     main_pokemon.hp = main_pokemon_data[0].get("current_hp", max_hp)
                 return main_pokemon, mainpokemon_empty
 
-            except Exception:
+            except Exception as _exc:
+                # Previously a bare `except Exception:` swallowed
+                # everything silently, which masked a CP-related
+                # AttributeError that would reset main_pokemon to
+                # Ditto every launch. Log before falling back so
+                # future regressions surface.
+                print(f"Ankimon update_main_pokemon fallback: {_exc}")
                 main_pokemon = PokemonObject(**MAIN_POKEMON_DEFAULT)
                 return main_pokemon, mainpokemon_empty
     else:

--- a/src/Ankimon/gui_classes/overview_team.py
+++ b/src/Ankimon/gui_classes/overview_team.py
@@ -317,8 +317,9 @@ def load_pokemon_team() -> list[dict[str, Any]]:
         return []
     except Exception as e:
         # Unexpected errors are logged but not allowed to crash Anki's UI.
-        if mw:
-            mw.progress.chrome_logger.log(f"Ankimon Team Overview Error: {e}")
+        # mw.progress has no chrome_logger attribute — the previous call
+        # would raise AttributeError and mask the original exception.
+        print(f"Ankimon Team Overview Error: {e}")
         return []
 
 

--- a/src/Ankimon/gui_classes/overview_team.py
+++ b/src/Ankimon/gui_classes/overview_team.py
@@ -30,6 +30,7 @@ from typing import Any
 
 from aqt import gui_hooks, mw
 
+from ..business import calculate_cp_from_dict
 from ..functions.sprite_functions import get_sprite_path
 from ..resources import mypokemon_path, icon_path as pokeball_path, team_pokemon_path
 from ..utils import png_to_base64
@@ -136,6 +137,7 @@ _GRID_CSS = """\
 }
 .poke-level { font-weight: 700; color: #0066cc; }
 .poke-hp    { color: #cc0000; }
+.poke-cp    { font-weight: 700; color: #6a4dac; }
 .poke-types { font-style: italic; color: #006600; }
 
 @media (max-width: 800px) {
@@ -237,6 +239,8 @@ def _build_card_html(pokemon: dict[str, Any], id_prefix: str) -> str:
     style_attr = f' style="{bg_style}"' if bg_style else ""
     pokeball_style = _build_pokeball_style()
 
+    cp_value = pokemon.get("cp") or calculate_cp_from_dict(pokemon)
+
     return (
         f'<div id="{safe_id}" class="poke-item"{style_attr}>'
         f'  <div class="poke-sprite-wrap"{pokeball_style}>'
@@ -245,6 +249,7 @@ def _build_card_html(pokemon: dict[str, Any], id_prefix: str) -> str:
         f'  <div class="poke-desc">'
         f"    <h3>{display_name}</h3>"
         f'    <p class="poke-level">Level {level}</p>'
+        f'    <p class="poke-cp">CP {cp_value:,}</p>'
         f'    <p class="poke-hp">HP: {current_hp}</p>'
         f'    <p class="poke-types">{type_str}</p>'
         f"  </div>"

--- a/src/Ankimon/gui_classes/overview_team.py
+++ b/src/Ankimon/gui_classes/overview_team.py
@@ -317,9 +317,18 @@ def load_pokemon_team() -> list[dict[str, Any]]:
         return []
     except Exception as e:
         # Unexpected errors are logged but not allowed to crash Anki's UI.
-        # mw.progress has no chrome_logger attribute — the previous call
-        # would raise AttributeError and mask the original exception.
-        print(f"Ankimon Team Overview Error: {e}")
+        # Previous code called mw.progress.chrome_logger.log(...), which
+        # doesn't exist and would mask the real error with AttributeError.
+        import traceback as _tb
+        _msg = f"Ankimon Team Overview Error: {e}\n{_tb.format_exc()}"
+        try:
+            if mw and getattr(mw, "logger", None) is not None:
+                mw.logger.log("error", _msg)
+            else:
+                print(_msg)
+        except Exception:
+            # Last-resort: never let the logging path swallow a raise.
+            print(_msg)
         return []
 
 

--- a/src/Ankimon/gui_classes/pokemon_details.py
+++ b/src/Ankimon/gui_classes/pokemon_details.py
@@ -226,7 +226,7 @@ def PokemonCollectionDetails(
         _cp_stats = base_stats if base_stats is not None else detail_stats
         _attack, _defense, _stamina = pokemon_go_raw_stats(_cp_stats, iv, ev)
         cp_value = calculate_pokemon_go_cp(_attack, _defense, _stamina, level)
-        cp_txt = f" CP: {cp_value}"
+        cp_txt = f"CP {cp_value:,}"
 
         name_label = QLabel(f"{capitalized_name} - {gender_symbol}")
         name_label.setFont(namefont)

--- a/src/Ankimon/gui_classes/pokemon_details.py
+++ b/src/Ankimon/gui_classes/pokemon_details.py
@@ -23,7 +23,12 @@ from PyQt6.QtWidgets import (
     QSizePolicy,
 )
 
-from ..business import calculate_pokemon_go_cp, pokemon_go_raw_stats
+from ..business import (
+    calculate_pokemon_go_cp,
+    pokemon_go_raw_stats,
+    calculate_cpm,
+    cp_breakdown_tooltip,
+)
 from ..pyobj.attack_dialog import AttackDialog
 from ..pyobj.pokemon_trade import PokemonTrade
 from ..pyobj.error_handler import show_warning_with_traceback
@@ -227,12 +232,16 @@ def PokemonCollectionDetails(
         _attack, _defense, _stamina = pokemon_go_raw_stats(_cp_stats, iv, ev)
         cp_value = calculate_pokemon_go_cp(_attack, _defense, _stamina, level)
         cp_txt = f"CP {cp_value:,}"
+        cp_tooltip = cp_breakdown_tooltip(
+            {"base_stats": _cp_stats, "iv": iv, "ev": ev, "level": level}
+        )
 
         name_label = QLabel(f"{capitalized_name} - {gender_symbol}")
         name_label.setFont(namefont)
         description_label = QLabel(description_txt)
         level_label = QLabel(lvl)
         cp_label = QLabel(cp_txt)
+        cp_label.setToolTip(cp_tooltip)
         ability_label = QLabel(ability_txt)
         attacks_label = QLabel(attacks_txt)
         pokemon_defeated_label = QLabel(f"Pokemon Defeated: {pokemon_defeated}")

--- a/src/Ankimon/gui_classes/pokemon_team_window.py
+++ b/src/Ankimon/gui_classes/pokemon_team_window.py
@@ -18,8 +18,9 @@ class PokemonTeamDialog(QDialog):
         self.logger = logger
         self.trainer_card = trainer_card
 
-        # Set the minimum size of the dialog
-        self.setMinimumSize(900, 500)  # Minimum size of 900x500 pixels
+        # Minimum fits a 3×2 sprite grid; previous 900×500 overflowed
+        # the main window on 13" laptops where Anki defaults to ~1200px.
+        self.setMinimumSize(650, 450)
 
         # Load the Pokémon team data
         self.my_pokemon = self.load_my_pokemon()

--- a/src/Ankimon/gui_entities.py
+++ b/src/Ankimon/gui_entities.py
@@ -164,7 +164,7 @@ class Credits(QWidget):
         self.initUI()
 
     def initUI(self):
-        self.setWindowTitle("AnkiMon License")
+        self.setWindowTitle("AnkiMon Credits")
 
         # Create a label and set HTML content
         label = QLabel()

--- a/src/Ankimon/gui_entities.py
+++ b/src/Ankimon/gui_entities.py
@@ -308,8 +308,12 @@ class Pokedex_Widget(QWidget):
         # Extract the IDs of the Pokémon listed in the JSON file
         self.available_pokedex_ids = {pokemon['id'] for pokemon in self.captured_pokemon_data}
 
-        # Now we generate the HTML rows for each Pokémon in the range 1-898, graying out those not in the JSON file
-        table_rows = [self.generate_table_row(i, i not in self.available_pokedex_ids) for i in range(1, 899)]
+        # Generate HTML rows for every Pokémon up through the latest
+        # supported generation (see const.gen_ids); grey out those not in
+        # the JSON file.
+        from .const import gen_ids as _gen_ids
+        _max_id = max(_gen_ids.values())
+        table_rows = [self.generate_table_row(i, i not in self.available_pokedex_ids) for i in range(1, _max_id + 1)]
 
         # Combine the HTML template with the generated rows
         html_content = pokedex_html_template.replace('<!-- Table Rows Will Go Here -->', ''.join(table_rows))

--- a/src/Ankimon/lang/en_text.json
+++ b/src/Ankimon/lang/en_text.json
@@ -453,5 +453,9 @@
   "futuresight_hits": "The foreseen attack strikes {side}!",
   "futuresight_fails": "Future Sight failed!",
   "wish_started": "{pokemon_name} made a wish! It will heal {heal_amount} HP soon.",
-  "pc_box_label": "Box {current}/{total}"
+  "pc_box_label": "Box {current}/{total}",
+  "cp_label": "CP",
+  "bp_label": "BP",
+  "combat_power": "Combat Power",
+  "battle_power": "Battle Power"
 }

--- a/src/Ankimon/lang/en_text.json
+++ b/src/Ankimon/lang/en_text.json
@@ -457,5 +457,12 @@
   "cp_label": "CP",
   "bp_label": "BP",
   "combat_power": "Combat Power",
-  "battle_power": "Battle Power"
+  "battle_power": "Battle Power",
+  "sort_label": "Sort:",
+  "sort_descending": "Descending",
+  "sort_capture_order": "Capture Order",
+  "sort_id": "ID",
+  "sort_cp": "CP",
+  "sort_level": "Level",
+  "sort_name": "Name"
 }

--- a/src/Ankimon/lang/setting_description.json
+++ b/src/Ankimon/lang/setting_description.json
@@ -4,6 +4,7 @@
     "battle.daily_average": "Set the amount of Cards you want to review per day.",
     "battle.card_max_time": "Goal of maximum amount of time needed to answer a card in seconds",
     "battle.review_based_damage": "If enabled, your Pokémon's damage will be modified depending on how you graded your last few cards.",
+    "battle.tag_biased_encounters": "If enabled, Anki card tags and deck-name components matching a Pokémon type (e.g. 'electric', 'water') bias wild encounters toward that type — so a 'japanese' deck tagged 'psychic' is more likely to spawn Psychic types. Falls back to unbiased if no compatible Pokémon exists.",
 
     "controls.pokemon_buttons": "Enable action buttons for Pokémon commands during reviews.",
     "controls.defeat_key": "Key for defeating Pokémon when its HP is 0. [A-Z]",

--- a/src/Ankimon/lang/setting_name.json
+++ b/src/Ankimon/lang/setting_name.json
@@ -4,6 +4,7 @@
     "battle.daily_average": "Goal of Daily Average Cards",
     "battle.card_max_time": "Card Max Time",
     "battle.review_based_damage": "Review Based Damage",
+    "battle.tag_biased_encounters": "Tag-Biased Encounters",
 
     "controls.pokemon_buttons": "Show Pokémon Buttons",
     "controls.defeat_key": "Key for Defeat",

--- a/src/Ankimon/pyobj/InfoLogger.py
+++ b/src/Ankimon/pyobj/InfoLogger.py
@@ -51,8 +51,10 @@ class ShowInfoLogger:
             self.game_log(message)  # Use the game-specific logging
 
         if level in ['info', 'warning', 'error']:
-            # Show the message in a QMessageBox dialog
-            msg_box = QMessageBox()
+            # Parent to the main window so the dialog appears ON TOP on
+            # macOS/Linux. Unparented QMessageBox often lands behind mw.
+            from aqt import mw as _mw
+            msg_box = QMessageBox(_mw if _mw is not None else None)
             msg_box.setWindowTitle("Log Message")
             msg_box.setText(message)
             msg_box.setIcon(QMessageBox.Icon.Information)

--- a/src/Ankimon/pyobj/ankimon_tracker.py
+++ b/src/Ankimon/pyobj/ankimon_tracker.py
@@ -75,9 +75,12 @@ class AnkimonTracker:
     def get_total_reviews(self):
         if mw.col is None:
             return 0
-        else:
-            studied_today_num = re.search(r'Studied\s+[^\d]*(\d+)(?=[^\n]*card)', mw.col.studied_today())
-            return int(studied_today_num.group(1))
+        match = re.search(r'Studied\s+[^\d]*(\d+)(?=[^\n]*card)', mw.col.studied_today())
+        if match is None:
+            # Empty-study session or localized Anki whose "Studied N cards"
+            # text doesn't match the English regex.
+            return 0
+        return int(match.group(1))
 
     def set_main_pokemon(self, pokemon):
         """Set the main Pokémon being used."""

--- a/src/Ankimon/pyobj/ankimon_tracker_window.py
+++ b/src/Ankimon/pyobj/ankimon_tracker_window.py
@@ -100,7 +100,9 @@ class AnkimonTrackerWindow:
             self.layout.addItem(QSpacerItem(20, 40, QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum))
             self.window.setLayout(self.layout)
             self.window.setWindowTitle("Ankimon Tracker Stats")
-            self.window.show()
+            # Don't show() here — toggle_window() is the sole caller and
+            # shows the window after create_gui() returns; the extra
+            # show() made the first open a show-then-show no-op.
 
     def update_stats(self):
         """Forcefully updates all displayed stats, regardless of change."""

--- a/src/Ankimon/pyobj/collection_dialog.py
+++ b/src/Ankimon/pyobj/collection_dialog.py
@@ -77,6 +77,13 @@ class PokemonCollectionDialog(QDialog):
         self.sort_combo.addItems(["Capture Order", "ID", "CP", "Level", "Name"])
         self.sort_combo.currentIndexChanged.connect(self.apply_sort_and_filter)
 
+        # Descending toggle — matches PC Box convention. Default ON so
+        # the common "strongest/highest first" CP and Level sorts keep
+        # their pre-existing behaviour.
+        self.desc_sort = QCheckBox("Descending")
+        self.desc_sort.setChecked(True)
+        self.desc_sort.stateChanged.connect(self.apply_sort_and_filter)
+
         # Search Filter
         self.search_edit = QLineEdit()
         self.search_edit.setPlaceholderText("Search Pokémon (by nickname, name)")
@@ -136,6 +143,7 @@ class PokemonCollectionDialog(QDialog):
         filter_layout.addWidget(self.type_combo)
         filter_layout.addWidget(QLabel("Sort:"))
         filter_layout.addWidget(self.sort_combo)
+        filter_layout.addWidget(self.desc_sort)
         self.layout.addLayout(filter_layout)
 
         self.scroll_area = QScrollArea()
@@ -274,9 +282,8 @@ class PokemonCollectionDialog(QDialog):
                 ability_label = self.create_label(
                     f"Ability: {pokemon_ability.capitalize()}", 8
                 )
-                cp_label = self.create_label(
-                    f"CP: {pokemon.get('cp') or calculate_cp_from_dict(pokemon)}", 8
-                )
+                cp_value = pokemon.get("cp") or calculate_cp_from_dict(pokemon)
+                cp_label = self.create_label(f"CP {cp_value:,}", 8)
 
                 image_label = QLabel()
                 image_label.setPixmap(pixmap)
@@ -455,15 +462,16 @@ class PokemonCollectionDialog(QDialog):
                 ):
                     filtered_pokemon.append(pokemon)
 
-            # Sort
+            # Sort — direction controlled by the Descending checkbox
+            reverse = self.desc_sort.isChecked()
             if sort_key == "ID":
-                filtered_pokemon.sort(key=lambda x: x["id"])
+                filtered_pokemon.sort(key=lambda x: x["id"], reverse=reverse)
             elif sort_key == "CP":
-                filtered_pokemon.sort(key=lambda x: x.get("cp") or calculate_cp_from_dict(x), reverse=True)
+                filtered_pokemon.sort(key=lambda x: x.get("cp") or calculate_cp_from_dict(x), reverse=reverse)
             elif sort_key == "Level":
-                filtered_pokemon.sort(key=lambda x: x.get("level", 0), reverse=True)
+                filtered_pokemon.sort(key=lambda x: x.get("level", 0), reverse=reverse)
             elif sort_key == "Name":
-                filtered_pokemon.sort(key=lambda x: x.get("name", "").lower())
+                filtered_pokemon.sort(key=lambda x: x.get("name", "").lower(), reverse=reverse)
 
             self.current_page = 0
             self.refresh_collection(filtered_pokemon)

--- a/src/Ankimon/pyobj/collection_dialog.py
+++ b/src/Ankimon/pyobj/collection_dialog.py
@@ -27,7 +27,7 @@ from ..functions.pokedex_functions import (
 from ..gui_classes.pokemon_details import PokemonCollectionDetails
 from ..gui_entities import MovieSplashLabel
 from ..resources import mypokemon_path, frontdefault, frontdefault, mainpokemon_path
-from ..business import calculate_cp_from_dict
+from ..business import calculate_cp_from_dict, cp_breakdown_tooltip
 
 
 class PokemonCollectionDialog(QDialog):
@@ -284,6 +284,7 @@ class PokemonCollectionDialog(QDialog):
                 )
                 cp_value = pokemon.get("cp") or calculate_cp_from_dict(pokemon)
                 cp_label = self.create_label(f"CP {cp_value:,}", 8)
+                cp_label.setToolTip(cp_breakdown_tooltip(pokemon))
 
                 image_label = QLabel()
                 image_label.setPixmap(pixmap)

--- a/src/Ankimon/pyobj/collection_dialog.py
+++ b/src/Ankimon/pyobj/collection_dialog.py
@@ -28,6 +28,7 @@ from ..gui_classes.pokemon_details import PokemonCollectionDetails
 from ..gui_entities import MovieSplashLabel
 from ..resources import mypokemon_path, frontdefault, frontdefault, mainpokemon_path
 from ..business import calculate_cp_from_dict, cp_breakdown_tooltip
+from ..const import gen_ids
 
 
 class PokemonCollectionDialog(QDialog):
@@ -95,16 +96,7 @@ class PokemonCollectionDialog(QDialog):
         self.generation_combo = QComboBox()
         self.generation_combo.addItem("All")
         self.generation_combo.addItems(
-            [
-                "Generation 1",
-                "Generation 2",
-                "Generation 3",
-                "Generation 4",
-                "Generation 5",
-                "Generation 6",
-                "Generation 7",
-                "Generation 8",
-            ]
+            [f"Generation {i}" for i in range(1, len(gen_ids) + 1)]
         )
         self.generation_combo.currentIndexChanged.connect(self.apply_sort_and_filter)
 
@@ -325,11 +317,14 @@ class PokemonCollectionDialog(QDialog):
             self.scroll_area.setWidget(self.container)
             # Add pagination controls (at the bottom)
             self.add_pagination_controls(pokemon_list)
-            # Add Pokémon grid to the main layout
-            self.layout.addWidget(self.scroll_area)
-            self.layout.addWidget(self.paginator)
-
-            self.setLayout(self.layout)
+            # Add scroll area + paginator to the main layout ONCE. Re-adding
+            # on every showEvent/refresh_collection stacked N scroll areas
+            # after N reopens — content repopulation happens above this line.
+            if not getattr(self, "_ui_assembled", False):
+                self.layout.addWidget(self.scroll_area)
+                self.layout.addWidget(self.paginator)
+                self.setLayout(self.layout)
+                self._ui_assembled = True
         except FileNotFoundError:
             self.layout.addWidget(
                 QLabel(f"Can't open the Saving File. {mypokemon_path}")
@@ -442,23 +437,18 @@ class PokemonCollectionDialog(QDialog):
                     pokemon_nickname += " (shiny) "
                 pokemon_type = pokemon.get("type", " ")
 
+                # Generation index 0 = "All"; 1..N match gen_ids order.
+                gen_match = generation_index == 0
+                if not gen_match and 1 <= generation_index <= len(gen_ids):
+                    low = 1 if generation_index == 1 else gen_ids[f"gen_{generation_index - 1}"] + 1
+                    high = gen_ids[f"gen_{generation_index}"]
+                    gen_match = low <= pokemon_id <= high
                 if (
                     (
                         search_text in pokemon_name.lower()
                         or search_text in pokemon_nickname.lower()
                     )
-                    and 0 <= generation_index <= 8
-                    and (
-                        generation_index == 0
-                        or (1 <= pokemon_id <= 151 and generation_index == 1)
-                        or (152 <= pokemon_id <= 251 and generation_index == 2)
-                        or (252 <= pokemon_id <= 386 and generation_index == 3)
-                        or (387 <= pokemon_id <= 493 and generation_index == 4)
-                        or (494 <= pokemon_id <= 649 and generation_index == 5)
-                        or (650 <= pokemon_id <= 721 and generation_index == 6)
-                        or (722 <= pokemon_id <= 809 and generation_index == 7)
-                        or (810 <= pokemon_id <= 898 and generation_index == 8)
-                    )
+                    and gen_match
                     and (type_index == 0 or type_text in pokemon_type)
                 ):
                     filtered_pokemon.append(pokemon)

--- a/src/Ankimon/pyobj/collection_dialog.py
+++ b/src/Ankimon/pyobj/collection_dialog.py
@@ -480,19 +480,18 @@ class PokemonCollectionDialog(QDialog):
             len(pokemon_list) + self.items_per_page - 1
         ) // self.items_per_page
 
-        if self.current_page > 0:
-            prev_button = QPushButton("Previous")
-            prev_button.clicked.connect(
-                lambda: self.previous_page(pokemon_list)
-            )  # Passing pokemon_list to previous_page
-            self.pagination_layout.addWidget(prev_button)
+        # Render both buttons always and disable at edges so neighbouring
+        # controls don't shift position when the user lands on page 0 or
+        # the final page.
+        prev_button = QPushButton("Previous")
+        prev_button.clicked.connect(lambda: self.previous_page(pokemon_list))
+        prev_button.setEnabled(self.current_page > 0)
+        self.pagination_layout.addWidget(prev_button)
 
-        if self.current_page < total_pages - 1:
-            next_button = QPushButton("Next")
-            next_button.clicked.connect(
-                lambda: self.next_page(pokemon_list)
-            )  # Passing pokemon_list to next_page
-            self.pagination_layout.addWidget(next_button)
+        next_button = QPushButton("Next")
+        next_button.clicked.connect(lambda: self.next_page(pokemon_list))
+        next_button.setEnabled(self.current_page < total_pages - 1)
+        self.pagination_layout.addWidget(next_button)
 
     def next_page(self, pokemon_list):
         self.current_page += 1

--- a/src/Ankimon/pyobj/collection_dialog.py
+++ b/src/Ankimon/pyobj/collection_dialog.py
@@ -73,15 +73,20 @@ class PokemonCollectionDialog(QDialog):
         self.setMinimumHeight(400)
         self.layout = QVBoxLayout(self)
 
-        # Sort dropdown
+        # Sort dropdown. Stable internal keys drive the sort logic; the
+        # visible strings route through the translator so non-English
+        # users see localized labels.
+        self._sort_keys = ["capture_order", "id", "cp", "level", "name"]
         self.sort_combo = QComboBox()
-        self.sort_combo.addItems(["Capture Order", "ID", "CP", "Level", "Name"])
+        self.sort_combo.addItems(
+            [self.translator.translate(f"sort_{k}") for k in self._sort_keys]
+        )
         self.sort_combo.currentIndexChanged.connect(self.apply_sort_and_filter)
 
         # Descending toggle — matches PC Box convention. Default ON so
         # the common "strongest/highest first" CP and Level sorts keep
         # their pre-existing behaviour.
-        self.desc_sort = QCheckBox("Descending")
+        self.desc_sort = QCheckBox(self.translator.translate("sort_descending"))
         self.desc_sort.setChecked(True)
         self.desc_sort.stateChanged.connect(self.apply_sort_and_filter)
 
@@ -133,7 +138,7 @@ class PokemonCollectionDialog(QDialog):
         filter_layout.addWidget(self.search_button)
         filter_layout.addWidget(self.generation_combo)
         filter_layout.addWidget(self.type_combo)
-        filter_layout.addWidget(QLabel("Sort:"))
+        filter_layout.addWidget(QLabel(self.translator.translate("sort_label")))
         filter_layout.addWidget(self.sort_combo)
         filter_layout.addWidget(self.desc_sort)
         self.layout.addLayout(filter_layout)
@@ -419,7 +424,8 @@ class PokemonCollectionDialog(QDialog):
         generation_index = self.generation_combo.currentIndex()
         type_index = self.type_combo.currentIndex()
         type_text = self.type_combo.currentText()
-        sort_key = self.sort_combo.currentText()
+        # Use the stable internal key, not the (possibly translated) label.
+        sort_key = self._sort_keys[self.sort_combo.currentIndex()]
 
         try:
             if not pokemon_list:
@@ -455,13 +461,13 @@ class PokemonCollectionDialog(QDialog):
 
             # Sort — direction controlled by the Descending checkbox
             reverse = self.desc_sort.isChecked()
-            if sort_key == "ID":
+            if sort_key == "id":
                 filtered_pokemon.sort(key=lambda x: x["id"], reverse=reverse)
-            elif sort_key == "CP":
+            elif sort_key == "cp":
                 filtered_pokemon.sort(key=lambda x: x.get("cp") or calculate_cp_from_dict(x), reverse=reverse)
-            elif sort_key == "Level":
+            elif sort_key == "level":
                 filtered_pokemon.sort(key=lambda x: x.get("level", 0), reverse=reverse)
-            elif sort_key == "Name":
+            elif sort_key == "name":
                 filtered_pokemon.sort(key=lambda x: x.get("name", "").lower(), reverse=reverse)
 
             self.current_page = 0

--- a/src/Ankimon/pyobj/collection_dialog.py
+++ b/src/Ankimon/pyobj/collection_dialog.py
@@ -381,7 +381,7 @@ class PokemonCollectionDialog(QDialog):
             shiny=pokemon.get("shiny", False),
             ability=pokemon["ability"],
             type=pokemon["type"],
-            detail_stats={**pokemon["stats"], "xp": pokemon.get("xp", 0)},
+            detail_stats={**(pokemon.get("base_stats") or pokemon["stats"]), "xp": pokemon.get("xp", 0)},
             attacks=pokemon["attacks"],
             base_experience=pokemon["base_experience"],
             growth_rate=pokemon["growth_rate"],

--- a/src/Ankimon/pyobj/evolution_window.py
+++ b/src/Ankimon/pyobj/evolution_window.py
@@ -384,7 +384,18 @@ class EvoWindow(QWidget):
                         pokemon["attacks"] = attacks
                         base_stats = search_pokedex(evo_name.lower(), "baseStats")
                         pokemon["base_stats"] = base_stats
-                        pokemon["stats"] = base_stats
+                        # Refresh level-scaled "stats" against new species
+                        # bases; previously we wrote base_stats here, which
+                        # collided with to_dict semantics (stats = scaled).
+                        _iv = pokemon.get("iv") or {}
+                        _ev = pokemon.get("ev") or {}
+                        _level = pokemon.get("level", 1)
+                        _nature = pokemon.get("nature", "serious")
+                        from ..pyobj.pokemon_obj import PokemonObject as _PO
+                        pokemon["stats"] = {
+                            k: _PO.calc_stat(k, base_stats[k], _level, _iv.get(k, 0), _ev.get(k, 0), _nature)
+                            for k in ("hp", "atk", "def", "spa", "spd", "spe")
+                        }
                         pokemon["xp"] = 0
                         # Refresh CP against the new species' base stats.
                         from ..business import calculate_cp_from_dict as _recalc_cp

--- a/src/Ankimon/pyobj/evolution_window.py
+++ b/src/Ankimon/pyobj/evolution_window.py
@@ -386,6 +386,9 @@ class EvoWindow(QWidget):
                         pokemon["base_stats"] = base_stats
                         pokemon["stats"] = base_stats
                         pokemon["xp"] = 0
+                        # Refresh CP against the new species' base stats.
+                        from ..business import calculate_cp_from_dict as _recalc_cp
+                        pokemon["cp"] = _recalc_cp(pokemon)
                         hp_stat = int(base_stats["hp"])
                         iv = pokemon["iv"]
                         ev = pokemon["ev"]

--- a/src/Ankimon/pyobj/pc_box.py
+++ b/src/Ankimon/pyobj/pc_box.py
@@ -1177,6 +1177,7 @@ class PokemonPC(QDialog):
             "tier",
             "is_favorite",
             "held_item",
+            "cp",
         }
 
         is_migration_needed = any(
@@ -1211,6 +1212,7 @@ class PokemonPC(QDialog):
             "tier": lambda p: get_tier_by_id(p.get("id", 0)) or "Normal",
             "is_favorite": False,
             "held_item": None,
+            "cp": lambda p: calculate_cp_from_dict(p),
         }
 
         for i, pokemon in enumerate(pokemon_list):

--- a/src/Ankimon/pyobj/pc_box.py
+++ b/src/Ankimon/pyobj/pc_box.py
@@ -43,6 +43,7 @@ from ..functions.sprite_functions import get_sprite_path
 from ..utils import load_custom_font, get_tier_by_id
 from ..resources import mypokemon_path, itembag_path
 from ..business import calculate_cp_from_dict
+from ..const import gen_ids
 
 
 def format_item_name(item_name: str) -> str:
@@ -856,17 +857,11 @@ class PokemonPC(QDialog):
 
             if self.generation_combo is not None:
                 gen_idx = self.generation_combo.currentIndex()
-                if gen_idx != 0 and (
-                    (1 <= pokemon["id"] <= 151 and gen_idx != 1)
-                    or (152 <= pokemon["id"] <= 251 and gen_idx != 2)
-                    or (252 <= pokemon["id"] <= 386 and gen_idx != 3)
-                    or (387 <= pokemon["id"] <= 493 and gen_idx != 4)
-                    or (494 <= pokemon["id"] <= 649 and gen_idx != 5)
-                    or (650 <= pokemon["id"] <= 721 and gen_idx != 6)
-                    or (722 <= pokemon["id"] <= 809 and gen_idx != 7)
-                    or (810 <= pokemon["id"] <= 898 and gen_idx != 8)
-                ):
-                    return False
+                if gen_idx != 0 and 1 <= gen_idx <= len(gen_ids):
+                    low = 1 if gen_idx == 1 else gen_ids[f"gen_{gen_idx - 1}"] + 1
+                    high = gen_ids[f"gen_{gen_idx}"]
+                    if not (low <= pokemon["id"] <= high):
+                        return False
 
             return True
 

--- a/src/Ankimon/pyobj/pc_box.py
+++ b/src/Ankimon/pyobj/pc_box.py
@@ -352,12 +352,14 @@ class PokemonPC(QDialog):
         self.scroll_area.setFrameShape(QFrame.Shape.NoFrame)
         self.scroll_area.setStyleSheet("background: transparent; border: none;")
         self.scroll_area.setMinimumSize(200, 200)  # Minimum size required for shrinking
-        # Enforce pagination by turning off scrollbars
+        # Show scrollbars only when needed; previously forced-off, which
+        # meant overflow Pokemon were unreachable if calculate_grid_dimensions
+        # slightly under-reported the number of fittable slots.
         self.scroll_area.setHorizontalScrollBarPolicy(
-            Qt.ScrollBarPolicy.ScrollBarAlwaysOff
+            Qt.ScrollBarPolicy.ScrollBarAsNeeded
         )
         self.scroll_area.setVerticalScrollBarPolicy(
-            Qt.ScrollBarPolicy.ScrollBarAlwaysOff
+            Qt.ScrollBarPolicy.ScrollBarAsNeeded
         )
 
         self.grid_container = QWidget()

--- a/src/Ankimon/pyobj/pokemon_obj.py
+++ b/src/Ankimon/pyobj/pokemon_obj.py
@@ -246,9 +246,18 @@ class PokemonObject:
         """Return the stats of the Pokémon."""
         return vars(self)
 
+    # Read-only @property getters. setattr() on any of these raises
+    # AttributeError (silently, when wrapped in update_stats's caller's
+    # bare `except Exception`). Skip them in update_stats so callers
+    # can safely splat a saved dict that may include cached/derived
+    # values like "cp".
+    _READONLY_ATTRS = frozenset({"cp", "stats", "max_hp"})
+
     def update_stats(self, **kwargs):
         """Update the attributes of the Pokémon object with keyword arguments."""
         for key, value in kwargs.items():
+            if key in self._READONLY_ATTRS:
+                continue
             if hasattr(self, key):
                 setattr(self, key, value)
         self._update_battle_stats()  # Update battle stats

--- a/src/Ankimon/pyobj/pokemon_obj.py
+++ b/src/Ankimon/pyobj/pokemon_obj.py
@@ -53,13 +53,14 @@ class PokemonObject:
         self.shiny = shiny
         self.id = id
         self.level = level
-        self.ability = ability
         self.type = type
         self.gender = gender
         self.tier = tier
         self.everstone = everstone
         self.pokemon_defeated = pokemon_defeated
 
+        # Normalise ability once; previously self.ability was assigned
+        # twice (the raw `ability` value, then the normalised value).
         if not ability or str(ability).strip().lower() in ("none", "no ability", ""):
             self.ability = "Run Away"
         else:
@@ -522,9 +523,11 @@ class PokemonEncoder(json.JSONEncoder):
     def default(self, obj):
         if isinstance(obj, PokemonObject):
             data = obj.__dict__.copy()
-            # Convert complex types to serializable formats
-            data['volatile_status'] = list(data['volatile_status'])
-            data['stat_stages'] = data.get('stat_stages', {})
-            data['moves'] = data.get('attacks', [])
+            # Convert complex types to serializable formats. Use .get()
+            # everywhere because a Pokemon constructed via from_engine_format
+            # / update_stats may not have every attribute set.
+            data['volatile_status'] = list(data.get('volatile_status', []) or [])
+            data['stat_stages'] = data.get('stat_stages', {}) or {}
+            data['moves'] = data.get('attacks', []) or []
             return data
         return super().default(obj)

--- a/src/Ankimon/pyobj/pokemon_obj.py
+++ b/src/Ankimon/pyobj/pokemon_obj.py
@@ -141,14 +141,38 @@ class PokemonObject:
 
         Uses raw stats (base + IV + EV/4) so CPM is the sole level
         multiplier.  See :func:`business.calculate_pokemon_go_cp`.
+
+        Memoized: attribute assignment to ``level``, ``ev``, ``iv``, or
+        ``base_stats`` invalidates the cache via ``__setattr__``. Mutating
+        those containers in-place (e.g. ``self.ev["atk"] += 1``) does not,
+        so call :meth:`invalidate_cp_cache` explicitly at those sites.
         """
+        cached = getattr(self, "_cached_cp", None)
+        if cached is not None:
+            return cached
         # Local import to avoid a circular dependency with ``business``.
         from ..business import calculate_pokemon_go_cp, pokemon_go_raw_stats
 
         attack, defense, stamina = pokemon_go_raw_stats(
             self.base_stats, self.iv, self.ev
         )
-        return calculate_pokemon_go_cp(attack, defense, stamina, self.level)
+        cp_val = calculate_pokemon_go_cp(attack, defense, stamina, self.level)
+        object.__setattr__(self, "_cached_cp", cp_val)
+        return cp_val
+
+    def invalidate_cp_cache(self) -> None:
+        """Drop memoized CP so the next ``cp`` access recomputes.
+
+        Call after mutating ``ev``/``iv``/``base_stats`` dict contents
+        in place (attribute reassignment is caught automatically by
+        ``__setattr__``).
+        """
+        object.__setattr__(self, "_cached_cp", None)
+
+    def __setattr__(self, name, value):
+        super().__setattr__(name, value)
+        if name in ("level", "ev", "iv", "base_stats"):
+            object.__setattr__(self, "_cached_cp", None)
 
     @classmethod
     def get_nature_stat_mult(cls, stat_name: str, nature: str) -> float:

--- a/src/Ankimon/pyobj/pokemon_obj.py
+++ b/src/Ankimon/pyobj/pokemon_obj.py
@@ -210,7 +210,7 @@ class PokemonObject:
             "tier": self.tier,  # Added tier
             "is_favorite": getattr(self, "is_favorite", False),  # Added with default
             # Additional fields from your example
-            "current_hp": getattr(self, "current_hp", "hp"),  # For backward compatibility
+            "current_hp": getattr(self, "current_hp", self.hp),
             "held_item": self.held_item,
         }
 

--- a/src/Ankimon/pyobj/pokemon_obj.py
+++ b/src/Ankimon/pyobj/pokemon_obj.py
@@ -247,11 +247,13 @@ class PokemonObject:
         """Return the stats of the Pokémon."""
         return vars(self)
 
-    # Read-only @property getters. setattr() on any of these raises
-    # AttributeError (silently, when wrapped in update_stats's caller's
-    # bare `except Exception`). Skip them in update_stats so callers
-    # can safely splat a saved dict that may include cached/derived
-    # values like "cp".
+    # Derived/read-only attributes to skip in update_stats. ``cp`` and
+    # ``stats`` are @property getters whose setattr raises
+    # AttributeError (silently swallowed by the caller's bare
+    # `except Exception`). ``max_hp`` is a plain cache field — setattr
+    # would succeed, but the splatted value is almost certainly stale
+    # relative to the new ``level``/``base_stats``, so we skip it and
+    # recompute it ourselves below.
     _READONLY_ATTRS = frozenset({"cp", "stats", "max_hp"})
 
     def update_stats(self, **kwargs):
@@ -261,6 +263,9 @@ class PokemonObject:
                 continue
             if hasattr(self, key):
                 setattr(self, key, value)
+        # Derived caches — recompute from the (possibly updated)
+        # base_stats/level/iv/ev so they don't go stale.
+        self.max_hp = self.calculate_max_hp()
         self._update_battle_stats()  # Update battle stats
 
     def reset_stats(self):

--- a/src/Ankimon/pyobj/reviewer_obj.py
+++ b/src/Ankimon/pyobj/reviewer_obj.py
@@ -165,7 +165,11 @@ class Reviewer_Manager:
 
             main_lang_name = (get_pokemon_diff_lang_name(int(self.main_pokemon.id), int(self.settings.get('misc.language'))).capitalize())
             if str(main_lang_name) == 'No translation in this language':
-                main_lang_name = 'RESTART ANKI NOW' 
+                # Silent fallback to the species name; the old "RESTART
+                # ANKI NOW" leak was a developer placeholder that surfaced
+                # mid-review for any language/id pair without a localized
+                # entry.
+                main_lang_name = self.main_pokemon.name.capitalize()
             if self.main_pokemon.shiny:
                 main_lang_name += " ⭐ "
             main_name_display_text = f"{main_lang_name} LvL: {self.main_pokemon.level}"

--- a/src/Ankimon/pyobj/settings.py
+++ b/src/Ankimon/pyobj/settings.py
@@ -20,6 +20,7 @@ DEFAULT_CONFIG = {
     "battle.daily_average": 100,
     "battle.card_max_time": 60,
     "battle.review_based_damage": True,
+    "battle.tag_biased_encounters": False,
     "controls.pokemon_buttons": True,
     "controls.defeat_key": "5",
     "controls.catch_key": "6",

--- a/src/Ankimon/pyobj/settings.py
+++ b/src/Ankimon/pyobj/settings.py
@@ -105,9 +105,6 @@ class Settings:
                         )
                     del config["items"]
 
-                if "trainer.team" in config:
-                    del config["trainer.team"]
-
                 # Type Coercion (from ankimon_sync.py)
                 keys_to_coerce_to_int = [
                     "battle.automatic_battle",

--- a/src/Ankimon/pyobj/settings_window.py
+++ b/src/Ankimon/pyobj/settings_window.py
@@ -555,12 +555,15 @@ class SettingsWindow(QMainWindow):
             changed_message = "\n".join(
                 [f"{key}: {value}" for key, value in friendly_changed.items()]
             )
-            QMessageBox.information(
-                self, "Settings Saved", "Your settings have been saved successfully."
-            )
-            QMessageBox.information(
-                self, "Config changes", f"Changed settings:\n{changed_message}"
-            )
+            # One dialog, not two — previous flow forced users to dismiss
+            # "saved" then "changed" back-to-back. Put the change list in
+            # informativeText so it appears inline, expandable via detail.
+            msg_box = QMessageBox(self)
+            msg_box.setWindowTitle("Settings Saved")
+            msg_box.setIcon(QMessageBox.Icon.Information)
+            msg_box.setText("Your settings have been saved successfully.")
+            msg_box.setInformativeText(f"Changed settings:\n{changed_message}")
+            msg_box.exec()
             self.original_config = self.config.copy()
         else:
             QMessageBox.information(self, "No Changes", "No settings were changed.")

--- a/src/Ankimon/pyobj/starter_window.py
+++ b/src/Ankimon/pyobj/starter_window.py
@@ -170,7 +170,10 @@ class StarterWindow(QWidget):
         from ..singletons import pokemon_pc
         pokemon_pc.refresh_pokemon_grid()
 
-        close_anki()
+        # Do NOT close Anki here. The previous behaviour killed the app
+        # immediately after starter selection and then asked the user to
+        # restart — the confirmation dialog was unreadable because the
+        # app was already shutting down. Let the user keep playing.
 
     def get_starters_of_gen(self):
         try:
@@ -228,7 +231,7 @@ class StarterWindow(QWidget):
         self.setMaximumHeight(340)
         self.show()
         self.starter = True
-        self.logger.log_and_showinfo("info","You have chosen your Starter Pokemon ! \n You can now close this window ! \n Please restart your Anki to restart your Pokemon Journey!")
+        self.logger.log_and_showinfo("info","You have chosen your Starter Pokemon ! \n You can close this window and begin your Pokemon journey!")
         #global achievments
         #check = check_for_badge(achievements, 7)
         #if check is False:

--- a/src/Ankimon/pyobj/test_window.py
+++ b/src/Ankimon/pyobj/test_window.py
@@ -189,17 +189,29 @@ class TestWindow(QWidget):
             getattr(self.main_pokemon, "type", None),
             getattr(self.enemy_pokemon, "type", None),
         )
+        enemy_stages = getattr(self.enemy_pokemon, "stat_stages", None) or {}
+        main_stages = getattr(self.main_pokemon, "stat_stages", None) or {}
         enemy_bp = calculate_present_power(
-            enemy_cp, getattr(self.enemy_pokemon, "hp", 0), enemy_vs_main
+            enemy_cp,
+            getattr(self.enemy_pokemon, "hp", 0),
+            enemy_vs_main,
+            enemy_stages.get("atk", 0),
+            enemy_stages.get("spa", 0),
         )
         main_bp = calculate_present_power(
-            main_cp, getattr(self.main_pokemon, "hp", 0), main_vs_enemy
+            main_cp,
+            getattr(self.main_pokemon, "hp", 0),
+            main_vs_enemy,
+            main_stages.get("atk", 0),
+            main_stages.get("spa", 0),
         )
 
-        painter.drawText(48, 104, f"CP {enemy_cp:,}")
-        painter.drawText(48, 118, f"BP {enemy_bp:,}")
-        painter.drawText(326, 216, f"CP {main_cp:,}")
-        painter.drawText(326, 230, f"BP {main_bp:,}")
+        cp_lbl = self.translator.translate("cp_label")
+        bp_lbl = self.translator.translate("bp_label")
+        painter.drawText(48, 104, f"{cp_lbl} {enemy_cp:,}")
+        painter.drawText(48, 118, f"{bp_lbl} {enemy_bp:,}")
+        painter.drawText(326, 216, f"{cp_lbl} {main_cp:,}")
+        painter.drawText(326, 230, f"{bp_lbl} {main_bp:,}")
 
     def pokemon_display_first_encounter(self):
         # Main window layout

--- a/src/Ankimon/pyobj/test_window.py
+++ b/src/Ankimon/pyobj/test_window.py
@@ -231,7 +231,7 @@ class TestWindow(QWidget):
 
         bckgimage_path = battlescene_path / self.ankimon_tracker_obj.battlescene_file
 
-        if self.ankimon_tracker_obj.pokemon_encouter > 0:
+        if self.ankimon_tracker_obj.pokemon_encounter > 0:
             bckgimage_path = battlescene_path_without_dialog / self.ankimon_tracker_obj.battlescene_file
 
         msg_font = load_custom_font(32, int(self.settings_obj.get("misc.language")))
@@ -407,11 +407,11 @@ class TestWindow(QWidget):
         return painter
 
     def pokemon_display_battle(self):
-        self.ankimon_tracker_obj.pokemon_encouter += 1
+        self.ankimon_tracker_obj.pokemon_encounter += 1
 
         bckgimage_path = battlescene_path / self.ankimon_tracker_obj.battlescene_file
 
-        if self.ankimon_tracker_obj.pokemon_encouter > 1:
+        if self.ankimon_tracker_obj.pokemon_encounter > 1:
             bckgimage_path = battlescene_path_without_dialog / self.ankimon_tracker_obj.battlescene_file
 
         ui_path = battle_ui_path

--- a/src/Ankimon/pyobj/test_window.py
+++ b/src/Ankimon/pyobj/test_window.py
@@ -290,7 +290,7 @@ class TestWindow(QWidget):
         # draw background to a specific pixel
         painter.drawPixmap(0, 0, pixmap_bckg)
 
-        painter = self.draw_hp_bar(118, 76, 8, 116, self.enemy_pokemon.current_hp, self.enemy_pokemon.max_hp, painter)  # enemy pokemon hp_bar
+        painter = self.draw_hp_bar(118, 76, 8, 116, self.enemy_pokemon.hp, self.enemy_pokemon.max_hp, painter)  # enemy pokemon hp_bar
 
         painter = self.draw_hp_bar(401, 208, 8, 116, self.main_pokemon.hp, self.main_pokemon.max_hp, painter)  # main pokemon hp_bar
 

--- a/src/Ankimon/pyobj/test_window.py
+++ b/src/Ankimon/pyobj/test_window.py
@@ -169,7 +169,7 @@ class TestWindow(QWidget):
 
         Battle Power = CP * current_HP * type-matchup multiplier.
         """
-        cp_font = load_custom_font(14, int(self.settings_obj.get("misc.language")))
+        cp_font = load_custom_font(18, int(self.settings_obj.get("misc.language")))
         painter.setFont(cp_font)
         painter.setPen(QColor(31, 31, 39))
         try:

--- a/src/Ankimon/user_files/web/ankimon_hud_portal.js
+++ b/src/Ankimon/user_files/web/ankimon_hud_portal.js
@@ -32,7 +32,11 @@
       "pointer-events": "none", // HUD outer lets clicks pass; inner can enable if needed
       display: "block",
       isolation: "isolate",
-      filter: "invert(1) hue-rotate(180deg) saturate(0.555) contrast(0.833)" // Counter-filter
+      // Counter-filter only when Anki's reviewer is in night mode; in
+      // light mode this inversion actively corrupts sprite colours.
+      filter: document.documentElement.classList.contains("night_mode")
+        ? "invert(1) hue-rotate(180deg) saturate(0.555) contrast(0.833)"
+        : "none"
     });
 
     // Append outside card flow to avoid scroll/overflow containers

--- a/tests/test_cp_formula.py
+++ b/tests/test_cp_formula.py
@@ -34,6 +34,7 @@ from Ankimon.business import (
     pokemon_go_raw_stats,
     type_compatibility_multiplier,
     calculate_cp_from_dict,
+    cp_breakdown_tooltip,
     _load_type_chart,
 )
 
@@ -270,3 +271,34 @@ class TestDictShapeEquivalence:
             *pokemon_go_raw_stats(self.BASE, self.IV, self.EV), self.LEVEL
         )
         assert calculate_cp_from_dict(self._to_dict_shape()) == direct
+
+
+class TestCPBreakdownTooltip:
+    BASE = {"hp": 100, "atk": 80, "def": 90, "spa": 70, "spd": 85, "spe": 95}
+
+    def test_contains_formula(self):
+        tip = cp_breakdown_tooltip(
+            {"base_stats": self.BASE, "iv": {}, "ev": {}, "level": 50}
+        )
+        assert "CP = floor(" in tip
+        assert "CPM²" in tip or "CPM^2" in tip or "CPM" in tip
+
+    def test_contains_level_100_projection(self):
+        tip = cp_breakdown_tooltip(
+            {"base_stats": self.BASE, "iv": {}, "ev": {}, "level": 50}
+        )
+        expected_max = calculate_pokemon_go_cp(
+            *pokemon_go_raw_stats(self.BASE, {}, {}), 100
+        )
+        assert f"{expected_max:,}" in tip
+
+    def test_handles_caught_shape(self):
+        # caught dicts have "stats"=base_stats, no "base_stats"
+        tip = cp_breakdown_tooltip(
+            {"stats": self.BASE, "iv": {}, "ev": {}, "level": 25}
+        )
+        assert "CP at Level 100" in tip
+
+    def test_handles_missing_level(self):
+        tip = cp_breakdown_tooltip({"base_stats": self.BASE})
+        assert "CP at Level 100" in tip

--- a/tests/test_cp_formula.py
+++ b/tests/test_cp_formula.py
@@ -208,3 +208,46 @@ class TestCalculateCPFromDict:
         pokemon = {"stats": {}, "level": 1}
         cp = calculate_cp_from_dict(pokemon)
         assert cp == 10  # minimum clamp with all defaults
+
+
+class TestDictShapeEquivalence:
+    """Sentinel: caught-Pokemon dicts ('stats' = base_stats, no 'base_stats')
+    and to_dict dicts ('base_stats' = bases, 'stats' = level-scaled) must
+    produce the same CP. Regression guard for the pokemon-persistence fix
+    that routed save_caught_pokemon through PokemonObject.to_dict().
+    """
+
+    BASE = {"hp": 100, "atk": 80, "def": 90, "spa": 70, "spd": 85, "spe": 95}
+    LEVEL = 50
+    IV = {"hp": 20, "atk": 25, "def": 30, "spa": 15, "spd": 28, "spe": 31}
+    EV = {"hp": 100, "atk": 200, "def": 150, "spa": 80, "spd": 100, "spe": 80}
+
+    def _caught_shape(self):
+        return {
+            "level": self.LEVEL,
+            "stats": self.BASE,
+            "iv": self.IV,
+            "ev": self.EV,
+        }
+
+    def _to_dict_shape(self):
+        return {
+            "level": self.LEVEL,
+            "base_stats": self.BASE,
+            "stats": {k: 999 for k in self.BASE},
+            "iv": self.IV,
+            "ev": self.EV,
+            "cp": 42,
+            "nature": "adamant",
+        }
+
+    def test_both_shapes_give_same_cp(self):
+        assert calculate_cp_from_dict(self._caught_shape()) == calculate_cp_from_dict(
+            self._to_dict_shape()
+        )
+
+    def test_to_dict_shape_ignores_level_scaled_stats(self):
+        direct = calculate_pokemon_go_cp(
+            *pokemon_go_raw_stats(self.BASE, self.IV, self.EV), self.LEVEL
+        )
+        assert calculate_cp_from_dict(self._to_dict_shape()) == direct

--- a/tests/test_cp_formula.py
+++ b/tests/test_cp_formula.py
@@ -160,6 +160,25 @@ class TestCalculatePresentPower:
         pp = calculate_present_power(None, None, None)
         assert pp == 0
 
+    def test_atk_boost_increases_bp(self):
+        # +2 stage = 5/3, BP = 100 × 50 × 1 × 5/3 = 8333.33 → floor 8333
+        assert calculate_present_power(100, 50, 1.0, atk_stage=2, spa_stage=2) == 8333
+
+    def test_atk_drop_decreases_bp(self):
+        # -2 stage = 3/5 = 0.6, BP = 100 × 50 × 1 × 0.6 = 3000
+        assert calculate_present_power(100, 50, 1.0, atk_stage=-2, spa_stage=-2) == 3000
+
+    def test_mixed_atk_spa_stages_averaged(self):
+        # atk +2 (5/3), spa -2 (3/5), avg = 17/15, BP = 5000 × 17/15 = 5666.66 → floor 5666
+        assert calculate_present_power(100, 50, 1.0, atk_stage=2, spa_stage=-2) == 5666
+
+    def test_out_of_range_stage_neutral(self):
+        # Stage 7 is invalid per get_multiplier_stats — should fall back to 1.0
+        assert calculate_present_power(100, 50, 1.0, atk_stage=7, spa_stage=7) == 5000
+
+    def test_none_stage_neutral(self):
+        assert calculate_present_power(100, 50, 1.0, atk_stage=None, spa_stage=None) == 5000
+
 
 class TestCalculateCPFromDict:
     """Tests for the dict-based CP entry point used by collection/PC box."""

--- a/tests/test_cp_formula.py
+++ b/tests/test_cp_formula.py
@@ -35,6 +35,7 @@ from Ankimon.business import (
     type_compatibility_multiplier,
     calculate_cp_from_dict,
     cp_breakdown_tooltip,
+    compute_type_bias,
     _load_type_chart,
 )
 
@@ -302,3 +303,62 @@ class TestCPBreakdownTooltip:
     def test_handles_missing_level(self):
         tip = cp_breakdown_tooltip({"base_stats": self.BASE})
         assert "CP at Level 100" in tip
+
+
+class TestComputeTypeBias:
+    """Pure-helper tests for the tag-biased-encounter logic. The wrapper
+    _get_card_type_bias() in encounter_functions.py delegates here once
+    it has read settings and mw state."""
+
+    def test_empty_inputs(self):
+        assert compute_type_bias([], "") == []
+        assert compute_type_bias(None, None) == []
+
+    def test_single_type_tag(self):
+        assert compute_type_bias(["electric"], "") == ["Electric"]
+
+    def test_case_insensitive_match(self):
+        assert compute_type_bias(["ELECTRIC"], "") == ["Electric"]
+        assert compute_type_bias(["Electric"], "") == ["Electric"]
+        assert compute_type_bias(["electRIC"], "") == ["Electric"]
+
+    def test_multiple_types_sorted(self):
+        # Output is sorted alphabetically for stability.
+        assert compute_type_bias(["water", "fire", "grass"], "") == [
+            "Fire", "Grass", "Water"
+        ]
+
+    def test_deck_name_nested_components(self):
+        # Anki uses :: as its nested-deck separator.
+        assert compute_type_bias([], "Biology::Psychic") == ["Psychic"]
+        assert compute_type_bias([], "Academic::Electric::Circuits") == ["Electric"]
+
+    def test_deck_name_whitespace_separated(self):
+        assert compute_type_bias([], "Water and fire tactics") == ["Fire", "Water"]
+
+    def test_tags_and_deck_name_combined(self):
+        result = compute_type_bias(["dragon"], "Studies::Psychic")
+        assert result == ["Dragon", "Psychic"]
+
+    def test_non_type_tokens_ignored(self):
+        # Tags that aren't Pokemon types are discarded.
+        assert compute_type_bias(["leech", "biology", "important"], "") == []
+
+    def test_deduplication(self):
+        # Same type appearing via tag AND deck name appears once.
+        assert compute_type_bias(["fire"], "Cooking::fire") == ["Fire"]
+        assert compute_type_bias(["fire", "fire", "FIRE"], "") == ["Fire"]
+
+    def test_all_eighteen_types_recognized(self):
+        all_types = [
+            "normal", "fire", "water", "electric", "grass", "ice",
+            "fighting", "poison", "ground", "flying", "psychic", "bug",
+            "rock", "ghost", "dragon", "dark", "steel", "fairy",
+        ]
+        result = compute_type_bias(all_types, "")
+        assert len(result) == 18
+        assert all(t.capitalize() in result for t in all_types)
+
+    def test_numeric_and_weird_tokens_safe(self):
+        # Non-string tags should coerce via str() without raising.
+        assert compute_type_bias([42, None, "fire"], "") == ["Fire"]


### PR DESCRIPTION
## Summary

Follow-up to PR #355 — a grab-bag of UX, quality, and one new feature surfaced by an independent multi-round code/UX review of the repo. Split into **6 clearly-labeled commits** so each can be reviewed (and reverted) independently. None overlap with commits in #355, #353, #361, #362, #363, #364, or #366.

### Commits

1. **fix(ui): persist trainer team, Gen 9 visibility, Collection Dialog layout stacking**
   - `trainer.team` was deliberately deleted from config on every load — team selections evaporated on restart. Delete line removed.
   - Gen 9 (ids 906–1025) was invisible in Collection Dialog filter, PC Box filter, and Pokedex grid despite `misc.gen9` existing. All three now use `const.gen_ids` as the source of truth.
   - Collection Dialog's `setup_ui` added `scroll_area` + `paginator` to the main layout on every `showEvent`/`refresh_collection` — after N reopens the layout held N stacked scroll areas. Guarded with an `_ui_assembled` flag.

2. **fix(ui): dialog parenting, save-dedup, translation fallback, team window size**
   - `InfoLogger.QMessageBox` unparented → frequently appeared behind Anki's main window on macOS/Linux. Now parented to `aqt.mw`.
   - Settings save fired **two** consecutive modals ("saved" then "changed: X"). Collapsed into one with changelist in `informativeText`.
   - Reviewer's `get_pokemon_diff_lang_name` leaked the literal placeholder `"RESTART ANKI NOW"` as the main Pokemon's name mid-review whenever translation was missing. Silent fallback to species name.
   - Team window `setMinimumSize(900, 500)` overflowed Anki on 13" displays. Reduced to 650×450.

3. **fix(ui): scrollbar, pagination, starter, credits title, tracker show-twice**
   - PC Box scrollbars forced `AlwaysOff`; overflow Pokemon unreachable when `calculate_grid_dimensions` under-reported slots. Now `AsNeeded`.
   - Collection pagination buttons were created-or-omitted — Next shifted into Prev's slot at page 0. Now always rendered, disabled at edges.
   - Starter selection called `close_anki()` then asked the user to restart; the confirmation dialog was unreadable because the app was shutting down. `close_anki()` removed; message updated.
   - Credits window title said "AnkiMon License" (copy-paste from sibling class). Fixed.
   - Tracker window `create_gui` called `self.window.show()`; `toggle_window` called it again — first open was a show-then-show. Removed duplicate.

4. **refactor(ui): HUD night-mode gating + sort dropdown through translator**
   - `ankimon_hud_portal.js` applied `filter: invert(1) hue-rotate(180deg)…` unconditionally; in light mode it corrupted sprite colours. Now gated on `document.documentElement.classList.contains("night_mode")`.
   - Collection Dialog sort dropdown and Descending checkbox routed through `self.translator` with stable internal keys separated from visible labels. Added `sort_*` keys to `en_text.json`.

5. **fix(quality): PokemonEncoder safety, \_\_init\_\_ dedup, logged update fallback**
   - `PokemonEncoder` indexed `data['volatile_status']`/`data['attacks']` unconditionally — `KeyError` for Pokemon built via `from_engine_format` / `update_stats`. Now uses `.get()`.
   - `PokemonObject.__init__` assigned `self.ability` twice (raw then normalized); first write dropped.
   - `update_main_pokemon.py` bare `except Exception:` swallowed a CP-related AttributeError silently (already fixed elsewhere), causing main_pokemon to reset to Ditto on every launch. Now logs the exception before fallback.

6. **feat: Anki card metadata (tags + deck name) biases wild encounter types**
   - New opt-in setting `battle.tag_biased_encounters` (default off). When on, Anki card tags and deck-name components matching a Pokemon type name bias encounters toward that type — e.g. tagging notes "electric" in a circuit-design deck increases Electric spawns.
   - Soft bias: 25-retry cap, defensive error handling, unbiased fallback. Setting registered in all 4 required places per CLAUDE.md.

## Test plan

- [ ] Save a team in the team dialog; restart Anki; team persists
- [ ] Catch a Gen 9 Pokemon (e.g. Sprigatito id 906); appears in Collection filter "Generation 9", PC Box Gen 9 filter, and the Pokedex grid
- [ ] Open Collection Dialog 3× in a row; verify only one scroll area in the layout tree
- [ ] Fire a log via `logger.log_and_showinfo("info", ...)` during review; dialog appears in front of Anki
- [ ] Save settings; one consolidated dialog instead of two
- [ ] Pick a starter; Anki does NOT close, window shows friendly message
- [ ] Sort by CP in Collection Dialog; stable internal key drives behaviour regardless of locale
- [ ] Toggle light/dark mode during review; HUD sprites no longer invert in light mode
- [ ] Enable `battle.tag_biased_encounters`; tag a note "water" or name a deck "…::Water"; encounters in that deck trend Water-type

🤖 Generated with [Claude Code](https://claude.com/claude-code)