### PR TITLE
Fix NameError search_pokeapi_db_by_id in evolution_window.py

### DIFF
--- a/src/Ankimon/pyobj/evolution_window.py
+++ b/src/Ankimon/pyobj/evolution_window.py
@@ -330,8 +330,8 @@ class EvoWindow(QWidget):
             level = pokemon["level"]
             hp = calculate_hp(hp_stat, level, ev, iv)
             pokemon["current_hp"] = int(hp)
-            pokemon["growth_rate"] = search_pokeapi_db_by_id(evo_id,"growth_rate")
-            pokemon["base_experience"] = search_pokeapi_db_by_id(evo_id,"base_experience")
+            pokemon["growth_rate"] = get_growth_rate(evo_id)
+            pokemon["base_experience"] = get_base_experience(evo_id)
             abilities = search_pokedex(evo_name.lower(), "abilities")
             numeric_abilities = None
             try:


### PR DESCRIPTION
Fixes an issue where `search_pokeapi_db_by_id` was not defined in `evolution_window.py`, causing a crash when trying to evolve a Pokemon. Replaced the undefined calls with the already-imported `get_growth_rate` and `get_base_experience` functions.

---
*PR created automatically by Jules for task [10993721452378561554](https://jules.google.com/task/10993721452378561554) started by @h0tp-ftw*