### PR TITLE
Fix Ultra Beasts and other Pokémon with missing moves in learnset lookup

### DIFF
--- a/src/Ankimon/functions/learnset_retrieval.py
+++ b/src/Ankimon/functions/learnset_retrieval.py
@@ -7,15 +7,7 @@ from ..resources import learnset_path
 def _get_learnset_moves(pokemon_name, pokemon_level, generation=9):
     """
     Return all moves a Pokémon can know at *pokemon_level* in a single *generation*.
-
-    Args:
-        pokemon_name: Pokémon name (case-insensitive).
-        pokemon_level: Current level of the Pokémon.
-        generation: Generation to filter learn_codes by (default 9).
-
-    Returns:
-        dict mapping move_name -> learn_level for every move learnable
-        at or below *pokemon_level* within the specified generation.
+    Falls back to earlier generations if no moves are found.
     """
     with open(learnset_path, "r", encoding="utf-8") as file:
         learnsets = json.load(file)
@@ -24,23 +16,30 @@ def _get_learnset_moves(pokemon_name, pokemon_level, generation=9):
     pokemon_learnset = learnsets.get(pokemon_name, {}).get("learnset", {})
 
     moves = {}
-
-    target_generation = str(generation)
-
-    for move, learn_codes in pokemon_learnset.items():
-        best = -1
-        for learn_code in learn_codes:
-            move_generation, _, move_level = learn_code.partition("L")
-            if move_generation != target_generation:
-                continue
-
-            learn_level = int(move_level)
-            if pokemon_level >= learn_level > best:
-                best = learn_level
-
-        if best >= 0:
-            moves[move] = best
-
+    
+    # Try the requested generation first, then fallback to 8, then 7
+    for gen in [generation, 8, 7]:
+        moves = {}
+        target_generation = str(gen)
+        
+        for move, learn_codes in pokemon_learnset.items():
+            best = -1
+            for learn_code in learn_codes:
+                move_generation, _, move_level = learn_code.partition("L")
+                if move_generation != target_generation:
+                    continue
+                
+                learn_level = int(move_level)
+                if pokemon_level >= learn_level > best:
+                    best = learn_level
+            
+            if best >= 0:
+                moves[move] = best
+        
+        # If we found moves, return them
+        if moves:
+            break
+    
     return moves
 
 

--- a/src/Ankimon/functions/learnset_retrieval.py
+++ b/src/Ankimon/functions/learnset_retrieval.py
@@ -3,17 +3,43 @@ import random
 
 from ..resources import learnset_path
 
+# === Cache learnset data ===
+_learnset_cache = None
+
+def _load_learnset_cache():
+    """Load learnset JSON once and cache it in memory"""
+    global _learnset_cache
+    if _learnset_cache is None:
+        try:
+            with open(learnset_path, "r", encoding="utf-8") as file:
+                _learnset_cache = json.load(file)
+        except Exception as e:
+            print(f"Error loading learnset cache: {e}")
+            _learnset_cache = {}
+    return _learnset_cache
+
+def clear_learnset_cache():
+    """Clear the learnset cache if data is updated"""
+    global _learnset_cache
+    _learnset_cache = None
 
 def _get_learnset_moves(pokemon_name, pokemon_level, generation=9):
     """
     Return all moves a Pokémon can know at *pokemon_level* in a single *generation*.
     Falls back to earlier generations if no moves are found.
+    Handles Mega/Gigantamax forms by falling back to base form learnset.
     """
     with open(learnset_path, "r", encoding="utf-8") as file:
         learnsets = json.load(file)
 
     pokemon_name = pokemon_name.lower()
     pokemon_learnset = learnsets.get(pokemon_name, {}).get("learnset", {})
+    
+    # Fallback to base form for Mega/Gigantamax if no learnset found
+    if not pokemon_learnset and ("mega" in pokemon_name or "gmax" in pokemon_name):
+        # Extract base name (e.g., "heracrossmega" -> "heracross")
+        base_name = pokemon_name.replace("mega", "").replace("gmax", "").replace("gigantamax", "")
+        pokemon_learnset = learnsets.get(base_name, {}).get("learnset", {})
 
     moves = {}
     

--- a/src/Ankimon/functions/learnset_retrieval.py
+++ b/src/Ankimon/functions/learnset_retrieval.py
@@ -17,8 +17,8 @@ def _get_learnset_moves(pokemon_name, pokemon_level, generation=9):
 
     moves = {}
     
-    # Try the requested generation first, then fallback to 8, then 7
-    for gen in [generation, 8, 7]:
+    # Try the requested generation first, then fallback to all earlier generations
+    for gen in range(generation, 0, -1):  # Try from requested gen down to gen 1
         moves = {}
         target_generation = str(gen)
         

--- a/src/Ankimon/functions/sprite_functions.py
+++ b/src/Ankimon/functions/sprite_functions.py
@@ -1,10 +1,26 @@
 import os
+import json
 
 from aqt import mw
 
-from ..resources import pkmnimgfolder
+from ..resources import pkmnimgfolder, pokedex_path
 
 SUBSTITUTE_PATH = f"{pkmnimgfolder}/front_default/substitute.png"
+
+
+def _get_pokemon_id_from_pokedex(pokemon_name):
+    """Get the sprite ID for a Pokémon form from pokedex (handles Mega/Gmax forms)."""
+    try:
+        with open(pokedex_path, "r", encoding="utf-8") as f:
+            pokedex = json.load(f)
+        
+        pokemon_key = pokemon_name.lower().replace(" ", "").replace("-", "")
+        if pokemon_key in pokedex:
+            return pokedex[pokemon_key].get("actual_id") or pokedex[pokemon_key].get("num")
+    except Exception as e:
+        mw.logger.log("debug", f"Error looking up pokemon ID in pokedex: {e}")
+    
+    return None
 
 
 def _path_format(back: bool, id: int, gif: bool, shiny: bool, female: bool):
@@ -31,7 +47,7 @@ def _try_gendered(back: bool, id: int, gif: bool, shiny: bool, female: bool):
         return path
 
     if female:
-        # requested gendered gif but not found, try non-gendered
+        # requested gendered but not found, try non-gendered
         path = _path_format(back, id, gif, shiny, False)
         if os.path.exists(path):
             mw.logger.log("debug", f"Sprite found (gender fallback): {path}")
@@ -44,40 +60,62 @@ def _try_back(back: bool, id: int, gif: bool, shiny: bool, female: bool):
         return path
 
     if back:
-        # requested back
-
-        # special fallback
-        if not gif:
-            path = f"sprites/missing_back/{id}.png"
-            if os.path.exists(path):
-                mw.logger.log("debug", f"Sprite found (back fallback): {path}")
-                return path
-
-        path = _try_gendered(False, id, gif, shiny, False)
+        # requested back, fallback to front
+        path = _try_gendered(False, id, gif, shiny, female)
         if path:
             return path
 
 
-def get_sprite_path(side: str, sprite_type: str, id: int, shiny: bool, gender: str):
-    """Return the path to the sprite of the Pokémon with robust fallbacks."""
+def get_sprite_path(side: str, sprite_type: str, id: int, shiny: bool, gender: str, pokemon_name: str = None):
+    """Return the path to the sprite of the Pokémon with robust fallbacks.
+    
+    Args:
+        side: "front" or "back"
+        sprite_type: "gif" or "png"
+        id: Pokémon ID (base form)
+        shiny: Whether the Pokémon is shiny
+        gender: "M" or "F"
+        pokemon_name: Optional Pokémon name (used for Mega/Gmax forms to lookup correct sprite ID)
+    """
 
     gif = sprite_type == "gif"
     female = gender == "F"
     back = side == "back"
+    
+    lookup_id = id
 
-    path = _try_back(back, id, gif, shiny, female)
+    # For Mega/Gmax forms, try to get the form-specific ID from pokedex
+    if pokemon_name and any(form in pokemon_name.lower() for form in ["mega", "gmax", "gigantamax"]):
+        forme_id = _get_pokemon_id_from_pokedex(pokemon_name)
+        if forme_id:
+            lookup_id = forme_id
+            mw.logger.log("debug", f"Using Mega/Gmax form ID {lookup_id} for {pokemon_name}")
+
+    # Try requested format first
+    path = _try_back(back, lookup_id, gif, shiny, female)
     if path:
         return path
 
+    # If GIF requested but not found, try PNG
     if gif:
-        # requested gif but not found, try png
-        path = _try_back(back, id, False, shiny, female)
+        path = _try_back(back, lookup_id, False, shiny, female)
         if path:
             return path
+
+    # If we used a forme ID and still found nothing, fallback to base form ID
+    if lookup_id != id:
+        path = _try_back(back, id, gif, shiny, female)
+        if path:
+            return path
+
+        if gif:
+            path = _try_back(back, id, False, shiny, female)
+            if path:
+                return path
 
     # Fallback to the generic substitute image
     mw.logger.log(
         "warning",
-        f"Unable to find sprite for ID {id} (Side: {side} Sprite: {sprite_type} Shiny: {shiny}, Gender: {gender}). Returning substitute.",
+        f"Unable to find sprite for {pokemon_name} ID {id} (Side: {side} Sprite: {sprite_type} Shiny: {shiny}, Gender: {gender}). Returning substitute.",
     )
     return SUBSTITUTE_PATH

--- a/src/Ankimon/gui_classes/overview_team.py
+++ b/src/Ankimon/gui_classes/overview_team.py
@@ -232,6 +232,7 @@ def _build_card_html(pokemon: dict[str, Any], id_prefix: str) -> str:
         pokemon.get("id", 132),
         pokemon.get("shiny", False),
         gender,
+        pokemon.get("name")
     )
     sprite_src = png_to_base64(sprite_path)
 

--- a/src/Ankimon/gui_classes/pokemon_details.py
+++ b/src/Ankimon/gui_classes/pokemon_details.py
@@ -117,7 +117,7 @@ def PokemonCollectionDetails(
         pkmnimage_label = QLabel()
         pkmnpixmap = QPixmap()
         pkmnimage_path = get_sprite_path(
-            "front", "gif" if gif_in_collection else "png", id, shiny, gender
+            "front", "gif" if gif_in_collection else "png", id, shiny, gender, name
         )
 
         if gif_in_collection:

--- a/src/Ankimon/gui_classes/pokemon_team_window.py
+++ b/src/Ankimon/gui_classes/pokemon_team_window.py
@@ -1,6 +1,6 @@
 from ..functions.sprite_functions import get_sprite_path
 from PyQt6.QtCore import Qt
-from PyQt6.QtWidgets import QApplication, QDialog, QVBoxLayout, QLabel, QPushButton, QScrollArea, QGroupBox, QFrame, QGridLayout, QComboBox, QDialogButtonBox
+from PyQt6.QtWidgets import QApplication, QDialog, QVBoxLayout, QHBoxLayout, QLineEdit, QLabel, QPushButton, QScrollArea, QGroupBox, QFrame, QGridLayout, QComboBox, QDialogButtonBox
 from PyQt6.QtGui import QPixmap
 import json
 import os
@@ -78,25 +78,24 @@ class PokemonTeamDialog(QDialog):
         scroll_area.setWidget(team_widget)
         layout.addWidget(scroll_area)
 
-        # XP Share dropdown
-        self.xp_share_combo = QComboBox()
-        self.xp_share_combo.addItem("No XP Share")
-        for pokemon in self.my_pokemon:
-            self.xp_share_combo.addItem(f"{pokemon['name']} (Level {pokemon['level']})", pokemon['individual_id'])
+        # XP Share selection
+        self.xp_share_selected_individual_id = None
+        self.xp_share_label = QLabel("XP Share: None")
+        xp_share_button = QPushButton("Choose Pokémon with XP Share")
+        xp_share_button.clicked.connect(self.choose_xp_share_pokemon)
 
-            # Set a preview image as item data
-            sprite_path = get_sprite_path("front", "png", pokemon['id'], pokemon["shiny"], pokemon["gender"])
-            pixmap = QPixmap(sprite_path)
-            self.xp_share_combo.setItemData(self.xp_share_combo.count() - 1, pixmap, Qt.ItemDataRole.DecorationRole)
-
-        # Set the initial XP Share Pokémon (based on settings)
+        # Load initial XP Share Pokémon (based on settings)
         xp_share_pokemon_individual_id = self.settings.get("trainer.xp_share")
         if xp_share_pokemon_individual_id:
-            xp_share_index = next((i for i, p in enumerate(self.my_pokemon) if p['individual_id'] == xp_share_pokemon_individual_id), 0) + 1
-            self.xp_share_combo.setCurrentIndex(xp_share_index)
+            self.xp_share_selected_individual_id = xp_share_pokemon_individual_id
+            # Find the name for display
+            for pokemon in self.my_pokemon:
+                if pokemon['individual_id'] == xp_share_pokemon_individual_id:
+                    self.xp_share_label.setText(f"XP Share: {pokemon['name']} (Level {pokemon['level']})")
+                    break
 
-        layout.addWidget(QLabel("Choose Pokémon with XP Share:"))
-        layout.addWidget(self.xp_share_combo)
+        layout.addWidget(self.xp_share_label)
+        layout.addWidget(xp_share_button)
 
         # OK Button
         ok_button = QPushButton("OK")
@@ -136,6 +135,44 @@ class PokemonTeamDialog(QDialog):
             })
         return my_pokemon
 
+    def _calculate_pokemon_cp(self, individual_id):
+        """Calculate CP for a Pokémon by fetching full data"""
+        from ..business import calculate_pokemon_go_cp, pokemon_go_raw_stats
+        
+        try:
+            pokemon_data = mw.ankimon_db.get_pokemon(individual_id)
+            if not pokemon_data:
+                return 0
+            
+            # Debug: print available keys
+            print(f"Pokemon data keys: {pokemon_data.keys()}")
+            print(f"Base stats: {pokemon_data.get('base_stats', 'NOT FOUND')}")
+            print(f"Detail stats: {pokemon_data.get('detail_stats', 'NOT FOUND')}")
+            
+            base_stats = pokemon_data.get('base_stats', {})
+            if not base_stats:
+                base_stats = pokemon_data.get('detail_stats', {})
+            
+            iv = pokemon_data.get('iv', {})
+            ev = pokemon_data.get('ev', {})
+            level = pokemon_data.get('level', 1)
+            
+            if not iv:
+                iv = {stat: 0 for stat in ['hp', 'atk', 'def', 'spa', 'spd', 'spe']}
+            if not ev:
+                ev = {stat: 0 for stat in ['hp', 'atk', 'def', 'spa', 'spd', 'spe']}
+            
+            attack, defense, stamina = pokemon_go_raw_stats(base_stats, iv, ev)
+            print(f"Attack: {attack}, Defense: {defense}, Stamina: {stamina}, Level: {level}")
+            
+            cp = calculate_pokemon_go_cp(attack, defense, stamina, level)
+            return cp
+        except Exception as e:
+            print(f"Error calculating CP for {individual_id}: {e}")
+            import traceback
+            traceback.print_exc()
+            return 0
+
     def load_pokemon_team(self):
         """Load the player's Pokémon Team from the database"""
         team_data = mw.ankimon_db.get_team()
@@ -163,10 +200,11 @@ class PokemonTeamDialog(QDialog):
                 pokemon = self.team_pokemon[i]
                 pokemon_name = pokemon['name']
                 pokemon_level = pokemon['level']
+                cp_value = self._calculate_pokemon_cp(pokemon['individual_id'])
                 sprite_path = os.path.join(frontdefault, f"{pokemon['id']}.png")
 
-                # Update label with name and level
-                frame_data['label'].setText(f"{pokemon_name} (Level {pokemon_level})")
+                # Update label with name, level, and CP
+                frame_data['label'].setText(f"{pokemon_name} (Level {pokemon_level}) - CP {cp_value}")
 
                 # Display the sprite image
                 if os.path.exists(sprite_path):
@@ -185,58 +223,113 @@ class PokemonTeamDialog(QDialog):
         # Create a dialog to choose a new Pokémon for the slot
         dialog = QDialog(self)
         dialog.setWindowTitle("Select Pokémon to Switch In")
-        dialog.setMinimumSize(300, 200)
+        dialog.setMinimumSize(500, 400)
 
         layout = QVBoxLayout()
 
         label = QLabel("Choose a Pokémon to switch in:")
         layout.addWidget(label)
 
+        # Add a search box and sort dropdown
+        search_layout = QHBoxLayout()
+
+        # Sorting dropdown
+        sort_label = QLabel("Sort by:")
+        sort_combo = QComboBox()
+        sort_combo.addItems(["Name (A-Z)", "Level (High-Low)", "Pokédex ID", "CP (High-Low)"])
+        search_layout.addWidget(sort_label)
+        search_layout.addWidget(sort_combo)
+
+        # Search box
+        search_label_box = QLabel("Search:")
+        search_input = QLineEdit()
+        search_input.setPlaceholderText("Type Pokémon name...")
+        search_layout.addWidget(search_label_box)
+        search_layout.addWidget(search_input)
+
+        layout.addLayout(search_layout)
+
         # Create a dropdown to select a new Pokémon
         combo_box = QComboBox()
 
-        # Add only those Pokémon to the combo box that are not already in the team (checked by individual_id)
+        # Add only those Pokémon to the combo box that are not already in the team
         used_pokemon_ids = []
         for i, pokemon in enumerate(self.team_pokemon):
             if pokemon is not None and i != slot:
                 used_pokemon_ids.append(pokemon['individual_id'])
-        # Check if there are Pokémon left to choose from (those whose individual_id is not in used_pokemon_ids)
+        
         available_pokemon = [pokemon for pokemon in self.my_pokemon if pokemon and pokemon['individual_id'] not in used_pokemon_ids]
 
-        if available_pokemon:
-            for pokemon in available_pokemon:
-                combo_box.addItem(f"{pokemon['name']} (Level {pokemon['level']})", pokemon)
-
-                # Set a preview image as item data
-                sprite_path = get_sprite_path("front", "png", pokemon['id'], pokemon["shiny"], pokemon["gender"])
-                pixmap = QPixmap(sprite_path)
-                combo_box.setItemData(combo_box.count() - 1, pixmap, Qt.ItemDataRole.DecorationRole)
-        else:
-            combo_box.addItem("No available Pokémon", None)  # Display a message if no Pokémon are available
-
-        layout.addWidget(combo_box)
-
-        # Label for the image preview
+        # Label and preview for image
         preview_label = QLabel("Preview:")
+        layout.addWidget(QLabel("Select Pokémon:"))
+        layout.addWidget(combo_box)
         layout.addWidget(preview_label)
+        
         image_label = QLabel()
+        image_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
         layout.addWidget(image_label)
+
+        # Function to update the combo box list based on search and sort
+        def update_pokemon_list():
+            search_text = search_input.text().lower()
+            sort_option = sort_combo.currentText()
+            
+            # Filter by search text
+            filtered = [p for p in available_pokemon if search_text in p['name'].lower()]
+            
+            # Sort based on selection
+            if "Name" in sort_option:
+                filtered.sort(key=lambda p: p['name'])
+            elif "Level" in sort_option:
+                filtered.sort(key=lambda p: p['level'], reverse=True)
+            elif "Pokédex" in sort_option:
+                filtered.sort(key=lambda p: p['id'])
+            elif "CP" in sort_option:
+                # Calculate CP for each and sort
+                filtered.sort(key=lambda p: self._calculate_pokemon_cp(p['individual_id']), reverse=True)
+            
+            # Update combo_box
+            combo_box.blockSignals(True)  # Prevent triggering update_preview while updating
+            combo_box.clear()
+            
+            if filtered:
+                for pokemon in filtered:
+                    cp_value = self._calculate_pokemon_cp(pokemon['individual_id'])
+                    display_text = f"{pokemon['name']} (Level {pokemon['level']}) - CP {cp_value}"
+                    
+                    combo_box.addItem(display_text, pokemon)
+                    sprite_path = get_sprite_path("front", "png", pokemon['id'], pokemon["shiny"], pokemon["gender"], pokemon.get("name"))
+                    pixmap = QPixmap(sprite_path)
+                    combo_box.setItemData(combo_box.count() - 1, pixmap, Qt.ItemDataRole.DecorationRole)
+            else:
+                combo_box.addItem("No Pokémon found", None)
+            
+            combo_box.blockSignals(False)
+            update_preview(0)
 
         # Function to update the image preview when a new item is selected
         def update_preview(index):
             pokemon = combo_box.itemData(index)
             if pokemon:
-                sprite_path = get_sprite_path("front", "png", pokemon['id'], pokemon["shiny"], pokemon["gender"])
+                sprite_path = get_sprite_path("front", "png", pokemon['id'], pokemon["shiny"], pokemon["gender"], pokemon.get("name"))
                 pixmap = QPixmap(sprite_path)
                 image_label.setPixmap(pixmap.scaled(100, 100, Qt.AspectRatioMode.KeepAspectRatio))
                 image_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
+            else:
+                image_label.clear()
 
-        # Connect the selection change to the preview update
+        # Connect signals
+        sort_combo.currentTextChanged.connect(update_pokemon_list)
+        search_input.textChanged.connect(update_pokemon_list)
         combo_box.currentIndexChanged.connect(lambda: update_preview(combo_box.currentIndex()))
+
+        # Initial population
+        update_pokemon_list()
 
         # Button to confirm the selection
         button_box = QDialogButtonBox(QDialogButtonBox.StandardButton.Ok | QDialogButtonBox.StandardButton.Cancel)
-        button_box.accepted.connect(lambda: self.confirm_switch(combo_box.currentIndex(), slot, dialog))
+        button_box.accepted.connect(lambda: self.confirm_switch(combo_box, slot, dialog))
         button_box.rejected.connect(dialog.reject)
 
         layout.addWidget(button_box)
@@ -244,15 +337,12 @@ class PokemonTeamDialog(QDialog):
         dialog.setLayout(layout)
         dialog.exec()
 
-    def confirm_switch(self, selected_index, slot, dialog):
+    def confirm_switch(self, combo_box, slot, dialog):
         """Confirm the Pokémon switch and update the team"""
-        # Get the selected Pokémon from combo_box.itemData()
-        selected_pokemon = dialog.findChild(QComboBox).itemData(selected_index)
+        selected_pokemon = combo_box.itemData(combo_box.currentIndex())
 
         if selected_pokemon:
             self.team_pokemon[slot] = selected_pokemon  # Replace the Pokémon in the team slot
-
-            # Update the team display
             self.update_team_display()
 
         dialog.accept()
@@ -300,13 +390,11 @@ class PokemonTeamDialog(QDialog):
                 pokemon_names.append(pokemon_name)
 
         # Get the selected Pokémon for XP Share
-        xp_share_pokemon = self.xp_share_combo.currentText()
-        if xp_share_pokemon != "No XP Share":
-            # Retrieve the individual_id of the selected Pokémon
-            current_index = self.xp_share_combo.currentIndex()
-            xp_share_individual_id = self.xp_share_combo.itemData(current_index)
+        xp_share_individual_id = self.xp_share_selected_individual_id
+        if xp_share_individual_id:
+            xp_share_pokemon = next((p['name'] for p in self.my_pokemon if p['individual_id'] == xp_share_individual_id), "Unknown")
         else:
-            xp_share_individual_id = None
+            xp_share_pokemon = "No XP Share"
 
         # Update settings with the selected team and XP Share setting
         self.settings.set("trainer.team", team_data)
@@ -325,3 +413,129 @@ class PokemonTeamDialog(QDialog):
             self.trainer_card.reload_team()
 
         self.accept()  # Close the dialog
+
+    def choose_xp_share_pokemon(self):
+        """Open dialog to select XP Share Pokémon"""
+        dialog = QDialog(self)
+        dialog.setWindowTitle("Select Pokémon for XP Share")
+        dialog.setMinimumSize(500, 400)
+
+        layout = QVBoxLayout()
+
+        label = QLabel("Choose a Pokémon to receive XP Share:")
+        layout.addWidget(label)
+
+        # Add a search box and sort dropdown
+        search_layout = QHBoxLayout()
+
+        # Sorting dropdown
+        sort_label = QLabel("Sort by:")
+        sort_combo = QComboBox()
+        sort_combo.addItems(["Name (A-Z)", "Level (High-Low)", "Pokédex ID", "CP (High-Low)"])
+        search_layout.addWidget(sort_label)
+        search_layout.addWidget(sort_combo)
+
+        # Search box
+        search_label_box = QLabel("Search:")
+        search_input = QLineEdit()
+        search_input.setPlaceholderText("Type Pokémon name...")
+        search_layout.addWidget(search_label_box)
+        search_layout.addWidget(search_input)
+
+        layout.addLayout(search_layout)
+
+        # Create a dropdown to select XP Share Pokémon
+        combo_box = QComboBox()
+        combo_box.addItem("No XP Share", None)
+
+        available_pokemon = self.my_pokemon
+
+        # Label and preview for image
+        preview_label = QLabel("Preview:")
+        layout.addWidget(QLabel("Select Pokémon:"))
+        layout.addWidget(combo_box)
+        layout.addWidget(preview_label)
+        
+        image_label = QLabel()
+        image_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        layout.addWidget(image_label)
+
+        # Function to update the combo box list based on search and sort
+        def update_pokemon_list():
+            search_text = search_input.text().lower()
+            sort_option = sort_combo.currentText()
+            
+            # Filter by search text
+            filtered = [p for p in available_pokemon if search_text in p['name'].lower()]
+            
+            # Sort based on selection
+            if "Name" in sort_option:
+                filtered.sort(key=lambda p: p['name'])
+            elif "Level" in sort_option:
+                filtered.sort(key=lambda p: p['level'], reverse=True)
+            elif "Pokédex" in sort_option:
+                filtered.sort(key=lambda p: p['id'])
+            elif "CP" in sort_option:
+                filtered.sort(key=lambda p: self._calculate_pokemon_cp(p['individual_id']), reverse=True)
+            
+            # Update combo_box
+            combo_box.blockSignals(True)
+            combo_box.clear()
+            combo_box.addItem("No XP Share", None)
+            
+            if filtered:
+                for pokemon in filtered:
+                    cp_value = self._calculate_pokemon_cp(pokemon['individual_id'])
+                    display_text = f"{pokemon['name']} (Level {pokemon['level']}) - CP {cp_value}"
+                    
+                    combo_box.addItem(display_text, pokemon['individual_id'])
+                    sprite_path = get_sprite_path("front", "png", pokemon['id'], pokemon["shiny"], pokemon["gender"], pokemon.get("name"))
+                    pixmap = QPixmap(sprite_path)
+                    combo_box.setItemData(combo_box.count() - 1, pixmap, Qt.ItemDataRole.DecorationRole)
+            
+            combo_box.blockSignals(False)
+            update_preview(0)
+
+        # Function to update the image preview when a new item is selected
+        def update_preview(index):
+            individual_id = combo_box.itemData(index)
+            if individual_id:
+                pokemon = next((p for p in self.my_pokemon if p['individual_id'] == individual_id), None)
+                if pokemon:
+                    sprite_path = get_sprite_path("front", "png", pokemon['id'], pokemon["shiny"], pokemon["gender"], pokemon.get("name"))
+                    pixmap = QPixmap(sprite_path)
+                    image_label.setPixmap(pixmap.scaled(100, 100, Qt.AspectRatioMode.KeepAspectRatio))
+                    image_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
+            else:
+                image_label.clear()
+
+        # Connect signals
+        sort_combo.currentTextChanged.connect(update_pokemon_list)
+        search_input.textChanged.connect(update_pokemon_list)
+        combo_box.currentIndexChanged.connect(lambda: update_preview(combo_box.currentIndex()))
+
+        # Initial population
+        update_pokemon_list()
+
+        # Button to confirm the selection
+        button_box = QDialogButtonBox(QDialogButtonBox.StandardButton.Ok | QDialogButtonBox.StandardButton.Cancel)
+        button_box.accepted.connect(lambda: self.confirm_xp_share(combo_box.itemData(combo_box.currentIndex()), dialog))
+        button_box.rejected.connect(dialog.reject)
+
+        layout.addWidget(button_box)
+
+        dialog.setLayout(layout)
+        dialog.exec()
+
+    def confirm_xp_share(self, selected_individual_id, dialog):
+        """Confirm the XP Share Pokémon selection"""
+        self.xp_share_selected_individual_id = selected_individual_id
+
+        if selected_individual_id:
+            pokemon = next((p for p in self.my_pokemon if p['individual_id'] == selected_individual_id), None)
+            if pokemon:
+                self.xp_share_label.setText(f"XP Share: {pokemon['name']} (Level {pokemon['level']})")
+        else:
+            self.xp_share_label.setText("XP Share: None")
+    
+        dialog.accept()

--- a/src/Ankimon/pyobj/pc_box.py
+++ b/src/Ankimon/pyobj/pc_box.py
@@ -612,6 +612,7 @@ class PokemonPC(QDialog):
                     pokemon["id"],
                     pokemon.get("shiny", False),
                     pokemon["gender"],
+                    pokemon.get("name"),
                 )
                 pokemon_button = PokemonSlotButton("")
                 pokemon_button.setFixedSize(self.slot_size, self.slot_size)
@@ -858,9 +859,12 @@ class PokemonPC(QDialog):
             order_clause = f"ORDER BY level {direction}"
         elif sort_key_str == "id":
             order_clause = f"ORDER BY pokedex_id {direction}"
+        elif sort_key_str == "cp":
+            order_clause = f"ORDER BY CAST(json_extract(data, '$.cp') AS REAL) {direction}"    
         else:
             # For IV/EV or default, sort by original_index first, then override in Python if needed
             order_clause = f"ORDER BY original_index {direction}"
+            
 
         query = " ".join(query_parts) + " " + order_clause
 
@@ -885,8 +889,7 @@ class PokemonPC(QDialog):
                 if sort_key_str in ["iv", "ev"]:
                     stats_json = row[f"{sort_key_str}_json"]
                     stats_dict = json.loads(stats_json) if stats_json else {}
-                    p["_sort_value"] = sum(stats_dict.values()) if isinstance(stats_dict, dict) else 0
-                
+                    p["_sort_value"] = sum(stats_dict.values()) if isinstance(stats_dict, dict) else sum(stats_dict) if isinstance(stats_dict, list) else 0                
                 results.append(p)
                 
             # Perform Python sorting for IV/EV

--- a/src/Ankimon/pyobj/pokemon_obj.py
+++ b/src/Ankimon/pyobj/pokemon_obj.py
@@ -289,7 +289,7 @@ class PokemonObject:
         return hp
 
     def get_sprite_path(self, side, sprite_type):
-        return get_sprite_path(side, sprite_type, self.id, self.shiny, self.gender)
+        return get_sprite_path(side, sprite_type, self.id, self.shiny, self.gender, self.name)
 
     def to_engine_format(self):
         from ..poke_engine.helpers import normalize_name

--- a/src/Ankimon/pyobj/pokemon_trade.py
+++ b/src/Ankimon/pyobj/pokemon_trade.py
@@ -209,7 +209,7 @@ class PokemonTrade:
         sprite_size = QSize(64, 64)
         your_pokemon_sprite_label.setMaximumSize(sprite_size)
         your_pokemon_sprite_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
-        your_pokemon_gif_path = get_sprite_path(side="front", sprite_type="gif", id=self.id, shiny=getattr(self, "shiny", False), gender=self.gender)
+        your_pokemon_gif_path = get_sprite_path(side="front", sprite_type="gif", id=self.id, shiny=getattr(self, "shiny", False), gender=self.gender, pokemon_name=self.name)
         
         your_pokemon_movie = QMovie(your_pokemon_gif_path)
         def set_bw_frame():
@@ -417,7 +417,8 @@ class PokemonTrade:
                     gender_map = {"0": "M", "1": "F", "2": "N"}
                     other_gender = gender_map.get(parts[2], "M")
                 
-                sprite_path = get_sprite_path(side="front", sprite_type="gif", id=pokemon_id, shiny=other_shiny, gender=other_gender)
+                other_name = self.get_pokemon_name_by_id(pokemon_id)
+                sprite_path = get_sprite_path(side="front", sprite_type="gif", id=pokemon_id, shiny=other_shiny, gender=other_gender, pokemon_name=other_name)
                 
                 if hasattr(self, '_other_pokemon_movie') and self._other_pokemon_movie is not None:
                     self._other_pokemon_movie.stop()
@@ -435,8 +436,6 @@ class PokemonTrade:
                 self.other_pokemon_sprite_label.setMovie(other_pokemon_movie)
                 other_pokemon_movie.start()
                 set_other_frame()
-                name = self.get_pokemon_name_by_id(pokemon_id)
-                self.other_pokemon_name_label.setText(name if name else "Unknown Pokémon")
             else:
                 self.other_pokemon_sprite_label.setPixmap(QPixmap(":/icons/pokeball.png").scaled(QSize(64, 64), Qt.AspectRatioMode.KeepAspectRatio, Qt.TransformationMode.SmoothTransformation))
                 self.other_pokemon_name_label.setText("")


### PR DESCRIPTION
Problem: Ultra Beasts had no learnable moves available in the PC tab's "Remember Attacks" feature. The move lookup function was filtering by generation (defaulting to Gen 9), but Ultra Beast data only contains Gen 7 and Gen 8 learn codes. When Gen 9 data wasn't available, no moves were returned.

fix: Implement fallback logic in _get_learnset_moves() to progressively try Gen 9 → Gen 8 → . . . → Gen 1 until moves are found. This ensures all Pokémon with incomplete generational data can still access their available moves.