### PR TITLE
Add search and sorting to Pokémon team selection

### DIFF
--- a/src/Ankimon/gui_classes/pokemon_team_window.py
+++ b/src/Ankimon/gui_classes/pokemon_team_window.py
@@ -144,11 +144,6 @@ class PokemonTeamDialog(QDialog):
             if not pokemon_data:
                 return 0
             
-            # Debug: print available keys
-            print(f"Pokemon data keys: {pokemon_data.keys()}")
-            print(f"Base stats: {pokemon_data.get('base_stats', 'NOT FOUND')}")
-            print(f"Detail stats: {pokemon_data.get('detail_stats', 'NOT FOUND')}")
-            
             base_stats = pokemon_data.get('base_stats', {})
             if not base_stats:
                 base_stats = pokemon_data.get('detail_stats', {})
@@ -163,14 +158,10 @@ class PokemonTeamDialog(QDialog):
                 ev = {stat: 0 for stat in ['hp', 'atk', 'def', 'spa', 'spd', 'spe']}
             
             attack, defense, stamina = pokemon_go_raw_stats(base_stats, iv, ev)
-            print(f"Attack: {attack}, Defense: {defense}, Stamina: {stamina}, Level: {level}")
-            
             cp = calculate_pokemon_go_cp(attack, defense, stamina, level)
             return cp
         except Exception as e:
-            print(f"Error calculating CP for {individual_id}: {e}")
-            import traceback
-            traceback.print_exc()
+            self.logger.log("error", f"Error calculating CP for {individual_id}: {e}")
             return 0
 
     def load_pokemon_team(self):

--- a/src/Ankimon/gui_classes/pokemon_team_window.py
+++ b/src/Ankimon/gui_classes/pokemon_team_window.py
@@ -78,25 +78,24 @@ class PokemonTeamDialog(QDialog):
         scroll_area.setWidget(team_widget)
         layout.addWidget(scroll_area)
 
-        # XP Share dropdown
-        self.xp_share_combo = QComboBox()
-        self.xp_share_combo.addItem("No XP Share")
-        for pokemon in self.my_pokemon:
-            self.xp_share_combo.addItem(f"{pokemon['name']} (Level {pokemon['level']})", pokemon['individual_id'])
+        # XP Share selection
+        self.xp_share_selected_individual_id = None
+        self.xp_share_label = QLabel("XP Share: None")
+        xp_share_button = QPushButton("Choose Pokémon with XP Share")
+        xp_share_button.clicked.connect(self.choose_xp_share_pokemon)
 
-            # Set a preview image as item data
-            sprite_path = get_sprite_path("front", "png", pokemon['id'], pokemon["shiny"], pokemon["gender"])
-            pixmap = QPixmap(sprite_path)
-            self.xp_share_combo.setItemData(self.xp_share_combo.count() - 1, pixmap, Qt.ItemDataRole.DecorationRole)
-
-        # Set the initial XP Share Pokémon (based on settings)
+        # Load initial XP Share Pokémon (based on settings)
         xp_share_pokemon_individual_id = self.settings.get("trainer.xp_share")
         if xp_share_pokemon_individual_id:
-            xp_share_index = next((i for i, p in enumerate(self.my_pokemon) if p['individual_id'] == xp_share_pokemon_individual_id), 0) + 1
-            self.xp_share_combo.setCurrentIndex(xp_share_index)
+            self.xp_share_selected_individual_id = xp_share_pokemon_individual_id
+            # Find the name for display
+            for pokemon in self.my_pokemon:
+                if pokemon['individual_id'] == xp_share_pokemon_individual_id:
+                    self.xp_share_label.setText(f"XP Share: {pokemon['name']} (Level {pokemon['level']})")
+                    break
 
-        layout.addWidget(QLabel("Choose Pokémon with XP Share:"))
-        layout.addWidget(self.xp_share_combo)
+        layout.addWidget(self.xp_share_label)
+        layout.addWidget(xp_share_button)
 
         # OK Button
         ok_button = QPushButton("OK")
@@ -136,6 +135,44 @@ class PokemonTeamDialog(QDialog):
             })
         return my_pokemon
 
+    def _calculate_pokemon_cp(self, individual_id):
+        """Calculate CP for a Pokémon by fetching full data"""
+        from ..business import calculate_pokemon_go_cp, pokemon_go_raw_stats
+        
+        try:
+            pokemon_data = mw.ankimon_db.get_pokemon(individual_id)
+            if not pokemon_data:
+                return 0
+            
+            # Debug: print available keys
+            print(f"Pokemon data keys: {pokemon_data.keys()}")
+            print(f"Base stats: {pokemon_data.get('base_stats', 'NOT FOUND')}")
+            print(f"Detail stats: {pokemon_data.get('detail_stats', 'NOT FOUND')}")
+            
+            base_stats = pokemon_data.get('base_stats', {})
+            if not base_stats:
+                base_stats = pokemon_data.get('detail_stats', {})
+            
+            iv = pokemon_data.get('iv', {})
+            ev = pokemon_data.get('ev', {})
+            level = pokemon_data.get('level', 1)
+            
+            if not iv:
+                iv = {stat: 0 for stat in ['hp', 'atk', 'def', 'spa', 'spd', 'spe']}
+            if not ev:
+                ev = {stat: 0 for stat in ['hp', 'atk', 'def', 'spa', 'spd', 'spe']}
+            
+            attack, defense, stamina = pokemon_go_raw_stats(base_stats, iv, ev)
+            print(f"Attack: {attack}, Defense: {defense}, Stamina: {stamina}, Level: {level}")
+            
+            cp = calculate_pokemon_go_cp(attack, defense, stamina, level)
+            return cp
+        except Exception as e:
+            print(f"Error calculating CP for {individual_id}: {e}")
+            import traceback
+            traceback.print_exc()
+            return 0
+
     def load_pokemon_team(self):
         """Load the player's Pokémon Team from the database"""
         team_data = mw.ankimon_db.get_team()
@@ -163,10 +200,11 @@ class PokemonTeamDialog(QDialog):
                 pokemon = self.team_pokemon[i]
                 pokemon_name = pokemon['name']
                 pokemon_level = pokemon['level']
+                cp_value = self._calculate_pokemon_cp(pokemon['individual_id'])
                 sprite_path = os.path.join(frontdefault, f"{pokemon['id']}.png")
 
-                # Update label with name and level
-                frame_data['label'].setText(f"{pokemon_name} (Level {pokemon_level})")
+                # Update label with name, level, and CP
+                frame_data['label'].setText(f"{pokemon_name} (Level {pokemon_level}) - CP {cp_value}")
 
                 # Display the sprite image
                 if os.path.exists(sprite_path):
@@ -198,7 +236,7 @@ class PokemonTeamDialog(QDialog):
         # Sorting dropdown
         sort_label = QLabel("Sort by:")
         sort_combo = QComboBox()
-        sort_combo.addItems(["Name (A-Z)", "Level (High-Low)", "Pokédex ID"])
+        sort_combo.addItems(["Name (A-Z)", "Level (High-Low)", "Pokédex ID", "CP (High-Low)"])
         search_layout.addWidget(sort_label)
         search_layout.addWidget(sort_combo)
 
@@ -247,6 +285,9 @@ class PokemonTeamDialog(QDialog):
                 filtered.sort(key=lambda p: p['level'], reverse=True)
             elif "Pokédex" in sort_option:
                 filtered.sort(key=lambda p: p['id'])
+            elif "CP" in sort_option:
+                # Calculate CP for each and sort
+                filtered.sort(key=lambda p: self._calculate_pokemon_cp(p['individual_id']), reverse=True)
             
             # Update combo_box
             combo_box.blockSignals(True)  # Prevent triggering update_preview while updating
@@ -254,7 +295,10 @@ class PokemonTeamDialog(QDialog):
             
             if filtered:
                 for pokemon in filtered:
-                    combo_box.addItem(f"{pokemon['name']} (Level {pokemon['level']})", pokemon)
+                    cp_value = self._calculate_pokemon_cp(pokemon['individual_id'])
+                    display_text = f"{pokemon['name']} (Level {pokemon['level']}) - CP {cp_value}"
+                    
+                    combo_box.addItem(display_text, pokemon)
                     sprite_path = get_sprite_path("front", "png", pokemon['id'], pokemon["shiny"], pokemon["gender"])
                     pixmap = QPixmap(sprite_path)
                     combo_box.setItemData(combo_box.count() - 1, pixmap, Qt.ItemDataRole.DecorationRole)
@@ -346,13 +390,11 @@ class PokemonTeamDialog(QDialog):
                 pokemon_names.append(pokemon_name)
 
         # Get the selected Pokémon for XP Share
-        xp_share_pokemon = self.xp_share_combo.currentText()
-        if xp_share_pokemon != "No XP Share":
-            # Retrieve the individual_id of the selected Pokémon
-            current_index = self.xp_share_combo.currentIndex()
-            xp_share_individual_id = self.xp_share_combo.itemData(current_index)
+        xp_share_individual_id = self.xp_share_selected_individual_id
+        if xp_share_individual_id:
+            xp_share_pokemon = next((p['name'] for p in self.my_pokemon if p['individual_id'] == xp_share_individual_id), "Unknown")
         else:
-            xp_share_individual_id = None
+            xp_share_pokemon = "No XP Share"
 
         # Update settings with the selected team and XP Share setting
         self.settings.set("trainer.team", team_data)
@@ -371,3 +413,129 @@ class PokemonTeamDialog(QDialog):
             self.trainer_card.reload_team()
 
         self.accept()  # Close the dialog
+
+    def choose_xp_share_pokemon(self):
+        """Open dialog to select XP Share Pokémon"""
+        dialog = QDialog(self)
+        dialog.setWindowTitle("Select Pokémon for XP Share")
+        dialog.setMinimumSize(500, 400)
+
+        layout = QVBoxLayout()
+
+        label = QLabel("Choose a Pokémon to receive XP Share:")
+        layout.addWidget(label)
+
+        # Add a search box and sort dropdown
+        search_layout = QHBoxLayout()
+
+        # Sorting dropdown
+        sort_label = QLabel("Sort by:")
+        sort_combo = QComboBox()
+        sort_combo.addItems(["Name (A-Z)", "Level (High-Low)", "Pokédex ID", "CP (High-Low)"])
+        search_layout.addWidget(sort_label)
+        search_layout.addWidget(sort_combo)
+
+        # Search box
+        search_label_box = QLabel("Search:")
+        search_input = QLineEdit()
+        search_input.setPlaceholderText("Type Pokémon name...")
+        search_layout.addWidget(search_label_box)
+        search_layout.addWidget(search_input)
+
+        layout.addLayout(search_layout)
+
+        # Create a dropdown to select XP Share Pokémon
+        combo_box = QComboBox()
+        combo_box.addItem("No XP Share", None)
+
+        available_pokemon = self.my_pokemon
+
+        # Label and preview for image
+        preview_label = QLabel("Preview:")
+        layout.addWidget(QLabel("Select Pokémon:"))
+        layout.addWidget(combo_box)
+        layout.addWidget(preview_label)
+        
+        image_label = QLabel()
+        image_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        layout.addWidget(image_label)
+
+        # Function to update the combo box list based on search and sort
+        def update_pokemon_list():
+            search_text = search_input.text().lower()
+            sort_option = sort_combo.currentText()
+            
+            # Filter by search text
+            filtered = [p for p in available_pokemon if search_text in p['name'].lower()]
+            
+            # Sort based on selection
+            if "Name" in sort_option:
+                filtered.sort(key=lambda p: p['name'])
+            elif "Level" in sort_option:
+                filtered.sort(key=lambda p: p['level'], reverse=True)
+            elif "Pokédex" in sort_option:
+                filtered.sort(key=lambda p: p['id'])
+            elif "CP" in sort_option:
+                filtered.sort(key=lambda p: self._calculate_pokemon_cp(p['individual_id']), reverse=True)
+            
+            # Update combo_box
+            combo_box.blockSignals(True)
+            combo_box.clear()
+            combo_box.addItem("No XP Share", None)
+            
+            if filtered:
+                for pokemon in filtered:
+                    cp_value = self._calculate_pokemon_cp(pokemon['individual_id'])
+                    display_text = f"{pokemon['name']} (Level {pokemon['level']}) - CP {cp_value}"
+                    
+                    combo_box.addItem(display_text, pokemon['individual_id'])
+                    sprite_path = get_sprite_path("front", "png", pokemon['id'], pokemon["shiny"], pokemon["gender"])
+                    pixmap = QPixmap(sprite_path)
+                    combo_box.setItemData(combo_box.count() - 1, pixmap, Qt.ItemDataRole.DecorationRole)
+            
+            combo_box.blockSignals(False)
+            update_preview(0)
+
+        # Function to update the image preview when a new item is selected
+        def update_preview(index):
+            individual_id = combo_box.itemData(index)
+            if individual_id:
+                pokemon = next((p for p in self.my_pokemon if p['individual_id'] == individual_id), None)
+                if pokemon:
+                    sprite_path = get_sprite_path("front", "png", pokemon['id'], pokemon["shiny"], pokemon["gender"])
+                    pixmap = QPixmap(sprite_path)
+                    image_label.setPixmap(pixmap.scaled(100, 100, Qt.AspectRatioMode.KeepAspectRatio))
+                    image_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
+            else:
+                image_label.clear()
+
+        # Connect signals
+        sort_combo.currentTextChanged.connect(update_pokemon_list)
+        search_input.textChanged.connect(update_pokemon_list)
+        combo_box.currentIndexChanged.connect(lambda: update_preview(combo_box.currentIndex()))
+
+        # Initial population
+        update_pokemon_list()
+
+        # Button to confirm the selection
+        button_box = QDialogButtonBox(QDialogButtonBox.StandardButton.Ok | QDialogButtonBox.StandardButton.Cancel)
+        button_box.accepted.connect(lambda: self.confirm_xp_share(combo_box.itemData(combo_box.currentIndex()), dialog))
+        button_box.rejected.connect(dialog.reject)
+
+        layout.addWidget(button_box)
+
+        dialog.setLayout(layout)
+        dialog.exec()
+
+    def confirm_xp_share(self, selected_individual_id, dialog):
+        """Confirm the XP Share Pokémon selection"""
+        self.xp_share_selected_individual_id = selected_individual_id
+
+        if selected_individual_id:
+            pokemon = next((p for p in self.my_pokemon if p['individual_id'] == selected_individual_id), None)
+            if pokemon:
+                self.xp_share_label.setText(f"XP Share: {pokemon['name']} (Level {pokemon['level']})")
+        else:
+            self.xp_share_label.setText("XP Share: None")
+    
+        dialog.accept()

--- a/src/Ankimon/gui_classes/pokemon_team_window.py
+++ b/src/Ankimon/gui_classes/pokemon_team_window.py
@@ -1,6 +1,6 @@
 from ..functions.sprite_functions import get_sprite_path
 from PyQt6.QtCore import Qt
-from PyQt6.QtWidgets import QApplication, QDialog, QVBoxLayout, QLabel, QPushButton, QScrollArea, QGroupBox, QFrame, QGridLayout, QComboBox, QDialogButtonBox
+from PyQt6.QtWidgets import QApplication, QDialog, QVBoxLayout, QHBoxLayout, QLineEdit, QLabel, QPushButton, QScrollArea, QGroupBox, QFrame, QGridLayout, QComboBox, QDialogButtonBox
 from PyQt6.QtGui import QPixmap
 import json
 import os
@@ -185,42 +185,84 @@ class PokemonTeamDialog(QDialog):
         # Create a dialog to choose a new Pokémon for the slot
         dialog = QDialog(self)
         dialog.setWindowTitle("Select Pokémon to Switch In")
-        dialog.setMinimumSize(300, 200)
+        dialog.setMinimumSize(500, 400)
 
         layout = QVBoxLayout()
 
         label = QLabel("Choose a Pokémon to switch in:")
         layout.addWidget(label)
 
+        # Add a search box and sort dropdown
+        search_layout = QHBoxLayout()
+
+        # Sorting dropdown
+        sort_label = QLabel("Sort by:")
+        sort_combo = QComboBox()
+        sort_combo.addItems(["Name (A-Z)", "Level (High-Low)", "Pokédex ID"])
+        search_layout.addWidget(sort_label)
+        search_layout.addWidget(sort_combo)
+
+        # Search box
+        search_label_box = QLabel("Search:")
+        search_input = QLineEdit()
+        search_input.setPlaceholderText("Type Pokémon name...")
+        search_layout.addWidget(search_label_box)
+        search_layout.addWidget(search_input)
+
+        layout.addLayout(search_layout)
+
         # Create a dropdown to select a new Pokémon
         combo_box = QComboBox()
 
-        # Add only those Pokémon to the combo box that are not already in the team (checked by individual_id)
+        # Add only those Pokémon to the combo box that are not already in the team
         used_pokemon_ids = []
         for i, pokemon in enumerate(self.team_pokemon):
             if pokemon is not None and i != slot:
                 used_pokemon_ids.append(pokemon['individual_id'])
-        # Check if there are Pokémon left to choose from (those whose individual_id is not in used_pokemon_ids)
+        
         available_pokemon = [pokemon for pokemon in self.my_pokemon if pokemon and pokemon['individual_id'] not in used_pokemon_ids]
 
-        if available_pokemon:
-            for pokemon in available_pokemon:
-                combo_box.addItem(f"{pokemon['name']} (Level {pokemon['level']})", pokemon)
-
-                # Set a preview image as item data
-                sprite_path = get_sprite_path("front", "png", pokemon['id'], pokemon["shiny"], pokemon["gender"])
-                pixmap = QPixmap(sprite_path)
-                combo_box.setItemData(combo_box.count() - 1, pixmap, Qt.ItemDataRole.DecorationRole)
-        else:
-            combo_box.addItem("No available Pokémon", None)  # Display a message if no Pokémon are available
-
-        layout.addWidget(combo_box)
-
-        # Label for the image preview
+        # Label and preview for image
         preview_label = QLabel("Preview:")
+        layout.addWidget(QLabel("Select Pokémon:"))
+        layout.addWidget(combo_box)
         layout.addWidget(preview_label)
+        
         image_label = QLabel()
+        image_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
         layout.addWidget(image_label)
+
+        # Function to update the combo box list based on search and sort
+        def update_pokemon_list():
+            search_text = search_input.text().lower()
+            sort_option = sort_combo.currentText()
+            
+            # Filter by search text
+            filtered = [p for p in available_pokemon if search_text in p['name'].lower()]
+            
+            # Sort based on selection
+            if "Name" in sort_option:
+                filtered.sort(key=lambda p: p['name'])
+            elif "Level" in sort_option:
+                filtered.sort(key=lambda p: p['level'], reverse=True)
+            elif "Pokédex" in sort_option:
+                filtered.sort(key=lambda p: p['id'])
+            
+            # Update combo_box
+            combo_box.blockSignals(True)  # Prevent triggering update_preview while updating
+            combo_box.clear()
+            
+            if filtered:
+                for pokemon in filtered:
+                    combo_box.addItem(f"{pokemon['name']} (Level {pokemon['level']})", pokemon)
+                    sprite_path = get_sprite_path("front", "png", pokemon['id'], pokemon["shiny"], pokemon["gender"])
+                    pixmap = QPixmap(sprite_path)
+                    combo_box.setItemData(combo_box.count() - 1, pixmap, Qt.ItemDataRole.DecorationRole)
+            else:
+                combo_box.addItem("No Pokémon found", None)
+            
+            combo_box.blockSignals(False)
+            update_preview(0)
 
         # Function to update the image preview when a new item is selected
         def update_preview(index):
@@ -230,13 +272,20 @@ class PokemonTeamDialog(QDialog):
                 pixmap = QPixmap(sprite_path)
                 image_label.setPixmap(pixmap.scaled(100, 100, Qt.AspectRatioMode.KeepAspectRatio))
                 image_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
+            else:
+                image_label.clear()
 
-        # Connect the selection change to the preview update
+        # Connect signals
+        sort_combo.currentTextChanged.connect(update_pokemon_list)
+        search_input.textChanged.connect(update_pokemon_list)
         combo_box.currentIndexChanged.connect(lambda: update_preview(combo_box.currentIndex()))
+
+        # Initial population
+        update_pokemon_list()
 
         # Button to confirm the selection
         button_box = QDialogButtonBox(QDialogButtonBox.StandardButton.Ok | QDialogButtonBox.StandardButton.Cancel)
-        button_box.accepted.connect(lambda: self.confirm_switch(combo_box.currentIndex(), slot, dialog))
+        button_box.accepted.connect(lambda: self.confirm_switch(combo_box, slot, dialog))
         button_box.rejected.connect(dialog.reject)
 
         layout.addWidget(button_box)
@@ -244,15 +293,12 @@ class PokemonTeamDialog(QDialog):
         dialog.setLayout(layout)
         dialog.exec()
 
-    def confirm_switch(self, selected_index, slot, dialog):
+    def confirm_switch(self, combo_box, slot, dialog):
         """Confirm the Pokémon switch and update the team"""
-        # Get the selected Pokémon from combo_box.itemData()
-        selected_pokemon = dialog.findChild(QComboBox).itemData(selected_index)
+        selected_pokemon = combo_box.itemData(combo_box.currentIndex())
 
         if selected_pokemon:
             self.team_pokemon[slot] = selected_pokemon  # Replace the Pokémon in the team slot
-
-            # Update the team display
             self.update_team_display()
 
         dialog.accept()


### PR DESCRIPTION
With a large Pokédex, finding the right Pokémon for the team was tedious as the list had no organization or search functionality.

Enhanced the Pokémon selection dialog with:
- Text search by Pokémon name (real-time filtering)
- Sort options: by Name (A-Z), Level (High-Low), Pokédex ID, and CP
- Live preview of selected Pokémon sprite
- Improved dialog layout with better UX
- Display CP value in all dialogs