### PR TITLE
Fix crash when XP share Pokemon is missing from DB

### DIFF
--- a/src/Ankimon/functions/trainer_functions.py
+++ b/src/Ankimon/functions/trainer_functions.py
@@ -78,6 +78,10 @@ def xp_share_gain_exp(logger, settings_obj, evo_window, main_pokemon_id, exp, xp
     evolution_triggered = False
 
     pokemon = db.get_pokemon(xp_share_individual_id)
+    if pokemon is None:
+        settings_obj.set("trainer.xp_share", "")
+        return original_exp
+
     current_level = int(pokemon['level'])  # MODIFIED: Use local variable for level
     if pokemon.get('held_item') == "lucky-egg":
         exp = int(exp * 1.5) # Multiply by 1.5 if pokemon holds lucky egg


### PR DESCRIPTION
Fixes a TypeError crash in `xp_share_gain_exp` by checking if the XP share Pokemon fetched from the database is None, and properly resetting the setting if it is missing.

---
*PR created automatically by Jules for task [13382437443794547805](https://jules.google.com/task/13382437443794547805) started by @h0tp-ftw*