### PR TITLE
fix(mobile-db): re-run schema setup on every init so migrations aren't skipped

### DIFF
--- a/src/Ankimon/pyobj/database_manager.py
+++ b/src/Ankimon/pyobj/database_manager.py
@@ -172,23 +172,12 @@ class AnkimonDB:
         conn = self._get_connection()
         cursor = conn.cursor()
 
-        # Check if database is already fully initialized to avoid redundant CREATE TABLE/INDEX statements
-        try:
-            cursor.execute("SELECT name FROM sqlite_master WHERE type='table'")
-            existing_tables = {row[0] for row in cursor.fetchall()}
-            required_tables = {
-                "captured_pokemon", "items", "badges", "metadata", "team", 
-                "pokemon_history", "user_data", "config", "pending_mobile_battles",
-                "mobile_battle_history"
-            }
-            if required_tables.issubset(existing_tables):
-                cursor.execute("PRAGMA table_info(captured_pokemon)")
-                columns = {row[1] for row in cursor.fetchall()}
-                if "is_main" in columns:
-                    # Fully initialized and migrated! Skip setup.
-                    return
-        except Exception as e:
-            self._log("warning", f"Failed to check database initialization status: {e}")
+        # NOTE: do NOT early-return here based on a hard-coded "fully initialized"
+        # table set. Every statement below is idempotent (CREATE TABLE/INDEX IF NOT
+        # EXISTS, guarded ALTER TABLE), so re-running them on each init is cheap and,
+        # crucially, keeps _setup_database the single place schema migrations live.
+        # A short-circuit on an allow-list of table names would silently skip any
+        # future migration (new column/index/table) on already-initialized DBs.
 
         # Table for captured pokemon (replaces mypokemon.json AND mainpokemon.json)
         # is_main flag: 0 = not main, 1 = main pokemon


### PR DESCRIPTION
## Problem

`AnkimonDB._setup_database()` was given an early-return guard:

```python
if required_tables.issubset(existing_tables):
    ... if "is_main" in columns:
        return   # "Fully initialized and migrated! Skip setup."
```

The schema **migrations** (the guarded `ALTER TABLE`, new indexes, future new
tables) all live *after* that guard. So on any DB that already has the hard-coded
table set, setup returns before reaching them. The current `is_main` migration is
protected (it's named in the guard), but **any migration added in the future**
will silently never run on an existing DB unless someone also remembers to extend
the `required_tables` allow-list. That makes `_setup_database` no longer the
single source of truth for the schema — a latent upgrade trap.

## Fix

Remove the short-circuit. Everything below it is idempotent
(`CREATE TABLE/INDEX IF NOT EXISTS`, guarded `ALTER TABLE`), so re-running it each
init is safe; the only cost is a handful of `IF NOT EXISTS` checks at startup. A
comment is left in place so the short-circuit isn't reintroduced.

## Verification

- The 6 DB/sync tests that run without WebEngine still pass
  (`test_process_mobile_reviews_after_sync`, `test_mobile_queue_cap`,
  `test_mobile_history_recording`, `test_detect_mobile_reviews`,
  `test_cross_db_resolution_sync`, `test_mobile_sync_database_and_engine`).
- A focused before/after check (drop a `_setup_database`-created index = a stand-in
  for any non-allow-listed migration, then re-init): **passes with this change,
  fails without it** (`re-init skipped setup — migration short-circuit still present`).

## Relationship to the other cleanup PRs

Independent — this one stands alone and is the foundation of the set. The
companion DB cleanup PR (remove redundant `_ensure_history_table`, dedupe the
history writers) touches a different region of the same file and does not conflict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)