### PR TITLE
Fix CP, IV, and EV sorting in PC Box

### DIFF
--- a/src/Ankimon/pyobj/pc_box.py
+++ b/src/Ankimon/pyobj/pc_box.py
@@ -858,6 +858,8 @@ class PokemonPC(QDialog):
             order_clause = f"ORDER BY level {direction}"
         elif sort_key_str == "id":
             order_clause = f"ORDER BY pokedex_id {direction}"
+        elif sort_key_str == "cp":
+            order_clause = f"ORDER BY CAST(json_extract(data, '$.cp') AS REAL) {direction}"
         else:
             # For IV/EV or default, sort by original_index first, then override in Python if needed
             order_clause = f"ORDER BY original_index {direction}"
@@ -885,7 +887,7 @@ class PokemonPC(QDialog):
                 if sort_key_str in ["iv", "ev"]:
                     stats_json = row[f"{sort_key_str}_json"]
                     stats_dict = json.loads(stats_json) if stats_json else {}
-                    p["_sort_value"] = sum(stats_dict.values()) if isinstance(stats_dict, dict) else 0
+                    p["_sort_value"] = sum(stats_dict.values()) if isinstance(stats_dict, dict) else sum(stats_dict) if isinstance(stats_dict, list) else 0
                 
                 results.append(p)
                 


### PR DESCRIPTION
This PR fixes issues where sorting by CP, IV, or EV failed or worked incorrectly in the PC window. 
1. Added explicit handling for CP sorting by extracting it via SQLite `json_extract`.
2. Updated the Python-side fallback logic for IV/EV sorting to correctly calculate the stats sum regardless of whether the migrated IV/EV data is stored as a dictionary or a list in the new database structure.

---
*PR created automatically by Jules for task [8614432327399331558](https://jules.google.com/task/8614432327399331558) started by @h0tp-ftw*