### PR TITLE
Fix NameError search_pokeapi_db_by_id in evolution_window.py

### DIFF
--- a/src/Ankimon/pyobj/evolution_window.py
+++ b/src/Ankimon/pyobj/evolution_window.py
@@ -330,8 +330,8 @@ class EvoWindow(QWidget):
             level = pokemon["level"]
             hp = calculate_hp(hp_stat, level, ev, iv)
             pokemon["current_hp"] = int(hp)
-            pokemon["growth_rate"] = search_pokeapi_db_by_id(evo_id,"growth_rate")
-            pokemon["base_experience"] = search_pokeapi_db_by_id(evo_id,"base_experience")
+            pokemon["growth_rate"] = get_growth_rate(evo_id)
+            pokemon["base_experience"] = get_base_experience(evo_id)
             abilities = search_pokedex(evo_name.lower(), "abilities")
             numeric_abilities = None
             try:


### PR DESCRIPTION
This pull request fixes a `NameError` crash reported by users when a Pokémon attempts to evolve (e.g. Shinx).

In `src/Ankimon/pyobj/evolution_window.py`, around line 333, the code was attempting to use a non-existent `search_pokeapi_db_by_id` function to retrieve `growth_rate` and `base_experience` for the newly evolved Pokémon.

This commit updates these calls to use `get_growth_rate(evo_id)` and `get_base_experience(evo_id)`, which are correctly imported at the top of the file. Tests have been run and verified to pass.

---
*PR created automatically by Jules for task [10829520882108549541](https://jules.google.com/task/10829520882108549541) started by @h0tp-ftw*