### PR TITLE
fix: Update Pecharunt to Mythical tier

### DIFF
--- a/src/Ankimon/resources.py
+++ b/src/Ankimon/resources.py
@@ -420,7 +420,6 @@ POKEMON_TIERS = {
   1022,  # iron-boulder
   1023,  # iron-crown
   1024,  # terapagos
-  1025,  # pecharunt
 ]
 ,
   "Mythical": [
@@ -439,7 +438,9 @@ POKEMON_TIERS = {
   # Gen 7
   801, 802, 807, 808, 809,   # Magearna, Marshadow, Zeraora, Meltan, Melmetal
   # Gen 8
-  893                        # Zarude
+  893,                       # Zarude
+  # Gen 9
+  1025                       # Pecharunt
 ]
 ,
   "Ultra": [


### PR DESCRIPTION
Moves Pecharunt (ID 1025) from the 'Legendary' list to the 'Mythical' list within the `POKEMON_TIERS` dictionary in `src/Ankimon/resources.py`. This correctly aligns Pecharunt with its official classification as a Mythical Pokémon. Tests passed.

---
*PR created automatically by Jules for task [14366677515708447049](https://jules.google.com/task/14366677515708447049) started by @h0tp-ftw*