### PR TITLE
feat(items): in-shell Pokémon picker for evolution + held items

### DIFF
--- a/src/Ankimon/ankidex/ankidex.css
+++ b/src/Ankimon/ankidex/ankidex.css
@@ -1837,7 +1837,6 @@ body {
     border-radius: 8px;
     padding: 8px;
     z-index: 100;
-    backdrop-filter: blur(8px);
 }
 
 .mini-map-label {

--- a/src/Ankimon/ankimon_items_web/shop.css
+++ b/src/Ankimon/ankimon_items_web/shop.css
@@ -3114,6 +3114,296 @@ body {
     cursor: not-allowed;
 }
 
+/* --- Pokémon picker modal (evolution + held items) --- */
+/* Picker reuses the `.pokemon-card` Ankidex visuals — same hover, same
+   sprite scaling. The team-specific bits (level pill, active outline,
+   held-item line) live in `.team-card` overrides below. */
+.picker-modal {
+    position: fixed;
+    inset: 0;
+    z-index: 1500;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    animation: fadeIn 0.18s ease-out;
+}
+
+.picker-modal.hidden {
+    display: none;
+}
+
+.picker-backdrop {
+    position: absolute;
+    inset: 0;
+    background: rgba(8, 10, 12, 0.7);
+    backdrop-filter: blur(4px);
+}
+
+.picker-card {
+    position: relative;
+    background: linear-gradient(160deg, var(--bg-card), var(--bg-darker));
+    border: 1px solid var(--border-main);
+    border-radius: 18px;
+    width: min(960px, calc(100vw - 60px));
+    height: min(720px, calc(100vh - 60px));
+    box-shadow: 0 24px 60px rgba(0, 0, 0, 0.6);
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+    animation: confirmPop 0.18s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+.picker-header {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 12px;
+    padding: 18px 22px 14px;
+    border-bottom: 1px solid var(--border-main);
+    flex-shrink: 0;
+}
+
+.picker-header-text {
+    flex: 1;
+    min-width: 0;
+}
+
+.picker-title {
+    font-size: 1.1rem;
+    font-weight: 800;
+    color: var(--text-bright);
+    letter-spacing: -0.3px;
+    margin: 0;
+}
+
+.picker-subtitle {
+    margin: 4px 0 0;
+    font-size: 0.78rem;
+    color: var(--text-muted);
+    letter-spacing: 0.4px;
+    text-transform: uppercase;
+    font-weight: 600;
+}
+
+.picker-close {
+    background: transparent;
+    border: 1px solid transparent;
+    color: var(--text-muted);
+    width: 30px;
+    height: 30px;
+    border-radius: 8px;
+    font-size: 1rem;
+    cursor: pointer;
+    transition: var(--transition-fast);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+}
+
+.picker-close:hover {
+    background: var(--bg-card-hover);
+    color: var(--text-bright);
+    border-color: var(--border-main);
+}
+
+.picker-toolbar {
+    padding: 12px 22px 10px;
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    flex-shrink: 0;
+}
+
+.picker-search {
+    flex: 1;
+    box-sizing: border-box;
+    background: var(--bg-darker);
+    border: 1px solid var(--border-main);
+    border-radius: 10px;
+    padding: 9px 14px;
+    color: var(--text-bright);
+    font-family: 'Outfit', sans-serif;
+    font-size: 0.9rem;
+    transition: var(--transition-fast);
+}
+
+.picker-search:focus {
+    outline: none;
+    border-color: var(--accent-blue);
+    box-shadow: 0 0 0 3px rgba(88, 166, 255, 0.15);
+}
+
+.picker-count {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 0.78rem;
+    color: var(--text-muted);
+    padding: 4px 10px;
+    background: var(--bg-darker);
+    border: 1px solid var(--border-main);
+    border-radius: 8px;
+    flex-shrink: 0;
+    min-width: 36px;
+    text-align: center;
+    white-space: nowrap;
+}
+
+.picker-count.truncated {
+    color: var(--accent-blue);
+    border-color: rgba(88, 166, 255, 0.4);
+    background: rgba(88, 166, 255, 0.08);
+}
+
+.picker-more-hint {
+    grid-column: 1 / -1;
+    text-align: center;
+    color: var(--text-muted);
+    font-size: 0.82rem;
+    padding: 18px 12px 8px;
+    border-top: 1px dashed var(--border-main);
+    margin-top: 6px;
+}
+
+.picker-grid {
+    flex: 1;
+    overflow-y: auto;
+    padding: 8px 18px 12px;
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
+    gap: 14px;
+    align-content: start;
+}
+
+.picker-grid::-webkit-scrollbar {
+    width: 10px;
+}
+
+.picker-grid::-webkit-scrollbar-thumb {
+    background: var(--border-main);
+    border-radius: 5px;
+}
+
+.picker-grid::-webkit-scrollbar-thumb:hover {
+    background: var(--text-muted);
+}
+
+/* Team-card variant of pokemon-card — drops the per-card hover lift
+   (modal is finite, we want the grid to feel stable) but keeps the
+   sprite scale + border-glow on hover. Fixed dimensions ensure the
+   grid stays uniform whether sprites have decoded yet or not. */
+.pokemon-card.team-card {
+    /* Lock card dimensions so the grid doesn't reflow as sprites load
+       and missing/404 sprites don't collapse the row. */
+    min-height: 180px;
+    padding: 36px 12px 14px;       /* room for absolute level pill + marks */
+    justify-content: flex-start;
+    cursor: pointer;
+}
+
+.pokemon-card.team-card:hover {
+    transform: none;
+    border-color: var(--accent-blue);
+    background: var(--bg-card-hover);
+    box-shadow: 0 6px 18px rgba(0, 0, 0, 0.35);
+}
+
+.pokemon-card.team-card.is-main {
+    border-color: var(--accent-blue);
+    background: rgba(88, 166, 255, 0.05);
+    box-shadow: inset 0 0 0 1px rgba(88, 166, 255, 0.4);
+}
+
+/* Always reserve the full sprite footprint — `flex-shrink: 0` keeps the
+   container at 96×96 even when img hasn't loaded (no intrinsic size). */
+.pokemon-card.team-card .card-sprite {
+    width: 96px;
+    height: 96px;
+    flex-shrink: 0;
+    margin: 0 0 8px;
+}
+
+.pokemon-card.team-card .card-sprite img {
+    width: 96px;
+    height: 96px;
+    object-fit: contain;
+}
+
+.pokemon-card.team-card .card-info {
+    min-height: 22px;              /* reserve space for the name line */
+}
+
+.team-card-level {
+    position: absolute;
+    top: 10px;
+    left: 12px;
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 0.72rem;
+    font-weight: 800;
+    color: var(--text-bright);
+    padding: 2px 8px;
+    background: var(--bg-darker);
+    border: 1px solid var(--border-main);
+    border-radius: 6px;
+    letter-spacing: 0.4px;
+}
+
+.team-card-marks {
+    position: absolute;
+    top: 10px;
+    right: 12px;
+    display: flex;
+    gap: 4px;
+    font-size: 0.85rem;
+}
+
+.team-card-marks .mark {
+    line-height: 1;
+}
+
+.team-card-marks .mark-main { color: var(--accent-blue); }
+.team-card-marks .mark-shiny { color: var(--accent-gold); }
+
+.team-card-meta {
+    margin-top: 6px;
+    font-size: 0.7rem;
+    color: var(--text-muted);
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    justify-content: center;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+}
+
+.team-card-meta .meta-held {
+    color: var(--accent-green);
+    font-weight: 700;
+}
+
+.picker-empty {
+    padding: 40px 22px;
+    text-align: center;
+    color: var(--text-muted);
+    font-size: 0.9rem;
+    flex: 1;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.picker-actions {
+    padding: 12px 22px 16px;
+    border-top: 1px solid var(--border-main);
+    display: flex;
+    justify-content: flex-end;
+    flex-shrink: 0;
+}
+
+.picker-actions .confirm-btn {
+    flex: 0 0 auto;
+    min-width: 110px;
+}
+
 /* --- Navigation switcher (sidebar logo dropdown) --- */
 .nav-switcher {
     position: relative;

--- a/src/Ankimon/ankimon_items_web/shop.css
+++ b/src/Ankimon/ankimon_items_web/shop.css
@@ -3136,7 +3136,6 @@ body {
     position: absolute;
     inset: 0;
     background: rgba(8, 10, 12, 0.7);
-    backdrop-filter: blur(4px);
 }
 
 .picker-card {
@@ -3741,9 +3740,26 @@ body {
     height: 24px;
 }
 
-/* --- Items identity icon (hyper-potion sprite used as Items' visual ID).
- * Sizing comes from .app-logo (32x32) and .nav-menu-icon img (18x18);
- * we just want crisp pixel art at small scales. */
+/* --- Gear icon (nav dropdown + Settings sidebar logo) --- */
+/* Default 18x18 to match the pokeball img sizing inside .nav-menu-icon. */
+.icon-gear {
+    width: 18px;
+    height: 18px;
+    display: block;
+    color: var(--accent-blue);
+}
+
+/* When the gear doubles as a sidebar logo it shares the .app-logo class
+ * which gives it 32x32 — but the size declared by .app-logo and .icon-gear
+ * are at equal specificity, so explicitly bump for the combo. */
+.app-logo.icon-gear {
+    width: 32px;
+    height: 32px;
+}
+
+/* --- Items icon (the hyper-potion sprite used as Items' identity).
+ * .nav-menu-icon img and .app-logo handle sizing; we just want crisp
+ * pixel art at the small icon scale. */
 .icon-item-sprite {
     image-rendering: pixelated;
     object-fit: contain;

--- a/src/Ankimon/ankimon_items_web/shop.html
+++ b/src/Ankimon/ankimon_items_web/shop.html
@@ -216,6 +216,31 @@
         </div>
     </div>
 
+    <!-- Pokémon picker modal (evolution items + held items) — reuses the
+         Ankidex card styling for a richer, faster grid. Choices are
+         pre-loaded with inventory data so opening is synchronous. -->
+    <div id="picker-modal" class="picker-modal hidden" role="dialog" aria-modal="true">
+        <div class="picker-backdrop"></div>
+        <div class="picker-card">
+            <div class="picker-header">
+                <div class="picker-header-text">
+                    <h3 id="picker-title" class="picker-title">Choose a Pokémon</h3>
+                    <p id="picker-subtitle" class="picker-subtitle">Item</p>
+                </div>
+                <button id="picker-close" class="picker-close" type="button" aria-label="Close">✕</button>
+            </div>
+            <div class="picker-toolbar">
+                <input id="picker-search" class="picker-search" type="text" placeholder="Filter by name, level, type…">
+                <span id="picker-count" class="picker-count">0</span>
+            </div>
+            <div id="picker-grid" class="picker-grid"></div>
+            <div id="picker-empty" class="picker-empty hidden">No Pokémon match that search.</div>
+            <div class="picker-actions">
+                <button id="picker-cancel" class="confirm-btn cancel">Cancel</button>
+            </div>
+        </div>
+    </div>
+
     <script src="shop.js"></script>
 </body>
 </html>

--- a/src/Ankimon/ankimon_items_web/shop.js
+++ b/src/Ankimon/ankimon_items_web/shop.js
@@ -38,6 +38,7 @@
     };
 
     let bridge = null;
+    let nav = null;
 
     function initChannel(callback) {
         if (typeof qt === 'undefined' || !qt.webChannelTransport) {
@@ -47,7 +48,9 @@
         }
         new QWebChannel(qt.webChannelTransport, function (channel) {
             bridge = channel.objects.bridge;
+            nav = channel.objects && channel.objects.nav;
             window.bridge = bridge;
+            window.nav = nav;
             callback(bridge);
         });
     }
@@ -110,7 +113,6 @@
             return;
         }
         empty.classList.add('hidden');
-
         // Keyed DOM Reconciliation to completely eliminate visual flicker:
         // Instead of destroying and rebuilding all card DOM elements (which
         // destroys <img> instances and triggers asynchronous image-decoding layout passes),
@@ -301,6 +303,12 @@
         // Update sprite src if different (preserves img DOM instance to avoid flickering)
         const img = card.querySelector('.shop-card-sprite img');
         if (img && img.getAttribute('src') !== (item.image_url || '')) {
+            img.style.opacity = '1';
+            img.onerror = () => {
+                img.onerror = () => { img.style.opacity = '0.25'; };
+                img.src = '../user_files/sprites/front_default/0.png';
+                img.style.opacity = '0.25';
+            };
             img.src = item.image_url || '';
         }
 
@@ -375,7 +383,11 @@
         img.decoding = 'sync';
         img.src = item.image_url || '';
         img.alt = item.ui_name || item.name;
-        img.onerror = () => { img.style.opacity = '0.25'; };
+        img.onerror = () => {
+            img.onerror = () => { img.style.opacity = '0.25'; };
+            img.src = '../user_files/sprites/front_default/0.png';
+            img.style.opacity = '0.25';
+        };
         spriteWrap.appendChild(img);
         card.appendChild(spriteWrap);
 
@@ -480,8 +492,14 @@
         }
 
         const sprite = document.getElementById('det-sprite');
+        sprite.style.opacity = '1';
         sprite.src = item.image_url || '';
         sprite.alt = item.ui_name || item.name;
+        sprite.onerror = () => {
+            sprite.onerror = null;
+            sprite.src = '../user_files/sprites/front_default/0.png';
+            sprite.style.opacity = '0.25';
+        };
 
         const glow = document.getElementById('det-glow');
         const glowColor = item.is_tm && item.move_type
@@ -1042,8 +1060,10 @@
                 const screen = item.dataset.screen;
                 closeMenu();
                 if (screen === 'items') return;
-                if (!bridge) return;
-                if (screen === 'ankidex' && bridge.openAnkidex) bridge.openAnkidex();
+                const router = (window.nav) || bridge;
+                if (!router) return;
+                if (screen === 'ankidex' && router.openAnkidex) router.openAnkidex();
+                else if (screen === 'settings' && router.openSettings) router.openSettings();
             });
         });
     }

--- a/src/Ankimon/ankimon_items_web/shop.js
+++ b/src/Ankimon/ankimon_items_web/shop.js
@@ -28,6 +28,13 @@
         category: 'all',       // all | tm | heal | pokeball | evolution | fossil
         search: '',
         selected: null,        // item name
+        picker: {
+            open: false,
+            item: null,        // item being applied
+            choices: null,     // null = not yet loaded, [] = empty team, [...] = cached
+            loading: false,
+            search: '',
+        },
     };
 
     let bridge = null;
@@ -609,6 +616,13 @@
 
     function onUse(item) {
         if (!bridge) return;
+        // Evolution items and held items need a Pokémon target — open the
+        // in-shell picker instead of calling useItem (which would trigger
+        // the legacy QInputDialog in Python).
+        if (item.category === 'evolution' || item.category === 'other') {
+            openPicker(item);
+            return;
+        }
         bridge.useItem(item.name, function (result) {
             if (!result) return;
             if (result.message) showToast(result.message, !result.ok);
@@ -686,14 +700,20 @@
 
         document.addEventListener('keydown', (e) => {
             if (e.key === 'Escape') {
+                const picker = document.getElementById('picker-modal');
                 const modal = document.getElementById('confirm-modal');
-                if (!modal.classList.contains('hidden')) {
+                if (!picker.classList.contains('hidden')) {
+                    closePicker();
+                } else if (!modal.classList.contains('hidden')) {
                     closeConfirm();
                 } else if (state.selected) {
                     state.selected = null;
                     render();
                 }
             } else if (e.key === '/' && document.activeElement !== searchInput) {
+                // Don't grab '/' while typing in the picker search box.
+                const pickerSearch = document.getElementById('picker-search');
+                if (document.activeElement === pickerSearch) return;
                 e.preventDefault();
                 searchInput.focus();
             } else if (e.key === 'Enter') {
@@ -726,6 +746,268 @@
 
     function closeConfirm() {
         document.getElementById('confirm-modal').classList.add('hidden');
+    }
+
+    // ---------- Pokémon picker (evolution items + held items) ----------
+    // Choices are lazy-fetched on first open (avoids shipping multi-MB
+    // payloads with every inventory push) and cached in state.picker.choices
+    // for the lifetime of the items window. Invalidated after team-mutating
+    // actions (useItemOnPokemon) so the next open reflects the change.
+    function openPicker(item) {
+        state.picker.item = item;
+        state.picker.search = '';
+        state.picker.open = true;
+
+        document.getElementById('picker-title').textContent =
+            item.category === 'evolution' ? 'Evolve which Pokémon?' : 'Give to which Pokémon?';
+        document.getElementById('picker-subtitle').textContent =
+            (item.ui_name || item.name || '').toUpperCase();
+
+        const searchEl = document.getElementById('picker-search');
+        searchEl.value = '';
+        document.getElementById('picker-modal').classList.remove('hidden');
+
+        if (state.picker.choices === null) {
+            loadPickerChoices(() => {
+                // Don't render if user closed the modal during fetch.
+                if (state.picker.open) renderPickerGrid();
+            });
+            renderPickerLoading();
+        } else {
+            renderPickerGrid();
+        }
+        // Auto-focus the search box so the user can type to filter.
+        setTimeout(() => searchEl.focus(), 0);
+    }
+
+    function loadPickerChoices(done) {
+        if (state.picker.loading || !bridge || !bridge.getPokemonChoices) {
+            if (done) done();
+            return;
+        }
+        state.picker.loading = true;
+        bridge.getPokemonChoices(function (result) {
+            state.picker.loading = false;
+            state.picker.choices = (result && result.choices) || [];
+            if (done) done();
+        });
+    }
+
+    function renderPickerLoading() {
+        const grid = document.getElementById('picker-grid');
+        const empty = document.getElementById('picker-empty');
+        const countEl = document.getElementById('picker-count');
+        empty.textContent = 'Loading your team…';
+        empty.classList.remove('hidden');
+        grid.replaceChildren();
+        grid.style.display = 'none';
+        countEl.textContent = '…';
+        countEl.classList.remove('truncated');
+    }
+
+    function closePicker() {
+        state.picker.open = false;
+        state.picker.item = null;
+        state.picker.search = '';
+        document.getElementById('picker-modal').classList.add('hidden');
+    }
+
+    // Hard cap on rendered cards — long-time players can have 10k+
+    // captured Pokémon, and rendering all of them blows out the DOM, the
+    // lazy-image queue, and any hope of a smooth open. Past the cap we
+    // require search to drill down (which is the natural UX for "pick
+    // one of many" anyway).
+    const PICKER_RENDER_CAP = 60;
+
+    function renderPickerGrid() {
+        const grid = document.getElementById('picker-grid');
+        const empty = document.getElementById('picker-empty');
+        const countEl = document.getElementById('picker-count');
+        const choices = state.picker.choices || [];
+        if (state.picker.choices === null) {
+            renderPickerLoading();
+            return;
+        }
+        const q = state.picker.search.trim().toLowerCase();
+        // Compact field names from Python — see get_pokemon_choices:
+        //   id=individual_id, p=pokedex_id, n=name, l=level,
+        //   s=shiny, m=is_main, h=held_item, nk=nickname (if differs)
+        const matched = q
+            ? choices.filter((c) => {
+                const hay = [c.nk, c.n, c.h, String(c.l || ''), String(c.p || '')]
+                    .filter(Boolean).join(' ').toLowerCase();
+                return hay.includes(q);
+            })
+            : choices;
+
+        const visible = matched.slice(0, PICKER_RENDER_CAP);
+
+        // Count chip — show "60 / 16,626" when we capped, plain count otherwise.
+        if (matched.length > visible.length) {
+            countEl.textContent = `${visible.length} / ${matched.length.toLocaleString()}`;
+            countEl.title = `Showing ${visible.length} of ${matched.length} — type to narrow down`;
+            countEl.classList.add('truncated');
+        } else {
+            countEl.textContent = String(matched.length);
+            countEl.title = '';
+            countEl.classList.remove('truncated');
+        }
+
+        if (matched.length === 0) {
+            grid.replaceChildren();
+            empty.textContent = state.picker.choices.length === 0
+                ? "You don't have any Pokémon yet."
+                : 'No Pokémon match that search.';
+            empty.classList.remove('hidden');
+            grid.style.display = 'none';
+            return;
+        }
+        empty.classList.add('hidden');
+        grid.style.display = '';
+
+        const frag = document.createDocumentFragment();
+        visible.forEach((choice) => frag.appendChild(buildPickerCard(choice)));
+
+        // Footer row when truncated — gives the user an obvious "more
+        // exist, refine to see them" cue instead of leaving them guessing.
+        if (matched.length > visible.length) {
+            const more = document.createElement('div');
+            more.className = 'picker-more-hint';
+            more.textContent =
+                `+ ${(matched.length - visible.length).toLocaleString()} more — type a name or level to find a specific Pokémon`;
+            frag.appendChild(more);
+        }
+
+        grid.replaceChildren(frag);
+        grid.scrollTop = 0;
+    }
+
+    function buildPickerCard(choice) {
+        // Compact fields from Python: id, p, n, l, s, m, h, nk.
+        // Match the Ankidex `.pokemon-card` shape so it picks up the same
+        // hover/sprite/border treatment automatically. Team-specific bits
+        // (level, active/shiny marks, held item) layer on top.
+        const isMain = !!choice.m;
+        const isShiny = !!choice.s;
+        const heldItem = choice.h || '';
+        const nickname = choice.nk || '';
+        const name = choice.n || '';
+        const displayName = nickname || name || 'Unknown';
+
+        const card = document.createElement('div');
+        card.className = 'pokemon-card team-card state-caught';
+        if (isMain) card.classList.add('is-main');
+
+        if (choice.l !== null && choice.l !== undefined) {
+            const lvl = document.createElement('div');
+            lvl.className = 'team-card-level';
+            lvl.textContent = 'Lv ' + choice.l;
+            card.appendChild(lvl);
+        }
+
+        if (isMain || isShiny) {
+            const marks = document.createElement('div');
+            marks.className = 'team-card-marks';
+            if (isMain) {
+                const m = document.createElement('span');
+                m.className = 'mark mark-main';
+                m.textContent = '★';
+                m.title = 'Active Pokémon';
+                marks.appendChild(m);
+            }
+            if (isShiny) {
+                const s = document.createElement('span');
+                s.className = 'mark mark-shiny';
+                s.textContent = '✦';
+                s.title = 'Shiny';
+                marks.appendChild(s);
+            }
+            card.appendChild(marks);
+        }
+
+        const spriteWrap = document.createElement('div');
+        spriteWrap.className = 'card-sprite';
+        const img = document.createElement('img');
+        // Explicit width/height attrs lock layout space before the
+        // sprite request fires — without them, the img collapses to 0
+        // and the card's column-flex shrinks to just the level pill.
+        img.width = 96;
+        img.height = 96;
+        // Reconstruct sprite path on the JS side — avoids shipping a
+        // ~100-byte URL per Pokémon in the inventory payload.
+        img.src = `../user_files/sprites/front_default/${choice.p || 0}.png`;
+        img.alt = displayName;
+        img.onerror = () => {
+            // Fallback to placeholder, then dim if even that fails.
+            img.onerror = () => { img.style.opacity = '0.25'; };
+            img.src = '../user_files/sprites/front_default/0.png';
+        };
+        spriteWrap.appendChild(img);
+        card.appendChild(spriteWrap);
+
+        const info = document.createElement('div');
+        info.className = 'card-info';
+        const nameEl = document.createElement('div');
+        nameEl.className = 'card-name';
+        nameEl.textContent = displayName;
+        info.appendChild(nameEl);
+
+        // Second line: held item (or species when nickname differs).
+        const metaParts = [];
+        if (heldItem) {
+            metaParts.push(`<span class="meta-held">Holds ${titleCase(heldItem)}</span>`);
+        } else if (nickname && name && nickname.toLowerCase() !== name.toLowerCase()) {
+            metaParts.push(titleCase(name));
+        }
+        if (metaParts.length > 0) {
+            const meta = document.createElement('div');
+            meta.className = 'team-card-meta';
+            meta.innerHTML = metaParts.join(' · ');
+            info.appendChild(meta);
+        }
+        card.appendChild(info);
+
+        card.addEventListener('click', () => onPickerChoose(choice));
+        return card;
+    }
+
+    function titleCase(s) {
+        return String(s || '').replace(/-/g, ' ').replace(
+            /\w\S*/g, (t) => t.charAt(0).toUpperCase() + t.slice(1).toLowerCase()
+        );
+    }
+
+    function onPickerChoose(choice) {
+        const item = state.picker.item;
+        if (!item || !bridge || !bridge.useItemOnPokemon) {
+            closePicker();
+            return;
+        }
+        closePicker();
+        // Held-item / evolution might change the team — invalidate so
+        // the next open re-fetches fresh data.
+        state.picker.choices = null;
+        // choice.id == individual_id in the compact payload.
+        bridge.useItemOnPokemon(item.name, choice.id, function (result) {
+            if (!result) return;
+            if (result.message) showToast(result.message, !result.ok);
+        });
+    }
+
+    function bindPickerUI() {
+        document.getElementById('picker-close').addEventListener('click', closePicker);
+        document.getElementById('picker-cancel').addEventListener('click', closePicker);
+        document.getElementById('picker-modal').addEventListener('click', (e) => {
+            if (e.target.classList.contains('picker-backdrop')) closePicker();
+        });
+        // Debounce search re-renders — typing fast in a 16k-row list
+        // shouldn't kick a full filter+render on every keystroke.
+        let searchTimer = null;
+        document.getElementById('picker-search').addEventListener('input', (e) => {
+            state.picker.search = e.target.value || '';
+            clearTimeout(searchTimer);
+            searchTimer = setTimeout(renderPickerGrid, 80);
+        });
     }
 
     // Nav switcher
@@ -768,6 +1050,7 @@
 
     document.addEventListener('DOMContentLoaded', () => {
         bindUI();
+        bindPickerUI();
         bindNavSwitcher();
         initChannel(() => {});
     });

--- a/src/Ankimon/ankimon_items_web/shop_obj.py
+++ b/src/Ankimon/ankimon_items_web/shop_obj.py
@@ -539,9 +539,7 @@ class AnkimonItemsWeb(QDialog):
             held_item = data.get("held_item") or ""
             level = data.get("level")
             shiny = bool(data.get("shiny"))
-            is_main = bool(
-                main_individual_id and individual_id == main_individual_id
-            )
+            is_main = bool(main_individual_id and individual_id == main_individual_id)
 
             # Per-entry payload is intentionally minimal — for players with
             # 10k+ captures, every extra byte multiplies into MB of IPC.

--- a/src/Ankimon/ankimon_items_web/shop_obj.py
+++ b/src/Ankimon/ankimon_items_web/shop_obj.py
@@ -67,6 +67,19 @@ class ItemsBridge(QObject):
         self._w.push_screen_data()
         return result
 
+    # In-shell Pokémon picker — replaces the legacy QInputDialog flow for
+    # evolution items + held items. JS calls getPokemonChoices() to populate
+    # the modal, then useItemOnPokemon() with the chosen individual_id.
+    @pyqtSlot(result="QVariant")
+    def getPokemonChoices(self):
+        return self._w.get_pokemon_choices()
+
+    @pyqtSlot(str, str, result="QVariant")
+    def useItemOnPokemon(self, item_name, individual_id):
+        result = self._w.handle_use_with_target(item_name, individual_id)
+        self._w.push_screen_data()
+        return result
+
     # Back-compat: items.shop.js previously called bridge.openAnkidex; keep
     # it as a passthrough so older cached pages still work.
     @pyqtSlot()
@@ -271,6 +284,9 @@ class AnkimonItemsWeb(QDialog):
             "cash": int(sm.get_callback("trainer.cash") or 0),
             "reroll_cost": int(sm.daily_items_reroll_cost or 0),
             "items": items,
+            # pokemon_choices intentionally NOT included — for players with
+            # 10k+ captures the payload is multiple MB. JS lazy-fetches via
+            # bridge.getPokemonChoices() on first picker open + caches.
         }
 
     def _serialize_item(
@@ -471,7 +487,135 @@ class AnkimonItemsWeb(QDialog):
         if self.item_window is None:
             return {"ok": False, "message": "Item bag service unavailable."}
         item_type = item.get("item_type") or ("TM" if item.get("is_tm") else None)
-        return self.item_window.dispatch_use(item_name, item_type)
+        result = self.item_window.dispatch_use(item_name, item_type)
+        # Fossils + healing main can change team data (new entry / hp).
+        if item.get("category") in ("fossil", "heal"):
+            self._invalidate_pokemon_cache()
+        return result
+
+    def _invalidate_pokemon_cache(self):
+        self._pokemon_choices_cache = None
+
+    def get_pokemon_choices(self):
+        """Return the player's Pokémon team for the in-shell picker — name,
+        nickname, level, id. Replaces the QInputDialog flow for evolution
+        items and held items.
+
+        Cached on the instance — `get_all_pokemon()` JSON-parses every
+        captured row, which costs hundreds of ms for players with 10k+
+        captures. Buy/reroll don't change the team, so they reuse the
+        cache; team-mutating actions call `_invalidate_pokemon_cache()`.
+        """
+        cached = getattr(self, "_pokemon_choices_cache", None)
+        if cached is not None:
+            return cached
+
+        try:
+            pokemons = mw.ankimon_db.get_all_pokemon() or []
+        except Exception as e:
+            print(f"[Ankimon] get_pokemon_choices: get_all_pokemon failed: {e}")
+            return {"choices": []}
+
+        # Active Pokémon's individual_id (so we can flag it in the UI).
+        main_individual_id = None
+        bag = self.item_window
+        if bag is not None and getattr(bag, "main_pokemon", None):
+            main_individual_id = getattr(bag.main_pokemon, "individual_id", None)
+
+        choices = []
+        for data in pokemons:
+            if not isinstance(data, dict):
+                continue
+            individual_id = data.get("individual_id")
+            pokedex_id = data.get("id")
+            name = data.get("name")
+            if not individual_id or not name:
+                # No id or no name means we can't display or address it —
+                # but pokedex_id == 0 / missing is fine (we just fall back
+                # to a placeholder sprite).
+                continue
+
+            nickname = (data.get("nickname") or "").strip()
+            held_item = data.get("held_item") or ""
+            level = data.get("level")
+            shiny = bool(data.get("shiny"))
+            is_main = bool(
+                main_individual_id and individual_id == main_individual_id
+            )
+
+            # Per-entry payload is intentionally minimal — for players with
+            # 10k+ captures, every extra byte multiplies into MB of IPC.
+            # JS reconstructs the sprite URL from pokedex_id; nickname is
+            # only shipped when it actually differs from the species name.
+            entry = {
+                "id": individual_id,
+                "p": pokedex_id or 0,
+                "n": name,
+                "l": int(level) if level is not None else None,
+            }
+            if shiny:
+                entry["s"] = 1
+            if is_main:
+                entry["m"] = 1
+            if held_item:
+                entry["h"] = held_item
+            if nickname and nickname.lower() != (name or "").lower():
+                entry["nk"] = nickname
+            choices.append(entry)
+
+        # Active first, then by level (high → low), then alphabetical.
+        choices.sort(
+            key=lambda c: (
+                not c.get("m"),
+                -(c.get("l") or 0),
+                (c.get("nk") or c.get("n") or "").lower(),
+            )
+        )
+        result = {"choices": choices}
+        self._pokemon_choices_cache = result
+        return result
+
+    def handle_use_with_target(self, item_name, individual_id):
+        """Apply an item to a specific Pokémon (chosen via the in-shell
+        picker). Bypasses dispatch_use's QInputDialog branches by calling
+        the underlying item_window helpers directly with the id."""
+        item = self._find_serialized(item_name)
+        if not item:
+            return {"ok": False, "message": "Item not found in your bag."}
+        if (item.get("owned_quantity") or 0) <= 0:
+            return {"ok": False, "message": "You don't own that item."}
+        if self.item_window is None:
+            return {"ok": False, "message": "Item bag service unavailable."}
+        if not individual_id:
+            return {"ok": False, "message": "No Pokémon selected."}
+
+        bag = self.item_window
+        # Either branch below mutates the team (held-item or evolution),
+        # so invalidate up front regardless of which path runs.
+        self._invalidate_pokemon_cache()
+        try:
+            if item.get("category") == "evolution":
+                # Check_Evo_Item needs the pre-evo's pokedex id to match
+                # against the evolution table. Pull it from the proven
+                # get_pokemon() API.
+                pokemon_data = None
+                try:
+                    pokemon_data = mw.ankimon_db.get_pokemon(individual_id)
+                except Exception as e:
+                    print(f"[Ankimon] get_pokemon({individual_id}) failed: {e}")
+                pokedex_id = (pokemon_data or {}).get("id")
+                if not pokedex_id:
+                    return {"ok": False, "message": "Could not look up that Pokémon."}
+                bag.Check_Evo_Item(individual_id, pokedex_id, item_name)
+                return {"ok": True, "message": ""}
+
+            # Held items (and anything else routed through the give-item
+            # flow) — the legacy method already surfaces success/error via
+            # log_and_showinfo, so we just return an empty message.
+            bag._give_held_item_by_id(individual_id, item_name)
+            return {"ok": True, "message": ""}
+        except Exception as e:
+            return {"ok": False, "message": f"Use failed: {e}"}
 
     def _find_serialized(self, item_name):
         data = self.get_inventory_data()


### PR DESCRIPTION
## Summary

Replaces the `QInputDialog` popup that "Use" opened for evolution items and held items with a card-grid modal that lives inside the Items window — same Ankidex card styling, in-modal search, and active/shiny/held marks. Heal items, fossils, and Poké Balls keep their direct-use path (no target picker needed).

Stacked on #464 — until that merges, this diff will show its commits too. Once #464 lands, the diff here collapses to just the picker work (~4 files, ~750 lines).

## Why this exists

The legacy bag's "Use" button on Thunder Stones, Lucky Eggs, Leftovers, etc. pops a native `QInputDialog.getItem(...)` listing every captured Pokémon. That's the last QInputDialog standing in the unified Items UI — porting it inline completes the "one shell window" story started in #464.

## Performance notes (this took several iterations)

This branch is sized to handle players with 10k+ captures without melting the browser:

- **Lazy fetch + cache.** `pokemon_choices` is *not* shipped with the inventory payload — for big teams that'd be multiple MB on every buy/reroll push. The picker fetches once on first open via `bridge.getPokemonChoices()`, caches in both JS and Python, and invalidates only after team-mutating actions.
- **Render cap (60 cards).** Past the cap, a count chip shows `60 / 16,626` and a "+ X more — type to find a specific Pokémon" footer prompts the user to refine. Rendering 16k DOM nodes was the original sluggishness.
- **Compact wire format.** Single-char keys (`id`/`p`/`n`/`l`/`s`/`m`/`h`/`nk`), sprite URL reconstructed JS-side from `pokedex_id`, optional fields omitted when false. ~50% smaller than a verbose payload.
- **Locked card layout.** Explicit `<img width=96 height=96>` + `min-height: 180px` on the card means the grid stays uniform even before sprites decode — no more rows collapsing to just the level pill while images load.
- **Debounced search (80ms).** Typing fast doesn't kick a full re-filter+render against 16k rows on every keystroke.

## Routing

```
ItemsBridge.useItemOnPokemon(item_name, individual_id)
  └─ AnkimonItemsWeb.handle_use_with_target(...)
      ├─ category == 'evolution'  → bag.Check_Evo_Item(id, pokedex_id, item)
      └─ otherwise (held items)   → bag._give_held_item_by_id(id, item)
```

No `QInputDialog`. The legacy item_window methods (`_select_pokemon`, `_prompt_and_*`) are untouched — still used by the legacy bag UI for backward compat.

## Test plan

- [ ] Use a Thunder Stone (or any evolution item) → picker opens with all owned Pokémon → pick one → evolution dialog fires.
- [ ] Use a Leftovers (or any held item) → picker opens → pick one → item attaches.
- [ ] Use a Potion (heal) → no picker, applies to active Pokémon directly.
- [ ] Use a Pokéball outside battle → no picker.
- [ ] Use a fossil → no picker, revival flow runs.
- [ ] Picker opens fast even with 10k+ captures (loading state briefly, then 60 cards).
- [ ] Search "dragonite" filters to just Dragonites; result chip shows accurate count.
- [ ] Cards have uniform dimensions even when sprites are still loading.
- [ ] Escape closes the picker; clicking the backdrop closes the picker; Cancel button closes the picker.
- [ ] After giving a held item, re-opening the picker shows the updated held-item mark.