### PR TITLE
refactor(mobile-db): drop on-the-fly history table, dedupe history writers

### DIFF
--- a/src/Ankimon/pyobj/database_manager.py
+++ b/src/Ankimon/pyobj/database_manager.py
@@ -1297,85 +1297,14 @@ class AnkimonDB:
         if revlog_id:
             self.sync_resolutions_to_other_db([revlog_id], now)
 
-    def _ensure_history_table(self):
-        """Ensures the mobile_battle_history table exists."""
-        try:
-            conn = self._get_connection()
-            cursor = conn.cursor()
-            cursor.execute("SELECT name FROM sqlite_master WHERE type='table' AND name='mobile_battle_history'")
-            if not cursor.fetchone():
-                cursor.execute("""
-                    CREATE TABLE IF NOT EXISTS mobile_battle_history (
-                        id                INTEGER PRIMARY KEY AUTOINCREMENT,
-                        timestamp         INTEGER NOT NULL,
-                        enemy_id          INTEGER NOT NULL,
-                        enemy_name        TEXT NOT NULL,
-                        enemy_level       INTEGER NOT NULL,
-                        enemy_shiny       INTEGER NOT NULL,
-                        companion_name    TEXT,
-                        companion_level   INTEGER,
-                        outcome           TEXT NOT NULL,
-                        xp_gained         INTEGER DEFAULT 0,
-                        trainer_xp_gained INTEGER DEFAULT 0,
-                        cash_gained       INTEGER DEFAULT 0
-                    )
-                """)
-                cursor.execute("CREATE INDEX IF NOT EXISTS idx_history_timestamp ON mobile_battle_history(timestamp)")
-                conn.commit()
-                self._log("info", "Created mobile_battle_history table on the fly.")
-        except Exception as e:
-            self._log("error", f"Failed to ensure mobile_battle_history table: {e}")
-
     def add_mobile_history_entry(self, entry: Dict[str, Any]) -> bool:
-        """Saves a mobile battle outcome to history."""
-        self._ensure_history_table()
-
-        def _clean_val(v, default):
-            if v is None or v.__class__.__name__ == "MagicMock":
-                return default
-            return v
-
-        try:
-            conn = self._get_connection()
-            with conn:
-                conn.execute(
-                    """INSERT INTO mobile_battle_history (
-                        timestamp, enemy_id, enemy_name, enemy_level, enemy_shiny,
-                        companion_name, companion_level, outcome, xp_gained,
-                        trainer_xp_gained, cash_gained
-                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
-                    (
-                        _clean_val(entry.get("timestamp"), 0),
-                        _clean_val(entry.get("enemy_id"), 0),
-                        str(_clean_val(entry.get("enemy_name"), "")),
-                        _clean_val(entry.get("enemy_level"), 0),
-                        1 if entry.get("enemy_shiny") else 0,
-                        str(_clean_val(entry.get("companion_name"), "")),
-                        _clean_val(entry.get("companion_level"), 0),
-                        str(_clean_val(entry.get("outcome"), "")),
-                        _clean_val(entry.get("xp_gained"), 0),
-                        _clean_val(entry.get("trainer_xp_gained"), 0),
-                        _clean_val(entry.get("cash_gained"), 0),
-                    )
-                )
-                conn.execute(
-                    """DELETE FROM mobile_battle_history
-                       WHERE id NOT IN (
-                           SELECT id FROM mobile_battle_history
-                           ORDER BY timestamp DESC, id DESC
-                           LIMIT 500
-                       )"""
-                )
-            return True
-        except Exception as e:
-            self._log("error", f"Failed to add mobile history entry: {e}")
-            return False
+        """Saves a single mobile battle outcome to history."""
+        return self.add_mobile_history_entries_batch([entry])
 
     def add_mobile_history_entries_batch(self, entries: List[Dict[str, Any]]) -> bool:
         """Saves a batch of mobile battle outcomes to history in a single transaction."""
         if not entries:
             return True
-        self._ensure_history_table()
 
         def _clean_val(v, default):
             if v is None or v.__class__.__name__ == "MagicMock":
@@ -1423,7 +1352,6 @@ class AnkimonDB:
 
     def get_mobile_history(self, limit: int = 500) -> List[Dict[str, Any]]:
         """Retrieves recent mobile battle history entries, newest first."""
-        self._ensure_history_table()
         try:
             rows = self.execute(
                 """SELECT id, timestamp, enemy_id, enemy_name, enemy_level, enemy_shiny,
@@ -1451,7 +1379,6 @@ class AnkimonDB:
 
     def clear_mobile_history(self) -> bool:
         """Clears all entries from the mobile battle history."""
-        self._ensure_history_table()
         try:
             conn = self._get_connection()
             with conn:


### PR DESCRIPTION
## What

Two related tidy-ups in the mobile history layer of `database_manager.py`:

1. **Removed `_ensure_history_table()` and its 4 call sites.** `mobile_battle_history`
   is already created centrally in `_setup_database()`, so this defensive method
   (which ran a `SELECT … FROM sqlite_master` probe on *every* history read and
   write) was redundant — and it was the only place in the file that created a
   table outside `_setup_database`, breaking that invariant.

2. **`add_mobile_history_entry()` now delegates to `add_mobile_history_entries_batch([entry])`.**
   The two methods previously held byte-for-byte copies of the 11-column `INSERT`,
   the nested `_clean_val` helper, and the 500-row trim query. One writer to
   maintain now.

Net: **−75 / +2 lines**, behavior unchanged.

## Verification

- The 6 DB/sync tests that run without WebEngine pass, including
  `test_mobile_history_recording` — which exercises add-single, add-510, the
  500-row truncation (asserts newest survives), `get_mobile_history(limit=…)`,
  and `clear_mobile_history`. So the delegated single-write path and the removed
  table-probe are both covered.
- `ruff check --config ci_ruff_check.toml` → **All checks passed** on the changed file.

## Relationship to the other cleanup PRs

Independent of #493 (the `_setup_database` migration fix). Both touch
`database_manager.py` but **different regions** (`_setup_database` vs the history
methods), so they do not textually conflict and can merge in either order.

> Note: this removes the per-call `_ensure_history_table()` safety net, which is
> only safe because the table is created in `_setup_database`. #493 reinforces
> that by guaranteeing `_setup_database` always runs its (idempotent) DDL — so the
> two PRs are complementary, though neither requires the other.

🤖 Generated with [Claude Code](https://claude.com/claude-code)