### PR TITLE
fix: allow recursive cloning to work with poke-engine submodule

### DIFF
--- a/.github/workflows/integrity_tests.yml
+++ b/.github/workflows/integrity_tests.yml
@@ -11,6 +11,8 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
+      with:
+        submodules: recursive
     - name: Set up Python
       uses: actions/setup-python@v5
       with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,6 +21,7 @@ jobs:
           fetch-depth: 0
           fetch-tags: true
           ref: ${{ github.ref }}
+          submodules: recursive
 
       - name: Setup Python
         uses: actions/setup-python@v5

--- a/src/Ankimon/pyobj/update_manager.py
+++ b/src/Ankimon/pyobj/update_manager.py
@@ -19,6 +19,7 @@ REPO_NAME = "ankimon"
 GITHUB_API = f"https://api.github.com/repos/{REPO_OWNER}/{REPO_NAME}"
 DOWNLOAD_TIMEOUT = 30
 USER_AGENT = "Ankimon-Updater (https://github.com/h0tp-ftw/ankimon)"
+DEFAULT_SUBMODULE_SHA = "f3092b03fbe1e37d1788ef802dee98906d621e36"
 
 
 def _make_request(url: str, accept: str = "application/vnd.github.v3+json") -> urllib.request.Request:
@@ -191,10 +192,12 @@ def _extract_ref_from_prefix(src_prefix: str) -> str:
     root_dir = parts[0]
     # Remove repo name prefix if present
     if root_dir.startswith("ankimon-"):
-        return root_dir[len("ankimon-"):]
+        ref = root_dir[len("ankimon-"):]
+        return ref if ref else "main"
     elif "ankimon-" in root_dir:
         # e.g. h0tp-ftw-ankimon-a1b2c3d -> a1b2c3d
-        return root_dir.split("ankimon-")[-1]
+        ref = root_dir.split("ankimon-")[-1]
+        return ref if ref else "main"
     return "main"
 
 
@@ -224,11 +227,8 @@ def _download_and_extract_submodule(sha: str, dest_dir: Path, status_cb=None):
         raise Exception("Failed to download poke_engine submodule zip archive.")
 
     log("Extracting poke_engine submodule...")
+    temp_extract_dir = Path(tempfile.mkdtemp(prefix="ankimon_submodule_extract_"))
     try:
-        if dest_dir.exists():
-            shutil.rmtree(dest_dir)
-        dest_dir.mkdir(parents=True, exist_ok=True)
-
         with zipfile.ZipFile(zip_path) as zf:
             names = zf.namelist()
             if not names:
@@ -243,10 +243,22 @@ def _download_and_extract_submodule(sha: str, dest_dir: Path, status_cb=None):
                 if not rel_path or rel_path.endswith("/"):
                     continue
                 
-                dest_file = dest_dir / rel_path
+                dest_file = temp_extract_dir / rel_path
                 dest_file.parent.mkdir(parents=True, exist_ok=True)
                 with zf.open(name) as source, dest_file.open("wb") as target:
                     shutil.copyfileobj(source, target)
+        
+        # Atomic swap: Delete old dest_dir if it exists, rename temp_extract_dir to dest_dir
+        if dest_dir.exists():
+            shutil.rmtree(dest_dir)
+        shutil.move(str(temp_extract_dir), str(dest_dir))
+    except Exception as e:
+        if temp_extract_dir.exists():
+            try:
+                shutil.rmtree(temp_extract_dir)
+            except Exception:
+                pass
+        raise e
     finally:
         if os.path.exists(zip_path):
             try:
@@ -343,7 +355,7 @@ def apply_update(zip_path: str, status_cb=None) -> tuple[bool, str]:
             # --- Download and install matching poke_engine submodule version ---
             ref = _extract_ref_from_prefix(src_prefix)
             log(f"Resolving poke_engine submodule for ref '{ref}'...")
-            sub_sha = _fetch_submodule_sha(ref) or "f3092b03fbe1e37d1788ef802dee98906d621e36"
+            sub_sha = _fetch_submodule_sha(ref) or DEFAULT_SUBMODULE_SHA
             
             _download_and_extract_submodule(sub_sha, addon_dir / "poke_engine", status_cb)
 

--- a/src/Ankimon/pyobj/update_manager.py
+++ b/src/Ankimon/pyobj/update_manager.py
@@ -183,6 +183,78 @@ def _collect_code_files(gitignore_patterns: list[str]) -> dict[str, Path]:
     return code_files
 
 
+def _extract_ref_from_prefix(src_prefix: str) -> str:
+    # src_prefix is e.g. "ankimon-main/src/Ankimon/" or "h0tp-ftw-ankimon-a1b2c3d/src/Ankimon/"
+    parts = src_prefix.strip("/").replace("\\", "/").split("/")
+    if not parts:
+        return "main"
+    root_dir = parts[0]
+    # Remove repo name prefix if present
+    if root_dir.startswith("ankimon-"):
+        return root_dir[len("ankimon-"):]
+    elif "ankimon-" in root_dir:
+        # e.g. h0tp-ftw-ankimon-a1b2c3d -> a1b2c3d
+        return root_dir.split("ankimon-")[-1]
+    return "main"
+
+
+def _fetch_submodule_sha(ref: str) -> Optional[str]:
+    url = f"https://api.github.com/repos/{REPO_OWNER}/{REPO_NAME}/contents/src/Ankimon/poke_engine?ref={ref}"
+    req = _make_request(url)
+    try:
+        with urllib.request.urlopen(req, timeout=DOWNLOAD_TIMEOUT) as resp:
+            data = json.loads(resp.read().decode())
+            if isinstance(data, dict) and data.get("type") == "submodule":
+                return data.get("sha")
+    except Exception:
+        pass
+    return None
+
+
+def _download_and_extract_submodule(sha: str, dest_dir: Path, status_cb=None):
+    def log(msg):
+        if status_cb:
+            status_cb(msg)
+
+    url = f"https://github.com/ArdentRoe/poke-engine/archive/{sha}.zip"
+    log("Downloading poke_engine submodule package...")
+    
+    zip_path = _download_zip_to_temp(url)
+    if not zip_path:
+        raise Exception("Failed to download poke_engine submodule zip archive.")
+
+    log("Extracting poke_engine submodule...")
+    try:
+        if dest_dir.exists():
+            shutil.rmtree(dest_dir)
+        dest_dir.mkdir(parents=True, exist_ok=True)
+
+        with zipfile.ZipFile(zip_path) as zf:
+            names = zf.namelist()
+            if not names:
+                raise Exception("poke_engine submodule archive is empty.")
+            # The root directory in zip is e.g. "poke-engine-{sha}"
+            root_prefix = names[0].split("/")[0] + "/"
+            
+            for name in names:
+                if not name.startswith(root_prefix) or name == root_prefix:
+                    continue
+                rel_path = name[len(root_prefix):]
+                if not rel_path or rel_path.endswith("/"):
+                    continue
+                
+                dest_file = dest_dir / rel_path
+                dest_file.parent.mkdir(parents=True, exist_ok=True)
+                with zf.open(name) as source, dest_file.open("wb") as target:
+                    shutil.copyfileobj(source, target)
+    finally:
+        if os.path.exists(zip_path):
+            try:
+                os.unlink(zip_path)
+            except Exception:
+                pass
+
+
 def apply_update(zip_path: str, status_cb=None) -> tuple[bool, str]:
     def log(msg):
         if status_cb:
@@ -267,6 +339,13 @@ def apply_update(zip_path: str, status_cb=None) -> tuple[bool, str]:
                 with zf.open(zip_name) as source, dest.open("wb") as target:
                     shutil.copyfileobj(source, target)
                 installed += 1
+
+            # --- Download and install matching poke_engine submodule version ---
+            ref = _extract_ref_from_prefix(src_prefix)
+            log(f"Resolving poke_engine submodule for ref '{ref}'...")
+            sub_sha = _fetch_submodule_sha(ref) or "f3092b03fbe1e37d1788ef802dee98906d621e36"
+            
+            _download_and_extract_submodule(sub_sha, addon_dir / "poke_engine", status_cb)
 
             cleanup()
             log(f"Update complete. Installed {installed} files.")

--- a/src/Ankimon/resources.py
+++ b/src/Ankimon/resources.py
@@ -594,12 +594,24 @@ def ensure_ankimon_infrastructure(base_path, base_user_path):
                 )
                 print("Ankimon: Submodule successfully initialized!")
             except Exception as e:
-                # If git command failed, raise a clear developer-friendly error message
+                # If git command failed, raise a clear developer-friendly error message with diagnostics
+                error_details = ""
+                if isinstance(e, subprocess.CalledProcessError):
+                    stderr_msg = e.stderr.decode("utf-8", errors="replace").strip() if e.stderr else ""
+                    stdout_msg = e.stdout.decode("utf-8", errors="replace").strip() if e.stdout else ""
+                    if stderr_msg:
+                        error_details = f"\nGit Diagnostics (stderr):\n{stderr_msg}\n"
+                    elif stdout_msg:
+                        error_details = f"\nGit Diagnostics (stdout):\n{stdout_msg}\n"
+                else:
+                    error_details = f"\nSystem Diagnostics:\n{str(e)}\n"
+
                 raise ImportError(
                     "\n\n[Developer Setup Error]\n"
                     "The 'poke_engine' submodule is missing or uninitialized!\n"
                     "Please initialize the submodule manually in your repository root:\n\n"
                     "    git submodule update --init --recursive\n"
+                    f"{error_details}"
                 ) from e
 
     # Create blank HelpInfos.html and updateinfos.md at base_path if they don't exist

--- a/src/Ankimon/resources.py
+++ b/src/Ankimon/resources.py
@@ -570,6 +570,38 @@ def ensure_ankimon_infrastructure(base_path, base_user_path):
     os.makedirs(os.path.join(base_user_path, "data_files"), exist_ok=True)
     os.makedirs(os.path.join(base_user_path, "sprites"), exist_ok=True)
 
+    # Automatically initialize git submodule for local developers if missing
+    objects_py = os.path.join(base_path, "poke_engine", "objects.py")
+    if not os.path.exists(objects_py):
+        parent = os.path.abspath(base_path)
+        is_git_repo = False
+        for _ in range(4):
+            if os.path.exists(os.path.join(parent, ".git")):
+                is_git_repo = True
+                break
+            parent = os.path.dirname(parent)
+
+        if is_git_repo:
+            print("Ankimon: Developer environment detected and poke_engine submodule is missing.")
+            print("Attempting to automatically initialize the Git submodule...")
+            try:
+                import subprocess
+                subprocess.run(
+                    ["git", "submodule", "update", "--init", "--recursive"],
+                    cwd=parent,
+                    check=True,
+                    capture_output=True
+                )
+                print("Ankimon: Submodule successfully initialized!")
+            except Exception as e:
+                # If git command failed, raise a clear developer-friendly error message
+                raise ImportError(
+                    "\n\n[Developer Setup Error]\n"
+                    "The 'poke_engine' submodule is missing or uninitialized!\n"
+                    "Please initialize the submodule manually in your repository root:\n\n"
+                    "    git submodule update --init --recursive\n"
+                ) from e
+
     # Create blank HelpInfos.html and updateinfos.md at base_path if they don't exist
     helpinfos_path = os.path.join(base_path, 'HelpInfos.html')
     updateinfos_path = os.path.join(base_path, 'updateinfos.md')


### PR DESCRIPTION
This changes workflows so that submodule recursive cloning is enabled, allowing proper cloning of ArdentRoe/poke-engine which is now a submodule.