### PR TITLE
Fix SettingsWindow saving logic and changed_settings detection

### DIFF
--- a/src/Ankimon/pyobj/settings_window.py
+++ b/src/Ankimon/pyobj/settings_window.py
@@ -229,8 +229,8 @@ class SettingsWindow(QMainWindow):
             true_radio.setChecked(value)
             false_radio.setChecked(not value)
             button_group = QButtonGroup(self)
-            button_group.addButton(true_radio)
-            button_group.addButton(false_radio)
+            button_group.addButton(true_radio, 1)
+            button_group.addButton(false_radio, 0)
             h_layout.addWidget(true_radio)
             h_layout.addWidget(false_radio)
             layout.addWidget(radio_container)
@@ -521,12 +521,12 @@ class SettingsWindow(QMainWindow):
                             self.config[key] = original_value
 
                 # Standard handling for other settings
-                elif isinstance(original_value, int):
+                elif type(original_value) is int:
                     try:
                         self.config[key] = int(new_text)
                     except ValueError:
                         self.config[key] = original_value
-                elif isinstance(original_value, float):
+                elif type(original_value) is float:
                     try:
                         self.config[key] = float(new_text)
                     except ValueError:
@@ -534,7 +534,7 @@ class SettingsWindow(QMainWindow):
                 else:
                     self.config[key] = str(new_text)
             elif isinstance(widget, QButtonGroup):
-                self.config[key] = widget.checkedButton().text() == "Enabled"
+                self.config[key] = widget.checkedId() == 1
         # --- Enforce bounds for cash rewards ---
         has_adjustments = False
         adjustment_msg = ""
@@ -620,7 +620,10 @@ class SettingsWindow(QMainWindow):
             key: self.config[key]
             for key in self.config
             if not any(pattern in key for pattern in excluded_patterns)
-            and self.config[key] != self.original_config.get(key)
+            and (
+                self.config[key] != self.original_config.get(key)
+                or type(self.config[key]) is not type(self.original_config.get(key))
+            )
         }
 
         if changed_settings:


### PR DESCRIPTION
Fix bugs related to boolean toggle saving and integer saving in SettingsWindow. Ensure "Cards per Round" correctly saves when changed to 1, by properly distinguishing between boolean True and integer 1 during type validation and change detection.

---
*PR created automatically by Jules for task [6031805257148763677](https://jules.google.com/task/6031805257148763677) started by @h0tp-ftw*