### PR TITLE
fix: Help-window unpack crash, per-encounter catch guard, and per-backup summary accuracy

### DIFF
--- a/src/Ankimon/functions/encounter_functions.py
+++ b/src/Ankimon/functions/encounter_functions.py
@@ -369,6 +369,13 @@ def new_pokemon(
     Returns:
         PokemonObject: The updated `pokemon` object representing the newly generated wild Pokémon ready for battle.
     """
+    # A fresh wild Pokémon is appearing, so reset the per-encounter catch guard.
+    # `caught` is set to 0 once in AnkimonTracker.__init__ and only ever
+    # incremented in catch_pokemon -- it is never reset anywhere else. Without
+    # this line it climbs without bound, so after the first catch of a session
+    # the `caught > 1` branch in catch_pokemon can skip saving later catches
+    # (silently, when gui.pop_up_dialog_message_on_defeat is enabled).
+    ankimon_tracker_obj.caught = 0
     (
         name,
         pkmn_id,

--- a/src/Ankimon/functions/encounter_functions.py
+++ b/src/Ankimon/functions/encounter_functions.py
@@ -375,7 +375,7 @@ def new_pokemon(
     # this line it climbs without bound, so after the first catch of a session
     # the `caught > 1` branch in catch_pokemon can skip saving later catches
     # (silently, when gui.pop_up_dialog_message_on_defeat is enabled).
-    ankimon_tracker_obj.caught = 0
+    ankimon_tracker.caught = 0
     (
         name,
         pkmn_id,

--- a/src/Ankimon/pyobj/backup_manager.py
+++ b/src/Ankimon/pyobj/backup_manager.py
@@ -132,7 +132,7 @@ class BackupManager:
                 def _config(key, default):
                     cur.execute("SELECT value FROM config WHERE key = ?", (key,))
                     row = cur.fetchone()
-                    if row is None:
+                    if row is None or row["value"] is None:
                         return default
                     try:
                         return json.loads(row["value"])
@@ -160,7 +160,7 @@ class BackupManager:
                 # showed up as "N/A".
                 summary["trainer_name"] = _config("trainer.name", "N/A")
                 summary["trainer_cash"] = _config("trainer.cash", 0)
-                summary["trainer_level"] = _config("trainer.level", 0)
+                summary["trainer_level"] = _config("trainer.level", 1)
 
                 return summary
             except Exception as e:

--- a/src/Ankimon/pyobj/backup_manager.py
+++ b/src/Ankimon/pyobj/backup_manager.py
@@ -3,6 +3,7 @@ import base64
 import json
 import os
 import shutil
+import sqlite3
 import datetime
 from pathlib import Path
 from typing import List, Dict, Any, Optional
@@ -115,27 +116,58 @@ class BackupManager:
             "item_count": 0,
         }
 
-        # Prefer database stats if available
-        db = mw.ankimon_db
-        if db:
+        # Prefer THIS backup's own database snapshot if it has one. The old
+        # code read mw.ankimon_db -- the *live* database -- for every backup,
+        # so every row showed identical, current stats (e.g. the same Pokemon
+        # count and trainer name) instead of that backup's actual contents.
+        backup_db_path = backup_dir / "ankimon.db"
+        if backup_db_path.exists():
+            conn = None
             try:
-                stats = db.get_stats()
-                summary["pokemon_count"] = stats.get("pokemon", 0)
-                summary["item_count"] = stats.get("items", 0)
-                
-                main_pokemon = db.get_main_pokemon()
-                if main_pokemon:
-                    summary["main_pokemon_name"] = main_pokemon.get("name", "N/A")
-                    summary["main_pokemon_level"] = main_pokemon.get("level", "N/A")
-                
-                # Trainer info from user_data
-                summary["trainer_name"] = db.get_user_data("trainer.name", "N/A")
-                summary["trainer_cash"] = db.get_user_data("trainer.cash", 0)
-                summary["trainer_level"] = db.get_user_data("trainer.level", 1)
-                
+                # Read-only connection so we never mutate the backup snapshot.
+                conn = sqlite3.connect(backup_db_path.as_uri() + "?mode=ro", uri=True)
+                conn.row_factory = sqlite3.Row
+                cur = conn.cursor()
+
+                def _config(key, default):
+                    cur.execute("SELECT value FROM config WHERE key = ?", (key,))
+                    row = cur.fetchone()
+                    if row is None:
+                        return default
+                    try:
+                        return json.loads(row["value"])
+                    except Exception:
+                        return row["value"]
+
+                cur.execute("SELECT COUNT(*) AS c FROM captured_pokemon")
+                summary["pokemon_count"] = cur.fetchone()["c"]
+
+                cur.execute("SELECT COALESCE(SUM(quantity), 0) AS c FROM items")
+                summary["item_count"] = cur.fetchone()["c"]
+
+                cur.execute("SELECT data FROM captured_pokemon WHERE is_main = 1 LIMIT 1")
+                main_row = cur.fetchone()
+                if main_row:
+                    try:
+                        main_pokemon = json.loads(main_row["data"])
+                        summary["main_pokemon_name"] = main_pokemon.get("name", "N/A")
+                        summary["main_pokemon_level"] = main_pokemon.get("level", "N/A")
+                    except Exception:
+                        pass
+
+                # Trainer info lives in the `config` table (the Settings store),
+                # NOT in `user_data` -- reading user_data is why the trainer name
+                # showed up as "N/A".
+                summary["trainer_name"] = _config("trainer.name", "N/A")
+                summary["trainer_cash"] = _config("trainer.cash", 0)
+                summary["trainer_level"] = _config("trainer.level", 0)
+
                 return summary
             except Exception as e:
-                self.logger.log("error", f"Failed to get DB stats for backup summary: {e}")
+                self.logger.log("error", f"Failed to read backup database {backup_db_path}: {e}")
+            finally:
+                if conn is not None:
+                    conn.close()
 
         # Fallback to legacy JSON for older backups or migration period
         # (Remaining legacy code omitted for brevity but I will keep it in the replacement)

--- a/src/Ankimon/pyobj/help_window.py
+++ b/src/Ankimon/pyobj/help_window.py
@@ -127,8 +127,13 @@ class HelpWindow(QDialog):
                 # Read local content
                 local_content = read_local_file(help_local_file_path)
 
-                # Read content from GitHub
-                github_content, github_html_content = read_github_file(help_github_url)
+                # Read content from GitHub. read_github_file() returns a single
+                # value (the raw text, or None); the help file is already HTML,
+                # so the raw content and the display content are the same thing.
+                # Unpacking into two names raised "ValueError: too many values
+                # to unpack (expected 2)" every time the window opened online.
+                github_content = read_github_file(help_github_url)
+                github_html_content = github_content
 
                 if local_content is not None and compare_files(local_content, github_content):
                     # If local file matches GitHub, use cached content


### PR DESCRIPTION
## Summary

Fixes three issues surfaced by a user bug report on v2.01-E (Help-window crash, caught Pokémon not saving, and a broken Backup Manager display). Each fix targets a verified root cause in the current code — diagnoses were confirmed by reading the code, not guessed.

## 1. Help window — `ValueError: too many values to unpack (expected 2)`

`read_github_file()` (`utils.py`) returns **one** value (raw text, or `None`), but `HelpWindow._get_html_content` unpacked it into two:

```python
github_content, github_html_content = read_github_file(help_github_url)
```

Online, the returned string was unpacked character-by-character → `ValueError` on **every** Help-window open. It was caught by the surrounding `except` and shown as an error popup before falling back to the cached local help, so Help still rendered but threw a scary traceback each time.

**Fix:** the help file is already HTML (raw == display content), so assign the single return value to both names in the caller. The function is intentionally left alone — switching it to return a tuple would silently break `changelog.py`, which relies on the single-value return.

> Note: a dead-code twin of this bug exists in `gui_entities.py:HelpWindow` (not instantiated anywhere; the live window is `pyobj/help_window.py`). Left untouched here — can be deleted in a cleanup pass.

## 2. Caught Pokémon not saved on later catches

`ankimon_tracker_obj.caught` is set to `0` once in `AnkimonTracker.__init__` and only ever incremented in `catch_pokemon` — it is **never reset**. After the first catch of a session it climbs without bound, so the `caught > 1` guard in `catch_pokemon` can silently skip saving subsequent catches (this path is gated on `gui.pop_up_dialog_message_on_defeat`, which defaults to `False` — so it bites users who enabled that popup).

**Fix:** reset `caught = 0` in `new_pokemon()`, which runs whenever a fresh wild Pokémon appears — restoring the intended once-per-encounter dedup while letting every new encounter be caught.

## 3. Backup Manager — every backup shows identical stats + "N/A" trainer name

`BackupManager._generate_summary(backup_dir)` read `mw.ankimon_db` — the **live** database — for every backup, ignoring `backup_dir` entirely. So every row displayed the same current stats (same Pokémon count, same name) instead of each backup's real contents. It also read the trainer name from the `user_data` table, where `trainer.*` is never stored (it lives in the `config` table via Settings) — hence the "N/A".

**Fix:** open each backup's **own** `ankimon.db` read-only (`Path.as_uri() + "?mode=ro"`, so paths with spaces work and the snapshot is never mutated), read counts from `captured_pokemon`/`items`, and read trainer info from the `config` table. The legacy-JSON fallback is preserved for pre-migration backups with no `ankimon.db`.

> Behavior note: the DB path's `item_count` now sums item quantities (`SUM(quantity)`) to match the legacy-JSON summary; the previous live-DB path used `COUNT(*)` (distinct item types). Backups already shown may display a different (more accurate) item total after this change.

## Context — what was intentionally *not* changed

- **Auto-battle setting 3 ("catch if new"):** most likely working as designed — it defeats species already owned, so a user with a large collection across enabled gens will see most encounters defeated rather than caught. Confirming a specific "lost" catch would need the user's `ankimon.db` to check whether that species was already in the collection. Workaround for users: auto-battle = 1 (always catch).
- **`config.json` showing stale values:** expected post-migration — Settings now persists to the DB `config` table; `config.json` on disk is legacy and non-authoritative.
- **"Missing files" in File Checker / "no re-download button":** the missing entries are sprite assets; the button exists as **Download Resources**. No code change needed.

## Verification

- `pytest tests/` — **66 passed**.
- Standalone functional check of the backup read path against a synthetic `ankimon.db`: per-backup count/main-Pokémon resolve correctly, trainer name reads from the `config` table (was "N/A"), `item_count` sums quantities, and the read-only connection rejects writes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
