### PR TITLE
Fix Pokemon generation infinite loop

### DIFF
--- a/src/Ankimon/functions/encounter_functions.py
+++ b/src/Ankimon/functions/encounter_functions.py
@@ -266,9 +266,21 @@ def generate_random_pokemon(
     min_allowed_pokemon_lvl = check_min_generate_level(
         str(name.lower())
     )  # Gets the minimum allowed level for that pokemon given its stage of evolution
+
+    attempts = 0
     while (not check_id_ok(pokemon_id)) or (
         wild_pokemon_lvl < min_allowed_pokemon_lvl
     ):  # We keep drawing a random pokemon until we find a valid one
+        attempts += 1
+        if attempts >= 500:
+            showWarning("Failed to generate a valid Pokémon after 500 attempts. Please ensure at least one generation is enabled in the settings. Defaulting to Rattata.")
+            pokemon_id = 19
+            name = search_pokedex_by_id(19)
+            tier = "Normal"
+            min_allowed_pokemon_lvl = check_min_generate_level(str(name.lower()))
+            wild_pokemon_lvl = max(wild_pokemon_lvl, min_allowed_pokemon_lvl)
+            break
+
         pokemon_id, tier = choose_random_pkmn_from_tier()
         name = search_pokedex_by_id(pokemon_id)
         min_allowed_pokemon_lvl = check_min_generate_level(

--- a/src/Ankimon/pyobj/settings_window.py
+++ b/src/Ankimon/pyobj/settings_window.py
@@ -530,6 +530,24 @@ class SettingsWindow(QMainWindow):
             elif isinstance(widget, QButtonGroup):
                 self.config[key] = widget.checkedButton().text() == "Enabled"
 
+        # Check if all generations are disabled
+        gen_keys = [f"misc.gen{i}" for i in range(1, 10)]
+        all_gens_disabled = all(self.config.get(key) is False for key in gen_keys)
+
+        if all_gens_disabled:
+            showWarning("You must enable at least one Pokémon generation. Reverting generations to previous settings.")
+            for key in gen_keys:
+                # Revert logic
+                self.config[key] = self.original_config.get(key, True)
+                # Update UI widgets
+                if key in self.input_widgets and isinstance(self.input_widgets[key], QButtonGroup):
+                    group = self.input_widgets[key]
+                    for button in group.buttons():
+                        if button.text() == "Enabled" and self.config[key]:
+                            button.setChecked(True)
+                        elif button.text() == "Disabled" and not self.config[key]:
+                            button.setChecked(True)
+
         # Now that self.config is up-to-date, call the save callback
         self.save_config_callback(self.config)
 


### PR DESCRIPTION
A critical hang occurs if a user disables all Pokemon generations in the settings. This causes the `while` loop in `ankimon/src/Ankimon/functions/encounter_functions.py`'s `generate_random_pokemon` function to spin forever. I added a fallback to ensure that it limits the spinning to 500 times, and restricted the settings UI from allowing all generations to be completely disabled.

---
*PR created automatically by Jules for task [7642916372204178686](https://jules.google.com/task/7642916372204178686) started by @h0tp-ftw*