### PR TITLE
fix: make the updater safe on git clones (ff-only) + PR-install warning + hide pre-v2.0 releases

### DIFF
--- a/src/Ankimon/lang/en_text.json
+++ b/src/Ankimon/lang/en_text.json
@@ -47,6 +47,7 @@
   "report_bug_button": "Report Bug",
   "rate_this_button": "Rate This Addon",
   "ankimon_version_button": "Ankimon Version",
+  "ankimon_update_button": "Update Ankimon",
   "ankimon_settings_button": "Ankimon Settings",
   "ankimon_data_button": "Ankimon Data",
   "ankimon_tracker_button": "Ankimon Tracker",

--- a/src/Ankimon/lang/en_text.json
+++ b/src/Ankimon/lang/en_text.json
@@ -46,6 +46,7 @@
   "report_bug_button": "Report Bug",
   "rate_this_button": "Rate This Addon",
   "ankimon_version_button": "Ankimon Version",
+  "ankimon_update_button": "Update Ankimon",
   "ankimon_settings_button": "Ankimon Settings",
   "ankimon_data_button": "Ankimon Data",
   "ankimon_tracker_button": "Ankimon Tracker",

--- a/src/Ankimon/menu_buttons.py
+++ b/src/Ankimon/menu_buttons.py
@@ -209,16 +209,46 @@ def create_menu_actions(
     rate_action.triggered.connect(rate_addon_url)
     mw.pokemenu.addAction(rate_action)
 
-    # Update Ankimon
-    def _open_update_dialog():
-        from .pyobj.update_dialog import UpdateDialog
-        dialog = UpdateDialog(parent=mw)
-        dialog.exec()
+    # Update Ankimon. On a git checkout the file-overwrite updater is unsafe (it
+    # would clobber the working tree), so offer a safe `git pull --ff-only`
+    # instead; otherwise the normal download-based updater dialog.
+    from .pyobj.update_manager import is_git_clone, git_pull_ff_only
+    if is_git_clone():
+        def _git_update():
+            if not askUser(
+                "Update Ankimon by fast-forwarding your git clone "
+                "(git pull --ff-only)?\n\nThis stops safely without making any "
+                "changes if you have local edits or commits.",
+                title="Update Ankimon (git)",
+            ):
+                return
 
-    update_action = QAction(mw.translator.translate("ankimon_update_button"), mw)
-    update_action.setMenuRole(QAction.MenuRole.NoRole)
-    update_action.triggered.connect(_open_update_dialog)
-    help_menu.addAction(update_action)
+            from aqt.operations import QueryOp
+
+            def on_done(result):
+                ok, msg = result
+                (showInfo if ok else showWarning)(msg)
+
+            QueryOp(
+                parent=mw, op=lambda col: git_pull_ff_only(), success=on_done
+            ).without_collection().run_in_background()
+
+        update_action = QAction(
+            mw.translator.translate("ankimon_update_button") + " (git pull)", mw
+        )
+        update_action.setMenuRole(QAction.MenuRole.NoRole)
+        update_action.triggered.connect(_git_update)
+        help_menu.addAction(update_action)
+    else:
+        def _open_update_dialog():
+            from .pyobj.update_dialog import UpdateDialog
+            dialog = UpdateDialog(parent=mw)
+            dialog.exec()
+
+        update_action = QAction(mw.translator.translate("ankimon_update_button"), mw)
+        update_action.setMenuRole(QAction.MenuRole.NoRole)
+        update_action.triggered.connect(_open_update_dialog)
+        help_menu.addAction(update_action)
 
     # Version
     version_action = QAction(mw.translator.translate("ankimon_version_button"), mw)

--- a/src/Ankimon/menu_buttons.py
+++ b/src/Ankimon/menu_buttons.py
@@ -209,16 +209,19 @@ def create_menu_actions(
     rate_action.triggered.connect(rate_addon_url)
     mw.pokemenu.addAction(rate_action)
 
-    # Update Ankimon
-    def _open_update_dialog():
-        from .pyobj.update_dialog import UpdateDialog
-        dialog = UpdateDialog(parent=mw)
-        dialog.exec()
+    # Update Ankimon — hidden on git checkouts: the updater overwrites files in
+    # place and would clobber a dev's working tree, so devs should use `git pull`.
+    from .pyobj.update_manager import is_git_clone
+    if not is_git_clone():
+        def _open_update_dialog():
+            from .pyobj.update_dialog import UpdateDialog
+            dialog = UpdateDialog(parent=mw)
+            dialog.exec()
 
-    update_action = QAction(mw.translator.translate("ankimon_update_button"), mw)
-    update_action.setMenuRole(QAction.MenuRole.NoRole)
-    update_action.triggered.connect(_open_update_dialog)
-    help_menu.addAction(update_action)
+        update_action = QAction(mw.translator.translate("ankimon_update_button"), mw)
+        update_action.setMenuRole(QAction.MenuRole.NoRole)
+        update_action.triggered.connect(_open_update_dialog)
+        help_menu.addAction(update_action)
 
     # Version
     version_action = QAction(mw.translator.translate("ankimon_version_button"), mw)

--- a/src/Ankimon/menu_buttons.py
+++ b/src/Ankimon/menu_buttons.py
@@ -209,10 +209,37 @@ def create_menu_actions(
     rate_action.triggered.connect(rate_addon_url)
     mw.pokemenu.addAction(rate_action)
 
-    # Update Ankimon — hidden on git checkouts: the updater overwrites files in
-    # place and would clobber a dev's working tree, so devs should use `git pull`.
-    from .pyobj.update_manager import is_git_clone
-    if not is_git_clone():
+    # Update Ankimon. On a git checkout the file-overwrite updater is unsafe (it
+    # would clobber the working tree), so offer a safe `git pull --ff-only`
+    # instead; otherwise the normal download-based updater dialog.
+    from .pyobj.update_manager import is_git_clone, git_pull_ff_only
+    if is_git_clone():
+        def _git_update():
+            if not askUser(
+                "Update Ankimon by fast-forwarding your git clone "
+                "(git pull --ff-only)?\n\nThis stops safely without making any "
+                "changes if you have local edits or commits.",
+                title="Update Ankimon (git)",
+            ):
+                return
+
+            from aqt.operations import QueryOp
+
+            def on_done(result):
+                ok, msg = result
+                (showInfo if ok else showWarning)(msg)
+
+            QueryOp(
+                parent=mw, op=lambda col: git_pull_ff_only(), success=on_done
+            ).without_collection().run_in_background()
+
+        update_action = QAction(
+            mw.translator.translate("ankimon_update_button") + " (git pull)", mw
+        )
+        update_action.setMenuRole(QAction.MenuRole.NoRole)
+        update_action.triggered.connect(_git_update)
+        help_menu.addAction(update_action)
+    else:
         def _open_update_dialog():
             from .pyobj.update_dialog import UpdateDialog
             dialog = UpdateDialog(parent=mw)

--- a/src/Ankimon/pyobj/update_dialog.py
+++ b/src/Ankimon/pyobj/update_dialog.py
@@ -291,6 +291,16 @@ class UpdateDialog(QDialog):
         info.setWordWrap(True)
         layout.addWidget(info)
 
+        warning = QLabel(
+            "⚠ Do not use this if you installed Ankimon by cloning the git "
+            "repository. The updater overwrites files in place and would clobber "
+            "your checkout — update with 'git pull' instead. (Your Pokémon "
+            "data and sprites are always preserved.)"
+        )
+        warning.setStyleSheet(f"color: {c['warning']}; font-size: 11px; font-weight: bold;")
+        warning.setWordWrap(True)
+        layout.addWidget(warning)
+
         group = QGroupBox("Install from Source")
         group_layout = QVBoxLayout(group)
         group_layout.setSpacing(10)
@@ -427,10 +437,13 @@ class UpdateDialog(QDialog):
             percent = int((current / total) * 100)
             mw.taskman.run_on_main(lambda: self.progress_bar.setValue(percent))
 
-    def _run_update(self, download_fn, label: str):
+    def _run_update(self, download_fn, label: str, extra_warning: str = None):
+        prompt = f"Update Ankimon to {label}?\n\nYour Pokemon data, settings, and sprites will be preserved."
+        if extra_warning:
+            prompt = f"{extra_warning}\n\n{prompt}"
         confirm = QMessageBox.question(
             self, "Confirm Update",
-            f"Update Ankimon to {label}?\n\nYour Pokemon data, settings, and sprites will be preserved.",
+            prompt,
             QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
         )
         if confirm != QMessageBox.StandardButton.Yes:
@@ -481,7 +494,16 @@ class UpdateDialog(QDialog):
         elif source == "pr":
             data = self.target_combo.currentData()
             if data:
-                self._run_update(lambda progress_cb: _download_pr_zip(data["head_sha"], progress_cb), f"PR #{data['number']} ({data['title']})")
+                self._run_update(
+                    lambda progress_cb: _download_pr_zip(data["head_sha"], progress_cb),
+                    f"PR #{data['number']} ({data['title']})",
+                    extra_warning=(
+                        "⚠ WARNING: Anyone can open a pull request. This code is "
+                        "unreviewed and unreleased — installing it runs unverified "
+                        "code on your computer. Only proceed if you trust this PR. "
+                        "Use at your own risk."
+                    ),
+                )
         elif source == "branch":
             data = self.target_combo.currentData()
             if data:

--- a/src/Ankimon/pyobj/update_dialog.py
+++ b/src/Ankimon/pyobj/update_dialog.py
@@ -437,10 +437,13 @@ class UpdateDialog(QDialog):
             percent = int((current / total) * 100)
             mw.taskman.run_on_main(lambda: self.progress_bar.setValue(percent))
 
-    def _run_update(self, download_fn, label: str):
+    def _run_update(self, download_fn, label: str, extra_warning: str = None):
+        prompt = f"Update Ankimon to {label}?\n\nYour Pokemon data, settings, and sprites will be preserved."
+        if extra_warning:
+            prompt = f"{extra_warning}\n\n{prompt}"
         confirm = QMessageBox.question(
             self, "Confirm Update",
-            f"Update Ankimon to {label}?\n\nYour Pokemon data, settings, and sprites will be preserved.",
+            prompt,
             QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
         )
         if confirm != QMessageBox.StandardButton.Yes:
@@ -491,7 +494,16 @@ class UpdateDialog(QDialog):
         elif source == "pr":
             data = self.target_combo.currentData()
             if data:
-                self._run_update(lambda progress_cb: _download_pr_zip(data["head_sha"], progress_cb), f"PR #{data['number']} ({data['title']})")
+                self._run_update(
+                    lambda progress_cb: _download_pr_zip(data["head_sha"], progress_cb),
+                    f"PR #{data['number']} ({data['title']})",
+                    extra_warning=(
+                        "⚠ WARNING: Anyone can open a pull request. This code is "
+                        "unreviewed and unreleased — installing it runs unverified "
+                        "code on your computer. Only proceed if you trust this PR. "
+                        "Use at your own risk."
+                    ),
+                )
         elif source == "branch":
             data = self.target_combo.currentData()
             if data:

--- a/src/Ankimon/pyobj/update_dialog.py
+++ b/src/Ankimon/pyobj/update_dialog.py
@@ -291,6 +291,16 @@ class UpdateDialog(QDialog):
         info.setWordWrap(True)
         layout.addWidget(info)
 
+        warning = QLabel(
+            "⚠ Do not use this if you installed Ankimon by cloning the git "
+            "repository. The updater overwrites files in place and would clobber "
+            "your checkout — update with 'git pull' instead. (Your Pokémon "
+            "data and sprites are always preserved.)"
+        )
+        warning.setStyleSheet(f"color: {c['warning']}; font-size: 11px; font-weight: bold;")
+        warning.setWordWrap(True)
+        layout.addWidget(warning)
+
         group = QGroupBox("Install from Source")
         group_layout = QVBoxLayout(group)
         group_layout.setSpacing(10)

--- a/src/Ankimon/pyobj/update_manager.py
+++ b/src/Ankimon/pyobj/update_manager.py
@@ -1,7 +1,9 @@
 import io
 import json
 import os
+import re
 import shutil
+import subprocess
 import tempfile
 import urllib.request
 import urllib.error
@@ -20,6 +22,126 @@ GITHUB_API = f"https://api.github.com/repos/{REPO_OWNER}/{REPO_NAME}"
 DOWNLOAD_TIMEOUT = 30
 USER_AGENT = "Ankimon-Updater (https://github.com/h0tp-ftw/ankimon)"
 DEFAULT_SUBMODULE_SHA = "f3092b03fbe1e37d1788ef802dee98906d621e36"
+# The in-app updater shipped in v2.0. Installing an older release would strip the
+# updater out (older versions predate it), so pre-2.0 versions are filtered from
+# the release/tag pickers — going back would break the update feature itself.
+MIN_UPDATER_VERSION = (2, 0)
+
+
+def _git_repo_root() -> Optional[Path]:
+    """Return the git repo root that contains the addon, else None.
+
+    For a GitHub clone the addon is ``src/Ankimon`` nested in the repo, so the
+    ``.git`` directory sits two levels *above* ``addon_dir`` at the repo root —
+    hence the upward parent walk. ``resolve()`` first follows the dev symlink
+    from ``addons21/`` into the repo so those parents land on the real repo root;
+    the walk is kept shallow to avoid false positives from an unrelated repo
+    higher up.
+    """
+    try:
+        base = Path(addon_dir).resolve()
+    except Exception:
+        base = Path(addon_dir)
+    for d in [base, *list(base.parents)[:3]]:
+        # .exists() rather than .is_dir(): in git worktrees and some submodule
+        # layouts ".git" is a *file* (containing "gitdir: ..."), not a directory.
+        if (d / ".git").exists():
+            return d
+    return None
+
+
+def is_git_clone() -> bool:
+    """True if Ankimon runs from a git working tree (a dev clone).
+
+    The in-place updater would overwrite every file under ``addon_dir`` with the
+    downloaded copy, trashing the working tree and any uncommitted/untracked
+    changes (``.git`` is above ``addon_dir`` so it survives, but the checkout is
+    clobbered). So the destructive updater is hidden for clones; a safe
+    ``git pull --ff-only`` is offered instead (see ``git_pull_ff_only``).
+    """
+    return _git_repo_root() is not None
+
+
+def git_pull_ff_only(status_cb=None) -> tuple[bool, str]:
+    """Update a dev clone via ``git pull --ff-only`` (+ submodule update).
+
+    Safe by construction: ``--ff-only`` refuses, without changing anything, when
+    the tree is dirty or the branch has diverged — so it never creates merge
+    conflicts. Returns ``(success, message)``.
+    """
+    def log(msg):
+        if status_cb:
+            status_cb(msg)
+
+    root = _git_repo_root()
+    if root is None:
+        return False, "Ankimon is not running from a git checkout."
+
+    if shutil.which("git") is None:
+        return False, (
+            "git wasn't found on Anki's PATH. This is common when Anki is "
+            "launched from the dock/Finder, which doesn't inherit your shell "
+            "PATH. Restart Anki from a terminal, or run 'git pull' in your "
+            "clone yourself."
+        )
+
+    def _git(*args, timeout=180):
+        return subprocess.run(
+            ["git", "-C", str(root), *args],
+            capture_output=True, text=True, timeout=timeout,
+        )
+
+    try:
+        branch = (_git("rev-parse", "--abbrev-ref", "HEAD", timeout=30).stdout or "").strip() or "HEAD"
+        log(f"Fast-forwarding '{branch}' (git pull --ff-only)...")
+        pull = _git("pull", "--ff-only")
+        if pull.returncode != 0:
+            err = (pull.stderr or pull.stdout or "").strip()
+            return False, (
+                f"Could not fast-forward '{branch}'. This is expected if you "
+                "have local changes/commits or no upstream — resolve it manually "
+                "with git.\n\n" + err
+            )
+        log("Updating submodules...")
+        sub = _git("submodule", "update", "--init", "--recursive")
+        out = (pull.stdout or "").strip()
+        if sub.returncode != 0:
+            return True, (
+                f"Updated '{branch}', but the submodule update failed — run "
+                "'git submodule update --init --recursive' manually.\n\n"
+                + (sub.stderr or "").strip()
+            )
+        return True, f"Updated '{branch}' via git pull --ff-only.\n\n{out}"
+    except subprocess.TimeoutExpired:
+        return False, "git timed out. Update manually with 'git pull'."
+    except Exception as e:
+        return False, f"git update failed: {e}. Update manually with 'git pull'."
+
+
+def _parse_version(name: str) -> Optional[tuple]:
+    """Coarse (major, minor) parse for the MIN_UPDATER_VERSION threshold gate ONLY.
+
+    Returns None for non-version names ('sprites', 'nightly-release', 'archive/*').
+
+    This is deliberately NOT a total ordering. It stops at minor and reads each
+    component as an int, so '2.01' and '2.1' both parse to (2, 1) and a '2.0.1'
+    patch is dropped. That is harmless for the `>= (2, 0)` threshold but WRONG for
+    sorting or equality: do not pass it to sorted()/max() or use it to compare two
+    releases. "Latest" is resolved by GitHub API order (newest first, see
+    fetch_releases / update_dialog), never by this function.
+    """
+    m = re.match(r"v?(\d+)(?:\.(\d+))?", name.strip())
+    if not m:
+        return None
+    return (int(m.group(1)), int(m.group(2) or 0))
+
+
+def _is_supported_version(name: str) -> bool:
+    """True for parseable version names >= MIN_UPDATER_VERSION. Non-version names
+    (the 'sprites' asset release, 'nightly-release', 'archive/*', …) return False
+    and are excluded from the pickers."""
+    v = _parse_version(name)
+    return v is not None and v >= MIN_UPDATER_VERSION
 
 
 def _make_request(url: str, accept: str = "application/vnd.github.v3+json") -> urllib.request.Request:
@@ -58,6 +180,11 @@ def _fetch_gitignore_patterns() -> list[str]:
 
 
 def _should_preserve(rel_path: str, gitignore_patterns: list[str]) -> bool:
+    # Holy Ground: NEVER touch anything in user_files/ during an update,
+    # regardless of gitignore patterns.
+    if rel_path == "user_files" or rel_path.startswith("user_files/"):
+        return True
+
     for pattern in gitignore_patterns:
         pattern = pattern.rstrip("/")
         if rel_path == pattern or rel_path.startswith(pattern + "/"):
@@ -79,14 +206,22 @@ def fetch_tags() -> list[dict]:
     data = _api_get("tags")
     if not data:
         return []
-    return [{"name": t["name"], "zipball_url": t["zipball_url"]} for t in data]
+    return [
+        {"name": t["name"], "zipball_url": t["zipball_url"]}
+        for t in data
+        if _is_supported_version(t["name"])
+    ]
 
 
 def fetch_releases() -> list[dict]:
     data = _api_get("releases")
     if not data:
         return []
-    return [{"name": r["tag_name"], "body": r.get("body", ""), "zipball_url": r["zipball_url"]} for r in data]
+    return [
+        {"name": r["tag_name"], "body": r.get("body", ""), "zipball_url": r["zipball_url"]}
+        for r in data
+        if _is_supported_version(r["tag_name"])
+    ]
 
 
 def fetch_branches() -> list[dict]:
@@ -278,6 +413,19 @@ def apply_update(zip_path: str, status_cb=None) -> tuple[bool, str]:
                 os.unlink(zip_path)
             except Exception:
                 pass
+
+    # Safety guard: this overwrites every file under addon_dir (the addon =
+    # src/Ankimon) with the downloaded copy. On a git clone that trashes the
+    # working tree and any uncommitted/untracked changes, so refuse. (.git lives
+    # above addon_dir and is untouched, but the checkout is still clobbered.)
+    if is_git_clone():
+        cleanup()
+        return False, (
+            "Detected a git checkout of Ankimon. The in-app updater overwrites "
+            "the addon's files in place and would clobber your working tree "
+            "(you'd lose uncommitted changes). Update your clone with 'git pull' "
+            "instead."
+        )
 
     log("Fetching latest .gitignore from main...")
     gitignore_patterns = _get_gitignore_patterns()

--- a/src/Ankimon/pyobj/update_manager.py
+++ b/src/Ankimon/pyobj/update_manager.py
@@ -22,6 +22,32 @@ USER_AGENT = "Ankimon-Updater (https://github.com/h0tp-ftw/ankimon)"
 DEFAULT_SUBMODULE_SHA = "f3092b03fbe1e37d1788ef802dee98906d621e36"
 
 
+def is_git_clone() -> bool:
+    """True if Ankimon lives inside a git working tree (i.e. a dev clone).
+
+    For a GitHub clone the addon is ``src/Ankimon`` nested in the repo, so the
+    ``.git`` directory sits two levels *above* ``addon_dir`` at the repo root —
+    hence the upward parent walk. ``resolve()`` first follows the dev symlink
+    from ``addons21/`` into the repo so those parents land on the real repo
+    root; the walk is kept shallow to avoid false positives from an unrelated
+    repo higher up. The in-place updater would overwrite every file under
+    ``addon_dir`` with the downloaded copy, trashing the working tree and any
+    uncommitted/untracked changes (``.git`` is above ``addon_dir`` so it
+    survives, but the checkout is clobbered), so the updater is hidden and
+    refuses to run when this returns True.
+    """
+    try:
+        base = Path(addon_dir).resolve()
+    except Exception:
+        base = Path(addon_dir)
+    for d in [base, *list(base.parents)[:3]]:
+        # .exists() rather than .is_dir(): in git worktrees and some submodule
+        # layouts ".git" is a *file* (containing "gitdir: ..."), not a directory.
+        if (d / ".git").exists():
+            return True
+    return False
+
+
 def _make_request(url: str, accept: str = "application/vnd.github.v3+json") -> urllib.request.Request:
     req = urllib.request.Request(url)
     req.add_header("Accept", accept)
@@ -278,6 +304,19 @@ def apply_update(zip_path: str, status_cb=None) -> tuple[bool, str]:
                 os.unlink(zip_path)
             except Exception:
                 pass
+
+    # Safety guard: this overwrites every file under addon_dir (the addon =
+    # src/Ankimon) with the downloaded copy. On a git clone that trashes the
+    # working tree and any uncommitted/untracked changes, so refuse. (.git lives
+    # above addon_dir and is untouched, but the checkout is still clobbered.)
+    if is_git_clone():
+        cleanup()
+        return False, (
+            "Detected a git checkout of Ankimon. The in-app updater overwrites "
+            "the addon's files in place and would clobber your working tree "
+            "(you'd lose uncommitted changes). Update your clone with 'git pull' "
+            "instead."
+        )
 
     log("Fetching latest .gitignore from main...")
     gitignore_patterns = _get_gitignore_patterns()

--- a/src/Ankimon/pyobj/update_manager.py
+++ b/src/Ankimon/pyobj/update_manager.py
@@ -1,7 +1,9 @@
 import io
 import json
 import os
+import re
 import shutil
+import subprocess
 import tempfile
 import urllib.request
 import urllib.error
@@ -20,21 +22,21 @@ GITHUB_API = f"https://api.github.com/repos/{REPO_OWNER}/{REPO_NAME}"
 DOWNLOAD_TIMEOUT = 30
 USER_AGENT = "Ankimon-Updater (https://github.com/h0tp-ftw/ankimon)"
 DEFAULT_SUBMODULE_SHA = "f3092b03fbe1e37d1788ef802dee98906d621e36"
+# The in-app updater shipped in v2.0. Installing an older release would strip the
+# updater out (older versions predate it), so pre-2.0 versions are filtered from
+# the release/tag pickers — going back would break the update feature itself.
+MIN_UPDATER_VERSION = (2, 0)
 
 
-def is_git_clone() -> bool:
-    """True if Ankimon lives inside a git working tree (i.e. a dev clone).
+def _git_repo_root() -> Optional[Path]:
+    """Return the git repo root that contains the addon, else None.
 
     For a GitHub clone the addon is ``src/Ankimon`` nested in the repo, so the
     ``.git`` directory sits two levels *above* ``addon_dir`` at the repo root —
     hence the upward parent walk. ``resolve()`` first follows the dev symlink
-    from ``addons21/`` into the repo so those parents land on the real repo
-    root; the walk is kept shallow to avoid false positives from an unrelated
-    repo higher up. The in-place updater would overwrite every file under
-    ``addon_dir`` with the downloaded copy, trashing the working tree and any
-    uncommitted/untracked changes (``.git`` is above ``addon_dir`` so it
-    survives, but the checkout is clobbered), so the updater is hidden and
-    refuses to run when this returns True.
+    from ``addons21/`` into the repo so those parents land on the real repo root;
+    the walk is kept shallow to avoid false positives from an unrelated repo
+    higher up.
     """
     try:
         base = Path(addon_dir).resolve()
@@ -44,8 +46,91 @@ def is_git_clone() -> bool:
         # .exists() rather than .is_dir(): in git worktrees and some submodule
         # layouts ".git" is a *file* (containing "gitdir: ..."), not a directory.
         if (d / ".git").exists():
-            return True
-    return False
+            return d
+    return None
+
+
+def is_git_clone() -> bool:
+    """True if Ankimon runs from a git working tree (a dev clone).
+
+    The in-place updater would overwrite every file under ``addon_dir`` with the
+    downloaded copy, trashing the working tree and any uncommitted/untracked
+    changes (``.git`` is above ``addon_dir`` so it survives, but the checkout is
+    clobbered). So the destructive updater is hidden for clones; a safe
+    ``git pull --ff-only`` is offered instead (see ``git_pull_ff_only``).
+    """
+    return _git_repo_root() is not None
+
+
+def git_pull_ff_only(status_cb=None) -> tuple[bool, str]:
+    """Update a dev clone via ``git pull --ff-only`` (+ submodule update).
+
+    Safe by construction: ``--ff-only`` refuses, without changing anything, when
+    the tree is dirty or the branch has diverged — so it never creates merge
+    conflicts. Returns ``(success, message)``.
+    """
+    def log(msg):
+        if status_cb:
+            status_cb(msg)
+
+    root = _git_repo_root()
+    if root is None:
+        return False, "Ankimon is not running from a git checkout."
+
+    if shutil.which("git") is None:
+        return False, (
+            "git wasn't found on Anki's PATH. This is common when Anki is "
+            "launched from the dock/Finder, which doesn't inherit your shell "
+            "PATH. Restart Anki from a terminal, or run 'git pull' in your "
+            "clone yourself."
+        )
+
+    def _git(*args, timeout=180):
+        return subprocess.run(
+            ["git", "-C", str(root), *args],
+            capture_output=True, text=True, timeout=timeout,
+        )
+
+    try:
+        branch = (_git("rev-parse", "--abbrev-ref", "HEAD", timeout=30).stdout or "").strip() or "HEAD"
+        log(f"Fast-forwarding '{branch}' (git pull --ff-only)...")
+        pull = _git("pull", "--ff-only")
+        if pull.returncode != 0:
+            err = (pull.stderr or pull.stdout or "").strip()
+            return False, (
+                f"Could not fast-forward '{branch}'. This is expected if you "
+                "have local changes/commits or no upstream — resolve it manually "
+                "with git.\n\n" + err
+            )
+        log("Updating submodules...")
+        sub = _git("submodule", "update", "--init", "--recursive")
+        out = (pull.stdout or "").strip()
+        if sub.returncode != 0:
+            return True, (
+                f"Updated '{branch}', but the submodule update failed — run "
+                "'git submodule update --init --recursive' manually.\n\n"
+                + (sub.stderr or "").strip()
+            )
+        return True, f"Updated '{branch}' via git pull --ff-only.\n\n{out}"
+    except subprocess.TimeoutExpired:
+        return False, "git timed out. Update manually with 'git pull'."
+    except Exception as e:
+        return False, f"git update failed: {e}. Update manually with 'git pull'."
+
+
+def _parse_version(name: str) -> Optional[tuple]:
+    m = re.match(r"v?(\d+)(?:\.(\d+))?", name.strip())
+    if not m:
+        return None
+    return (int(m.group(1)), int(m.group(2) or 0))
+
+
+def _is_supported_version(name: str) -> bool:
+    """True for parseable version names >= MIN_UPDATER_VERSION. Non-version names
+    (the 'sprites' asset release, 'nightly-release', 'archive/*', …) return False
+    and are excluded from the pickers."""
+    v = _parse_version(name)
+    return v is not None and v >= MIN_UPDATER_VERSION
 
 
 def _make_request(url: str, accept: str = "application/vnd.github.v3+json") -> urllib.request.Request:
@@ -105,14 +190,22 @@ def fetch_tags() -> list[dict]:
     data = _api_get("tags")
     if not data:
         return []
-    return [{"name": t["name"], "zipball_url": t["zipball_url"]} for t in data]
+    return [
+        {"name": t["name"], "zipball_url": t["zipball_url"]}
+        for t in data
+        if _is_supported_version(t["name"])
+    ]
 
 
 def fetch_releases() -> list[dict]:
     data = _api_get("releases")
     if not data:
         return []
-    return [{"name": r["tag_name"], "body": r.get("body", ""), "zipball_url": r["zipball_url"]} for r in data]
+    return [
+        {"name": r["tag_name"], "body": r.get("body", ""), "zipball_url": r["zipball_url"]}
+        for r in data
+        if _is_supported_version(r["tag_name"])
+    ]
 
 
 def fetch_branches() -> list[dict]:

--- a/tests/test_update_manager.py
+++ b/tests/test_update_manager.py
@@ -1,0 +1,184 @@
+"""
+Tests for the updater's git-clone safety guard (is_git_clone + apply_update).
+
+Loading note: sibling test modules (test_database_manager, test_encounter_functions)
+replace sys.modules['Ankimon'] / ['Ankimon.pyobj'] / ['Ankimon.resources'] with
+bare or mock objects at import time. A plain `from Ankimon.pyobj import
+update_manager` here therefore breaks depending on pytest collection order. We
+rebuild a real namespace and exec the module from source so the test is
+order-independent. (Removing the need for this kind of global stubbing is exactly
+what the services-registry refactor targets.)
+"""
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+_SRC = Path(__file__).parent.parent / "src"
+
+
+def _load_update_manager():
+    # update_manager imports these at module load; only stub if nothing else has.
+    if "aqt" not in sys.modules:
+        aqt = types.ModuleType("aqt")
+        aqt.mw = None
+        sys.modules["aqt"] = aqt
+    if "aqt.operations" not in sys.modules:
+        ops = types.ModuleType("aqt.operations")
+        ops.QueryOp = object
+        sys.modules["aqt.operations"] = ops
+
+    # Force real namespace packages (siblings may have replaced them with mocks).
+    # Overwriting sys.modules['Ankimon'] here is safe because this test file
+    # sorts last alphabetically — no other test module is collected/run after it.
+    for name, path in [
+        ("Ankimon", _SRC / "Ankimon"),
+        ("Ankimon.pyobj", _SRC / "Ankimon" / "pyobj"),
+    ]:
+        ns = types.ModuleType(name)
+        ns.__path__ = [str(path)]
+        sys.modules[name] = ns
+
+    # Load real resources (provides addon_dir) then update_manager, from disk.
+    for modname, relpath in [
+        ("Ankimon.resources", "resources.py"),
+        ("Ankimon.pyobj.update_manager", "pyobj/update_manager.py"),
+    ]:
+        spec = importlib.util.spec_from_file_location(modname, _SRC / "Ankimon" / relpath)
+        module = importlib.util.module_from_spec(spec)
+        sys.modules[modname] = module
+        spec.loader.exec_module(module)
+
+    return sys.modules["Ankimon.pyobj.update_manager"]
+
+
+um = _load_update_manager()
+
+
+def test_is_git_clone_true_when_repo_root_has_dot_git(tmp_path, monkeypatch):
+    # Mirror the real layout: <repo>/src/Ankimon, with .git at the repo root.
+    addon = tmp_path / "repo" / "src" / "Ankimon"
+    addon.mkdir(parents=True)
+    monkeypatch.setattr(um, "addon_dir", addon)
+
+    assert um.is_git_clone() is False  # no .git anywhere yet
+
+    (tmp_path / "repo" / ".git").mkdir()  # repo root, two levels up
+    assert um.is_git_clone() is True
+
+
+def test_is_git_clone_true_when_addon_dir_is_repo(tmp_path, monkeypatch):
+    addon = tmp_path / "ankimon"
+    addon.mkdir()
+    (addon / ".git").mkdir()
+    monkeypatch.setattr(um, "addon_dir", addon)
+
+    assert um.is_git_clone() is True
+
+
+def test_is_git_clone_false_for_plain_install(tmp_path, monkeypatch):
+    addon = tmp_path / "addons21" / "ankimon"
+    addon.mkdir(parents=True)
+    monkeypatch.setattr(um, "addon_dir", addon)
+
+    assert um.is_git_clone() is False
+
+
+def test_apply_update_refuses_on_git_clone_and_cleans_zip(tmp_path, monkeypatch):
+    monkeypatch.setattr(um, "is_git_clone", lambda: True)
+    dummy_zip = tmp_path / "update.zip"
+    dummy_zip.write_bytes(b"PK\x03\x04")
+
+    ok, msg = um.apply_update(str(dummy_zip))
+
+    assert ok is False
+    assert "git" in msg.lower()
+    assert not dummy_zip.exists()  # guard cleaned up the downloaded archive
+
+
+# --- git_pull_ff_only --------------------------------------------------------
+
+class _FakeProc:
+    def __init__(self, returncode=0, stdout="", stderr=""):
+        self.returncode = returncode
+        self.stdout = stdout
+        self.stderr = stderr
+
+
+def _fake_git(responses):
+    """Fake subprocess.run dispatching on the git subcommand (cmd[3])."""
+    def _run(cmd, **kwargs):
+        return responses.get(cmd[3], _FakeProc(0))
+    return _run
+
+
+def test_git_pull_reports_not_a_clone(monkeypatch):
+    monkeypatch.setattr(um, "_git_repo_root", lambda: None)
+    ok, msg = um.git_pull_ff_only()
+    assert ok is False
+    assert "not running from a git checkout" in msg.lower()
+
+
+def test_git_pull_handles_git_missing_from_path(tmp_path, monkeypatch):
+    monkeypatch.setattr(um, "_git_repo_root", lambda: tmp_path)
+    monkeypatch.setattr(um.shutil, "which", lambda _name: None)
+    ok, msg = um.git_pull_ff_only()
+    assert ok is False
+    assert "path" in msg.lower()
+
+
+def test_git_pull_success_names_the_branch(tmp_path, monkeypatch):
+    monkeypatch.setattr(um, "_git_repo_root", lambda: tmp_path)
+    monkeypatch.setattr(um.shutil, "which", lambda _name: "/usr/bin/git")
+    monkeypatch.setattr(um.subprocess, "run", _fake_git({
+        "rev-parse": _FakeProc(0, "main\n"),
+        "pull": _FakeProc(0, "Updating 111..222\n"),
+        "submodule": _FakeProc(0, ""),
+    }))
+    ok, msg = um.git_pull_ff_only()
+    assert ok is True
+    assert "main" in msg
+
+
+def test_git_pull_ff_failure_is_safe(tmp_path, monkeypatch):
+    monkeypatch.setattr(um, "_git_repo_root", lambda: tmp_path)
+    monkeypatch.setattr(um.shutil, "which", lambda _name: "/usr/bin/git")
+    monkeypatch.setattr(um.subprocess, "run", _fake_git({
+        "rev-parse": _FakeProc(0, "feature\n"),
+        "pull": _FakeProc(1, "", "fatal: Not possible to fast-forward, aborting."),
+    }))
+    ok, msg = um.git_pull_ff_only()
+    assert ok is False
+    assert "fast-forward" in msg.lower()
+
+
+# --- pre-v2.0 version filtering ----------------------------------------------
+
+def test_version_filter_keeps_2_0_and_above():
+    assert um._is_supported_version("2.01-E") is True
+    assert um._is_supported_version("2.0-E") is True
+    assert um._is_supported_version("v2.0") is True
+
+
+def test_version_filter_drops_pre_2_0_and_non_versions():
+    for name in ["1.52-E", "1.931-E", "1.3962-E", "sprites", "nightly-release", "archive/h0tp/x"]:
+        assert um._is_supported_version(name) is False, name
+
+
+def test_fetch_releases_filters_pre_2_0(monkeypatch):
+    monkeypatch.setattr(um, "_api_get", lambda _ep: [
+        {"tag_name": "sprites", "zipball_url": "z", "body": ""},
+        {"tag_name": "2.01-E", "zipball_url": "z", "body": ""},
+        {"tag_name": "1.52-E", "zipball_url": "z", "body": ""},
+    ])
+    assert [r["name"] for r in um.fetch_releases()] == ["2.01-E"]
+
+
+def test_fetch_tags_filters_pre_2_0(monkeypatch):
+    monkeypatch.setattr(um, "_api_get", lambda _ep: [
+        {"name": "nightly-release", "zipball_url": "z"},
+        {"name": "2.0-E", "zipball_url": "z"},
+        {"name": "1.3962-E", "zipball_url": "z"},
+    ])
+    assert [t["name"] for t in um.fetch_tags()] == ["2.0-E"]

--- a/tests/test_update_manager.py
+++ b/tests/test_update_manager.py
@@ -19,38 +19,58 @@ _SRC = Path(__file__).parent.parent / "src"
 
 
 def _load_update_manager():
-    # update_manager imports these at module load; only stub if nothing else has.
-    if "aqt" not in sys.modules:
-        aqt = types.ModuleType("aqt")
-        aqt.mw = None
-        sys.modules["aqt"] = aqt
-    if "aqt.operations" not in sys.modules:
-        ops = types.ModuleType("aqt.operations")
-        ops.QueryOp = object
-        sys.modules["aqt.operations"] = ops
+    # This runs at collection time and temporarily overwrites global sys.modules
+    # entries to exec update_manager from source in isolation. Snapshot every key
+    # we touch and RESTORE it in a finally, so collecting this file does not leak a
+    # bare 'Ankimon' namespace / 'aqt' stub into sibling tests (e.g. it would break
+    # test_addon_integrity's import walk -> tip_of_the_day NameError on QDialog).
+    # The returned module object stays valid for the test functions regardless.
+    # (Removing the need for this global stubbing is what the #437 service-registry
+    # refactor targets.)
+    _keys = (
+        "aqt", "aqt.operations", "Ankimon", "Ankimon.pyobj",
+        "Ankimon.resources", "Ankimon.pyobj.update_manager",
+    )
+    _saved = {k: sys.modules.get(k) for k in _keys}
+    try:
+        # update_manager imports these at module load; only stub if nothing else has.
+        if "aqt" not in sys.modules:
+            aqt = types.ModuleType("aqt")
+            aqt.mw = None
+            sys.modules["aqt"] = aqt
+        if "aqt.operations" not in sys.modules:
+            ops = types.ModuleType("aqt.operations")
+            ops.QueryOp = object
+            sys.modules["aqt.operations"] = ops
 
-    # Force real namespace packages (siblings may have replaced them with mocks).
-    # Overwriting sys.modules['Ankimon'] here is safe because this test file
-    # sorts last alphabetically — no other test module is collected/run after it.
-    for name, path in [
-        ("Ankimon", _SRC / "Ankimon"),
-        ("Ankimon.pyobj", _SRC / "Ankimon" / "pyobj"),
-    ]:
-        ns = types.ModuleType(name)
-        ns.__path__ = [str(path)]
-        sys.modules[name] = ns
+        # Force real namespace packages (siblings may have replaced them with mocks).
+        for name, path in [
+            ("Ankimon", _SRC / "Ankimon"),
+            ("Ankimon.pyobj", _SRC / "Ankimon" / "pyobj"),
+        ]:
+            ns = types.ModuleType(name)
+            ns.__path__ = [str(path)]
+            sys.modules[name] = ns
 
-    # Load real resources (provides addon_dir) then update_manager, from disk.
-    for modname, relpath in [
-        ("Ankimon.resources", "resources.py"),
-        ("Ankimon.pyobj.update_manager", "pyobj/update_manager.py"),
-    ]:
-        spec = importlib.util.spec_from_file_location(modname, _SRC / "Ankimon" / relpath)
-        module = importlib.util.module_from_spec(spec)
-        sys.modules[modname] = module
-        spec.loader.exec_module(module)
+        # Load real resources (provides addon_dir) then update_manager, from disk.
+        for modname, relpath in [
+            ("Ankimon.resources", "resources.py"),
+            ("Ankimon.pyobj.update_manager", "pyobj/update_manager.py"),
+        ]:
+            spec = importlib.util.spec_from_file_location(modname, _SRC / "Ankimon" / relpath)
+            module = importlib.util.module_from_spec(spec)
+            sys.modules[modname] = module
+            spec.loader.exec_module(module)
 
-    return sys.modules["Ankimon.pyobj.update_manager"]
+        return sys.modules["Ankimon.pyobj.update_manager"]
+    finally:
+        # Restore the global module table so this collection-time load can't
+        # corrupt other test modules.
+        for _k, _v in _saved.items():
+            if _v is None:
+                sys.modules.pop(_k, None)
+            else:
+                sys.modules[_k] = _v
 
 
 um = _load_update_manager()

--- a/tests/test_update_manager.py
+++ b/tests/test_update_manager.py
@@ -95,3 +95,90 @@ def test_apply_update_refuses_on_git_clone_and_cleans_zip(tmp_path, monkeypatch)
     assert ok is False
     assert "git" in msg.lower()
     assert not dummy_zip.exists()  # guard cleaned up the downloaded archive
+
+
+# --- git_pull_ff_only --------------------------------------------------------
+
+class _FakeProc:
+    def __init__(self, returncode=0, stdout="", stderr=""):
+        self.returncode = returncode
+        self.stdout = stdout
+        self.stderr = stderr
+
+
+def _fake_git(responses):
+    """Fake subprocess.run dispatching on the git subcommand (cmd[3])."""
+    def _run(cmd, **kwargs):
+        return responses.get(cmd[3], _FakeProc(0))
+    return _run
+
+
+def test_git_pull_reports_not_a_clone(monkeypatch):
+    monkeypatch.setattr(um, "_git_repo_root", lambda: None)
+    ok, msg = um.git_pull_ff_only()
+    assert ok is False
+    assert "not running from a git checkout" in msg.lower()
+
+
+def test_git_pull_handles_git_missing_from_path(tmp_path, monkeypatch):
+    monkeypatch.setattr(um, "_git_repo_root", lambda: tmp_path)
+    monkeypatch.setattr(um.shutil, "which", lambda _name: None)
+    ok, msg = um.git_pull_ff_only()
+    assert ok is False
+    assert "path" in msg.lower()
+
+
+def test_git_pull_success_names_the_branch(tmp_path, monkeypatch):
+    monkeypatch.setattr(um, "_git_repo_root", lambda: tmp_path)
+    monkeypatch.setattr(um.shutil, "which", lambda _name: "/usr/bin/git")
+    monkeypatch.setattr(um.subprocess, "run", _fake_git({
+        "rev-parse": _FakeProc(0, "main\n"),
+        "pull": _FakeProc(0, "Updating 111..222\n"),
+        "submodule": _FakeProc(0, ""),
+    }))
+    ok, msg = um.git_pull_ff_only()
+    assert ok is True
+    assert "main" in msg
+
+
+def test_git_pull_ff_failure_is_safe(tmp_path, monkeypatch):
+    monkeypatch.setattr(um, "_git_repo_root", lambda: tmp_path)
+    monkeypatch.setattr(um.shutil, "which", lambda _name: "/usr/bin/git")
+    monkeypatch.setattr(um.subprocess, "run", _fake_git({
+        "rev-parse": _FakeProc(0, "feature\n"),
+        "pull": _FakeProc(1, "", "fatal: Not possible to fast-forward, aborting."),
+    }))
+    ok, msg = um.git_pull_ff_only()
+    assert ok is False
+    assert "fast-forward" in msg.lower()
+
+
+# --- pre-v2.0 version filtering ----------------------------------------------
+
+def test_version_filter_keeps_2_0_and_above():
+    assert um._is_supported_version("2.01-E") is True
+    assert um._is_supported_version("2.0-E") is True
+    assert um._is_supported_version("v2.0") is True
+
+
+def test_version_filter_drops_pre_2_0_and_non_versions():
+    for name in ["1.52-E", "1.931-E", "1.3962-E", "sprites", "nightly-release", "archive/h0tp/x"]:
+        assert um._is_supported_version(name) is False, name
+
+
+def test_fetch_releases_filters_pre_2_0(monkeypatch):
+    monkeypatch.setattr(um, "_api_get", lambda _ep: [
+        {"tag_name": "sprites", "zipball_url": "z", "body": ""},
+        {"tag_name": "2.01-E", "zipball_url": "z", "body": ""},
+        {"tag_name": "1.52-E", "zipball_url": "z", "body": ""},
+    ])
+    assert [r["name"] for r in um.fetch_releases()] == ["2.01-E"]
+
+
+def test_fetch_tags_filters_pre_2_0(monkeypatch):
+    monkeypatch.setattr(um, "_api_get", lambda _ep: [
+        {"name": "nightly-release", "zipball_url": "z"},
+        {"name": "2.0-E", "zipball_url": "z"},
+        {"name": "1.3962-E", "zipball_url": "z"},
+    ])
+    assert [t["name"] for t in um.fetch_tags()] == ["2.0-E"]

--- a/tests/test_update_manager.py
+++ b/tests/test_update_manager.py
@@ -1,0 +1,97 @@
+"""
+Tests for the updater's git-clone safety guard (is_git_clone + apply_update).
+
+Loading note: sibling test modules (test_database_manager, test_encounter_functions)
+replace sys.modules['Ankimon'] / ['Ankimon.pyobj'] / ['Ankimon.resources'] with
+bare or mock objects at import time. A plain `from Ankimon.pyobj import
+update_manager` here therefore breaks depending on pytest collection order. We
+rebuild a real namespace and exec the module from source so the test is
+order-independent. (Removing the need for this kind of global stubbing is exactly
+what the services-registry refactor targets.)
+"""
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+_SRC = Path(__file__).parent.parent / "src"
+
+
+def _load_update_manager():
+    # update_manager imports these at module load; only stub if nothing else has.
+    if "aqt" not in sys.modules:
+        aqt = types.ModuleType("aqt")
+        aqt.mw = None
+        sys.modules["aqt"] = aqt
+    if "aqt.operations" not in sys.modules:
+        ops = types.ModuleType("aqt.operations")
+        ops.QueryOp = object
+        sys.modules["aqt.operations"] = ops
+
+    # Force real namespace packages (siblings may have replaced them with mocks).
+    # Overwriting sys.modules['Ankimon'] here is safe because this test file
+    # sorts last alphabetically — no other test module is collected/run after it.
+    for name, path in [
+        ("Ankimon", _SRC / "Ankimon"),
+        ("Ankimon.pyobj", _SRC / "Ankimon" / "pyobj"),
+    ]:
+        ns = types.ModuleType(name)
+        ns.__path__ = [str(path)]
+        sys.modules[name] = ns
+
+    # Load real resources (provides addon_dir) then update_manager, from disk.
+    for modname, relpath in [
+        ("Ankimon.resources", "resources.py"),
+        ("Ankimon.pyobj.update_manager", "pyobj/update_manager.py"),
+    ]:
+        spec = importlib.util.spec_from_file_location(modname, _SRC / "Ankimon" / relpath)
+        module = importlib.util.module_from_spec(spec)
+        sys.modules[modname] = module
+        spec.loader.exec_module(module)
+
+    return sys.modules["Ankimon.pyobj.update_manager"]
+
+
+um = _load_update_manager()
+
+
+def test_is_git_clone_true_when_repo_root_has_dot_git(tmp_path, monkeypatch):
+    # Mirror the real layout: <repo>/src/Ankimon, with .git at the repo root.
+    addon = tmp_path / "repo" / "src" / "Ankimon"
+    addon.mkdir(parents=True)
+    monkeypatch.setattr(um, "addon_dir", addon)
+
+    assert um.is_git_clone() is False  # no .git anywhere yet
+
+    (tmp_path / "repo" / ".git").mkdir()  # repo root, two levels up
+    assert um.is_git_clone() is True
+
+
+def test_is_git_clone_true_when_addon_dir_is_repo(tmp_path, monkeypatch):
+    addon = tmp_path / "ankimon"
+    addon.mkdir()
+    (addon / ".git").mkdir()
+    monkeypatch.setattr(um, "addon_dir", addon)
+
+    assert um.is_git_clone() is True
+
+
+def test_is_git_clone_false_for_plain_install(tmp_path, monkeypatch):
+    addon = tmp_path / "addons21" / "ankimon"
+    addon.mkdir(parents=True)
+    monkeypatch.setattr(um, "addon_dir", addon)
+
+    assert um.is_git_clone() is False
+
+
+def test_apply_update_refuses_on_git_clone_and_cleans_zip(tmp_path, monkeypatch):
+    monkeypatch.setattr(um, "is_git_clone", lambda: True)
+    dummy_zip = tmp_path / "update.zip"
+    dummy_zip.write_bytes(b"PK\x03\x04")
+
+    ok, msg = um.apply_update(str(dummy_zip))
+
+    assert ok is False
+    assert "git" in msg.lower()
+    assert not dummy_zip.exists()  # guard cleaned up the downloaded archive


### PR DESCRIPTION
## Problem 1 (the serious one): the updater can destroy a dev's git clone

The in-app **Update Ankimon** feature works by *overwriting files in place* — it deletes every non-preserved file under the addon dir and reinstalls from a downloaded zip (`update_manager.apply_update`). On a normal (zip) install that's fine. But for a **GitHub clone** the addon is the repo's `src/Ankimon`, which lives inside a git working tree — so running the updater **overwrites every source file in your checkout**, losing uncommitted/untracked work and leaving a massive diff. (`.git` sits two levels above the addon dir at the repo root, so it survives and the checkout is recoverable via `git checkout` — but it's still destructive and confusing for any contributor.)

## Problem 2: the update menu item shows a raw key

`ankimon_update_button` was never added to the language files, and `translate()` returns the raw key when missing — so the menu item currently displays the literal text **`ankimon_update_button`** instead of a name. (Its siblings — `report_bug_button`, `rate_this_button`, `ankimon_version_button` — all have translations.)

## Changes

**Git-clone safety (Problem 1)**
- `update_manager.is_git_clone()` / `_git_repo_root()` — bounded, symlink-aware `.git` detection (resolves the `addons21/` symlink and walks *up* to the repo root, since the addon is the nested `src/Ankimon`).
- **`apply_update()` hard-refuses** on a git clone (cleaning up the downloaded zip) — *the actual safety*, since it's the code that does the deleting.
- For clones, the destructive download dialog is **replaced in the menu by a safe "Update Ankimon (git pull)" item** that runs `git pull --ff-only` + `git submodule update --init` in the background. `--ff-only` fails safely on a dirty/diverged tree; a clear message is shown if `git` isn't on Anki's PATH (common when Anki is dock/Finder-launched on macOS). A warning also sits in the dialog's Developer tab.

**Menu name (Problem 2)**
- Added `ankimon_update_button` → `"Update Ankimon"` to `en_text.json` (the fallback source, so all languages resolve it).

**PR-install warning**
- Installing a pull request now shows an explicit warning first: *anyone can open a PR; the code is unreviewed/unreleased; installing runs unverified code — at your own risk.*

**Hide pre-v2.0 releases/tags**
- The release and tag pickers now filter out anything below **v2.0** — the version the updater shipped in. Installing an older build would strip the updater out and strand the user. This also drops non-version entries: the **`sprites` asset release** (which was wrongly surfacing as the "latest release" the quick-update button targeted) and the `nightly-release` / `archive/*` tags.

## Verified unchanged (these already worked correctly)

- **poke-engine submodule** is still installed properly: GitHub zipballs exclude submodule contents, so `apply_update` separately resolves the matching poke-engine SHA for the ref and swaps it into `poke_engine/`.
- **Sprites + DB are preserved**: `user_files/sprites/` and `user_files/ankimon.db` are in the updater's always-preserve list and are never touched.

## Testing

- `tests/test_update_manager.py` — covers `is_git_clone()`, the `apply_update` refuse-and-cleanup guard, `git_pull_ff_only()` (success / ff-failure / git-missing-from-PATH / not-a-clone), and the pre-v2.0 version filter (`fetch_releases` / `fetch_tags`). The parser was verified against the live release/tag names.
- The test loads the module from disk under a rebuilt namespace so it's independent of pytest collection order (sibling tests replace `sys.modules['Ankimon.*']` with mocks at import time — the kind of fragility #437 targets).
- Full suite: **77 passed** (`--deselect` the one integrity test that needs live network at import). `ruff --config ci_ruff_check.toml` clean.

> Independent of #437 (branched off `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
