### PR TITLE
fix(pc-box): sort by CP using base stats with a stats fallback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ src/Ankimon/user_files/backups
 .vscode
 .gemini
 .agents
+.claude/
 debug_console.py
 src/Ankimon/user_files/todays_shop.json
 src/Ankimon/user_files/meta.json

--- a/src/Ankimon/pyobj/pc_box.py
+++ b/src/Ankimon/pyobj/pc_box.py
@@ -1722,9 +1722,10 @@ class PokemonPC(QDialog):
                         iv_dict = json.loads(row["iv_json"]) if row["iv_json"] else {}
                         ev_dict = json.loads(row["ev_json"]) if row["ev_json"] else {}
                         base_stats_dict = json.loads(row["base_stats_json"]) if row["base_stats_json"] else {}
+                        stats_dict = json.loads(row["stats_json"]) if row["stats_json"] else {}
                         
-                        # Use PokemonObject's calculation logic
-                        base_val = base_stats_dict.get(target_stat, 1)
+                        # Use PokemonObject's calculation logic (with fallback for legacy stats)
+                        base_val = (base_stats_dict or stats_dict).get(target_stat, 1)
                         iv_val = iv_dict.get(target_stat, 0)
                         ev_val = ev_dict.get(target_stat, 0)
                         

--- a/src/Ankimon/pyobj/pc_box.py
+++ b/src/Ankimon/pyobj/pc_box.py
@@ -1583,7 +1583,7 @@ class PokemonPC(QDialog):
             "json_extract(data, '$.friendship') as friendship, "
             "json_extract(data, '$.evolution_rejected') as evolution_rejected, "
             "json_extract(data, '$.iv') as iv_json, json_extract(data, '$.ev') as ev_json, "
-            "json_extract(data, '$.base_stats') as base_stats_json, json_extract(data, '$.nature') as nature, "
+            "json_extract(data, '$.base_stats') as base_stats_json, json_extract(data, '$.stats') as stats_json, json_extract(data, '$.nature') as nature, "
             "json_extract(data, '$.attacks') as attacks_json "
             "FROM captured_pokemon WHERE 1=1"
         ]
@@ -1734,13 +1734,19 @@ class PokemonPC(QDialog):
                         iv_dict = json.loads(row["iv_json"]) if row["iv_json"] else {}
                         ev_dict = json.loads(row["ev_json"]) if row["ev_json"] else {}
                         base_stats_dict = json.loads(row["base_stats_json"]) if row["base_stats_json"] else {}
+                        stats_dict = json.loads(row["stats_json"]) if row["stats_json"] else {}
                         
-                        p["_sort_value"] = calculate_cp_from_dict({
+                        # Mirror calculate_cp_from_dict's contract: prefer base_stats, else stats fallback
+                        cp_dict = {
                             "level": row["level"],
                             "iv": iv_dict,
-                            "ev": ev_dict,
-                            "base_stats": base_stats_dict
-                        })
+                            "ev": ev_dict
+                        }
+                        if base_stats_dict:
+                            cp_dict["base_stats"] = base_stats_dict
+                        else:
+                            cp_dict["stats"] = stats_dict
+                        p["_sort_value"] = calculate_cp_from_dict(cp_dict)
 
                 results.append(p)
                 


### PR DESCRIPTION
## What
The PC Box "Sort by CP" was ordering most Pokémon by a garbage value.

## Why
The CP-sort recompute read base stats only from `$.base_stats`, but most
captured Pokémon store their base stats under `$.stats` (only mega/gmax forms
carry a separate `$.base_stats`). Feeding an empty base-stats dict made every
base-stats-less Pokémon compute a near-minimum CP and sink to the bottom — so
a 20,629-CP Lunala sorted *below* a 20,065-CP Mega Baxcalibur.

## Fix
Mirror `calculate_cp_from_dict`'s own contract: prefer `$.base_stats` when
present, otherwise fall back to `$.stats`. Verified the recompute now matches
the stored CP for the affected Pokémon.

Self-contained — touches only `pyobj/pc_box.py`.
