### PR TITLE
style(ankidex): center empty-state in viewport with balanced vertical rhythm

### DIFF
--- a/src/Ankimon/ankidex/ankidex.css
+++ b/src/Ankimon/ankidex/ankidex.css
@@ -485,6 +485,8 @@ body {
     flex: 1;
     overflow-y: auto;
     padding: 12px 24px 24px;
+    display: flex;
+    flex-direction: column;
 }
 
 /* Generation Grouping */
@@ -1197,19 +1199,34 @@ body {
 }
 
 .empty-state {
+    flex: 1;
     display: flex;
     flex-direction: column;
     align-items: center;
     justify-content: center;
-    padding: 100px 40px;
+    padding: 40px 20px;
     text-align: center;
     color: var(--text-muted);
+}
+
+.empty-state h2 {
+    margin: 0 0 16px;
+    line-height: 1.3;
+}
+
+.empty-state p {
+    margin: 0 0 32px;
+    line-height: 1.5;
+}
+
+.empty-state .btn {
+    margin: 0;
 }
 
 .empty-icon {
     width: 120px;
     height: 120px;
-    margin: 0 auto 24px;
+    margin: 0 0 28px;
     background: url('../user_files/sprites/items/poke-doll.png') no-repeat center;
     background-size: contain;
     filter: drop-shadow(0 10px 15px rgba(0, 0, 0, 0.3));

--- a/src/Ankimon/ankidex/ankidex.html
+++ b/src/Ankimon/ankidex/ankidex.html
@@ -120,6 +120,13 @@
                     <!-- Grid items will be injected here -->
                 </div>
 
+                <!-- Empty State -->
+                <div id="empty-state" class="empty-state hidden">
+                    <div class="empty-icon"></div>
+                    <h2>No Pokémon found</h2>
+                    <p>Try adjusting your search or filters.</p>
+                    <button onclick="document.getElementById('clear-filters').click()" class="btn btn-primary">Clear all filters</button>
+                </div>
             </div>
 
             <!-- Discovery Map View -->
@@ -161,14 +168,6 @@
 
                 </div>
             </div>
-                
-                <!-- Empty State -->
-                <div id="empty-state" class="empty-state hidden">
-                    <div class="empty-icon"></div>
-                    <h2>No Pokémon found</h2>
-                    <p>Try adjusting your search or filters.</p>
-                    <button onclick="document.getElementById('clear-filters').click()" class="btn btn-primary">Clear all filters</button>
-                </div>
             </main>
 
             <!-- Detail Panel -->


### PR DESCRIPTION
## Summary

The Ankidex "No Pokémon found" empty state was rendering pinned to the bottom of the main content area instead of being vertically centered. Root cause: `#empty-state` was a sibling of `.content-scroll` (which has `flex: 1`), so it got pushed below the scroll area inside `.main-content`.

## Changes

- **HTML:** Moved `#empty-state` from outside `.content-scroll` to inside it (sibling of `#pokemon-grid`).
- **CSS:**
  - `.content-scroll` is now a flex column so its children can flex.
  - `.empty-state` uses `flex: 1` to fill the available space and centers its content vertically.
  - Replaced uniform `gap` with explicit margins (icon→h2: 28px, h2→p: 16px, p→button: 32px) plus `line-height` on the text for better readability.

## Before / After

Before: icon + text + button stuck near the bottom of the viewport, with cramped spacing between heading and subtitle.
After: the whole block sits centered in the available content area with a clearer vertical hierarchy.

## Test plan

- [ ] Open the Ankidex
- [ ] Type a query that returns no results (e.g. `zzzzz`)
- [ ] Confirm the empty state is vertically centered in the main content area
- [ ] Confirm spacing between icon, heading, subtitle, and "Clear all filters" button looks balanced
- [ ] Clear the search and confirm the normal grid view still renders correctly (no layout regression from making `.content-scroll` a flex column)

🤖 Generated with [Claude Code](https://claude.com/claude-code)