### PR TITLE
fix: resolve UnboundLocalError for online_connectivity in profile hooks

### DIFF
--- a/src/Ankimon/profile_hooks.py
+++ b/src/Ankimon/profile_hooks.py
@@ -12,6 +12,7 @@ sync_dialog = None
 
 def _on_profile_did_open(online_connectivity):
     def handler():
+        nonlocal online_connectivity
         try:
             show_tip_of_the_day()
         except Exception as e:


### PR DESCRIPTION
This PR fixes an `UnboundLocalError` related to the `online_connectivity` variable in `_on_profile_did_open` -> `handler()` on Anki Python 3.13.

### Changes made
* Added `nonlocal online_connectivity` directly under the `def handler():` definition in `src/Ankimon/profile_hooks.py`. This ensures the closure explicitly captures and binds the variable to the nearest enclosing scope rather than treating it as a local uninitialized variable.

All tests passed.

---
*PR created automatically by Jules for task [16261999324861419617](https://jules.google.com/task/16261999324861419617) started by @h0tp-ftw*