### PR TITLE
Fix `ValueError` unpacking return value from `read_github_file`

### DIFF
--- a/src/Ankimon/gui_entities.py
+++ b/src/Ankimon/gui_entities.py
@@ -217,15 +217,15 @@ class HelpWindow(QDialog):
                 # Path to the local file
                 local_content = read_local_file(help_local_file_path)
                 # Read content from GitHub
-                github_content, github_html_content = read_github_file(help_github_url)
+                github_content = read_github_file(help_github_url)
                 if local_content is not None and compare_files(local_content, github_content):
-                    html_content = github_html_content
+                    html_content = github_content
                 else:
                     # Download new content from GitHub
                     if github_content is not None:
                         # Write new content to the local file
                         write_local_file(help_local_file_path, github_content)
-                        html_content = github_html_content
+                        html_content = github_content
             else:
                 help_local_file_path = addon_dir / "HelpInfos.html"
                 local_content = read_local_file(help_local_file_path)

--- a/src/Ankimon/gui_entities.py
+++ b/src/Ankimon/gui_entities.py
@@ -226,6 +226,9 @@ class HelpWindow(QDialog):
                         # Write new content to the local file
                         write_local_file(help_local_file_path, github_content)
                         html_content = github_content
+                    elif local_content is not None:
+                        # GitHub unreachable — fall back to the cached local copy
+                        html_content = local_content
             else:
                 help_local_file_path = addon_dir / "HelpInfos.html"
                 local_content = read_local_file(help_local_file_path)

--- a/src/Ankimon/pyobj/help_window.py
+++ b/src/Ankimon/pyobj/help_window.py
@@ -138,6 +138,9 @@ class HelpWindow(QDialog):
                     if github_content is not None:
                         write_local_file(help_local_file_path, github_content)
                         html_content = github_content
+                    elif local_content is not None:
+                        # GitHub unreachable — fall back to the cached local copy
+                        html_content = local_content
             else:
                 # Use local file when offline
                 local_content = read_local_file(help_local_file_path)

--- a/src/Ankimon/pyobj/help_window.py
+++ b/src/Ankimon/pyobj/help_window.py
@@ -128,16 +128,16 @@ class HelpWindow(QDialog):
                 local_content = read_local_file(help_local_file_path)
 
                 # Read content from GitHub
-                github_content, github_html_content = read_github_file(help_github_url)
+                github_content = read_github_file(help_github_url)
 
                 if local_content is not None and compare_files(local_content, github_content):
                     # If local file matches GitHub, use cached content
-                    html_content = github_html_content
+                    html_content = github_content
                 else:
                     # Otherwise, save and use GitHub content
                     if github_content is not None:
                         write_local_file(help_local_file_path, github_content)
-                        html_content = github_html_content
+                        html_content = github_content
             else:
                 # Use local file when offline
                 local_content = read_local_file(help_local_file_path)


### PR DESCRIPTION
Fixes a bug where fetching the help HTML content resulted in a crash due to incorrect unpacking.

---
*PR created automatically by Jules for task [9114976157698890243](https://jules.google.com/task/9114976157698890243) started by @h0tp-ftw*