### PR TITLE
fix: preserve sprite aspect ratio in Ankidex

### DIFF
--- a/src/Ankimon/ankidex/ankidex.css
+++ b/src/Ankimon/ankidex/ankidex.css
@@ -887,6 +887,10 @@ body {
 #det-sprite {
     width: 180px;
     height: 180px;
+    /* object-fit:contain scales the sprite to fit the 180x180 hero box while
+     * preserving its natural aspect ratio — wide Pokémon (Kyogre, Wailord)
+     * no longer get stretched into a square. */
+    object-fit: contain;
     image-rendering: pixelated;
     position: relative;
     z-index: 1;
@@ -1037,6 +1041,7 @@ body {
 .form-chip img {
     width: 24px;
     height: 24px;
+    object-fit: contain;
     image-rendering: pixelated;
 }
 
@@ -1165,6 +1170,7 @@ body {
 .evo-sprite {
     width: 40px;
     height: 40px;
+    object-fit: contain;
     image-rendering: pixelated;
 }
 
@@ -2023,6 +2029,7 @@ body {
 .prereq-item img {
     width: 48px;
     height: 48px;
+    object-fit: contain;
     image-rendering: pixelated;
 }
 

--- a/src/Ankimon/ankidex/ankidex.html
+++ b/src/Ankimon/ankidex/ankidex.html
@@ -29,7 +29,7 @@
         }
     </style>
     <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700;800;900&family=JetBrains+Mono:wght@500;700&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="ankidex.css">
+    <link rel="stylesheet" href="ankidex.css?v=20260531">
     <link rel="stylesheet" href="../ankimon_items_web/nav-switcher.css?v=20260633">
     <script src="qrc:///qtwebchannel/qwebchannel.js"></script>
 </head>


### PR DESCRIPTION
## Problem
Non-square sprites render **stretched** in the Ankidex. It's most visible on animated sprites — e.g. Kyogre's animated GIF has a 234×55 canvas (~4.25:1), which got squeezed into the fixed 180×180 detail/hero box and stretched vertically out of proportion.

## Cause
Several sprite rules set fixed `width`/`height` (or a fixed box) **without `object-fit`**, so the browser distorts the image to fill the box instead of preserving its aspect ratio.

## Fix
Add `object-fit: contain` to the affected sprite rules so sprites are letterboxed within their boxes at their natural proportions:

- `#det-sprite` — detail / hero view
- `.evo-sprite` — evolution chain
- `.form-chip img` — form-selector chips
- `.prereq-item img` — capture-requirement sprites

This mirrors the same fix already applied to the item bag. The collection grid (`.card-sprite img`) already used `max-width`/`max-height` and was left unchanged.

Also adds a `?v=20260531` cache-buster to the `ankidex.css` `<link>` (it previously had **none**), since the embedded `QWebEngineView` otherwise serves a stale stylesheet across restarts and would mask the change.

## Scope / testing
CSS + HTML only — no Python touched. Verified in a local static-server preview by opening the detail view with the real Kyogre GIF: it now renders at natural proportions, letterboxed in the hero box, instead of stretched.
