### PR TITLE
Fix monthly challenge Pokémon checks and shiny crash

### DIFF
--- a/src/Ankimon/functions/rate_addon_functions.py
+++ b/src/Ankimon/functions/rate_addon_functions.py
@@ -17,7 +17,7 @@ def rate_this_addon():
     # Only check database
     db_rate_this = mw.ankimon_db.get_user_data("rate_this")
     
-    if db_rate_this is True:
+    if db_rate_this in (True, "true"):
         return
 
     # If we get here, user hasn't rated yet

--- a/src/Ankimon/pyobj/pokemon_trade.py
+++ b/src/Ankimon/pyobj/pokemon_trade.py
@@ -64,7 +64,7 @@ def check_and_award_monthly_pokemon(logger):
     """Checks for and automatically awards the current monthly challenge Pokémon."""
     try:
         db = mw.ankimon_db
-        if db.get_user_data("rate_this") is not True:
+        if db.get_user_data("rate_this") not in (True, "true"):
             logger.log("info", "Monthly Pokemon check skipped: user has not rated the addon.")
             return
 
@@ -113,7 +113,7 @@ def check_and_award_monthly_pokemon(logger):
         if prev_id and threshold:
             logger.log("info", f"Checking for shiny eligibility: prev_id={prev_id}, threshold={threshold}")
             previous_challenge_pokemon = db.get_pokemon(prev_id)
-            if previous_challenge_pokemon.get("pokemon_defeated", 0) >= threshold:
+            if previous_challenge_pokemon and previous_challenge_pokemon.get("pokemon_defeated", 0) >= threshold:
                 logger.log("info", f"Shiny criteria met for {challenge_pokemon_data.get('name')}.")
                 make_shiny = True
         

--- a/src/Ankimon/pyobj/tip_of_the_day.py
+++ b/src/Ankimon/pyobj/tip_of_the_day.py
@@ -66,7 +66,7 @@ def show_tip_of_the_day():
         return
 
     # Check if the addon has been rated
-    if mw.ankimon_db.get_user_data("rate_this") is not True:
+    if mw.ankimon_db.get_user_data("rate_this") not in (True, "true"):
         return
 
     tips_path = Path(__file__).parent.parent / "addon_files" / "tips.json"


### PR DESCRIPTION
Fixes two bugs preventing users from receiving monthly challenge Pokémon:
1. Updates the `rate_this` check to accept the string `"true"` in addition to boolean `True`, which was necessary due to earlier string-conversion migrations causing strict boolean checks to skip the challenge.
2. Fixes a `NoneType` attribute access crash when attempting to evaluate shiny eligibility by checking the statistics of the previous challenge Pokémon, handling the case where the user does not own it.

---
*PR created automatically by Jules for task [5692779802246000971](https://jules.google.com/task/5692779802246000971) started by @h0tp-ftw*