### PR TITLE
fix: Handle plain strings in legacy json migrations

### DIFF
--- a/src/Ankimon/pyobj/migration_dialog.py
+++ b/src/Ankimon/pyobj/migration_dialog.py
@@ -153,6 +153,12 @@ class MigrationDialog(QDialog):
                     total = len(pokemon_list)
                     for i, pokemon in enumerate(pokemon_list):
                         if self.cancelled: break
+
+                        if isinstance(pokemon, (str, int)):
+                            pokemon = {"name": str(pokemon), "individual_id": str(pokemon)}
+                        elif not isinstance(pokemon, dict):
+                            continue
+
                         if self.db.save_pokemon(pokemon):
                             stats["pokemon"] += 1
                         if total > 0 and (i % 20 == 0 or i == total - 1):
@@ -175,7 +181,11 @@ class MigrationDialog(QDialog):
                         main_data = json.load(f)
                     if main_data:
                         main_pokemon = main_data[0] if isinstance(main_data, list) else main_data
-                        if self.db.save_main_pokemon(main_pokemon):
+
+                        if isinstance(main_pokemon, (str, int)):
+                            main_pokemon = {"name": str(main_pokemon), "individual_id": str(main_pokemon)}
+
+                        if isinstance(main_pokemon, dict) and self.db.save_main_pokemon(main_pokemon):
                             stats["main"] = 1
                     self._update_progress(55, "✓ Migrated main Pokemon")
                 
@@ -189,6 +199,9 @@ class MigrationDialog(QDialog):
                         if self.cancelled: break
                         if not item: continue
                         
+                        if isinstance(item, str):
+                            item = {"item": item, "quantity": 1}
+
                         item_name = item.get("item") or item.get("item_name") or item.get("name")
                         quantity = item.get("quantity", item.get("amount", 1))
                         
@@ -208,12 +221,16 @@ class MigrationDialog(QDialog):
                         badges_list = json.load(f)
                     for badge in badges_list:
                         if self.cancelled: break
-                        if isinstance(badge, int):
-                            badge_id = str(badge); badge_data = {"id": badge, "achieved": True}
-                        else:
+                        if isinstance(badge, (int, str)):
+                            badge_id = str(badge)
+                            badge_data = {"id": badge_id, "achieved": True}
+                        elif isinstance(badge, dict):
                             badge_id = str(badge.get("id", badge.get("badge_id", "")))
                             badge_data = badge
                             badge_data["achieved"] = True
+                        else:
+                            continue
+
                         if badge_id:
                             self.db.save_badge(badge_id, badge_data)
                             stats["badges"] += 1
@@ -235,7 +252,15 @@ class MigrationDialog(QDialog):
             if self.team_path and self.team_path.is_file():
                 self._update_progress(66, "Migrating team...")
                 with open(self.team_path, 'r', encoding='utf-8') as f:
-                    team_list = json.load(f)
+                    raw_team_list = json.load(f)
+
+                team_list = []
+                for member in raw_team_list:
+                    if isinstance(member, dict):
+                        team_list.append(member)
+                    elif isinstance(member, (str, int)):
+                        team_list.append({"individual_id": str(member)})
+
                 if self.db.save_team(team_list):
                     stats["team"] = len(team_list)
                 self._update_progress(70, f"✓ Migrated team ({stats['team']} members)")
@@ -249,6 +274,12 @@ class MigrationDialog(QDialog):
                 total_hist = len(history_list)
                 for i, pokemon in enumerate(history_list):
                     if self.cancelled: break
+
+                    if isinstance(pokemon, (str, int)):
+                        pokemon = {"name": str(pokemon), "individual_id": str(pokemon)}
+                    elif not isinstance(pokemon, dict):
+                        continue
+
                     if self.db.add_to_history(pokemon):
                         stats["history"] += 1
                     if total_hist > 0 and (i % 50 == 0 or i == total_hist - 1):


### PR DESCRIPTION
Resolves AttributeError during SQLite migration when legacy data files contain string representations instead of dictionaries. Added robust type checking throughout the migration pipeline to safely convert string items, badges, team members, pokemon, and history records into expected formats before DB insertion.

---
*PR created automatically by Jules for task [6739010794261406063](https://jules.google.com/task/6739010794261406063) started by @h0tp-ftw*