### PR TITLE
fix: handle legacy string items and missing individual_ids during migration

### DIFF
--- a/src/Ankimon/pyobj/migration_dialog.py
+++ b/src/Ankimon/pyobj/migration_dialog.py
@@ -154,6 +154,8 @@ class MigrationDialog(QDialog):
                     total = len(pokemon_list)
                     for i, pokemon in enumerate(pokemon_list):
                         if self.cancelled: break
+                        if not isinstance(pokemon, dict):
+                            continue
                         if "individual_id" not in pokemon:
                             pokemon["individual_id"] = str(uuid.uuid4())
                         if self.db.save_pokemon(pokemon):
@@ -178,10 +180,11 @@ class MigrationDialog(QDialog):
                         main_data = json.load(f)
                     if main_data:
                         main_pokemon = main_data[0] if isinstance(main_data, list) else main_data
-                        if "individual_id" not in main_pokemon:
-                            main_pokemon["individual_id"] = str(uuid.uuid4())
-                        if self.db.save_main_pokemon(main_pokemon):
-                            stats["main"] = 1
+                        if isinstance(main_pokemon, dict):
+                            if "individual_id" not in main_pokemon:
+                                main_pokemon["individual_id"] = str(uuid.uuid4())
+                            if self.db.save_main_pokemon(main_pokemon):
+                                stats["main"] = 1
                     self._update_progress(55, "✓ Migrated main Pokemon")
                 
                 # Step 3: Migrate items.json
@@ -198,10 +201,12 @@ class MigrationDialog(QDialog):
                             item_name = item
                             quantity = 1
                             extra_data = None
-                        else:
+                        elif isinstance(item, dict):
                             item_name = item.get("item") or item.get("item_name") or item.get("name")
                             quantity = item.get("quantity", item.get("amount", 1))
                             extra_data = item
+                        else:
+                            continue
                         
                         if item_name:
                             self.db.add_item(item_name, quantity, extra_data=extra_data, commit=False)
@@ -247,11 +252,14 @@ class MigrationDialog(QDialog):
                 self._update_progress(66, "Migrating team...")
                 with open(self.team_path, 'r', encoding='utf-8') as f:
                     team_list = json.load(f)
+                valid_team_list = []
                 for member in team_list:
-                    if "individual_id" not in member:
-                        member["individual_id"] = str(uuid.uuid4())
-                if self.db.save_team(team_list):
-                    stats["team"] = len(team_list)
+                    if isinstance(member, dict):
+                        if "individual_id" not in member:
+                            member["individual_id"] = str(uuid.uuid4())
+                        valid_team_list.append(member)
+                if self.db.save_team(valid_team_list):
+                    stats["team"] = len(valid_team_list)
                 self._update_progress(70, f"✓ Migrated team ({stats['team']} members)")
 
             # Step 6: Migrate History (This can be large)

--- a/src/Ankimon/pyobj/migration_dialog.py
+++ b/src/Ankimon/pyobj/migration_dialog.py
@@ -8,6 +8,7 @@ The program is not usable until migration completes.
 import json
 import shutil
 import traceback
+import uuid
 from PyQt6.QtWidgets import (
     QDialog, QVBoxLayout, QHBoxLayout, QLabel, QPushButton,
     QProgressBar, QTextEdit, QApplication, QMessageBox
@@ -153,6 +154,8 @@ class MigrationDialog(QDialog):
                     total = len(pokemon_list)
                     for i, pokemon in enumerate(pokemon_list):
                         if self.cancelled: break
+                        if "individual_id" not in pokemon:
+                            pokemon["individual_id"] = str(uuid.uuid4())
                         if self.db.save_pokemon(pokemon):
                             stats["pokemon"] += 1
                         if total > 0 and (i % 20 == 0 or i == total - 1):
@@ -175,6 +178,8 @@ class MigrationDialog(QDialog):
                         main_data = json.load(f)
                     if main_data:
                         main_pokemon = main_data[0] if isinstance(main_data, list) else main_data
+                        if "individual_id" not in main_pokemon:
+                            main_pokemon["individual_id"] = str(uuid.uuid4())
                         if self.db.save_main_pokemon(main_pokemon):
                             stats["main"] = 1
                     self._update_progress(55, "✓ Migrated main Pokemon")
@@ -189,11 +194,17 @@ class MigrationDialog(QDialog):
                         if self.cancelled: break
                         if not item: continue
                         
-                        item_name = item.get("item") or item.get("item_name") or item.get("name")
-                        quantity = item.get("quantity", item.get("amount", 1))
+                        if isinstance(item, str):
+                            item_name = item
+                            quantity = 1
+                            extra_data = None
+                        else:
+                            item_name = item.get("item") or item.get("item_name") or item.get("name")
+                            quantity = item.get("quantity", item.get("amount", 1))
+                            extra_data = item
                         
                         if item_name:
-                            self.db.add_item(item_name, quantity, extra_data=item, commit=False)
+                            self.db.add_item(item_name, quantity, extra_data=extra_data, commit=False)
                             stats["items"] += 1
                     
                     # Final commit for items
@@ -236,6 +247,9 @@ class MigrationDialog(QDialog):
                 self._update_progress(66, "Migrating team...")
                 with open(self.team_path, 'r', encoding='utf-8') as f:
                     team_list = json.load(f)
+                for member in team_list:
+                    if "individual_id" not in member:
+                        member["individual_id"] = str(uuid.uuid4())
                 if self.db.save_team(team_list):
                     stats["team"] = len(team_list)
                 self._update_progress(70, f"✓ Migrated team ({stats['team']} members)")

--- a/src/Ankimon/pyobj/migration_dialog.py
+++ b/src/Ankimon/pyobj/migration_dialog.py
@@ -156,7 +156,7 @@ class MigrationDialog(QDialog):
                         if self.cancelled: break
                         if not isinstance(pokemon, dict):
                             continue
-                        if "individual_id" not in pokemon:
+                        if not pokemon.get("individual_id"):
                             pokemon["individual_id"] = str(uuid.uuid4())
                         if self.db.save_pokemon(pokemon):
                             stats["pokemon"] += 1
@@ -181,7 +181,7 @@ class MigrationDialog(QDialog):
                     if main_data:
                         main_pokemon = main_data[0] if isinstance(main_data, list) else main_data
                         if isinstance(main_pokemon, dict):
-                            if "individual_id" not in main_pokemon:
+                            if not main_pokemon.get("individual_id"):
                                 main_pokemon["individual_id"] = str(uuid.uuid4())
                             if self.db.save_main_pokemon(main_pokemon):
                                 stats["main"] = 1
@@ -224,12 +224,15 @@ class MigrationDialog(QDialog):
                         badges_list = json.load(f)
                     for badge in badges_list:
                         if self.cancelled: break
-                        if isinstance(badge, int):
-                            badge_id = str(badge); badge_data = {"id": badge, "achieved": True}
-                        else:
+                        if isinstance(badge, (int, str)):
+                            badge_id = str(badge)
+                            badge_data = {"id": badge_id, "achieved": True}
+                        elif isinstance(badge, dict):
                             badge_id = str(badge.get("id", badge.get("badge_id", "")))
                             badge_data = badge
                             badge_data["achieved"] = True
+                        else:
+                            continue
                         if badge_id:
                             self.db.save_badge(badge_id, badge_data)
                             stats["badges"] += 1
@@ -255,7 +258,7 @@ class MigrationDialog(QDialog):
                 valid_team_list = []
                 for member in team_list:
                     if isinstance(member, dict):
-                        if "individual_id" not in member:
+                        if not member.get("individual_id"):
                             member["individual_id"] = str(uuid.uuid4())
                         valid_team_list.append(member)
                 if self.db.save_team(valid_team_list):


### PR DESCRIPTION
Resolves an `AttributeError` caused by legacy string items during `items.json` migration, and prevents Pokémon data loss by assigning generated `individual_id`s to legacy JSON records missing them.

---
*PR created automatically by Jules for task [8661290998763507273](https://jules.google.com/task/8661290998763507273) started by @h0tp-ftw*