### PR TITLE
Add HUD hide-on-startup setting & toggle

### DIFF
--- a/src/Ankimon/config.json
+++ b/src/Ankimon/config.json
@@ -20,6 +20,7 @@
     "gui.reviewer_text_message_box": true,
     "gui.reviewer_text_message_box_time": 3,
     "gui.show_mainpkmn_in_reviewer": 1,
+    "gui.hud_hidden_on_startup": false,
     "gui.team_deck_view": true,
     "gui.view_main_front": true,
     "gui.xp_bar_config": true,

--- a/src/Ankimon/lang/setting_description.json
+++ b/src/Ankimon/lang/setting_description.json
@@ -20,6 +20,7 @@
     "gui.reviewer_text_message_box": "Enable colorful pop-up messages in the reviewer.",
     "gui.reviewer_text_message_box_time": "Duration for message box display in seconds [1-5].",
     "gui.show_mainpkmn_in_reviewer": "Show main Pokémon in reviewer. [0: Hide, 1: Same level view, 2: Battle view]",
+    "gui.hud_hidden_on_startup": "Hide the Heads-Up Display (HUD) when the reviewer starts.",   
     "gui.team_deck_view": "Enable a quick overview of your Pokémon team at the bottom of the deck overview.",
     "gui.view_main_front": "View front of main Pokémon in reviewer when GIFs are enabled. Set Disabled to show from the back.",
     "gui.xp_bar_config": "Enable XP bar in the reviewer to show XP progression for main Pokémon.",

--- a/src/Ankimon/lang/setting_name.json
+++ b/src/Ankimon/lang/setting_name.json
@@ -21,6 +21,7 @@
     "gui.reviewer_text_message_box": "Show Text Message Box in Reviewer",
     "gui.reviewer_text_message_box_time": "Message Box Display Time",
     "gui.show_mainpkmn_in_reviewer": "Show Main Pokémon in Reviewer",
+    "gui.hud_hidden_on_startup": "Hide HUD on Reviewer Startup",
     "gui.team_deck_view": "Team Overview in Deck Overview",
     "gui.view_main_front": "View Main Pokémon Front",
     "gui.team_deck_view": "Team Overview in Deck Overview",

--- a/src/Ankimon/pyobj/reviewer_obj.py
+++ b/src/Ankimon/pyobj/reviewer_obj.py
@@ -19,6 +19,8 @@ class Reviewer_Manager:
         self.life_bar_injected = False
         self.seconds = 0
         self.myseconds = 0
+        self.hud_hidden = False 
+        self.hud_data = None    
 
         # Register the functions for the hooks
         gui_hooks.reviewer_will_end.append(self.reviewer_reset_life_bar_inject)
@@ -232,12 +234,32 @@ class Reviewer_Manager:
         """
 
         # Use reviewer.web.eval to call the portal
+        # Store HUD data and auto-render if not hidden on startup
+        hud_hidden_on_startup = bool(self.settings.get("gui.hud_hidden_on_startup"))
         js_code = f"""
-        (function(h,c){{
-            if(window.__ankimonHud && window.__ankimonHud.update){{
-                window.__ankimonHud.update(h,c);
+        (function(h,c,hiddenOnStartup){{
+            if(window.__ankimonHud){{
+                // Always update the stored data, regardless of visibility
+                window.__ankimonHudData = {{html: h, css: c}};
+                
+                // Only initialize on first call - preserve user's toggle state on subsequent updates
+                if(window.__ankimonHudHidden === undefined){{
+                    window.__ankimonHudHidden = hiddenOnStartup;
+                    window.__ankimonHudRendered = false;
+                }}
+                
+                // If HUD should be visible on startup, render it now
+                if(!hiddenOnStartup && !window.__ankimonHudRendered){{
+                    window.__ankimonHud.update(h,c);
+                    window.__ankimonHudRendered = true;
+                }}
+                // If HUD is already rendered and visible, update it with new data
+                else if(window.__ankimonHudRendered && !window.__ankimonHudHidden){{
+                    window.__ankimonHud.update(h,c);
+                }}
+                // If HUD is hidden, data is still stored in __ankimonHudData for when it's toggled on
             }}
-        }})({json.dumps(hud_html)}, {json.dumps(hud_css)});
+        }})({json.dumps(hud_html)}, {json.dumps(hud_css)}, {str(hud_hidden_on_startup).lower()});
         """
         reviewer.web.eval(js_code)
 
@@ -246,25 +268,47 @@ class Reviewer_Manager:
             (function() {
                 if (window.ankimonKeyListener) return;
                 window.ankimonKeyListener = true;
-                let originalParent = null; // To store the parent element
-                let hudHost = null; // To store the ankimon-hud-host element
+                let originalParent = null;
+                let hudHost = null;
 
                 document.addEventListener('keydown', function(event) {
                     if (event.key === '8') {
-                        if (!hudHost) { // First time '8' is pressed, find the element
+                        if (!hudHost) {
                             hudHost = document.getElementById('ankimon-hud-host');
                             if (hudHost) {
-                                originalParent = hudHost.parentNode; // Store its parent
+                                originalParent = hudHost.parentNode;
                             } else {
-                                console.error('Ankimon: ankimon-hud-host not found for removal.');
+                                console.error('Ankimon: ankimon-hud-host not found.');
                                 return;
                             }
                         }
 
-                        if (hudHost.parentNode) { // If it has a parent, it's currently in the DOM, so remove it
-                            hudHost.parentNode.removeChild(hudHost);
-                        } else if (originalParent) { // If it has no parent but we have an original parent, re-add it
-                            originalParent.appendChild(hudHost);
+                        // First time: render if not yet rendered
+                        if (!window.__ankimonHudRendered && window.__ankimonHudData && window.__ankimonHud) {
+                            window.__ankimonHud.update(window.__ankimonHudData.html, window.__ankimonHudData.css);
+                            window.__ankimonHudRendered = true;
+                            originalParent = hudHost.parentNode;
+                            // Toggle visibility on first render
+                            window.__ankimonHudHidden = !window.__ankimonHudHidden;
+                            // If should be hidden, remove it from DOM
+                            if (window.__ankimonHudHidden && originalParent) {
+                                originalParent.removeChild(hudHost);
+                            }
+                        } else if (window.__ankimonHudRendered) {
+                            // Already rendered, toggle visibility
+                            window.__ankimonHudHidden = !window.__ankimonHudHidden;
+                            
+                            // If showing (unhiding), update with latest data
+                            if (!window.__ankimonHudHidden && window.__ankimonHudData && window.__ankimonHud) {
+                                window.__ankimonHud.update(window.__ankimonHudData.html, window.__ankimonHudData.css);
+                            }
+                            
+                            // Toggle DOM visibility
+                            if (hudHost.parentNode) {
+                                hudHost.parentNode.removeChild(hudHost);
+                            } else if (originalParent) {
+                                originalParent.appendChild(hudHost);
+                            }
                         }
                     }
                 });

--- a/src/Ankimon/pyobj/settings.py
+++ b/src/Ankimon/pyobj/settings.py
@@ -35,6 +35,7 @@ DEFAULT_CONFIG = {
     "gui.reviewer_text_message_box": True,
     "gui.reviewer_text_message_box_time": 3,
     "gui.show_mainpkmn_in_reviewer": 1,
+    "gui.hud_hidden_on_startup": False,    
     "gui.team_deck_view": True,
     "gui.view_main_front": True,
     "gui.xp_bar_config": True,

--- a/src/Ankimon/pyobj/settings_window.py
+++ b/src/Ankimon/pyobj/settings_window.py
@@ -318,6 +318,7 @@ class SettingsWindow(QMainWindow):
                     "Automatic Battle",
                     "Cards per Round",
                     "Show Main Pokémon in Reviewer",
+                    "Hide HUD on Reviewer Startup", 
                     "Show Pokémon Buttons",
                     "Pop-Up on Defeat",
                     "Show Text Message Box in Reviewer",


### PR DESCRIPTION
This pull request adds a user-configurable option to control HUD visibility on reviewer startup. Previously, the Pokémon HUD (Heads-Up Display showing enemy stats, HP, and trainer information) would always render automatically when the reviewer opened a card.

This change introduces a new setting, "Hide HUD on Reviewer Startup", that allows users to:

Enable (default): HUD remains hidden until the user presses the '8' key to toggle it on
Disable: HUD displays automatically on reviewer startup (preserves original behavior)
The implementation defers HUD rendering until needed while maintaining all existing functionality. The solution stores HUD data independently of its visibility state, ensuring that HP values and other dynamic information update correctly whether the HUD is visible or hidden. When toggling the HUD on via the '8' key, it always renders with the latest data. This provides users with a distraction-free reviewing experience while maintaining the option to view Pokémon stats on demand.