### PR TITLE
chore: add Discord info for scotej (w0mp0s)

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -194,8 +194,8 @@
       "contributions": [
         "code"
       ],
-      "nickname": "scotej",
-      "discord_id": ""
+      "nickname": "w0mp0s",
+      "discord_id": "720180197403525120"
     },
     {
       "login": "maciej-baruch",


### PR DESCRIPTION
## Summary
- Populates the `nickname` and `discord_id` fields for my contributor entry in `.all-contributorsrc` so I can be assigned the Discord contributor role.
- `nickname`: `w0mp0s`
- `discord_id`: `720180197403525120`

No code changes — single 2-line edit to `.all-contributorsrc`.

## Test plan
- [x] `.all-contributorsrc` still parses as valid JSON
- [x] Only my entry (`login: scotej`) is touched; all other contributors untouched