### PR TITLE
Fix random pokemon generation hang and UI generation settings constraint

### DIFF
--- a/src/Ankimon/functions/encounter_functions.py
+++ b/src/Ankimon/functions/encounter_functions.py
@@ -266,9 +266,19 @@ def generate_random_pokemon(
     min_allowed_pokemon_lvl = check_min_generate_level(
         str(name.lower())
     )  # Gets the minimum allowed level for that pokemon given its stage of evolution
+
+    iteration_count = 0
+    max_iterations = 100
     while (not check_id_ok(pokemon_id)) or (
         wild_pokemon_lvl < min_allowed_pokemon_lvl
     ):  # We keep drawing a random pokemon until we find a valid one
+        iteration_count += 1
+        if iteration_count >= max_iterations:
+            pokemon_id = 19  # Fallback to Rattata
+            tier = "common"
+            name = search_pokedex_by_id(pokemon_id)
+            break
+
         pokemon_id, tier = choose_random_pkmn_from_tier()
         name = search_pokedex_by_id(pokemon_id)
         min_allowed_pokemon_lvl = check_min_generate_level(

--- a/src/Ankimon/pyobj/settings_window.py
+++ b/src/Ankimon/pyobj/settings_window.py
@@ -229,8 +229,8 @@ class SettingsWindow(QMainWindow):
             true_radio.setChecked(value)
             false_radio.setChecked(not value)
             button_group = QButtonGroup(self)
-            button_group.addButton(true_radio)
-            button_group.addButton(false_radio)
+            button_group.addButton(true_radio, 1)
+            button_group.addButton(false_radio, 0)
             h_layout.addWidget(true_radio)
             h_layout.addWidget(false_radio)
             layout.addWidget(radio_container)
@@ -528,7 +528,22 @@ class SettingsWindow(QMainWindow):
                 else:
                     self.config[key] = str(new_text)
             elif isinstance(widget, QButtonGroup):
-                self.config[key] = widget.checkedButton().text() == "Enabled"
+                self.config[key] = widget.checkedId() == 1
+
+        # Check if all generations are disabled
+        gen_keys = [f"misc.gen{i}" for i in range(1, 10)]
+        if all(not self.config.get(key, True) for key in gen_keys):
+            self.config["misc.gen1"] = True
+            if "misc.gen1" in self.input_widgets:
+                # Update the UI button to match the enforced config
+                btn_group = self.input_widgets["misc.gen1"]
+                if isinstance(btn_group, QButtonGroup):
+                    btn_group.button(1).setChecked(True)
+            QMessageBox.warning(
+                self,
+                "Warning",
+                "At least one generation must be enabled. Generation 1 has been re-enabled automatically.",
+            )
 
         # Now that self.config is up-to-date, call the save callback
         self.save_config_callback(self.config)


### PR DESCRIPTION
Fixes a critical hang during random encounter generation and improves Settings UI toggles logic, preventing invalid disabled states for generation filters.

---
*PR created automatically by Jules for task [4648610583321845844](https://jules.google.com/task/4648610583321845844) started by @h0tp-ftw*