### PR TITLE
Fix trade-based item evolutions

### DIFF
--- a/src/Ankimon/functions/pokedex_functions.py
+++ b/src/Ankimon/functions/pokedex_functions.py
@@ -394,12 +394,15 @@ def check_evolution_by_item(pokemon_id, item_id, file_path=poke_evo_path):
     for evos in possible_evos:
         evo_data = get_pokemon_evolution_data(int(evos))
         if evo_data:
-            if int(evo_data["evolution_trigger_id"]) == 3 and int(
-                evo_data["trigger_item_id"]
-            ) == int(item_id):
+            trigger_id = int(evo_data.get("evolution_trigger_id", 0))
+            if trigger_id == 3 and str(evo_data.get("trigger_item_id", "")) == str(item_id):
                 return int(
                     evo_data["evolved_species_id"]
                 )  # Return True as soon as a matching evolution is found
+            elif trigger_id == 2 and str(evo_data.get("held_item_id", "")) == str(item_id):
+                return int(
+                    evo_data["evolved_species_id"]
+                )  # Support trade evolutions with held item like Clamperl
 
     # If no evolution matches the criteria, return False
     return None

--- a/src/Ankimon/pyobj/item_window.py
+++ b/src/Ankimon/pyobj/item_window.py
@@ -540,6 +540,10 @@ class ItemWindow(QWidget):
                         item_id = row['trigger_item_id']
                         if item_id:
                             evolution_item_ids.add(item_id)
+                    elif row['evolution_trigger_id'] == '2':
+                        item_id = row['held_item_id']
+                        if item_id:
+                            evolution_item_ids.add(item_id)
 
             with open(csv_file_items_cost, mode='r', newline='', encoding='utf-8') as items_file:
                 reader = csv.DictReader(items_file)


### PR DESCRIPTION
Fixes trade-based item evolutions for Pokémon like Clamperl. It treats `evolution_trigger_id == 2` with a `held_item_id` similar to a Use Item evolution (`evolution_trigger_id == 3`), allowing the user to "use" items like Deep Sea Tooth from their inventory to evolve their Pokémon.

---
*PR created automatically by Jules for task [1328275117887306269](https://jules.google.com/task/1328275117887306269) started by @h0tp-ftw*