### PR TITLE
feat(shop): daily skip-confirm option + slimmer reroll modal

### DIFF
--- a/src/Ankimon/ankimon_items_web/shop.css
+++ b/src/Ankimon/ankimon_items_web/shop.css
@@ -2978,8 +2978,8 @@ body {
     background: linear-gradient(160deg, var(--bg-card), var(--bg-darker));
     border: 1px solid var(--border-main);
     border-radius: 18px;
-    padding: 28px 28px 22px;
-    width: 380px;
+    padding: 22px 24px 18px;
+    width: 340px;
     max-width: calc(100vw - 40px);
     box-shadow: 0 24px 60px rgba(0, 0, 0, 0.6);
     text-align: center;
@@ -2992,17 +2992,15 @@ body {
 }
 
 .confirm-icon {
-    width: 52px;
-    height: 52px;
+    width: 40px;
+    height: 40px;
     border-radius: 50%;
-    margin: 0 auto 14px;
+    margin: 0 auto 10px;
     background:
         radial-gradient(circle at 30% 30%, rgba(248, 81, 73, 0.35), transparent 60%),
         var(--bg-darker);
     border: 1px solid rgba(248, 81, 73, 0.4);
     color: var(--accent-red);
-    font-size: 1.4rem;
-    font-weight: 800;
     display: flex;
     align-items: center;
     justify-content: center;
@@ -3010,24 +3008,11 @@ body {
 }
 
 .confirm-title {
-    font-size: 1.15rem;
+    font-size: 1.1rem;
     font-weight: 800;
     color: var(--text-bright);
-    margin-bottom: 8px;
+    margin-bottom: 10px;
     letter-spacing: -0.3px;
-}
-
-.confirm-body {
-    font-size: 0.88rem;
-    line-height: 1.5;
-    color: var(--text-main);
-    margin-bottom: 18px;
-}
-
-.confirm-body em {
-    font-style: normal;
-    color: var(--accent-blue);
-    font-weight: 600;
 }
 
 .confirm-cost {
@@ -3036,34 +3021,89 @@ body {
     font-weight: 700;
 }
 
-.confirm-balance {
-    background: rgba(255, 255, 255, 0.025);
-    border: 1px solid var(--border-main);
-    border-radius: 10px;
-    padding: 10px 14px;
-    margin-bottom: 20px;
+.confirm-summary {
     display: flex;
-    align-items: center;
-    justify-content: space-between;
+    align-items: baseline;
+    justify-content: center;
+    gap: 8px;
+    margin-bottom: 14px;
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 0.9rem;
+    font-weight: 700;
 }
 
-.confirm-balance-label {
-    font-size: 0.7rem;
-    text-transform: uppercase;
+.confirm-summary-arrow {
     color: var(--text-muted);
+    font-weight: 400;
+}
+
+.confirm-summary-suffix {
+    font-family: 'Outfit', sans-serif;
+    font-size: 0.75rem;
+    font-weight: 600;
+    color: var(--text-muted);
+    text-transform: uppercase;
     letter-spacing: 1px;
-    font-weight: 700;
 }
 
 .confirm-balance-value {
-    font-family: 'JetBrains Mono', monospace;
-    font-size: 0.95rem;
-    font-weight: 700;
     color: var(--accent-gold);
 }
 
-.confirm-balance.insufficient .confirm-balance-value {
+.confirm-summary.insufficient .confirm-balance-value {
     color: var(--accent-red);
+}
+
+.confirm-skip {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    margin: 0 0 14px;
+    font-size: 0.78rem;
+    color: var(--text-muted);
+    cursor: pointer;
+    user-select: none;
+    transition: color 0.15s ease;
+}
+
+.confirm-skip:hover {
+    color: var(--text-bright);
+}
+
+.confirm-skip input[type="checkbox"] {
+    appearance: none;
+    -webkit-appearance: none;
+    width: 14px;
+    height: 14px;
+    margin: 0;
+    border-radius: 4px;
+    border: 1px solid var(--border-main);
+    background: var(--bg-darker);
+    cursor: pointer;
+    position: relative;
+    transition: var(--transition-fast);
+}
+
+.confirm-skip:hover input[type="checkbox"] {
+    border-color: var(--text-muted);
+}
+
+.confirm-skip input[type="checkbox"]:checked {
+    background: var(--accent-red);
+    border-color: var(--accent-red);
+}
+
+.confirm-skip input[type="checkbox"]:checked::after {
+    content: '';
+    position: absolute;
+    left: 3px;
+    top: 0px;
+    width: 4px;
+    height: 8px;
+    border: solid var(--text-bright);
+    border-width: 0 2px 2px 0;
+    transform: rotate(45deg);
 }
 
 .confirm-actions {
@@ -3736,8 +3776,8 @@ body {
 }
 
 .confirm-icon .icon-reroll {
-    width: 24px;
-    height: 24px;
+    width: 18px;
+    height: 18px;
 }
 
 /* --- Gear icon (nav dropdown + Settings sidebar logo) --- */

--- a/src/Ankimon/ankimon_items_web/shop.html
+++ b/src/Ankimon/ankimon_items_web/shop.html
@@ -209,14 +209,16 @@
                 </svg>
             </div>
             <h3 id="confirm-title" class="confirm-title">Reroll Stock?</h3>
-            <p id="confirm-body" class="confirm-body">
-                This will spend <span id="confirm-cost" class="confirm-cost">100¥</span>
-                and replace today's items <em>and</em> TMs with a fresh roll.
-            </p>
-            <div id="confirm-balance" class="confirm-balance">
-                <span class="confirm-balance-label">Balance after</span>
+            <div id="confirm-balance" class="confirm-summary">
+                <span id="confirm-cost" class="confirm-cost">100¥</span>
+                <span class="confirm-summary-arrow">→</span>
                 <span id="confirm-balance-value" class="confirm-balance-value">0¥</span>
+                <span class="confirm-summary-suffix">left</span>
             </div>
+            <label class="confirm-skip">
+                <input id="confirm-skip" type="checkbox">
+                <span>Don't ask again today</span>
+            </label>
             <div class="confirm-actions">
                 <button id="confirm-cancel" class="confirm-btn cancel">Cancel</button>
                 <button id="confirm-ok" class="confirm-btn primary">Confirm Reroll</button>

--- a/src/Ankimon/ankimon_items_web/shop.js
+++ b/src/Ankimon/ankimon_items_web/shop.js
@@ -707,6 +707,14 @@
             if (e.target.classList.contains('confirm-backdrop')) closeConfirm();
         });
         document.getElementById('confirm-ok').addEventListener('click', () => {
+            const skip = document.getElementById('confirm-skip');
+            if (skip && skip.checked && bridge && bridge.setSkipRerollConfirm) {
+                bridge.setSkipRerollConfirm(true, function () {});
+                // Optimistic — push_screen_data() will overwrite, but this
+                // keeps the flag set if the next click happens to land before
+                // the round-trip completes.
+                if (state.data) state.data.skip_reroll_confirm = true;
+            }
             closeConfirm();
             onReroll();
         });
@@ -750,6 +758,14 @@
         const after = (state.data.cash || 0) - cost;
         const insufficient = after < 0;
 
+        // "Don't ask again today" — skip the modal entirely when affordable.
+        // The insufficient case still falls through so the user sees the
+        // "Not Enough ¥" disabled-button feedback.
+        if (state.data.skip_reroll_confirm && !insufficient) {
+            onReroll();
+            return;
+        }
+
         document.getElementById('confirm-cost').textContent = formatMoney(cost) + '¥';
         const balance = document.getElementById('confirm-balance');
         document.getElementById('confirm-balance-value').textContent = formatMoney(after) + '¥';
@@ -758,6 +774,9 @@
         const okBtn = document.getElementById('confirm-ok');
         okBtn.disabled = insufficient;
         okBtn.textContent = insufficient ? 'Not Enough ¥' : 'Confirm Reroll';
+
+        const skipCheckbox = document.getElementById('confirm-skip');
+        if (skipCheckbox) skipCheckbox.checked = false;
 
         document.getElementById('confirm-modal').classList.remove('hidden');
     }

--- a/src/Ankimon/ankimon_items_web/shop_obj.py
+++ b/src/Ankimon/ankimon_items_web/shop_obj.py
@@ -188,9 +188,15 @@ class AnkimonItemsWeb(QDialog):
         self.channel_settings.registerObject("settings", self.settings_bridge)
         self.webview_settings.page().setWebChannel(self.channel_settings)
 
-        self.webview_items.loadFinished.connect(lambda ok, s=SCREEN_ITEMS: self._on_screen_load_finished(ok, s))
-        self.webview_ankidex.loadFinished.connect(lambda ok, s=SCREEN_ANKIDEX: self._on_screen_load_finished(ok, s))
-        self.webview_settings.loadFinished.connect(lambda ok, s=SCREEN_SETTINGS: self._on_screen_load_finished(ok, s))
+        self.webview_items.loadFinished.connect(
+            lambda ok, s=SCREEN_ITEMS: self._on_screen_load_finished(ok, s)
+        )
+        self.webview_ankidex.loadFinished.connect(
+            lambda ok, s=SCREEN_ANKIDEX: self._on_screen_load_finished(ok, s)
+        )
+        self.webview_settings.loadFinished.connect(
+            lambda ok, s=SCREEN_SETTINGS: self._on_screen_load_finished(ok, s)
+        )
 
         self.loaded_screens = set()
 
@@ -287,6 +293,7 @@ class AnkimonItemsWeb(QDialog):
     def _restore_geometry(self):
         import base64
         from PyQt6.QtCore import QByteArray
+
         try:
             geo = mw.pm.profile.get("ankimon.items_web_window.geometry")
             if geo:
@@ -296,9 +303,12 @@ class AnkimonItemsWeb(QDialog):
 
     def _save_geometry(self):
         import base64
+
         try:
             if not self.isMinimized():
-                mw.pm.profile["ankimon.items_web_window.geometry"] = base64.b64encode(bytes(self.saveGeometry())).decode()
+                mw.pm.profile["ankimon.items_web_window.geometry"] = base64.b64encode(
+                    bytes(self.saveGeometry())
+                ).decode()
         except Exception:
             pass
 

--- a/src/Ankimon/ankimon_items_web/shop_obj.py
+++ b/src/Ankimon/ankimon_items_web/shop_obj.py
@@ -92,6 +92,10 @@ class ItemsBridge(QObject):
         self._w.push_screen_data()
         return result
 
+    @pyqtSlot(bool, result="QVariant")
+    def setSkipRerollConfirm(self, skip):
+        return self._w.handle_set_skip_reroll_confirm(bool(skip))
+
     @pyqtSlot(str, result="QVariant")
     def useItem(self, item_name):
         result = self._w.handle_use(item_name)
@@ -383,11 +387,36 @@ class AnkimonItemsWeb(QDialog):
         return {
             "cash": int(sm.get_callback("trainer.cash") or 0),
             "reroll_cost": int(sm.daily_items_reroll_cost or 0),
+            "skip_reroll_confirm": self._get_skip_reroll_today(),
             "items": items,
             # pokemon_choices intentionally NOT included — for players with
             # 10k+ captures the payload is multiple MB. JS lazy-fetches via
             # bridge.getPokemonChoices() on first picker open + caches.
         }
+
+    def _get_skip_reroll_today(self):
+        # Stored as {"date": "YYYY-MM-DD", "skip": bool}. Treated as False
+        # whenever the date doesn't match today, which gives the "reset every
+        # day" behavior without needing a separate cleanup pass.
+        try:
+            data = mw.ankimon_db.get_user_data("shop_skip_reroll_confirm")
+        except Exception:
+            return False
+        if not isinstance(data, dict):
+            return False
+        if data.get("date") != datetime.now().strftime("%Y-%m-%d"):
+            return False
+        return bool(data.get("skip"))
+
+    def handle_set_skip_reroll_confirm(self, skip):
+        try:
+            mw.ankimon_db.set_user_data(
+                "shop_skip_reroll_confirm",
+                {"date": datetime.now().strftime("%Y-%m-%d"), "skip": bool(skip)},
+            )
+        except Exception as e:
+            return {"ok": False, "message": str(e)}
+        return {"ok": True}
 
     def _serialize_item(
         self, name, is_tm, in_shop, shop_price, item_type, owned_quantity


### PR DESCRIPTION
## Summary
- Adds a **"Don't ask again today"** checkbox to the reroll confirmation modal. When checked, future reroll clicks today skip the confirmation entirely and reroll immediately.
- The preference is stored in `user_data` as `{date, skip}` and treated as false whenever the stored date doesn't match today — same daily-reset pattern as `get_daily_items`, no cleanup pass needed.
- The "not enough ¥" case still shows the modal so the user sees the disabled-button feedback rather than a silent failure.
- Slims down the modal itself: drops the verbose body paragraph, shrinks the icon (52→40px container), and replaces the boxy "Balance after" panel with an inline `cost → balance left` summary.

## Files changed
- `shop_obj.py` — new `setSkipRerollConfirm` bridge slot, `_get_skip_reroll_today` / `handle_set_skip_reroll_confirm` helpers, `skip_reroll_confirm` exposed in the inventory payload.
- `shop.html` — checkbox row added; verbose body paragraph removed; balance display restructured into a compact summary line.
- `shop.css` — `.confirm-skip` styling with a custom-painted checkbox that matches the theme; `.confirm-summary` rules replace the old `.confirm-balance` box; tighter card padding and smaller icon.
- `shop.js` — `openRerollConfirm` short-circuits to `onReroll()` when the flag is set and the user can afford it; confirm-ok handler persists the checkbox state via the bridge and optimistically updates local state.

## Test plan
- [ ] Open shop, click reroll → modal appears with unchecked "Don't ask again today" checkbox.
- [ ] Check the box, click Confirm Reroll → reroll happens, modal closes.
- [ ] Click reroll again → reroll happens immediately, no modal.
- [ ] Close & reopen Anki, click reroll → still skips (same day).
- [ ] Wait until next day (or manually edit the stored date), click reroll → modal reappears.
- [ ] With insufficient cash, click reroll while flag is on → modal still appears showing "Not Enough ¥".