### PR TITLE
docs(mobile-sync): fix select_best_companion docstring + remove dead vars

### DIFF
--- a/src/Ankimon/functions/mobile_sync.py
+++ b/src/Ankimon/functions/mobile_sync.py
@@ -170,12 +170,13 @@ def load_active_team_clones(ankimon_db, settings_obj, main_pokemon_fallback) -> 
 
 def select_best_companion(team_clones: list, enemy_pokemon) -> object:
     """
-    Pick the team member most likely to finish the battle fastest.
+    Pick the team member with the highest estimated damage output against this enemy.
 
-    EDO (Estimated Damage Output) is calculated as the average of the scores of all active moves:
-    Move Score = Base Power * Stat (Atk/Sp.Atk based on category) * Move Type Matchup * STAB
-
-    The final score is EDO * Companion Type Matchup * Speed * HP Fraction.
+    Per move: Base Power * Stat (Atk or Sp.Atk by category) * type effectiveness vs
+    the enemy * STAB. EDO (Estimated Damage Output) is the average of those move
+    scores. The final score is EDO * Speed -- HP is intentionally excluded so a
+    low-HP-but-strong companion isn't passed over. Ties break on Speed, then level.
+    Fainted members are skipped; if the whole team has fainted they are revived first.
     """
     from ..business import _load_type_chart
     from .pokedex_functions import _load_moves_cache
@@ -242,9 +243,6 @@ def select_best_companion(team_clones: list, enemy_pokemon) -> object:
         hp = get_hp_safe(c)
         if hp <= 0:
             continue  # Skip fainted
-
-        max_hp = get_max_hp_safe(c)
-        hp_fraction = (hp / max_hp) if max_hp > 0 else 1.0
 
         stats = getattr(c, "stats", {}) or {}
         if stats.__class__.__name__ == "MagicMock":


### PR DESCRIPTION
## What

Small clarity fixes in `functions/mobile_sync.py`, no behavior change:

1. **`select_best_companion` docstring was wrong.** It claimed the final score is
   `EDO * Companion Type Matchup * Speed * HP Fraction`. The code actually computes
   `score = EDO * Speed` — there is **no** separate companion type-matchup factor,
   and HP is **deliberately excluded** (per the inline comment, to avoid
   health-biased selection). A docstring that contradicts the code is a trap: it
   invites someone to "fix" the implementation to match a spec that was never
   intended. Rewrote it to match the real formula and the Speed→level tie-breakers.

2. **Removed the dead `max_hp` / `hp_fraction` locals** in the scoring loop.
   `hp_fraction` was computed every iteration but never read after HP was dropped
   from the score, and `max_hp` fed only `hp_fraction`.

## Verification

- `ruff check --config ci_ruff_check.toml` → **All checks passed**; the `ruff format`
  delta in this file is entirely pre-existing (none of it falls in the edited
  regions).
- The 6 DB/sync tests that run without WebEngine still pass (they import and
  exercise `mobile_sync`'s detect/process/cap paths).
- `grep` confirms no remaining `hp_fraction` references.

## Relationship to the other cleanup PRs

Independent — different file from #493 / #494 (`mobile_sync.py` vs
`database_manager.py`). No ordering or conflict between any of the three.

🤖 Generated with [Claude Code](https://claude.com/claude-code)