### PR TITLE
fix: start Discord Rich Presence correctly on first review session

### DIFF
--- a/src/Ankimon/discord_integration.py
+++ b/src/Ankimon/discord_integration.py
@@ -16,14 +16,11 @@ def setup_discord_hooks():
     )
 
     def on_reviewer_initialized(rev, card, ease):
-        if mw.ankimon_presence:
-            if mw.ankimon_presence.loop is False:
-                mw.ankimon_presence.loop = True
-                mw.ankimon_presence.start()
-        else:
+        if not hasattr(mw, "ankimon_presence") or not mw.ankimon_presence:
             mw.ankimon_presence = DiscordPresence(
                 CLIENT_ID, LARGE_IMAGE_URL, ankimon_tracker_obj, logger, settings_obj
             )
+        if mw.ankimon_presence.loop is False:
             mw.ankimon_presence.loop = True
             mw.ankimon_presence.start()
 
@@ -32,5 +29,5 @@ def setup_discord_hooks():
         mw.ankimon_presence.stop_presence()
 
     gui_hooks.reviewer_did_answer_card.append(on_reviewer_initialized)
-    gui_hooks.reviewer_will_end.append(mw.ankimon_presence.stop_presence)
+    gui_hooks.reviewer_will_end.append(on_reviewer_will_end)
     gui_hooks.sync_did_finish.append(mw.ankimon_presence.stop)

--- a/src/Ankimon/functions/discord_function.py
+++ b/src/Ankimon/functions/discord_function.py
@@ -18,7 +18,7 @@ class DiscordPresence:
             self.ankimon_tracker: AnkimonTracker = ankimon_tracker
             self.logger_obj = mw.logger
             self.settings = settings_obj
-            self.loop = True
+            self.loop = False
             self.start_time = time.time()
             self.thread = None
             self.quotes = [

--- a/src/Ankimon/functions/discord_function.py
+++ b/src/Ankimon/functions/discord_function.py
@@ -11,6 +11,7 @@ logger = mw.logger
 
 class DiscordPresence:
     def __init__(self, client_id, large_image_url, ankimon_tracker, logger, settings_obj, parent=mw):
+        self.loop = False
         try:
             self.RPC = Presence(client_id)
             self.RPC.connect()
@@ -18,7 +19,6 @@ class DiscordPresence:
             self.ankimon_tracker: AnkimonTracker = ankimon_tracker
             self.logger_obj = mw.logger
             self.settings = settings_obj
-            self.loop = False
             self.start_time = time.time()
             self.thread = None
             self.quotes = [


### PR DESCRIPTION
Fixes an issue where Ankimon's Discord Rich Presence fails to show the status on the first review session directly after launching Anki.

1. Sets `self.loop` to `False` within the instantiation of `DiscordPresence` so that the object does not masquerade as "running" when created.
2. Updates `setup_discord_hooks` in `discord_integration.py` to use a cleaner `hasattr(mw, "ankimon_presence")` check for existence.
3. Corrects the `reviewer_will_end` hook in `setup_discord_hooks` to use the defined wrapper function `on_reviewer_will_end`, ensuring `loop` resets to `False` properly between review sessions so subsequent sessions can trigger again.

---
*PR created automatically by Jules for task [4257211108863042158](https://jules.google.com/task/4257211108863042158) started by @h0tp-ftw*