### PR TITLE
feat(settings): port Ankimon settings into the unified shell window

### DIFF
--- a/src/Ankimon/ankidex/ankidex.html
+++ b/src/Ankimon/ankidex/ankidex.html
@@ -7,8 +7,8 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <!-- Inline dark bg + skeleton placeholders so the user sees structure
-         while external CSS + initial dex data load. The first render in
-         ankidex.js does pokemon-grid.innerHTML='' which clears them. -->
+         while the external CSS + initial dex data load. The first render
+         in ankidex.js does pokemon-grid.innerHTML='' which clears them. -->
     <style>
         html { background: #0d1117; }
         .skeleton-grid {
@@ -60,7 +60,7 @@
                             </div>
                         </button>
                         <button class="nav-menu-item" role="menuitem" data-screen="settings">
-                            <span class="nav-menu-icon">⚙</span>
+                            <span class="nav-menu-icon"><svg class="icon-gear" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1 0 2.83 2 2 0 0 1-2.83 0l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-2 2 2 2 0 0 1-2-2v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83 0 2 2 0 0 1 0-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1-2-2 2 2 0 0 1 2-2h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 0-2.83 2 2 0 0 1 2.83 0l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 2-2 2 2 0 0 1 2 2v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 0 2 2 0 0 1 0 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 2 2 2 2 0 0 1-2 2h-.09a1.65 1.65 0 0 0-1.51 1z"/></svg></span>
                             <div class="nav-menu-text">
                                 <span class="nav-menu-title">Settings</span>
                                 <span class="nav-menu-desc">Configure Ankimon</span>
@@ -167,9 +167,10 @@
 
             <div class="content-scroll">
                 <div id="pokemon-grid" class="pokemon-grid">
-                    <!-- Skeleton placeholders wrapped in a grid (.pokemon-grid
-                         is display:block; sub-grids handle layout normally).
-                         Cleared on first render by ankidex.js innerHTML=''. -->
+                    <!-- Skeleton placeholders wrapped in a grid (the real
+                         .pokemon-grid is display:block, sub-grids handle
+                         the layout). innerHTML='' on first render clears
+                         the whole wrapper. -->
                     <div class="skeleton-grid">
                         <div class="skeleton"></div><div class="skeleton"></div>
                         <div class="skeleton"></div><div class="skeleton"></div>

--- a/src/Ankimon/ankidex/ankidex.html
+++ b/src/Ankimon/ankidex/ankidex.html
@@ -59,6 +59,13 @@
                                 <span class="nav-menu-desc">Browse caught Pokémon</span>
                             </div>
                         </button>
+                        <button class="nav-menu-item" role="menuitem" data-screen="settings">
+                            <span class="nav-menu-icon">⚙</span>
+                            <div class="nav-menu-text">
+                                <span class="nav-menu-title">Settings</span>
+                                <span class="nav-menu-desc">Configure Ankimon</span>
+                            </div>
+                        </button>
                     </div>
                 </div>
             </div>

--- a/src/Ankimon/ankidex/nav-switcher.css
+++ b/src/Ankimon/ankidex/nav-switcher.css
@@ -166,7 +166,15 @@ body:not(.shell-mode) .nav-trigger {
     pointer-events: none;
 }
 
-/* --- Items identity icon (hyper-potion sprite used as Items' visual ID). */
+/* --- Gear icon (Settings entry in the nav dropdown) --- */
+.icon-gear {
+    width: 18px;
+    height: 18px;
+    display: block;
+    color: var(--accent-blue);
+}
+
+/* --- Items icon (hyper-potion sprite used as Items' identity). --- */
 .icon-item-sprite {
     image-rendering: pixelated;
     object-fit: contain;

--- a/src/Ankimon/ankidex/nav-switcher.js
+++ b/src/Ankimon/ankidex/nav-switcher.js
@@ -3,7 +3,7 @@
 // Tries to connect to the shell's QWebChannel. If a bridge is available we
 // flip body.shell-mode (which makes the dropdown affordances visible per
 // nav-switcher.css), wire the trigger click, and route menu clicks through
-// window.nav.openItems() / openAnkidex(). Standalone (no bridge) is a no-op.
+// window.nav.openItems() / openAnkidex() / openSettings(). Standalone (no bridge) is a no-op.
 
 (function () {
     'use strict';
@@ -47,6 +47,7 @@
                 if (item.classList.contains('active')) return;
                 if (screen === 'items' && nav.openItems) nav.openItems();
                 else if (screen === 'ankidex' && nav.openAnkidex) nav.openAnkidex();
+                else if (screen === 'settings' && nav.openSettings) nav.openSettings();
             });
         });
     }

--- a/src/Ankimon/ankimon_items_web/settings.css
+++ b/src/Ankimon/ankimon_items_web/settings.css
@@ -1,0 +1,332 @@
+/* Settings screen — form-specific styles layered on top of shop.css. */
+
+/* --- Sidebar group jumps --- */
+#group-jumps {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+}
+
+.group-jump {
+    width: 100%;
+    text-align: left;
+    background: transparent;
+    border: none;
+    color: var(--text-main);
+    padding: 8px 12px;
+    border-radius: 8px;
+    font-family: inherit;
+    font-size: 0.85rem;
+    font-weight: 500;
+    cursor: pointer;
+    transition: 0.15s ease;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
+}
+
+.group-jump:hover {
+    background: var(--bg-card);
+    color: var(--text-bright);
+}
+
+.group-jump.active {
+    background: var(--bg-card-hover);
+    color: var(--accent-blue);
+    font-weight: 600;
+}
+
+.group-jump-count {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 0.7rem;
+    color: var(--text-muted);
+}
+
+/* --- Save action dirty pill --- */
+.dirty-pill {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 0.7rem;
+    font-weight: 700;
+    color: var(--accent-gold);
+    background: rgba(210, 153, 34, 0.12);
+    border: 1px solid rgba(210, 153, 34, 0.3);
+    padding: 1px 7px;
+    border-radius: 4px;
+}
+
+.dirty-pill.hidden {
+    display: none;
+}
+
+.icon-save {
+    width: 16px;
+    height: 16px;
+    flex-shrink: 0;
+    display: block;
+    color: var(--accent-blue);
+}
+
+#save-btn:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+}
+
+#save-btn.dirty {
+    background: linear-gradient(135deg,
+        rgba(63, 185, 80, 0.18),
+        rgba(63, 185, 80, 0.06));
+    border-color: rgba(63, 185, 80, 0.45);
+}
+
+#save-btn.dirty .icon-save { color: var(--accent-green); }
+
+/* --- Top-bar discard --- */
+.settings-discard-btn {
+    background: transparent;
+    color: var(--text-muted);
+    border: 1px solid var(--border-main);
+    border-radius: 8px;
+    padding: 6px 14px;
+    font-family: inherit;
+    font-size: 0.8rem;
+    font-weight: 600;
+    cursor: pointer;
+    transition: 0.15s ease;
+}
+
+.settings-discard-btn:hover {
+    background: var(--bg-card-hover);
+    color: var(--accent-red);
+    border-color: rgba(248, 81, 73, 0.4);
+}
+
+.settings-discard-btn.hidden { display: none; }
+
+/* --- Group sections --- */
+.settings-group {
+    margin-bottom: 40px;
+}
+
+.settings-group.hidden { display: none; }
+
+.settings-group-header {
+    display: flex;
+    align-items: baseline;
+    gap: 12px;
+    margin-bottom: 18px;
+    padding-bottom: 10px;
+    border-bottom: 1px solid var(--border-main);
+}
+
+.settings-group-title {
+    font-size: 1.2rem;
+    font-weight: 800;
+    letter-spacing: -0.3px;
+    color: var(--text-bright);
+}
+
+.settings-group-count {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 0.75rem;
+    color: var(--text-muted);
+}
+
+.settings-subgroup {
+    margin-top: 24px;
+    padding: 18px 20px;
+    background: var(--bg-card);
+    border: 1px solid var(--border-main);
+    border-radius: 14px;
+}
+
+.settings-subgroup.hidden { display: none; }
+
+.settings-subgroup-title {
+    font-size: 0.75rem;
+    font-weight: 800;
+    letter-spacing: 1.5px;
+    text-transform: uppercase;
+    color: var(--accent-blue);
+    margin-bottom: 14px;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+}
+
+.settings-subgroup-title::after {
+    content: '';
+    flex: 1;
+    height: 1px;
+    background: linear-gradient(to right, var(--border-main), transparent);
+}
+
+/* --- Setting row --- */
+.setting-row {
+    display: grid;
+    grid-template-columns: 1fr 280px;
+    gap: 28px;
+    padding: 16px 0;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.04);
+    align-items: start;
+}
+
+.setting-row:last-child { border-bottom: none; }
+
+.setting-row.hidden { display: none; }
+
+.setting-row.dirty .setting-label::after {
+    content: '●';
+    color: var(--accent-gold);
+    margin-left: 6px;
+    font-size: 0.75rem;
+}
+
+.setting-info {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    min-width: 0;
+}
+
+.setting-label {
+    font-size: 0.92rem;
+    font-weight: 700;
+    color: var(--text-bright);
+    line-height: 1.3;
+}
+
+.setting-key {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 0.65rem;
+    color: var(--text-muted);
+    letter-spacing: 0.5px;
+    opacity: 0.7;
+}
+
+.setting-description {
+    font-size: 0.78rem;
+    color: var(--text-muted);
+    line-height: 1.5;
+    margin-top: 4px;
+    white-space: pre-wrap;
+}
+
+.setting-control {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    align-self: start;
+}
+
+/* --- Form controls --- */
+.setting-input {
+    width: 100%;
+    background: var(--bg-darker);
+    border: 1px solid var(--border-main);
+    color: var(--text-bright);
+    font-family: inherit;
+    font-size: 0.88rem;
+    padding: 9px 12px;
+    border-radius: 8px;
+    transition: 0.15s ease;
+    outline: none;
+}
+
+.setting-input:hover {
+    border-color: var(--text-muted);
+}
+
+.setting-input:focus {
+    border-color: var(--accent-blue);
+    box-shadow: 0 0 0 3px rgba(88, 166, 255, 0.12);
+}
+
+.setting-input.numeric {
+    font-family: 'JetBrains Mono', monospace;
+    text-align: right;
+}
+
+.setting-select {
+    width: 100%;
+    background: var(--bg-darker);
+    border: 1px solid var(--border-main);
+    color: var(--text-bright);
+    font-family: inherit;
+    font-size: 0.88rem;
+    padding: 9px 12px;
+    border-radius: 8px;
+    cursor: pointer;
+    appearance: none;
+    -webkit-appearance: none;
+    background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 24 24' fill='none' stroke='%238b949e' stroke-width='2.5' stroke-linecap='round' stroke-linejoin='round'><polyline points='6 9 12 15 18 9'/></svg>");
+    background-repeat: no-repeat;
+    background-position: right 12px center;
+    padding-right: 36px;
+}
+
+.setting-select:focus {
+    border-color: var(--accent-blue);
+    box-shadow: 0 0 0 3px rgba(88, 166, 255, 0.12);
+    outline: none;
+}
+
+/* --- Boolean toggle (segmented control style) --- */
+.setting-toggle {
+    display: inline-flex;
+    background: var(--bg-darker);
+    border: 1px solid var(--border-main);
+    border-radius: 8px;
+    padding: 3px;
+    gap: 2px;
+    width: 100%;
+}
+
+.setting-toggle-option {
+    flex: 1;
+    background: transparent;
+    border: none;
+    color: var(--text-muted);
+    font-family: inherit;
+    font-size: 0.8rem;
+    font-weight: 700;
+    padding: 6px 12px;
+    border-radius: 5px;
+    cursor: pointer;
+    transition: 0.15s ease;
+    letter-spacing: 0.5px;
+}
+
+.setting-toggle-option:hover {
+    color: var(--text-bright);
+}
+
+.setting-toggle-option.active {
+    background: var(--accent-blue);
+    color: #0d1117;
+}
+
+.setting-toggle-option.active.off {
+    background: var(--bg-card-hover);
+    color: var(--text-muted);
+}
+
+/* --- Validation hint --- */
+.setting-hint {
+    font-size: 0.7rem;
+    color: var(--text-muted);
+    font-family: 'JetBrains Mono', monospace;
+}
+
+.setting-hint.error {
+    color: var(--accent-red);
+}
+
+/* --- Responsive collapse on narrow widths --- */
+@media (max-width: 900px) {
+    .setting-row {
+        grid-template-columns: 1fr;
+        gap: 12px;
+    }
+    .setting-control { max-width: 320px; }
+}

--- a/src/Ankimon/ankimon_items_web/settings.css
+++ b/src/Ankimon/ankimon_items_web/settings.css
@@ -50,15 +50,25 @@
 }
 
 .group-jump.active {
-    background: var(--bg-card-hover);
+    background: rgba(88, 166, 255, 0.10);
     color: var(--accent-blue);
     font-weight: 600;
+    /* Left accent bar so the highlight reads as a clear "you are here"
+     * marker anchored to the title text. Inset box-shadow avoids the
+     * layout shift a border-left would cause. */
+    box-shadow: inset 3px 0 0 var(--accent-blue);
 }
 
 .group-jump-count {
     font-family: 'JetBrains Mono', monospace;
     font-size: 0.7rem;
     color: var(--text-muted);
+    transition: color 0.15s ease;
+}
+
+.group-jump.active .group-jump-count {
+    color: var(--accent-blue);
+    opacity: 0.75;
 }
 
 /* --- Save action dirty pill --- */
@@ -85,6 +95,22 @@
     color: var(--accent-blue);
 }
 
+/* Override .nav-action's red palette — Save isn't destructive like the
+ * Mart's reroll, so use a neutral blue tint at rest and green when dirty. */
+#save-btn {
+    background: linear-gradient(135deg,
+        rgba(88, 166, 255, 0.10),
+        rgba(88, 166, 255, 0.03));
+    border-color: rgba(88, 166, 255, 0.25);
+}
+
+#save-btn:hover:not(:disabled) {
+    background: linear-gradient(135deg,
+        rgba(88, 166, 255, 0.22),
+        rgba(88, 166, 255, 0.08));
+    border-color: var(--accent-blue);
+}
+
 #save-btn:disabled {
     opacity: 0.5;
     cursor: not-allowed;
@@ -95,6 +121,13 @@
         rgba(63, 185, 80, 0.18),
         rgba(63, 185, 80, 0.06));
     border-color: rgba(63, 185, 80, 0.45);
+}
+
+#save-btn.dirty:hover:not(:disabled) {
+    background: linear-gradient(135deg,
+        rgba(63, 185, 80, 0.30),
+        rgba(63, 185, 80, 0.10));
+    border-color: var(--accent-green);
 }
 
 #save-btn.dirty .icon-save { color: var(--accent-green); }
@@ -150,33 +183,23 @@
     color: var(--text-muted);
 }
 
+/* Subgroups visually match top-level groups — same heading treatment,
+ * no card chrome. Slightly smaller heading preserves the implicit
+ * "nested under parent group" hierarchy without a visual container. */
 .settings-subgroup {
-    margin-top: 24px;
-    padding: 18px 20px;
-    background: var(--bg-card);
-    border: 1px solid var(--border-main);
-    border-radius: 14px;
+    margin-top: 32px;
 }
 
 .settings-subgroup.hidden { display: none; }
 
 .settings-subgroup-title {
-    font-size: 0.75rem;
-    font-weight: 800;
-    letter-spacing: 1.5px;
-    text-transform: uppercase;
-    color: var(--accent-blue);
+    font-size: 1.05rem;
+    font-weight: 700;
+    letter-spacing: -0.2px;
+    color: var(--text-bright);
     margin-bottom: 14px;
-    display: flex;
-    align-items: center;
-    gap: 10px;
-}
-
-.settings-subgroup-title::after {
-    content: '';
-    flex: 1;
-    height: 1px;
-    background: linear-gradient(to right, var(--border-main), transparent);
+    padding-bottom: 8px;
+    border-bottom: 1px solid var(--border-main);
 }
 
 /* --- Setting row --- */
@@ -392,4 +415,48 @@
 /* Chip rows are wider than form inputs — let them spill across the control column. */
 .setting-row:has(.setting-chips) {
     grid-template-columns: 1fr 360px;
+}
+
+/* --- Section jump highlight --- */
+/* When the user clicks a section in the sidebar nav, briefly tint the
+ * landing section so they get a clear visual confirmation.
+ *
+ * Uses a ::before pseudo-element rather than box-shadow so we can apply
+ * an asymmetric inset: extend 14px above and on the sides, but crop 14px
+ * INTO the section's bottom — the last setting-row already has 16px of
+ * padding below its text, which the section bg would naturally pick up.
+ * Without the crop, the visible tinted area below the last row ends up
+ * ~30px (row padding + box-shadow extension) vs ~14px above the header.
+ * The crop balances both edges to ~14px. */
+.settings-group,
+.settings-subgroup {
+    position: relative;
+    /* isolation: isolate forces a new stacking context so the flash
+     * pseudo-element's z-index: -1 stays scoped inside the section
+     * (otherwise it escapes upward and renders behind opaque ancestor
+     * backgrounds, making the flash invisible). */
+    isolation: isolate;
+}
+
+.settings-group.flash-highlight::before,
+.settings-subgroup.flash-highlight::before {
+    content: '';
+    position: absolute;
+    /* top right bottom left — negative outsets, positive insets crop:
+     *   top: -14px  → tint extends 14px above section
+     *   bottom: 2px → tint crops 2px from section's bottom, leaving the
+     *                 last 14px of the row's 16px padding-bottom as tinted
+     *                 area below the last row's text. Matches the 14px above
+     *                 the header. */
+    inset: -14px -14px 2px -14px;
+    background: rgba(88, 166, 255, 0.16);
+    border-radius: 10px;
+    pointer-events: none;
+    z-index: -1;
+    animation: section-flash 1.2s ease-out forwards;
+}
+
+@keyframes section-flash {
+    0%   { opacity: 1; }
+    100% { opacity: 0; }
 }

--- a/src/Ankimon/ankimon_items_web/settings.css
+++ b/src/Ankimon/ankimon_items_web/settings.css
@@ -1,5 +1,23 @@
 /* Settings screen — form-specific styles layered on top of shop.css. */
 
+/* --- Search input (shop.css's #pokemon-search / #shop-search rules don't
+ * apply to our #settings-search; mirror them here) --- */
+#settings-search {
+    width: 100%;
+    background: transparent;
+    border: none;
+    color: var(--text-main);
+    font-family: inherit;
+    font-size: 0.95rem;
+    outline: none;
+    padding-right: 30px;
+}
+
+#settings-search::placeholder {
+    color: var(--text-muted);
+    opacity: 0.7;
+}
+
 /* --- Sidebar group jumps --- */
 #group-jumps {
     display: flex;
@@ -329,4 +347,49 @@
         gap: 12px;
     }
     .setting-control { max-width: 320px; }
+}
+
+/* --- Chip group (used for gen toggles) --- */
+.setting-chips {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+}
+
+.setting-chip {
+    background: var(--bg-darker);
+    border: 1px solid var(--border-main);
+    color: var(--text-muted);
+    font-family: inherit;
+    font-size: 0.78rem;
+    font-weight: 700;
+    letter-spacing: 0.5px;
+    padding: 7px 12px;
+    border-radius: 8px;
+    cursor: pointer;
+    transition: 0.15s ease;
+    min-width: 60px;
+    text-align: center;
+}
+
+.setting-chip:hover:not(.active) {
+    color: var(--text-bright);
+    border-color: var(--text-muted);
+}
+
+.setting-chip.active {
+    background: var(--accent-blue);
+    border-color: var(--accent-blue);
+    color: #0d1117;
+    box-shadow: 0 0 12px rgba(88, 166, 255, 0.25);
+}
+
+.setting-chip.active:hover {
+    background: #79c0ff;
+    border-color: #79c0ff;
+}
+
+/* Chip rows are wider than form inputs — let them spill across the control column. */
+.setting-row:has(.setting-chips) {
+    grid-template-columns: 1fr 360px;
 }

--- a/src/Ankimon/ankimon_items_web/settings.html
+++ b/src/Ankimon/ankimon_items_web/settings.html
@@ -76,7 +76,6 @@
                         <span class="currency-icon">⚙</span>
                     </div>
                     <div id="save-status" class="shop-currency-value">All saved</div>
-                    <div class="currency-sub">Changes auto-validate on save</div>
                 </div>
             </div>
         </aside>

--- a/src/Ankimon/ankimon_items_web/settings.html
+++ b/src/Ankimon/ankimon_items_web/settings.html
@@ -6,6 +6,30 @@
     <title>Ankimon Settings</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <!-- Inline dark bg + skeleton placeholders so the user sees structure
+         instead of empty space while the external CSS + initial settings
+         data load. Real renderContent() clears the placeholders. -->
+    <style>
+        html { background: #0d1117; }
+        .skeleton {
+            background: #161b22;
+            border: 1px solid #30363d;
+            border-radius: 12px;
+            animation: skeleton-pulse 1.5s ease-in-out infinite;
+        }
+        .skeleton-section {
+            background: transparent;
+            border: none;
+            margin-bottom: 36px;
+            animation: none;
+        }
+        .skeleton-heading { height: 32px; width: 180px; margin-bottom: 18px; }
+        .skeleton-row { height: 64px; margin-bottom: 12px; }
+        @keyframes skeleton-pulse {
+            0%, 100% { opacity: 0.35; }
+            50%      { opacity: 0.6; }
+        }
+    </style>
     <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700;800;900&family=JetBrains+Mono:wght@500;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="shop.css">
     <link rel="stylesheet" href="settings.css">
@@ -19,13 +43,16 @@
             <div class="sidebar-header">
                 <div id="nav-switcher" class="nav-switcher">
                     <button id="nav-trigger" class="nav-trigger" type="button" aria-haspopup="true" aria-expanded="false">
-                        <img src="../user_files/sprites/items/poke-ball.png" class="app-logo">
+                        <svg class="app-logo icon-gear" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                            <circle cx="12" cy="12" r="3"/>
+                            <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1 0 2.83 2 2 0 0 1-2.83 0l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-2 2 2 2 0 0 1-2-2v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83 0 2 2 0 0 1 0-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1-2-2 2 2 0 0 1 2-2h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 0-2.83 2 2 0 0 1 2.83 0l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 2-2 2 2 0 0 1 2 2v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 0 2 2 0 0 1 0 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 2 2 2 2 0 0 1-2 2h-.09a1.65 1.65 0 0 0-1.51 1z"/>
+                        </svg>
                         <h1>SETTINGS</h1>
                         <span class="nav-chevron">▾</span>
                     </button>
                     <div id="nav-menu" class="nav-menu hidden" role="menu">
                         <button class="nav-menu-item" role="menuitem" data-screen="items">
-                            <span class="nav-menu-icon"><img src="../user_files/sprites/items/poke-ball.png" alt=""></span>
+                            <span class="nav-menu-icon"><img src="../user_files/sprites/items/hyper-potion.png" class="icon-item-sprite" alt=""></span>
                             <div class="nav-menu-text">
                                 <span class="nav-menu-title">Items</span>
                                 <span class="nav-menu-desc">Your inventory and today's Mart</span>
@@ -39,7 +66,7 @@
                             </div>
                         </button>
                         <button class="nav-menu-item active" role="menuitem" data-screen="settings">
-                            <span class="nav-menu-icon">⚙</span>
+                            <span class="nav-menu-icon"><svg class="icon-gear" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1 0 2.83 2 2 0 0 1-2.83 0l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-2 2 2 2 0 0 1-2-2v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83 0 2 2 0 0 1 0-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1-2-2 2 2 0 0 1 2-2h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 0-2.83 2 2 0 0 1 2.83 0l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 2-2 2 2 0 0 1 2 2v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 0 2 2 0 0 1 0 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 2 2 2 2 0 0 1-2 2h-.09a1.65 1.65 0 0 0-1.51 1z"/></svg></span>
                             <div class="nav-menu-text">
                                 <span class="nav-menu-title">Settings</span>
                                 <span class="nav-menu-desc">Configure Ankimon</span>
@@ -96,7 +123,21 @@
             </header>
 
             <div class="content-scroll" style="padding: 20px 24px 64px;">
-                <div id="settings-content"></div>
+                <div id="settings-content">
+                    <!-- Skeleton placeholders — cleared by renderContent()
+                         when initializeSettings() fires. -->
+                    <section class="skeleton-section">
+                        <div class="skeleton skeleton-heading"></div>
+                        <div class="skeleton skeleton-row"></div>
+                        <div class="skeleton skeleton-row"></div>
+                        <div class="skeleton skeleton-row"></div>
+                    </section>
+                    <section class="skeleton-section">
+                        <div class="skeleton skeleton-heading"></div>
+                        <div class="skeleton skeleton-row"></div>
+                        <div class="skeleton skeleton-row"></div>
+                    </section>
+                </div>
                 <div id="settings-empty" class="shop-empty hidden">No settings match your search.</div>
             </div>
         </main>

--- a/src/Ankimon/ankimon_items_web/settings.html
+++ b/src/Ankimon/ankimon_items_web/settings.html
@@ -32,7 +32,7 @@
                             </div>
                         </button>
                         <button class="nav-menu-item" role="menuitem" data-screen="ankidex">
-                            <span class="nav-menu-icon">✦</span>
+                            <span class="nav-menu-icon"><img src="../user_files/sprites/items/poke-ball.png" alt=""></span>
                             <div class="nav-menu-text">
                                 <span class="nav-menu-title">Ankidex</span>
                                 <span class="nav-menu-desc">Browse caught Pokémon</span>

--- a/src/Ankimon/ankimon_items_web/settings.html
+++ b/src/Ankimon/ankimon_items_web/settings.html
@@ -1,0 +1,110 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Ankimon Settings</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700;800;900&family=JetBrains+Mono:wght@500;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="shop.css">
+    <link rel="stylesheet" href="settings.css">
+    <script src="qrc:///qtwebchannel/qwebchannel.js"></script>
+</head>
+<body class="dark-mode">
+    <div class="app-container">
+
+        <!-- Sidebar -->
+        <aside class="sidebar">
+            <div class="sidebar-header">
+                <div id="nav-switcher" class="nav-switcher">
+                    <button id="nav-trigger" class="nav-trigger" type="button" aria-haspopup="true" aria-expanded="false">
+                        <img src="../user_files/sprites/items/poke-ball.png" class="app-logo">
+                        <h1>SETTINGS</h1>
+                        <span class="nav-chevron">▾</span>
+                    </button>
+                    <div id="nav-menu" class="nav-menu hidden" role="menu">
+                        <button class="nav-menu-item" role="menuitem" data-screen="items">
+                            <span class="nav-menu-icon"><img src="../user_files/sprites/items/poke-ball.png" alt=""></span>
+                            <div class="nav-menu-text">
+                                <span class="nav-menu-title">Items</span>
+                                <span class="nav-menu-desc">Your inventory and today's Mart</span>
+                            </div>
+                        </button>
+                        <button class="nav-menu-item" role="menuitem" data-screen="ankidex">
+                            <span class="nav-menu-icon">✦</span>
+                            <div class="nav-menu-text">
+                                <span class="nav-menu-title">Ankidex</span>
+                                <span class="nav-menu-desc">Browse caught Pokémon</span>
+                            </div>
+                        </button>
+                        <button class="nav-menu-item active" role="menuitem" data-screen="settings">
+                            <span class="nav-menu-icon">⚙</span>
+                            <div class="nav-menu-text">
+                                <span class="nav-menu-title">Settings</span>
+                                <span class="nav-menu-desc">Configure Ankimon</span>
+                            </div>
+                        </button>
+                    </div>
+                </div>
+            </div>
+
+            <nav id="settings-nav" class="sidebar-nav">
+                <div class="nav-group">
+                    <label>Sections</label>
+                    <div id="group-jumps"></div>
+                </div>
+
+                <div class="nav-group">
+                    <label>Actions</label>
+                    <button id="save-btn" class="nav-item nav-action" title="Save all settings" disabled>
+                        <svg class="icon-save" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                            <path d="M19 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11l5 5v11a2 2 0 0 1-2 2z"/>
+                            <polyline points="17 21 17 13 7 13 7 21"/>
+                            <polyline points="7 3 7 8 15 8"/>
+                        </svg>
+                        <span style="flex: 1">Save Changes</span>
+                        <span id="dirty-count" class="dirty-pill hidden">0</span>
+                    </button>
+                </div>
+            </nav>
+
+            <div class="sidebar-footer">
+                <div class="shop-currency-card">
+                    <div class="currency-label-row">
+                        <span class="shop-currency-label">Status</span>
+                        <span class="currency-icon">⚙</span>
+                    </div>
+                    <div id="save-status" class="shop-currency-value">All saved</div>
+                    <div class="currency-sub">Changes auto-validate on save</div>
+                </div>
+            </div>
+        </aside>
+
+        <!-- Main Content -->
+        <main class="main-content">
+            <header class="top-bar">
+                <div class="search-container">
+                    <div class="search-input-wrapper">
+                        <input type="text" id="settings-search" placeholder="Search settings... (Press /)">
+                        <button id="clear-search" class="clear-btn hidden" title="Clear search">×</button>
+                    </div>
+                </div>
+
+                <div class="top-actions">
+                    <button id="discard-btn" class="settings-discard-btn hidden" title="Discard unsaved changes">Discard</button>
+                </div>
+            </header>
+
+            <div class="content-scroll" style="padding: 20px 24px 64px;">
+                <div id="settings-content"></div>
+                <div id="settings-empty" class="shop-empty hidden">No settings match your search.</div>
+            </div>
+        </main>
+    </div>
+
+    <div id="toast" class="shop-toast"></div>
+
+    <script src="settings.js"></script>
+</body>
+</html>

--- a/src/Ankimon/ankimon_items_web/settings.js
+++ b/src/Ankimon/ankimon_items_web/settings.js
@@ -45,7 +45,9 @@
 
     function renderGroupJumps() {
         const container = document.getElementById('group-jumps');
-        container.innerHTML = '';
+        // Build into a fragment then swap atomically to avoid a brief
+        // empty-state on every save refresh.
+        const frag = document.createDocumentFragment();
         (state.data.groups || []).forEach((g) => {
             const btn = document.createElement('button');
             btn.className = 'group-jump';
@@ -58,8 +60,9 @@
             btn.appendChild(label);
             btn.appendChild(count);
             btn.addEventListener('click', () => scrollToGroup(g.label));
-            container.appendChild(btn);
+            frag.appendChild(btn);
         });
+        container.replaceChildren(frag);
     }
 
     function countSettings(group) {
@@ -70,7 +73,10 @@
 
     function renderContent() {
         const root = document.getElementById('settings-content');
-        root.innerHTML = '';
+        // Build the whole settings tree into a fragment off-DOM, then swap
+        // it in atomically. Without this, every save → re-fetch cycle
+        // flashes an empty form area while ~60 rows rebuild sequentially.
+        const frag = document.createDocumentFragment();
         (state.data.groups || []).forEach((group) => {
             const groupEl = document.createElement('section');
             groupEl.className = 'settings-group';
@@ -106,8 +112,9 @@
                 groupEl.appendChild(subEl);
             });
 
-            root.appendChild(groupEl);
+            frag.appendChild(groupEl);
         });
+        root.replaceChildren(frag);
     }
 
     function buildSettingRow(setting) {

--- a/src/Ankimon/ankimon_items_web/settings.js
+++ b/src/Ankimon/ankimon_items_web/settings.js
@@ -123,11 +123,14 @@
         const label = document.createElement('span');
         label.className = 'setting-label';
         label.textContent = setting.label;
-        const key = document.createElement('span');
-        key.className = 'setting-key';
-        key.textContent = setting.key;
         info.appendChild(label);
-        info.appendChild(key);
+        // Config key only surfaces in dev mode — irrelevant noise otherwise.
+        if (state.data && state.data.dev_mode) {
+            const key = document.createElement('span');
+            key.className = 'setting-key';
+            key.textContent = setting.key;
+            info.appendChild(key);
+        }
         if (setting.description) {
             const desc = document.createElement('div');
             desc.className = 'setting-description';
@@ -154,9 +157,49 @@
             case 'int':
             case 'float':
                 return buildNumberInput(setting);
+            case 'chips':
+                return buildChipGroup(setting);
             default:
                 return buildTextInput(setting);
         }
+    }
+
+    function buildChipGroup(setting) {
+        const wrap = document.createElement('div');
+        wrap.className = 'setting-chips';
+        (setting.chips || []).forEach((chip) => {
+            const btn = document.createElement('button');
+            btn.type = 'button';
+            btn.className = 'setting-chip';
+            btn.dataset.key = chip.key;
+            const current = (Object.prototype.hasOwnProperty.call(state.edits, chip.key))
+                ? state.edits[chip.key] : chip.value;
+            if (current) btn.classList.add('active');
+            btn.textContent = chip.label;
+            btn.addEventListener('click', () => {
+                const now = !btn.classList.contains('active');
+                // Manually track edits since chips don't go through setEdit's
+                // findSetting() lookup (each chip's "setting" is a sub-entry).
+                if (chip.value === now) {
+                    delete state.edits[chip.key];
+                } else {
+                    state.edits[chip.key] = now;
+                }
+                btn.classList.toggle('active', now);
+                updateDirtyUI();
+                markChipRowDirty(setting.key);
+            });
+            wrap.appendChild(btn);
+        });
+        return wrap;
+    }
+
+    function markChipRowDirty(rowKey) {
+        const row = document.querySelector(`.setting-row[data-key="${cssEscape(rowKey)}"]`);
+        if (!row) return;
+        const anyDirty = Array.from(row.querySelectorAll('.setting-chip')).some((c) =>
+            Object.prototype.hasOwnProperty.call(state.edits, c.dataset.key));
+        row.classList.toggle('dirty', anyDirty);
     }
 
     function buildToggle(setting) {

--- a/src/Ankimon/ankimon_items_web/settings.js
+++ b/src/Ankimon/ankimon_items_web/settings.js
@@ -1,0 +1,466 @@
+// Settings screen — renders the group schema, tracks dirty state, persists
+// via the QWebChannel `settings` bridge object.
+
+(function () {
+    'use strict';
+
+    const state = {
+        data: null,           // raw payload from Python
+        edits: {},            // key → new value (only present if dirty)
+        search: '',
+        activeGroup: null,    // currently scrolled-into-view group label
+    };
+
+    let bridge = null;
+    let nav = null;
+
+    function initChannel(cb) {
+        if (typeof qt === 'undefined' || !qt.webChannelTransport) {
+            console.warn('qt.webChannelTransport unavailable — standalone mode');
+            cb(null);
+            return;
+        }
+        new QWebChannel(qt.webChannelTransport, function (channel) {
+            bridge = channel.objects && channel.objects.settings;
+            nav = channel.objects && channel.objects.nav;
+            window.bridge = bridge;
+            window.nav = nav;
+            cb(bridge);
+        });
+    }
+
+    window.initializeSettings = function (data) {
+        state.data = data || {groups: []};
+        state.edits = {};  // fresh data resets dirty state
+        renderAll();
+    };
+
+    // ---------- Rendering ----------
+    function renderAll() {
+        renderGroupJumps();
+        renderContent();
+        applySearchFilter();
+        updateDirtyUI();
+    }
+
+    function renderGroupJumps() {
+        const container = document.getElementById('group-jumps');
+        container.innerHTML = '';
+        (state.data.groups || []).forEach((g) => {
+            const btn = document.createElement('button');
+            btn.className = 'group-jump';
+            btn.dataset.group = g.label;
+            const label = document.createElement('span');
+            label.textContent = g.label;
+            const count = document.createElement('span');
+            count.className = 'group-jump-count';
+            count.textContent = countSettings(g);
+            btn.appendChild(label);
+            btn.appendChild(count);
+            btn.addEventListener('click', () => scrollToGroup(g.label));
+            container.appendChild(btn);
+        });
+    }
+
+    function countSettings(group) {
+        let n = (group.settings || []).length;
+        (group.subgroups || []).forEach((s) => { n += (s.settings || []).length; });
+        return n;
+    }
+
+    function renderContent() {
+        const root = document.getElementById('settings-content');
+        root.innerHTML = '';
+        (state.data.groups || []).forEach((group) => {
+            const groupEl = document.createElement('section');
+            groupEl.className = 'settings-group';
+            groupEl.dataset.group = group.label;
+
+            const header = document.createElement('div');
+            header.className = 'settings-group-header';
+            const title = document.createElement('h2');
+            title.className = 'settings-group-title';
+            title.textContent = group.label;
+            const count = document.createElement('span');
+            count.className = 'settings-group-count';
+            count.textContent = countSettings(group) + ' settings';
+            header.appendChild(title);
+            header.appendChild(count);
+            groupEl.appendChild(header);
+
+            (group.settings || []).forEach((s) => {
+                groupEl.appendChild(buildSettingRow(s));
+            });
+
+            (group.subgroups || []).forEach((sub) => {
+                const subEl = document.createElement('div');
+                subEl.className = 'settings-subgroup';
+                subEl.dataset.subgroup = sub.label;
+                const subTitle = document.createElement('div');
+                subTitle.className = 'settings-subgroup-title';
+                subTitle.textContent = sub.label;
+                subEl.appendChild(subTitle);
+                (sub.settings || []).forEach((s) => {
+                    subEl.appendChild(buildSettingRow(s));
+                });
+                groupEl.appendChild(subEl);
+            });
+
+            root.appendChild(groupEl);
+        });
+    }
+
+    function buildSettingRow(setting) {
+        const row = document.createElement('div');
+        row.className = 'setting-row';
+        row.dataset.key = setting.key;
+        row.dataset.label = (setting.label || '').toLowerCase();
+        row.dataset.desc = (setting.description || '').toLowerCase();
+
+        // Info column
+        const info = document.createElement('div');
+        info.className = 'setting-info';
+        const label = document.createElement('span');
+        label.className = 'setting-label';
+        label.textContent = setting.label;
+        const key = document.createElement('span');
+        key.className = 'setting-key';
+        key.textContent = setting.key;
+        info.appendChild(label);
+        info.appendChild(key);
+        if (setting.description) {
+            const desc = document.createElement('div');
+            desc.className = 'setting-description';
+            desc.textContent = setting.description;
+            info.appendChild(desc);
+        }
+        row.appendChild(info);
+
+        // Control column
+        const control = document.createElement('div');
+        control.className = 'setting-control';
+        control.appendChild(buildControl(setting));
+        row.appendChild(control);
+
+        return row;
+    }
+
+    function buildControl(setting) {
+        switch (setting.type) {
+            case 'boolean':
+                return buildToggle(setting);
+            case 'select':
+                return buildSelect(setting);
+            case 'int':
+            case 'float':
+                return buildNumberInput(setting);
+            default:
+                return buildTextInput(setting);
+        }
+    }
+
+    function buildToggle(setting) {
+        const wrap = document.createElement('div');
+        wrap.className = 'setting-toggle';
+        const current = currentValue(setting);
+        ['Enabled', 'Disabled'].forEach((label, i) => {
+            const isOn = (i === 0 && current) || (i === 1 && !current);
+            const btn = document.createElement('button');
+            btn.type = 'button';
+            btn.className = 'setting-toggle-option' + (isOn ? ' active' : '') + (i === 1 ? ' off' : '');
+            btn.textContent = label;
+            btn.addEventListener('click', () => {
+                setEdit(setting.key, i === 0);
+                renderAll();  // refresh control + dirty pip
+            });
+            wrap.appendChild(btn);
+        });
+        return wrap;
+    }
+
+    function buildSelect(setting) {
+        const sel = document.createElement('select');
+        sel.className = 'setting-select';
+        const current = currentValue(setting);
+        (setting.options || []).forEach((opt, i) => {
+            const o = document.createElement('option');
+            o.value = (opt.value === null || opt.value === undefined) ? '__null__' : String(opt.value);
+            o.textContent = opt.label;
+            if (opt.value === current) o.selected = true;
+            sel.appendChild(o);
+        });
+        sel.addEventListener('change', () => {
+            const raw = sel.value === '__null__' ? null : sel.value;
+            setEdit(setting.key, raw);
+            renderAll();
+        });
+        return sel;
+    }
+
+    function buildNumberInput(setting) {
+        const input = document.createElement('input');
+        input.type = 'text';  // text so range strings like "1-3" work too
+        input.className = 'setting-input numeric';
+        input.value = currentValue(setting);
+        input.addEventListener('input', () => {
+            const raw = input.value.trim();
+            // Allow ranges for cards_per_round; otherwise coerce to number.
+            if (setting.key === 'battle.cards_per_round' && raw.includes('-')) {
+                setEdit(setting.key, raw);
+            } else if (raw === '') {
+                setEdit(setting.key, raw);
+            } else {
+                const n = Number(raw);
+                setEdit(setting.key, Number.isFinite(n) ? n : raw);
+            }
+            updateDirtyUI();
+            markRowDirty(setting.key);
+        });
+        return input;
+    }
+
+    function buildTextInput(setting) {
+        const input = document.createElement('input');
+        input.type = 'text';
+        input.className = 'setting-input';
+        input.value = currentValue(setting) ?? '';
+        input.addEventListener('input', () => {
+            setEdit(setting.key, input.value);
+            updateDirtyUI();
+            markRowDirty(setting.key);
+        });
+        return input;
+    }
+
+    function currentValue(setting) {
+        if (Object.prototype.hasOwnProperty.call(state.edits, setting.key)) {
+            return state.edits[setting.key];
+        }
+        return setting.value;
+    }
+
+    // ---------- Edit tracking ----------
+    function setEdit(key, value) {
+        const original = findSetting(key);
+        if (!original) return;
+        if (deepEqual(original.value, value)) {
+            delete state.edits[key];
+        } else {
+            state.edits[key] = value;
+        }
+    }
+
+    function findSetting(key) {
+        for (const g of (state.data.groups || [])) {
+            for (const s of (g.settings || [])) {
+                if (s.key === key) return s;
+            }
+            for (const sub of (g.subgroups || [])) {
+                for (const s of (sub.settings || [])) {
+                    if (s.key === key) return s;
+                }
+            }
+        }
+        return null;
+    }
+
+    function deepEqual(a, b) {
+        if (a === b) return true;
+        if (typeof a !== typeof b) return false;
+        return JSON.stringify(a) === JSON.stringify(b);
+    }
+
+    function markRowDirty(key) {
+        document.querySelectorAll('.setting-row').forEach((row) => {
+            if (row.dataset.key !== key) return;
+            row.classList.toggle('dirty',
+                Object.prototype.hasOwnProperty.call(state.edits, key));
+        });
+    }
+
+    function updateDirtyUI() {
+        const n = Object.keys(state.edits).length;
+        const dirty = n > 0;
+        const saveBtn = document.getElementById('save-btn');
+        const discardBtn = document.getElementById('discard-btn');
+        const pill = document.getElementById('dirty-count');
+        const status = document.getElementById('save-status');
+        saveBtn.disabled = !dirty;
+        saveBtn.classList.toggle('dirty', dirty);
+        discardBtn.classList.toggle('hidden', !dirty);
+        if (dirty) {
+            pill.classList.remove('hidden');
+            pill.textContent = n;
+            status.textContent = n + ' unsaved';
+            status.style.color = 'var(--accent-gold)';
+        } else {
+            pill.classList.add('hidden');
+            status.textContent = 'All saved';
+            status.style.color = 'var(--accent-green)';
+        }
+        // Sync the row-level dirty markers (in case render rebuilt them)
+        document.querySelectorAll('.setting-row').forEach((row) => {
+            row.classList.toggle('dirty',
+                Object.prototype.hasOwnProperty.call(state.edits, row.dataset.key));
+        });
+    }
+
+    // ---------- Search ----------
+    function applySearchFilter() {
+        const q = state.search;
+        const empty = document.getElementById('settings-empty');
+        let visible = 0;
+        document.querySelectorAll('.settings-group').forEach((groupEl) => {
+            let groupVisible = 0;
+            groupEl.querySelectorAll('.setting-row').forEach((row) => {
+                const hit = !q || row.dataset.label.includes(q) || row.dataset.desc.includes(q);
+                row.classList.toggle('hidden', !hit);
+                if (hit) groupVisible++;
+            });
+            // Hide empty subgroups
+            groupEl.querySelectorAll('.settings-subgroup').forEach((sub) => {
+                const anyHit = Array.from(sub.querySelectorAll('.setting-row'))
+                    .some((r) => !r.classList.contains('hidden'));
+                sub.classList.toggle('hidden', !anyHit);
+            });
+            groupEl.classList.toggle('hidden', groupVisible === 0);
+            visible += groupVisible;
+        });
+        empty.classList.toggle('hidden', visible > 0);
+    }
+
+    // ---------- Save ----------
+    function onSave() {
+        if (!bridge) return;
+        const payload = {...state.edits};
+        if (Object.keys(payload).length === 0) return;
+        bridge.saveSettings(payload, function (result) {
+            if (!result) return;
+            if (result.ok) {
+                const adj = (result.adjustments || []).join('\n');
+                const msg = adj ? result.message + '\n' + adj : result.message;
+                showToast(msg);
+                // Re-fetch fresh data so the UI reflects what was actually
+                // persisted (including any clamping).
+                bridge.getSettings(function (fresh) {
+                    if (fresh) window.initializeSettings(fresh);
+                });
+            } else {
+                showToast(result.message || 'Save failed', true);
+            }
+        });
+    }
+
+    function onDiscard() {
+        if (Object.keys(state.edits).length === 0) return;
+        state.edits = {};
+        renderAll();
+        showToast('Changes discarded');
+    }
+
+    function showToast(message, isError) {
+        if (!message) return;
+        const toast = document.getElementById('toast');
+        toast.textContent = message;
+        toast.classList.toggle('error', !!isError);
+        toast.classList.add('visible');
+        clearTimeout(toast._timer);
+        toast._timer = setTimeout(() => toast.classList.remove('visible'), 2800);
+    }
+
+    // ---------- Scroll spy / jumps ----------
+    function scrollToGroup(label) {
+        const el = document.querySelector(`.settings-group[data-group="${cssEscape(label)}"]`);
+        if (el) el.scrollIntoView({behavior: 'smooth', block: 'start'});
+    }
+
+    function cssEscape(s) {
+        return s.replace(/"/g, '\\"');
+    }
+
+    function updateActiveJump() {
+        const groups = document.querySelectorAll('.settings-group');
+        const scroller = document.querySelector('.content-scroll');
+        if (!scroller) return;
+        const scrollTop = scroller.scrollTop;
+        let active = null;
+        groups.forEach((g) => {
+            if (g.classList.contains('hidden')) return;
+            if (g.offsetTop - 24 <= scrollTop) active = g.dataset.group;
+        });
+        if (active === state.activeGroup) return;
+        state.activeGroup = active;
+        document.querySelectorAll('.group-jump').forEach((b) => {
+            b.classList.toggle('active', b.dataset.group === active);
+        });
+    }
+
+    // ---------- UI plumbing ----------
+    function bindUI() {
+        const search = document.getElementById('settings-search');
+        const clear = document.getElementById('clear-search');
+        search.addEventListener('input', () => {
+            state.search = search.value.trim().toLowerCase();
+            clear.classList.toggle('hidden', !state.search);
+            applySearchFilter();
+        });
+        clear.addEventListener('click', () => {
+            search.value = '';
+            state.search = '';
+            clear.classList.add('hidden');
+            applySearchFilter();
+        });
+
+        document.getElementById('save-btn').addEventListener('click', onSave);
+        document.getElementById('discard-btn').addEventListener('click', onDiscard);
+
+        const scroller = document.querySelector('.content-scroll');
+        if (scroller) scroller.addEventListener('scroll', updateActiveJump);
+
+        document.addEventListener('keydown', (e) => {
+            if (e.key === '/' && document.activeElement !== search) {
+                e.preventDefault();
+                search.focus();
+            } else if ((e.metaKey || e.ctrlKey) && e.key === 's') {
+                e.preventDefault();
+                onSave();
+            }
+        });
+    }
+
+    function bindNavSwitcher() {
+        const trigger = document.getElementById('nav-trigger');
+        const menu = document.getElementById('nav-menu');
+        if (!trigger || !menu) return;
+
+        const open = () => { menu.classList.remove('hidden'); trigger.setAttribute('aria-expanded', 'true'); };
+        const close = () => { menu.classList.add('hidden'); trigger.setAttribute('aria-expanded', 'false'); };
+
+        trigger.addEventListener('click', (e) => {
+            e.stopPropagation();
+            menu.classList.contains('hidden') ? open() : close();
+        });
+        document.addEventListener('click', (e) => {
+            if (!menu.classList.contains('hidden') && !menu.contains(e.target) && e.target !== trigger) close();
+        });
+        document.addEventListener('keydown', (e) => {
+            if (e.key === 'Escape' && !menu.classList.contains('hidden')) close();
+        });
+        menu.querySelectorAll('.nav-menu-item[data-screen]').forEach((item) => {
+            item.addEventListener('click', () => {
+                const screen = item.dataset.screen;
+                close();
+                if (item.classList.contains('active')) return;
+                if (!nav) return;
+                if (screen === 'items' && nav.openItems) nav.openItems();
+                else if (screen === 'ankidex' && nav.openAnkidex) nav.openAnkidex();
+                else if (screen === 'settings' && nav.openSettings) nav.openSettings();
+            });
+        });
+    }
+
+    document.addEventListener('DOMContentLoaded', () => {
+        bindUI();
+        initChannel(() => bindNavSwitcher());
+    });
+})();

--- a/src/Ankimon/ankimon_items_web/settings.js
+++ b/src/Ankimon/ankimon_items_web/settings.js
@@ -377,7 +377,10 @@
         if (!bridge) return;
         const payload = {...state.edits};
         if (Object.keys(payload).length === 0) return;
-        bridge.saveSettings(payload, function (result) {
+        // Stringify so the bridge sees a stable `str` parameter — see the
+        // SettingsBridge.saveSettings comment for why we avoid passing the
+        // dict directly through QVariant.
+        bridge.saveSettings(JSON.stringify(payload), function (result) {
             if (!result) return;
             if (result.ok) {
                 const adj = (result.adjustments || []).join('\n');
@@ -413,8 +416,15 @@
 
     // ---------- Scroll spy / jumps ----------
     function scrollToGroup(label) {
+        // scrollIntoView in QtWebEngine sometimes targets the document
+        // rather than .content-scroll. Compute the offset relative to the
+        // scroll container and call scrollTo() on it directly — reliable
+        // across Qt versions.
         const el = document.querySelector(`.settings-group[data-group="${cssEscape(label)}"]`);
-        if (el) el.scrollIntoView({behavior: 'smooth', block: 'start'});
+        const scroller = document.querySelector('.content-scroll');
+        if (!el || !scroller) return;
+        const top = el.offsetTop - 16;  // small breathing room above the header
+        scroller.scrollTo({top: Math.max(0, top), behavior: 'smooth'});
     }
 
     function cssEscape(s) {

--- a/src/Ankimon/ankimon_items_web/settings.js
+++ b/src/Ankimon/ankimon_items_web/settings.js
@@ -41,6 +41,10 @@
         renderContent();
         applySearchFilter();
         updateDirtyUI();
+        // Re-run the spy after render so the active button reflects the
+        // post-render scroll position (in case the DOM rebuild moved things
+        // around).
+        updateActiveSection();
     }
 
     function renderGroupJumps() {
@@ -422,37 +426,100 @@
     }
 
     // ---------- Scroll spy / jumps ----------
+    //
+    // Approach (after several iterations):
+    // 1. Clicking a section in the sidebar SETS the active state directly
+    //    and suppresses the scroll-spy for 1.5s. This means the user's
+    //    explicit choice wins even when the scroll lands at max (e.g.
+    //    Generations near the bottom of a short page).
+    // 2. Otherwise the spy runs on scroll. The active section is the LAST
+    //    one whose top has crossed a reading line near the top of the
+    //    scroller — the classic "where am I" check.
+    // 3. When the user is at max scroll AND later sections couldn't reach
+    //    the line, fall back to whichever section's top is closest to
+    //    (just below) the line. That's how Study/Generations become
+    //    select-able via manual scrolling on short content.
+
+    let suppressSpyUntil = 0;
+    const READING_LINE_PX = 80;
+
+    function setActiveButton(label) {
+        if (label === state.activeGroup) return;
+        state.activeGroup = label;
+        document.querySelectorAll('.group-jump').forEach((b) => {
+            b.classList.toggle('active', b.dataset.group === label);
+        });
+    }
+
     function scrollToGroup(label) {
-        // scrollIntoView in QtWebEngine sometimes targets the document
-        // rather than .content-scroll. Compute the offset relative to the
-        // scroll container and call scrollTo() on it directly — reliable
-        // across Qt versions.
         const el = document.querySelector(`.settings-group[data-group="${cssEscape(label)}"]`);
         const scroller = document.querySelector('.content-scroll');
         if (!el || !scroller) return;
-        const top = el.offsetTop - 16;  // small breathing room above the header
-        scroller.scrollTo({top: Math.max(0, top), behavior: 'smooth'});
+        const elTop = el.getBoundingClientRect().top;
+        const scrollerTop = scroller.getBoundingClientRect().top;
+        const offsetWithinScroller = elTop - scrollerTop + scroller.scrollTop;
+        // 32px breathing room so the section header sits comfortably
+        // below the top-bar instead of butting up against it.
+        const target = Math.max(0, offsetWithinScroller - 32);
+        scroller.scrollTo({top: target, behavior: 'smooth'});
+        flashSection(el);
+        // Win against the spy: the user's click wins even if the resulting
+        // scroll position would normally activate a different section.
+        setActiveButton(label);
+        suppressSpyUntil = Date.now() + 1500;
+    }
+
+    function flashSection(el) {
+        // Brief tint so the user sees the jump landed on the right section.
+        // Re-trigger the animation if the class is already present
+        // (consecutive clicks on the same nav item).
+        el.classList.remove('flash-highlight');
+        // Force reflow so the animation restarts on re-add.
+        void el.offsetWidth;
+        el.classList.add('flash-highlight');
     }
 
     function cssEscape(s) {
         return s.replace(/"/g, '\\"');
     }
 
-    function updateActiveJump() {
-        const groups = document.querySelectorAll('.settings-group');
+    function updateActiveSection() {
+        if (Date.now() < suppressSpyUntil) return;
         const scroller = document.querySelector('.content-scroll');
         if (!scroller) return;
-        const scrollTop = scroller.scrollTop;
+        const sRect = scroller.getBoundingClientRect();
+        const sections = Array.from(document.querySelectorAll('.settings-group'))
+            .filter((g) => !g.classList.contains('hidden'));
+        if (!sections.length) return;
+
+        const readingLine = sRect.top + READING_LINE_PX;
+
+        // Primary: last section whose top has crossed the reading line.
         let active = null;
-        groups.forEach((g) => {
-            if (g.classList.contains('hidden')) return;
-            if (g.offsetTop - 24 <= scrollTop) active = g.dataset.group;
+        sections.forEach((g) => {
+            if (g.getBoundingClientRect().top <= readingLine + 4) active = g;
         });
-        if (active === state.activeGroup) return;
-        state.activeGroup = active;
-        document.querySelectorAll('.group-jump').forEach((b) => {
-            b.classList.toggle('active', b.dataset.group === active);
-        });
+
+        // Fallback when we're at max scroll: short later sections that
+        // couldn't physically be scrolled past the line still need to be
+        // select-able. Pick whichever section's top is closest to (just
+        // below) the line.
+        const atMax = scroller.scrollHeight - scroller.scrollTop - scroller.clientHeight < 4;
+        if (atMax) {
+            let nearestBelow = null;
+            let nearestDist = Infinity;
+            sections.forEach((g) => {
+                const dist = g.getBoundingClientRect().top - readingLine;
+                if (dist > 0 && dist < nearestDist) {
+                    nearestDist = dist;
+                    nearestBelow = g;
+                }
+            });
+            if (nearestBelow) active = nearestBelow;
+        }
+
+        if (!active) active = sections[0];
+        setActiveButton(active.dataset.group);
     }
 
     // ---------- UI plumbing ----------
@@ -475,7 +542,7 @@
         document.getElementById('discard-btn').addEventListener('click', onDiscard);
 
         const scroller = document.querySelector('.content-scroll');
-        if (scroller) scroller.addEventListener('scroll', updateActiveJump);
+        if (scroller) scroller.addEventListener('scroll', updateActiveSection);
 
         document.addEventListener('keydown', (e) => {
             if (e.key === '/' && document.activeElement !== search) {

--- a/src/Ankimon/ankimon_items_web/settings_schema.py
+++ b/src/Ankimon/ankimon_items_web/settings_schema.py
@@ -108,16 +108,28 @@ GROUPS = [
         "label": "Generations",
         "settings": [
             "Active Region",
-            "Generation 1",
-            "Generation 2",
-            "Generation 3",
-            "Generation 4",
-            "Generation 5",
-            "Generation 6",
-            "Generation 7",
-            "Generation 8",
-            "Generation 9",
         ],
+        # The 9 per-generation booleans render as a single chip row instead of
+        # 9 separate Enabled/Disabled rows — much faster to scan and toggle.
+        "chip_group": {
+            "label": "Enabled Generations",
+            "description": (
+                "Toggle which generations can spawn. Disabled gens are "
+                "excluded from the encounter pool entirely; the Active Region "
+                "only biases spawns within the enabled set."
+            ),
+            "keys": [
+                ("misc.gen1", "Gen 1"),
+                ("misc.gen2", "Gen 2"),
+                ("misc.gen3", "Gen 3"),
+                ("misc.gen4", "Gen 4"),
+                ("misc.gen5", "Gen 5"),
+                ("misc.gen6", "Gen 6"),
+                ("misc.gen7", "Gen 7"),
+                ("misc.gen8", "Gen 8"),
+                ("misc.gen9", "Gen 9"),
+            ],
+        },
     },
 ]
 

--- a/src/Ankimon/ankimon_items_web/settings_schema.py
+++ b/src/Ankimon/ankimon_items_web/settings_schema.py
@@ -124,16 +124,16 @@ GROUPS = [
 
 # Active region dropdown options — preserved verbatim from the legacy window.
 ACTIVE_REGION_OPTIONS = [
-    {"value": None,     "label": "No Region"},
-    {"value": "kanto",  "label": "Kanto (Gen 1)"},
-    {"value": "johto",  "label": "Johto (Gen 2)"},
-    {"value": "hoenn",  "label": "Hoenn (Gen 3)"},
+    {"value": None, "label": "No Region"},
+    {"value": "kanto", "label": "Kanto (Gen 1)"},
+    {"value": "johto", "label": "Johto (Gen 2)"},
+    {"value": "hoenn", "label": "Hoenn (Gen 3)"},
     {"value": "sinnoh", "label": "Sinnoh (Gen 4)"},
-    {"value": "unova",  "label": "Unova (Gen 5)"},
-    {"value": "kalos",  "label": "Kalos (Gen 6)"},
-    {"value": "alola",  "label": "Alola (Gen 7)"},
-    {"value": "galar",  "label": "Galar (Gen 8)"},
-    {"value": "hisui",  "label": "Hisui (Gen 8)"},
+    {"value": "unova", "label": "Unova (Gen 5)"},
+    {"value": "kalos", "label": "Kalos (Gen 6)"},
+    {"value": "alola", "label": "Alola (Gen 7)"},
+    {"value": "galar", "label": "Galar (Gen 8)"},
+    {"value": "hisui", "label": "Hisui (Gen 8)"},
     {"value": "paldea", "label": "Paldea (Gen 9)"},
 ]
 

--- a/src/Ankimon/ankimon_items_web/settings_schema.py
+++ b/src/Ankimon/ankimon_items_web/settings_schema.py
@@ -1,0 +1,199 @@
+"""Settings schema + validation for the web settings screen.
+
+Mirrors the hierarchical structure of the legacy QMainWindow settings_window.py
+so users see the same groups in the same order, but exposed as data so the
+web shell can render it.
+"""
+
+# Two-level group structure. Each group has a friendly-name list of settings
+# (matched against lang/setting_name.json) and optional subgroups.
+GROUPS = [
+    {
+        "label": "General",
+        "settings": [
+            "Trainer Name",
+            "Language",
+            "Show Tip of the Day On Startup",
+        ],
+        "subgroups": [
+            {
+                "label": "Technical Settings",
+                "settings": [
+                    "SSH Access",
+                    "Prevent Ankimon News on Startup",
+                    "AnkiWeb Sync",
+                    "Ankimon Leaderboard",
+                    "Developer Mode",
+                ],
+            },
+            {
+                "label": "Discord Integration",
+                "settings": [
+                    "Discord Rich Presence - Ankimon",
+                    "Discord Rich Presence - Quote Type",
+                ],
+            },
+        ],
+    },
+    {
+        "label": "Battle",
+        "settings": [
+            "Automatic Battle",
+            "Always catch Special Pokémon",
+            "Cards per Round",
+            "Show Main Pokémon in Reviewer",
+            "Hide HUD on Reviewer Startup",
+            "Show Pokémon Buttons",
+            "Pop-Up on Defeat",
+            "Show Text Message Box in Reviewer",
+            "Message Box Display Time",
+            "Review Based Damage",
+            "Friendship & Time Evolution",
+            "Auto-detect Time Zone",
+            "Time Zone UTC Offset",
+        ],
+        "subgroups": [
+            {
+                "label": "Fight Hotkeys",
+                "settings": [
+                    "Key for Defeat",
+                    "Key for Catching",
+                    "Key for Team Cycling",
+                    "Key for Opening/Closing Ankimon",
+                    "Allow Choosing Moves",
+                ],
+            },
+            {
+                "label": "HP, XP and Level Settings",
+                "settings": [
+                    "HP Bar Configuration",
+                    "XP Bar Configuration",
+                    "XP Bar Location",
+                    "Remove Level Cap",
+                ],
+            },
+        ],
+    },
+    {
+        "label": "Styling",
+        "settings": [
+            "Styling in Reviewer",
+            "Team Overview in Deck Overview",
+            "Animate Time",
+            "HP Bar Thickness",
+            "Reviewer Image as GIF",
+            "View Main Pokémon Front",
+            "Show GIFs in Collection",
+        ],
+    },
+    {
+        "label": "Sound",
+        "settings": [
+            "Enable Sound Effects",
+            "Enable Sounds",
+            "Enable Battle Sounds",
+            "Volume",
+        ],
+    },
+    {
+        "label": "Study",
+        "settings": [
+            "Goal of Daily Average Cards",
+            "Card Max Time",
+            "Cash Reward Per Interval",
+            "Cards Per Cash Reward",
+        ],
+    },
+    {
+        "label": "Generations",
+        "settings": [
+            "Active Region",
+            "Generation 1",
+            "Generation 2",
+            "Generation 3",
+            "Generation 4",
+            "Generation 5",
+            "Generation 6",
+            "Generation 7",
+            "Generation 8",
+            "Generation 9",
+        ],
+    },
+]
+
+
+# Active region dropdown options — preserved verbatim from the legacy window.
+ACTIVE_REGION_OPTIONS = [
+    {"value": None,     "label": "No Region"},
+    {"value": "kanto",  "label": "Kanto (Gen 1)"},
+    {"value": "johto",  "label": "Johto (Gen 2)"},
+    {"value": "hoenn",  "label": "Hoenn (Gen 3)"},
+    {"value": "sinnoh", "label": "Sinnoh (Gen 4)"},
+    {"value": "unova",  "label": "Unova (Gen 5)"},
+    {"value": "kalos",  "label": "Kalos (Gen 6)"},
+    {"value": "alola",  "label": "Alola (Gen 7)"},
+    {"value": "galar",  "label": "Galar (Gen 8)"},
+    {"value": "hisui",  "label": "Hisui (Gen 8)"},
+    {"value": "paldea", "label": "Paldea (Gen 9)"},
+]
+
+
+def validate_and_clamp(config):
+    """Apply the legacy window's save-time bounds. Returns (config, adjustments)
+    where adjustments is a list of human-readable strings describing what
+    was changed (empty if nothing was clamped)."""
+    adjustments = []
+
+    if "battle.cards_per_round" in config:
+        config["battle.cards_per_round"] = _coerce_cards_per_round(
+            config["battle.cards_per_round"]
+        )
+
+    if "trainer.cash_reward_interval" in config:
+        v = config["trainer.cash_reward_interval"]
+        if isinstance(v, int):
+            new_v = max(5, min(250, v))
+            if new_v != v:
+                config["trainer.cash_reward_interval"] = new_v
+                adjustments.append(
+                    f"Reward Interval adjusted to {new_v} (range 5–250)."
+                )
+
+    if "trainer.cash_reward_amount" in config:
+        amt = config["trainer.cash_reward_amount"]
+        if isinstance(amt, int):
+            new_amt = max(10, min(2000, amt))
+            interval = config.get("trainer.cash_reward_interval", 10)
+            max_allowed = interval * 100
+            if new_amt > max_allowed:
+                new_amt = max_allowed
+                adjustments.append(
+                    f"Reward Amount capped at {new_amt}¥ (100:1 ratio limit)."
+                )
+            elif new_amt != amt:
+                adjustments.append(
+                    f"Reward Amount adjusted to {new_amt}¥ (range 10–2000)."
+                )
+            config["trainer.cash_reward_amount"] = new_amt
+
+    return config, adjustments
+
+
+def _coerce_cards_per_round(value):
+    """Accept an int, the string "a-b" range, or fall back to 2 on garbage."""
+    if isinstance(value, int):
+        return 1 if value == 0 else value
+    text = str(value).strip()
+    try:
+        n = int(text)
+        return 1 if n == 0 else n
+    except ValueError:
+        pass
+    if "-" in text:
+        try:
+            a, b = (int(x) for x in text.split("-", 1))
+            low, high = min(a, b), max(a, b)
+            return f"{low}-{high}"
+        except ValueError:
+            pass
+    return 2

--- a/src/Ankimon/ankimon_items_web/shop.css
+++ b/src/Ankimon/ankimon_items_web/shop.css
@@ -3451,9 +3451,26 @@ body {
     height: 24px;
 }
 
-/* --- Items identity icon (hyper-potion sprite used as Items' visual ID).
- * Sizing comes from .app-logo (32x32) and .nav-menu-icon img (18x18);
- * we just want crisp pixel art at small scales. */
+/* --- Gear icon (nav dropdown + Settings sidebar logo) --- */
+/* Default 18x18 to match the pokeball img sizing inside .nav-menu-icon. */
+.icon-gear {
+    width: 18px;
+    height: 18px;
+    display: block;
+    color: var(--accent-blue);
+}
+
+/* When the gear doubles as a sidebar logo it shares the .app-logo class
+ * which gives it 32x32 — but the size declared by .app-logo and .icon-gear
+ * are at equal specificity, so explicitly bump for the combo. */
+.app-logo.icon-gear {
+    width: 32px;
+    height: 32px;
+}
+
+/* --- Items icon (the hyper-potion sprite used as Items' identity).
+ * .nav-menu-icon img and .app-logo handle sizing; we just want crisp
+ * pixel art at the small icon scale. */
 .icon-item-sprite {
     image-rendering: pixelated;
     object-fit: contain;

--- a/src/Ankimon/ankimon_items_web/shop.html
+++ b/src/Ankimon/ankimon_items_web/shop.html
@@ -55,6 +55,13 @@
                                 <span class="nav-menu-desc">Browse caught Pokémon</span>
                             </div>
                         </button>
+                        <button class="nav-menu-item" role="menuitem" data-screen="settings">
+                            <span class="nav-menu-icon">⚙</span>
+                            <div class="nav-menu-text">
+                                <span class="nav-menu-title">Settings</span>
+                                <span class="nav-menu-desc">Configure Ankimon</span>
+                            </div>
+                        </button>
                     </div>
                 </div>
             </div>

--- a/src/Ankimon/ankimon_items_web/shop.html
+++ b/src/Ankimon/ankimon_items_web/shop.html
@@ -6,9 +6,10 @@
     <title>Ankimon Items</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <!-- Inline dark bg + skeleton placeholders so the user sees structure
-         instead of empty space while external CSS + initial data load.
-         Real renderGrid() clears the skeleton on first push from Python. -->
+    <!-- Inline dark bg so the first paint is dark, even before shop.css
+         finishes loading. Prevents the white flash between window-show
+         and full CSS application. Skeleton placeholders pulse dimly so
+         the main content area shows structure during the load window. -->
     <style>
         html { background: #0d1117; }
         .skeleton {
@@ -56,7 +57,7 @@
                             </div>
                         </button>
                         <button class="nav-menu-item" role="menuitem" data-screen="settings">
-                            <span class="nav-menu-icon">⚙</span>
+                            <span class="nav-menu-icon"><svg class="icon-gear" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1 0 2.83 2 2 0 0 1-2.83 0l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-2 2 2 2 0 0 1-2-2v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83 0 2 2 0 0 1 0-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1-2-2 2 2 0 0 1 2-2h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 0-2.83 2 2 0 0 1 2.83 0l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 2-2 2 2 0 0 1 2 2v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 0 2 2 0 0 1 0 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 2 2 2 2 0 0 1-2 2h-.09a1.65 1.65 0 0 0-1.51 1z"/></svg></span>
                             <div class="nav-menu-text">
                                 <span class="nav-menu-title">Settings</span>
                                 <span class="nav-menu-desc">Configure Ankimon</span>
@@ -138,8 +139,8 @@
 
             <div class="content-scroll" style="padding: 20px 24px;">
                 <div id="items-grid" class="pokemon-grid shop-grid">
-                    <!-- Skeleton placeholders — cleared by render() on first
-                         push from Python. -->
+                    <!-- Skeleton placeholders — cleared by render() on
+                         first push from Python. -->
                     <div class="skeleton skeleton-card"></div>
                     <div class="skeleton skeleton-card"></div>
                     <div class="skeleton skeleton-card"></div>

--- a/src/Ankimon/ankimon_items_web/shop.js
+++ b/src/Ankimon/ankimon_items_web/shop.js
@@ -31,6 +31,7 @@
     };
 
     let bridge = null;
+    let nav = null;
 
     function initChannel(callback) {
         if (typeof qt === 'undefined' || !qt.webChannelTransport) {
@@ -40,7 +41,9 @@
         }
         new QWebChannel(qt.webChannelTransport, function (channel) {
             bridge = channel.objects.bridge;
+            nav = channel.objects && channel.objects.nav;
             window.bridge = bridge;
+            window.nav = nav;
             callback(bridge);
         });
     }
@@ -760,8 +763,10 @@
                 const screen = item.dataset.screen;
                 closeMenu();
                 if (screen === 'items') return;
-                if (!bridge) return;
-                if (screen === 'ankidex' && bridge.openAnkidex) bridge.openAnkidex();
+                const router = (window.nav) || bridge;
+                if (!router) return;
+                if (screen === 'ankidex' && router.openAnkidex) router.openAnkidex();
+                else if (screen === 'settings' && router.openSettings) router.openSettings();
             });
         });
     }

--- a/src/Ankimon/ankimon_items_web/shop.js
+++ b/src/Ankimon/ankimon_items_web/shop.js
@@ -106,7 +106,6 @@
             return;
         }
         empty.classList.add('hidden');
-
         // Keyed DOM Reconciliation to completely eliminate visual flicker:
         // Instead of destroying and rebuilding all card DOM elements (which
         // destroys <img> instances and triggers asynchronous image-decoding layout passes),

--- a/src/Ankimon/ankimon_items_web/shop_obj.py
+++ b/src/Ankimon/ankimon_items_web/shop_obj.py
@@ -471,8 +471,13 @@ class AnkimonItemsWeb(QDialog):
         from ..pyobj.ankimon_shop import DAILY_ITEMS_POOL
 
         random.seed()
-        new_items = random.sample(DAILY_ITEMS_POOL, sm.number_of_daily_items)
-        new_tms = random.sample(sm.get_tm_pool(), sm.number_of_daily_items)
+        # Clamp sample sizes — random.sample raises if asked for more entries
+        # than the pool contains, which would crash the bridge call.
+        tm_pool = sm.get_tm_pool()
+        num_items = min(sm.number_of_daily_items, len(DAILY_ITEMS_POOL))
+        num_tms = min(sm.number_of_daily_items, len(tm_pool))
+        new_items = random.sample(DAILY_ITEMS_POOL, num_items)
+        new_tms = random.sample(tm_pool, num_tms)
 
         try:
             mw.ankimon_db.set_user_data(
@@ -655,20 +660,31 @@ class AnkimonItemsWeb(QDialog):
         except Exception:
             config = dict(settings_obj.config)
 
+        # Snapshot what's on disk so we can skip writes for unchanged keys
+        # after clamping (avoids spurious observer notifications).
+        original_config = dict(config)
+
         # Coerce incoming values back to the type of the existing config
         # entry so e.g. an int field doesn't silently become a string.
-        for raw_key, raw_val in payload.items():
-            key = str(raw_key)
-            if key not in config:
-                continue
-            config[key] = self._coerce_incoming(config[key], raw_val)
+        try:
+            for raw_key, raw_val in payload.items():
+                key = str(raw_key)
+                if key not in config:
+                    continue
+                config[key] = self._coerce_incoming(config[key], raw_val)
+        except ValueError as e:
+            return {"ok": False, "message": f"Validation error: {e}"}
 
         config, adjustments = settings_schema.validate_and_clamp(config)
 
         try:
+            changed = False
             for key, val in config.items():
-                settings_obj.set(key, val)
-            settings_obj.save_config()
+                if original_config.get(key) != val:
+                    settings_obj.set(key, val)
+                    changed = True
+            if changed:
+                settings_obj.save_config()
         except Exception as e:
             return {"ok": False, "message": f"Save failed: {e}"}
 
@@ -685,20 +701,25 @@ class AnkimonItemsWeb(QDialog):
     @staticmethod
     def _coerce_incoming(existing, incoming):
         """Match the new value's type to the existing config entry so a
-        text-input UI doesn't accidentally rewrite an int field as a str."""
+        text-input UI doesn't accidentally rewrite an int field as a str.
+        Raises ValueError for non-coercible numeric input — caller surfaces
+        the failure rather than silently writing garbage to config."""
         if isinstance(existing, bool):
             return bool(incoming)
         if isinstance(existing, int) and not isinstance(existing, bool):
             try:
-                # Allow strings that look like ints; fall through for ranges.
                 return int(incoming)
             except (TypeError, ValueError):
-                return incoming
+                # Range strings (e.g. "1-3" for cards_per_round) pass through;
+                # validate_and_clamp's _coerce_cards_per_round normalizes them.
+                if isinstance(incoming, str) and "-" in incoming:
+                    return incoming
+                raise ValueError(f"Expected integer, got {incoming!r}")
         if isinstance(existing, float):
             try:
                 return float(incoming)
             except (TypeError, ValueError):
-                return incoming
+                raise ValueError(f"Expected float, got {incoming!r}")
         if existing is None:
             # active_region accepts None or a string region name
             return incoming if incoming not in ("", None, "None") else None

--- a/src/Ankimon/ankimon_items_web/shop_obj.py
+++ b/src/Ankimon/ankimon_items_web/shop_obj.py
@@ -139,7 +139,7 @@ class AnkimonItemsWeb(QDialog):
         self.webview = QWebEngineView()
         # Suppress the QtWebEngine browser-style right-click menu (Inspect,
         # Reload, etc.) — irrelevant noise in a game UI.
-        self.webview.page().setContextMenuPolicy(Qt.ContextMenuPolicy.NoContextMenu)
+        self.webview.setContextMenuPolicy(Qt.ContextMenuPolicy.NoContextMenu)
         # Paint the underlying webview page dark so the user doesn't see a
         # white flash between window-show and HTML/CSS first paint.
         self.webview.page().setBackgroundColor(QColor("#0d1117"))

--- a/src/Ankimon/ankimon_items_web/shop_obj.py
+++ b/src/Ankimon/ankimon_items_web/shop_obj.py
@@ -534,32 +534,47 @@ class AnkimonItemsWeb(QDialog):
             group = {
                 "label": group_def["label"],
                 "settings": self._serialize_settings_list(
-                    group_def.get("settings", []), key_by_friendly,
-                    name_map, desc_map, config,
+                    group_def.get("settings", []),
+                    key_by_friendly,
+                    name_map,
+                    desc_map,
+                    config,
                 ),
                 "subgroups": [],
             }
             for sub in group_def.get("subgroups", []):
-                group["subgroups"].append({
-                    "label": sub["label"],
-                    "settings": self._serialize_settings_list(
-                        sub.get("settings", []), key_by_friendly,
-                        name_map, desc_map, config,
-                    ),
-                })
+                group["subgroups"].append(
+                    {
+                        "label": sub["label"],
+                        "settings": self._serialize_settings_list(
+                            sub.get("settings", []),
+                            key_by_friendly,
+                            name_map,
+                            desc_map,
+                            config,
+                        ),
+                    }
+                )
             groups.append(group)
         return {"groups": groups}
 
-    def _serialize_settings_list(self, friendly_names, key_by_friendly,
-                                  name_map, desc_map, config):
+    def _serialize_settings_list(
+        self, friendly_names, key_by_friendly, name_map, desc_map, config
+    ):
         out = []
         for friendly in friendly_names:
             key = key_by_friendly.get(friendly)
             if not key or key not in config:
                 continue
-            out.append(self._serialize_setting(
-                key, friendly, name_map, desc_map, config.get(key),
-            ))
+            out.append(
+                self._serialize_setting(
+                    key,
+                    friendly,
+                    name_map,
+                    desc_map,
+                    config.get(key),
+                )
+            )
         return out
 
     @staticmethod
@@ -588,6 +603,7 @@ class AnkimonItemsWeb(QDialog):
 
     def _load_lang_json(self, filename):
         import json as _json
+
         cache_attr = f"_lang_{filename.replace('.', '_')}_cache"
         cached = getattr(self, cache_attr, None)
         if cached is not None:
@@ -667,6 +683,7 @@ class AnkimonItemsWeb(QDialog):
     def _refresh_reviewer_hotkeys(config):
         try:
             from ..reviewer_ui import setup_reviewer_ui
+
             setup_reviewer_ui(
                 config.get("controls.catch_key", "6"),
                 config.get("controls.defeat_key", "5"),

--- a/src/Ankimon/ankimon_items_web/shop_obj.py
+++ b/src/Ankimon/ankimon_items_web/shop_obj.py
@@ -17,7 +17,7 @@ from PyQt6.QtWebChannel import QWebChannel
 
 import csv
 
-from ..utils import give_item
+from ..utils import give_item, is_dev_mode
 from ..resources import items_path, csv_file_items_cost, csv_file_descriptions
 from ..functions.pokedex_functions import find_details_move
 
@@ -531,15 +531,18 @@ class AnkimonItemsWeb(QDialog):
 
         groups = []
         for group_def in settings_schema.GROUPS:
+            settings = self._serialize_settings_list(
+                group_def.get("settings", []), key_by_friendly,
+                name_map, desc_map, config,
+            )
+            # Append a chip-group as one composite setting after the regular
+            # settings — keeps it in the same scroll section.
+            chip_def = group_def.get("chip_group")
+            if chip_def:
+                settings.append(self._serialize_chip_group(chip_def, config))
             group = {
                 "label": group_def["label"],
-                "settings": self._serialize_settings_list(
-                    group_def.get("settings", []),
-                    key_by_friendly,
-                    name_map,
-                    desc_map,
-                    config,
-                ),
+                "settings": settings,
                 "subgroups": [],
             }
             for sub in group_def.get("subgroups", []):
@@ -556,7 +559,24 @@ class AnkimonItemsWeb(QDialog):
                     }
                 )
             groups.append(group)
-        return {"groups": groups}
+        return {"groups": groups, "dev_mode": bool(is_dev_mode())}
+
+    @staticmethod
+    def _serialize_chip_group(chip_def, config):
+        chips = []
+        for key, chip_label in chip_def["keys"]:
+            chips.append({
+                "key": key,
+                "label": chip_label,
+                "value": bool(config.get(key, False)),
+            })
+        return {
+            "key": "__chips__" + chip_def["label"].lower().replace(" ", "_"),
+            "label": chip_def["label"],
+            "description": chip_def.get("description", ""),
+            "type": "chips",
+            "chips": chips,
+        }
 
     def _serialize_settings_list(
         self, friendly_names, key_by_friendly, name_map, desc_map, config

--- a/src/Ankimon/ankimon_items_web/shop_obj.py
+++ b/src/Ankimon/ankimon_items_web/shop_obj.py
@@ -159,6 +159,7 @@ class AnkimonItemsWeb(QDialog):
         # Boot with Items by default; menu entries can call load_screen()
         # before show() to pick a different initial screen.
         self.load_screen(SCREEN_ITEMS)
+        self._restore_geometry()
 
     # ------------------------------------------------------------------
     # Screen switching
@@ -228,10 +229,41 @@ class AnkimonItemsWeb(QDialog):
             on_state_ready,
         )
 
+    def show(self):
+        if self.isMinimized():
+            self.showNormal()
+        else:
+            super().show()
+        self.raise_()
+        self.activateWindow()
+
+    def _restore_geometry(self):
+        import base64
+        from PyQt6.QtCore import QByteArray
+        try:
+            geo = mw.pm.profile.get("ankimon.items_web_window.geometry")
+            if geo:
+                self.restoreGeometry(QByteArray(base64.b64decode(geo)))
+        except Exception:
+            pass
+
+    def _save_geometry(self):
+        import base64
+        try:
+            if not self.isMinimized():
+                mw.pm.profile["ankimon.items_web_window.geometry"] = base64.b64encode(bytes(self.saveGeometry())).decode()
+        except Exception:
+            pass
+
     def closeEvent(self, event):
         if self.current_screen == SCREEN_ANKIDEX:
             self._save_ankidex_prefs()
+        self._save_geometry()
         super().closeEvent(event)
+
+    def hideEvent(self, event):
+        self._save_geometry()
+        super().hideEvent(event)
 
     def showEvent(self, event):
         # Re-push fresh data on every show (e.g. after buy/use happened

--- a/src/Ankimon/ankimon_items_web/shop_obj.py
+++ b/src/Ankimon/ankimon_items_web/shop_obj.py
@@ -532,8 +532,11 @@ class AnkimonItemsWeb(QDialog):
         groups = []
         for group_def in settings_schema.GROUPS:
             settings = self._serialize_settings_list(
-                group_def.get("settings", []), key_by_friendly,
-                name_map, desc_map, config,
+                group_def.get("settings", []),
+                key_by_friendly,
+                name_map,
+                desc_map,
+                config,
             )
             # Append a chip-group as one composite setting after the regular
             # settings — keeps it in the same scroll section.
@@ -565,11 +568,13 @@ class AnkimonItemsWeb(QDialog):
     def _serialize_chip_group(chip_def, config):
         chips = []
         for key, chip_label in chip_def["keys"]:
-            chips.append({
-                "key": key,
-                "label": chip_label,
-                "value": bool(config.get(key, False)),
-            })
+            chips.append(
+                {
+                    "key": key,
+                    "label": chip_label,
+                    "value": bool(config.get(key, False)),
+                }
+            )
         return {
             "key": "__chips__" + chip_def["label"].lower().replace(" ", "_"),
             "label": chip_def["label"],

--- a/src/Ankimon/ankimon_items_web/shop_obj.py
+++ b/src/Ankimon/ankimon_items_web/shop_obj.py
@@ -139,7 +139,7 @@ class AnkimonItemsWeb(QDialog):
         self.webview = QWebEngineView()
         # Suppress the QtWebEngine browser-style right-click menu (Inspect,
         # Reload, etc.) — irrelevant noise in a game UI.
-        self.webview.setContextMenuPolicy(Qt.ContextMenuPolicy.NoContextMenu)
+        self.webview.page().setContextMenuPolicy(Qt.ContextMenuPolicy.NoContextMenu)
         # Paint the underlying webview page dark so the user doesn't see a
         # white flash between window-show and HTML/CSS first paint.
         self.webview.page().setBackgroundColor(QColor("#0d1117"))

--- a/src/Ankimon/ankimon_items_web/shop_obj.py
+++ b/src/Ankimon/ankimon_items_web/shop_obj.py
@@ -58,8 +58,17 @@ class SettingsBridge(QObject):
     def getSettings(self):
         return self._w.get_settings_data()
 
-    @pyqtSlot("QVariant", result="QVariant")
-    def saveSettings(self, payload):
+    # Accept a JSON-encoded string rather than a QVariant dict — PyQt's
+    # QVariant → dict auto-unwrap can fail on the first invocation
+    # (depending on Qt/PyQt versions), making the first save click error
+    # out while later clicks succeed. Round-tripping through JSON removes
+    # that ambiguity entirely.
+    @pyqtSlot(str, result="QVariant")
+    def saveSettings(self, payload_json):
+        try:
+            payload = json.loads(payload_json) if payload_json else {}
+        except (TypeError, ValueError) as e:
+            return {"ok": False, "message": f"Invalid payload JSON: {e}"}
         return self._w.handle_save_settings(payload)
 
 

--- a/src/Ankimon/ankimon_items_web/shop_obj.py
+++ b/src/Ankimon/ankimon_items_web/shop_obj.py
@@ -693,7 +693,9 @@ class AnkimonItemsWeb(QDialog):
                     settings_obj.set(key, val)
                     changed = True
             if changed:
-                settings_obj.save_config()
+                # Settings.save_config(config) requires the dict — passing
+                # the fully-merged config persists every key in one write.
+                settings_obj.save_config(config)
         except Exception as e:
             return {"ok": False, "message": f"Save failed: {e}"}
 

--- a/src/Ankimon/ankimon_items_web/shop_obj.py
+++ b/src/Ankimon/ankimon_items_web/shop_obj.py
@@ -24,10 +24,11 @@ from ..functions.pokedex_functions import find_details_move
 
 SCREEN_ITEMS = "items"
 SCREEN_ANKIDEX = "ankidex"
+SCREEN_SETTINGS = "settings"
 
 
 class NavBridge(QObject):
-    """Cross-screen navigation — exposed in both Items and Ankidex pages."""
+    """Cross-screen navigation — exposed in all shell pages."""
 
     def __init__(self, window):
         super().__init__()
@@ -40,6 +41,26 @@ class NavBridge(QObject):
     @pyqtSlot()
     def openAnkidex(self):
         self._w.load_screen(SCREEN_ANKIDEX)
+
+    @pyqtSlot()
+    def openSettings(self):
+        self._w.load_screen(SCREEN_SETTINGS)
+
+
+class SettingsBridge(QObject):
+    """Settings-screen actions — only meaningful when Settings is loaded."""
+
+    def __init__(self, window):
+        super().__init__()
+        self._w = window
+
+    @pyqtSlot(result="QVariant")
+    def getSettings(self):
+        return self._w.get_settings_data()
+
+    @pyqtSlot("QVariant", result="QVariant")
+    def saveSettings(self, payload):
+        return self._w.handle_save_settings(payload)
 
 
 class ItemsBridge(QObject):
@@ -118,8 +139,10 @@ class AnkimonItemsWeb(QDialog):
         self.channel = QWebChannel(self.webview)
         self.bridge = ItemsBridge(self)
         self.nav = NavBridge(self)
+        self.settings_bridge = SettingsBridge(self)
         self.channel.registerObject("bridge", self.bridge)
         self.channel.registerObject("nav", self.nav)
+        self.channel.registerObject("settings", self.settings_bridge)
         self.webview.page().setWebChannel(self.channel)
 
         self.webview.loadFinished.connect(self._on_load_finished)
@@ -140,6 +163,9 @@ class AnkimonItemsWeb(QDialog):
             elif screen == SCREEN_ANKIDEX:
                 path = self.addon_dir / "ankidex" / "ankidex.html"
                 title = "Ankimon — Ankidex"
+            elif screen == SCREEN_SETTINGS:
+                path = self.addon_dir / "ankimon_items_web" / "settings.html"
+                title = "Ankimon — Settings"
             else:
                 return
             self.setWindowTitle(title)
@@ -165,6 +191,9 @@ class AnkimonItemsWeb(QDialog):
         elif self.current_screen == SCREEN_ANKIDEX:
             data = self._get_ankidex_data()
             js = f"if (window.initializeAnkidex) window.initializeAnkidex({json.dumps(data)});"
+        elif self.current_screen == SCREEN_SETTINGS:
+            data = self.get_settings_data()
+            js = f"if (window.initializeSettings) window.initializeSettings({json.dumps(data)});"
         else:
             return
         self.webview.page().runJavaScript(js)
@@ -479,3 +508,171 @@ class AnkimonItemsWeb(QDialog):
             if entry["name"] == item_name:
                 return entry
         return None
+
+    # ------------------------------------------------------------------
+    # Settings screen
+    # ------------------------------------------------------------------
+    def get_settings_data(self):
+        """Build the schema + current values payload for the Settings screen."""
+        from . import settings_schema
+
+        settings_obj = self.shop_manager.settings_obj
+        # Refresh config from disk so external edits are picked up.
+        try:
+            config = settings_obj.load_config()
+        except Exception:
+            config = settings_obj.config
+
+        name_map = self._load_lang_json("setting_name.json")
+        desc_map = self._load_lang_json("setting_description.json")
+        # Reverse the friendly_name → key map so we can resolve friendly names
+        # from the schema back to their config keys.
+        key_by_friendly = {v: k for k, v in name_map.items()}
+
+        groups = []
+        for group_def in settings_schema.GROUPS:
+            group = {
+                "label": group_def["label"],
+                "settings": self._serialize_settings_list(
+                    group_def.get("settings", []), key_by_friendly,
+                    name_map, desc_map, config,
+                ),
+                "subgroups": [],
+            }
+            for sub in group_def.get("subgroups", []):
+                group["subgroups"].append({
+                    "label": sub["label"],
+                    "settings": self._serialize_settings_list(
+                        sub.get("settings", []), key_by_friendly,
+                        name_map, desc_map, config,
+                    ),
+                })
+            groups.append(group)
+        return {"groups": groups}
+
+    def _serialize_settings_list(self, friendly_names, key_by_friendly,
+                                  name_map, desc_map, config):
+        out = []
+        for friendly in friendly_names:
+            key = key_by_friendly.get(friendly)
+            if not key or key not in config:
+                continue
+            out.append(self._serialize_setting(
+                key, friendly, name_map, desc_map, config.get(key),
+            ))
+        return out
+
+    @staticmethod
+    def _serialize_setting(key, friendly, name_map, desc_map, value):
+        from . import settings_schema
+
+        entry = {
+            "key": key,
+            "label": friendly,
+            "description": desc_map.get(key, ""),
+            "value": value,
+        }
+
+        if key == "misc.active_region":
+            entry["type"] = "select"
+            entry["options"] = settings_schema.ACTIVE_REGION_OPTIONS
+        elif isinstance(value, bool):
+            entry["type"] = "boolean"
+        elif isinstance(value, int):
+            entry["type"] = "int"
+        elif isinstance(value, float):
+            entry["type"] = "float"
+        else:
+            entry["type"] = "text"
+        return entry
+
+    def _load_lang_json(self, filename):
+        import json as _json
+        cache_attr = f"_lang_{filename.replace('.', '_')}_cache"
+        cached = getattr(self, cache_attr, None)
+        if cached is not None:
+            return cached
+        path = self.addon_dir / "lang" / filename
+        try:
+            with open(path, "r", encoding="utf-8") as f:
+                data = _json.load(f)
+        except (OSError, _json.JSONDecodeError):
+            data = {}
+        setattr(self, cache_attr, data)
+        return data
+
+    def handle_save_settings(self, payload):
+        """Apply the JS-side payload, run legacy bounds checks, persist."""
+        from . import settings_schema
+
+        if not isinstance(payload, dict):
+            return {"ok": False, "message": "Invalid payload."}
+
+        settings_obj = self.shop_manager.settings_obj
+        try:
+            config = settings_obj.load_config()
+        except Exception:
+            config = dict(settings_obj.config)
+
+        # Coerce incoming values back to the type of the existing config
+        # entry so e.g. an int field doesn't silently become a string.
+        for raw_key, raw_val in payload.items():
+            key = str(raw_key)
+            if key not in config:
+                continue
+            config[key] = self._coerce_incoming(config[key], raw_val)
+
+        config, adjustments = settings_schema.validate_and_clamp(config)
+
+        try:
+            for key, val in config.items():
+                settings_obj.set(key, val)
+            settings_obj.save_config()
+        except Exception as e:
+            return {"ok": False, "message": f"Save failed: {e}"}
+
+        self._refresh_reviewer_hotkeys(config)
+
+        if adjustments:
+            return {
+                "ok": True,
+                "message": "Saved (with adjustments).",
+                "adjustments": adjustments,
+            }
+        return {"ok": True, "message": "Settings saved."}
+
+    @staticmethod
+    def _coerce_incoming(existing, incoming):
+        """Match the new value's type to the existing config entry so a
+        text-input UI doesn't accidentally rewrite an int field as a str."""
+        if isinstance(existing, bool):
+            return bool(incoming)
+        if isinstance(existing, int) and not isinstance(existing, bool):
+            try:
+                # Allow strings that look like ints; fall through for ranges.
+                return int(incoming)
+            except (TypeError, ValueError):
+                return incoming
+        if isinstance(existing, float):
+            try:
+                return float(incoming)
+            except (TypeError, ValueError):
+                return incoming
+        if existing is None:
+            # active_region accepts None or a string region name
+            return incoming if incoming not in ("", None, "None") else None
+        return incoming if incoming is None else str(incoming)
+
+    @staticmethod
+    def _refresh_reviewer_hotkeys(config):
+        try:
+            from ..reviewer_ui import setup_reviewer_ui
+            setup_reviewer_ui(
+                config.get("controls.catch_key", "6"),
+                config.get("controls.defeat_key", "5"),
+                config.get("controls.pokemon_buttons", True),
+                config.get("controls.team_cycle_key", "9"),
+            )
+        except Exception:
+            # Best-effort — settings still saved even if the hook fails.
+            pass

--- a/src/Ankimon/menu_buttons.py
+++ b/src/Ankimon/menu_buttons.py
@@ -304,7 +304,7 @@ def create_menu_actions(
     # still calls into it directly, but is no longer launched from the menu.
     config_action = QAction(mw.translator.translate("ankimon_settings_button"), mw)
     config_action.setMenuRole(QAction.MenuRole.NoRole)
-    config_action.triggered.connect(lambda: _open_shell_at('settings'))
+    config_action.triggered.connect(lambda: _open_shell_at("settings"))
 
     # Show the Settings window
     mw.pokemenu.addAction(config_action)

--- a/src/Ankimon/menu_buttons.py
+++ b/src/Ankimon/menu_buttons.py
@@ -114,6 +114,16 @@ def create_menu_actions(
 
     actions = []
 
+    def _open_shell_at(screen):
+        w = get_items_window()
+        if w.isMinimized():
+            w.showNormal()
+        if w.current_screen != screen:
+            w.load_screen(screen)
+        w.show()
+        w.raise_()
+        w.activateWindow()
+
     if database_complete:
         # Pokémon PC
         pokemon_pc_action = QAction("Pokémon PC", mw)
@@ -134,13 +144,6 @@ def create_menu_actions(
         )
 
         # Itembag — unified shell window, items screen.
-        def _open_shell_at(screen):
-            w = get_items_window()
-            if w.current_screen != screen:
-                w.load_screen(screen)
-            w.show()
-            w.raise_()
-            w.activateWindow()
 
         itembag_action = QAction(mw.translator.translate("itembag_button"), mw)
         itembag_action.setMenuRole(QAction.MenuRole.NoRole)
@@ -377,7 +380,7 @@ def create_menu_actions(
     # Mart entry — opens the same unified Items window as the Item Bag entry.
     shop_manager_action = QAction(mw.translator.translate("item_shop_button"), mw)
     shop_manager_action.setMenuRole(QAction.MenuRole.NoRole)
-    shop_manager_action.triggered.connect(lambda: get_items_window().show())
+    shop_manager_action.triggered.connect(lambda: _open_shell_at("items"))
     game_menu.addAction(shop_manager_action)
 
     # Choose Trainer Sprite Action

--- a/src/Ankimon/menu_buttons.py
+++ b/src/Ankimon/menu_buttons.py
@@ -299,9 +299,12 @@ def create_menu_actions(
     version_action.triggered.connect(lambda: get_version_dialog().open())
     help_menu.addAction(version_action)
 
+    # Settings — opens the unified shell at the Settings screen. The legacy
+    # SettingsWindow singleton stays available as a service for anything that
+    # still calls into it directly, but is no longer launched from the menu.
     config_action = QAction(mw.translator.translate("ankimon_settings_button"), mw)
     config_action.setMenuRole(QAction.MenuRole.NoRole)
-    config_action.triggered.connect(lambda: get_settings_window().show_window())
+    config_action.triggered.connect(lambda: _open_shell_at('settings'))
 
     # Show the Settings window
     mw.pokemenu.addAction(config_action)

--- a/src/Ankimon/pyobj/item_window.py
+++ b/src/Ankimon/pyobj/item_window.py
@@ -469,8 +469,9 @@ class ItemWindow(QWidget):
                 from ..functions.pokedex_functions import search_pokedex_by_id
 
                 fossil_pokemon_name = search_pokedex_by_id(fossil_id)
-                self.Evolve_Fossil(name, fossil_id, fossil_pokemon_name)
-                return {"ok": True, "message": f"Revived {fossil_pokemon_name}."}
+                if self.Evolve_Fossil(name, fossil_id, fossil_pokemon_name):
+                    return {"ok": True, "message": f"Revived {fossil_pokemon_name}."}
+                return {"ok": False, "message": f"Failed to revive {fossil_pokemon_name}."}
             if name in self.pokeball_chances:
                 self.Handle_Pokeball(name)
                 return {"ok": True, "message": f"Threw {name}."}
@@ -564,9 +565,12 @@ class ItemWindow(QWidget):
         individual_id, prevo_id = selected
         self.Check_Evo_Item(individual_id, prevo_id, item_name)
 
-    def Evolve_Fossil(self, item_name: str, fossil_id: int, fossil_poke_name: str):
+    def Evolve_Fossil(self, item_name: str, fossil_id: int, fossil_poke_name: str) -> bool:
+        """Revive a fossil into its corresponding Pokémon. Returns True on
+        success, False if another item action is already running or revival
+        threw. Existing PyQt button callers ignore the return value."""
         if self._item_action_in_progress:
-            return
+            return False
         self._item_action_in_progress = True
         try:
             if not isinstance(fossil_id, int):
@@ -579,12 +583,14 @@ class ItemWindow(QWidget):
 
             if is_alive(pokemon_pc):
                 pokemon_pc.refresh_pokemon_grid()
+            return True
         except Exception as e:
             show_warning_with_traceback(
                 parent=self,
                 exception=e,
                 message=f"Error using fossil item '{item_name}'",
             )
+            return False
         finally:
             self._item_action_in_progress = False
 

--- a/src/Ankimon/pyobj/item_window.py
+++ b/src/Ankimon/pyobj/item_window.py
@@ -672,7 +672,7 @@ class ItemWindow(QWidget):
             if evo_id:
                 # Perform your action when the item matches the Pokémon's evolution item
                 self.logger.log_and_showinfo("info", "Pokemon Evolution is fitting !")
-                self.evo_window.ask_pokemon_evo(individual_id, prevo_id, evo_id)
+                self.evo_window.ask_pokemon_evo(individual_id, prevo_id, evo_id, item_name=item_name)
             else:
                 self.logger.log_and_showinfo(
                     "info", "This Pokemon does not need this item."
@@ -682,24 +682,19 @@ class ItemWindow(QWidget):
 
     def load_evolution_items(self):
         try:
-            evolution_item_ids = set()
-            with open(
-                poke_evo_path, mode="r", newline="", encoding="utf-8"
-            ) as evo_file:
-                reader = csv.DictReader(evo_file)
-                for row in reader:
-                    if row["evolution_trigger_id"] == "3":
-                        item_id = row["trigger_item_id"]
-                        if item_id:
-                            evolution_item_ids.add(item_id)
-
-            with open(
-                csv_file_items_cost, mode="r", newline="", encoding="utf-8"
-            ) as items_file:
-                reader = csv.DictReader(items_file)
-                for row in reader:
-                    if row["id"] in evolution_item_ids:
-                        self.evolution_items.add(row["identifier"])
+            self.evolution_items = set()
+            
+            # Load all items from pokedex.json that are used as evolution items (evoType == "useItem")
+            from ..functions.pokedex_functions import _load_pokedex_cache
+            pokedex_data = _load_pokedex_cache()
+            
+            for details in pokedex_data.values():
+                if details.get("evoType") == "useItem":
+                    evo_item = details.get("evoItem")
+                    if evo_item:
+                        # e.g., Convert "Galarica Cuff" -> "galarica-cuff", "Ice Stone" -> "ice-stone"
+                        identifier = evo_item.lower().replace(" ", "-")
+                        self.evolution_items.add(identifier)
 
         except Exception as e:
             self.logger.log_and_showinfo("error", f"Error loading evolution items: {e}")

--- a/src/Ankimon/pyobj/item_window.py
+++ b/src/Ankimon/pyobj/item_window.py
@@ -471,7 +471,10 @@ class ItemWindow(QWidget):
                 fossil_pokemon_name = search_pokedex_by_id(fossil_id)
                 if self.Evolve_Fossil(name, fossil_id, fossil_pokemon_name):
                     return {"ok": True, "message": f"Revived {fossil_pokemon_name}."}
-                return {"ok": False, "message": f"Failed to revive {fossil_pokemon_name}."}
+                return {
+                    "ok": False,
+                    "message": f"Failed to revive {fossil_pokemon_name}.",
+                }
             if name in self.pokeball_chances:
                 self.Handle_Pokeball(name)
                 return {"ok": True, "message": f"Threw {name}."}
@@ -565,7 +568,9 @@ class ItemWindow(QWidget):
         individual_id, prevo_id = selected
         self.Check_Evo_Item(individual_id, prevo_id, item_name)
 
-    def Evolve_Fossil(self, item_name: str, fossil_id: int, fossil_poke_name: str) -> bool:
+    def Evolve_Fossil(
+        self, item_name: str, fossil_id: int, fossil_poke_name: str
+    ) -> bool:
         """Revive a fossil into its corresponding Pokémon. Returns True on
         success, False if another item action is already running or revival
         threw. Existing PyQt button callers ignore the return value."""

--- a/src/Ankimon/pyobj/item_window.py
+++ b/src/Ankimon/pyobj/item_window.py
@@ -672,7 +672,9 @@ class ItemWindow(QWidget):
             if evo_id:
                 # Perform your action when the item matches the Pokémon's evolution item
                 self.logger.log_and_showinfo("info", "Pokemon Evolution is fitting !")
-                self.evo_window.ask_pokemon_evo(individual_id, prevo_id, evo_id, item_name=item_name)
+                self.evo_window.ask_pokemon_evo(
+                    individual_id, prevo_id, evo_id, item_name=item_name
+                )
             else:
                 self.logger.log_and_showinfo(
                     "info", "This Pokemon does not need this item."
@@ -683,11 +685,12 @@ class ItemWindow(QWidget):
     def load_evolution_items(self):
         try:
             self.evolution_items = set()
-            
+
             # Load all items from pokedex.json that are used as evolution items (evoType == "useItem")
             from ..functions.pokedex_functions import _load_pokedex_cache
+
             pokedex_data = _load_pokedex_cache()
-            
+
             for details in pokedex_data.values():
                 if details.get("evoType") == "useItem":
                     evo_item = details.get("evoItem")


### PR DESCRIPTION
## Summary
- Adds **Settings** as the third screen in the unified shell window (joining Items and Ankidex from #464). Same `QDialog`, same `QWebEngineView`, same QWebChannel — dropdown switches between all three in place.
- Replaces the legacy `QMainWindow`-based `settings_window.py` from the menu; the old class stays alive as a backing service for anything that calls it directly.
- Faithful parity with the legacy window: same two-level group structure, same labels/descriptions from `lang/setting_name.json` + `lang/setting_description.json`, same validation + clamping rules.

> **Stacked on top of #464**. This PR's diff includes commits from #464 — once that merges, this rebases cleanly.

## Architecture
- `ankimon_items_web/settings_schema.py` — declarative group structure (six top-level groups, two with subgroups) + the legacy clamping pass (`cards_per_round` int-or-range, `cash_reward_interval` 5..250, `cash_reward_amount` 10..2000 with a 100:1 ratio cap).
- `shop_obj.py` extensions:
  - `SCREEN_SETTINGS` constant + `load_screen('settings')` routing
  - `SettingsBridge` (`getSettings()`, `saveSettings(payload)`) registered as `settings` on the QWebChannel
  - `get_settings_data()` builds the payload by joining the schema with `lang/setting_*.json` (cached on first read) and current `settings_obj` values
  - `handle_save_settings(payload)` coerces incoming values back to the type of the existing config entry, runs the schema clamp pass, persists via `settings_obj.save_config`, and refreshes reviewer hotkeys

## UI
- **Sidebar**: jump-to-section nav for each group with live setting counts, a green-glowing **Save Changes** action with a dirty count pill, and a status indicator at the bottom (green "All saved" / gold "N unsaved").
- **Main**: per-group sections with a labelled header. Subgroups render as nested cards with a cyan accent header. Search filters by both label and description; empty subgroups auto-collapse.
- **Form primitives**:
  - Text input (trainer name, language id, etc.)
  - Numeric input (right-aligned, monospace; accepts ranges for `battle.cards_per_round`)
  - Dropdown (active region)
  - Segmented Enabled/Disabled toggle (booleans)
- Per-row gold dot marks dirty fields. Discard button appears in the top-right while changes are pending. `Ctrl+S` / `⌘S` triggers Save.

## Nav switcher
All three screens now have **Items / Ankidex / Settings** in the dropdown:
- `shop.html`, `ankidex.html`, `settings.html` carry the same `.nav-switcher` markup
- `shop.js`, `nav-switcher.js`, `settings.js` route through `window.nav.openItems/Ankidex/Settings` (with passthrough back-compat on `ItemsBridge`)

## Menu wiring
`menu_buttons.py` Tools → Settings entry now calls `_open_shell_at('settings')` instead of the legacy `get_settings_window().show_window()`.

## Test plan
- [ ] Restart Anki, open Tools → Ankimon → Settings — opens the shell at the Settings screen.
- [ ] Toggle a boolean, change a text field — Save Changes lights up green with the dirty count; per-row gold dots appear; status footer shows "N unsaved".
- [ ] Click Save (or `⌘S` / `Ctrl+S`) — toast confirms; if values were clamped (e.g. `cash_reward_amount > 2000`), the adjustment is shown in the toast; UI re-renders with the actual persisted values.
- [ ] Click Discard — reverts all unsaved edits.
- [ ] Search "potion" — filters to matching rows; empty groups hide; search "/" focuses the field.
- [ ] Click each group in the sidebar — smooth-scrolls to the section.
- [ ] Switch to Items, then Ankidex, then back to Settings via the dropdown — same window, no flicker.
- [ ] Change `controls.catch_key` / `controls.defeat_key` and save — reviewer hotkeys refresh via `setup_reviewer_ui`.