### PR TITLE
Fix: Save in-memory main pokemon state to DB during swap

### DIFF
--- a/src/Ankimon/pyobj/collection_dialog.py
+++ b/src/Ankimon/pyobj/collection_dialog.py
@@ -32,10 +32,11 @@ def MainPokemon(
     
     # --- Save the existing mainpokemon to mypokemon before replacing ---
     try:
-        current_main = db.get_main_pokemon()
-        if current_main:
+        # Only save if there's already an active main pokemon
+        if db.get_main_pokemon():
             # Update or save the current main pokemon to captured_pokemon
-            db.save_pokemon(current_main)
+            # Use main_pokemon.to_dict() to capture in-memory stats like xp
+            db.save_pokemon(main_pokemon.to_dict())
     except Exception:
         pass  # If no main pokemon exists, just continue
 


### PR DESCRIPTION
Fixes an issue where a Pokémon's EXP bar drops or is lost after switching to another Pokémon and switching back. The state was not synced properly to the DB during swap, meaning stale DB data was saved back over the in-memory changes.

---
*PR created automatically by Jules for task [13384758897818391939](https://jules.google.com/task/13384758897818391939) started by @h0tp-ftw*