### PR TITLE
fix: lookup crash for hyphenated Pokemon names

### DIFF
--- a/src/Ankimon/functions/pokedex_functions.py
+++ b/src/Ankimon/functions/pokedex_functions.py
@@ -94,8 +94,26 @@ def special_pokemon_names_for_min_level(name):
         return "celebi"
     elif name == "magearna[e]":
         return "magearna"
-    elif name == "type: null":
+    elif name == "type: null" or name == "type-null":
         return "typenull"
+    elif name == "ho-oh":
+        return "hooh"
+    elif name == "tapu-koko":
+        return "tapukoko"
+    elif name == "tapu-lele":
+        return "tapulele"
+    elif name == "tapu-bulu":
+        return "tapubulu"
+    elif name == "tapu-fini":
+        return "tapufini"
+    elif name == "ting-lu":
+        return "tinglu"
+    elif name == "chien-pao":
+        return "chienpao"
+    elif name == "wo-chien":
+        return "wochien"
+    elif name == "chi-yu":
+        return "chiyu"
     else:
         return name
 


### PR DESCRIPTION
## Summary
- Add unhyphenated name mappings for Ho-Oh, Tapus, Treasures of Ruin, and Type: Null
- Prevents search_pokedex crashes on hyphenated species names

Incorporates the fix from #362.

🤖 Generated with [Claude Code](https://claude.com/claude-code)