### PR TITLE
team cycling feature using a hotkey

### DIFF
--- a/src/Ankimon/__init__.py
+++ b/src/Ankimon/__init__.py
@@ -169,6 +169,7 @@ setup_reviewer_ui(
     settings_obj.get("controls.catch_key"),
     settings_obj.get("controls.defeat_key"),
     settings_obj.get("controls.pokemon_buttons"),
+    settings_obj.get("controls.team_cycle_key", "9"),
 )
 
 from .discord_integration import setup_discord_hooks

--- a/src/Ankimon/config.json
+++ b/src/Ankimon/config.json
@@ -7,6 +7,7 @@
     "controls.pokemon_buttons": true,
     "controls.defeat_key": "5",
     "controls.catch_key": "6",
+    "controls.team_cycle_key": "9",
     "controls.key_for_opening_closing_ankimon": "Ctrl+N",
     "controls.allow_to_choose_moves": false,
 

--- a/src/Ankimon/functions/update_main_pokemon.py
+++ b/src/Ankimon/functions/update_main_pokemon.py
@@ -1,5 +1,6 @@
 import json
 import uuid
+from collections import defaultdict
 from typing import Optional
 
 from ..functions.pokedex_functions import search_pokedex, search_pokedex_by_id
@@ -116,3 +117,87 @@ def save_main_pokemon(main_pokemon: PokemonObject):
         data = main_pokemon.__dict__
     
     db.save_main_pokemon(data)
+
+
+def set_main_from_record(pokemon_data: dict, main_pokemon: PokemonObject) -> PokemonObject:
+    """Switch the active/main Pokémon to ``pokemon_data`` (a collection record).
+
+    Single source of truth shared by the collection picker (``collection_dialog``)
+    and the in-review team-cycle hotkey. It:
+      1. Persists the OUTGOING main's in-memory state (xp/HP/status) back to the
+         collection, so switching never silently drops progress.
+      2. Rebuilds ``main_pokemon`` in place from the record.
+      3. Preserves the new main's stored current HP (clamped to max) on the
+         authoritative ``hp`` field and its ``current_hp`` mirror -- so switching
+         is NOT a free heal.
+    Returns the same ``main_pokemon`` object, mutated in place.
+    """
+    db = mw.ankimon_db
+
+    # 1. Persist the outgoing main before replacing it.
+    try:
+        if (
+            main_pokemon is not None
+            and getattr(main_pokemon, "individual_id", None)
+            and db.get_main_pokemon()
+        ):
+            db.save_pokemon(main_pokemon.to_dict())
+    except Exception:
+        pass  # No active main yet -- nothing to preserve.
+
+    # 2. Build the new main from the record.
+    pokemon_id = pokemon_data.get("id")
+    pokemon_name = search_pokedex_by_id(pokemon_id)
+    base_stats = search_pokedex(pokemon_name, "baseStats")
+    new_main = PokemonObject(
+        name=pokemon_name,
+        level=pokemon_data.get("level", 5),
+        ability=pokemon_data.get("ability", ["none"]),
+        type=pokemon_data.get("type", ["Normal"]),
+        base_stats=base_stats,
+        ev=pokemon_data.get("ev", defaultdict(int)),
+        iv=pokemon_data.get("iv", defaultdict(int)),
+        attacks=pokemon_data.get("attacks", ["Struggle"]),
+        base_experience=pokemon_data.get("base_experience", 0),
+        growth_rate=pokemon_data.get("growth_rate", "medium"),
+        gender=pokemon_data.get("gender", "N"),
+        shiny=pokemon_data.get("shiny", False),
+        individual_id=pokemon_data.get("individual_id", str(uuid.uuid4())),
+        id=pokemon_data.get("id", 133),
+        status=pokemon_data.get("status", None),
+        volatile_status=set(pokemon_data.get("volatile_status", [])),
+        xp=pokemon_data.get("xp", 0),
+        nickname=pokemon_data.get("nickname", ""),
+        friendship=pokemon_data.get("friendship", 0),
+        pokemon_defeated=pokemon_data.get("pokemon_defeated", 0),
+        everstone=pokemon_data.get("everstone", False),
+        mega=pokemon_data.get("mega", False),
+        special_form=pokemon_data.get("special_form", None),
+        tier=pokemon_data.get("tier", None),
+        captured_date=pokemon_data.get("captured_date", None),
+        is_favorite=pokemon_data.get("is_favorite", False),
+        held_item=pokemon_data.get("held_item"),
+    )
+    for attr in (
+        "captured_date", "tier", "friendship", "pokemon_defeated",
+        "everstone", "mega", "special_form", "base_experience",
+    ):
+        if attr in pokemon_data:
+            setattr(new_main, attr, pokemon_data[attr])
+
+    # 3. Preserve stored current HP (no free heal). ``hp`` is authoritative;
+    #    ``current_hp`` mirrors it. Both clamped to max.
+    max_hp = new_main.calculate_max_hp()
+    new_main.max_hp = max_hp
+    stored_hp = pokemon_data.get("current_hp", pokemon_data.get("hp", max_hp))
+    try:
+        stored_hp = int(stored_hp)
+    except (TypeError, ValueError):
+        stored_hp = max_hp
+    new_main.hp = max(0, min(stored_hp, max_hp))
+    new_main.current_hp = new_main.hp
+
+    # 4. Mutate the existing reference in place and persist as the main pokemon.
+    main_pokemon.__dict__.update(new_main.__dict__)
+    db.save_main_pokemon(main_pokemon.to_dict())
+    return main_pokemon

--- a/src/Ankimon/functions/update_main_pokemon.py
+++ b/src/Ankimon/functions/update_main_pokemon.py
@@ -119,7 +119,7 @@ def save_main_pokemon(main_pokemon: PokemonObject):
     db.save_main_pokemon(data)
 
 
-def set_main_from_record(pokemon_data: dict, main_pokemon: PokemonObject) -> PokemonObject:
+def set_main_from_record(pokemon_data: dict, main_pokemon: PokemonObject, heal_to_full: bool = False) -> PokemonObject:
     """Switch the active/main Pokémon to ``pokemon_data`` (a collection record).
 
     Single source of truth shared by the collection picker (``collection_dialog``)
@@ -160,6 +160,7 @@ def set_main_from_record(pokemon_data: dict, main_pokemon: PokemonObject) -> Pok
         attacks=pokemon_data.get("attacks", ["Struggle"]),
         base_experience=pokemon_data.get("base_experience", 0),
         growth_rate=pokemon_data.get("growth_rate", "medium"),
+        nature=pokemon_data.get("nature", "serious"),
         gender=pokemon_data.get("gender", "N"),
         shiny=pokemon_data.get("shiny", False),
         individual_id=pokemon_data.get("individual_id", str(uuid.uuid4())),
@@ -189,12 +190,18 @@ def set_main_from_record(pokemon_data: dict, main_pokemon: PokemonObject) -> Pok
     #    ``current_hp`` mirrors it. Both clamped to max.
     max_hp = new_main.calculate_max_hp()
     new_main.max_hp = max_hp
-    stored_hp = pokemon_data.get("current_hp", pokemon_data.get("hp", max_hp))
-    try:
-        stored_hp = int(stored_hp)
-    except (TypeError, ValueError):
-        stored_hp = max_hp
-    new_main.hp = max(0, min(stored_hp, max_hp))
+    if heal_to_full:
+        # Collection picker: keep its long-standing heal-on-pick behaviour.
+        new_main.hp = max_hp
+    else:
+        # Team-cycle hotkey: preserve the incoming Pokémon's stored HP (no free
+        # heal). hp is authoritative; current_hp mirrors it.
+        stored_hp = pokemon_data.get("current_hp", pokemon_data.get("hp", max_hp))
+        try:
+            stored_hp = int(stored_hp)
+        except (TypeError, ValueError):
+            stored_hp = max_hp
+        new_main.hp = max(0, min(stored_hp, max_hp))
     new_main.current_hp = new_main.hp
 
     # 4. Mutate the existing reference in place and persist as the main pokemon.

--- a/src/Ankimon/pyobj/collection_dialog.py
+++ b/src/Ankimon/pyobj/collection_dialog.py
@@ -1,6 +1,4 @@
 import json
-from collections import defaultdict
-import uuid
 
 from aqt.utils import showInfo, showWarning
 from ..pyobj.error_handler import show_warning_with_traceback
@@ -16,7 +14,6 @@ from ..pyobj.InfoLogger import ShowInfoLogger
 from ..pyobj.translator import Translator
 from ..pyobj.test_window import TestWindow
 from ..pyobj.reviewer_obj import Reviewer_Manager
-from ..functions.pokedex_functions import search_pokedex, search_pokedex_by_id
 
 def MainPokemon(
     pokemon_data: dict,
@@ -26,88 +23,12 @@ def MainPokemon(
     reviewer_obj: Reviewer_Manager,
     test_window: TestWindow,
 ):
-    from ..functions.migration import migrate_starter_individual_id
+    from ..functions.update_main_pokemon import set_main_from_record
 
-    db = mw.ankimon_db
-    
-    # --- Save the existing mainpokemon to mypokemon before replacing ---
-    # Persist the OUTGOING main's IN-MEMORY state (xp, friendship, current_hp
-    # gained during reviews) rather than the stale on-disk copy returned by
-    # db.get_main_pokemon(). At this point ``main_pokemon`` still references the
-    # current main; it is only overwritten with the new selection further below.
-    try:
-        # Only save if there's already an active main pokemon to replace.
-        if main_pokemon is not None and getattr(main_pokemon, "individual_id", None) and db.get_main_pokemon():
-            # Use main_pokemon.to_dict() to capture in-memory stats like xp.
-            db.save_pokemon(main_pokemon.to_dict())
-    except Exception:
-        pass  # If no main pokemon exists, just continue
-
-    # --- Now proceed to set the new mainpokemon as before ---
-    pokemon_id = pokemon_data.get("id")
-    pokemon_name = search_pokedex_by_id(pokemon_id)
-    base_stats = search_pokedex(pokemon_name, "baseStats")
-    current_hp = PokemonObject.calc_stat(
-        "hp",
-        base_stats["hp"],
-        pokemon_data["level"],
-        pokemon_data["iv"]["hp"],
-        pokemon_data["ev"]["hp"],
-        pokemon_data.get("nature", "serious"),
-    )
-    # Create NEW PokemonObject instance using class constructor
-    new_main_pokemon = PokemonObject(
-        name=pokemon_name,
-        level=pokemon_data.get("level", 5),
-        ability=pokemon_data.get("ability", ["none"]),
-        type=pokemon_data.get("type", ["Normal"]),
-        base_stats=base_stats,
-        ev=pokemon_data.get("ev", defaultdict(int)),
-        iv=pokemon_data.get("iv", defaultdict(int)),
-        attacks=pokemon_data.get("attacks", ["Struggle"]),
-        base_experience=pokemon_data.get("base_experience", 0),
-        growth_rate=pokemon_data.get("growth_rate", "medium"),
-        current_hp=current_hp,
-        gender=pokemon_data.get("gender", "N"),
-        shiny=pokemon_data.get("shiny", False),
-        individual_id=pokemon_data.get("individual_id", str(uuid.uuid4())),
-        id=pokemon_data.get("id", 133),
-        status=pokemon_data.get("status", None),
-        volatile_status=set(pokemon_data.get("volatile_status", [])),
-        xp=pokemon_data.get("xp", 0),
-        nickname=pokemon_data.get("nickname", ""),
-        # Add common extra fields if constructor supports them
-        friendship=pokemon_data.get("friendship", 0),
-        pokemon_defeated=pokemon_data.get("pokemon_defeated", 0),
-        everstone=pokemon_data.get("everstone", False),
-        mega=pokemon_data.get("mega", False),
-        special_form=pokemon_data.get("special_form", None),
-        tier=pokemon_data.get("tier", None),
-        captured_date=pokemon_data.get("captured_date", None),
-        is_favorite=pokemon_data.get("is_favorite", False),
-        held_item=pokemon_data.get("held_item"),
-    )
-    # Set any additional fields not in constructor
-    extra_fields = [
-        "captured_date",
-        "tier",
-        "friendship",
-        "pokemon_defeated",
-        "everstone",
-        "mega",
-        "special_form",
-        "current_hp",
-        "base_experience",
-    ]
-    for attr in extra_fields:
-        if attr in pokemon_data:
-            setattr(new_main_pokemon, attr, pokemon_data[attr])
-
-    # Update existing reference
-    main_pokemon.__dict__.update(new_main_pokemon.__dict__)
-
-    # Save to database
-    db.save_main_pokemon(main_pokemon.to_dict())
+    # Switch the active/main Pokémon. Shared with the in-review team-cycle hotkey
+    # via set_main_from_record: it saves the outgoing main's progress and
+    # preserves the incoming Pokémon's stored HP (no free heal).
+    set_main_from_record(pokemon_data, main_pokemon)
 
     logger.log_and_showinfo(
         "info",

--- a/src/Ankimon/pyobj/collection_dialog.py
+++ b/src/Ankimon/pyobj/collection_dialog.py
@@ -28,7 +28,7 @@ def MainPokemon(
     # Switch the active/main Pokémon. Shared with the in-review team-cycle hotkey
     # via set_main_from_record: it saves the outgoing main's progress and
     # preserves the incoming Pokémon's stored HP (no free heal).
-    set_main_from_record(pokemon_data, main_pokemon)
+    set_main_from_record(pokemon_data, main_pokemon, heal_to_full=True)
 
     logger.log_and_showinfo(
         "info",

--- a/src/Ankimon/pyobj/settings.py
+++ b/src/Ankimon/pyobj/settings.py
@@ -29,6 +29,7 @@ DEFAULT_CONFIG = {
     "controls.pokemon_buttons": True,
     "controls.defeat_key": "5",
     "controls.catch_key": "6",
+    "controls.team_cycle_key": "9",
     "controls.key_for_opening_closing_ankimon": "Ctrl+Shift+P",
     "controls.allow_to_choose_moves": False,
     "gui.animate_time": True,

--- a/src/Ankimon/reviewer_ui.py
+++ b/src/Ankimon/reviewer_ui.py
@@ -1,6 +1,7 @@
 from anki.hooks import wrap
 from aqt.reviewer import Reviewer
 from aqt.utils import downArrow, tooltip, tr
+from aqt import mw
 
 from .singletons import (
     enemy_pokemon,
@@ -53,14 +54,56 @@ def defeat_shortcut_function():
         tooltip("Wild pokemon has to be fainted to defeat it!")
 
 
-def setup_reviewer_ui(catch_shortcut: str, defeat_shortcut: str, reviewer_buttons: bool):
+_team_cycle_index = 0
+
+
+def cycle_team_pokemon():
+    """Cycle the active/main Pokémon to the next of the first 3 team slots.
+
+    Reuses ``set_main_from_record`` -- the same routine the collection picker
+    uses -- so the outgoing main's progress is saved and the incoming Pokémon
+    keeps its stored HP (cycling is never a free heal).
+    """
+    global _team_cycle_index
+    from .functions.update_main_pokemon import set_main_from_record
+
+    db = mw.ankimon_db
+    team = db.get_team() or []
+    team_ids = [e.get("individual_id") for e in team[:3] if e.get("individual_id")]
+    if len(team_ids) < 2:
+        tooltip("Need at least 2 team members to cycle.")
+        return
+
+    _team_cycle_index = (_team_cycle_index + 1) % len(team_ids)
+    record = db.get_pokemon(team_ids[_team_cycle_index])
+    if not record or not record.get("id"):
+        tooltip("Could not load that team member.")
+        return
+
+    set_main_from_record(record, main_pokemon)
+
+    # Refresh the in-review HUD (life bar / sprite).
+    try:
+        reviewer = mw.reviewer
+        if reviewer and reviewer.web:
+            reviewer_obj.update_life_bar(reviewer, 0, 0)
+    except Exception as e:
+        logger.log("error", f"Team cycle HUD refresh failed: {e}")
+
+    name = main_pokemon.nickname or main_pokemon.name
+    tooltip(f"Switched to {name} (Lvl {main_pokemon.level}, HP {main_pokemon.hp}/{main_pokemon.max_hp})")
+
+
+def setup_reviewer_ui(catch_shortcut: str, defeat_shortcut: str, reviewer_buttons: bool, team_cycle_shortcut: str = "9"):
     catch_key = str(catch_shortcut).lower()
     defeat_key = str(defeat_shortcut).lower()
+    team_cycle_key = str(team_cycle_shortcut).lower()
 
     def _shortcutKeys_wrap(self, _old):
         original = _old(self)
         original.append((catch_key, lambda: catch_shortcut_function()))
         original.append((defeat_key, lambda: defeat_shortcut_function()))
+        original.append((team_cycle_key, lambda: cycle_team_pokemon()))
         return original
 
     Reviewer._shortcutKeys = wrap(Reviewer._shortcutKeys, _shortcutKeys_wrap, "around")

--- a/src/Ankimon/reviewer_ui.py
+++ b/src/Ankimon/reviewer_ui.py
@@ -54,18 +54,27 @@ def defeat_shortcut_function():
         tooltip("Wild pokemon has to be fainted to defeat it!")
 
 
-_team_cycle_index = 0
+_last_team_cycle = 0.0
 
 
 def cycle_team_pokemon():
-    """Cycle the active/main Pokémon to the next of the first 3 team slots.
+    """Switch the active/main Pokémon to the next non-fainted of the first 3 team
+    slots, relative to whoever is currently active.
 
-    Reuses ``set_main_from_record`` -- the same routine the collection picker
-    uses -- so the outgoing main's progress is saved and the incoming Pokémon
-    keeps its stored HP (cycling is never a free heal).
+    Reuses ``set_main_from_record`` (the same routine the collection picker uses)
+    so the outgoing main's progress is saved and the incoming Pokémon keeps its
+    stored HP -- cycling is never a free heal. Fainted (0-HP) members are skipped
+    on purpose: switching a 0-HP Pokémon in would just be auto-revived + trigger
+    an enemy reroll by the next card's faint handler, i.e. a free heal/escape.
     """
-    global _team_cycle_index
+    global _last_team_cycle
+    import time
     from .functions.update_main_pokemon import set_main_from_record
+
+    now = time.time()
+    if now - _last_team_cycle < 0.3:  # debounce: each switch writes the DB
+        return
+    _last_team_cycle = now
 
     db = mw.ankimon_db
     team = db.get_team() or []
@@ -74,24 +83,43 @@ def cycle_team_pokemon():
         tooltip("Need at least 2 team members to cycle.")
         return
 
-    _team_cycle_index = (_team_cycle_index + 1) % len(team_ids)
-    record = db.get_pokemon(team_ids[_team_cycle_index])
-    if not record or not record.get("id"):
-        tooltip("Could not load that team member.")
+    # Start from the current main's slot so "next" is relative to who's active.
+    current_id = getattr(main_pokemon, "individual_id", None)
+    try:
+        start = team_ids.index(current_id)
+    except ValueError:
+        start = -1  # current main isn't in the first 3 -> first step lands on slot 0
+
+    n = len(team_ids)
+    for step in range(1, n + 1):
+        cand_id = team_ids[(start + step) % n]
+        if cand_id == current_id:
+            continue
+        record = db.get_pokemon(cand_id)
+        if not record or not record.get("id"):
+            continue
+        stored_hp = record.get("current_hp", record.get("hp", 1))
+        try:
+            stored_hp = int(stored_hp)
+        except (TypeError, ValueError):
+            stored_hp = 1
+        if stored_hp < 1:
+            continue  # skip fainted members (see docstring)
+
+        set_main_from_record(record, main_pokemon)
+
+        try:
+            reviewer = mw.reviewer
+            if reviewer and reviewer.web:
+                reviewer_obj.update_life_bar(reviewer, 0, 0)
+        except Exception as e:
+            logger.log("error", f"Team cycle HUD refresh failed: {e}")
+
+        name = main_pokemon.nickname or main_pokemon.name
+        tooltip(f"Switched to {name} (Lvl {main_pokemon.level}, HP {main_pokemon.hp}/{main_pokemon.max_hp})")
         return
 
-    set_main_from_record(record, main_pokemon)
-
-    # Refresh the in-review HUD (life bar / sprite).
-    try:
-        reviewer = mw.reviewer
-        if reviewer and reviewer.web:
-            reviewer_obj.update_life_bar(reviewer, 0, 0)
-    except Exception as e:
-        logger.log("error", f"Team cycle HUD refresh failed: {e}")
-
-    name = main_pokemon.nickname or main_pokemon.name
-    tooltip(f"Switched to {name} (Lvl {main_pokemon.level}, HP {main_pokemon.hp}/{main_pokemon.max_hp})")
+    tooltip("No other healthy team member to switch to.")
 
 
 def setup_reviewer_ui(catch_shortcut: str, defeat_shortcut: str, reviewer_buttons: bool, team_cycle_shortcut: str = "9"):


### PR DESCRIPTION
I'm implementing a team cycling feature that lets players quickly switch between their first 3 Pokémon (from the team) using a hotkey (default: Key 9) during card review, without opening the Pokémon PC window.

Adds a configurable hotkey that cycles the active Pokémon through the first 3 team slots (1→2→3→1→2→3...) while reviewing cards. Each press does:
- Switch the active Pokémon instantly
- Reset HP to full (like the PC window does)
- Update the HUD sprite/HP bar immediately
- Show a tooltip with the new Pokémon name
- Persist the switch so the next encounter uses the new active Pokémon