### PR TITLE
refactor: aqt-free service registry to decouple addon logic from mw

### DIFF
--- a/src/Ankimon/__init__.py
+++ b/src/Ankimon/__init__.py
@@ -64,11 +64,14 @@ from .menu_buttons import create_menu_actions
 from .hooks import setupHooks
 from .pyobj.error_handler import show_warning_with_traceback
 
-# --- Register singletons on mw for global access ---
-mw.settings_ankimon = settings_window
-mw.logger = logger
+# singletons.py already populated the service registry and mirrored these onto
+# mw (see services.py), so the previous mw.settings_ankimon/logger/settings_obj
+# writes here were pure duplication and are gone. The translator write stays:
+# importing menu_buttons (above) re-creates mw.translator at its module top
+# (menu_buttons.py:45), so we re-point mw.translator back to the registry's
+# instance to keep mw.translator identical to services.translator. Remove this
+# once menu_buttons stops building its own translator.
 mw.translator = translator
-mw.settings_obj = settings_obj
 
 from .gui_classes import overview_team
 

--- a/src/Ankimon/functions/badges_functions.py
+++ b/src/Ankimon/functions/badges_functions.py
@@ -2,12 +2,12 @@ import json
 from typing import List
 
 from ..resources import badgebag_path
-from aqt import mw
+from ..services import services
 
 
 def get_achieved_badges() -> List[int]:
     """Gets list of achieved badge IDs from the database."""
-    db = mw.ankimon_db
+    db = services.db
     
     if db.is_migrated():
         badges = db.get_all_badges()
@@ -38,7 +38,7 @@ def check_for_badge(achievements, rec_badge_num):
 
 def save_badges(badges_collection: List[int]):
     """Saves badges collection to the database."""
-    db = mw.ankimon_db
+    db = services.db
     
     # Clear existing badges and save new ones
     # Each badge is saved with its ID as the key

--- a/src/Ankimon/functions/migration.py
+++ b/src/Ankimon/functions/migration.py
@@ -1,6 +1,6 @@
 import json
-from aqt import mw
-from aqt.utils import showWarning
+
+from ..services import services
 from ..resources import mainpokemon_path, mypokemon_path
 
 def get_starter_evolution_ids(starter_id: int) -> list[int]:
@@ -46,9 +46,9 @@ def migrate_starter_individual_id():
     This function is now triggered only when the main pokemon is changed and
     is a starter or an evolution of a starter.
     """
-    mw.logger.log("info", "Starting starter individual_id migration check...")
+    services.logger.log("info", "Starting starter individual_id migration check...")
     if not mainpokemon_path.is_file() or not mypokemon_path.is_file():
-        mw.logger.log("info", "Migration skipped: One or more data files missing.")
+        services.logger.log("info", "Migration skipped: One or more data files missing.")
         return
 
     try:
@@ -57,7 +57,7 @@ def migrate_starter_individual_id():
         with open(mypokemon_path, "r", encoding="utf-8") as f:
             my_pokemon_data = json.load(f)
     except (json.JSONDecodeError, IOError) as e:
-        mw.logger.log("error", f"Migration failed: Error reading data files: {str(e)}")
+        services.logger.log("error", f"Migration failed: Error reading data files: {str(e)}")
         # Files might be empty or corrupted, so we can't proceed.
         return
 
@@ -74,7 +74,7 @@ def migrate_starter_individual_id():
 
     # Check if the individual_id from mainpokemon exists in mypokemon
     if any(p.get("individual_id") == main_individual_id for p in my_pokemon_data):
-        mw.logger.log("info", "Migration skipped: individual_id already synchronized.")
+        services.logger.log("info", "Migration skipped: individual_id already synchronized.")
         # The ID already matches, so no migration is needed.
         return
 
@@ -84,7 +84,7 @@ def migrate_starter_individual_id():
         all_starter_evolution_ids.extend(get_starter_evolution_ids(starter_id))
 
     if main_pokemon_id not in all_starter_evolution_ids:
-        mw.logger.log("info", f"Migration skipped: Main Pokemon (ID: {main_pokemon_id}) is not a starter or evolution.")
+        services.logger.log("info", f"Migration skipped: Main Pokemon (ID: {main_pokemon_id}) is not a starter or evolution.")
         # The main Pokemon is not a starter or its evolution, so we don't apply the fix.
         return
 
@@ -101,8 +101,10 @@ def migrate_starter_individual_id():
             break # Found a match
 
     if potential_match:
+        from aqt.utils import showWarning  # lazy: only needed on the fix path
+
         # We found the starter. Now, update its individual_id.
-        mw.logger.log("info", f"Starter match found in mypokemon.json. Syncing individual_id: {main_individual_id}")
+        services.logger.log("info", f"Starter match found in mypokemon.json. Syncing individual_id: {main_individual_id}")
         showWarning(
             "Ankimon has detected and fixed an issue with your starter Pokémon's data. "
             "Your starter's unique ID has been synchronized. No action is needed from you."
@@ -112,12 +114,12 @@ def migrate_starter_individual_id():
         try:
             with open(mypokemon_path, "w", encoding="utf-8") as f:
                 json.dump(my_pokemon_data, f, indent=4)
-            mw.logger.log("info", "Starter migration successful: mypokemon.json updated.")
+            services.logger.log("info", "Starter migration successful: mypokemon.json updated.")
         except IOError as e:
-            mw.logger.log("error", f"Starter migration failed: Could not write mypokemon.json: {str(e)}")
+            services.logger.log("error", f"Starter migration failed: Could not write mypokemon.json: {str(e)}")
             showWarning(
                 "Ankimon could not save the fix for your starter Pokémon. "
                 "Please check file permissions for the Ankimon addon folder."
             )
     else:
-        mw.logger.log("warning", "Migration failed: No matching starter found in mypokemon.json despite ID check.")
+        services.logger.log("warning", "Migration failed: No matching starter found in mypokemon.json despite ID check.")

--- a/src/Ankimon/functions/sprite_functions.py
+++ b/src/Ankimon/functions/sprite_functions.py
@@ -1,7 +1,6 @@
 import os
 
-from aqt import mw
-
+from ..services import services
 from ..resources import pkmnimgfolder
 
 SUBSTITUTE_PATH = f"{pkmnimgfolder}/front_default/substitute.png"
@@ -27,14 +26,14 @@ def _path_format(back: bool, id: int, gif: bool, shiny: bool, female: bool):
 def _try_gendered(back: bool, id: int, gif: bool, shiny: bool, female: bool):
     path = _path_format(back, id, gif, shiny, female)
     if os.path.exists(path):
-        mw.logger.log("debug", f"Sprite found: {path}")
+        services.logger.log("debug", f"Sprite found: {path}")
         return path
 
     if female:
         # requested gendered gif but not found, try non-gendered
         path = _path_format(back, id, gif, shiny, False)
         if os.path.exists(path):
-            mw.logger.log("debug", f"Sprite found (gender fallback): {path}")
+            services.logger.log("debug", f"Sprite found (gender fallback): {path}")
             return path
 
 
@@ -50,7 +49,7 @@ def _try_back(back: bool, id: int, gif: bool, shiny: bool, female: bool):
         if not gif:
             path = f"sprites/missing_back/{id}.png"
             if os.path.exists(path):
-                mw.logger.log("debug", f"Sprite found (back fallback): {path}")
+                services.logger.log("debug", f"Sprite found (back fallback): {path}")
                 return path
 
         path = _try_gendered(False, id, gif, shiny, False)
@@ -76,7 +75,7 @@ def get_sprite_path(side: str, sprite_type: str, id: int, shiny: bool, gender: s
             return path
 
     # Fallback to the generic substitute image
-    mw.logger.log(
+    services.logger.log(
         "warning",
         f"Unable to find sprite for ID {id} (Side: {side} Sprite: {sprite_type} Shiny: {shiny}, Gender: {gender}). Returning substitute.",
     )

--- a/src/Ankimon/services.py
+++ b/src/Ankimon/services.py
@@ -1,0 +1,91 @@
+"""
+services.py — the addon's own service registry.
+
+Historically Ankimon hung its own objects (database, logger, translator,
+settings) on Anki's global ``mw`` (the main window). That coupled every module
+to Anki: importing anything pulled in ``aqt``, and the only way to substitute a
+fake in a test was to monkeypatch a global. This module is the replacement — a
+small registry that holds those services and, deliberately, does **not** import
+``aqt`` or ``anki``.
+
+This is a *registry* pattern, not full dependency injection. It is still a
+global, but one the tests own and one that does not drag in Anki. Constructor
+injection can be layered on top later, module by module; until then this is the
+seam that makes the addon's own logic testable without an Anki runtime.
+
+Usage
+-----
+Populate it **once** at the composition root (see ``singletons.py``)::
+
+    from .services import services
+    services.populate(db=ankimon_db, logger=logger,
+                      settings=settings_obj, translator=translator)
+
+Read it anywhere instead of reaching into ``mw``::
+
+    from .services import services
+    services.db.get_pokemon(...)
+
+In a test, assign fakes — no Anki, no ``sys.modules`` surgery::
+
+    from Ankimon.services import services
+    services.db = FakeDB()
+
+Author: Ankimon contributors
+Created: 2026-05-21
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Optional
+
+if TYPE_CHECKING:
+    # Type-checker-only imports. Guarded by TYPE_CHECKING so they never execute
+    # at runtime — that is what keeps this module free of any aqt/anki import.
+    from .pyobj.database_manager import AnkimonDB
+    from .pyobj.InfoLogger import ShowInfoLogger
+    from .pyobj.settings import Settings
+    from .pyobj.translator import Translator
+
+
+class Services:
+    """Holds the addon's own services. Has no Anki dependency."""
+
+    def __init__(self) -> None:
+        self.db: Optional["AnkimonDB"] = None
+        self.logger: Optional["ShowInfoLogger"] = None
+        self.settings: Optional["Settings"] = None
+        self.translator: Optional["Translator"] = None
+
+    def populate(
+        self,
+        *,
+        db: Optional["AnkimonDB"] = None,
+        logger: Optional["ShowInfoLogger"] = None,
+        settings: Optional["Settings"] = None,
+        translator: Optional["Translator"] = None,
+    ) -> None:
+        """Wire up services at the composition root.
+
+        Keyword-only and skip-if-None so the call site reads clearly and a
+        partial re-populate never clobbers an already-set service with ``None``.
+        """
+        if db is not None:
+            self.db = db
+        if logger is not None:
+            self.logger = logger
+        if settings is not None:
+            self.settings = settings
+        if translator is not None:
+            self.translator = translator
+
+    def reset(self) -> None:
+        """Clear every service. Intended for test isolation."""
+        self.db = None
+        self.logger = None
+        self.settings = None
+        self.translator = None
+
+
+# The single shared registry instance. Import this, not the class.
+services = Services()

--- a/src/Ankimon/singletons.py
+++ b/src/Ankimon/singletons.py
@@ -48,6 +48,7 @@ from .gui_entities import (
 from .functions.update_main_pokemon import update_main_pokemon
 from .functions.badges_functions import populate_achievements_from_badges
 from .resources import addon_dir
+from .services import services
 
 # start loggerobject for Ankimon
 logger = ShowInfoLogger()
@@ -75,7 +76,23 @@ settings_window = SettingsWindow(
 # Init Translator
 translator = Translator(language=int(settings_obj.get("misc.language")))
 
-# Not sure what this does, but from afar it looks like a bad idea
+# --- Composition root: populate the aqt-free service registry ONCE. ---
+# This is the single source of truth for the addon's own services. Code should
+# read these from `services` (see services.py) rather than reaching into `mw`,
+# which is what makes that code testable without an Anki runtime.
+services.populate(
+    db=ankimon_db,
+    logger=logger,
+    settings=settings_obj,
+    translator=translator,
+)
+
+# Back-compat shims: modules not yet migrated still read `mw.<service>`. These
+# mirror the registry and are removed file-by-file as call sites move to
+# `services`. Do NOT add new writes here — populate the registry above instead.
+# (NOTE: menu_buttons.py:45 re-creates mw.translator at its own import time;
+# __init__.py re-points mw.translator back to this registry instance afterwards.
+# Both that clobber and the compensation go away when menu_buttons is migrated.)
 mw.settings_ankimon = settings_window
 mw.logger = logger
 mw.translator = translator

--- a/tests/test_badges_functions.py
+++ b/tests/test_badges_functions.py
@@ -1,0 +1,105 @@
+"""
+Tests for badges_functions — the post-registry testing story.
+
+Contrast this file with tests/test_encounter_functions.py and
+tests/test_database_manager.py: those must stub ``aqt``, ``anki`` and a dozen
+internal ``Ankimon.*`` modules in ``sys.modules`` by hand before they can even
+import the code under test, and that mock list rots whenever an import changes.
+
+Because badges_functions.py now reads its database from the aqt-free ``services``
+registry instead of ``from aqt import mw``, this file needs none of that. A plain
+import (the Ankimon namespace comes from conftest.py) and ``services.db = FakeDB()``
+is the whole setup. No Anki runtime, no sys.modules surgery.
+"""
+
+import json
+
+import pytest
+
+# Plain imports. Binding the module objects here (rather than re-importing inside
+# each test) also makes the file robust to other test modules mutating
+# sys.modules during collection.
+from Ankimon.services import services
+from Ankimon.functions import badges_functions as bf
+
+
+class FakeDB:
+    """Stand-in for AnkimonDB exposing only what badges_functions touches."""
+
+    def __init__(self, migrated=True, badges=None):
+        self._migrated = migrated
+        self._badges = badges if badges is not None else []
+        self.saved = []
+
+    def is_migrated(self):
+        return self._migrated
+
+    def get_all_badges(self):
+        return list(self._badges)
+
+    def save_badge(self, key, value):
+        self.saved.append((key, value))
+
+
+@pytest.fixture(autouse=True)
+def clean_registry():
+    """Isolate each test: empty registry before and after."""
+    services.reset()
+    yield
+    services.reset()
+
+
+def test_get_achieved_badges_returns_only_achieved():
+    services.db = FakeDB(
+        migrated=True,
+        badges=[
+            {"badge_id": 1, "achieved": True},
+            {"badge_id": 2, "achieved": 0},      # not achieved
+            {"badge_id": 5, "achieved": "true"},
+        ],
+    )
+    assert bf.get_achieved_badges() == [1, 5]
+
+
+def test_get_achieved_badges_falls_back_to_json_when_not_migrated(tmp_path, monkeypatch):
+    services.db = FakeDB(migrated=False)
+    badge_file = tmp_path / "badges.json"
+    badge_file.write_text(json.dumps([7, 9]))
+    # badgebag_path was imported into the module's namespace; redirect it.
+    monkeypatch.setattr(bf, "badgebag_path", str(badge_file))
+
+    assert bf.get_achieved_badges() == [7, 9]
+
+
+def test_receive_badge_marks_and_persists():
+    db = FakeDB(migrated=True)
+    services.db = db
+    achievements = {str(i): False for i in range(1, 69)}
+
+    result = bf.receive_badge(3, achievements)
+
+    assert result["3"] is True
+    assert ("3", {"id": 3, "achieved": True}) in db.saved
+
+
+def test_handle_review_count_achievement_awards_milestone():
+    services.db = FakeDB(migrated=True)
+    achievements = {str(i): False for i in range(1, 69)}
+
+    result = bf.handle_review_count_achievement(100, achievements)
+
+    assert result["1"] is True  # 100 reviews -> badge 1
+
+
+def test_handle_review_count_achievement_ignores_non_milestone():
+    services.db = FakeDB(migrated=True)
+    achievements = {str(i): False for i in range(1, 69)}
+
+    result = bf.handle_review_count_achievement(150, achievements)
+
+    assert all(value is False for value in result.values())
+
+
+def test_check_for_badge_is_pure():
+    assert bf.check_for_badge({"5": True}, 5) is True
+    assert bf.check_for_badge({"5": True}, 6) is False

--- a/tests/test_migration.py
+++ b/tests/test_migration.py
@@ -1,0 +1,98 @@
+"""
+Tests for migration.migrate_starter_individual_id — migrated off mw onto the
+services registry. The logger comes from `services` (no Anki). The only Anki
+touch left is `showWarning`, lazy-imported inside the fix path; the skip-path
+tests below never trigger it, and the fix-path test installs a tiny 2-module
+aqt.utils stub (vs. the ~20-module sys.modules surgery the legacy tests need).
+"""
+
+import json
+import sys
+import types
+
+import pytest
+
+from Ankimon.services import services
+from Ankimon.functions import migration as mig
+
+
+class FakeLogger:
+    def __init__(self):
+        self.logs = []
+
+    def log(self, level, message):
+        self.logs.append((level, message))
+
+
+@pytest.fixture(autouse=True)
+def fake_logger():
+    services.reset()
+    logger = FakeLogger()
+    services.logger = logger
+    yield logger
+    services.reset()
+
+
+@pytest.fixture
+def recording_showwarning():
+    """Stub aqt.utils.showWarning for the lazy import on the fix path."""
+    calls = []
+    aqt = types.ModuleType("aqt")
+    aqt_utils = types.ModuleType("aqt.utils")
+    aqt_utils.showWarning = lambda *a, **k: calls.append(a[0] if a else "")
+    aqt.utils = aqt_utils
+    saved = {k: sys.modules.get(k) for k in ("aqt", "aqt.utils")}
+    sys.modules["aqt"] = aqt
+    sys.modules["aqt.utils"] = aqt_utils
+    try:
+        yield calls
+    finally:
+        for k, v in saved.items():
+            if v is None:
+                sys.modules.pop(k, None)
+            else:
+                sys.modules[k] = v
+
+
+def test_get_starter_evolution_ids_is_pure():
+    assert mig.get_starter_evolution_ids(1) == [1, 2, 3]
+
+
+def test_skips_when_data_files_missing(fake_logger, monkeypatch, tmp_path):
+    monkeypatch.setattr(mig, "mainpokemon_path", tmp_path / "absent_main.json")
+    monkeypatch.setattr(mig, "mypokemon_path", tmp_path / "absent_my.json")
+
+    mig.migrate_starter_individual_id()
+
+    assert any("data files missing" in m for _, m in fake_logger.logs)
+
+
+def test_skips_when_already_synchronized(fake_logger, monkeypatch, tmp_path):
+    main = tmp_path / "main.json"
+    my = tmp_path / "my.json"
+    main.write_text(json.dumps([{"id": 1, "individual_id": "abc"}]))
+    my.write_text(json.dumps([{"id": 1, "individual_id": "abc"}]))
+    monkeypatch.setattr(mig, "mainpokemon_path", main)
+    monkeypatch.setattr(mig, "mypokemon_path", my)
+
+    mig.migrate_starter_individual_id()
+
+    assert any("already synchronized" in m for _, m in fake_logger.logs)
+
+
+def test_fixes_starter_id_and_warns_user(fake_logger, recording_showwarning, monkeypatch, tmp_path):
+    # Same starter (bulbasaur, id 1) in both files but with mismatched individual_id.
+    shared = {"id": 1, "iv": {"hp": 10}, "gender": "M", "ability": "Overgrow", "shiny": False}
+    main = tmp_path / "main.json"
+    my = tmp_path / "my.json"
+    main.write_text(json.dumps([{**shared, "individual_id": "NEW-ID"}]))
+    my.write_text(json.dumps([{**shared, "individual_id": "OLD-DIFFERENT"}]))
+    monkeypatch.setattr(mig, "mainpokemon_path", main)
+    monkeypatch.setattr(mig, "mypokemon_path", my)
+
+    mig.migrate_starter_individual_id()
+
+    # the my-pokemon's id was synced, the file rewritten, and the user warned once
+    assert json.loads(my.read_text())[0]["individual_id"] == "NEW-ID"
+    assert len(recording_showwarning) == 1
+    assert any("successful" in m for _, m in fake_logger.logs)

--- a/tests/test_sprite_functions.py
+++ b/tests/test_sprite_functions.py
@@ -1,0 +1,59 @@
+"""
+Tests for sprite_functions — migrated off `mw.logger` onto the `services`
+registry. Like test_badges_functions, the entire setup is a plain import plus
+`services.logger = FakeLogger()`; no `aqt`, no `sys.modules` surgery. The import
+below would fail outright if the module still pulled in Anki.
+"""
+
+import pytest
+
+from Ankimon.services import services
+from Ankimon.functions import sprite_functions as sf
+
+
+class FakeLogger:
+    """Records log calls so tests can assert on them, with no Qt/Anki."""
+
+    def __init__(self):
+        self.logs = []
+
+    def log(self, level, message):
+        self.logs.append((level, message))
+
+
+@pytest.fixture(autouse=True)
+def fake_logger():
+    services.reset()
+    logger = FakeLogger()
+    services.logger = logger
+    yield logger
+    services.reset()
+
+
+def test_found_sprite_returns_path_and_logs_debug(fake_logger, monkeypatch):
+    expected = sf._path_format(back=False, id=25, gif=False, shiny=False, female=False)
+    monkeypatch.setattr("os.path.exists", lambda p: p == expected)
+
+    result = sf.get_sprite_path("front", "png", 25, shiny=False, gender="M")
+
+    assert result == expected
+    assert ("debug", f"Sprite found: {expected}") in fake_logger.logs
+
+
+def test_missing_sprite_returns_substitute_and_logs_warning(fake_logger, monkeypatch):
+    monkeypatch.setattr("os.path.exists", lambda p: False)
+
+    result = sf.get_sprite_path("front", "png", 999999, shiny=False, gender="M")
+
+    assert result == sf.SUBSTITUTE_PATH
+    assert any(level == "warning" for level, _ in fake_logger.logs)
+
+
+def test_gender_fallback_to_nongendered(fake_logger, monkeypatch):
+    # Female sprite absent, non-gendered present -> should fall back to it.
+    nongendered = sf._path_format(back=False, id=25, gif=False, shiny=False, female=False)
+    monkeypatch.setattr("os.path.exists", lambda p: p == nongendered)
+
+    result = sf.get_sprite_path("front", "png", 25, shiny=False, gender="F")
+
+    assert result == nongendered


### PR DESCRIPTION
## Problem

The addon uses Anki's `mw` (main window) as a service-locator: ~80% of `mw.X` accesses are the addon's *own* objects parked on it — `mw.ankimon_db` (53), `mw.translator` (36), `mw.logger` (24), `mw.settings_obj` (6), etc. Only ~35 refs are genuine Anki APIs. Because most modules do `from aqt import mw` at module top, importing almost anything drags in Anki, so every test has to hand-stub `aqt` plus a dozen internal modules in `sys.modules` (see the boilerplate in `tests/test_encounter_functions.py`). That coupling is what makes the code hard to test without a running Anki.

## Approach

Introduce `src/Ankimon/services.py` — an **aqt-free registry** that holds the addon's own services (`db`, `logger`, `settings`, `translator`). Code reads its dependencies from `services` instead of reaching into `mw`. This is a *registry pattern, not full DI* — still a global, but one tests own and one that doesn't import Anki. It's the seam that makes the addon's logic testable without an Anki runtime; constructor injection can be layered on later, module by module.

This PR lands the registry and **migrates modules onto it incrementally**, one file per commit, each fully decoupled and unit-tested.

## Changes

**The seam**
- **`services.py`** (new): registry singleton with `populate()` / `reset()`; provably imports with zero `aqt`/`anki`.
- **`singletons.py`**: populates the registry **once** at the composition root; keeps the existing `mw.X` writes as labeled back-compat shims.
- **`__init__.py`**: removes the duplicate `mw.X` writes (singletons already sets them); keeps the `mw.translator` re-point that compensates for `menu_buttons.py:45` so `mw.translator` stays identical to `services.translator`.

**Migrated modules (each now imports zero `aqt`, each with a no-Anki-mocking test)**
- **`functions/badges_functions.py`** → `services.db` (was `mw.ankimon_db`). Test: `tests/test_badges_functions.py` (6 tests).
- **`functions/sprite_functions.py`** → `services.logger` (was `mw.logger`). Test: `tests/test_sprite_functions.py` (3 tests).
- **`functions/migration.py`** → `services.logger`; its 2 `showWarning` calls are lazy-imported inside the fix path so the skip-path logic tests with zero Anki. Test: `tests/test_migration.py` (4 tests).

On `showWarning`/`showInfo`: rather than build a UI abstraction prematurely, dead `aqt.utils` imports are deleted and genuine call sites are lazy-imported. A proper `services.ui` adapter is deferred to the Phase 2 boundary pass (there are ~71 such calls codebase-wide — worth doing once, consistently, alongside `col`/`reviewer`/`taskman`).

## Testing

- Full suite: **78 passed** (with `--deselect` of the one integrity test that needs live network at import).
- `services.py` imports in a clean interpreter with no `aqt`/`anki` present.
- `ruff check --config ci_ruff_check.toml` clean on all changed files.

## Follow-up (continuing on this branch / future PRs)

- Migrate the remaining `functions/` modules off `mw` → `services`, file by file, shrinking the conftest stub list and integrity ignore-list as each lands. Files that also use `aqt.utils.showWarning`/`showInfo` need a small decision (lazy-import vs a thin UI adapter on the registry).
- The ~35 genuine Anki refs (`mw.col` / `mw.reviewer` / `mw.taskman` / …) get a thin adapter/Protocol the tests can fake.
- (Optional) move `singletons.py`'s import-time construction into an explicit `boot()` so importing a module has no side effects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
