### PR TITLE
Fix crash and bugs related to Monthly Challenge check

### DIFF
--- a/src/Ankimon/pyobj/database_manager.py
+++ b/src/Ankimon/pyobj/database_manager.py
@@ -896,7 +896,7 @@ class AnkimonDB:
                 with open(rate_path, 'r', encoding='utf-8') as f:
                     rate_data = json.load(f)
                 
-                if isinstance(rate_data, dict) and rate_data.get("rate_this"):
+                if isinstance(rate_data, dict) and rate_data.get("rate_this") in (True, "true"):
                     self.set_user_data("rate_this", True)
                     self._log("info", "Migrated rate_this.json")
             except Exception as e:

--- a/src/Ankimon/pyobj/database_manager.py
+++ b/src/Ankimon/pyobj/database_manager.py
@@ -897,7 +897,7 @@ class AnkimonDB:
                     rate_data = json.load(f)
                 
                 if isinstance(rate_data, dict) and rate_data.get("rate_this"):
-                    self.set_user_data("rate_this", "true")
+                    self.set_user_data("rate_this", True)
                     self._log("info", "Migrated rate_this.json")
             except Exception as e:
                 self._log("error", f"Failed to migrate rate_this.json: {e}")

--- a/src/Ankimon/pyobj/pokemon_trade.py
+++ b/src/Ankimon/pyobj/pokemon_trade.py
@@ -113,9 +113,14 @@ def check_and_award_monthly_pokemon(logger):
         if prev_id and threshold:
             logger.log("info", f"Checking for shiny eligibility: prev_id={prev_id}, threshold={threshold}")
             previous_challenge_pokemon = db.get_pokemon(prev_id)
-            if previous_challenge_pokemon and previous_challenge_pokemon.get("pokemon_defeated", 0) >= threshold:
-                logger.log("info", f"Shiny criteria met for {challenge_pokemon_data.get('name')}.")
-                make_shiny = True
+            if previous_challenge_pokemon:
+                try:
+                    meets_threshold = int(previous_challenge_pokemon.get("pokemon_defeated", 0)) >= int(threshold)
+                except (ValueError, TypeError):
+                    meets_threshold = False
+                if meets_threshold:
+                    logger.log("info", f"Shiny criteria met for {challenge_pokemon_data.get('name')}.")
+                    make_shiny = True
         
         new_pokemon = create_monthly_challenge_pokemon(challenge_pokemon_data, make_shiny=make_shiny)
         add_pokemon_to_collection(new_pokemon)

--- a/src/Ankimon/pyobj/pokemon_trade.py
+++ b/src/Ankimon/pyobj/pokemon_trade.py
@@ -64,7 +64,7 @@ def check_and_award_monthly_pokemon(logger):
     """Checks for and automatically awards the current monthly challenge Pokémon."""
     try:
         db = mw.ankimon_db
-        if db.get_user_data("rate_this") is not True:
+        if db.get_user_data("rate_this") not in (True, "true"):
             logger.log("info", "Monthly Pokemon check skipped: user has not rated the addon.")
             return
 
@@ -113,7 +113,7 @@ def check_and_award_monthly_pokemon(logger):
         if prev_id and threshold:
             logger.log("info", f"Checking for shiny eligibility: prev_id={prev_id}, threshold={threshold}")
             previous_challenge_pokemon = db.get_pokemon(prev_id)
-            if previous_challenge_pokemon.get("pokemon_defeated", 0) >= threshold:
+            if previous_challenge_pokemon and previous_challenge_pokemon.get("pokemon_defeated", 0) >= threshold:
                 logger.log("info", f"Shiny criteria met for {challenge_pokemon_data.get('name')}.")
                 make_shiny = True
         

--- a/tests/test_monthly_challenge_fixes.py
+++ b/tests/test_monthly_challenge_fixes.py
@@ -1,0 +1,194 @@
+import pytest
+import sys
+import importlib.util
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+# Mock Anki dependencies
+sys.modules["aqt"] = MagicMock()
+sys.modules["aqt.qt"] = MagicMock()
+sys.modules["aqt.utils"] = MagicMock()
+sys.modules["aqt.theme"] = MagicMock()
+sys.modules["anki"] = MagicMock()
+sys.modules["anki.buildinfo"] = MagicMock()
+sys.modules["anki.utils"] = MagicMock()
+sys.modules["PyQt6"] = MagicMock()
+sys.modules["PyQt6.QtWidgets"] = MagicMock()
+sys.modules["PyQt6.QtGui"] = MagicMock()
+sys.modules["PyQt6.QtCore"] = MagicMock()
+
+# Instead of direct import, use importlib to avoid breaking conftest's module stubbing
+_src = Path(__file__).parent.parent / "src"
+spec = importlib.util.spec_from_file_location(
+    "Ankimon.pyobj.pokemon_trade",
+    _src / "Ankimon" / "pyobj" / "pokemon_trade.py",
+)
+pokemon_trade_module = importlib.util.module_from_spec(spec)
+sys.modules["Ankimon.pyobj.pokemon_trade"] = pokemon_trade_module
+spec.loader.exec_module(pokemon_trade_module)
+check_and_award_monthly_pokemon = pokemon_trade_module.check_and_award_monthly_pokemon
+
+
+
+class MockLogger:
+    def log(self, level, message):
+        print(f"[{level}] {message}")
+
+@pytest.fixture
+def mock_db():
+    db = MagicMock()
+    return db
+
+@pytest.fixture
+def mock_mw(mock_db):
+    with patch("Ankimon.pyobj.pokemon_trade.mw") as mw_mock:
+        mw_mock.ankimon_db = mock_db
+        yield mw_mock
+
+@pytest.fixture
+def mock_requests():
+    with patch("Ankimon.pyobj.pokemon_trade.requests.get") as get_mock:
+        yield get_mock
+
+@patch("Ankimon.pyobj.pokemon_trade.datetime")
+@patch("Ankimon.pyobj.pokemon_trade.add_pokemon_to_collection")
+@patch("Ankimon.pyobj.pokemon_trade.utils.showInfo")
+def test_rate_this_check(show_info_mock, add_pokemon_mock, datetime_mock, mock_requests, mock_mw, mock_db):
+    logger = MockLogger()
+
+    # Setup datetime to return known values
+    dt_mock = MagicMock()
+    dt_mock.month = 1
+    dt_mock.year = 2024
+    datetime_mock.now.return_value = dt_mock
+
+    mock_response = MagicMock()
+    mock_response.json.return_value = [
+        {
+            "month": "January 2024",
+            "pokemon": {
+                "name": "TestMon",
+                "id": 1,
+                "individual_id": "test-id"
+            }
+        }
+    ]
+    mock_requests.return_value = mock_response
+
+    # Test case 1: user hasn't rated (returns None)
+    mock_db.get_user_data.return_value = None
+    check_and_award_monthly_pokemon(logger)
+    mock_requests.assert_not_called()
+
+    # Test case 2: user hasn't rated (returns False)
+    mock_db.get_user_data.return_value = False
+    check_and_award_monthly_pokemon(logger)
+    mock_requests.assert_not_called()
+
+    # Test case 3: user rated using old 'true' string
+    mock_db.get_user_data.return_value = "true"
+    mock_db.get_pokemon.return_value = None # Pokémon not found yet
+    check_and_award_monthly_pokemon(logger)
+    mock_requests.assert_called_once()
+    add_pokemon_mock.assert_called_once()
+
+    mock_requests.reset_mock()
+    add_pokemon_mock.reset_mock()
+
+    # Test case 4: user rated using new boolean True
+    mock_db.get_user_data.return_value = True
+    check_and_award_monthly_pokemon(logger)
+    mock_requests.assert_called_once()
+    add_pokemon_mock.assert_called_once()
+
+
+@patch("Ankimon.pyobj.pokemon_trade.datetime")
+@patch("Ankimon.pyobj.pokemon_trade.add_pokemon_to_collection")
+@patch("Ankimon.pyobj.pokemon_trade.utils.showInfo")
+def test_previous_challenge_pokemon_null_check(show_info_mock, add_pokemon_mock, datetime_mock, mock_requests, mock_mw, mock_db):
+    logger = MockLogger()
+
+    # Setup datetime to return known values
+    dt_mock = MagicMock()
+    dt_mock.month = 1
+    dt_mock.year = 2024
+    datetime_mock.now.return_value = dt_mock
+
+    mock_response = MagicMock()
+    mock_response.json.return_value = [
+        {
+            "month": "January 2024",
+            "previous_challenge_individual_id": "prev-id",
+            "defeat_threshold": 10,
+            "pokemon": {
+                "name": "TestMon",
+                "id": 1,
+                "individual_id": "test-id"
+            }
+        }
+    ]
+    mock_requests.return_value = mock_response
+
+    mock_db.get_user_data.return_value = True
+
+    # Setup get_pokemon to handle target and previous pokemon
+    def get_pokemon_side_effect(individual_id):
+        if individual_id == "test-id":
+            return None # Don't have target
+        if individual_id == "prev-id":
+            return None # Simulate user missing the previous challenge pokemon
+        return None
+
+    mock_db.get_pokemon.side_effect = get_pokemon_side_effect
+
+    # Call the function - it shouldn't crash
+    check_and_award_monthly_pokemon(logger)
+
+    # Should have added the new pokemon (not shiny)
+    add_pokemon_mock.assert_called_once()
+    added_pokemon = add_pokemon_mock.call_args[0][0]
+    assert added_pokemon["shiny"] is False
+
+
+@patch("Ankimon.pyobj.pokemon_trade.datetime")
+@patch("Ankimon.pyobj.pokemon_trade.add_pokemon_to_collection")
+@patch("Ankimon.pyobj.pokemon_trade.utils.showInfo")
+def test_previous_challenge_pokemon_has_enough_defeats(show_info_mock, add_pokemon_mock, datetime_mock, mock_requests, mock_mw, mock_db):
+    logger = MockLogger()
+
+    dt_mock = MagicMock()
+    dt_mock.month = 1
+    dt_mock.year = 2024
+    datetime_mock.now.return_value = dt_mock
+
+    mock_response = MagicMock()
+    mock_response.json.return_value = [
+        {
+            "month": "January 2024",
+            "previous_challenge_individual_id": "prev-id",
+            "defeat_threshold": 10,
+            "pokemon": {
+                "name": "TestMon",
+                "id": 1,
+                "individual_id": "test-id"
+            }
+        }
+    ]
+    mock_requests.return_value = mock_response
+
+    mock_db.get_user_data.return_value = True
+
+    def get_pokemon_side_effect(individual_id):
+        if individual_id == "test-id":
+            return None
+        if individual_id == "prev-id":
+            return {"pokemon_defeated": 15}
+        return None
+
+    mock_db.get_pokemon.side_effect = get_pokemon_side_effect
+
+    check_and_award_monthly_pokemon(logger)
+
+    add_pokemon_mock.assert_called_once()
+    added_pokemon = add_pokemon_mock.call_args[0][0]
+    assert added_pokemon["shiny"] is True


### PR DESCRIPTION
Fix crash and bugs related to Monthly Challenge check

- Added null check in pokemon_trade.py when validating previous monthly challenge status
- Fixed rate_this value checking to support both boolean and legacy string format
- Updated rate_this migration in database_manager.py to properly store a boolean
- Created test suite tests/test_monthly_challenge_fixes.py ensuring regressions don't occur

---
*PR created automatically by Jules for task [6688822858659190870](https://jules.google.com/task/6688822858659190870) started by @h0tp-ftw*