### PR TITLE
feat: implement Macho Brace & Power item EV scaling (#398)

### DIFF
--- a/src/Ankimon/functions/encounter_functions.py
+++ b/src/Ankimon/functions/encounter_functions.py
@@ -572,32 +572,37 @@ def save_main_pokemon_progress(
         mainpkmndata["level"] = int(main_pokemon.level)
         # Clone raw EV yield to avoid mutating the in-memory enemy template
         raw_ev_yield = enemy_pokemon.ev_yield.copy()
+        
+        # Normalize keys to the standard long form expected by limit_ev_yield
+        normalized_yield = {
+            "hp": raw_ev_yield.get("hp", 0),
+            "attack": raw_ev_yield.get("attack", 0) + raw_ev_yield.get("atk", 0),
+            "defense": raw_ev_yield.get("defense", 0) + raw_ev_yield.get("def", 0),
+            "special-attack": raw_ev_yield.get("special-attack", 0) + raw_ev_yield.get("spa", 0),
+            "special-defense": raw_ev_yield.get("special-defense", 0) + raw_ev_yield.get("spd", 0),
+            "speed": raw_ev_yield.get("speed", 0) + raw_ev_yield.get("spe", 0),
+        }
+
         held_item = mainpkmndata.get("held_item", main_pokemon.held_item)
+
         # Apply EV-boosting held items
         if held_item == "macho-brace":
-            for stat in raw_ev_yield:
-                raw_ev_yield[stat] *= 2
+            for stat in normalized_yield:
+                normalized_yield[stat] *= 2
         else:
-            # Map Power items to both full and short key forms for maximum compatibility
             power_item_mapping = {
-                "power-weight": ["hp"],
-                "power-bracer": ["attack", "atk"],
-                "power-belt": ["defense", "def"],
-                "power-lens": ["special-attack", "spa"],
-                "power-band": ["special-defense", "spd"],
-                "power-anklet": ["speed", "spe"],
+                "power-weight": "hp",
+                "power-bracer": "attack",
+                "power-belt": "defense",
+                "power-lens": "special-attack",
+                "power-band": "special-defense",
+                "power-anklet": "speed",
             }
             if held_item in power_item_mapping:
-                target_keys = power_item_mapping[held_item]
-                # Find which key style is used in the raw_ev_yield dictionary
-                for key in target_keys:
-                    if key in raw_ev_yield:
-                        raw_ev_yield[key] += 8
-                        break
-                else:
-                    # Fallback: if neither key style exists, add the long style (used by limit_ev_yield)
-                    raw_ev_yield[target_keys[0]] = 8
-        ev_yield = limit_ev_yield(mainpkmndata["ev"], raw_ev_yield)
+                stat_to_boost = power_item_mapping[held_item]
+                normalized_yield[stat_to_boost] += 8
+
+        ev_yield = limit_ev_yield(mainpkmndata["ev"], normalized_yield)
         mainpkmndata["ev"]["hp"] += ev_yield["hp"]
         mainpkmndata["ev"]["atk"] += ev_yield["attack"]
         mainpkmndata["ev"]["def"] += ev_yield["defense"]

--- a/src/Ankimon/functions/encounter_functions.py
+++ b/src/Ankimon/functions/encounter_functions.py
@@ -570,7 +570,34 @@ def save_main_pokemon_progress(
         mainpkmndata["stats"] = main_pokemon.stats
         mainpkmndata["xp"] = int(main_pokemon.xp)
         mainpkmndata["level"] = int(main_pokemon.level)
-        ev_yield = limit_ev_yield(mainpkmndata["ev"], enemy_pokemon.ev_yield)
+        # Clone raw EV yield to avoid mutating the in-memory enemy template
+        raw_ev_yield = enemy_pokemon.ev_yield.copy()
+        held_item = mainpkmndata.get("held_item", main_pokemon.held_item)
+        # Apply EV-boosting held items
+        if held_item == "macho-brace":
+            for stat in raw_ev_yield:
+                raw_ev_yield[stat] *= 2
+        else:
+            # Map Power items to both full and short key forms for maximum compatibility
+            power_item_mapping = {
+                "power-weight": ["hp"],
+                "power-bracer": ["attack", "atk"],
+                "power-belt": ["defense", "def"],
+                "power-lens": ["special-attack", "spa"],
+                "power-band": ["special-defense", "spd"],
+                "power-anklet": ["speed", "spe"],
+            }
+            if held_item in power_item_mapping:
+                target_keys = power_item_mapping[held_item]
+                # Find which key style is used in the raw_ev_yield dictionary
+                for key in target_keys:
+                    if key in raw_ev_yield:
+                        raw_ev_yield[key] += 8
+                        break
+                else:
+                    # Fallback: if neither key style exists, add the long style (used by limit_ev_yield)
+                    raw_ev_yield[target_keys[0]] = 8
+        ev_yield = limit_ev_yield(mainpkmndata["ev"], raw_ev_yield)
         mainpkmndata["ev"]["hp"] += ev_yield["hp"]
         mainpkmndata["ev"]["atk"] += ev_yield["attack"]
         mainpkmndata["ev"]["def"] += ev_yield["defense"]

--- a/src/Ankimon/pyobj/item_window.py
+++ b/src/Ankimon/pyobj/item_window.py
@@ -293,6 +293,11 @@ class ItemWindow(QWidget):
             if target_pokemon_data:
                 pokemon_obj = PokemonObject.from_dict(target_pokemon_data)
                 pokemon_obj.give_held_item(item_name)
+                                
+                # Sync the main_pokemon singleton if it's the target
+                if self.main_pokemon and self.main_pokemon.individual_id == individual_id:
+                    self.main_pokemon.held_item = item_name
+                   
                 self.logger.log_and_showinfo("info", f"{item_name} was given to {target_pokemon_data.get('name')}.")
                 self.renewWidgets()
             else:


### PR DESCRIPTION
This PR addresses issue #398 by implementing the EV-scaling mechanics for held items (Macho Brace and Power Items)

1. EV Scaling Mechanics (Issue #398) We updated the EV yield logic when defeating wild Pokémon:

Macho Brace: Doubles all EV gains from the defeated Pokémon. Power Items (power-weight, power-bracer, etc.): Adds +8 to the corresponding EV stat (HP, Attack, Defense, Special Attack, Special Defense, Speed) of the user's active Pokémon. Compatibility & Safety: Handled both short stat keys (atk, spa, etc.) and full stat names (attack, special-attack, etc.) dynamically, passing the final yields to limit_ev_yield to enforce standard caps (max 252 per stat, max 510 total).
2. Held Item Memory Sync Bug Fix During testing, we discovered that equipping a held item via the Bag UI (item_window.py) only updated the SQLite database. The active, in-memory main_pokemon singleton object remained unaffected, meaning its held_item attribute stayed None. When battle results calculated EVs:

It read held_item = main_pokemon.held_item (which was None). The EV boost was bypassed, awarding only the base EV yield. The normal EVs were written back to the database, overwriting any expected progress. Resolved by:

Updating item_window.py to immediately sync self.main_pokemon.held_item in memory when equipping items. Modifying encounter_functions.py to fetch held_item dynamically from the freshly loaded database record (mainpkmndata.get("held_item")) as a secondary defensive fallback.

fixes #398 