### PR TITLE
feat(items): unify Mart and Item Bag into a web-based shell window

### DIFF
--- a/src/Ankimon/ankidex/ankidex.html
+++ b/src/Ankimon/ankidex/ankidex.html
@@ -6,6 +6,28 @@
     <title>Ankidex</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <!-- Inline dark bg + skeleton placeholders so the user sees structure
+         while external CSS + initial dex data load. The first render in
+         ankidex.js does pokemon-grid.innerHTML='' which clears them. -->
+    <style>
+        html { background: #0d1117; }
+        .skeleton-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
+            gap: 14px;
+        }
+        .skeleton {
+            background: #161b22;
+            border: 1px solid #30363d;
+            border-radius: 14px;
+            height: 160px;
+            animation: skeleton-pulse 1.5s ease-in-out infinite;
+        }
+        @keyframes skeleton-pulse {
+            0%, 100% { opacity: 0.35; }
+            50%      { opacity: 0.6; }
+        }
+    </style>
     <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700;800;900&family=JetBrains+Mono:wght@500;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="ankidex.css">
     <link rel="stylesheet" href="nav-switcher.css">
@@ -24,7 +46,7 @@
                     </button>
                     <div id="nav-menu" class="nav-menu hidden" role="menu">
                         <button class="nav-menu-item" role="menuitem" data-screen="items">
-                            <span class="nav-menu-icon"><img src="../user_files/sprites/items/poke-ball.png" alt=""></span>
+                            <span class="nav-menu-icon"><img src="../user_files/sprites/items/hyper-potion.png" class="icon-item-sprite" alt=""></span>
                             <div class="nav-menu-text">
                                 <span class="nav-menu-title">Items</span>
                                 <span class="nav-menu-desc">Your inventory and today's Mart</span>
@@ -138,7 +160,17 @@
 
             <div class="content-scroll">
                 <div id="pokemon-grid" class="pokemon-grid">
-                    <!-- Grid items will be injected here -->
+                    <!-- Skeleton placeholders wrapped in a grid (.pokemon-grid
+                         is display:block; sub-grids handle layout normally).
+                         Cleared on first render by ankidex.js innerHTML=''. -->
+                    <div class="skeleton-grid">
+                        <div class="skeleton"></div><div class="skeleton"></div>
+                        <div class="skeleton"></div><div class="skeleton"></div>
+                        <div class="skeleton"></div><div class="skeleton"></div>
+                        <div class="skeleton"></div><div class="skeleton"></div>
+                        <div class="skeleton"></div><div class="skeleton"></div>
+                        <div class="skeleton"></div><div class="skeleton"></div>
+                    </div>
                 </div>
 
             </div>

--- a/src/Ankimon/ankidex/ankidex.html
+++ b/src/Ankimon/ankidex/ankidex.html
@@ -31,7 +31,7 @@
                             </div>
                         </button>
                         <button class="nav-menu-item active" role="menuitem" data-screen="ankidex">
-                            <span class="nav-menu-icon">✦</span>
+                            <span class="nav-menu-icon"><img src="../user_files/sprites/items/poke-ball.png" alt=""></span>
                             <div class="nav-menu-text">
                                 <span class="nav-menu-title">Ankidex</span>
                                 <span class="nav-menu-desc">Browse caught Pokémon</span>

--- a/src/Ankimon/ankidex/ankidex.html
+++ b/src/Ankimon/ankidex/ankidex.html
@@ -8,15 +8,36 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700;800;900&family=JetBrains+Mono:wght@500;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="ankidex.css">
+    <link rel="stylesheet" href="nav-switcher.css">
+    <script src="qrc:///qtwebchannel/qwebchannel.js"></script>
 </head>
 <body class="dark-mode">
     <div class="app-container">
         <!-- Sidebar Navigation -->
         <aside class="sidebar">
             <div class="sidebar-header">
-                <div class="pokedex-logo">
-                    <img src="../user_files/sprites/items/poke-ball.png" class="app-logo">
-                    <h1>ANKIDEX</h1>
+                <div id="nav-switcher" class="nav-switcher">
+                    <button id="nav-trigger" class="nav-trigger" type="button" aria-haspopup="true" aria-expanded="false">
+                        <img src="../user_files/sprites/items/poke-ball.png" class="app-logo">
+                        <h1>ANKIDEX</h1>
+                        <span class="nav-chevron">▾</span>
+                    </button>
+                    <div id="nav-menu" class="nav-menu hidden" role="menu">
+                        <button class="nav-menu-item" role="menuitem" data-screen="items">
+                            <span class="nav-menu-icon"><img src="../user_files/sprites/items/poke-ball.png" alt=""></span>
+                            <div class="nav-menu-text">
+                                <span class="nav-menu-title">Items</span>
+                                <span class="nav-menu-desc">Your inventory and today's Mart</span>
+                            </div>
+                        </button>
+                        <button class="nav-menu-item active" role="menuitem" data-screen="ankidex">
+                            <span class="nav-menu-icon">✦</span>
+                            <div class="nav-menu-text">
+                                <span class="nav-menu-title">Ankidex</span>
+                                <span class="nav-menu-desc">Browse caught Pokémon</span>
+                            </div>
+                        </button>
+                    </div>
                 </div>
             </div>
             
@@ -377,5 +398,6 @@
     </template>
 
     <script src="ankidex.js"></script>
+    <script src="nav-switcher.js"></script>
 </body>
 </html>

--- a/src/Ankimon/ankidex/ankidex_obj.py
+++ b/src/Ankimon/ankidex/ankidex_obj.py
@@ -18,7 +18,11 @@ class Ankidex(QDialog):
         # Disabled WA_TranslucentBackground to prevent heavy window-level repaint
         # flickering under Windows DWM when QWebEngineView re-composes or updates.
         # self.setAttribute(Qt.WidgetAttribute.WA_TranslucentBackground)
-        self.setWindowFlags(self.windowFlags() | Qt.WindowType.WindowMaximizeButtonHint | Qt.WindowType.WindowMinimizeButtonHint)
+        self.setWindowFlags(
+            self.windowFlags()
+            | Qt.WindowType.WindowMaximizeButtonHint
+            | Qt.WindowType.WindowMinimizeButtonHint
+        )
         self.resize(1200, 720)
 
         self.layout = QVBoxLayout()
@@ -35,7 +39,7 @@ class Ankidex(QDialog):
         self.webview = QWebEngineView()
         # Enable remote debugging for development if needed
         # self.webview.page().settings().setAttribute(QWebEngineSettings.WebAttribute.DeveloperExtrasEnabled, True)
-        
+
         self.frame.setLayout(QVBoxLayout())
         self.frame.layout().setContentsMargins(0, 0, 0, 0)
         self.frame.layout().addWidget(self.webview)
@@ -51,21 +55,28 @@ class Ankidex(QDialog):
         db = mw.ankimon_db
 
         # 1. Shiny Owned
-        cursor = db.execute("SELECT DISTINCT pokedex_id FROM captured_pokemon WHERE shiny = 1 AND pokedex_id IS NOT NULL")
+        cursor = db.execute(
+            "SELECT DISTINCT pokedex_id FROM captured_pokemon WHERE shiny = 1 AND pokedex_id IS NOT NULL"
+        )
         shiny_owned_ids = [row[0] for row in cursor.fetchall()]
 
         # 1. Caught Status (Currently in collection OR released)
         # Currently owned
-        cursor = db.execute("SELECT pokedex_id FROM captured_pokemon WHERE pokedex_id IS NOT NULL")
+        cursor = db.execute(
+            "SELECT pokedex_id FROM captured_pokemon WHERE pokedex_id IS NOT NULL"
+        )
         caught_ids = {row[0] for row in cursor.fetchall()}
-        
+
         # Released Pokémon (from history)
-        cursor = db.execute("SELECT DISTINCT json_extract(data, '$.id') FROM pokemon_history")
+        cursor = db.execute(
+            "SELECT DISTINCT json_extract(data, '$.id') FROM pokemon_history"
+        )
         for row in cursor.fetchall():
-            if row[0]: caught_ids.add(int(row[0]))
+            if row[0]:
+                caught_ids.add(int(row[0]))
 
         # Explicitly recorded caught Pokémon (e.g. from evolutions or prior captures)
-        if hasattr(db, 'get_caught_ids'):
+        if hasattr(db, "get_caught_ids"):
             try:
                 caught_ids.update(db.get_caught_ids())
             except Exception:
@@ -73,56 +84,92 @@ class Ankidex(QDialog):
 
         # 2. Seen Status (Encountered but not caught)
         seen_ids = set()
-        if hasattr(db, 'get_seen_ids'):
+        if hasattr(db, "get_seen_ids"):
             seen_ids.update(db.get_seen_ids())
         else:
             seen_data = db.get_user_data("pokedex_seen", [])
             if isinstance(seen_data, list):
                 seen_ids.update(set(seen_data))
-        
+
         # Remove caught IDs from seen IDs to keep them strictly separate
         seen_ids = seen_ids - caught_ids
-        
+
         # 3. Stats Summary
         total_caught_count = db.get_pokemon_count()
-        cursor = db.execute("SELECT SUM(CAST(json_extract(data, '$.pokemon_defeated') AS INTEGER)) FROM captured_pokemon")
+        cursor = db.execute(
+            "SELECT SUM(CAST(json_extract(data, '$.pokemon_defeated') AS INTEGER)) FROM captured_pokemon"
+        )
         defeated_caught = cursor.fetchone()[0] or 0
-        
-        cursor = db.execute("SELECT COUNT(*), SUM(CAST(json_extract(data, '$.pokemon_defeated') AS INTEGER)) FROM pokemon_history")
+
+        cursor = db.execute(
+            "SELECT COUNT(*), SUM(CAST(json_extract(data, '$.pokemon_defeated') AS INTEGER)) FROM pokemon_history"
+        )
         row = cursor.fetchone()
         released_count = row[0] or 0
         defeated_released = row[1] or 0
-        
+
         defeated_total = defeated_caught + defeated_released
-        
+
         # 4. Encounterable IDs
         encounterable_ids = set()
         # Positive lists
-        for list_name in ['LEGENDARY', 'MYTHICAL', 'BABY', 'ULTRA', 'NORMAL', 'STARTERS', 'MEGA', 'GMAX']:
+        for list_name in [
+            "LEGENDARY",
+            "MYTHICAL",
+            "BABY",
+            "ULTRA",
+            "NORMAL",
+            "STARTERS",
+            "MEGA",
+            "GMAX",
+        ]:
             l = getattr(encounter_data, list_name, [])
             encounterable_ids.update(l)
-        
+
         # Explicit exclusions
-        unavail = getattr(encounter_data, 'UNAVAILABLE', [])
+        unavail = getattr(encounter_data, "UNAVAILABLE", [])
         for uid in unavail:
             if uid in encounterable_ids:
                 encounterable_ids.remove(uid)
 
         # Add encounterable regional form IDs for the active region
         from ..functions.encounter_data import REGIONAL_FORMS
+
         active_region = mw.settings_obj.get("misc.active_region")
         if active_region and active_region in REGIONAL_FORMS:
             encounterable_ids.update(REGIONAL_FORMS[active_region])
-        
+
         # Add Fossils back (they are in UNAVAILABLE because they aren't wild, but are obtainable)
         fossils = [
-            138, 139, 140, 141, 142,  # Gen 1
-            345, 346, 347, 348,       # Gen 3
-            408, 409, 410, 411,       # Gen 4
-            564, 565, 566, 567,       # Gen 5
-            568, 569, 570, 571,       # Gen 6 (Fixing possible index mismatch in placeholder)
-            696, 697, 698, 699,       
-            880, 881, 882, 883        # Gen 8
+            138,
+            139,
+            140,
+            141,
+            142,  # Gen 1
+            345,
+            346,
+            347,
+            348,  # Gen 3
+            408,
+            409,
+            410,
+            411,  # Gen 4
+            564,
+            565,
+            566,
+            567,  # Gen 5
+            568,
+            569,
+            570,
+            571,  # Gen 6 (Fixing possible index mismatch in placeholder)
+            696,
+            697,
+            698,
+            699,
+            880,
+            881,
+            882,
+            883,  # Gen 8
         ]
         # 5. Prerequisites
         prereqs = {}
@@ -145,28 +192,46 @@ class Ankidex(QDialog):
             "stats": {
                 "caughtCount": total_caught_count,
                 "releasedCount": released_count,
-                "defeatedCount": defeated_total
+                "defeatedCount": defeated_total,
             },
             "prefs": {
-                "viewMode": mw.settings_obj.get("ankidex.viewMode", mw.settings_obj.get("pokedex_v2.viewMode", "grid")),
-                "sortMode": mw.settings_obj.get("ankidex.sortMode", mw.settings_obj.get("pokedex_v2.sortMode", "id-asc")),
-                "spriteMode": mw.settings_obj.get("ankidex.spriteMode", mw.settings_obj.get("pokedex_v2.spriteMode", "static")),
+                "viewMode": mw.settings_obj.get(
+                    "ankidex.viewMode",
+                    mw.settings_obj.get("pokedex_v2.viewMode", "grid"),
+                ),
+                "sortMode": mw.settings_obj.get(
+                    "ankidex.sortMode",
+                    mw.settings_obj.get("pokedex_v2.sortMode", "id-asc"),
+                ),
+                "spriteMode": mw.settings_obj.get(
+                    "ankidex.spriteMode",
+                    mw.settings_obj.get("pokedex_v2.spriteMode", "static"),
+                ),
             },
             "regional_data": {
                 "boosts": {
-                    "kanto": [1], "johto": [2], "hoenn": [3], "sinnoh": [4],
-                    "unova": [5], "kalos": [6], "alola": [7], "galar": [8],
-                    "paldea": [9], "hisui": [4, 8]
+                    "kanto": [1],
+                    "johto": [2],
+                    "hoenn": [3],
+                    "sinnoh": [4],
+                    "unova": [5],
+                    "kalos": [6],
+                    "alola": [7],
+                    "galar": [8],
+                    "paldea": [9],
+                    "hisui": [4, 8],
                 },
-                "forms": encounter_data.REGIONAL_FORM_REGION
+                "forms": encounter_data.REGIONAL_FORM_REGION,
             },
-            "evolutionNote": "In Ankimon, evolutions are currently supported through level progression only."
+            "evolutionNote": "In Ankimon, evolutions are currently supported through level progression only.",
         }
 
     def load_initial_html(self):
-        file_path = os.path.join(self.addon_dir, "ankidex", "ankidex.html").replace("\\", "/")
+        file_path = os.path.join(self.addon_dir, "ankidex", "ankidex.html").replace(
+            "\\", "/"
+        )
         url = QUrl.fromLocalFile(file_path)
-        
+
         # Instead of URL query, we push data via JS
         self.webview.setUrl(url)
 
@@ -174,7 +239,7 @@ class Ankidex(QDialog):
         """Pushes data to the frontend."""
         data = self.get_ankidex_data()
         data_js = json.dumps(data)
-        
+
         js_code = f"if (window.initializeAnkidex) window.initializeAnkidex({data_js});"
         self.webview.page().runJavaScript(js_code)
 
@@ -199,4 +264,6 @@ class Ankidex(QDialog):
                     mw.settings_obj.set(f"ankidex.{key}", val)
 
         if self.webview:
-            self.webview.page().runJavaScript("if (window.getAnkidexState) window.getAnkidexState();", on_state_ready)
+            self.webview.page().runJavaScript(
+                "if (window.getAnkidexState) window.getAnkidexState();", on_state_ready
+            )

--- a/src/Ankimon/ankidex/ankidex_obj.py
+++ b/src/Ankimon/ankidex/ankidex_obj.py
@@ -14,8 +14,10 @@ class Ankidex(QDialog):
         self.ankimon_tracker = ankimon_tracker
         self.setWindowTitle("Ankidex")
 
-        # Premium feel: translucent background and larger default size
-        self.setAttribute(Qt.WidgetAttribute.WA_TranslucentBackground)
+        # Premium feel: larger default size
+        # Disabled WA_TranslucentBackground to prevent heavy window-level repaint
+        # flickering under Windows DWM when QWebEngineView re-composes or updates.
+        # self.setAttribute(Qt.WidgetAttribute.WA_TranslucentBackground)
         self.setWindowFlags(self.windowFlags() | Qt.WindowType.WindowMaximizeButtonHint | Qt.WindowType.WindowMinimizeButtonHint)
         self.resize(1200, 720)
 

--- a/src/Ankimon/ankidex/nav-switcher.css
+++ b/src/Ankimon/ankidex/nav-switcher.css
@@ -1,0 +1,167 @@
+/* Cross-screen navigation switcher — also used by the Items page (shop.css
+ * carries an inlined copy until Phase 2 extracts a shared web_shell). */
+
+.nav-switcher {
+    position: relative;
+}
+
+.nav-trigger {
+    width: 100%;
+    background: transparent;
+    border: 1px solid transparent;
+    color: inherit;
+    padding: 6px 10px;
+    border-radius: 10px;
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    cursor: pointer;
+    transition: 0.15s ease;
+    text-align: left;
+    font-family: inherit;
+}
+
+.nav-trigger:hover {
+    background: var(--bg-card);
+    border-color: var(--border-main);
+}
+
+.nav-trigger[aria-expanded="true"] {
+    background: var(--bg-card);
+    border-color: var(--accent-blue);
+}
+
+.nav-trigger .app-logo {
+    flex-shrink: 0;
+}
+
+.nav-trigger h1 {
+    flex: 1;
+    margin: 0;
+}
+
+.nav-chevron {
+    font-size: 0.9rem;
+    color: var(--text-muted);
+    transition: transform 0.2s ease;
+    margin-right: 2px;
+}
+
+.nav-trigger[aria-expanded="true"] .nav-chevron {
+    transform: rotate(180deg);
+    color: var(--accent-blue);
+}
+
+.nav-menu {
+    position: absolute;
+    top: calc(100% + 8px);
+    left: 0;
+    right: 0;
+    z-index: 200;
+    background: linear-gradient(180deg, var(--bg-card), var(--bg-darker));
+    border: 1px solid var(--border-main);
+    border-radius: 12px;
+    padding: 6px;
+    box-shadow: 0 14px 32px rgba(0, 0, 0, 0.55);
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    animation: navMenuPop 0.16s cubic-bezier(0.22, 1, 0.36, 1);
+    transform-origin: top left;
+}
+
+.nav-menu.hidden {
+    display: none;
+}
+
+@keyframes navMenuPop {
+    0%   { opacity: 0; transform: translateY(-6px) scale(0.97); }
+    100% { opacity: 1; transform: translateY(0)    scale(1); }
+}
+
+.nav-menu-item {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    width: 100%;
+    background: transparent;
+    border: 1px solid transparent;
+    color: var(--text-main);
+    padding: 10px 12px;
+    border-radius: 8px;
+    cursor: pointer;
+    font-family: inherit;
+    text-align: left;
+    transition: 0.15s ease;
+}
+
+.nav-menu-item:hover {
+    background: var(--bg-card-hover);
+    border-color: var(--border-main);
+    color: var(--text-bright);
+}
+
+.nav-menu-item.active {
+    background: rgba(88, 166, 255, 0.08);
+    border-color: rgba(88, 166, 255, 0.4);
+    color: var(--text-bright);
+}
+
+.nav-menu-icon {
+    width: 28px;
+    height: 28px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: var(--bg-darker);
+    border: 1px solid var(--border-main);
+    border-radius: 6px;
+    color: var(--accent-blue);
+    font-size: 0.95rem;
+    flex-shrink: 0;
+}
+
+.nav-menu-item.active .nav-menu-icon {
+    border-color: var(--accent-blue);
+    color: var(--accent-blue);
+    box-shadow: 0 0 12px rgba(88, 166, 255, 0.25);
+}
+
+.nav-menu-icon img {
+    width: 18px;
+    height: 18px;
+    object-fit: contain;
+}
+
+.nav-menu-text {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+}
+
+.nav-menu-title {
+    font-size: 0.88rem;
+    font-weight: 700;
+    line-height: 1.15;
+}
+
+.nav-menu-desc {
+    font-size: 0.7rem;
+    color: var(--text-muted);
+    letter-spacing: 0.3px;
+    line-height: 1.2;
+}
+
+/* Standalone mode (no QWebChannel bridge) — hide the dropdown affordance
+ * so users don't see a non-functional switcher. The switcher only makes
+ * sense when hosted inside the shell. */
+body:not(.shell-mode) .nav-chevron,
+body:not(.shell-mode) .nav-menu {
+    display: none;
+}
+
+body:not(.shell-mode) .nav-trigger {
+    cursor: default;
+    pointer-events: none;
+}

--- a/src/Ankimon/ankidex/nav-switcher.css
+++ b/src/Ankimon/ankidex/nav-switcher.css
@@ -165,3 +165,9 @@ body:not(.shell-mode) .nav-trigger {
     cursor: default;
     pointer-events: none;
 }
+
+/* --- Items identity icon (hyper-potion sprite used as Items' visual ID). */
+.icon-item-sprite {
+    image-rendering: pixelated;
+    object-fit: contain;
+}

--- a/src/Ankimon/ankidex/nav-switcher.js
+++ b/src/Ankimon/ankidex/nav-switcher.js
@@ -1,0 +1,67 @@
+// Cross-screen navigation switcher logic.
+//
+// Tries to connect to the shell's QWebChannel. If a bridge is available we
+// flip body.shell-mode (which makes the dropdown affordances visible per
+// nav-switcher.css), wire the trigger click, and route menu clicks through
+// window.nav.openItems() / openAnkidex(). Standalone (no bridge) is a no-op.
+
+(function () {
+    'use strict';
+
+    function bindSwitcher(nav) {
+        document.body.classList.add('shell-mode');
+
+        const trigger = document.getElementById('nav-trigger');
+        const menu = document.getElementById('nav-menu');
+        if (!trigger || !menu) return;
+
+        const open = () => {
+            menu.classList.remove('hidden');
+            trigger.setAttribute('aria-expanded', 'true');
+        };
+        const close = () => {
+            menu.classList.add('hidden');
+            trigger.setAttribute('aria-expanded', 'false');
+        };
+
+        trigger.addEventListener('click', (e) => {
+            e.stopPropagation();
+            menu.classList.contains('hidden') ? open() : close();
+        });
+
+        document.addEventListener('click', (e) => {
+            if (!menu.classList.contains('hidden') &&
+                !menu.contains(e.target) && e.target !== trigger) {
+                close();
+            }
+        });
+
+        document.addEventListener('keydown', (e) => {
+            if (e.key === 'Escape' && !menu.classList.contains('hidden')) close();
+        });
+
+        menu.querySelectorAll('.nav-menu-item[data-screen]').forEach((item) => {
+            item.addEventListener('click', () => {
+                const screen = item.dataset.screen;
+                close();
+                if (item.classList.contains('active')) return;
+                if (screen === 'items' && nav.openItems) nav.openItems();
+                else if (screen === 'ankidex' && nav.openAnkidex) nav.openAnkidex();
+            });
+        });
+    }
+
+    function init() {
+        if (typeof qt === 'undefined' || !qt.webChannelTransport) return;
+        new QWebChannel(qt.webChannelTransport, function (channel) {
+            const nav = channel.objects && channel.objects.nav;
+            if (nav) bindSwitcher(nav);
+        });
+    }
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', init);
+    } else {
+        init();
+    }
+})();

--- a/src/Ankimon/ankimon_items_web/shop.css
+++ b/src/Ankimon/ankimon_items_web/shop.css
@@ -1820,7 +1820,6 @@ body {
     border-radius: 8px;
     padding: 8px;
     z-index: 100;
-    backdrop-filter: blur(8px);
 }
 
 .mini-map-label {
@@ -2972,7 +2971,6 @@ body {
     position: absolute;
     inset: 0;
     background: rgba(8, 10, 12, 0.7);
-    backdrop-filter: blur(4px);
 }
 
 .confirm-card {

--- a/src/Ankimon/ankimon_items_web/shop.css
+++ b/src/Ankimon/ankimon_items_web/shop.css
@@ -1,0 +1,3451 @@
+:root {
+    /* Color Palette */
+    --bg-darker: #080a0c;
+    --bg-dark: #0d1117;
+    --bg-card: #161b22;
+    --bg-card-hover: #21262d;
+    --border-main: #30363d;
+    --text-main: #c9d1d9;
+    --text-muted: #8b949e;
+    --text-bright: #ffffff;
+    --accent-blue: #58a6ff;
+    --accent-red: #f85149;
+    --accent-gold: #d29922;
+    --accent-green: #3fb950;
+    
+    /* Type Colors */
+    --type-normal: #A8A77A; --type-fire: #EE8130; --type-water: #6390F0;
+    --type-electric: #F7D02C; --type-grass: #7AC74C; --type-ice: #96D9D6;
+    --type-fighting: #C22E28; --type-poison: #A33EA1; --type-ground: #E2BF65;
+    --type-flying: #A98FF3; --type-psychic: #F95587; --type-bug: #A6B91A;
+    --type-rock: #B6A136; --type-ghost: #735797; --type-dragon: #6F35FC;
+    --type-dark: #705746; --type-steel: #B7B7CE; --type-fairy: #D685AD;
+
+    /* Status Colors */
+    --status-caught: var(--accent-blue);
+    --status-seen: #8b949e;
+    --status-unseen: #30363d;
+    --status-shiny: var(--accent-gold);
+
+    /* Spacing & Sizing */
+    --sidebar-width: 260px;
+    --detail-width: 340px;
+    --header-height: 70px;
+    --transition-fast: 0.15s ease;
+    --transition-mid: 0.25s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+* {
+    box-sizing: border-box;
+    margin: 0;
+    padding: 0;
+    -webkit-user-select: none;
+    user-select: none;
+}
+
+body {
+    font-family: 'Outfit', sans-serif;
+    background: transparent;
+    color: var(--text-main);
+    height: 100vh;
+    overflow: hidden;
+}
+
+.app-container {
+    display: flex;
+    width: 100vw;
+    height: 100vh;
+    background: var(--bg-dark);
+    border-radius: 0;
+    overflow: hidden;
+    box-shadow: 0 20px 50px rgba(0,0,0,0.5);
+}
+
+/* Sidebar */
+.sidebar {
+    width: var(--sidebar-width);
+    background: var(--bg-darker);
+    border-right: 1px solid var(--border-main);
+    display: flex;
+    flex-direction: column;
+    flex-shrink: 0;
+}
+
+.sidebar-header {
+    padding: 24px;
+}
+
+.pokedex-logo {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+}
+
+.app-logo {
+    width: 32px;
+    height: 32px;
+    filter: drop-shadow(0 0 10px rgba(255, 255, 255, 0.2));
+}
+
+.pokedex-logo h1 {
+    font-size: 1.4rem;
+    font-weight: 800;
+    letter-spacing: -0.5px;
+    background: linear-gradient(to bottom, #fff, #ccc);
+    -webkit-background-clip: text;
+    background-clip: text;
+    -webkit-text-fill-color: transparent;
+}
+
+.logo-dot {
+    width: 14px;
+    height: 14px;
+    background: var(--accent-red);
+    border-radius: 50%;
+    box-shadow: 0 0 10px var(--accent-red);
+}
+
+.nav-item-icon {
+    width: 18px;
+    height: 18px;
+    object-fit: contain;
+}
+
+.sidebar-nav {
+    flex: 1;
+    overflow-y: auto;
+    padding: 0 16px;
+}
+
+.nav-group {
+    margin-bottom: 24px;
+}
+
+.nav-group label {
+    display: block;
+    font-size: 0.7rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    color: var(--text-muted);
+    letter-spacing: 1px;
+    margin-bottom: 12px;
+    margin-left: 8px;
+}
+
+.nav-item {
+    width: 100%;
+    text-align: left;
+    background: transparent;
+    border: none;
+    color: var(--text-main);
+    padding: 10px 12px;
+    border-radius: 8px;
+    font-size: 0.9rem;
+    font-weight: 500;
+    cursor: pointer;
+    transition: var(--transition-fast);
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    margin-bottom: 2px;
+}
+
+.nav-item:hover {
+    background: var(--bg-card);
+    color: var(--text-bright);
+}
+
+.nav-item.active {
+    background: var(--bg-card-hover);
+    color: var(--accent-blue);
+    font-weight: 600;
+}
+
+.sub-nav {
+    margin-top: 4px;
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+}
+
+.sub-nav .nav-item {
+    padding: 8px 12px 8px 16px;
+    font-size: 0.8rem;
+    color: var(--text-muted);
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 4px;
+}
+
+.gen-progress-mini {
+    width: 100%;
+    height: 3px;
+    background: rgba(255, 255, 255, 0.05);
+    border-radius: 2px;
+    overflow: hidden;
+}
+
+.gen-progress-mini-fill {
+    height: 100%;
+    background: var(--accent-blue);
+    width: 0%;
+    transition: width 0.5s ease;
+}
+
+.gen-info-row {
+    width: 100%;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+.gen-count-mini {
+    font-size: 0.7rem;
+    opacity: 0.7;
+}
+
+.type-grid {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 6px;
+}
+
+.type-filter {
+    height: 32px;
+    border-radius: 6px;
+    font-size: 0.7rem;
+    font-weight: 700;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: white;
+    text-transform: uppercase;
+    cursor: pointer;
+    opacity: 0.6;
+    transition: var(--transition-fast);
+}
+
+.type-filter:hover, .type-filter.active {
+    opacity: 1;
+    transform: translateY(-1px);
+}
+
+.sidebar-footer {
+    padding: 20px;
+    border-top: 1px solid var(--border-main);
+}
+
+.progress-card {
+    background: var(--bg-card);
+    padding: 16px;
+    border-radius: 12px;
+    border: 1px solid var(--border-main);
+}
+
+.progress-info {
+    display: flex;
+    justify-content: space-between;
+    font-size: 0.8rem;
+    font-weight: 600;
+    margin-bottom: 10px;
+}
+
+.progress-bar {
+    height: 6px;
+    background: var(--bg-darker);
+    border-radius: 3px;
+    overflow: hidden;
+    margin-bottom: 8px;
+}
+
+.progress-fill {
+    height: 100%;
+    background: linear-gradient(90deg, var(--accent-blue), #00d2ff);
+    box-shadow: 0 0 10px rgba(88, 166, 255, 0.4);
+    transition: width 0.5s ease-out;
+}
+
+.progress-stats {
+    font-size: 0.7rem;
+    color: var(--text-muted);
+    font-weight: 500;
+}
+
+/* Main Content */
+.main-content {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    min-width: 0;
+    overflow: hidden; /* Prevent entire main area from scrolling */
+}
+
+.top-bar {
+    height: var(--header-height);
+    padding: 0 24px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 24px;
+    border-bottom: 1px solid var(--border-main);
+}
+
+.search-container {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    background: var(--bg-darker);
+    border: 1px solid var(--border-main);
+    padding: 8px 16px;
+    border-radius: 12px;
+    width: 400px;
+    transition: var(--transition-fast);
+    position: relative;
+}
+
+.search-container:focus-within {
+    border-color: var(--accent-blue);
+    background: var(--bg-card);
+    box-shadow: 0 0 0 3px rgba(88, 166, 255, 0.1);
+}
+
+.search-icon {
+    width: 20px;
+    height: 20px;
+    background: url('../user_files/sprites/items/poke-ball.png') no-repeat center;
+    background-size: contain;
+    opacity: 0.7;
+}
+
+.search-icon i {
+    display: none;
+}
+
+#pokemon-search {
+    width: 100%;
+    background: transparent;
+    border: none;
+    color: var(--text-main);
+    font-family: inherit;
+    font-size: 0.95rem;
+    outline: none;
+    padding-right: 30px; /* Space for X button */
+}
+
+.search-input-wrapper {
+    position: relative;
+    flex: 1;
+    display: flex;
+    align-items: center;
+}
+
+.clear-btn {
+    position: absolute;
+    right: 0;
+    background: transparent;
+    border: none;
+    color: var(--text-muted);
+    font-size: 1.2rem;
+    cursor: pointer;
+    padding: 4px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: var(--transition-fast);
+    z-index: 5;
+}
+
+.clear-btn:hover {
+    color: var(--text-main);
+}
+
+.clear-btn.hidden {
+    display: none;
+}
+
+#sprite-toggle {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    background: var(--bg-darker);
+    border: 1px solid var(--border-main);
+    color: var(--text-main);
+}
+
+#sprite-toggle:hover {
+    border-color: var(--accent-blue);
+    background: var(--bg-card);
+}
+
+.top-actions {
+    display: flex;
+    align-items: center;
+    gap: 16px;
+}
+
+.meta-grid {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 12px;
+}
+
+.meta-item {
+    background: rgba(255, 255, 255, 0.02);
+    padding: 12px;
+    border-radius: 8px;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+}
+
+.meta-label {
+    font-size: 0.65rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    color: var(--text-muted);
+}
+
+.meta-value {
+    font-size: 0.9rem;
+    font-weight: 600;
+    color: var(--text-main);
+}
+
+.sort-control {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 0.85rem;
+    color: var(--text-muted);
+}
+
+#sort-mode {
+    background: var(--bg-darker);
+    border: 1px solid var(--border-main);
+    color: var(--text-main);
+    padding: 6px 12px;
+    border-radius: 6px;
+    outline: none;
+}
+
+.view-toggle {
+    display: flex;
+    background: var(--bg-darker);
+    border: 1px solid var(--border-main);
+    border-radius: 8px;
+    padding: 4px;
+}
+
+.view-btn {
+    width: 32px;
+    height: 32px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: transparent;
+    border: none;
+    color: var(--text-muted);
+    cursor: pointer;
+    border-radius: 6px;
+    transition: var(--transition-fast);
+}
+
+.view-btn.active {
+    background: var(--bg-card);
+    color: var(--accent-blue);
+}
+
+.filter-pills {
+    padding: 12px 24px;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    min-height: 52px;
+}
+
+.pill {
+    background: var(--bg-card);
+    border: 1px solid var(--border-main);
+    padding: 4px 12px;
+    border-radius: 20px;
+    font-size: 0.75rem;
+    font-weight: 600;
+    display: flex;
+    align-items: center;
+    gap: 6px;
+}
+
+.pill-remove {
+    cursor: pointer;
+    color: var(--accent-red);
+}
+
+.content-scroll {
+    flex: 1;
+    overflow-y: auto;
+    padding: 12px 24px 24px;
+}
+
+/* Generation Grouping */
+.gen-section {
+    margin-bottom: 48px;
+}
+
+.gen-header {
+    display: flex;
+    align-items: baseline;
+    gap: 16px;
+    margin-bottom: 24px;
+    padding-bottom: 12px;
+    border-bottom: 1px solid var(--border-main);
+}
+
+.gen-title {
+    font-size: 1.5rem;
+    font-weight: 800;
+    color: var(--text-bright);
+    letter-spacing: -0.5px;
+}
+
+.gen-count {
+    font-size: 0.85rem;
+    color: var(--text-muted);
+    font-weight: 500;
+}
+
+.gen-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
+    gap: 20px;
+}
+
+.pokemon-grid {
+    display: block; /* Sub-grids handle the layout */
+}
+
+/* Pokemon Card */
+.pokemon-card {
+    background: var(--bg-card);
+    border: 1px solid var(--border-main);
+    border-radius: 16px;
+    padding: 16px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    position: relative;
+    cursor: pointer;
+    transition: var(--transition-mid);
+    overflow: hidden;
+}
+
+.pokemon-card:hover {
+    transform: translateY(-4px);
+    border-color: var(--accent-blue);
+    background: var(--bg-card-hover);
+    box-shadow: 0 10px 25px rgba(0,0,0,0.4);
+}
+
+/* State-based card badges removed per user request */
+.state-badge {
+    display: none;
+}
+
+.pokemon-card.selected {
+    border-color: var(--accent-blue);
+    background: rgba(88, 166, 255, 0.05);
+    box-shadow: 0 0 0 2px var(--accent-blue);
+}
+
+.pokemon-card.state-unseen {
+    opacity: 0.6;
+}
+
+.pokemon-card.state-unseen .card-sprite img {
+    filter: brightness(0) invert(1) brightness(0.15); /* Solid dark grey silhouette */
+}
+
+.pokemon-card.state-seen {
+    border-color: rgba(255, 255, 255, 0.05);
+}
+
+.pokemon-card.state-seen .card-sprite img {
+    filter: brightness(0) invert(1) brightness(0.4); /* Solid light grey silhouette */
+}
+
+.pokemon-card.state-caught {
+    border-color: var(--accent-blue);
+    background: rgba(88, 166, 255, 0.03);
+}
+
+.card-id {
+    position: absolute;
+    top: 12px;
+    left: 14px;
+    font-size: 0.75rem;
+    font-weight: 800;
+    color: var(--text-muted);
+    font-family: 'JetBrains Mono', monospace;
+}
+
+.card-badges {
+    position: absolute;
+    top: 12px;
+    right: 12px;
+    display: flex;
+    gap: 4px;
+}
+
+.shiny-badge, .favorite-badge {
+    font-size: 0.8rem;
+}
+
+.card-sprite {
+    width: 96px;
+    height: 96px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    margin: 10px 0;
+}
+
+.card-sprite img {
+    max-width: 100%;
+    max-height: 100%;
+    image-rendering: pixelated;
+    transition: transform 0.3s cubic-bezier(0.175, 0.885, 0.32, 1.275);
+}
+
+
+
+.pokemon-card:hover .card-sprite img {
+    transform: scale(1.15);
+}
+
+.card-info {
+    text-align: center;
+    width: 100%;
+}
+
+.card-name {
+    display: block;
+    font-weight: 700;
+    font-size: 0.95rem;
+    text-transform: capitalize;
+    color: var(--text-bright);
+    margin-bottom: 8px;
+}
+
+.card-types {
+    display: flex;
+    justify-content: center;
+    gap: 4px;
+}
+
+.mini-type {
+    padding: 2px 8px;
+    border-radius: 4px;
+    font-size: 0.6rem;
+    font-weight: 800;
+    text-transform: uppercase;
+    color: white;
+}
+
+
+.pokemon-grid.list-view .gen-grid {
+    grid-template-columns: 1fr;
+    gap: 8px;
+}
+
+.pokemon-grid.list-view .pokemon-card {
+    flex-direction: row;
+    height: 60px;
+    padding: 0 16px;
+    justify-content: flex-start;
+    gap: 20px;
+}
+
+.pokemon-grid.list-view .card-id {
+    position: static;
+    width: 60px;
+}
+
+.pokemon-grid.list-view .card-sprite {
+    width: 40px;
+    height: 40px;
+    margin: 0;
+}
+
+.pokemon-grid.list-view .card-info {
+    text-align: left;
+    display: flex;
+    align-items: center;
+    gap: 20px;
+    flex: 1;
+}
+
+.pokemon-grid.list-view .card-name {
+    margin-bottom: 0;
+    width: 150px;
+}
+
+.pokemon-grid.list-view .card-badges {
+    position: static;
+}
+
+/* Detail Panel */
+.detail-panel {
+    width: var(--detail-width);
+    background: var(--bg-darker);
+    border-left: 1px solid var(--border-main);
+    display: flex;
+    flex-direction: column;
+    flex-shrink: 0;
+}
+
+.detail-placeholder {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    color: var(--text-muted);
+    padding: 60px 40px;
+    text-align: center;
+}
+
+.detail-placeholder h3 {
+    font-size: 1.2rem;
+    color: var(--text-main);
+    margin-bottom: 12px;
+    letter-spacing: 1px;
+    text-transform: uppercase;
+}
+
+.detail-placeholder p {
+    font-size: 0.9rem;
+    line-height: 1.5;
+    max-width: 200px;
+    opacity: 0.6;
+}
+
+.placeholder-icon {
+    width: 64px;
+    height: 64px;
+    margin: 0 auto 20px;
+    background: url('../user_files/sprites/items/poke-ball.png') no-repeat center;
+    background-size: contain;
+    opacity: 0.15;
+    filter: grayscale(1);
+}
+
+.detail-content {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    animation: fadeIn 0.3s ease-out;
+}
+
+.detail-header-fixed {
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    height: 60px;
+    z-index: 100;
+    pointer-events: none;
+}
+
+.detail-header-fixed .close-btn {
+    pointer-events: auto;
+}
+
+.detail-hero-scroll {
+    padding: 40px 24px 20px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    text-align: center;
+    position: relative;
+}
+
+.det-id-badge {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 0.85rem;
+    font-weight: 800;
+    color: var(--accent-blue);
+    margin-bottom: 8px;
+    opacity: 0.8;
+}
+
+.det-name-main {
+    font-size: 1.8rem;
+    font-weight: 800;
+    letter-spacing: -0.5px;
+    color: var(--text-bright);
+    margin-bottom: 12px;
+    text-transform: capitalize;
+}
+
+.det-status-row {
+    display: flex;
+    gap: 8px;
+    margin-bottom: 16px;
+}
+
+.det-status-pill {
+    padding: 2px 8px;
+    border-radius: 8px;
+    font-size: 0.55rem;
+    font-weight: 800;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+}
+
+.det-status-pill.caught { background: var(--accent-blue); color: #000; }
+.det-status-pill.seen { background: var(--bg-card); color: var(--text-muted); border: 1px solid var(--border-main); }
+.det-status-pill.unseen { background: transparent; color: var(--text-muted); border: 1px dashed var(--border-main); }
+
+.detail-body {
+    flex: 1;
+    overflow-y: auto;
+    padding: 0 24px 40px;
+}
+
+/* Sections */
+.det-section {
+    margin-bottom: 32px;
+    animation: fadeIn 0.4s ease-out;
+}
+
+.det-section-label {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 0.75rem;
+    font-weight: 800;
+    text-transform: uppercase;
+    color: var(--text-muted);
+    letter-spacing: 1.5px;
+    margin-bottom: 16px;
+}
+
+.det-section-label::after {
+    content: '';
+    flex: 1;
+    height: 1px;
+    background: linear-gradient(to right, var(--border-main), transparent);
+}
+
+.detail-id {
+    font-family: 'JetBrains Mono', monospace;
+    font-weight: 700;
+    color: var(--text-muted);
+}
+
+.close-btn {
+    position: absolute;
+    top: 20px;
+    right: 20px;
+    width: 32px;
+    height: 32px;
+    border-radius: 50%;
+    background: rgba(255, 255, 255, 0.05);
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    color: var(--text-muted);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    z-index: 10;
+    transition: all 0.2s ease;
+    font-size: 0.9rem;
+}
+
+.close-btn:hover {
+    background: rgba(255, 255, 255, 0.15);
+    color: var(--text-bright);
+    transform: rotate(90deg);
+}
+
+.detail-glow {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    width: 250px;
+    height: 250px;
+    z-index: 0;
+    pointer-events: none;
+    transition: opacity 0.3s ease;
+    border-radius: 50%;
+}
+
+#det-sprite {
+    width: 180px;
+    height: 180px;
+    image-rendering: pixelated;
+    position: relative;
+    z-index: 1;
+}
+
+.detail-types {
+    display: flex;
+    justify-content: center;
+    gap: 8px;
+    margin-top: 12px;
+}
+
+.type-filter {
+    padding: 6px 10px;
+    border-radius: 6px;
+    font-size: 0.75rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    cursor: pointer;
+    transition: var(--transition-fast);
+    opacity: 0.25;
+    border: 1px solid transparent;
+    color: white;
+}
+
+.type-filter.active {
+    opacity: 1;
+    border-color: rgba(255, 255, 255, 0.3);
+    box-shadow: 0 0 10px rgba(0, 0, 0, 0.2);
+}
+
+.type-filter:hover {
+    transform: translateY(-1px);
+    opacity: 0.8;
+}
+
+.type-badge {
+    padding: 6px 16px;
+    border-radius: 20px;
+    font-size: 0.75rem;
+    font-weight: 800;
+    text-transform: uppercase;
+    color: white;
+    box-shadow: 0 4px 10px rgba(0,0,0,0.2);
+}
+
+.detail-scroll {
+    flex: 1;
+    overflow-y: auto;
+    padding: 0 24px 24px;
+}
+
+.detail-section {
+    margin-top: 32px;
+}
+
+.detail-section h3 {
+    font-size: 0.8rem;
+    font-weight: 800;
+    text-transform: uppercase;
+    color: var(--text-muted);
+    letter-spacing: 1px;
+    margin-bottom: 16px;
+    border-bottom: 1px solid var(--border-main);
+    padding-bottom: 8px;
+}
+
+.stats-grid {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+.stat-item {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    margin-bottom: 0;
+}
+
+.stat-label {
+    display: flex;
+    justify-content: space-between;
+    font-size: 0.75rem;
+    font-weight: 700;
+    color: var(--text-muted);
+    text-transform: uppercase;
+}
+
+.stat-bar-bg {
+    height: 8px;
+    background: var(--bg-dark);
+    border-radius: 4px;
+    overflow: hidden;
+}
+
+.stat-bar-fill {
+    height: 100%;
+    background: var(--accent-blue);
+    border-radius: 4px;
+    width: 0;
+    transition: width 1s cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.stat-total {
+    margin-top: 20px;
+    padding: 12px;
+    background: var(--bg-card);
+    border-radius: 8px;
+    display: flex;
+    justify-content: space-between;
+    font-weight: 800;
+    font-size: 0.9rem;
+}
+
+.forms-grid {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    margin-top: 8px;
+}
+
+.form-chip {
+    background: var(--bg-card);
+    border: 1px solid var(--border-main);
+    padding: 6px 10px;
+    border-radius: 10px;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    cursor: pointer;
+    transition: var(--transition-fast);
+    font-size: 0.75rem;
+    font-weight: 600;
+}
+
+.form-chip:hover {
+    background: var(--bg-card-hover);
+    border-color: var(--accent-blue);
+}
+
+.form-chip.active {
+    background: rgba(88, 166, 255, 0.1);
+    border-color: var(--accent-blue);
+    color: var(--accent-blue);
+}
+
+.form-chip img {
+    width: 24px;
+    height: 24px;
+    image-rendering: pixelated;
+}
+
+.info-grid {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 16px;
+}
+
+/* Expansion Drawer */
+.expansion-drawer {
+    grid-column: 1 / -1;
+    background: var(--bg-darker);
+    border: 1px solid var(--accent-blue);
+    border-radius: 12px;
+    margin: 10px 0;
+    overflow: hidden;
+    animation: drawerSlideDown 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.drawer-content {
+    padding: 20px;
+    display: flex;
+    gap: 30px;
+    position: relative;
+}
+
+.drawer-forms {
+    flex: 1;
+}
+
+.drawer-forms h4 {
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    color: var(--text-muted);
+    margin-bottom: 12px;
+    letter-spacing: 1px;
+}
+
+.drawer-forms-list {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px;
+}
+
+.close-drawer {
+    position: absolute;
+    top: 15px;
+    right: 15px;
+    background: transparent;
+    border: none;
+    color: var(--text-muted);
+    font-size: 1.5rem;
+    cursor: pointer;
+}
+
+@keyframes drawerSlideDown {
+    from { opacity: 0; max-height: 0; transform: translateY(-10px); }
+    to { opacity: 1; max-height: 500px; transform: translateY(0); }
+}
+
+.pokemon-card.has-drawer {
+    border-color: var(--accent-blue);
+    background: rgba(88, 166, 255, 0.05);
+}
+
+.info-item {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+}
+
+.info-item label {
+    font-size: 0.7rem;
+    color: var(--text-muted);
+    font-weight: 600;
+}
+
+.info-item span {
+    font-weight: 700;
+    font-size: 0.9rem;
+}
+
+.evo-chain {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.evo-node {
+    background: var(--bg-card);
+    border: 1px solid var(--border-main);
+    border-radius: 12px;
+    padding: 12px 18px;
+    display: flex;
+    align-items: center;
+    gap: 16px;
+    cursor: pointer;
+    transition: var(--transition-fast);
+}
+
+
+.evo-info {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+}
+
+.evo-name {
+    font-size: 0.85rem;
+    font-weight: 700;
+    color: var(--text-bright);
+}
+
+.evo-id {
+    font-size: 0.7rem;
+    color: var(--text-muted);
+    font-family: 'JetBrains Mono', monospace;
+}
+
+.evo-node:hover {
+    background: var(--bg-card-hover);
+    border-color: var(--accent-blue);
+}
+
+.evo-sprite {
+    width: 40px;
+    height: 40px;
+    image-rendering: pixelated;
+}
+
+.evo-name {
+    font-size: 0.85rem;
+    font-weight: 600;
+    text-transform: capitalize;
+}
+
+/* Helpers */
+.hidden { display: none !important; }
+
+.btn {
+    padding: 8px 16px;
+    border-radius: 8px;
+    font-weight: 600;
+    font-size: 0.85rem;
+    cursor: pointer;
+    border: none;
+    transition: var(--transition-fast);
+}
+
+.btn-secondary {
+    background: var(--bg-card);
+    border: 1px solid var(--border-main);
+    color: var(--text-main);
+}
+
+.btn-secondary:hover {
+    background: var(--bg-card-hover);
+    border-color: var(--text-muted);
+}
+
+.empty-state {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    padding: 100px 40px;
+    text-align: center;
+    color: var(--text-muted);
+}
+
+.empty-icon {
+    width: 120px;
+    height: 120px;
+    margin: 0 auto 24px;
+    background: url('../user_files/sprites/items/poke-doll.png') no-repeat center;
+    background-size: contain;
+    filter: drop-shadow(0 10px 15px rgba(0, 0, 0, 0.3));
+}
+
+@keyframes fadeIn {
+    from { opacity: 0; transform: translateX(10px); }
+    to { opacity: 1; transform: translateX(0); }
+}
+
+/* Scrollbar */
+::-webkit-scrollbar {
+    width: 8px;
+}
+
+::-webkit-scrollbar-track {
+    background: transparent;
+}
+
+::-webkit-scrollbar-thumb {
+    background: var(--border-main);
+    border-radius: 10px;
+}
+
+::-webkit-scrollbar-thumb:hover {
+    background: var(--text-muted);
+}
+
+/* Lore / Description */
+.lore-section {
+    background: linear-gradient(135deg, rgba(255, 255, 255, 0.03) 0%, rgba(255, 255, 255, 0.01) 100%);
+    border-radius: 16px;
+    padding: 24px;
+    border: 1px solid rgba(255, 255, 255, 0.05);
+    position: relative;
+    overflow: hidden;
+}
+
+.lore-section::before {
+    content: '"';
+    position: absolute;
+    top: -10px;
+    left: 10px;
+    font-size: 4rem;
+    font-family: serif;
+    color: var(--accent-blue);
+    opacity: 0.1;
+}
+
+.dex-entry-text {
+    font-size: 1rem;
+    line-height: 1.7;
+    color: var(--text-main);
+    font-weight: 400;
+    margin: 0;
+    font-style: italic;
+    letter-spacing: 0.3px;
+    position: relative;
+    z-index: 1;
+}
+
+.callout-body {
+    font-size: 0.9rem;
+    color: var(--text-bright);
+    line-height: 1.4;
+    font-weight: 500;
+}
+
+/* ---- Briefing Hints ---- */
+.briefing-hint-card {
+    background: rgba(63, 185, 80, 0.08);
+    border: 1px solid rgba(63, 185, 80, 0.3);
+    border-radius: 8px;
+    padding: 12px 16px;
+    position: relative;
+    overflow: hidden;
+}
+
+.briefing-hint-card::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 3px;
+    height: 100%;
+    background: var(--accent-green);
+}
+
+.hint-header {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 0.6rem;
+    text-transform: uppercase;
+    color: var(--accent-green);
+    letter-spacing: 1px;
+    margin-bottom: 6px;
+    font-weight: 700;
+}
+
+.hint-body {
+    font-size: 0.85rem;
+    color: var(--text-main);
+    line-height: 1.4;
+}
+
+.hint-region-tag {
+    color: var(--accent-green);
+    font-weight: 700;
+    text-transform: capitalize;
+}
+
+.evo-disclaimer {
+    margin-top: 16px;
+    font-size: 0.75rem;
+    color: var(--text-muted);
+    line-height: 1.4;
+    padding: 10px;
+    border-radius: 8px;
+    background: rgba(255, 255, 255, 0.02);
+    border-left: 3px solid var(--border-main);
+}
+
+.detail-forms-list {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px;
+    margin-top: 12px;
+}
+
+.detail-form-item {
+    background: var(--bg-card);
+    border: 1px solid var(--border-main);
+    padding: 8px 12px;
+    border-radius: 8px;
+    cursor: pointer;
+    transition: var(--transition-fast);
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.detail-form-item:hover {
+    border-color: var(--accent-blue);
+    background: rgba(255, 255, 255, 0.05);
+}
+
+.detail-form-item.active {
+    border-color: var(--accent-blue);
+    background: rgba(88, 166, 255, 0.15);
+}
+
+.detail-form-item img {
+    width: 24px;
+    height: 24px;
+}
+
+.evo-condition {
+    font-size: 0.6rem;
+    font-weight: 800;
+    color: var(--accent-blue);
+    background: rgba(88, 166, 255, 0.1);
+    padding: 2px 6px;
+    border-radius: 4px;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    max-width: 80px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+
+
+/* Abilities */
+.abilities-list {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.ability-item {
+    background: rgba(255, 255, 255, 0.03);
+    border-radius: 12px;
+    padding: 12px 16px;
+    border: 1px solid rgba(255, 255, 255, 0.05);
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+}
+
+.ability-name-row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.ability-name {
+    font-size: 0.9rem;
+    font-weight: 700;
+    color: var(--text-bright);
+    text-transform: capitalize;
+}
+
+.ability-tag {
+    font-size: 0.6rem;
+    font-weight: 800;
+    background: rgba(88, 166, 255, 0.1);
+    color: var(--accent-blue);
+    padding: 2px 6px;
+    border-radius: 4px;
+    text-transform: uppercase;
+}
+
+/* ============================================================
+   DISCOVERY MAP — full layout system
+   ============================================================ */
+
+.discovery-view {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    background: #05070a; /* Deep tech background */
+    overflow: hidden;
+    position: relative;
+    color: #e0e6ed;
+}
+
+/* ---- Map Controls Overlay ---- */
+.map-controls-overlay {
+    position: absolute;
+    top: 20px;
+    left: 20px;
+    z-index: 1000;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    pointer-events: none;
+    transform: translateZ(0);
+    will-change: transform;
+}
+
+.overlay-zoom-btn {
+    width: 40px;
+    height: 40px;
+    background: rgba(13, 17, 23, 0.95);
+    border: 1px solid var(--border-main);
+    color: var(--text-bright);
+    border-radius: 8px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 1.2rem;
+    font-weight: 700;
+    cursor: pointer;
+    pointer-events: auto;
+    transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1);
+    box-shadow: 0 4px 12px rgba(0,0,0,0.3);
+}
+
+.overlay-zoom-btn:hover {
+    background: var(--bg-card-hover);
+    border-color: var(--accent-blue);
+    transform: translateY(-2px);
+    box-shadow: 0 6px 16px rgba(0,0,0,0.4);
+    color: var(--accent-blue);
+}
+
+.overlay-zoom-btn:active {
+    transform: translateY(0);
+}
+
+#map-btn-reset, #map-btn-center, #map-btn-collapse {
+    font-size: 1rem;
+}
+
+/* ---- Map Progress Overlay ---- */
+.map-progress-overlay {
+    position: absolute;
+    top: 24px;
+    right: 24px;
+    z-index: 1000;
+    background: rgba(13, 17, 23, 0.95);
+    border: 1px solid var(--border-main);
+    border-radius: 12px;
+    padding: 16px;
+    width: 280px;
+    box-shadow: 0 10px 30px rgba(0,0,0,0.5);
+    pointer-events: auto;
+    transform: translateZ(0);
+    will-change: transform;
+}
+
+.map-progress-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    font-size: 0.75rem;
+    font-weight: 600;
+    color: var(--text-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    margin-bottom: 6px;
+}
+
+#map-progress-percent {
+    color: var(--accent-blue);
+    font-weight: 900;
+}
+
+.map-progress-bar {
+    height: 6px;
+    background: rgba(255, 255, 255, 0.05);
+    border-radius: 3px;
+    overflow: hidden;
+    margin-bottom: 12px;
+}
+
+.map-progress-fill {
+    height: 100%;
+    background: linear-gradient(90deg, var(--accent-blue), #00d2ff);
+    box-shadow: 0 0 10px rgba(88, 166, 255, 0.4);
+    transition: width 0.3s ease-out;
+    will-change: width;
+    transform: translateZ(0);
+}
+
+.map-progress-stats {
+    display: flex;
+    justify-content: space-between;
+    font-size: 0.75rem;
+    font-weight: 700;
+    color: var(--text-bright);
+}
+
+/* ---- Two-panel body ---- */
+.map-body {
+    flex: 1;
+    display: flex;
+    overflow: hidden;
+    min-height: 0;
+}
+
+/* ---- Canvas area ---- */
+.map-canvas-area {
+    flex: 1;
+    overflow: auto;
+    position: relative;
+    cursor: grab;
+    background: var(--bg-dark);
+    background-image: 
+        linear-gradient(rgba(255,255,255,0.015) 1px, transparent 1px),
+        linear-gradient(90deg, rgba(255,255,255,0.015) 1px, transparent 1px);
+    background-size: 60px 60px;
+    contain: paint;
+}
+
+.map-canvas-area:active { cursor: grabbing; }
+
+.discovery-map-content {
+    position: relative;
+    transform-origin: 0 0;
+}
+
+.discovery-svg {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    pointer-events: none;
+    z-index: 1;
+    overflow: visible;
+    transform: translateZ(0);
+    backface-visibility: hidden;
+}
+
+.discovery-nodes {
+    position: absolute;
+    top: 0;
+    left: 0;
+    z-index: 10;
+    pointer-events: none;
+    transform: translateZ(0);
+    backface-visibility: hidden;
+}
+
+.discovery-tier-labels {
+    position: absolute;
+    top: 0;
+    left: 0;
+    z-index: 5;
+    pointer-events: none;
+}
+
+
+
+/* ---- Discovery Nodes ---- */
+.discovery-node {
+    position: absolute;
+    background: #12171e;
+    border: 1px solid rgba(88, 166, 255, 0.4);
+    border-radius: 12px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    pointer-events: auto;
+    transform: translate(-50%, -50%);
+    transition: border-color 0.1s ease, box-shadow 0.1s ease, transform 0.2s cubic-bezier(0.2, 0, 0, 1);
+    will-change: transform, border-color;
+    backface-visibility: hidden;
+    z-index: 11;
+    box-shadow: 0 2px 8px rgba(0,0,0,0.4);
+}
+
+.discovery-node:hover {
+    border-color: #00f2ff;
+    background: #1a222c;
+    box-shadow: 0 0 20px rgba(0, 242, 255, 0.15);
+}
+
+.discovery-node.selected {
+    border-color: #00f2ff;
+    background: #1c2632;
+    box-shadow: 0 0 30px rgba(0, 242, 255, 0.25);
+    z-index: 20;
+}
+
+.node-inner {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 3px;
+    width: 100%;
+    padding: 4px 6px;
+}
+
+.node-sprite {
+    width: 75%;
+    height: 75%;
+    object-fit: contain;
+    image-rendering: pixelated;
+    transition: transform 0.2s ease;
+}
+
+.node-label {
+    font-size: 2.7rem;
+    font-weight: 950;
+    color: var(--text-bright);
+    text-shadow: 0 2px 8px rgba(0,0,0,1);
+    text-align: center;
+    text-transform: capitalize;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    max-width: 90%;
+    letter-spacing: 0.2px;
+}
+
+.discovery-node:hover {
+    transform: translate(-50%, -50%) scale(1.12);
+    z-index: 20;
+}
+
+.discovery-node:hover .node-sprite {
+    transform: scale(1.05);
+}
+
+/* --- Node States Redesign --- */
+
+/* 1. CAUGHT (vis-2) */
+.discovery-node.vis-2 {
+    border-color: rgba(255, 255, 255, 0.3);
+    background: #1a222c;
+    box-shadow: 0 0 15px rgba(255, 255, 255, 0.05);
+}
+
+.discovery-node.vis-2::after {
+    content: '✓';
+    position: absolute;
+    top: -6px;
+    right: -6px;
+    width: 18px;
+    height: 18px;
+    background: var(--text-main);
+    color: var(--bg-darker);
+    border-radius: 50%;
+    font-size: 0.65rem;
+    font-weight: 900;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    line-height: 18px;
+    text-align: center;
+    box-shadow: 0 2px 4px rgba(0,0,0,0.3);
+}
+
+/* 2. SEEN BUT NOT CAUGHT (vis-1) */
+.discovery-node.vis-1 {
+    border-color: rgba(255, 255, 255, 0.15);
+    background: transparent;
+}
+
+/* 3. UNSEEN (vis-0) */
+.discovery-node.vis-0 {
+    border-color: rgba(255, 255, 255, 0.05);
+    background: transparent;
+}
+
+/* 4. LOCKED / NOT ENCOUNTERABLE */
+.discovery-node.state-restricted {
+    border-style: dashed;
+    border-color: rgba(255, 255, 255, 0.1);
+}
+
+.discovery-node.state-restricted::after {
+    content: '✕';
+    position: absolute;
+    top: -6px;
+    right: -6px;
+    width: 16px;
+    height: 16px;
+    background: rgba(255, 255, 255, 0.1);
+    color: var(--text-muted);
+    border-radius: 50%;
+    font-size: 0.6rem;
+    font-weight: 900;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    line-height: 16px;
+    text-align: center;
+}
+
+/* 5. SELECTED */
+.discovery-node.selected {
+    border-color: var(--accent-blue) !important;
+    background: rgba(88, 166, 255, 0.08) !important;
+    box-shadow: 0 0 0 2px var(--accent-blue), 0 6px 24px rgba(88, 166, 255, 0.25) !important;
+    transform: translate(-50%, -50%) scale(1.08) !important;
+    z-index: 25 !important;
+    animation: none !important;
+    opacity: 1 !important;
+}
+
+/* Tier sizing overrides applied by JS via width/height, but label font scales with tier */
+.discovery-node.tier-0 .node-label { font-size: 0.52rem; opacity: 0.6; }
+.discovery-node.tier-1 .node-label { font-size: 0.56rem; opacity: 0.7; }
+.discovery-node.tier-2 .node-label { font-size: 0.60rem; color: var(--text-main); opacity: 0.9; }
+.discovery-node.tier-3 .node-label { font-size: 0.65rem; color: var(--text-bright); font-weight: 800; opacity: 1; }
+
+.discovery-node.selected .node-label { opacity: 1; }
+
+/* Filter states */
+.discovery-node.map-filtered-out {
+    opacity: 0 !important;
+    pointer-events: none;
+}
+
+.discovery-node.state-collapsed {
+    transform: translate(-50%, -50%) scale(0.55);
+    opacity: 0.3;
+}
+
+/* ---- Connection Lines Redesign ---- */
+.discovery-line {
+    stroke: rgba(255, 255, 255, 0.05); /* Blocked / Unavailable / Default structure */
+    stroke-width: 2;
+    fill: none;
+    transition: all 0.2s ease;
+}
+
+/* Prerequisites that are fulfilled (Source Caught) */
+.discovery-line.line-met {
+    stroke: rgba(255, 255, 255, 0.25); /* Calm, resolved */
+    stroke-width: 3;
+}
+
+/* Fully completed path (Target Caught) */
+.discovery-line.line-completed {
+    stroke: rgba(255, 255, 255, 0.15); /* Calm */
+    stroke-width: 3;
+}
+
+/* Selected Chain */
+.discovery-line.line-active {
+    stroke: var(--accent-blue); /* Brightest, strongest */
+    stroke-width: 5;
+    stroke-opacity: 1;
+    z-index: 20;
+}
+
+/* If active AND met? Still accent blue, thick */
+.discovery-line.line-met.line-active, .discovery-line.line-completed.line-active {
+    stroke: var(--accent-blue);
+    stroke-opacity: 0.8;
+    stroke-width: 5;
+}
+
+/* ---- Mini-map ---- */
+.mini-map-container {
+    position: absolute;
+    bottom: 16px;
+    right: 16px;
+    background: rgba(13, 17, 23, 0.9);
+    border: 1px solid var(--border-main);
+    border-radius: 8px;
+    padding: 8px;
+    z-index: 100;
+    backdrop-filter: blur(8px);
+}
+
+.mini-map-label {
+    font-size: 0.6rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+    color: var(--text-muted);
+    margin-bottom: 5px;
+    text-align: center;
+}
+
+.mini-map-canvas {
+    display: block;
+    border-radius: 4px;
+    border: 1px solid rgba(255,255,255,0.05);
+}
+
+.mini-map-viewport {
+    position: absolute;
+    border: 1.5px solid rgba(88,166,255,0.6);
+    border-radius: 2px;
+    background: rgba(88,166,255,0.07);
+    pointer-events: none;
+    /* positioned dynamically by JS; top/left offset by container padding */
+    top: 29px; /* label + margin-bottom + padding */
+    left: 8px;
+}
+
+/* ---- Chain Briefing Panel (Redesign) ---- */
+.chain-inspector {
+    width: 320px;
+    min-width: 320px;
+    flex-shrink: 0;
+    background: var(--bg-darker);
+    border-left: 1px solid var(--border-main);
+    display: flex;
+    flex-direction: column;
+    overflow-y: auto;
+    position: relative;
+    box-shadow: -10px 0 30px rgba(0,0,0,0.3);
+}
+
+.detail-placeholder, .briefing-placeholder {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    padding: 60px 40px;
+    text-align: center;
+    color: var(--text-muted);
+}
+
+.placeholder-icon {
+    font-size: 3.5rem;
+    margin-bottom: 24px;
+    opacity: 0.2;
+    filter: grayscale(1);
+    transition: all 0.5s ease;
+}
+
+.detail-placeholder:hover .placeholder-icon {
+    opacity: 0.4;
+    transform: scale(1.05);
+}
+
+.detail-placeholder h3, .briefing-placeholder h3 {
+    font-size: 1.1rem;
+    color: var(--text-main);
+    margin-bottom: 12px;
+    text-transform: uppercase;
+    letter-spacing: 1.5px;
+    font-weight: 800;
+}
+
+.detail-placeholder p, .briefing-placeholder p {
+    font-size: 0.85rem;
+    line-height: 1.6;
+    max-width: 240px;
+    margin: 0 auto;
+}
+
+.inspector-content {
+    padding: 24px;
+    display: flex;
+    flex-direction: column;
+    gap: 28px;
+    animation: slideInRight 0.4s cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+@keyframes slideInRight {
+    from { transform: translateX(20px); opacity: 0; }
+    to { transform: translateX(0); opacity: 1; }
+}
+
+
+
+/* 5. Chain Context */
+.insp-context-grid {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+}
+
+.insp-context-group {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.insp-context-sublabel {
+    font-size: 0.6rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    color: var(--text-muted);
+    opacity: 0.7;
+}
+
+.insp-context-list {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+}
+
+.insp-context-chip {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 6px 14px;
+    background: rgba(255,255,255,0.04);
+    border: 1px solid rgba(255,255,255,0.05);
+    border-radius: 24px;
+    font-size: 0.8rem;
+    font-weight: 600;
+    cursor: pointer;
+    transition: all 0.2s ease;
+}
+
+.insp-context-chip:hover {
+    background: rgba(255,255,255,0.08);
+    border-color: var(--accent-blue);
+    transform: translateY(-1px);
+}
+
+.insp-context-chip img {
+    width: 40px;
+    height: 40px;
+    object-fit: contain;
+    image-rendering: pixelated;
+}
+
+
+
+/* ---- Prereqs list (still used in main detail panel) ---- */
+.prereqs-list {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px;
+    margin-top: 10px;
+}
+
+.prereq-item {
+    width: 72px;
+    height: 84px;
+    background: var(--bg-card);
+    border: 1px solid var(--border-main);
+    border-radius: 12px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    position: relative;
+    transition: all 0.2s ease;
+    cursor: pointer;
+    padding-bottom: 4px;
+}
+
+.prereq-item:hover {
+    border-color: var(--accent-blue);
+    transform: translateY(-2px);
+}
+
+.prereq-item img {
+    width: 48px;
+    height: 48px;
+    image-rendering: pixelated;
+}
+
+.prereq-id {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 0.6rem;
+    font-weight: 700;
+    color: var(--text-muted);
+    margin-top: 2px;
+}
+
+.prereq-item.locked img {
+    filter: grayscale(1) brightness(0.2);
+    opacity: 0.3;
+}
+
+.prereq-item.caught::after {
+    content: '✓';
+    position: absolute;
+    top: -5px;
+    right: -5px;
+    width: 16px;
+    height: 16px;
+    background: var(--accent-green);
+    color: #000;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 0.6rem;
+    font-weight: 900;
+}
+
+.prereq-logic-label {
+    width: 100%;
+    font-size: 0.7rem;
+    color: var(--text-muted);
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    margin-bottom: 4px;
+    padding-left: 2px;
+}
+
+.ability-desc {
+    grid-column: 1 / -1;
+    font-size: 0.8rem;
+    line-height: 1.4;
+    color: var(--text-muted);
+    padding-top: 4px;
+    border-top: 1px solid rgba(255, 255, 255, 0.03);
+    margin-top: 4px;
+}
+
+/* ---- Panel Mode Switcher ---- */
+.panel-mode-switcher {
+    display: flex;
+    padding: 8px;
+    background: var(--bg-darker);
+    border-bottom: 1px solid var(--border-main);
+    gap: 4px;
+}
+
+.panel-mode-btn {
+    flex: 1;
+    background: transparent;
+    border: 1px solid transparent;
+    color: var(--text-muted);
+    padding: 6px 12px;
+    font-size: 0.8rem;
+    font-weight: 600;
+    border-radius: 6px;
+    cursor: pointer;
+    transition: all 0.2s ease;
+}
+
+.panel-mode-btn:hover {
+    color: var(--text-main);
+    background: rgba(255, 255, 255, 0.05);
+}
+
+.panel-mode-btn.active {
+    background: var(--bg-card);
+    border-color: var(--border-main);
+    color: var(--text-bright);
+    box-shadow: 0 2px 8px rgba(0,0,0,0.2);
+}
+
+/* ---- Chain Briefing View ---- */
+.briefing-content {
+    display: flex;
+    flex-direction: column;
+    flex: 1;
+    height: 100%;
+    overflow: hidden;
+}
+
+.briefing-header {
+    display: flex;
+    align-items: center;
+    padding: 20px;
+    gap: 16px;
+    border-bottom: 1px solid var(--border-main);
+    background: linear-gradient(180deg, rgba(255,255,255,0.02) 0%, transparent 100%);
+}
+
+#briefing-sprite {
+    width: 60px;
+    height: 60px;
+    object-fit: contain;
+    image-rendering: pixelated;
+    background: rgba(0,0,0,0.2);
+    border-radius: 8px;
+    padding: 4px;
+    border: 1px solid rgba(255,255,255,0.05);
+}
+
+.briefing-identity {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+}
+
+#briefing-id {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 0.75rem;
+    color: var(--text-muted);
+    font-weight: 700;
+}
+
+#briefing-name {
+    font-size: 1.4rem;
+    font-weight: 800;
+    color: var(--text-bright);
+    margin: 0;
+    line-height: 1.2;
+}
+
+.state-badge {
+    padding: 3px 10px;
+    border-radius: 20px;
+    font-size: 0.65rem;
+    font-weight: 800;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    border: 1px solid;
+    display: inline-block;
+    white-space: nowrap;
+}
+
+/* ---- Panel Mode Switcher ---- */
+.panel-mode-switcher {
+    display: flex;
+    gap: 2px;
+    padding: 8px 16px;
+    background: var(--bg-darker);
+    border-bottom: 1px solid var(--border-main);
+}
+
+.panel-mode-btn {
+    flex: 1;
+    padding: 8px;
+    background: transparent;
+    border: 1px solid transparent;
+    border-radius: 6px;
+    color: var(--text-muted);
+    font-size: 0.75rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    cursor: pointer;
+    transition: all 0.2s ease;
+}
+
+.panel-mode-btn:hover {
+    color: var(--text-bright);
+    background: rgba(255,255,255,0.03);
+}
+
+.panel-mode-btn.active {
+    background: rgba(88, 166, 255, 0.1);
+    color: var(--accent-blue);
+    border-color: rgba(88, 166, 255, 0.2);
+}
+
+.state-badge.locked { color: var(--text-muted); border-color: rgba(255,255,255,0.15); background: rgba(255,255,255,0.05); }
+.state-badge.available { color: var(--accent-blue); border-color: rgba(88,166,255,0.25); background: rgba(88,166,255,0.1); }
+.state-badge.in-progress { color: var(--accent-gold); border-color: rgba(210,153,34,0.25); background: rgba(210,153,34,0.1); }
+.state-badge.completed { color: var(--accent-green); border-color: rgba(63,185,80,0.25); background: rgba(63,185,80,0.1); }
+
+
+.briefing-scroll-area {
+    flex: 1;
+    overflow-y: auto;
+    padding: 20px;
+    display: flex;
+    flex-direction: column;
+    gap: 20px;
+}
+
+.briefing-section {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.briefing-summary {
+    font-size: 0.95rem;
+    line-height: 1.4;
+    color: var(--text-main);
+    margin: 0;
+}
+
+.briefing-callout {
+    background: rgba(88,166,255,0.08);
+    border: 1px solid rgba(88,166,255,0.3);
+    border-radius: 8px;
+    padding: 12px 16px;
+}
+
+.briefing-callout .callout-header {
+    font-size: 0.7rem;
+    text-transform: uppercase;
+    font-weight: 800;
+    color: var(--accent-blue);
+    margin-bottom: 4px;
+    letter-spacing: 0.5px;
+}
+
+.briefing-callout .callout-body {
+    font-size: 0.95rem;
+    font-weight: 600;
+    color: var(--text-bright);
+}
+
+.briefing-section-label {
+    font-size: 0.7rem;
+    text-transform: uppercase;
+    font-weight: 800;
+    color: var(--text-muted);
+    letter-spacing: 0.5px;
+    display: flex;
+    justify-content: space-between;
+    border-bottom: 1px solid var(--border-main);
+    padding-bottom: 4px;
+}
+
+.briefing-reqs-list {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+}
+
+.req-row {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 8px;
+    background: var(--bg-card);
+    border: 1px solid var(--border-main);
+    border-radius: 6px;
+    cursor: pointer;
+    transition: all 0.15s ease;
+}
+
+.req-row:hover {
+    border-color: rgba(255,255,255,0.2);
+    background: var(--bg-card-hover);
+}
+
+.req-sprite {
+    width: 32px;
+    height: 32px;
+    object-fit: contain;
+    image-rendering: pixelated;
+}
+
+.req-name {
+    flex: 1;
+    font-size: 0.9rem;
+    font-weight: 600;
+    color: var(--text-main);
+}
+
+.req-status {
+    font-size: 0.7rem;
+    font-weight: 700;
+    text-transform: uppercase;
+}
+
+.req-status.caught { color: var(--accent-green); }
+.req-status.seen { color: var(--text-main); }
+.req-status.missing { color: var(--text-muted); }
+.req-status.locked { color: var(--accent-red); opacity: 0.7; }
+
+.briefing-context-list {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    font-size: 0.8rem;
+    color: var(--text-muted);
+}
+/* ---- Global Close Button ---- */
+.detail-close-global {
+    position: absolute;
+    top: 12px;
+    right: 12px;
+    z-index: 100;
+    background: rgba(0, 0, 0, 0.4);
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    color: white;
+    width: 32px;
+    height: 32px;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    transition: all 0.2s ease;
+}
+
+.detail-close-global:hover {
+    background: rgba(255, 255, 255, 0.1);
+    transform: scale(1.1);
+}
+
+.detail-panel .hidden + .detail-close-global {
+    display: none; /* Hide if no content is visible? No, we handle this in JS visibility */
+}
+
+
+/* ====================================================================
+ * SHOP-SPECIFIC OVERRIDES (Phase 1)
+ * Everything above is verbatim from ankidex.css. Phase 2 will extract
+ * the intersection into web_shell/shell.css.
+ * ==================================================================== */
+
+/* --- Search input (shell CSS keys on #pokemon-search; mirror it here) --- */
+#shop-search {
+    width: 100%;
+    background: transparent;
+    border: none;
+    color: var(--text-main);
+    font-family: inherit;
+    font-size: 0.95rem;
+    outline: none;
+    padding-right: 30px;
+}
+
+#shop-search::placeholder {
+    color: var(--text-muted);
+    opacity: 0.7;
+}
+
+/* --- Sidebar tweaks --- */
+.nav-icon {
+    display: inline-flex;
+    width: 14px;
+    justify-content: center;
+    font-size: 0.7rem;
+    color: var(--accent-blue);
+}
+
+.nav-item.nav-action {
+    background: linear-gradient(135deg,
+        rgba(248, 81, 73, 0.12),
+        rgba(248, 81, 73, 0.04));
+    border: 1px solid rgba(248, 81, 73, 0.25);
+    color: var(--text-bright);
+    font-weight: 600;
+}
+
+.nav-item.nav-action:hover {
+    background: linear-gradient(135deg,
+        rgba(248, 81, 73, 0.25),
+        rgba(248, 81, 73, 0.10));
+    border-color: var(--accent-red);
+    color: var(--text-bright);
+}
+
+.nav-item.nav-action:disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
+}
+
+.reroll-cost-pill {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 0.7rem;
+    font-weight: 700;
+    color: var(--accent-gold);
+    background: rgba(210, 153, 34, 0.12);
+    border: 1px solid rgba(210, 153, 34, 0.3);
+    padding: 1px 7px;
+    border-radius: 4px;
+}
+
+/* --- Currency card (sidebar footer) — premium feel --- */
+.shop-currency-card {
+    margin: 16px;
+    padding: 18px 18px 16px;
+    background:
+        linear-gradient(135deg,
+            rgba(210, 153, 34, 0.10),
+            rgba(210, 153, 34, 0.02) 50%,
+            transparent),
+        var(--bg-card);
+    border: 1px solid var(--border-main);
+    border-radius: 14px;
+    position: relative;
+    overflow: hidden;
+}
+
+.shop-currency-card::before {
+    content: '';
+    position: absolute;
+    top: -40px;
+    right: -40px;
+    width: 120px;
+    height: 120px;
+    background: radial-gradient(circle, rgba(210, 153, 34, 0.18), transparent 60%);
+    pointer-events: none;
+}
+
+.currency-label-row {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 6px;
+    position: relative;
+    z-index: 1;
+}
+
+.shop-currency-label {
+    font-size: 0.7rem;
+    font-weight: 800;
+    text-transform: uppercase;
+    color: var(--text-muted);
+    letter-spacing: 1.5px;
+}
+
+.currency-icon {
+    font-size: 0.95rem;
+    opacity: 0.7;
+}
+
+.shop-currency-value {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 1.55rem;
+    font-weight: 700;
+    color: var(--accent-gold);
+    letter-spacing: -0.5px;
+    line-height: 1.1;
+    text-shadow: 0 0 24px rgba(210, 153, 34, 0.35);
+    position: relative;
+    z-index: 1;
+}
+
+.currency-sub {
+    font-size: 0.65rem;
+    color: var(--text-muted);
+    letter-spacing: 1px;
+    text-transform: uppercase;
+    margin-top: 4px;
+    opacity: 0.7;
+    position: relative;
+    z-index: 1;
+}
+
+/* --- Top bar count chips --- */
+.shop-stat-chip {
+    display: inline-flex;
+    flex-direction: column;
+    align-items: center;
+    background: var(--bg-card);
+    border: 1px solid var(--border-main);
+    border-radius: 10px;
+    padding: 6px 14px;
+    min-width: 58px;
+}
+
+.shop-stat-chip-label {
+    font-size: 0.6rem;
+    font-weight: 700;
+    color: var(--text-muted);
+    text-transform: uppercase;
+    letter-spacing: 1px;
+}
+
+.shop-stat-chip-value {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 1.1rem;
+    font-weight: 700;
+    color: var(--text-bright);
+    line-height: 1.2;
+}
+
+/* --- Section headers (use Ankidex's gradient-underline pattern) --- */
+.shop-section {
+    margin-bottom: 36px;
+}
+
+.shop-section-header {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    margin-bottom: 18px;
+}
+
+.shop-section-title {
+    font-size: 0.8rem;
+    font-weight: 800;
+    text-transform: uppercase;
+    letter-spacing: 2px;
+    color: var(--text-bright);
+    position: relative;
+    padding-left: 12px;
+}
+
+.shop-section-title::before {
+    content: '';
+    position: absolute;
+    left: 0;
+    top: 50%;
+    transform: translateY(-50%);
+    width: 4px;
+    height: 16px;
+    border-radius: 2px;
+    background: var(--accent-blue);
+}
+
+.shop-section-title.items::before { background: var(--accent-red); }
+.shop-section-title.tms::before { background: var(--accent-blue); }
+
+.shop-section-sub {
+    font-size: 0.7rem;
+    color: var(--text-muted);
+    letter-spacing: 0.5px;
+    flex: 1;
+    border-bottom: 1px dashed var(--border-main);
+    padding-bottom: 4px;
+    margin-left: 4px;
+}
+
+/* --- Grid uses Ankidex's pokemon-grid behaviour --- */
+.shop-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(170px, 1fr));
+    gap: 14px;
+}
+
+/* --- Shop card — built on .pokemon-card hover + structure --- */
+.shop-card {
+    background: var(--bg-card);
+    border: 1px solid var(--border-main);
+    border-radius: 16px;
+    padding: 16px 14px 14px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    position: relative;
+    cursor: pointer;
+    transition: var(--transition-mid);
+    overflow: hidden;
+}
+
+.shop-card:hover {
+    transform: translateY(-4px);
+    border-color: var(--accent-blue);
+    background: var(--bg-card-hover);
+    box-shadow: 0 10px 25px rgba(0, 0, 0, 0.4);
+}
+
+.shop-card.selected {
+    border-color: var(--accent-blue);
+    background: rgba(88, 166, 255, 0.05);
+    box-shadow: 0 0 0 2px var(--accent-blue);
+}
+
+.shop-card.owned {
+    border-color: rgba(63, 185, 80, 0.4);
+}
+
+.shop-card.unaffordable {
+    opacity: 0.6;
+}
+
+.shop-card.unaffordable .shop-card-sprite img {
+    filter: grayscale(0.6);
+}
+
+/* Item type / category strip badge in corner */
+.shop-card-tag {
+    position: absolute;
+    top: 10px;
+    left: 12px;
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 0.6rem;
+    font-weight: 800;
+    text-transform: uppercase;
+    color: var(--text-muted);
+    letter-spacing: 1px;
+}
+
+.shop-card-tag.items { color: var(--accent-red); }
+.shop-card-tag.tms { color: var(--accent-blue); }
+
+.shop-card-badges {
+    position: absolute;
+    top: 10px;
+    right: 10px;
+    display: flex;
+    gap: 4px;
+}
+
+.shop-card-badge {
+    font-size: 0.6rem;
+    font-weight: 800;
+    padding: 2px 6px;
+    border-radius: 4px;
+    letter-spacing: 1px;
+    text-transform: uppercase;
+}
+
+.shop-card-badge.owned {
+    color: var(--accent-green);
+    background: rgba(63, 185, 80, 0.12);
+    border: 1px solid rgba(63, 185, 80, 0.4);
+}
+
+.shop-card-badge.qty {
+    color: var(--text-bright);
+    background: var(--bg-darker);
+    border: 1px solid var(--border-main);
+    font-family: 'JetBrains Mono', monospace;
+}
+
+/* Sprite */
+.shop-card-sprite {
+    width: 80px;
+    height: 80px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    margin: 12px 0 10px;
+}
+
+.shop-card-sprite img {
+    /* width/height + object-fit so tiny TM discs scale up to fill the
+     * container while larger item sprites still fit naturally — both
+     * preserve aspect ratio. */
+    width: 100%;
+    height: 100%;
+    object-fit: contain;
+    image-rendering: pixelated;
+    transition: transform 0.3s cubic-bezier(0.175, 0.885, 0.32, 1.275);
+}
+
+.shop-card:hover .shop-card-sprite img {
+    transform: scale(1.15);
+}
+
+.shop-card-name {
+    display: block;
+    font-weight: 700;
+    font-size: 0.9rem;
+    text-align: center;
+    color: var(--text-bright);
+    margin-bottom: 8px;
+    line-height: 1.2;
+    min-height: 2.2em;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+/* TM move-type pill (uses Ankidex's --type-* colors) */
+.shop-card-types {
+    display: flex;
+    justify-content: center;
+    gap: 4px;
+    margin-bottom: 10px;
+    min-height: 18px;
+}
+
+.shop-card-types .mini-type {
+    padding: 2px 8px;
+    border-radius: 4px;
+    font-size: 0.6rem;
+    font-weight: 800;
+    text-transform: uppercase;
+    color: white;
+}
+
+/* Price pill — gold, like a type badge but currency-themed */
+.shop-card-price-pill {
+    padding: 5px 12px;
+    border-radius: 12px;
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 0.75rem;
+    font-weight: 700;
+    color: var(--accent-gold);
+    background: rgba(210, 153, 34, 0.12);
+    border: 1px solid rgba(210, 153, 34, 0.35);
+    box-shadow: 0 2px 8px rgba(210, 153, 34, 0.08);
+    letter-spacing: 0.3px;
+}
+
+.shop-card.unaffordable .shop-card-price-pill {
+    color: var(--accent-red);
+    background: rgba(248, 81, 73, 0.10);
+    border-color: rgba(248, 81, 73, 0.35);
+}
+
+/* --- Detail panel customization --- */
+.detail-sprite {
+    /* Fixed 180x180 container gives consistent hero proportions across all
+     * sprite sizes — tiny TM discs (~28px native) and large item sprites
+     * both land at the same visual scale. */
+    margin-top: 20px;
+    margin-bottom: 16px;
+    width: 180px;
+    height: 180px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    position: relative;
+    z-index: 1;
+}
+
+.detail-sprite img,
+.detail-sprite #det-sprite {
+    /* Override Ankidex's stretching 180x180 rule. object-fit:contain
+     * scales the image to fill the container while preserving its
+     * natural aspect ratio. */
+    width: 100%;
+    height: 100%;
+    object-fit: contain;
+    image-rendering: pixelated;
+}
+
+#det-id {
+    text-transform: uppercase;
+}
+
+.det-status-row .det-pill {
+    padding: 4px 10px;
+    border-radius: 10px;
+    font-size: 0.65rem;
+    font-weight: 800;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+}
+
+.det-pill.price {
+    color: var(--accent-gold);
+    background: rgba(210, 153, 34, 0.12);
+    border: 1px solid rgba(210, 153, 34, 0.4);
+    font-family: 'JetBrains Mono', monospace;
+}
+
+.det-pill.owned {
+    color: var(--accent-green);
+    background: rgba(63, 185, 80, 0.10);
+    border: 1px solid rgba(63, 185, 80, 0.4);
+}
+
+.det-pill.move-type {
+    color: white;
+}
+
+.dex-entry-text {
+    font-size: 0.9rem;
+    line-height: 1.55;
+    color: var(--text-main);
+}
+
+/* Move stats use Ankidex .stats-grid pattern */
+#det-move-stats .stat-item {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+}
+
+#det-move-stats .stat-label {
+    display: flex;
+    justify-content: space-between;
+    font-size: 0.7rem;
+    font-weight: 700;
+    color: var(--text-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+}
+
+#det-move-stats .stat-label .stat-val {
+    font-family: 'JetBrains Mono', monospace;
+    color: var(--text-bright);
+    font-weight: 800;
+    letter-spacing: 0;
+}
+
+#det-move-stats .stat-bar-bg {
+    height: 6px;
+    background: var(--bg-dark);
+    border-radius: 3px;
+    overflow: hidden;
+}
+
+#det-move-stats .stat-bar-fill {
+    height: 100%;
+    background: linear-gradient(90deg, var(--accent-blue), #79c0ff);
+    border-radius: 3px;
+    width: 0;
+    transition: width 0.6s cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+/* Purchase row */
+.purchase-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    background: var(--bg-card);
+    border: 1px solid var(--border-main);
+    border-radius: 12px;
+    padding: 14px 16px;
+    gap: 14px;
+}
+
+.purchase-price {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+}
+
+.purchase-label {
+    font-size: 0.65rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    color: var(--text-muted);
+    letter-spacing: 1px;
+}
+
+.purchase-value {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 1.4rem;
+    font-weight: 700;
+    color: var(--accent-gold);
+    line-height: 1;
+    text-shadow: 0 0 18px rgba(210, 153, 34, 0.3);
+}
+
+.det-buy-btn {
+    background: linear-gradient(135deg, var(--accent-blue), #4a8edb);
+    color: #0d1117;
+    border: none;
+    padding: 12px 28px;
+    border-radius: 10px;
+    font-family: 'Outfit', sans-serif;
+    font-size: 0.95rem;
+    font-weight: 800;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+    cursor: pointer;
+    transition: var(--transition-fast);
+    box-shadow: 0 4px 14px rgba(88, 166, 255, 0.3);
+}
+
+.det-buy-btn:hover:not(:disabled) {
+    transform: translateY(-1px);
+    box-shadow: 0 6px 20px rgba(88, 166, 255, 0.45);
+    background: linear-gradient(135deg, #79c0ff, var(--accent-blue));
+}
+
+.det-buy-btn:disabled {
+    background: var(--bg-card-hover);
+    color: var(--text-muted);
+    box-shadow: none;
+    cursor: not-allowed;
+}
+
+.affordability-hint {
+    margin-top: 10px;
+    font-size: 0.75rem;
+    color: var(--text-muted);
+    text-align: center;
+    min-height: 1em;
+}
+
+.affordability-hint.error {
+    color: var(--accent-red);
+}
+
+.affordability-hint.success {
+    color: var(--accent-green);
+}
+
+/* --- Empty state --- */
+.shop-empty {
+    grid-column: 1 / -1;
+    text-align: center;
+    color: var(--text-muted);
+    padding: 40px 20px;
+    font-size: 0.85rem;
+    border: 1px dashed var(--border-main);
+    border-radius: 12px;
+    background: rgba(255, 255, 255, 0.01);
+}
+
+/* --- Toast --- */
+.shop-toast {
+    position: fixed;
+    bottom: 28px;
+    left: 50%;
+    transform: translateX(-50%) translateY(20px);
+    background: linear-gradient(135deg, var(--bg-card), var(--bg-card-hover));
+    color: var(--text-bright);
+    border: 1px solid var(--accent-green);
+    border-radius: 10px;
+    padding: 12px 22px;
+    font-size: 0.88rem;
+    font-weight: 600;
+    box-shadow: 0 10px 30px rgba(0, 0, 0, 0.5);
+    opacity: 0;
+    transition: opacity 0.25s ease, transform 0.25s ease;
+    pointer-events: none;
+    z-index: 1000;
+    letter-spacing: 0.3px;
+}
+
+.shop-toast.visible {
+    opacity: 1;
+    transform: translateX(-50%) translateY(0);
+}
+
+.shop-toast.error {
+    border-color: var(--accent-red);
+    box-shadow: 0 10px 30px rgba(248, 81, 73, 0.25);
+}
+
+/* --- Close button visibility tweak for shop --- */
+.detail-close-global.hidden {
+    display: none;
+}
+
+/* --- Confirmation modal --- */
+.confirm-modal {
+    position: fixed;
+    inset: 0;
+    z-index: 1500;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    animation: fadeIn 0.18s ease-out;
+}
+
+.confirm-modal.hidden {
+    display: none;
+}
+
+.confirm-backdrop {
+    position: absolute;
+    inset: 0;
+    background: rgba(8, 10, 12, 0.7);
+    backdrop-filter: blur(4px);
+}
+
+.confirm-card {
+    position: relative;
+    background: linear-gradient(160deg, var(--bg-card), var(--bg-darker));
+    border: 1px solid var(--border-main);
+    border-radius: 18px;
+    padding: 28px 28px 22px;
+    width: 380px;
+    max-width: calc(100vw - 40px);
+    box-shadow: 0 24px 60px rgba(0, 0, 0, 0.6);
+    text-align: center;
+    animation: confirmPop 0.22s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+@keyframes confirmPop {
+    0% { transform: scale(0.92); opacity: 0; }
+    100% { transform: scale(1); opacity: 1; }
+}
+
+.confirm-icon {
+    width: 52px;
+    height: 52px;
+    border-radius: 50%;
+    margin: 0 auto 14px;
+    background:
+        radial-gradient(circle at 30% 30%, rgba(248, 81, 73, 0.35), transparent 60%),
+        var(--bg-darker);
+    border: 1px solid rgba(248, 81, 73, 0.4);
+    color: var(--accent-red);
+    font-size: 1.4rem;
+    font-weight: 800;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    box-shadow: 0 0 24px rgba(248, 81, 73, 0.18);
+}
+
+.confirm-title {
+    font-size: 1.15rem;
+    font-weight: 800;
+    color: var(--text-bright);
+    margin-bottom: 8px;
+    letter-spacing: -0.3px;
+}
+
+.confirm-body {
+    font-size: 0.88rem;
+    line-height: 1.5;
+    color: var(--text-main);
+    margin-bottom: 18px;
+}
+
+.confirm-body em {
+    font-style: normal;
+    color: var(--accent-blue);
+    font-weight: 600;
+}
+
+.confirm-cost {
+    font-family: 'JetBrains Mono', monospace;
+    color: var(--accent-gold);
+    font-weight: 700;
+}
+
+.confirm-balance {
+    background: rgba(255, 255, 255, 0.025);
+    border: 1px solid var(--border-main);
+    border-radius: 10px;
+    padding: 10px 14px;
+    margin-bottom: 20px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+}
+
+.confirm-balance-label {
+    font-size: 0.7rem;
+    text-transform: uppercase;
+    color: var(--text-muted);
+    letter-spacing: 1px;
+    font-weight: 700;
+}
+
+.confirm-balance-value {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 0.95rem;
+    font-weight: 700;
+    color: var(--accent-gold);
+}
+
+.confirm-balance.insufficient .confirm-balance-value {
+    color: var(--accent-red);
+}
+
+.confirm-actions {
+    display: flex;
+    gap: 10px;
+}
+
+.confirm-btn {
+    flex: 1;
+    padding: 10px 16px;
+    border-radius: 10px;
+    font-family: 'Outfit', sans-serif;
+    font-size: 0.88rem;
+    font-weight: 700;
+    letter-spacing: 0.5px;
+    cursor: pointer;
+    transition: var(--transition-fast);
+    border: 1px solid transparent;
+}
+
+.confirm-btn.cancel {
+    background: transparent;
+    color: var(--text-muted);
+    border-color: var(--border-main);
+}
+
+.confirm-btn.cancel:hover {
+    background: var(--bg-card-hover);
+    color: var(--text-bright);
+    border-color: var(--text-muted);
+}
+
+.confirm-btn.primary {
+    background: linear-gradient(135deg, var(--accent-red), #c93b34);
+    color: var(--text-bright);
+    box-shadow: 0 4px 14px rgba(248, 81, 73, 0.3);
+}
+
+.confirm-btn.primary:hover:not(:disabled) {
+    transform: translateY(-1px);
+    box-shadow: 0 6px 18px rgba(248, 81, 73, 0.45);
+}
+
+.confirm-btn.primary:disabled {
+    background: var(--bg-card-hover);
+    color: var(--text-muted);
+    box-shadow: none;
+    cursor: not-allowed;
+}
+
+/* --- Navigation switcher (sidebar logo dropdown) --- */
+.nav-switcher {
+    position: relative;
+}
+
+.nav-trigger {
+    width: 100%;
+    background: transparent;
+    border: 1px solid transparent;
+    color: inherit;
+    padding: 6px 10px;
+    border-radius: 10px;
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    cursor: pointer;
+    transition: var(--transition-fast);
+    text-align: left;
+    font-family: inherit;
+}
+
+.nav-trigger:hover {
+    background: var(--bg-card);
+    border-color: var(--border-main);
+}
+
+.nav-trigger[aria-expanded="true"] {
+    background: var(--bg-card);
+    border-color: var(--accent-blue);
+}
+
+.nav-trigger .app-logo {
+    flex-shrink: 0;
+}
+
+.nav-trigger h1 {
+    flex: 1;
+    margin: 0;
+}
+
+.nav-chevron {
+    font-size: 0.9rem;
+    color: var(--text-muted);
+    transition: transform 0.2s ease;
+    margin-right: 2px;
+}
+
+.nav-trigger[aria-expanded="true"] .nav-chevron {
+    transform: rotate(180deg);
+    color: var(--accent-blue);
+}
+
+.nav-menu {
+    position: absolute;
+    top: calc(100% + 8px);
+    left: 0;
+    right: 0;
+    z-index: 200;
+    background: linear-gradient(180deg, var(--bg-card), var(--bg-darker));
+    border: 1px solid var(--border-main);
+    border-radius: 12px;
+    padding: 6px;
+    box-shadow: 0 14px 32px rgba(0, 0, 0, 0.55);
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    animation: navMenuPop 0.16s cubic-bezier(0.22, 1, 0.36, 1);
+    transform-origin: top left;
+}
+
+.nav-menu.hidden {
+    display: none;
+}
+
+@keyframes navMenuPop {
+    0%   { opacity: 0; transform: translateY(-6px) scale(0.97); }
+    100% { opacity: 1; transform: translateY(0)    scale(1); }
+}
+
+.nav-menu-item {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    width: 100%;
+    background: transparent;
+    border: 1px solid transparent;
+    color: var(--text-main);
+    padding: 10px 12px;
+    border-radius: 8px;
+    cursor: pointer;
+    font-family: inherit;
+    text-align: left;
+    transition: var(--transition-fast);
+}
+
+.nav-menu-item:hover {
+    background: var(--bg-card-hover);
+    border-color: var(--border-main);
+    color: var(--text-bright);
+}
+
+.nav-menu-item.active {
+    background: rgba(88, 166, 255, 0.08);
+    border-color: rgba(88, 166, 255, 0.4);
+    color: var(--text-bright);
+}
+
+.nav-menu-item:disabled {
+    opacity: 0.45;
+    cursor: not-allowed;
+}
+
+.nav-menu-icon {
+    width: 28px;
+    height: 28px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: var(--bg-darker);
+    border: 1px solid var(--border-main);
+    border-radius: 6px;
+    color: var(--accent-blue);
+    font-size: 0.95rem;
+    flex-shrink: 0;
+}
+
+.nav-menu-item.active .nav-menu-icon {
+    border-color: var(--accent-blue);
+    color: var(--accent-blue);
+    box-shadow: 0 0 12px rgba(88, 166, 255, 0.25);
+}
+
+.nav-menu-icon img {
+    width: 18px;
+    height: 18px;
+    object-fit: contain;
+}
+
+.nav-menu-text {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+}
+
+.nav-menu-title {
+    font-size: 0.88rem;
+    font-weight: 700;
+    line-height: 1.15;
+}
+
+.nav-menu-desc {
+    font-size: 0.7rem;
+    color: var(--text-muted);
+    letter-spacing: 0.3px;
+    line-height: 1.2;
+}
+
+.nav-menu-status {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 0.6rem;
+    font-weight: 800;
+    text-transform: uppercase;
+    color: var(--accent-blue);
+    background: rgba(88, 166, 255, 0.10);
+    border: 1px solid rgba(88, 166, 255, 0.35);
+    padding: 2px 6px;
+    border-radius: 4px;
+    letter-spacing: 1px;
+}
+
+/* --- Unified inventory: card-state additions --- */
+.nav-count {
+    margin-left: auto;
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 0.7rem;
+    font-weight: 700;
+    color: var(--text-muted);
+    background: var(--bg-darker);
+    border: 1px solid var(--border-main);
+    border-radius: 4px;
+    padding: 1px 6px;
+    min-width: 22px;
+    text-align: center;
+}
+
+.nav-item.active .nav-count {
+    color: var(--accent-blue);
+    border-color: rgba(88, 166, 255, 0.4);
+    background: rgba(88, 166, 255, 0.08);
+}
+
+.shop-card.owned-only {
+    border-color: rgba(63, 185, 80, 0.35);
+}
+
+.shop-card.in-shop-only {
+    border-color: rgba(248, 81, 73, 0.30);
+}
+
+.shop-card.in-shop-and-owned {
+    border-color: rgba(210, 153, 34, 0.40);
+}
+
+.shop-card-tag.owned-only { color: var(--accent-green); }
+.shop-card-tag.in-shop-only { color: var(--accent-red); }
+.shop-card-tag.in-shop-and-owned { color: var(--accent-gold); }
+.shop-card-tag.tm { color: var(--accent-blue); }
+
+.shop-card-tags-row {
+    display: flex;
+    gap: 4px;
+    flex-wrap: wrap;
+    justify-content: center;
+    margin-bottom: 10px;
+    min-height: 18px;
+}
+
+.shop-card-tags-row .mini-type {
+    padding: 2px 8px;
+    border-radius: 4px;
+    font-size: 0.6rem;
+    font-weight: 800;
+    text-transform: uppercase;
+    color: white;
+}
+
+.shop-card-tags-row .cat-pill {
+    padding: 2px 8px;
+    border-radius: 4px;
+    font-size: 0.58rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    background: var(--bg-darker);
+    color: var(--text-muted);
+    border: 1px solid var(--border-main);
+}
+
+/* Detail panel: action buttons row */
+.actions-grid {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+}
+
+.det-action-btn {
+    width: 100%;
+    padding: 12px 18px;
+    border-radius: 10px;
+    font-family: 'Outfit', sans-serif;
+    font-size: 0.9rem;
+    font-weight: 800;
+    text-transform: uppercase;
+    letter-spacing: 0.8px;
+    cursor: pointer;
+    transition: var(--transition-fast);
+    border: none;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 10px;
+}
+
+.det-action-btn .det-action-meta {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 0.75rem;
+    font-weight: 700;
+    opacity: 0.85;
+    letter-spacing: 0;
+    text-transform: none;
+}
+
+.det-action-btn.buy {
+    background: linear-gradient(135deg, var(--accent-gold), #b58319);
+    color: #1a1308;
+    box-shadow: 0 4px 14px rgba(210, 153, 34, 0.28);
+}
+
+.det-action-btn.buy:hover:not(:disabled) {
+    transform: translateY(-1px);
+    box-shadow: 0 6px 20px rgba(210, 153, 34, 0.45);
+    background: linear-gradient(135deg, #f0b536, var(--accent-gold));
+}
+
+.det-action-btn.use {
+    background: linear-gradient(135deg, var(--accent-green), #2c8c3c);
+    color: #0a1f0e;
+    box-shadow: 0 4px 14px rgba(63, 185, 80, 0.28);
+}
+
+.det-action-btn.use:hover:not(:disabled) {
+    transform: translateY(-1px);
+    box-shadow: 0 6px 20px rgba(63, 185, 80, 0.45);
+    background: linear-gradient(135deg, #5ed16f, var(--accent-green));
+}
+
+.det-action-btn:disabled {
+    background: var(--bg-card-hover);
+    color: var(--text-muted);
+    box-shadow: none;
+    cursor: not-allowed;
+}
+
+.shop-empty.hidden { display: none; }
+
+/* --- In-grid section headers (used when both Items and TMs are visible) --- */
+.shop-section-header.inline {
+    grid-column: 1 / -1;
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    margin-top: 6px;
+    margin-bottom: 4px;
+}
+
+.shop-section-header.inline:first-child {
+    margin-top: 0;
+}
+
+/* --- Reroll icon (used in sidebar button and confirmation modal) --- */
+.icon-reroll {
+    width: 16px;
+    height: 16px;
+    flex-shrink: 0;
+    display: block;
+}
+
+.nav-item .icon-reroll {
+    color: var(--accent-red);
+}
+
+.confirm-icon .icon-reroll {
+    width: 24px;
+    height: 24px;
+}

--- a/src/Ankimon/ankimon_items_web/shop.css
+++ b/src/Ankimon/ankimon_items_web/shop.css
@@ -2555,6 +2555,9 @@ body {
     display: grid;
     grid-template-columns: repeat(auto-fill, minmax(170px, 1fr));
     gap: 14px;
+    /* Scope reflow/paint to the grid so refreshing the cards (e.g. after
+     * a buy/use/reroll) doesn't cause perceptible layout shift elsewhere. */
+    contain: layout style;
 }
 
 /* --- Shop card — built on .pokemon-card hover + structure --- */

--- a/src/Ankimon/ankimon_items_web/shop.css
+++ b/src/Ankimon/ankimon_items_web/shop.css
@@ -3452,3 +3452,11 @@ body {
     width: 24px;
     height: 24px;
 }
+
+/* --- Items identity icon (hyper-potion sprite used as Items' visual ID).
+ * Sizing comes from .app-logo (32x32) and .nav-menu-icon img (18x18);
+ * we just want crisp pixel art at small scales. */
+.icon-item-sprite {
+    image-rendering: pixelated;
+    object-fit: contain;
+}

--- a/src/Ankimon/ankimon_items_web/shop.html
+++ b/src/Ankimon/ankimon_items_web/shop.html
@@ -123,8 +123,8 @@
 
             <div id="detail-placeholder" class="detail-placeholder">
                 <div class="placeholder-icon"></div>
-                <h3>Mart Counter</h3>
-                <p>Select any item or TM to inspect its details, buy from the Mart, or use from your bag.</p>
+                <h3>Item Inspector</h3>
+                <p>Pick a card to see its effect, price, and what you can do with it.</p>
             </div>
 
             <div id="detail-content" class="detail-content hidden">

--- a/src/Ankimon/ankimon_items_web/shop.html
+++ b/src/Ankimon/ankimon_items_web/shop.html
@@ -31,7 +31,7 @@
                             </div>
                         </button>
                         <button class="nav-menu-item" role="menuitem" data-screen="ankidex">
-                            <span class="nav-menu-icon">✦</span>
+                            <span class="nav-menu-icon"><img src="../user_files/sprites/items/poke-ball.png" alt=""></span>
                             <div class="nav-menu-text">
                                 <span class="nav-menu-title">Ankidex</span>
                                 <span class="nav-menu-desc">Browse caught Pokémon</span>

--- a/src/Ankimon/ankimon_items_web/shop.html
+++ b/src/Ankimon/ankimon_items_web/shop.html
@@ -1,0 +1,194 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Ankimon Items</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700;800;900&family=JetBrains+Mono:wght@500;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="shop.css">
+    <script src="qrc:///qtwebchannel/qwebchannel.js"></script>
+</head>
+<body class="dark-mode">
+    <div class="app-container">
+
+        <!-- Sidebar -->
+        <aside class="sidebar">
+            <div class="sidebar-header">
+                <div id="nav-switcher" class="nav-switcher">
+                    <button id="nav-trigger" class="nav-trigger" type="button" aria-haspopup="true" aria-expanded="false">
+                        <img src="../user_files/sprites/items/poke-ball.png" class="app-logo">
+                        <h1>ITEMS</h1>
+                        <span class="nav-chevron">▾</span>
+                    </button>
+                    <div id="nav-menu" class="nav-menu hidden" role="menu">
+                        <button class="nav-menu-item active" role="menuitem" data-screen="items">
+                            <span class="nav-menu-icon"><img src="../user_files/sprites/items/poke-ball.png" alt=""></span>
+                            <div class="nav-menu-text">
+                                <span class="nav-menu-title">Items</span>
+                                <span class="nav-menu-desc">Your inventory and today's Mart</span>
+                            </div>
+                        </button>
+                        <button class="nav-menu-item" role="menuitem" data-screen="ankidex">
+                            <span class="nav-menu-icon">✦</span>
+                            <div class="nav-menu-text">
+                                <span class="nav-menu-title">Ankidex</span>
+                                <span class="nav-menu-desc">Browse caught Pokémon</span>
+                            </div>
+                        </button>
+                    </div>
+                </div>
+            </div>
+
+            <nav class="sidebar-nav">
+                <div class="nav-group">
+                    <label>View</label>
+                    <button class="nav-item active" data-filter="in_shop">
+                        <span class="nav-icon" style="color: var(--accent-red)">●</span>In Shop Today
+                        <span class="nav-count" id="count-in-shop">0</span>
+                    </button>
+                    <button class="nav-item" data-filter="owned">
+                        <span class="nav-icon" style="color: var(--accent-green)">●</span>In Your Bag
+                        <span class="nav-count" id="count-owned">0</span>
+                    </button>
+                </div>
+
+                <div class="nav-group">
+                    <label>Category</label>
+                    <button class="nav-item active" data-category="all">Any</button>
+                    <button class="nav-item" data-category="tm">TMs</button>
+                    <button class="nav-item" data-category="heal">Heal Items</button>
+                    <button class="nav-item" data-category="pokeball">Poké Balls</button>
+                    <button class="nav-item" data-category="evolution">Evolution</button>
+                    <button class="nav-item" data-category="fossil">Fossils</button>
+                </div>
+
+                <div class="nav-group">
+                    <label>Actions</label>
+                    <button id="reroll-btn" class="nav-item nav-action" title="Reroll today's stock">
+                        <svg class="icon-reroll" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                            <path d="M21 12a9 9 0 1 1-3-6.7"/>
+                            <path d="M21 3v5h-5"/>
+                        </svg>
+                        <span style="flex: 1">Reroll Stock</span>
+                        <span id="reroll-cost-label" class="reroll-cost-pill">100¥</span>
+                    </button>
+                </div>
+            </nav>
+
+            <div class="sidebar-footer">
+                <div class="shop-currency-card">
+                    <div class="currency-label-row">
+                        <span class="shop-currency-label">Wallet</span>
+                        <span class="currency-icon">💰</span>
+                    </div>
+                    <div id="currency-value" class="shop-currency-value">0¥</div>
+                    <div class="currency-sub">Trainer Funds</div>
+                </div>
+            </div>
+        </aside>
+
+        <!-- Main Content -->
+        <main class="main-content">
+            <header class="top-bar">
+                <div class="search-container">
+                    <div class="search-input-wrapper">
+                        <input type="text" id="shop-search" placeholder="Search items, TMs, moves... (Press /)">
+                        <button id="clear-search" class="clear-btn hidden" title="Clear search">×</button>
+                    </div>
+                </div>
+
+                <div class="top-actions">
+                    <div class="shop-stat-chip">
+                        <span class="shop-stat-chip-label">Shop</span>
+                        <span id="stat-shop" class="shop-stat-chip-value">0</span>
+                    </div>
+                    <div class="shop-stat-chip">
+                        <span class="shop-stat-chip-label">Owned</span>
+                        <span id="stat-owned" class="shop-stat-chip-value">0</span>
+                    </div>
+                </div>
+            </header>
+
+            <div class="content-scroll" style="padding: 20px 24px;">
+                <div id="items-grid" class="pokemon-grid shop-grid"></div>
+                <div id="empty-state" class="shop-empty hidden">No items match your filters.</div>
+            </div>
+        </main>
+
+        <!-- Detail Panel -->
+        <section class="detail-panel" id="detail-panel">
+            <button id="close-detail" class="close-btn detail-close-global hidden" title="Close panel">✕</button>
+
+            <div id="detail-placeholder" class="detail-placeholder">
+                <div class="placeholder-icon"></div>
+                <h3>Mart Counter</h3>
+                <p>Select any item or TM to inspect its details, buy from the Mart, or use from your bag.</p>
+            </div>
+
+            <div id="detail-content" class="detail-content hidden">
+                <div class="detail-body">
+                    <div class="detail-hero-scroll">
+                        <div id="det-glow" class="detail-glow"></div>
+                        <span id="det-id" class="det-id-badge">ITEM</span>
+                        <h2 id="det-name" class="det-name-main">Item Name</h2>
+
+                        <div class="det-status-row" id="det-status-row"></div>
+
+                        <div class="detail-sprite">
+                            <img id="det-sprite" src="" alt="">
+                        </div>
+                    </div>
+
+                    <div class="det-section">
+                        <div class="det-section-label">Effect</div>
+                        <p id="det-description" class="dex-entry-text"></p>
+                    </div>
+
+                    <div id="det-move-section" class="det-section hidden">
+                        <div class="det-section-label">Move Profile</div>
+                        <div id="det-move-stats" class="stats-grid"></div>
+                    </div>
+
+                    <div class="det-section">
+                        <div class="det-section-label">Actions</div>
+                        <div id="det-actions" class="actions-grid"></div>
+                        <div id="det-hint" class="affordability-hint"></div>
+                    </div>
+                </div>
+            </div>
+        </section>
+    </div>
+
+    <div id="toast" class="shop-toast"></div>
+
+    <!-- Confirmation modal -->
+    <div id="confirm-modal" class="confirm-modal hidden" role="dialog" aria-modal="true">
+        <div class="confirm-backdrop"></div>
+        <div class="confirm-card">
+            <div class="confirm-icon">
+                <svg class="icon-reroll" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                    <path d="M21 12a9 9 0 1 1-3-6.7"/>
+                    <path d="M21 3v5h-5"/>
+                </svg>
+            </div>
+            <h3 id="confirm-title" class="confirm-title">Reroll Stock?</h3>
+            <p id="confirm-body" class="confirm-body">
+                This will spend <span id="confirm-cost" class="confirm-cost">100¥</span>
+                and replace today's items <em>and</em> TMs with a fresh roll.
+            </p>
+            <div id="confirm-balance" class="confirm-balance">
+                <span class="confirm-balance-label">Balance after</span>
+                <span id="confirm-balance-value" class="confirm-balance-value">0¥</span>
+            </div>
+            <div class="confirm-actions">
+                <button id="confirm-cancel" class="confirm-btn cancel">Cancel</button>
+                <button id="confirm-ok" class="confirm-btn primary">Confirm Reroll</button>
+            </div>
+        </div>
+    </div>
+
+    <script src="shop.js"></script>
+</body>
+</html>

--- a/src/Ankimon/ankimon_items_web/shop.html
+++ b/src/Ankimon/ankimon_items_web/shop.html
@@ -6,6 +6,24 @@
     <title>Ankimon Items</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <!-- Inline dark bg + skeleton placeholders so the user sees structure
+         instead of empty space while external CSS + initial data load.
+         Real renderGrid() clears the skeleton on first push from Python. -->
+    <style>
+        html { background: #0d1117; }
+        .skeleton {
+            background: #161b22;
+            border: 1px solid #30363d;
+            border-radius: 14px;
+            opacity: 0.5;
+            animation: skeleton-pulse 1.5s ease-in-out infinite;
+        }
+        .skeleton-card { height: 220px; }
+        @keyframes skeleton-pulse {
+            0%, 100% { opacity: 0.35; }
+            50%      { opacity: 0.6; }
+        }
+    </style>
     <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700;800;900&family=JetBrains+Mono:wght@500;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="shop.css">
     <script src="qrc:///qtwebchannel/qwebchannel.js"></script>
@@ -18,13 +36,13 @@
             <div class="sidebar-header">
                 <div id="nav-switcher" class="nav-switcher">
                     <button id="nav-trigger" class="nav-trigger" type="button" aria-haspopup="true" aria-expanded="false">
-                        <img src="../user_files/sprites/items/poke-ball.png" class="app-logo">
+                        <img src="../user_files/sprites/items/hyper-potion.png" class="app-logo icon-item-sprite" alt="">
                         <h1>ITEMS</h1>
                         <span class="nav-chevron">▾</span>
                     </button>
                     <div id="nav-menu" class="nav-menu hidden" role="menu">
                         <button class="nav-menu-item active" role="menuitem" data-screen="items">
-                            <span class="nav-menu-icon"><img src="../user_files/sprites/items/poke-ball.png" alt=""></span>
+                            <span class="nav-menu-icon"><img src="../user_files/sprites/items/hyper-potion.png" class="icon-item-sprite" alt=""></span>
                             <div class="nav-menu-text">
                                 <span class="nav-menu-title">Items</span>
                                 <span class="nav-menu-desc">Your inventory and today's Mart</span>
@@ -112,7 +130,16 @@
             </header>
 
             <div class="content-scroll" style="padding: 20px 24px;">
-                <div id="items-grid" class="pokemon-grid shop-grid"></div>
+                <div id="items-grid" class="pokemon-grid shop-grid">
+                    <!-- Skeleton placeholders — cleared by render() on first
+                         push from Python. -->
+                    <div class="skeleton skeleton-card"></div>
+                    <div class="skeleton skeleton-card"></div>
+                    <div class="skeleton skeleton-card"></div>
+                    <div class="skeleton skeleton-card"></div>
+                    <div class="skeleton skeleton-card"></div>
+                    <div class="skeleton skeleton-card"></div>
+                </div>
                 <div id="empty-state" class="shop-empty hidden">No items match your filters.</div>
             </div>
         </main>

--- a/src/Ankimon/ankimon_items_web/shop.js
+++ b/src/Ankimon/ankimon_items_web/shop.js
@@ -73,14 +73,21 @@
         const visible = items.filter(matchesFilters);
         const grid = document.getElementById('items-grid');
         const empty = document.getElementById('empty-state');
-        grid.innerHTML = '';
 
         if (visible.length === 0) {
+            grid.replaceChildren();
             empty.classList.remove('hidden');
             refreshDetailPanel();
             return;
         }
         empty.classList.add('hidden');
+
+        // Build the new content off-DOM in a DocumentFragment, then swap it
+        // in atomically with replaceChildren. Avoids the empty-grid flash
+        // and the per-appendChild reflow cascade that the old
+        // innerHTML='' + sequential appendChild loop caused on every
+        // buy/use/reroll refresh.
+        const frag = document.createDocumentFragment();
 
         // Split into Items vs TMs whenever both are visible and no specific
         // category is selected. Keeps the Mart's familiar Items/TMs grouping
@@ -92,14 +99,15 @@
             && tmEntries.length > 0;
 
         if (splitSections) {
-            grid.appendChild(buildSectionHeader('Items', 'items', itemEntries.length));
-            itemEntries.forEach((item) => grid.appendChild(buildCard(item)));
-            grid.appendChild(buildSectionHeader('TMs', 'tms', tmEntries.length));
-            tmEntries.forEach((item) => grid.appendChild(buildCard(item)));
+            frag.appendChild(buildSectionHeader('Items', 'items', itemEntries.length));
+            itemEntries.forEach((item) => frag.appendChild(buildCard(item)));
+            frag.appendChild(buildSectionHeader('TMs', 'tms', tmEntries.length));
+            tmEntries.forEach((item) => frag.appendChild(buildCard(item)));
         } else {
-            visible.forEach((item) => grid.appendChild(buildCard(item)));
+            visible.forEach((item) => frag.appendChild(buildCard(item)));
         }
 
+        grid.replaceChildren(frag);
         refreshDetailPanel();
     }
 

--- a/src/Ankimon/ankimon_items_web/shop.js
+++ b/src/Ankimon/ankimon_items_web/shop.js
@@ -1,0 +1,617 @@
+// Ankimon Items — unified Mart + Bag web UI.
+// Talks to Python via QWebChannel (window.bridge) for buy / reroll / use.
+
+(function () {
+    'use strict';
+
+    const TYPE_COLORS = {
+        normal: '#A8A77A', fire: '#EE8130', water: '#6390F0',
+        electric: '#F7D02C', grass: '#7AC74C', ice: '#96D9D6',
+        fighting: '#C22E28', poison: '#A33EA1', ground: '#E2BF65',
+        flying: '#A98FF3', psychic: '#F95587', bug: '#A6B91A',
+        rock: '#B6A136', ghost: '#735797', dragon: '#6F35FC',
+        dark: '#705746', steel: '#B7B7CE', fairy: '#D685AD',
+    };
+
+    const CATEGORY_LABELS = {
+        tm: 'TM',
+        heal: 'Heal',
+        pokeball: 'Ball',
+        evolution: 'Evolution',
+        fossil: 'Fossil',
+        other: '',
+    };
+
+    const state = {
+        data: null,
+        filter: 'in_shop',     // in_shop | owned
+        category: 'all',       // all | tm | heal | pokeball | evolution | fossil
+        search: '',
+        selected: null,        // item name
+    };
+
+    let bridge = null;
+
+    function initChannel(callback) {
+        if (typeof qt === 'undefined' || !qt.webChannelTransport) {
+            console.warn('qt.webChannelTransport unavailable — standalone mode');
+            callback(null);
+            return;
+        }
+        new QWebChannel(qt.webChannelTransport, function (channel) {
+            bridge = channel.objects.bridge;
+            window.bridge = bridge;
+            callback(bridge);
+        });
+    }
+
+    // Entry from Python
+    window.initializeItems = function (data) {
+        state.data = data;
+        render();
+    };
+
+    // ---------- Rendering ----------
+    function render() {
+        if (!state.data) return;
+        const items = state.data.items || [];
+
+        document.getElementById('currency-value').textContent =
+            formatMoney(state.data.cash) + '¥';
+
+        const rerollBtn = document.getElementById('reroll-btn');
+        const rerollCost = state.data.reroll_cost || 0;
+        document.getElementById('reroll-cost-label').textContent = rerollCost + '¥';
+        rerollBtn.disabled = state.data.cash < rerollCost;
+
+        const counts = countItems(items);
+        document.getElementById('count-in-shop').textContent = counts.in_shop;
+        document.getElementById('count-owned').textContent = counts.owned;
+        document.getElementById('stat-shop').textContent = counts.in_shop;
+        document.getElementById('stat-owned').textContent = counts.owned;
+
+        const visible = items.filter(matchesFilters);
+        const grid = document.getElementById('items-grid');
+        const empty = document.getElementById('empty-state');
+        grid.innerHTML = '';
+
+        if (visible.length === 0) {
+            empty.classList.remove('hidden');
+            refreshDetailPanel();
+            return;
+        }
+        empty.classList.add('hidden');
+
+        // Split into Items vs TMs whenever both are visible and no specific
+        // category is selected. Keeps the Mart's familiar Items/TMs grouping
+        // inside the unified view, but collapses to a flat grid otherwise.
+        const itemEntries = visible.filter((i) => !i.is_tm);
+        const tmEntries = visible.filter((i) => i.is_tm);
+        const splitSections = state.category === 'all'
+            && itemEntries.length > 0
+            && tmEntries.length > 0;
+
+        if (splitSections) {
+            grid.appendChild(buildSectionHeader('Items', 'items', itemEntries.length));
+            itemEntries.forEach((item) => grid.appendChild(buildCard(item)));
+            grid.appendChild(buildSectionHeader('TMs', 'tms', tmEntries.length));
+            tmEntries.forEach((item) => grid.appendChild(buildCard(item)));
+        } else {
+            visible.forEach((item) => grid.appendChild(buildCard(item)));
+        }
+
+        refreshDetailPanel();
+    }
+
+    function buildSectionHeader(label, kind, count) {
+        const header = document.createElement('div');
+        header.className = 'shop-section-header inline';
+        header.innerHTML =
+            '<span class="shop-section-title ' + kind + '">' + label + '</span>' +
+            '<span class="shop-section-sub">' + count + ' ' +
+                (count === 1 ? 'entry' : 'entries') + '</span>';
+        return header;
+    }
+
+    function countItems(items) {
+        const counts = {all: items.length, in_shop: 0, owned: 0};
+        items.forEach((i) => {
+            if (i.in_shop) counts.in_shop++;
+            if ((i.owned_quantity || 0) > 0) counts.owned++;
+        });
+        return counts;
+    }
+
+    function matchesFilters(item) {
+        if (state.filter === 'in_shop' && !item.in_shop) return false;
+        if (state.filter === 'owned' && (item.owned_quantity || 0) <= 0) return false;
+        if (state.category !== 'all' && item.category !== state.category) return false;
+        if (state.search) {
+            const q = state.search.toLowerCase();
+            const hay = [
+                item.ui_name, item.name, item.move_type, item.category
+            ].filter(Boolean).join(' ').toLowerCase();
+            if (!hay.includes(q)) return false;
+        }
+        return true;
+    }
+
+    function cardStateClass(item) {
+        const inShop = item.in_shop;
+        const owned = (item.owned_quantity || 0) > 0;
+        if (inShop && owned) return 'in-shop-and-owned';
+        if (inShop) return 'in-shop-only';
+        if (owned) return 'owned-only';
+        return '';
+    }
+
+    // Returns {label, cls} or null. Tag is suppressed when the filter context
+    // already communicates everything (e.g. "OWNED" tag in the Bag filter).
+    function cardTagFor(item) {
+        if (item.is_tm) return {label: 'TM', cls: 'tm'};
+
+        const owned = (item.owned_quantity || 0) > 0;
+        const inShop = !!item.in_shop;
+
+        // Build the parts that aren't already implied by the active filter.
+        const parts = [];
+        let cls = '';
+        if (inShop && state.filter !== 'in_shop') {
+            parts.push('STOCK');
+            cls = owned ? 'in-shop-and-owned' : 'in-shop-only';
+        }
+        if (owned && state.filter !== 'owned') {
+            parts.push('OWNED');
+            if (!cls) cls = 'owned-only';
+        }
+        if (parts.length === 0) return null;  // category pill below carries it
+        return {label: parts.join(' · '), cls};
+    }
+
+    function buildCard(item) {
+        const card = document.createElement('div');
+        card.className = 'shop-card pokemon-card-equivalent';
+        const stateCls = cardStateClass(item);
+        if (stateCls) card.classList.add(stateCls);
+        if (item.is_tm && (item.owned_quantity || 0) > 0) card.classList.add('owned');
+        if (item.in_shop && state.data.cash < (item.price || 0) &&
+            (!item.is_tm || (item.owned_quantity || 0) === 0)) {
+            card.classList.add('unaffordable');
+        }
+        if (state.selected === item.name) card.classList.add('selected');
+
+        // Top-left tag — only show information the filter doesn't already imply.
+        const tag = document.createElement('div');
+        const tagText = cardTagFor(item);
+        if (tagText) {
+            tag.className = 'shop-card-tag ' + tagText.cls;
+            tag.textContent = tagText.label;
+            card.appendChild(tag);
+        }
+
+        // Top-right badges. TMs are binary (owned or not), so we surface a
+        // word "OWNED" instead of a redundant "x1" quantity.
+        const badges = document.createElement('div');
+        badges.className = 'shop-card-badges';
+        if ((item.owned_quantity || 0) > 0) {
+            const badge = document.createElement('span');
+            if (item.is_tm) {
+                badge.className = 'shop-card-badge owned';
+                badge.textContent = 'OWNED';
+            } else {
+                badge.className = 'shop-card-badge qty';
+                badge.textContent = 'x' + item.owned_quantity;
+            }
+            badges.appendChild(badge);
+        }
+        card.appendChild(badges);
+
+        // Sprite
+        const spriteWrap = document.createElement('div');
+        spriteWrap.className = 'shop-card-sprite';
+        const img = document.createElement('img');
+        img.src = item.image_url || '';
+        img.alt = item.ui_name || item.name;
+        img.onerror = () => { img.style.opacity = '0.25'; };
+        spriteWrap.appendChild(img);
+        card.appendChild(spriteWrap);
+
+        // Name
+        const name = document.createElement('div');
+        name.className = 'shop-card-name';
+        name.textContent = item.ui_name || item.name;
+        card.appendChild(name);
+
+        // Tags row: TM type + category
+        const tagsRow = document.createElement('div');
+        tagsRow.className = 'shop-card-tags-row';
+        if (item.is_tm && item.move_type) {
+            const t = document.createElement('span');
+            t.className = 'mini-type';
+            t.textContent = item.move_type;
+            t.style.background = TYPE_COLORS[item.move_type.toLowerCase()] || 'var(--border-main)';
+            tagsRow.appendChild(t);
+        } else if (CATEGORY_LABELS[item.category]) {
+            const c = document.createElement('span');
+            c.className = 'cat-pill';
+            c.textContent = CATEGORY_LABELS[item.category];
+            tagsRow.appendChild(c);
+        }
+        card.appendChild(tagsRow);
+
+        // Price pill (only if in_shop)
+        if (item.in_shop) {
+            const price = document.createElement('div');
+            price.className = 'shop-card-price-pill';
+            price.textContent = formatMoney(item.price || 0) + '¥';
+            card.appendChild(price);
+        }
+
+        card.addEventListener('click', () => selectItem(item.name));
+        return card;
+    }
+
+    function formatMoney(n) {
+        return (n || 0).toLocaleString();
+    }
+
+    // ---------- Detail panel ----------
+    function selectItem(name) {
+        state.selected = name;
+        render();
+    }
+
+    function refreshDetailPanel() {
+        const placeholder = document.getElementById('detail-placeholder');
+        const content = document.getElementById('detail-content');
+        const closeBtn = document.getElementById('close-detail');
+
+        if (!state.selected) {
+            placeholder.classList.remove('hidden');
+            content.classList.add('hidden');
+            closeBtn.classList.add('hidden');
+            return;
+        }
+
+        const item = (state.data.items || []).find((i) => i.name === state.selected);
+        if (!item) {
+            state.selected = null;
+            placeholder.classList.remove('hidden');
+            content.classList.add('hidden');
+            closeBtn.classList.add('hidden');
+            return;
+        }
+
+        placeholder.classList.add('hidden');
+        content.classList.remove('hidden');
+        closeBtn.classList.remove('hidden');
+        renderDetail(item);
+    }
+
+    function renderDetail(item) {
+        document.getElementById('det-id').textContent =
+            item.is_tm ? 'TM' : (CATEGORY_LABELS[item.category] || 'ITEM').toUpperCase();
+        document.getElementById('det-name').textContent = item.ui_name || item.name;
+
+        const statusRow = document.getElementById('det-status-row');
+        statusRow.innerHTML = '';
+
+        if (item.in_shop) {
+            const p = document.createElement('span');
+            p.className = 'det-pill price';
+            p.textContent = formatMoney(item.price || 0) + '¥';
+            statusRow.appendChild(p);
+        }
+        if ((item.owned_quantity || 0) > 0) {
+            const o = document.createElement('span');
+            o.className = 'det-pill owned';
+            o.textContent = item.is_tm ? 'Owned' : 'Owned x' + item.owned_quantity;
+            statusRow.appendChild(o);
+        }
+        if (item.is_tm && item.move_type) {
+            const t = document.createElement('span');
+            t.className = 'det-pill move-type';
+            t.textContent = item.move_type;
+            t.style.background = TYPE_COLORS[item.move_type.toLowerCase()] || 'var(--border-main)';
+            statusRow.appendChild(t);
+        }
+
+        const sprite = document.getElementById('det-sprite');
+        sprite.src = item.image_url || '';
+        sprite.alt = item.ui_name || item.name;
+
+        const glow = document.getElementById('det-glow');
+        const glowColor = item.is_tm && item.move_type
+            ? (TYPE_COLORS[item.move_type.toLowerCase()] || '#58a6ff')
+            : (item.in_shop ? '#d29922' : '#3fb950');
+        glow.style.background = `radial-gradient(circle, ${glowColor}55, transparent 70%)`;
+
+        document.getElementById('det-description').textContent =
+            item.description || 'No description available.';
+
+        // Move stats (TMs)
+        const moveSection = document.getElementById('det-move-section');
+        const moveStats = document.getElementById('det-move-stats');
+        moveStats.innerHTML = '';
+        if (item.is_tm && (item.move_power || item.move_accuracy || item.move_pp)) {
+            moveSection.classList.remove('hidden');
+            const rows = [
+                {label: 'Power', value: item.move_power, max: 250},
+                {label: 'Accuracy', value: item.move_accuracy, max: 100},
+                {label: 'PP', value: item.move_pp, max: 40},
+            ];
+            if (item.move_damage_class) {
+                rows.push({label: 'Category', value: item.move_damage_class, max: null});
+            }
+            rows.forEach((row) => {
+                if (row.value === null || row.value === undefined || row.value === '') return;
+                moveStats.appendChild(buildStatRow(row));
+            });
+            setTimeout(() => {
+                moveStats.querySelectorAll('.stat-bar-fill').forEach((el) => {
+                    el.style.width = el.dataset.targetWidth || '0%';
+                });
+            }, 50);
+        } else {
+            moveSection.classList.add('hidden');
+        }
+
+        // Actions
+        const actions = document.getElementById('det-actions');
+        actions.innerHTML = '';
+        const hint = document.getElementById('det-hint');
+        hint.textContent = '';
+        hint.className = 'affordability-hint';
+
+        const ownedQty = item.owned_quantity || 0;
+        const blockedTm = item.is_tm && ownedQty > 0;
+        const unaffordable = state.data.cash < (item.price || 0);
+
+        if (item.in_shop) {
+            const buy = document.createElement('button');
+            buy.className = 'det-action-btn buy';
+            if (blockedTm) {
+                buy.disabled = true;
+                buy.innerHTML = '<span>Already Owned</span>';
+            } else if (unaffordable) {
+                buy.disabled = true;
+                buy.innerHTML = '<span>Buy</span><span class="det-action-meta">Not Enough ¥</span>';
+            } else {
+                buy.innerHTML = '<span>Buy</span><span class="det-action-meta">' + formatMoney(item.price || 0) + '¥</span>';
+                buy.onclick = () => onBuy(item);
+            }
+            actions.appendChild(buy);
+        }
+
+        if (ownedQty > 0 && !item.is_tm) {
+            const use = document.createElement('button');
+            use.className = 'det-action-btn use';
+            const label = useLabelFor(item);
+            use.innerHTML = '<span>' + label + '</span><span class="det-action-meta">x' + ownedQty + '</span>';
+            use.onclick = () => onUse(item);
+            actions.appendChild(use);
+        }
+
+        if (actions.childElementCount === 0) {
+            hint.textContent = 'Nothing to do for this item right now.';
+        } else if (item.in_shop && unaffordable && !blockedTm) {
+            const shortBy = (item.price || 0) - state.data.cash;
+            hint.textContent = `Need ${formatMoney(shortBy)}¥ more to buy.`;
+            hint.classList.add('error');
+        } else if (item.in_shop && !blockedTm) {
+            const after = state.data.cash - (item.price || 0);
+            hint.textContent = `Balance after buy: ${formatMoney(after)}¥`;
+        }
+    }
+
+    function useLabelFor(item) {
+        switch (item.category) {
+            case 'heal': return 'Use on Active Pokémon';
+            case 'fossil': return 'Revive Fossil';
+            case 'pokeball': return 'Throw at Wild Pokémon';
+            case 'evolution': return 'Evolve a Pokémon';
+            default: return 'Give to a Pokémon';
+        }
+    }
+
+    function buildStatRow({label, value, max}) {
+        const row = document.createElement('div');
+        row.className = 'stat-item';
+        const labelEl = document.createElement('div');
+        labelEl.className = 'stat-label';
+        const lbl = document.createElement('span');
+        lbl.textContent = label;
+        const val = document.createElement('span');
+        val.className = 'stat-val';
+        val.textContent = value;
+        labelEl.appendChild(lbl);
+        labelEl.appendChild(val);
+        row.appendChild(labelEl);
+
+        if (max !== null && typeof value === 'number') {
+            const bg = document.createElement('div');
+            bg.className = 'stat-bar-bg';
+            const fill = document.createElement('div');
+            fill.className = 'stat-bar-fill';
+            const pct = Math.max(0, Math.min(100, (value / max) * 100));
+            fill.dataset.targetWidth = pct + '%';
+            bg.appendChild(fill);
+            row.appendChild(bg);
+        }
+        return row;
+    }
+
+    // ---------- Actions ----------
+    function onBuy(item) {
+        if (!bridge) return;
+        bridge.buy(item.name, !!item.is_tm, function (result) {
+            if (!result) return;
+            showToast(result.message || (result.ok ? 'Purchased!' : 'Purchase failed.'), !result.ok);
+        });
+    }
+
+    function onUse(item) {
+        if (!bridge) return;
+        bridge.useItem(item.name, function (result) {
+            if (!result) return;
+            if (result.message) showToast(result.message, !result.ok);
+        });
+    }
+
+    function onReroll() {
+        if (!bridge) return;
+        bridge.reroll(function (result) {
+            if (!result) return;
+            showToast(result.message || (result.ok ? 'Stock rerolled!' : 'Reroll failed.'), !result.ok);
+        });
+    }
+
+    function showToast(message, isError) {
+        if (!message) return;
+        const toast = document.getElementById('toast');
+        toast.textContent = message;
+        toast.classList.toggle('error', !!isError);
+        toast.classList.add('visible');
+        clearTimeout(toast._timer);
+        toast._timer = setTimeout(() => toast.classList.remove('visible'), 2400);
+    }
+
+    // ---------- UI plumbing ----------
+    function bindUI() {
+        document.querySelectorAll('.nav-item[data-filter]').forEach((btn) => {
+            btn.addEventListener('click', () => {
+                document.querySelectorAll('.nav-item[data-filter]').forEach((b) =>
+                    b.classList.remove('active'));
+                btn.classList.add('active');
+                state.filter = btn.dataset.filter;
+                render();
+            });
+        });
+
+        document.querySelectorAll('.nav-item[data-category]').forEach((btn) => {
+            btn.addEventListener('click', () => {
+                document.querySelectorAll('.nav-item[data-category]').forEach((b) =>
+                    b.classList.remove('active'));
+                btn.classList.add('active');
+                state.category = btn.dataset.category;
+                render();
+            });
+        });
+
+        const searchInput = document.getElementById('shop-search');
+        const clearBtn = document.getElementById('clear-search');
+        searchInput.addEventListener('input', (e) => {
+            state.search = e.target.value.trim();
+            clearBtn.classList.toggle('hidden', !state.search);
+            render();
+        });
+        clearBtn.addEventListener('click', () => {
+            searchInput.value = '';
+            state.search = '';
+            clearBtn.classList.add('hidden');
+            render();
+        });
+
+        document.getElementById('reroll-btn').addEventListener('click', openRerollConfirm);
+        document.getElementById('confirm-cancel').addEventListener('click', closeConfirm);
+        document.getElementById('confirm-modal').addEventListener('click', (e) => {
+            if (e.target.classList.contains('confirm-backdrop')) closeConfirm();
+        });
+        document.getElementById('confirm-ok').addEventListener('click', () => {
+            closeConfirm();
+            onReroll();
+        });
+
+        document.getElementById('close-detail').addEventListener('click', () => {
+            state.selected = null;
+            render();
+        });
+
+        document.addEventListener('keydown', (e) => {
+            if (e.key === 'Escape') {
+                const modal = document.getElementById('confirm-modal');
+                if (!modal.classList.contains('hidden')) {
+                    closeConfirm();
+                } else if (state.selected) {
+                    state.selected = null;
+                    render();
+                }
+            } else if (e.key === '/' && document.activeElement !== searchInput) {
+                e.preventDefault();
+                searchInput.focus();
+            } else if (e.key === 'Enter') {
+                const modal = document.getElementById('confirm-modal');
+                if (!modal.classList.contains('hidden')) {
+                    const ok = document.getElementById('confirm-ok');
+                    if (!ok.disabled) ok.click();
+                }
+            }
+        });
+    }
+
+    function openRerollConfirm() {
+        if (!state.data) return;
+        const cost = state.data.reroll_cost || 0;
+        const after = (state.data.cash || 0) - cost;
+        const insufficient = after < 0;
+
+        document.getElementById('confirm-cost').textContent = formatMoney(cost) + '¥';
+        const balance = document.getElementById('confirm-balance');
+        document.getElementById('confirm-balance-value').textContent = formatMoney(after) + '¥';
+        balance.classList.toggle('insufficient', insufficient);
+
+        const okBtn = document.getElementById('confirm-ok');
+        okBtn.disabled = insufficient;
+        okBtn.textContent = insufficient ? 'Not Enough ¥' : 'Confirm Reroll';
+
+        document.getElementById('confirm-modal').classList.remove('hidden');
+    }
+
+    function closeConfirm() {
+        document.getElementById('confirm-modal').classList.add('hidden');
+    }
+
+    // Nav switcher
+    function bindNavSwitcher() {
+        const trigger = document.getElementById('nav-trigger');
+        const menu = document.getElementById('nav-menu');
+
+        function openMenu() {
+            menu.classList.remove('hidden');
+            trigger.setAttribute('aria-expanded', 'true');
+        }
+        function closeMenu() {
+            menu.classList.add('hidden');
+            trigger.setAttribute('aria-expanded', 'false');
+        }
+
+        trigger.addEventListener('click', (e) => {
+            e.stopPropagation();
+            menu.classList.contains('hidden') ? openMenu() : closeMenu();
+        });
+        document.addEventListener('click', (e) => {
+            if (!menu.classList.contains('hidden') &&
+                !menu.contains(e.target) && e.target !== trigger) {
+                closeMenu();
+            }
+        });
+        document.addEventListener('keydown', (e) => {
+            if (e.key === 'Escape' && !menu.classList.contains('hidden')) closeMenu();
+        });
+        menu.querySelectorAll('.nav-menu-item[data-screen]').forEach((item) => {
+            item.addEventListener('click', () => {
+                const screen = item.dataset.screen;
+                closeMenu();
+                if (screen === 'items') return;
+                if (!bridge) return;
+                if (screen === 'ankidex' && bridge.openAnkidex) bridge.openAnkidex();
+            });
+        });
+    }
+
+    document.addEventListener('DOMContentLoaded', () => {
+        bindUI();
+        bindNavSwitcher();
+        initChannel(() => {});
+    });
+})();

--- a/src/Ankimon/ankimon_items_web/shop.js
+++ b/src/Ankimon/ankimon_items_web/shop.js
@@ -190,19 +190,24 @@
         }
 
         // Top-right badges. TMs are binary (owned or not), so we surface a
-        // word "OWNED" instead of a redundant "x1" quantity.
+        // word "OWNED" instead of a redundant "x1" quantity — and suppress
+        // it entirely in the Bag view where every visible card is owned.
         const badges = document.createElement('div');
         badges.className = 'shop-card-badges';
         if ((item.owned_quantity || 0) > 0) {
-            const badge = document.createElement('span');
             if (item.is_tm) {
-                badge.className = 'shop-card-badge owned';
-                badge.textContent = 'OWNED';
+                if (state.filter !== 'owned') {
+                    const badge = document.createElement('span');
+                    badge.className = 'shop-card-badge owned';
+                    badge.textContent = 'OWNED';
+                    badges.appendChild(badge);
+                }
             } else {
+                const badge = document.createElement('span');
                 badge.className = 'shop-card-badge qty';
                 badge.textContent = 'x' + item.owned_quantity;
+                badges.appendChild(badge);
             }
-            badges.appendChild(badge);
         }
         card.appendChild(badges);
 

--- a/src/Ankimon/ankimon_items_web/shop.js
+++ b/src/Ankimon/ankimon_items_web/shop.js
@@ -45,10 +45,32 @@
         });
     }
 
+    function preloadImages(urls, callback) {
+        if (!urls || urls.length === 0) {
+            callback();
+            return;
+        }
+        let loaded = 0;
+        const target = urls.length;
+        urls.forEach((url) => {
+            const img = new Image();
+            img.onload = img.onerror = () => {
+                loaded++;
+                if (loaded === target) {
+                    callback();
+                }
+            };
+            img.src = url;
+        });
+    }
+
     // Entry from Python
     window.initializeItems = function (data) {
         state.data = data;
-        render();
+        const urls = (data.items || []).map((i) => i.image_url).filter(Boolean);
+        preloadImages(urls, function () {
+            render();
+        });
     };
 
     // ---------- Rendering ----------
@@ -82,32 +104,74 @@
         }
         empty.classList.add('hidden');
 
-        // Build the new content off-DOM in a DocumentFragment, then swap it
-        // in atomically with replaceChildren. Avoids the empty-grid flash
-        // and the per-appendChild reflow cascade that the old
-        // innerHTML='' + sequential appendChild loop caused on every
-        // buy/use/reroll refresh.
-        const frag = document.createDocumentFragment();
+        // Keyed DOM Reconciliation to completely eliminate visual flicker:
+        // Instead of destroying and rebuilding all card DOM elements (which
+        // destroys <img> instances and triggers asynchronous image-decoding layout passes),
+        // we map existing cards by their item name and update/reorder them in-place.
+        const existingCards = Array.from(grid.querySelectorAll('.shop-card'));
+        const cardMap = new Map();
+        existingCards.forEach(card => {
+            const name = card.getAttribute('data-item-name');
+            if (name) cardMap.set(name, card);
+        });
 
-        // Split into Items vs TMs whenever both are visible and no specific
-        // category is selected. Keeps the Mart's familiar Items/TMs grouping
-        // inside the unified view, but collapses to a flat grid otherwise.
         const itemEntries = visible.filter((i) => !i.is_tm);
         const tmEntries = visible.filter((i) => i.is_tm);
         const splitSections = state.category === 'all'
             && itemEntries.length > 0
             && tmEntries.length > 0;
 
+        const targetElements = [];
+
         if (splitSections) {
-            frag.appendChild(buildSectionHeader('Items', 'items', itemEntries.length));
-            itemEntries.forEach((item) => frag.appendChild(buildCard(item)));
-            frag.appendChild(buildSectionHeader('TMs', 'tms', tmEntries.length));
-            tmEntries.forEach((item) => frag.appendChild(buildCard(item)));
+            targetElements.push({type: 'header', kind: 'items', label: 'Items', count: itemEntries.length});
+            itemEntries.forEach((item) => targetElements.push({type: 'card', item}));
+            targetElements.push({type: 'header', kind: 'tms', label: 'TMs', count: tmEntries.length});
+            tmEntries.forEach((item) => targetElements.push({type: 'card', item}));
         } else {
-            visible.forEach((item) => frag.appendChild(buildCard(item)));
+            visible.forEach((item) => targetElements.push({type: 'card', item}));
         }
 
-        grid.replaceChildren(frag);
+        const elementsList = targetElements.map(target => {
+            if (target.type === 'card') {
+                const existing = cardMap.get(target.item.name);
+                if (existing) {
+                    updateCard(existing, target.item);
+                    return existing;
+                } else {
+                    return buildCard(target.item);
+                }
+            } else {
+                // Find existing header or create a new one
+                let headerEl = grid.querySelector(`.shop-section-header .shop-section-title.${target.kind}`);
+                if (headerEl) {
+                    headerEl = headerEl.closest('.shop-section-header');
+                    const countEl = headerEl.querySelector('.shop-section-sub');
+                    if (countEl) {
+                        countEl.textContent = target.count + ' ' + (target.count === 1 ? 'entry' : 'entries');
+                    }
+                    return headerEl;
+                } else {
+                    return buildSectionHeader(target.label, target.kind, target.count);
+                }
+            }
+        });
+
+        // Remove obsolete elements
+        const activeSet = new Set(elementsList);
+        Array.from(grid.childNodes).forEach(node => {
+            if (!activeSet.has(node)) {
+                node.remove();
+            }
+        });
+
+        // Order elements in the grid in-place
+        elementsList.forEach((el, index) => {
+            if (grid.childNodes[index] !== el) {
+                grid.insertBefore(el, grid.childNodes[index] || null);
+            }
+        });
+
         refreshDetailPanel();
     }
 
@@ -176,9 +240,87 @@
         return {label: parts.join(' · '), cls};
     }
 
+    function updateCard(card, item) {
+        // Reset and update class list
+        card.className = 'shop-card pokemon-card-equivalent';
+        const stateCls = cardStateClass(item);
+        if (stateCls) card.classList.add(stateCls);
+        if (item.is_tm && (item.owned_quantity || 0) > 0) card.classList.add('owned');
+        if (item.in_shop && state.data.cash < (item.price || 0) &&
+            (!item.is_tm || (item.owned_quantity || 0) === 0)) {
+            card.classList.add('unaffordable');
+        }
+        if (state.selected === item.name) card.classList.add('selected');
+
+        // Update tag
+        let tag = card.querySelector('.shop-card-tag');
+        const tagText = cardTagFor(item);
+        if (tagText) {
+            if (!tag) {
+                tag = document.createElement('div');
+                card.insertBefore(tag, card.firstChild);
+            }
+            tag.className = 'shop-card-tag ' + tagText.cls;
+            tag.textContent = tagText.label;
+        } else if (tag) {
+            tag.remove();
+        }
+
+        // Update badges
+        let badges = card.querySelector('.shop-card-badges');
+        if (!badges) {
+            badges = document.createElement('div');
+            badges.className = 'shop-card-badges';
+            const refNode = card.querySelector('.shop-card-tag') ? card.querySelector('.shop-card-tag').nextSibling : card.firstChild;
+            card.insertBefore(badges, refNode);
+        }
+        badges.innerHTML = '';
+        if ((item.owned_quantity || 0) > 0) {
+            if (item.is_tm) {
+                if (state.filter !== 'owned') {
+                    const badge = document.createElement('span');
+                    badge.className = 'shop-card-badge owned';
+                    badge.textContent = 'OWNED';
+                    badges.appendChild(badge);
+                }
+            } else {
+                const badge = document.createElement('span');
+                badge.className = 'shop-card-badge qty';
+                badge.textContent = 'x' + item.owned_quantity;
+                badges.appendChild(badge);
+            }
+        }
+
+        // Update sprite src if different (preserves img DOM instance to avoid flickering)
+        const img = card.querySelector('.shop-card-sprite img');
+        if (img && img.getAttribute('src') !== (item.image_url || '')) {
+            img.src = item.image_url || '';
+        }
+
+        // Update name
+        const nameEl = card.querySelector('.shop-card-name');
+        if (nameEl) {
+            nameEl.textContent = item.ui_name || item.name;
+        }
+
+        // Update price pill
+        let priceEl = card.querySelector('.shop-card-price-pill');
+        if (item.in_shop) {
+            if (!priceEl) {
+                priceEl = document.createElement('div');
+                priceEl.className = 'shop-card-price-pill';
+                card.appendChild(priceEl);
+            }
+            priceEl.textContent = formatMoney(item.price || 0) + '¥';
+        } else if (priceEl) {
+            priceEl.remove();
+        }
+    }
+
     function buildCard(item) {
         const card = document.createElement('div');
         card.className = 'shop-card pokemon-card-equivalent';
+        card.setAttribute('data-item-name', item.name);
         const stateCls = cardStateClass(item);
         if (stateCls) card.classList.add(stateCls);
         if (item.is_tm && (item.owned_quantity || 0) > 0) card.classList.add('owned');
@@ -223,6 +365,7 @@
         const spriteWrap = document.createElement('div');
         spriteWrap.className = 'shop-card-sprite';
         const img = document.createElement('img');
+        img.decoding = 'sync';
         img.src = item.image_url || '';
         img.alt = item.ui_name || item.name;
         img.onerror = () => { img.style.opacity = '0.25'; };
@@ -441,12 +584,13 @@
         labelEl.appendChild(val);
         row.appendChild(labelEl);
 
-        if (max !== null && typeof value === 'number') {
+        if (max !== null) {
             const bg = document.createElement('div');
             bg.className = 'stat-bar-bg';
             const fill = document.createElement('div');
             fill.className = 'stat-bar-fill';
-            const pct = Math.max(0, Math.min(100, (value / max) * 100));
+            const numVal = typeof value === 'number' ? value : 0;
+            const pct = Math.max(0, Math.min(100, (numVal / max) * 100));
             fill.dataset.targetWidth = pct + '%';
             bg.appendChild(fill);
             row.appendChild(bg);

--- a/src/Ankimon/ankimon_items_web/shop_obj.py
+++ b/src/Ankimon/ankimon_items_web/shop_obj.py
@@ -12,6 +12,7 @@ from datetime import datetime
 from aqt import QDialog, QVBoxLayout, QWebEngineView, mw
 from aqt.qt import Qt, QUrl, QFrame
 from PyQt6.QtCore import QObject, pyqtSlot
+from PyQt6.QtGui import QColor
 from PyQt6.QtWebChannel import QWebChannel
 
 import csv
@@ -107,6 +108,9 @@ class AnkimonItemsWeb(QDialog):
         # Suppress the QtWebEngine browser-style right-click menu (Inspect,
         # Reload, etc.) — irrelevant noise in a game UI.
         self.webview.setContextMenuPolicy(Qt.ContextMenuPolicy.NoContextMenu)
+        # Paint the underlying webview page dark so the user doesn't see a
+        # white flash between window-show and HTML/CSS first paint.
+        self.webview.page().setBackgroundColor(QColor("#0d1117"))
         frame.layout().addWidget(self.webview)
 
         self.channel = QWebChannel(self.webview)

--- a/src/Ankimon/ankimon_items_web/shop_obj.py
+++ b/src/Ankimon/ankimon_items_web/shop_obj.py
@@ -104,6 +104,9 @@ class AnkimonItemsWeb(QDialog):
         layout.addWidget(frame)
 
         self.webview = QWebEngineView()
+        # Suppress the QtWebEngine browser-style right-click menu (Inspect,
+        # Reload, etc.) — irrelevant noise in a game UI.
+        self.webview.setContextMenuPolicy(Qt.ContextMenuPolicy.NoContextMenu)
         frame.layout().addWidget(self.webview)
 
         self.channel = QWebChannel(self.webview)

--- a/src/Ankimon/ankimon_items_web/shop_obj.py
+++ b/src/Ankimon/ankimon_items_web/shop_obj.py
@@ -4,6 +4,7 @@ The same QWebEngineView swaps between two screens by changing its URL. No
 window close/open flicker; the dropdown switcher in either screen calls back
 through QWebChannel to swap content in place.
 """
+
 import json
 import random
 from datetime import datetime
@@ -20,8 +21,8 @@ from ..resources import items_path, csv_file_items_cost, csv_file_descriptions
 from ..functions.pokedex_functions import find_details_move
 
 
-SCREEN_ITEMS = 'items'
-SCREEN_ANKIDEX = 'ankidex'
+SCREEN_ITEMS = "items"
+SCREEN_ANKIDEX = "ankidex"
 
 
 class NavBridge(QObject):
@@ -47,19 +48,19 @@ class ItemsBridge(QObject):
         super().__init__()
         self._w = window
 
-    @pyqtSlot(str, bool, result='QVariant')
+    @pyqtSlot(str, bool, result="QVariant")
     def buy(self, item_name, is_tm):
         result = self._w.handle_buy(item_name, bool(is_tm))
         self._w.push_screen_data()
         return result
 
-    @pyqtSlot(result='QVariant')
+    @pyqtSlot(result="QVariant")
     def reroll(self):
         result = self._w.handle_reroll()
         self._w.push_screen_data()
         return result
 
-    @pyqtSlot(str, result='QVariant')
+    @pyqtSlot(str, result="QVariant")
     def useItem(self, item_name):
         result = self._w.handle_use(item_name)
         self._w.push_screen_data()
@@ -108,8 +109,8 @@ class AnkimonItemsWeb(QDialog):
         self.channel = QWebChannel(self.webview)
         self.bridge = ItemsBridge(self)
         self.nav = NavBridge(self)
-        self.channel.registerObject('bridge', self.bridge)
-        self.channel.registerObject('nav', self.nav)
+        self.channel.registerObject("bridge", self.bridge)
+        self.channel.registerObject("nav", self.nav)
         self.webview.page().setWebChannel(self.channel)
 
         self.webview.loadFinished.connect(self._on_load_finished)
@@ -159,6 +160,7 @@ class AnkimonItemsWeb(QDialog):
         # Reuse the existing Ankidex singleton's data getter — keeps the
         # dex query logic in one place.
         from ..singletons import get_ankidex_window
+
         ankidex = get_ankidex_window()
         return ankidex.get_ankidex_data()
 
@@ -167,6 +169,7 @@ class AnkimonItemsWeb(QDialog):
             if state and isinstance(state, dict):
                 for key, val in state.items():
                     mw.settings_obj.set(f"ankidex.{key}", val)
+
         self.webview.page().runJavaScript(
             "if (window.getAnkidexState) window.getAnkidexState();",
             on_state_ready,
@@ -192,7 +195,9 @@ class AnkimonItemsWeb(QDialog):
     # ------------------------------------------------------------------
     def update_ui_data(self):
         data = self.get_inventory_data()
-        js_code = f"if (window.initializeItems) window.initializeItems({json.dumps(data)});"
+        js_code = (
+            f"if (window.initializeItems) window.initializeItems({json.dumps(data)});"
+        )
         self.webview.page().runJavaScript(js_code)
 
     def get_inventory_data(self):
@@ -246,14 +251,16 @@ class AnkimonItemsWeb(QDialog):
                 (shop_entry or {}).get("is_tm")
                 or (owned_entry or {}).get("category_id") == 37
             )
-            items.append(self._serialize_item(
-                name=name,
-                is_tm=is_tm,
-                in_shop=bool(shop_entry),
-                shop_price=(shop_entry or {}).get("price"),
-                item_type=(shop_entry or {}).get("item_type"),
-                owned_quantity=(owned_entry or {}).get("quantity", 0),
-            ))
+            items.append(
+                self._serialize_item(
+                    name=name,
+                    is_tm=is_tm,
+                    in_shop=bool(shop_entry),
+                    shop_price=(shop_entry or {}).get("price"),
+                    item_type=(shop_entry or {}).get("item_type"),
+                    owned_quantity=(owned_entry or {}).get("quantity", 0),
+                )
+            )
 
         return {
             "cash": int(sm.get_callback("trainer.cash") or 0),
@@ -261,7 +268,9 @@ class AnkimonItemsWeb(QDialog):
             "items": items,
         }
 
-    def _serialize_item(self, name, is_tm, in_shop, shop_price, item_type, owned_quantity):
+    def _serialize_item(
+        self, name, is_tm, in_shop, shop_price, item_type, owned_quantity
+    ):
         ui_name = name.replace("-", " ").title()
         entry = {
             "name": name,
@@ -294,8 +303,9 @@ class AnkimonItemsWeb(QDialog):
             entry["image_url"] = QUrl.fromLocalFile(
                 str(items_path / f"{name}.png")
             ).toString()
-            entry["description"] = self._lookup_description(name) \
-                or f"A useful item: {ui_name}"
+            entry["description"] = (
+                self._lookup_description(name) or f"A useful item: {ui_name}"
+            )
 
         return entry
 
@@ -419,15 +429,21 @@ class AnkimonItemsWeb(QDialog):
         sm.set_callback("trainer.cash", int(cash - cost))
 
         from ..pyobj.ankimon_shop import DAILY_ITEMS_POOL
+
         random.seed()
-        sm.todays_daily_items = random.sample(DAILY_ITEMS_POOL, sm.number_of_daily_items)
+        sm.todays_daily_items = random.sample(
+            DAILY_ITEMS_POOL, sm.number_of_daily_items
+        )
         sm.todays_daily_tms = random.sample(sm.get_tm_pool(), sm.number_of_daily_items)
 
-        mw.ankimon_db.set_user_data("todays_shop", {
-            "items": sm.todays_daily_items,
-            "technical_machines": sm.todays_daily_tms,
-            "date": datetime.now().strftime("%Y-%m-%d"),
-        })
+        mw.ankimon_db.set_user_data(
+            "todays_shop",
+            {
+                "items": sm.todays_daily_items,
+                "technical_machines": sm.todays_daily_tms,
+                "date": datetime.now().strftime("%Y-%m-%d"),
+            },
+        )
 
         return {"ok": True, "message": f"Rerolled stock for {cost}¥"}
 
@@ -448,4 +464,3 @@ class AnkimonItemsWeb(QDialog):
             if entry["name"] == item_name:
                 return entry
         return None
-

--- a/src/Ankimon/ankimon_items_web/shop_obj.py
+++ b/src/Ankimon/ankimon_items_web/shop_obj.py
@@ -84,7 +84,9 @@ class AnkimonItemsWeb(QDialog):
         self.current_screen = None
         self.setWindowTitle("Ankimon")
 
-        self.setAttribute(Qt.WidgetAttribute.WA_TranslucentBackground)
+        # Disabled WA_TranslucentBackground to prevent heavy window-level repaint
+        # flickering under Windows DWM when QWebEngineView re-composes or updates.
+        # self.setAttribute(Qt.WidgetAttribute.WA_TranslucentBackground)
         self.setWindowFlags(
             self.windowFlags()
             | Qt.WindowType.WindowMaximizeButtonHint
@@ -299,7 +301,8 @@ class AnkimonItemsWeb(QDialog):
             )
             entry["move_type"] = move_type
             entry["move_power"] = self._coerce_int(move.get("basePower"))
-            entry["move_accuracy"] = self._coerce_int(move.get("accuracy"))
+            accuracy = move.get("accuracy")
+            entry["move_accuracy"] = "—" if accuracy is True else self._coerce_int(accuracy)
             entry["move_pp"] = self._coerce_int(move.get("pp"))
             entry["move_damage_class"] = (move.get("category") or "").title() or None
         else:
@@ -391,6 +394,8 @@ class AnkimonItemsWeb(QDialog):
     def _coerce_int(value):
         try:
             if value in (None, "", "—"):
+                return None
+            if isinstance(value, bool):
                 return None
             return int(value)
         except (TypeError, ValueError):

--- a/src/Ankimon/ankimon_items_web/shop_obj.py
+++ b/src/Ankimon/ankimon_items_web/shop_obj.py
@@ -123,22 +123,26 @@ class AnkimonItemsWeb(QDialog):
     # Screen switching
     # ------------------------------------------------------------------
     def load_screen(self, screen):
-        # Save Ankidex prefs before navigating away (preserves the in-page
-        # state the user toggled — view mode, sort, etc.)
-        if self.current_screen == SCREEN_ANKIDEX and screen != SCREEN_ANKIDEX:
-            self._save_ankidex_prefs()
+        def do_load():
+            self.current_screen = screen
+            if screen == SCREEN_ITEMS:
+                path = self.addon_dir / "ankimon_items_web" / "shop.html"
+                title = "Ankimon — Items"
+            elif screen == SCREEN_ANKIDEX:
+                path = self.addon_dir / "ankidex" / "ankidex.html"
+                title = "Ankimon — Ankidex"
+            else:
+                return
+            self.setWindowTitle(title)
+            self.webview.setUrl(QUrl.fromLocalFile(path.as_posix()))
 
-        self.current_screen = screen
-        if screen == SCREEN_ITEMS:
-            path = self.addon_dir / "ankimon_items_web" / "shop.html"
-            title = "Ankimon — Items"
-        elif screen == SCREEN_ANKIDEX:
-            path = self.addon_dir / "ankidex" / "ankidex.html"
-            title = "Ankimon — Ankidex"
+        # Save Ankidex prefs before navigating away — defer the URL change
+        # until the async getAnkidexState() callback fires, otherwise the JS
+        # context tears down before prefs are read.
+        if self.current_screen == SCREEN_ANKIDEX and screen != SCREEN_ANKIDEX:
+            self._save_ankidex_prefs(callback=do_load)
         else:
-            return
-        self.setWindowTitle(title)
-        self.webview.setUrl(QUrl.fromLocalFile(path.as_posix()))
+            do_load()
 
     def _on_load_finished(self, ok):
         if not ok:
@@ -164,12 +168,13 @@ class AnkimonItemsWeb(QDialog):
         ankidex = get_ankidex_window()
         return ankidex.get_ankidex_data()
 
-    def _save_ankidex_prefs(self):
+    def _save_ankidex_prefs(self, callback=None):
         def on_state_ready(state):
             if state and isinstance(state, dict):
                 for key, val in state.items():
                     mw.settings_obj.set(f"ankidex.{key}", val)
-
+            if callback:
+                callback()
         self.webview.page().runJavaScript(
             "if (window.getAnkidexState) window.getAnkidexState();",
             on_state_ready,
@@ -189,16 +194,6 @@ class AnkimonItemsWeb(QDialog):
     # Back-compat alias for the bridge methods that still call update_ui_data.
     def update_ui_data(self):
         self.push_screen_data()
-
-    # ------------------------------------------------------------------
-    # Data push (Python → JS)
-    # ------------------------------------------------------------------
-    def update_ui_data(self):
-        data = self.get_inventory_data()
-        js_code = (
-            f"if (window.initializeItems) window.initializeItems({json.dumps(data)});"
-        )
-        self.webview.page().runJavaScript(js_code)
 
     def get_inventory_data(self):
         sm = self.shop_manager
@@ -426,24 +421,26 @@ class AnkimonItemsWeb(QDialog):
         if cash < cost:
             return {"ok": False, "message": "Not enough money to reroll."}
 
-        sm.set_callback("trainer.cash", int(cash - cost))
-
+        # Compute new stock + write to DB first; only deduct cash once the
+        # write succeeds. Otherwise a DB failure could swallow the reroll
+        # cost with nothing to show for it.
         from ..pyobj.ankimon_shop import DAILY_ITEMS_POOL
 
         random.seed()
-        sm.todays_daily_items = random.sample(
-            DAILY_ITEMS_POOL, sm.number_of_daily_items
-        )
-        sm.todays_daily_tms = random.sample(sm.get_tm_pool(), sm.number_of_daily_items)
+        new_items = random.sample(DAILY_ITEMS_POOL, sm.number_of_daily_items)
+        new_tms = random.sample(sm.get_tm_pool(), sm.number_of_daily_items)
 
-        mw.ankimon_db.set_user_data(
-            "todays_shop",
-            {
-                "items": sm.todays_daily_items,
-                "technical_machines": sm.todays_daily_tms,
+        try:
+            mw.ankimon_db.set_user_data("todays_shop", {
+                "items": new_items,
+                "technical_machines": new_tms,
                 "date": datetime.now().strftime("%Y-%m-%d"),
-            },
-        )
+            })
+            sm.todays_daily_items = new_items
+            sm.todays_daily_tms = new_tms
+            sm.set_callback("trainer.cash", int(cash - cost))
+        except Exception as e:
+            return {"ok": False, "message": f"Reroll failed: {e}"}
 
         return {"ok": True, "message": f"Rerolled stock for {cost}¥"}
 

--- a/src/Ankimon/ankimon_items_web/shop_obj.py
+++ b/src/Ankimon/ankimon_items_web/shop_obj.py
@@ -1,0 +1,451 @@
+"""Unified shell window — Items (Mart + Bag) and Ankidex live in one QDialog.
+
+The same QWebEngineView swaps between two screens by changing its URL. No
+window close/open flicker; the dropdown switcher in either screen calls back
+through QWebChannel to swap content in place.
+"""
+import json
+import random
+from datetime import datetime
+
+from aqt import QDialog, QVBoxLayout, QWebEngineView, mw
+from aqt.qt import Qt, QUrl, QFrame
+from PyQt6.QtCore import QObject, pyqtSlot
+from PyQt6.QtWebChannel import QWebChannel
+
+import csv
+
+from ..utils import give_item
+from ..resources import items_path, csv_file_items_cost, csv_file_descriptions
+from ..functions.pokedex_functions import find_details_move
+
+
+SCREEN_ITEMS = 'items'
+SCREEN_ANKIDEX = 'ankidex'
+
+
+class NavBridge(QObject):
+    """Cross-screen navigation — exposed in both Items and Ankidex pages."""
+
+    def __init__(self, window):
+        super().__init__()
+        self._w = window
+
+    @pyqtSlot()
+    def openItems(self):
+        self._w.load_screen(SCREEN_ITEMS)
+
+    @pyqtSlot()
+    def openAnkidex(self):
+        self._w.load_screen(SCREEN_ANKIDEX)
+
+
+class ItemsBridge(QObject):
+    """Items-screen actions — only meaningful when Items is loaded."""
+
+    def __init__(self, window):
+        super().__init__()
+        self._w = window
+
+    @pyqtSlot(str, bool, result='QVariant')
+    def buy(self, item_name, is_tm):
+        result = self._w.handle_buy(item_name, bool(is_tm))
+        self._w.push_screen_data()
+        return result
+
+    @pyqtSlot(result='QVariant')
+    def reroll(self):
+        result = self._w.handle_reroll()
+        self._w.push_screen_data()
+        return result
+
+    @pyqtSlot(str, result='QVariant')
+    def useItem(self, item_name):
+        result = self._w.handle_use(item_name)
+        self._w.push_screen_data()
+        return result
+
+    # Back-compat: items.shop.js previously called bridge.openAnkidex; keep
+    # it as a passthrough so older cached pages still work.
+    @pyqtSlot()
+    def openAnkidex(self):
+        self._w.load_screen(SCREEN_ANKIDEX)
+
+
+class AnkimonItemsWeb(QDialog):
+    def __init__(self, addon_dir, shop_manager, item_window, ankimon_tracker):
+        super().__init__()
+        self.addon_dir = addon_dir
+        self.shop_manager = shop_manager
+        self.item_window = item_window
+        self.ankimon_tracker = ankimon_tracker
+        self.current_screen = None
+        self.setWindowTitle("Ankimon")
+
+        self.setAttribute(Qt.WidgetAttribute.WA_TranslucentBackground)
+        self.setWindowFlags(
+            self.windowFlags()
+            | Qt.WindowType.WindowMaximizeButtonHint
+            | Qt.WindowType.WindowMinimizeButtonHint
+        )
+        self.resize(1180, 720)
+
+        layout = QVBoxLayout()
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(0)
+        self.setLayout(layout)
+
+        frame = QFrame()
+        frame.setContentsMargins(0, 0, 0, 0)
+        frame.setFrameStyle(QFrame.Shape.NoFrame)
+        frame.setLayout(QVBoxLayout())
+        frame.layout().setContentsMargins(0, 0, 0, 0)
+        layout.addWidget(frame)
+
+        self.webview = QWebEngineView()
+        frame.layout().addWidget(self.webview)
+
+        self.channel = QWebChannel(self.webview)
+        self.bridge = ItemsBridge(self)
+        self.nav = NavBridge(self)
+        self.channel.registerObject('bridge', self.bridge)
+        self.channel.registerObject('nav', self.nav)
+        self.webview.page().setWebChannel(self.channel)
+
+        self.webview.loadFinished.connect(self._on_load_finished)
+
+        # Boot with Items by default; menu entries can call load_screen()
+        # before show() to pick a different initial screen.
+        self.load_screen(SCREEN_ITEMS)
+
+    # ------------------------------------------------------------------
+    # Screen switching
+    # ------------------------------------------------------------------
+    def load_screen(self, screen):
+        # Save Ankidex prefs before navigating away (preserves the in-page
+        # state the user toggled — view mode, sort, etc.)
+        if self.current_screen == SCREEN_ANKIDEX and screen != SCREEN_ANKIDEX:
+            self._save_ankidex_prefs()
+
+        self.current_screen = screen
+        if screen == SCREEN_ITEMS:
+            path = self.addon_dir / "ankimon_items_web" / "shop.html"
+            title = "Ankimon — Items"
+        elif screen == SCREEN_ANKIDEX:
+            path = self.addon_dir / "ankidex" / "ankidex.html"
+            title = "Ankimon — Ankidex"
+        else:
+            return
+        self.setWindowTitle(title)
+        self.webview.setUrl(QUrl.fromLocalFile(path.as_posix()))
+
+    def _on_load_finished(self, ok):
+        if not ok:
+            return
+        self.push_screen_data()
+
+    def push_screen_data(self):
+        if self.current_screen == SCREEN_ITEMS:
+            data = self.get_inventory_data()
+            js = f"if (window.initializeItems) window.initializeItems({json.dumps(data)});"
+        elif self.current_screen == SCREEN_ANKIDEX:
+            data = self._get_ankidex_data()
+            js = f"if (window.initializeAnkidex) window.initializeAnkidex({json.dumps(data)});"
+        else:
+            return
+        self.webview.page().runJavaScript(js)
+
+    def _get_ankidex_data(self):
+        # Reuse the existing Ankidex singleton's data getter — keeps the
+        # dex query logic in one place.
+        from ..singletons import get_ankidex_window
+        ankidex = get_ankidex_window()
+        return ankidex.get_ankidex_data()
+
+    def _save_ankidex_prefs(self):
+        def on_state_ready(state):
+            if state and isinstance(state, dict):
+                for key, val in state.items():
+                    mw.settings_obj.set(f"ankidex.{key}", val)
+        self.webview.page().runJavaScript(
+            "if (window.getAnkidexState) window.getAnkidexState();",
+            on_state_ready,
+        )
+
+    def closeEvent(self, event):
+        if self.current_screen == SCREEN_ANKIDEX:
+            self._save_ankidex_prefs()
+        super().closeEvent(event)
+
+    def showEvent(self, event):
+        # Re-push fresh data on every show (e.g. after buy/use happened
+        # while the window was hidden).
+        self.push_screen_data()
+        super().showEvent(event)
+
+    # Back-compat alias for the bridge methods that still call update_ui_data.
+    def update_ui_data(self):
+        self.push_screen_data()
+
+    # ------------------------------------------------------------------
+    # Data push (Python → JS)
+    # ------------------------------------------------------------------
+    def update_ui_data(self):
+        data = self.get_inventory_data()
+        js_code = f"if (window.initializeItems) window.initializeItems({json.dumps(data)});"
+        self.webview.page().runJavaScript(js_code)
+
+    def get_inventory_data(self):
+        sm = self.shop_manager
+
+        # Today's stock (cached by PokemonShopManager.get_daily_items)
+        raw_items = sm.get_daily_items() or []
+        raw_tms = sm.get_daily_tms() or []
+        sm.todays_daily_items = raw_items
+        sm.todays_daily_tms = raw_tms
+
+        shop_index = {}
+        for entry in raw_items:
+            shop_index[entry["name"]] = {
+                "price": int(self._lookup_price(entry["name"]) or 0),
+                "is_tm": False,
+                "item_type": entry.get("item_type"),
+            }
+        for entry in raw_tms:
+            shop_index[entry["name"]] = {
+                "price": int(sm.tm_price or 0),
+                "is_tm": True,
+                "item_type": entry.get("item_type") or "TM",
+            }
+
+        # Player's bag (every owned item)
+        owned_rows = []
+        try:
+            owned_rows = mw.ankimon_db.get_all_items() or []
+        except Exception:
+            owned_rows = []
+
+        owned_index = {}
+        for row in owned_rows:
+            name = row.get("item_name") or row.get("name")
+            qty = int(row.get("quantity") or 0)
+            if not name or qty <= 0:
+                continue
+            owned_index[name] = {
+                "quantity": qty,
+                "category_id": row.get("category_id"),
+            }
+
+        all_names = sorted(set(shop_index.keys()) | set(owned_index.keys()))
+
+        items = []
+        for name in all_names:
+            shop_entry = shop_index.get(name)
+            owned_entry = owned_index.get(name)
+            is_tm = bool(
+                (shop_entry or {}).get("is_tm")
+                or (owned_entry or {}).get("category_id") == 37
+            )
+            items.append(self._serialize_item(
+                name=name,
+                is_tm=is_tm,
+                in_shop=bool(shop_entry),
+                shop_price=(shop_entry or {}).get("price"),
+                item_type=(shop_entry or {}).get("item_type"),
+                owned_quantity=(owned_entry or {}).get("quantity", 0),
+            ))
+
+        return {
+            "cash": int(sm.get_callback("trainer.cash") or 0),
+            "reroll_cost": int(sm.daily_items_reroll_cost or 0),
+            "items": items,
+        }
+
+    def _serialize_item(self, name, is_tm, in_shop, shop_price, item_type, owned_quantity):
+        ui_name = name.replace("-", " ").title()
+        entry = {
+            "name": name,
+            "ui_name": ui_name,
+            "is_tm": is_tm,
+            "in_shop": in_shop,
+            "price": int(shop_price) if shop_price is not None else None,
+            "owned_quantity": int(owned_quantity or 0),
+            "item_type": item_type,
+            "category": self._categorize(name, is_tm),
+        }
+
+        if is_tm:
+            move = find_details_move(name) or {}
+            move_type = move.get("type") or "Normal"
+            entry["image_url"] = QUrl.fromLocalFile(
+                str(items_path / f"Bag_TM_{move_type}_SV_Sprite.png")
+            ).toString()
+            short_desc = move.get("shortDesc") or ""
+            entry["description"] = (
+                f"Teaches a compatible Pokémon the move {ui_name}."
+                + (f" {short_desc}" if short_desc else "")
+            )
+            entry["move_type"] = move_type
+            entry["move_power"] = self._coerce_int(move.get("basePower"))
+            entry["move_accuracy"] = self._coerce_int(move.get("accuracy"))
+            entry["move_pp"] = self._coerce_int(move.get("pp"))
+            entry["move_damage_class"] = (move.get("category") or "").title() or None
+        else:
+            entry["image_url"] = QUrl.fromLocalFile(
+                str(items_path / f"{name}.png")
+            ).toString()
+            entry["description"] = self._lookup_description(name) \
+                or f"A useful item: {ui_name}"
+
+        return entry
+
+    def _categorize(self, name, is_tm):
+        """Bucket items into the same groups the legacy bag exposed."""
+        if is_tm:
+            return "tm"
+        bag = self.item_window
+        if bag is not None:
+            if name in getattr(bag, "hp_heal_items", {}):
+                return "heal"
+            if name in getattr(bag, "fossil_pokemon", {}):
+                return "fossil"
+            if name in getattr(bag, "pokeball_chances", {}):
+                return "pokeball"
+            if name in getattr(bag, "evolution_items", set()):
+                return "evolution"
+        return "other"
+
+    def _lookup_price(self, name):
+        entry = self._items_csv.get(name)
+        return entry["cost"] if entry else 0
+
+    def _lookup_description(self, name):
+        entry = self._items_csv.get(name)
+        if not entry:
+            return None
+        try:
+            lang = int(self.shop_manager.settings_obj.get("misc.language") or 9)
+        except (TypeError, ValueError):
+            lang = 9
+        if lang == 14:  # es_latam → fall back to es per legacy behaviour
+            lang = 7
+        return self._descriptions.get((entry["id"], lang))
+
+    @property
+    def _items_csv(self):
+        """{identifier: {"id": int, "cost": int}} — items.csv loaded once."""
+        cached = getattr(self, "_items_csv_cache", None)
+        if cached is not None:
+            return cached
+        index = {}
+        try:
+            with open(csv_file_items_cost, mode="r", newline="", encoding="utf-8") as f:
+                for row in csv.DictReader(f):
+                    try:
+                        index[row["identifier"]] = {
+                            "id": int(row["id"]),
+                            "cost": int(row["cost"]),
+                        }
+                    except (KeyError, ValueError):
+                        continue
+        except OSError:
+            pass
+        self._items_csv_cache = index
+        return index
+
+    @property
+    def _descriptions(self):
+        """{(item_id, language_id): flavor_text} — item_flavor_text.csv loaded once."""
+        cached = getattr(self, "_descriptions_cache", None)
+        if cached is not None:
+            return cached
+        index = {}
+        try:
+            with open(csv_file_descriptions, mode="r", encoding="utf-8") as f:
+                for row in csv.DictReader(f):
+                    try:
+                        key = (int(row["item_id"]), int(row["language_id"]))
+                    except (KeyError, ValueError):
+                        continue
+                    # First occurrence wins (legacy get_item_description does the same).
+                    index.setdefault(key, row.get("flavor_text"))
+        except OSError:
+            pass
+        self._descriptions_cache = index
+        return index
+
+    @staticmethod
+    def _coerce_int(value):
+        try:
+            if value in (None, "", "—"):
+                return None
+            return int(value)
+        except (TypeError, ValueError):
+            return None
+
+    # ------------------------------------------------------------------
+    # Actions (JS → Python)
+    # ------------------------------------------------------------------
+    def handle_buy(self, item_name, is_tm):
+        item = self._find_serialized(item_name)
+        if not item or not item.get("in_shop"):
+            return {"ok": False, "message": "Item is not in today's stock."}
+
+        ui_name = item["ui_name"]
+        price = int(item.get("price") or 0)
+        cash = int(self.shop_manager.get_callback("trainer.cash") or 0)
+
+        if is_tm and item.get("owned_quantity", 0) > 0:
+            return {"ok": False, "message": f"{ui_name} is already owned."}
+        if cash < price:
+            return {"ok": False, "message": "Not enough money."}
+
+        try:
+            self.shop_manager.set_callback("trainer.cash", int(cash - price))
+            give_item(item_name, item.get("item_type") if is_tm else None)
+        except Exception as e:
+            self.shop_manager.set_callback("trainer.cash", cash)
+            return {"ok": False, "message": f"Purchase failed: {e}"}
+
+        return {"ok": True, "message": f"Bought {ui_name} for {price}¥"}
+
+    def handle_reroll(self):
+        sm = self.shop_manager
+        cost = int(sm.daily_items_reroll_cost or 0)
+        cash = int(sm.get_callback("trainer.cash") or 0)
+        if cash < cost:
+            return {"ok": False, "message": "Not enough money to reroll."}
+
+        sm.set_callback("trainer.cash", int(cash - cost))
+
+        from ..pyobj.ankimon_shop import DAILY_ITEMS_POOL
+        random.seed()
+        sm.todays_daily_items = random.sample(DAILY_ITEMS_POOL, sm.number_of_daily_items)
+        sm.todays_daily_tms = random.sample(sm.get_tm_pool(), sm.number_of_daily_items)
+
+        mw.ankimon_db.set_user_data("todays_shop", {
+            "items": sm.todays_daily_items,
+            "technical_machines": sm.todays_daily_tms,
+            "date": datetime.now().strftime("%Y-%m-%d"),
+        })
+
+        return {"ok": True, "message": f"Rerolled stock for {cost}¥"}
+
+    def handle_use(self, item_name):
+        item = self._find_serialized(item_name)
+        if not item:
+            return {"ok": False, "message": "Item not found in your bag."}
+        if (item.get("owned_quantity") or 0) <= 0:
+            return {"ok": False, "message": "You don't own that item."}
+        if self.item_window is None:
+            return {"ok": False, "message": "Item bag service unavailable."}
+        item_type = item.get("item_type") or ("TM" if item.get("is_tm") else None)
+        return self.item_window.dispatch_use(item_name, item_type)
+
+    def _find_serialized(self, item_name):
+        data = self.get_inventory_data()
+        for entry in data["items"]:
+            if entry["name"] == item_name:
+                return entry
+        return None
+

--- a/src/Ankimon/ankimon_items_web/shop_obj.py
+++ b/src/Ankimon/ankimon_items_web/shop_obj.py
@@ -175,6 +175,7 @@ class AnkimonItemsWeb(QDialog):
                     mw.settings_obj.set(f"ankidex.{key}", val)
             if callback:
                 callback()
+
         self.webview.page().runJavaScript(
             "if (window.getAnkidexState) window.getAnkidexState();",
             on_state_ready,
@@ -431,11 +432,14 @@ class AnkimonItemsWeb(QDialog):
         new_tms = random.sample(sm.get_tm_pool(), sm.number_of_daily_items)
 
         try:
-            mw.ankimon_db.set_user_data("todays_shop", {
-                "items": new_items,
-                "technical_machines": new_tms,
-                "date": datetime.now().strftime("%Y-%m-%d"),
-            })
+            mw.ankimon_db.set_user_data(
+                "todays_shop",
+                {
+                    "items": new_items,
+                    "technical_machines": new_tms,
+                    "date": datetime.now().strftime("%Y-%m-%d"),
+                },
+            )
             sm.todays_daily_items = new_items
             sm.todays_daily_tms = new_tms
             sm.set_callback("trainer.cash", int(cash - cost))

--- a/src/Ankimon/ankimon_items_web/shop_obj.py
+++ b/src/Ankimon/ankimon_items_web/shop_obj.py
@@ -302,7 +302,9 @@ class AnkimonItemsWeb(QDialog):
             entry["move_type"] = move_type
             entry["move_power"] = self._coerce_int(move.get("basePower"))
             accuracy = move.get("accuracy")
-            entry["move_accuracy"] = "—" if accuracy is True else self._coerce_int(accuracy)
+            entry["move_accuracy"] = (
+                "—" if accuracy is True else self._coerce_int(accuracy)
+            )
             entry["move_pp"] = self._coerce_int(move.get("pp"))
             entry["move_damage_class"] = (move.get("category") or "").title() or None
         else:

--- a/src/Ankimon/menu_buttons.py
+++ b/src/Ankimon/menu_buttons.py
@@ -99,6 +99,7 @@ def create_menu_actions(
         get_version_dialog,
         get_settings_window,
         get_ankimon_tracker_window,
+        get_items_window,
     )
     actions = []
 
@@ -116,10 +117,18 @@ def create_menu_actions(
         ankimon_window_action.setShortcut(QKeySequence(f"{ankimon_key}"))
         qconnect(ankimon_window_action.triggered, lambda: get_test_window().open_dynamic_window())
 
-        # Itembag
+        # Itembag — unified shell window, items screen.
+        def _open_shell_at(screen):
+            w = get_items_window()
+            if w.current_screen != screen:
+                w.load_screen(screen)
+            w.show()
+            w.raise_()
+            w.activateWindow()
+
         itembag_action = QAction(mw.translator.translate("itembag_button"), mw)
         itembag_action.setMenuRole(QAction.MenuRole.NoRole)
-        itembag_action.triggered.connect(lambda: get_item_window().show_window())
+        itembag_action.triggered.connect(lambda: _open_shell_at('items'))
         collection_menu.addAction(itembag_action)
 
         # Achievements
@@ -160,10 +169,10 @@ def create_menu_actions(
         qconnect(flex_pokecoll_action.triggered, lambda: flex_pokemon_collection())
         export_menu.addAction(flex_pokecoll_action)
 
-        from .singletons import get_ankidex_window
+        # Ankidex — same shell window, ankidex screen pre-loaded.
         ankidex_action = QAction("Ankidex", mw)
         ankidex_action.setMenuRole(QAction.MenuRole.NoRole)
-        qconnect(ankidex_action.triggered, lambda: get_ankidex_window().show())
+        qconnect(ankidex_action.triggered, lambda: _open_shell_at('ankidex'))
         collection_menu.addAction(ankidex_action)
 
     # Backup Manager
@@ -267,6 +276,7 @@ def create_menu_actions(
     from .reloader import restart_ankimon
     restart_action = QAction("Restart Ankimon", mw)
     restart_action.setMenuRole(QAction.MenuRole.NoRole)
+    restart_action.setShortcut(QKeySequence("Ctrl+Shift+R"))
     restart_action.triggered.connect(restart_ankimon)
     mw.pokemenu.addAction(restart_action)
 
@@ -302,10 +312,10 @@ def create_menu_actions(
     ankimon_trainer_card_action.triggered.connect(lambda: TrainerCardGUI(trainer_card, settings_obj, parent=mw))
     profile_menu.addAction(ankimon_trainer_card_action)
 
-    # Add AnkimonShop Action to toggle the shop
+    # Mart entry — opens the same unified Items window as the Item Bag entry.
     shop_manager_action = QAction(mw.translator.translate("item_shop_button"), mw)
     shop_manager_action.setMenuRole(QAction.MenuRole.NoRole)
-    shop_manager_action.triggered.connect(shop_manager.toggle_window)
+    shop_manager_action.triggered.connect(lambda: get_items_window().show())
     game_menu.addAction(shop_manager_action)
 
     # Choose Trainer Sprite Action

--- a/src/Ankimon/menu_buttons.py
+++ b/src/Ankimon/menu_buttons.py
@@ -26,6 +26,7 @@ from .pyobj.trainer_card import TrainerCard
 from .pyobj.settings_window import SettingsWindow
 from .pyobj.test_window import TestWindow
 from .pyobj.ankimon_shop import PokemonShopManager
+
 # Removed old Pokedex import
 from .pyobj.achievement_window import AchievementWindow
 from .pyobj.ankimon_tracker_window import AnkimonTrackerWindow
@@ -45,14 +46,23 @@ debug = True
 
 # Initialize the menu
 mw.translator = Translator(language=int(mw.settings_obj.get("misc.language")))
-mw.pokemenu = QMenu('&' + mw.translator.translate("ankimon_button_title"), mw)
+mw.pokemenu = QMenu("&" + mw.translator.translate("ankimon_button_title"), mw)
 game_menu = mw.pokemenu.addMenu(mw.translator.translate("ankimon_game_button_title"))
-profile_menu = mw.pokemenu.addMenu(mw.translator.translate("ankimon_profile_button_title"))
-collection_menu = mw.pokemenu.addMenu(mw.translator.translate("ankimon_collection_button_title"))
-export_menu = mw.pokemenu.addMenu(mw.translator.translate("ankimon_export_button_title"))
+profile_menu = mw.pokemenu.addMenu(
+    mw.translator.translate("ankimon_profile_button_title")
+)
+collection_menu = mw.pokemenu.addMenu(
+    mw.translator.translate("ankimon_collection_button_title")
+)
+export_menu = mw.pokemenu.addMenu(
+    mw.translator.translate("ankimon_export_button_title")
+)
 help_menu = mw.pokemenu.addMenu(mw.translator.translate("ankimon_help_button_title"))
 if debug is True:
-    debug_menu = mw.pokemenu.addMenu(mw.translator.translate("ankimon_debug_button_title"))
+    debug_menu = mw.pokemenu.addMenu(
+        mw.translator.translate("ankimon_debug_button_title")
+    )
+
 
 def create_menu_actions(
     database_complete: bool,
@@ -101,6 +111,7 @@ def create_menu_actions(
         get_ankimon_tracker_window,
         get_items_window,
     )
+
     actions = []
 
     if database_complete:
@@ -111,11 +122,16 @@ def create_menu_actions(
         qconnect(pokemon_pc_action.triggered, lambda: get_pokemon_pc().show())
 
         # Ankimon Window
-        ankimon_window_action = QAction(mw.translator.translate("open_ankimon_window_button"), mw)
+        ankimon_window_action = QAction(
+            mw.translator.translate("open_ankimon_window_button"), mw
+        )
         ankimon_window_action.setMenuRole(QAction.MenuRole.NoRole)
         game_menu.addAction(ankimon_window_action)
         ankimon_window_action.setShortcut(QKeySequence(f"{ankimon_key}"))
-        qconnect(ankimon_window_action.triggered, lambda: get_test_window().open_dynamic_window())
+        qconnect(
+            ankimon_window_action.triggered,
+            lambda: get_test_window().open_dynamic_window(),
+        )
 
         # Itembag — unified shell window, items screen.
         def _open_shell_at(screen):
@@ -128,43 +144,57 @@ def create_menu_actions(
 
         itembag_action = QAction(mw.translator.translate("itembag_button"), mw)
         itembag_action.setMenuRole(QAction.MenuRole.NoRole)
-        itembag_action.triggered.connect(lambda: _open_shell_at('items'))
+        itembag_action.triggered.connect(lambda: _open_shell_at("items"))
         collection_menu.addAction(itembag_action)
 
         # Achievements
         def show_achievements_window():
             from .pyobj.achievements_dialog import AchievementsDialog
-            if not hasattr(mw, "_achievements_dialog") or mw._achievements_dialog is None:
+
+            if (
+                not hasattr(mw, "_achievements_dialog")
+                or mw._achievements_dialog is None
+            ):
                 mw._achievements_dialog = AchievementsDialog(addon_dir, trainer_card)
             mw._achievements_dialog.setWindowModality(Qt.WindowModality.NonModal)
             mw._achievements_dialog.show()
             mw._achievements_dialog.raise_()
             mw._achievements_dialog.activateWindow()
 
-        achievement_bag_action = QAction(mw.translator.translate("achievements_button"), mw)
+        achievement_bag_action = QAction(
+            mw.translator.translate("achievements_button"), mw
+        )
         achievement_bag_action.setMenuRole(QAction.MenuRole.NoRole)
         achievement_bag_action.triggered.connect(show_achievements_window)
         profile_menu.addAction(achievement_bag_action)
 
         # Showdown Teambuilder
-        pokemon_showdown_action = QAction(mw.translator.translate("open_showdown_teambuilder_button"), mw)
+        pokemon_showdown_action = QAction(
+            mw.translator.translate("open_showdown_teambuilder_button"), mw
+        )
         pokemon_showdown_action.setMenuRole(QAction.MenuRole.NoRole)
         qconnect(pokemon_showdown_action.triggered, lambda: open_team_builder())
         export_menu.addAction(pokemon_showdown_action)
 
         # Export to Showdown
-        export_main_to_showdown = QAction(mw.translator.translate("export_main_pokemon_button"), mw)
+        export_main_to_showdown = QAction(
+            mw.translator.translate("export_main_pokemon_button"), mw
+        )
         export_main_to_showdown.setMenuRole(QAction.MenuRole.NoRole)
         qconnect(export_main_to_showdown.triggered, lambda: export_to_pkmn_showdown())
         export_menu.addAction(export_main_to_showdown)
 
-        export_all_to_showdown = QAction(mw.translator.translate("export_all_pokemon_button"), mw)
+        export_all_to_showdown = QAction(
+            mw.translator.translate("export_all_pokemon_button"), mw
+        )
         export_all_to_showdown.setMenuRole(QAction.MenuRole.NoRole)
         qconnect(export_all_to_showdown.triggered, lambda: export_all_pkmn_showdown())
         export_menu.addAction(export_all_to_showdown)
 
         # Flexing Collection
-        flex_pokecoll_action = QAction(mw.translator.translate("export_all_pokemon_to_pokepaste_button"), mw)
+        flex_pokecoll_action = QAction(
+            mw.translator.translate("export_all_pokemon_to_pokepaste_button"), mw
+        )
         flex_pokecoll_action.setMenuRole(QAction.MenuRole.NoRole)
         qconnect(flex_pokecoll_action.triggered, lambda: flex_pokemon_collection())
         export_menu.addAction(flex_pokecoll_action)
@@ -172,13 +202,15 @@ def create_menu_actions(
         # Ankidex — same shell window, ankidex screen pre-loaded.
         ankidex_action = QAction("Ankidex", mw)
         ankidex_action.setMenuRole(QAction.MenuRole.NoRole)
-        qconnect(ankidex_action.triggered, lambda: _open_shell_at('ankidex'))
+        qconnect(ankidex_action.triggered, lambda: _open_shell_at("ankidex"))
         collection_menu.addAction(ankidex_action)
 
     # Backup Manager
     backup_manager_action = QAction("Backup Manager", mw)
     backup_manager_action.setMenuRole(QAction.MenuRole.NoRole)
-    backup_manager_action.triggered.connect(lambda: BackupManagerDialog(backup_manager, mw).exec())
+    backup_manager_action.triggered.connect(
+        lambda: BackupManagerDialog(backup_manager, mw).exec()
+    )
     game_menu.addAction(backup_manager_action)
 
     # Effectiveness chart
@@ -190,13 +222,17 @@ def create_menu_actions(
     # Generations and Pokémon chart
     gen_and_poke_chart_action = QAction(mw.translator.translate("gen_chart_button"), mw)
     gen_and_poke_chart_action.setMenuRole(QAction.MenuRole.NoRole)
-    gen_and_poke_chart_action.triggered.connect(lambda: get_gen_id_chart().show_gen_chart())
+    gen_and_poke_chart_action.triggered.connect(
+        lambda: get_gen_id_chart().show_gen_chart()
+    )
     help_menu.addAction(gen_and_poke_chart_action)
 
     # Nature chart
     nature_chart_action = QAction(mw.translator.translate("nature_chart_button"), mw)
     nature_chart_action.setMenuRole(QAction.MenuRole.NoRole)
-    nature_chart_action.triggered.connect(lambda: get_nature_chart().show_nature_chart())
+    nature_chart_action.triggered.connect(
+        lambda: get_nature_chart().show_nature_chart()
+    )
     help_menu.addAction(nature_chart_action)
 
     # Join Discord
@@ -218,7 +254,9 @@ def create_menu_actions(
     help_menu.addAction(credits_action)
 
     # About and License
-    about_and_license_action = QAction(mw.translator.translate("ankimon_about_and_license_button"), mw)
+    about_and_license_action = QAction(
+        mw.translator.translate("ankimon_about_and_license_button"), mw
+    )
     about_and_license_action.setMenuRole(QAction.MenuRole.NoRole)
     about_and_license_action.triggered.connect(lambda: get_license().show_window())
     help_menu.addAction(about_and_license_action)
@@ -226,7 +264,9 @@ def create_menu_actions(
     # Help Guide
     help_action = QAction(mw.translator.translate("open_help_guide_button"), mw)
     help_action.setMenuRole(QAction.MenuRole.NoRole)
-    help_action.triggered.connect(lambda: open_help_window(getattr(mw, "online_connectivity", False)))
+    help_action.triggered.connect(
+        lambda: open_help_window(getattr(mw, "online_connectivity", False))
+    )
     help_menu.addAction(help_action)
 
     # Report Bug
@@ -244,6 +284,7 @@ def create_menu_actions(
     # Update Ankimon
     def _open_update_dialog():
         from .pyobj.update_dialog import UpdateDialog
+
         dialog = UpdateDialog(parent=mw)
         dialog.exec()
 
@@ -267,6 +308,7 @@ def create_menu_actions(
 
     # Switch Account Action
     from .singletons import swap_ankimon_account
+
     switch_account_action = QAction("Switch Account (DEV/Normal)", mw)
     switch_account_action.setMenuRole(QAction.MenuRole.NoRole)
     switch_account_action.triggered.connect(swap_ankimon_account)
@@ -274,6 +316,7 @@ def create_menu_actions(
 
     # Restart Ankimon Action
     from .reloader import restart_ankimon
+
     restart_action = QAction("Restart Ankimon", mw)
     restart_action.setMenuRole(QAction.MenuRole.NoRole)
     restart_action.setShortcut(QKeySequence("Ctrl+Shift+R"))
@@ -290,9 +333,13 @@ def create_menu_actions(
     update_dev_actions_visibility()
 
     if debug is True:
-        tracker_window_action = QAction(mw.translator.translate("ankimon_tracker_button"), mw)
+        tracker_window_action = QAction(
+            mw.translator.translate("ankimon_tracker_button"), mw
+        )
         tracker_window_action.setMenuRole(QAction.MenuRole.NoRole)
-        tracker_window_action.triggered.connect(lambda: get_ankimon_tracker_window().toggle_window())
+        tracker_window_action.triggered.connect(
+            lambda: get_ankimon_tracker_window().toggle_window()
+        )
         tracker_window_action.setShortcut(QKeySequence("Ctrl+Shift+K"))
         # Show the Settings window
         debug_menu.addAction(tracker_window_action)
@@ -305,11 +352,15 @@ def create_menu_actions(
     game_menu.addAction(ankimon_logger_action)
 
     # Set up a shortcut (Ctrl+L) to open the log window
-    ankimon_trainer_card_action = QAction(mw.translator.translate("trainer_card_button"), mw)
+    ankimon_trainer_card_action = QAction(
+        mw.translator.translate("trainer_card_button"), mw
+    )
     ankimon_trainer_card_action.setMenuRole(QAction.MenuRole.NoRole)
     ankimon_trainer_card_action.setShortcut(QKeySequence("Ctrl+Shift+Q"))
     # Create the TrainerCard GUI and show it inside Anki's main window
-    ankimon_trainer_card_action.triggered.connect(lambda: TrainerCardGUI(trainer_card, settings_obj, parent=mw))
+    ankimon_trainer_card_action.triggered.connect(
+        lambda: TrainerCardGUI(trainer_card, settings_obj, parent=mw)
+    )
     profile_menu.addAction(ankimon_trainer_card_action)
 
     # Mart entry — opens the same unified Items window as the Item Bag entry.
@@ -319,27 +370,41 @@ def create_menu_actions(
     game_menu.addAction(shop_manager_action)
 
     # Choose Trainer Sprite Action
-    choose_trainer_sprite_action = QAction(mw.translator.translate("choose_trainer_sprite_button"), mw)
+    choose_trainer_sprite_action = QAction(
+        mw.translator.translate("choose_trainer_sprite_button"), mw
+    )
     choose_trainer_sprite_action.setMenuRole(QAction.MenuRole.NoRole)
-    choose_trainer_sprite_action.triggered.connect(lambda: TrainerSpriteGraphicalDialog(settings_obj=settings_obj).exec())
+    choose_trainer_sprite_action.triggered.connect(
+        lambda: TrainerSpriteGraphicalDialog(settings_obj=settings_obj).exec()
+    )
     game_menu.addAction(choose_trainer_sprite_action)
 
-    pokemon_team_action = QAction(mw.translator.translate("choose_pokemon_team_button"), mw)
+    pokemon_team_action = QAction(
+        mw.translator.translate("choose_pokemon_team_button"), mw
+    )
     pokemon_team_action.setMenuRole(QAction.MenuRole.NoRole)
-    pokemon_team_action.triggered.connect(lambda: PokemonTeamDialog(settings_obj, logger, trainer_card))
+    pokemon_team_action.triggered.connect(
+        lambda: PokemonTeamDialog(settings_obj, logger, trainer_card)
+    )
     game_menu.addAction(pokemon_team_action)
 
-    file_check_action = QAction(mw.translator.translate("ankimon_file_checker_button"), mw)
+    file_check_action = QAction(
+        mw.translator.translate("ankimon_file_checker_button"), mw
+    )
     file_check_action.setMenuRole(QAction.MenuRole.NoRole)
     file_check_action.triggered.connect(lambda: FileCheckerApp().exec())
     help_menu.addAction(file_check_action)
 
-    file_check_action = QAction(mw.translator.translate("ankimon_leaderboard_credentials_button"), mw)
+    file_check_action = QAction(
+        mw.translator.translate("ankimon_leaderboard_credentials_button"), mw
+    )
     file_check_action.setMenuRole(QAction.MenuRole.NoRole)
     file_check_action.triggered.connect(show_api_key_dialog)
     mw.pokemenu.addAction(file_check_action)
 
-    downloader_action = QAction(mw.translator.translate("download_resources_button"), mw)
+    downloader_action = QAction(
+        mw.translator.translate("download_resources_button"), mw
+    )
     downloader_action.setMenuRole(QAction.MenuRole.NoRole)
     downloader_action.triggered.connect(show_agreement_and_download_dialog)
     help_menu.addAction(downloader_action)

--- a/src/Ankimon/pyobj/ankimon_shop.py
+++ b/src/Ankimon/pyobj/ankimon_shop.py
@@ -468,6 +468,12 @@ class PokemonShopManager:
         return random.sample(tm_pool, self.number_of_daily_items)
 
     def get_tm_pool(self) -> list[str]:
+        # Cached: pokemon_tm_learnset.json is immutable at runtime, and this
+        # is on the hot path of the Items window's data fetch.
+        cached = getattr(self, "_tm_pool_cache", None)
+        if cached is not None:
+            return cached
+
         with open(pokemon_tm_learnset_path, "r") as f:
             pokemon_tm_learnset = json.load(f)
 
@@ -489,6 +495,7 @@ class PokemonShopManager:
         # Ensure deterministic order
         all_tms.sort(key=lambda tm: tm["name"])
 
+        self._tm_pool_cache = all_tms
         return all_tms
 
     def buy_item(self, item, item_type: Union[str, None] = None):

--- a/src/Ankimon/pyobj/ankimon_shop.py
+++ b/src/Ankimon/pyobj/ankimon_shop.py
@@ -399,7 +399,9 @@ class PokemonShopManager:
         buy_font.setPointSize(8)
         buy_button.setFont(buy_font)
         buy_button.setFixedHeight(35)
-        buy_button.setFixedWidth(buy_button.fontMetrics().boundingRect(button_text).width() + 20)
+        buy_button.setFixedWidth(
+            buy_button.fontMetrics().boundingRect(button_text).width() + 20
+        )
 
         if is_tm and owned_quantity > 0:
             buy_button.setEnabled(False)
@@ -447,7 +449,9 @@ class PokemonShopManager:
         db = mw.ankimon_db
         shop_data = db.get_user_data("todays_shop")
         if shop_data:
-            if shop_data.get("items") and shop_data.get("date") == datetime.now().strftime("%Y-%m-%d"):
+            if shop_data.get("items") and shop_data.get(
+                "date"
+            ) == datetime.now().strftime("%Y-%m-%d"):
                 return shop_data.get("items")
 
         seed = datetime.now().strftime("%Y-%m-%d")
@@ -459,7 +463,9 @@ class PokemonShopManager:
         db = mw.ankimon_db
         shop_data = db.get_user_data("todays_shop")
         if shop_data:
-            if shop_data.get("technical_machines") and shop_data.get("date") == datetime.now().strftime("%Y-%m-%d"):
+            if shop_data.get("technical_machines") and shop_data.get(
+                "date"
+            ) == datetime.now().strftime("%Y-%m-%d"):
                 return shop_data.get("technical_machines")
 
         tm_pool = self.get_tm_pool()

--- a/src/Ankimon/pyobj/item_window.py
+++ b/src/Ankimon/pyobj/item_window.py
@@ -392,6 +392,42 @@ class ItemWindow(QWidget):
 
         return item_frame_widget
 
+    def dispatch_use(self, item_name: str, item_type: Optional[str] = None) -> dict:
+        """Invoke the right use-action for an item without requiring the bag UI
+        to be visible. Returns {ok, message} for callers that want to surface
+        a result (e.g. the web Items window's toast).
+
+        The branching mirrors ItemLabel above; keep them in sync if rules change.
+        """
+        name = (item_name or "").lower()
+        if item_type == "TM":
+            return {"ok": False, "message": "TMs are taught from the move-learning flow, not used directly."}
+        try:
+            if name in self.hp_heal_items:
+                if not self.main_pokemon:
+                    return {"ok": False, "message": "No active Pokémon to heal."}
+                hp_heal = self.hp_heal_items[name]
+                self.Check_Heal_Item(self.main_pokemon.name, hp_heal, name, self.achievements)
+                return {"ok": True, "message": f"Healed {self.main_pokemon.name} with {name}."}
+            if name in self.fossil_pokemon:
+                fossil_id = self.fossil_pokemon[name]
+                from ..functions.pokedex_functions import search_pokedex_by_id
+                fossil_pokemon_name = search_pokedex_by_id(fossil_id)
+                self.Evolve_Fossil(name, fossil_id, fossil_pokemon_name)
+                return {"ok": True, "message": f"Revived {fossil_pokemon_name}."}
+            if name in self.pokeball_chances:
+                self.Handle_Pokeball(name)
+                return {"ok": True, "message": f"Threw {name}."}
+            if name in self.evolution_items:
+                self._prompt_and_check_evo_item(name)
+                return {"ok": True, "message": ""}
+            if name in GiveItemWindow.NOT_YET_IMPLEMENTED_ITEMS or name.endswith("-berry") or name.endswith("-gem"):
+                return {"ok": False, "message": "This item isn't usable yet."}
+            self._prompt_and_give_held_item(name)
+            return {"ok": True, "message": ""}
+        except Exception as e:
+            return {"ok": False, "message": f"Use failed: {e}"}
+
     def PokemonList(self, comboBox):
         try:
             db = mw.ankimon_db

--- a/src/Ankimon/pyobj/item_window.py
+++ b/src/Ankimon/pyobj/item_window.py
@@ -30,14 +30,12 @@ from ..pyobj.pokemon_obj import PokemonObject
 from ..pyobj.settings import Settings
 from ..pyobj.starter_window import StarterWindow
 
-from ..business import (
-    get_id_and_description_by_item_name
-)
+from ..business import get_id_and_description_by_item_name
 from ..functions.pokedex_functions import (
     search_pokedex_by_id,
     return_id_for_item_name,
     check_evolution_by_item,
-    find_details_move
+    find_details_move,
 )
 
 from ..resources import icon_path, items_path, csv_file_items_cost, poke_evo_path
@@ -49,17 +47,18 @@ from .error_handler import show_warning_with_traceback
 # At the moment when I write this line, "UserRole" is defined as UserRole 1000 in the Ankimon __init__.py file. IDK what it's about.
 UserRole = 1000
 
+
 class ItemWindow(QWidget):
     def __init__(
-            self,
-            logger: ShowInfoLogger,
-            settings_obj: Settings,
-            main_pokemon: PokemonObject,
-            enemy_pokemon: PokemonObject,
-            achievements: dict[str, bool],
-            starter_window: StarterWindow,
-            evo_window: EvoWindow,
-            ):
+        self,
+        logger: ShowInfoLogger,
+        settings_obj: Settings,
+        main_pokemon: PokemonObject,
+        enemy_pokemon: PokemonObject,
+        achievements: dict[str, bool],
+        starter_window: StarterWindow,
+        evo_window: EvoWindow,
+    ):
         super().__init__()
         self.logger: ShowInfoLogger = logger
         self.settings_obj: Settings = settings_obj
@@ -74,19 +73,19 @@ class ItemWindow(QWidget):
 
     def initUI(self):
         self.hp_heal_items = {
-            'potion': 20,
-            'sweet-heart': 20,
-            'berry-juice': 20,
-            'fresh-water': 30,
-            'soda-pop': 50,
-            'super-potion': 60,
-            'energy-powder': 60,
-            'lemonade': 70,
-            'moomoo-milk': 100,
-            'hyper-potion': 120,
-            'energy-root': 120,
-            'full-restore': 1000,
-            'max-potion': 1000
+            "potion": 20,
+            "sweet-heart": 20,
+            "berry-juice": 20,
+            "fresh-water": 30,
+            "soda-pop": 50,
+            "super-potion": 60,
+            "energy-powder": 60,
+            "lemonade": 70,
+            "moomoo-milk": 100,
+            "hyper-potion": 120,
+            "energy-root": 120,
+            "full-restore": 1000,
+            "max-potion": 1000,
         }
 
         self.fossil_pokemon = {
@@ -98,28 +97,28 @@ class ItemWindow(QWidget):
             "skull-fossil": 408,
             "armor-fossil": 410,
             "cover-fossil": 564,
-            "plume-fossil": 566
+            "plume-fossil": 566,
         }
 
         self.pokeball_chances = {
-            'dive-ball': 11,      # Increased chance when fishing or underwater
-            'dusk-ball': 11,      # Increased chance at night or in caves
-            'great-ball': 12,     # Increased catch rate (original was 9, now 12)
-            'heal-ball': 12,      # Same as a Poké Ball but heals the Pokémon
-            'iron-ball': 12,      # Used for Steel-type Pokémon, 1.5x chance
-            'light-ball': 1,      # Not actually used for catching Pokémon; it's an item
-            'luxury-ball': 12,    # Same as a Poké Ball but increases happiness
-            'master-ball': 100,   # Guarantees a successful catch (100% chance)
-            'nest-ball': 12,      # Works better on lower-level Pokémon
-            'net-ball': 12,       # Higher chance for Water- and Bug-type Pokémon
-            'poke-ball': 8,       # Increased chance from 5 to 8
-            'premier-ball': 8,    # Same as Poké Ball, but it's a special ball
-            'quick-ball': 13,     # High chance if used at the start of battle
-            'repeat-ball': 12,    # Higher chance on Pokémon that have been caught before
-            'safari-ball': 8,     # Used in Safari Zone, with a fixed catch rate
-            'smoke-ball': 1,      # Used to flee from wild battles, no catch chance
-            'timer-ball': 13,     # Higher chance the longer the battle goes
-            'ultra-ball': 13      # Increased catch rate (original was 10, now 13)
+            "dive-ball": 11,  # Increased chance when fishing or underwater
+            "dusk-ball": 11,  # Increased chance at night or in caves
+            "great-ball": 12,  # Increased catch rate (original was 9, now 12)
+            "heal-ball": 12,  # Same as a Poké Ball but heals the Pokémon
+            "iron-ball": 12,  # Used for Steel-type Pokémon, 1.5x chance
+            "light-ball": 1,  # Not actually used for catching Pokémon; it's an item
+            "luxury-ball": 12,  # Same as a Poké Ball but increases happiness
+            "master-ball": 100,  # Guarantees a successful catch (100% chance)
+            "nest-ball": 12,  # Works better on lower-level Pokémon
+            "net-ball": 12,  # Higher chance for Water- and Bug-type Pokémon
+            "poke-ball": 8,  # Increased chance from 5 to 8
+            "premier-ball": 8,  # Same as Poké Ball, but it's a special ball
+            "quick-ball": 13,  # High chance if used at the start of battle
+            "repeat-ball": 12,  # Higher chance on Pokémon that have been caught before
+            "safari-ball": 8,  # Used in Safari Zone, with a fixed catch rate
+            "smoke-ball": 1,  # Used to flee from wild battles, no catch chance
+            "timer-ball": 13,  # Higher chance the longer the battle goes
+            "ultra-ball": 13,  # Increased catch rate (original was 10, now 13)
         }
 
         self.evolution_items = set()
@@ -183,7 +182,9 @@ class ItemWindow(QWidget):
 
         # FIX 3: Increase initial window size to better accommodate 3 columns
         # Calculate appropriate width: 3 columns * min_width + spacing + margins
-        initial_width = 3 * min_column_width + 2 * 10 + 40  # 3 cols + 2 spacings + margins
+        initial_width = (
+            3 * min_column_width + 2 * 10 + 40
+        )  # 3 cols + 2 spacings + margins
         initial_height = 600  # Increased from 500
         self.resize(initial_width, initial_height)
 
@@ -205,7 +206,9 @@ class ItemWindow(QWidget):
         else:
             for item in itembag_list:
                 try:
-                    item_widget = self.ItemLabel(item["item"], item["quantity"], item.get("type"))
+                    item_widget = self.ItemLabel(
+                        item["item"], item["quantity"], item.get("type")
+                    )
                     item_widget.setMinimumWidth(180)
                     self.contentLayout.addWidget(item_widget, row, col)
                     col += 1
@@ -236,29 +239,45 @@ class ItemWindow(QWidget):
             # Filter items based on category index
             if category_index == 1:  # Fossils
                 filtered_items = [
-                    item for item in filtered_items
-                    if isinstance(item, dict) and "item" in item and item["item"] in self.fossil_pokemon
+                    item
+                    for item in filtered_items
+                    if isinstance(item, dict)
+                    and "item" in item
+                    and item["item"] in self.fossil_pokemon
                 ]
             elif category_index == 2:  # TMs and HMs
-                filtered_items = list(filter(lambda item: item.get("type") == "TM", filtered_items))
+                filtered_items = list(
+                    filter(lambda item: item.get("type") == "TM", filtered_items)
+                )
             elif category_index == 3:  # Heal items
                 filtered_items = [
-                    item for item in filtered_items
-                    if isinstance(item, dict) and "item" in item and item["item"] in self.hp_heal_items
+                    item
+                    for item in filtered_items
+                    if isinstance(item, dict)
+                    and "item" in item
+                    and item["item"] in self.hp_heal_items
                 ]
             elif category_index == 4:  # Evolution items
                 filtered_items = [
-                    item for item in filtered_items
-                    if isinstance(item, dict) and "item" in item and item["item"] in self.evolution_items
+                    item
+                    for item in filtered_items
+                    if isinstance(item, dict)
+                    and "item" in item
+                    and item["item"] in self.evolution_items
                 ]
-            elif category_index == 5: # Pokeballs
+            elif category_index == 5:  # Pokeballs
                 filtered_items = [
-                    item for item in filtered_items
-                    if isinstance(item, dict) and "item" in item and item["item"] in self.pokeball_chances
+                    item
+                    for item in filtered_items
+                    if isinstance(item, dict)
+                    and "item" in item
+                    and item["item"] in self.pokeball_chances
                 ]
 
             # Now filter by search
-            filtered_items = list(filter(lambda item: search_text in item["item"].lower(), filtered_items))
+            filtered_items = list(
+                filter(lambda item: search_text in item["item"].lower(), filtered_items)
+            )
         except Exception as e:
             filtered_items = []
             self.logger.log_and_showinfo("error", f"Error filtering items: {e}")
@@ -270,7 +289,9 @@ class ItemWindow(QWidget):
 
         for item in filtered_items:
             try:
-                item_widget = self.ItemLabel(item["item"], item["quantity"], item.get("type"))
+                item_widget = self.ItemLabel(
+                    item["item"], item["quantity"], item.get("type")
+                )
                 item_widget.setMinimumWidth(180)
                 self.contentLayout.addWidget(item_widget, row, col)
                 col += 1
@@ -295,12 +316,18 @@ class ItemWindow(QWidget):
             if target_pokemon_data:
                 pokemon_obj = PokemonObject.from_dict(target_pokemon_data)
                 pokemon_obj.give_held_item(item_name)
-                
+
                 # Sync the main_pokemon singleton if it's the target
-                if self.main_pokemon and self.main_pokemon.individual_id == individual_id:
+                if (
+                    self.main_pokemon
+                    and self.main_pokemon.individual_id == individual_id
+                ):
                     self.main_pokemon.held_item = item_name
-                    
-                self.logger.log_and_showinfo("info", f"{item_name} was given to {target_pokemon_data.get('name')}.")
+
+                self.logger.log_and_showinfo(
+                    "info",
+                    f"{item_name} was given to {target_pokemon_data.get('name')}.",
+                )
                 self.renewWidgets()
             else:
                 self.logger.log_and_showinfo("error", "Could not find Pokemon data.")
@@ -312,9 +339,13 @@ class ItemWindow(QWidget):
         item_frame = QVBoxLayout()  # itemframe
         info_item_button = QPushButton("More Info")
         info_item_button.clicked.connect(lambda: self.more_info_button_act(item_name))
-        
-        item_name_for_label = item_name.replace("-", " ")  # Remove hyphens from item_name
-        item_name_for_label = f"{item_name_for_label.capitalize()} x{quantity}"  # Display quantity
+
+        item_name_for_label = item_name.replace(
+            "-", " "
+        )  # Remove hyphens from item_name
+        item_name_for_label = (
+            f"{item_name_for_label.capitalize()} x{quantity}"  # Display quantity
+        )
         if item_type == "TM":
             item_name_for_label = f"TM: {item_name_for_label}"
         item_name_label = QLabel(item_name_for_label)
@@ -323,7 +354,10 @@ class ItemWindow(QWidget):
         if item_type == "TM":
             details = find_details_move(item_name)
             if not details or "type" not in details:
-                self.logger.log_and_showinfo("error", f"Report the following: Missing details for item: {item_name!r}")
+                self.logger.log_and_showinfo(
+                    "error",
+                    f"Report the following: Missing details for item: {item_name!r}",
+                )
                 tm_type = "normal"
             else:
                 tm_type = details["type"].lower()
@@ -333,8 +367,9 @@ class ItemWindow(QWidget):
             item_file_path = items_path / f"{item_name}.png"
         item_picture_pixmap = QPixmap(str(item_file_path))
         item_picture_pixmap_scaled = item_picture_pixmap.scaled(
-            96, 96,
-            Qt.AspectRatioMode.KeepAspectRatio, # Important: Keeps the image from stretching
+            96,
+            96,
+            Qt.AspectRatioMode.KeepAspectRatio,  # Important: Keeps the image from stretching
         )
         item_picture_label = QLabel()
         item_picture_label.setPixmap(item_picture_pixmap_scaled)
@@ -347,12 +382,20 @@ class ItemWindow(QWidget):
         if item_name in self.hp_heal_items:
             use_item_button = QPushButton("Heal Mainpokemon")
             hp_heal = self.hp_heal_items[item_name]
-            use_item_button.clicked.connect(lambda: self.Check_Heal_Item(self.main_pokemon.name, hp_heal, item_name, self.achievements))
+            use_item_button.clicked.connect(
+                lambda: self.Check_Heal_Item(
+                    self.main_pokemon.name, hp_heal, item_name, self.achievements
+                )
+            )
         elif item_name in self.fossil_pokemon:
             fossil_id = self.fossil_pokemon[item_name]
             fossil_pokemon_name = search_pokedex_by_id(fossil_id)
-            use_item_button = QPushButton(f"Evolve Fossil to {fossil_pokemon_name.capitalize()}")
-            use_item_button.clicked.connect(lambda: self.Evolve_Fossil(item_name, fossil_id, fossil_pokemon_name))
+            use_item_button = QPushButton(
+                f"Evolve Fossil to {fossil_pokemon_name.capitalize()}"
+            )
+            use_item_button.clicked.connect(
+                lambda: self.Evolve_Fossil(item_name, fossil_id, fossil_pokemon_name)
+            )
         elif item_name in self.pokeball_chances:
             use_item_button = QPushButton("Try catching wild Pokemon")
             use_item_button.clicked.connect(lambda: self.Handle_Pokeball(item_name))
@@ -362,7 +405,7 @@ class ItemWindow(QWidget):
             # FIX: Remove indentation by using textwrap.dedent() or reformatting the string
             import textwrap
 
-            description_text = f"""Allows the user to teach {item_name.replace('-', ' ').title()} to Pokémon that can learn this move.\n\nTeaching the move doesn't consume the TM."""
+            description_text = f"""Allows the user to teach {item_name.replace("-", " ").title()} to Pokémon that can learn this move.\n\nTeaching the move doesn't consume the TM."""
 
             info_item_button = QLabel(textwrap.dedent(description_text).strip())
 
@@ -376,7 +419,11 @@ class ItemWindow(QWidget):
             use_item_button.clicked.connect(
                 lambda: self._prompt_and_check_evo_item(item_name)
             )
-        elif item_name in GiveItemWindow.NOT_YET_IMPLEMENTED_ITEMS or item_name.endswith("-berry") or item_name.endswith("-gem"):
+        elif (
+            item_name in GiveItemWindow.NOT_YET_IMPLEMENTED_ITEMS
+            or item_name.endswith("-berry")
+            or item_name.endswith("-gem")
+        ):
             use_item_button = QLabel("Not implemented yet")
             use_item_button.setAlignment(Qt.AlignmentFlag.AlignCenter)
         else:
@@ -401,17 +448,26 @@ class ItemWindow(QWidget):
         """
         name = (item_name or "").lower()
         if item_type == "TM":
-            return {"ok": False, "message": "TMs are taught from the move-learning flow, not used directly."}
+            return {
+                "ok": False,
+                "message": "TMs are taught from the move-learning flow, not used directly.",
+            }
         try:
             if name in self.hp_heal_items:
                 if not self.main_pokemon:
                     return {"ok": False, "message": "No active Pokémon to heal."}
                 hp_heal = self.hp_heal_items[name]
-                self.Check_Heal_Item(self.main_pokemon.name, hp_heal, name, self.achievements)
-                return {"ok": True, "message": f"Healed {self.main_pokemon.name} with {name}."}
+                self.Check_Heal_Item(
+                    self.main_pokemon.name, hp_heal, name, self.achievements
+                )
+                return {
+                    "ok": True,
+                    "message": f"Healed {self.main_pokemon.name} with {name}.",
+                }
             if name in self.fossil_pokemon:
                 fossil_id = self.fossil_pokemon[name]
                 from ..functions.pokedex_functions import search_pokedex_by_id
+
                 fossil_pokemon_name = search_pokedex_by_id(fossil_id)
                 self.Evolve_Fossil(name, fossil_id, fossil_pokemon_name)
                 return {"ok": True, "message": f"Revived {fossil_pokemon_name}."}
@@ -421,7 +477,11 @@ class ItemWindow(QWidget):
             if name in self.evolution_items:
                 self._prompt_and_check_evo_item(name)
                 return {"ok": True, "message": ""}
-            if name in GiveItemWindow.NOT_YET_IMPLEMENTED_ITEMS or name.endswith("-berry") or name.endswith("-gem"):
+            if (
+                name in GiveItemWindow.NOT_YET_IMPLEMENTED_ITEMS
+                or name.endswith("-berry")
+                or name.endswith("-gem")
+            ):
                 return {"ok": False, "message": "This item isn't usable yet."}
             self._prompt_and_give_held_item(name)
             return {"ok": True, "message": ""}
@@ -431,7 +491,9 @@ class ItemWindow(QWidget):
     def PokemonList(self, comboBox):
         try:
             db = mw.ankimon_db
-            pokemon_list = db.execute("SELECT name, individual_id, pokedex_id FROM captured_pokemon").fetchall()
+            pokemon_list = db.execute(
+                "SELECT name, individual_id, pokedex_id FROM captured_pokemon"
+            ).fetchall()
             if pokemon_list:
                 for pokemon in pokemon_list:
                     pokemon_name = pokemon[0]
@@ -441,10 +503,16 @@ class ItemWindow(QWidget):
                         # Add Pokémon name to comboBox
                         comboBox.addItem(pokemon_name)
                         # Store both individual_id and id as separate data using roles
-                        comboBox.setItemData(comboBox.count() - 1, individual_id, role=UserRole)
-                        comboBox.setItemData(comboBox.count() - 1, id_, role=UserRole + 1)
+                        comboBox.setItemData(
+                            comboBox.count() - 1, individual_id, role=UserRole
+                        )
+                        comboBox.setItemData(
+                            comboBox.count() - 1, id_, role=UserRole + 1
+                        )
         except Exception as e:
-            self.logger.log_and_showinfo("error", f"Error loading Pokémon list: {e} {pokemon}")
+            self.logger.log_and_showinfo(
+                "error", f"Error loading Pokémon list: {e} {pokemon}"
+            )
 
     def _load_pokemon_choices(self):
         if self._pokemon_choices_cache is not None:
@@ -452,11 +520,15 @@ class ItemWindow(QWidget):
         choices = []
         try:
             db = mw.ankimon_db
-            rows = db.execute("SELECT name, individual_id, pokedex_id FROM captured_pokemon").fetchall()
+            rows = db.execute(
+                "SELECT name, individual_id, pokedex_id FROM captured_pokemon"
+            ).fetchall()
             for row in rows:
                 name, individual_id, poke_id = row[0], row[1], row[2]
                 if name and individual_id and poke_id:
-                    choices.append((f"{name} ({individual_id[:8]})", individual_id, poke_id))
+                    choices.append(
+                        (f"{name} ({individual_id[:8]})", individual_id, poke_id)
+                    )
         except Exception as e:
             self.logger.log("error", f"Error loading Pokemon list: {e}")
         self._pokemon_choices_cache = choices
@@ -468,7 +540,9 @@ class ItemWindow(QWidget):
             self.logger.log_and_showinfo("error", "No Pokemon available.")
             return None
         labels = [c[0] for c in choices]
-        selected_label, ok = QInputDialog.getItem(self, title, "Select Pokemon:", labels, 0, False)
+        selected_label, ok = QInputDialog.getItem(
+            self, title, "Select Pokemon:", labels, 0, False
+        )
         if not ok:
             return None
         for label, individual_id, poke_id in choices:
@@ -502,23 +576,32 @@ class ItemWindow(QWidget):
             self.delete_item(item_name)
             self.starter_window.display_fossil_pokemon(fossil_id, fossil_poke_name)
             from ..singletons import pokemon_pc
+
             pokemon_pc.refresh_pokemon_grid()
         except Exception as e:
-            show_warning_with_traceback(parent=self, exception=e, message=f"Error using fossil item '{item_name}'")
+            show_warning_with_traceback(
+                parent=self,
+                exception=e,
+                message=f"Error using fossil item '{item_name}'",
+            )
         finally:
             self._item_action_in_progress = False
 
     def modified_pokeball_chances(self, item_name: str, catch_chance: int):
         # Adjust catch chance based on Pokémon type and Poké Ball
-        if item_name == 'net-ball' and ('water' in self.enemy_pokemon.type or 'bug' in self.enemy_pokemon.type):
+        if item_name == "net-ball" and (
+            "water" in self.enemy_pokemon.type or "bug" in self.enemy_pokemon.type
+        ):
             catch_chance += 10  # Additional 10% for Water or Bug-type Pokémon
-            self.logger.log("game", f"{item_name} gets a bonus for Water/Bug-type Pokémon!")
+            self.logger.log(
+                "game", f"{item_name} gets a bonus for Water/Bug-type Pokémon!"
+            )
 
-        elif item_name == 'iron-ball' and 'steel' in self.enemy_pokemon.type:
+        elif item_name == "iron-ball" and "steel" in self.enemy_pokemon.type:
             catch_chance += 10  # Additional 10% for Steel-type Pokémon
             self.logger.log("game", f"{item_name} gets a bonus for Steel-type Pokémon!")
 
-        elif item_name == 'dive-ball' and 'water' in self.enemy_pokemon.type:
+        elif item_name == "dive-ball" and "water" in self.enemy_pokemon.type:
             catch_chance += 10  # Additional 10% for Water-type Pokémon
             self.logger.log("game", f"{item_name} gets a bonus for Water-type Pokémon!")
 
@@ -533,21 +616,29 @@ class ItemWindow(QWidget):
             # Simulate catching the Pokémon based on the catch chance
             if random.randint(1, 100) <= catch_chance:
                 # Pokémon caught successfully
-                self.logger.log_and_showinfo("info", f"{item_name} successfully caught the Pokémon!")
+                self.logger.log_and_showinfo(
+                    "info", f"{item_name} successfully caught the Pokémon!"
+                )
                 self.delete_item(item_name)  # Delete the Poké Ball after use
             else:
                 # Pokémon was not caught
-                self.logger.log_and_showinfo("info", f"{item_name} failed to catch the Pokémon.")
+                self.logger.log_and_showinfo(
+                    "info", f"{item_name} failed to catch the Pokémon."
+                )
                 self.delete_item(item_name)  # Still delete the Poké Ball after use
         else:
-            self.logger.log_and_showinfo("error", f"{item_name} is not a valid Poké Ball!")
+            self.logger.log_and_showinfo(
+                "error", f"{item_name} is not a valid Poké Ball!"
+            )
 
     def delete_item(self, item_name: str):
         # Update database directly for performance
         mw.ankimon_db.update_item_quantity(item_name, -1)
         self.renewWidgets()
 
-    def Check_Heal_Item(self, prevo_name: str, heal_points: int, item_name: str, achievements):
+    def Check_Heal_Item(
+        self, prevo_name: str, heal_points: int, item_name: str, achievements
+    ):
         check = check_for_badge(achievements, 20)
         if check is False:
             receive_badge(20, achievements)
@@ -558,7 +649,9 @@ class ItemWindow(QWidget):
             self.main_pokemon.hp = self.main_pokemon.max_hp
         self.delete_item(item_name)
         play_effect_sound(self.settings_obj, "HpHeal")
-        self.logger.log_and_showinfo("info", f"{prevo_name} was healed for {heal_points}")
+        self.logger.log_and_showinfo(
+            "info", f"{prevo_name} was healed for {heal_points}"
+        )
 
     def Check_Evo_Item(self, individual_id: str, prevo_id: str, item_name: str):
         try:
@@ -569,27 +662,33 @@ class ItemWindow(QWidget):
                 self.logger.log_and_showinfo("info", "Pokemon Evolution is fitting !")
                 self.evo_window.ask_pokemon_evo(individual_id, prevo_id, evo_id)
             else:
-                self.logger.log_and_showinfo("info", "This Pokemon does not need this item.")
+                self.logger.log_and_showinfo(
+                    "info", "This Pokemon does not need this item."
+                )
         except Exception as e:
             show_warning_with_traceback(parent=self, exception=e, message=f"{e}")
 
     def load_evolution_items(self):
         try:
             evolution_item_ids = set()
-            with open(poke_evo_path, mode='r', newline='', encoding='utf-8') as evo_file:
+            with open(
+                poke_evo_path, mode="r", newline="", encoding="utf-8"
+            ) as evo_file:
                 reader = csv.DictReader(evo_file)
                 for row in reader:
-                    if row['evolution_trigger_id'] == '3':
-                        item_id = row['trigger_item_id']
+                    if row["evolution_trigger_id"] == "3":
+                        item_id = row["trigger_item_id"]
                         if item_id:
                             evolution_item_ids.add(item_id)
 
-            with open(csv_file_items_cost, mode='r', newline='', encoding='utf-8') as items_file:
+            with open(
+                csv_file_items_cost, mode="r", newline="", encoding="utf-8"
+            ) as items_file:
                 reader = csv.DictReader(items_file)
                 for row in reader:
-                    if row['id'] in evolution_item_ids:
-                        self.evolution_items.add(row['identifier'])
-            
+                    if row["id"] in evolution_item_ids:
+                        self.evolution_items.add(row["identifier"])
+
         except Exception as e:
             self.logger.log_and_showinfo("error", f"Error loading evolution items: {e}")
 
@@ -602,14 +701,14 @@ class ItemWindow(QWidget):
             quantity = item.get("quantity", 1)
             # Pass cached metadata back to database
             db.save_item(
-                item_id, 
-                item_name, 
-                quantity, 
-                extra_data=item, 
+                item_id,
+                item_name,
+                quantity,
+                extra_data=item,
                 category_id=item.get("category_id"),
                 cost=item.get("cost"),
                 fling_power=item.get("fling_power"),
-                fling_effect_id=item.get("fling_effect_id")
+                fling_effect_id=item.get("fling_effect_id"),
             )
 
     def read_items_file(self):
@@ -626,7 +725,7 @@ class ItemWindow(QWidget):
                 # Prioritize SQL columns over JSON blob
                 cat_id = item.get("category_id")
                 item_type = "TM" if cat_id == 37 else None
-                
+
                 # Combine database columns into the UI dictionary (preserving extra_data for legacy)
                 item_dict = {
                     "id": item.get("id"),
@@ -636,15 +735,15 @@ class ItemWindow(QWidget):
                     "category_id": cat_id,
                     "cost": item.get("cost"),
                     "fling_power": item.get("fling_power"),
-                    "fling_effect_id": item.get("fling_effect_id")
+                    "fling_effect_id": item.get("fling_effect_id"),
                 }
-                
+
                 # Merge with any existing extra_data for backward compatibility
                 if item.get("extra_data"):
                     for k, v in item["extra_data"].items():
                         if k not in item_dict:
                             item_dict[k] = v
-                            
+
                 result.append(item_dict)
             return result
         except Exception as e:
@@ -668,11 +767,13 @@ class ItemWindow(QWidget):
                 quantity = 1
             if quantity < 1:
                 continue
-            normalized.append({
-                **raw,
-                "item": name.strip(),
-                "quantity": quantity,
-            })
+            normalized.append(
+                {
+                    **raw,
+                    "item": name.strip(),
+                    "quantity": quantity,
+                }
+            )
         return normalized
 
     def clear_layout(self, layout):

--- a/src/Ankimon/singletons.py
+++ b/src/Ankimon/singletons.py
@@ -493,6 +493,9 @@ def swap_ankimon_account():
         if hasattr(mw, "ankidex_window") and is_alive(mw.ankidex_window):
             mw.ankidex_window.update_ui_data()
 
+        if hasattr(mw, "items_web_window") and is_alive(mw.items_web_window):
+            mw.items_web_window.update_ui_data()
+
         # If in reviewer, force HUD update
         if hasattr(mw, "reviewer") and mw.reviewer and hasattr(mw, "reviewer_obj"):
             mw.reviewer_obj.update_life_bar(mw.reviewer, None, 0)

--- a/src/Ankimon/singletons.py
+++ b/src/Ankimon/singletons.py
@@ -184,6 +184,21 @@ def get_ankidex_window():
         mw.ankidex_window = ankidex_window
     return ankidex_window
 
+# Unified Ankimon shell window (Items + Ankidex in one web view)
+items_web_window = getattr(mw, "items_web_window", None)
+def get_items_window():
+    global items_web_window
+    if not is_alive(items_web_window):
+        from .ankimon_items_web.shop_obj import AnkimonItemsWeb
+        items_web_window = AnkimonItemsWeb(
+            addon_dir,
+            shop_manager=shop_manager,
+            item_window=get_item_window(),
+            ankimon_tracker=ankimon_tracker_obj,
+        )
+        mw.items_web_window = items_web_window
+    return items_web_window
+
 evo_window = None
 def get_evo_window():
     global evo_window

--- a/src/Ankimon/singletons.py
+++ b/src/Ankimon/singletons.py
@@ -44,12 +44,15 @@ settings_obj = getattr(mw, "settings_obj", None) or Settings()
 mw.settings_obj = settings_obj
 
 settings_window = None
+
+
 def get_settings_window():
     global settings_window
     if not is_alive(settings_window):
         settings_window = getattr(mw, "settings_ankimon", None)
         if not is_alive(settings_window):
             from .pyobj.settings_window import SettingsWindow
+
             settings_window = SettingsWindow(
                 config=settings_obj.config,
                 set_config_callback=settings_obj.set,
@@ -59,8 +62,11 @@ def get_settings_window():
             mw.settings_ankimon = settings_window
     return settings_window
 
+
 # Init Translator
-translator = getattr(mw, "translator", None) or Translator(language=int(settings_obj.get("misc.language")))
+translator = getattr(mw, "translator", None) or Translator(
+    language=int(settings_obj.get("misc.language"))
+)
 mw.translator = translator
 
 # Main Pokemon
@@ -73,13 +79,34 @@ if main_pokemon is None:
 enemy_pokemon = getattr(mw, "enemy_pokemon", None)
 if enemy_pokemon is None:
     enemy_pokemon = PokemonObject(
-        name="Rattata", shiny=False, id=19, level=5, ability="Run Away", type=["Normal"],
-        stats={"hp": 39, "atk": 52, "def": 43, "spa": 60, "spd": 50, "spe": 65, "xp": 101},
-        attacks=["Quick Attack", "Tackle", "Tail Whip"], base_experience=58, growth_rate="medium-slow",
-        hp=30, ev={"hp": 3, "atk": 5, "def": 4, "spa": 1, "spd": 2, "spe": 3},
-        iv={"hp": 27, "atk": 24, "def": 3, "spa": 24, "spd": 16, "spe": 21}, gender="M",
-        battle_status="Fighting", xp=0, position=(5, 5), tier="Normal",
-        captured_date=None, individual_id=str(uuid.uuid4()),
+        name="Rattata",
+        shiny=False,
+        id=19,
+        level=5,
+        ability="Run Away",
+        type=["Normal"],
+        stats={
+            "hp": 39,
+            "atk": 52,
+            "def": 43,
+            "spa": 60,
+            "spd": 50,
+            "spe": 65,
+            "xp": 101,
+        },
+        attacks=["Quick Attack", "Tackle", "Tail Whip"],
+        base_experience=58,
+        growth_rate="medium-slow",
+        hp=30,
+        ev={"hp": 3, "atk": 5, "def": 4, "spa": 1, "spd": 2, "spe": 3},
+        iv={"hp": 27, "atk": 24, "def": 3, "spa": 24, "spd": 16, "spe": 21},
+        gender="M",
+        battle_status="Fighting",
+        xp=0,
+        position=(5, 5),
+        tier="Normal",
+        captured_date=None,
+        individual_id=str(uuid.uuid4()),
     )
     mw.enemy_pokemon = enemy_pokemon
 
@@ -87,7 +114,9 @@ if enemy_pokemon is None:
 trainer_card = getattr(mw, "trainer_card", None)
 if trainer_card is None:
     trainer_card = TrainerCard(
-        logger, main_pokemon, settings_obj,
+        logger,
+        main_pokemon,
+        settings_obj,
         trainer_name=settings_obj.get("trainer.name"),
         trainer_id="".join(filter(str.isdigit, str(uuid.uuid4()).replace("-", ""))),
         team="Pikachu (Level 25), Charizard (Level 50), Bulbasaur (Level 15)",
@@ -97,15 +126,19 @@ if trainer_card is None:
 
 # --- LAZY WINDOWS & DIALOGS ---
 starter_window = None
+
+
 def get_starter_window():
     global starter_window
     if not is_alive(starter_window):
         starter_window = getattr(mw, "starter_window", None)
         if not is_alive(starter_window):
             from .pyobj.starter_window import StarterWindow
+
             starter_window = StarterWindow(logger, settings_obj)
             mw.starter_window = starter_window
     return starter_window
+
 
 # Ankimon Tracker
 ankimon_tracker_obj = getattr(mw, "ankimon_tracker_obj", None)
@@ -117,79 +150,108 @@ if ankimon_tracker_obj is None:
 
 # Test Window
 test_window = None
+
+
 def get_test_window():
     global test_window
     if not is_alive(test_window):
         test_window = getattr(mw, "test_window", None)
         if not is_alive(test_window):
             from .pyobj.test_window import TestWindow
+
             test_window = TestWindow(
-                main_pokemon=main_pokemon, enemy_pokemon=enemy_pokemon,
-                settings_obj=settings_obj, ankimon_tracker_obj=ankimon_tracker_obj,
-                translator=translator, parent=mw, logger=logger,
+                main_pokemon=main_pokemon,
+                enemy_pokemon=enemy_pokemon,
+                settings_obj=settings_obj,
+                ankimon_tracker_obj=ankimon_tracker_obj,
+                translator=translator,
+                parent=mw,
+                logger=logger,
             )
             mw.test_window = test_window
     return test_window
 
+
 # Shop Manager
 shop_manager = getattr(mw, "shop_manager", None) or PokemonShopManager(
-    logger=logger, settings_obj=settings_obj,
-    set_callback=settings_obj.set, get_callback=settings_obj.get,
+    logger=logger,
+    settings_obj=settings_obj,
+    set_callback=settings_obj.set,
+    get_callback=settings_obj.get,
 )
 mw.shop_manager = shop_manager
 
 # Reviewer Manager
 reviewer_obj = getattr(mw, "reviewer_obj", None) or Reviewer_Manager(
-    settings_obj=settings_obj, main_pokemon=main_pokemon,
-    enemy_pokemon=enemy_pokemon, ankimon_tracker=ankimon_tracker_obj,
+    settings_obj=settings_obj,
+    main_pokemon=main_pokemon,
+    enemy_pokemon=enemy_pokemon,
+    ankimon_tracker=ankimon_tracker_obj,
 )
 mw.reviewer_obj = reviewer_obj
 
 # Achievements
 achievements = getattr(mw, "achievements_dict", None)
 if achievements is None:
-    achievements = populate_achievements_from_badges({str(i): False for i in range(1, 69)})
+    achievements = populate_achievements_from_badges(
+        {str(i): False for i in range(1, 69)}
+    )
     mw.achievements_dict = achievements
 
 # Windows & Bags
 achievement_bag = None
+
+
 def get_achievement_bag():
     global achievement_bag
     if not is_alive(achievement_bag):
         achievement_bag = getattr(mw, "achievement_bag", None)
         if not is_alive(achievement_bag):
             from .pyobj.achievement_window import AchievementWindow
+
             achievement_bag = AchievementWindow()
             mw.achievement_bag = achievement_bag
     return achievement_bag
 
+
 ankimon_tracker_window = None
+
+
 def get_ankimon_tracker_window():
     global ankimon_tracker_window
     if not is_alive(ankimon_tracker_window):
         ankimon_tracker_window = getattr(mw, "ankimon_tracker_window", None)
         if not is_alive(ankimon_tracker_window):
             from .pyobj.ankimon_tracker_window import AnkimonTrackerWindow
+
             ankimon_tracker_window = AnkimonTrackerWindow(tracker=ankimon_tracker_obj)
             mw.ankimon_tracker_window = ankimon_tracker_window
     return ankimon_tracker_window
 
+
 # Ankidex
 ankidex_window = getattr(mw, "ankidex_window", None)
+
+
 def get_ankidex_window():
     global ankidex_window
     if not is_alive(ankidex_window):
         from .ankidex.ankidex_obj import Ankidex
+
         ankidex_window = Ankidex(addon_dir, ankimon_tracker=ankimon_tracker_obj)
         mw.ankidex_window = ankidex_window
     return ankidex_window
 
+
 # Unified Ankimon shell window (Items + Ankidex in one web view)
 items_web_window = getattr(mw, "items_web_window", None)
+
+
 def get_items_window():
     global items_web_window
     if not is_alive(items_web_window):
         from .ankimon_items_web.shop_obj import AnkimonItemsWeb
+
         items_web_window = AnkimonItemsWeb(
             addon_dir,
             shop_manager=shop_manager,
@@ -199,97 +261,146 @@ def get_items_window():
         mw.items_web_window = items_web_window
     return items_web_window
 
+
 evo_window = None
+
+
 def get_evo_window():
     global evo_window
     if not is_alive(evo_window):
         evo_window = getattr(mw, "evo_window", None)
         if not is_alive(evo_window):
             from .pyobj.evolution_window import EvoWindow
+
             evo_window = EvoWindow(
-                logger, settings_obj, main_pokemon, translator, reviewer_obj, get_test_window(), achievements,
+                logger,
+                settings_obj,
+                main_pokemon,
+                translator,
+                reviewer_obj,
+                get_test_window(),
+                achievements,
             )
             mw.evo_window = evo_window
     return evo_window
 
+
 item_window = None
+
+
 def get_item_window():
     global item_window
     if not is_alive(item_window):
         item_window = getattr(mw, "item_window", None)
         if not is_alive(item_window):
             from .pyobj.item_window import ItemWindow
+
             item_window = ItemWindow(
-                logger=logger, settings_obj=settings_obj, main_pokemon=main_pokemon,
-                enemy_pokemon=enemy_pokemon, achievements=achievements,
+                logger=logger,
+                settings_obj=settings_obj,
+                main_pokemon=main_pokemon,
+                enemy_pokemon=enemy_pokemon,
+                achievements=achievements,
                 starter_window=get_starter_window(),
                 evo_window=get_evo_window(),
             )
             mw.item_window = item_window
     return item_window
 
+
 # Pokemon PC
 pokemon_pc = getattr(mw, "pokemon_pc", None)
+
+
 def get_pokemon_pc():
     global pokemon_pc
     if not is_alive(pokemon_pc):
         pokemon_pc = getattr(mw, "pokemon_pc", None)
         if not is_alive(pokemon_pc):
             from .pyobj.pc_box import PokemonPC
+
             pokemon_pc = PokemonPC(
-                logger=logger, translator=translator, reviewer_obj=reviewer_obj,
-                test_window=get_test_window(), settings=settings_obj, main_pokemon=main_pokemon,
+                logger=logger,
+                translator=translator,
+                reviewer_obj=reviewer_obj,
+                test_window=get_test_window(),
+                settings=settings_obj,
+                main_pokemon=main_pokemon,
                 achievements=achievements,
             )
             mw.pokemon_pc = pokemon_pc
     return pokemon_pc
 
+
 # UI Utilities
 eff_chart = None
+
+
 def get_eff_chart():
     global eff_chart
     if not is_alive(eff_chart):
         from .gui_entities import TableWidget
+
         eff_chart = TableWidget()
     return eff_chart
 
+
 gen_id_chart = None
+
+
 def get_gen_id_chart():
     global gen_id_chart
     if not is_alive(gen_id_chart):
         from .gui_entities import IDTableWidget
+
         gen_id_chart = IDTableWidget()
     return gen_id_chart
 
+
 nature_chart = None
+
+
 def get_nature_chart():
     global nature_chart
     if not is_alive(nature_chart):
         from .gui_entities import NatureTableWidget
+
         nature_chart = NatureTableWidget()
     return nature_chart
 
+
 license = None
+
+
 def get_license():
     global license
     if not is_alive(license):
         from .gui_entities import License
+
         license = License()
     return license
 
+
 credits = None
+
+
 def get_credits():
     global credits
     if not is_alive(credits):
         from .gui_entities import Credits
+
         credits = Credits()
     return credits
 
+
 version_dialog = None
+
+
 def get_version_dialog():
     global version_dialog
     if not is_alive(version_dialog):
         from .gui_entities import Version_Dialog
+
         version_dialog = Version_Dialog()
     return version_dialog
 
@@ -349,10 +460,11 @@ def swap_ankimon_account():
         # Reset battle and capture state so no stale data can bleed through
         mw.ankimon_tracker_obj.caught = 0
         mw.ankimon_tracker_obj.general_card_count_for_battle = 0
-        
+
         # Sync collected IDs to current account
         from .reviewer_ui import set_collected_ids
         from .battle_loop import init_battle_state
+
         new_ids = mw.ankimon_db.get_all_pokemon_ids()
         set_collected_ids(new_ids)
         init_battle_state(new_ids)
@@ -361,7 +473,12 @@ def swap_ankimon_account():
         clear_encounter_cache()
 
         # Generate a fresh encounter for the new account
-        new_pokemon(mw.enemy_pokemon, getattr(mw, "test_window", None), mw.ankimon_tracker_obj, mw.reviewer_obj)
+        new_pokemon(
+            mw.enemy_pokemon,
+            getattr(mw, "test_window", None),
+            mw.ankimon_tracker_obj,
+            mw.reviewer_obj,
+        )
 
         # Refresh windows if they are open
         if hasattr(mw, "pokemon_pc") and is_alive(mw.pokemon_pc):
@@ -369,7 +486,7 @@ def swap_ankimon_account():
             mw.pokemon_pc._selected_individual_id = None
             mw.pokemon_pc.pokemon_details_layout = None
             mw.pokemon_pc.refresh_gui()
-        
+
         if hasattr(mw, "item_window") and is_alive(mw.item_window):
             mw.item_window.renewWidgets()
 
@@ -384,4 +501,5 @@ def swap_ankimon_account():
     except Exception as e:
         tooltip(f"Failed to switch account: {e}")
         import traceback
+
         traceback.print_exc()


### PR DESCRIPTION
## Summary
- Merges the Ankimon Mart and the legacy PyQt Item Bag into a single web window (`src/Ankimon/ankimon_items_web/`), built on the same QWebEngineView pattern as the Ankidex.
- One unified grid with state-aware cards (in shop / owned / both), category filters (TMs, Heal, Poké Balls, Evolution, Fossils), and a detail panel with Buy + Use actions wired to the existing inventory dispatch.
- In-page nav dropdown shared with the Ankidex so the user can switch between screens within the same window — same `QDialog`, same `QWebEngineView`, only the loaded HTML changes.

## What's in the window
- **Sidebar**: View (In Shop Today / In Your Bag with live counts), Category filter, Reroll Stock action, Wallet currency card.
- **Main**: filterable grid of cards. Items and TMs split into labeled sections when both are visible; flat grid otherwise.
- **Detail panel**: hero sprite with type-aware glow (TMs colored by move type), effect text, TM move stats (Power / Accuracy / PP / Category with animated bars), and an Actions block scoped to the card's state — Buy if in shop, Use if owned, both if applicable.

## Single-window navigation
- `AnkimonItemsWeb` hosts both Items and Ankidex via `load_screen(name)` — one `QDialog`, one `QWebEngineView`, one `QWebChannel` for the lifetime of the window.
- `NavBridge` exposed as \`nav\` on both pages; click dropdown → URL swap → fresh data injected on `loadFinished`. No window close/reopen flicker.
- Ankidex page gets the switcher additively (new `nav-switcher.css` + `nav-switcher.js`). Standalone Ankidex window still launches cleanly: the CSS hides the dropdown affordance unless \`body.shell-mode\` is set, and the JS only sets it when QWebChannel successfully connects.
- Ankidex preferences are saved both on shell close and when navigating away from the Ankidex screen (same \`getAnkidexState()\` callback the standalone window used).

## Performance
- \`PokemonShopManager.get_tm_pool()\` caches the flattened TM pool on first call. \`pokemon_tm_learnset.json\` is immutable at runtime — matches the BRRRR_Experimental in-memory caching pattern.
- \`AnkimonItemsWeb\` indexes \`items.csv\` and \`item_flavor_text.csv\` into dicts on first use. Per-item price + description lookups become O(1) dict reads instead of full CSV scans — significant speedup for a heavy bag (was opening + scanning each CSV per item).

## Legacy bridge
- \`ItemWindow.dispatch_use(item_name, item_type)\` extracts the use-item branching (heal / fossil / pokeball / evolution-item / held-item) from \`ItemLabel\` into a public method the web shell invokes without showing the old bag. The old PyQt render code is untouched in this PR — cleanup is left to a follow-up.

## Menu wiring
Both Tools → Ankimon entries now open the same shell:
- **Collection → Itembag** → shell at Items
- **Collection → Ankidex** → shell at Ankidex
- **Game → Item Shop** (if present) → shell at Items

## Test plan
- [ ] Restart Anki, open Tools → Ankimon → Collection → Itembag — opens the new shell at Items.
- [ ] Open Tools → Ankimon → Collection → Ankidex — same window, lands on Ankidex.
- [ ] Click the dropdown in either screen, switch to the other — no window flicker, content swaps in place.
- [ ] Buy an item (or TM) from the Mart — cash deducts, owned count updates, card state changes.
- [ ] Reroll Stock — confirmation modal appears, deducts 100¥, stock changes.
- [ ] Use a Potion / Pokeball / Evolution item — existing dispatch flows fire (heal pops, ball roll, evo prompt).
- [ ] Close and reopen the window — Ankidex preferences (view mode, sort, etc.) persist.
- [ ] Filter by category (TMs only / Heal only / etc.) — single grid section, no headers.
- [ ] Search across name, move type, and category.