### PR TITLE
Fix NoneType crash when XP Share target is released or traded

### DIFF
--- a/src/Ankimon/functions/trainer_functions.py
+++ b/src/Ankimon/functions/trainer_functions.py
@@ -78,6 +78,10 @@ def xp_share_gain_exp(logger, settings_obj, evo_window, main_pokemon_id, exp, xp
     evolution_triggered = False
 
     pokemon = db.get_pokemon(xp_share_individual_id)
+    if pokemon is None:
+        settings_obj.set("trainer.xp_share", "")
+        return original_exp
+
     current_level = int(pokemon['level'])  # MODIFIED: Use local variable for level
     if pokemon.get('held_item') == "lucky-egg":
         exp = int(exp * 1.5) # Multiply by 1.5 if pokemon holds lucky egg

--- a/src/Ankimon/gui_classes/pokemon_details.py
+++ b/src/Ankimon/gui_classes/pokemon_details.py
@@ -1166,6 +1166,10 @@ def PokemonFree(
     else:
         logger.log_and_showinfo("error", f"Failed to add {name} to history.")
     
+    # Check if released pokemon was XP share target
+    if mw.settings_obj.get("trainer.xp_share") == individual_id:
+        mw.settings_obj.set("trainer.xp_share", "")
+
     # Delete from database
     mw.ankimon_db.delete_pokemon(individual_id)
     logger.log_and_showinfo("info", f"{name.capitalize()} has been let free.")

--- a/src/Ankimon/pyobj/pokemon_trade.py
+++ b/src/Ankimon/pyobj/pokemon_trade.py
@@ -587,6 +587,9 @@ class PokemonTrade:
             
             try:
                 db.replace_pokemon(new_pokemon, self.individual_id)
+
+                if mw.settings_obj.get("trainer.xp_share") == self.individual_id:
+                    mw.settings_obj.set("trainer.xp_share", "")
             except Exception as e:
                 show_warning_with_traceback(parent=self.parent_window, exception=e, message=f"An error occurred during trade: {e}")
 


### PR DESCRIPTION
Fixes a bug where the game crashes with a TypeError ('NoneType' object is not subscriptable) in `xp_share_gain_exp` when the target Pokemon for XP Share has been deleted/released.

Changes:
1. In `src/Ankimon/functions/trainer_functions.py`, modified `xp_share_gain_exp` to check if `pokemon` is None after `db.get_pokemon()`. If it is None, it clears the `trainer.xp_share` setting and returns the original `exp`.
2. In `src/Ankimon/gui_classes/pokemon_details.py`, inside `PokemonFree`, added a check if the released pokemon was the xp_share target and clears the setting if so.
3. In `src/Ankimon/pyobj/pokemon_trade.py`, inside `replace_pokemon`, added the same check.

---
*PR created automatically by Jules for task [14775327266832162515](https://jules.google.com/task/14775327266832162515) started by @h0tp-ftw*