### PR TITLE
ci(ruff): make Ruff Format workflow tolerate fork PRs

### DIFF
--- a/.github/workflows/ruff_format.yml
+++ b/.github/workflows/ruff_format.yml
@@ -4,10 +4,22 @@ jobs:
   ruff:
     runs-on: ubuntu-latest
     steps:
+      - name: Detect fork PR
+        id: ctx
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ] \
+             && [ "${{ github.event.pull_request.head.repo.full_name }}" != "${{ github.repository }}" ]; then
+            echo "is_fork_pr=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "is_fork_pr=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - uses: actions/checkout@v4
         with:
-          # Required to push changes back
-          token: ${{ secrets.GH_PAT }}
+          # Same-repo events use the PAT so the auto-commit step can push back.
+          # Fork PRs can't receive secrets, so fall back to the default read-only
+          # token — we'll run ruff in --check mode instead of committing.
+          token: ${{ secrets.GH_PAT || github.token }}
 
       - name: Get changed files
         id: changed-files
@@ -25,14 +37,21 @@ jobs:
         if: steps.changed-files.outputs.any_changed == 'true'
         run: pip install ruff
 
-      - name: Run Ruff Format on changed files
-        if: steps.changed-files.outputs.any_changed == 'true'
+      - name: Run Ruff Format (auto-fix, same-repo)
+        if: steps.changed-files.outputs.any_changed == 'true' && steps.ctx.outputs.is_fork_pr == 'false'
         run: |
           # Use xargs to handle spaces in filenames
           echo "${{ steps.changed-files.outputs.all_changed_files }}" | xargs -r ruff format --config ci_ruff_check.toml
 
+      - name: Run Ruff Format (check-only, fork PR)
+        if: steps.changed-files.outputs.any_changed == 'true' && steps.ctx.outputs.is_fork_pr == 'true'
+        run: |
+          # Fork PRs can't be auto-committed to, so fail the job if the
+          # contributor hasn't already run `ruff format` locally.
+          echo "${{ steps.changed-files.outputs.all_changed_files }}" | xargs -r ruff format --check --config ci_ruff_check.toml
+
       - name: Commit formatting changes
-        if: steps.changed-files.outputs.any_changed == 'true'
+        if: steps.changed-files.outputs.any_changed == 'true' && steps.ctx.outputs.is_fork_pr == 'false'
         uses: stefanzweifel/git-auto-commit-action@v5
         with:
           commit_message: "style: auto ruff format"


### PR DESCRIPTION
## Summary

- Detects fork PRs (where `secrets.GH_PAT` is unavailable) and runs `ruff format --check` instead of auto-formatting + committing.
- Falls back to the default `GITHUB_TOKEN` for `actions/checkout` when the PAT secret is missing, so checkout no longer fails before any code runs.

## Problem

PRs from forks currently fail Ruff Format at the very first step:

```
Error: Input required and not supplied: token
```

`actions/checkout@v4` is configured with `token: ${{ secrets.GH_PAT }}` so the later `git-auto-commit-action` can push back. GitHub deliberately does not pass repo secrets to workflows triggered by `pull_request` events from forks (security model), so `secrets.GH_PAT` resolves to an empty string and the job fails before doing anything useful. Every fork PR therefore shows a red ✗ on Ruff Format regardless of whether the diff is actually formatted correctly.

## Fix

A new `Detect fork PR` step sets `is_fork_pr` based on whether `pull_request.head.repo.full_name` matches `github.repository`. Subsequent steps branch on that:

| event | checkout token | ruff step | auto-commit |
|---|---|---|---|
| push (any branch) | `GH_PAT` | `ruff format` (mutates) | runs |
| PR from same repo | `GH_PAT` | `ruff format` (mutates) | runs |
| PR from a fork | `GITHUB_TOKEN` (default) | `ruff format --check` (read-only, fails on diff) | skipped |

So fork contributors still get a useful signal — if they didn't run ruff locally, the job fails loudly with the diff. They just don't get free auto-formatting commits pushed to their branch (which wasn't actually possible from the upstream workflow anyway without cross-repo write access).

## Test plan

- [x] `yaml.safe_load` parses the workflow without errors.
- [ ] After merge: a fork PR with a deliberately misformatted Python file should fail `ruff format --check`; a properly-formatted one should pass.
- [ ] Same-repo PRs and pushes should continue to auto-format and commit as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)