### PR TITLE
feat(harness): load existing saves + construct state for bug repro (dev-only)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -160,6 +160,12 @@ python -m harness.scenarios.screenshots     # PNGs of the real battle window + P
   and confirm: no `error` events, HP stays in `[0, max]`, caught-count/levels move as
   expected. `drain_events()` after each action is how you observe.
 - Editing a real window → run the matching Tier-2 scenario + a screenshot.
+- Reproducing a bug report ("X's move/ability won't work") → construct the exact
+  state and drive it: `Driver(seed={"main": {...}})` for a specific team, `set_enemy(...)`
+  for a specific wild Pokemon, or `Driver(db=<save>)` to boot on an existing save, then
+  watch the `battle` events. See `harness/fixtures.py` + `harness/checks/probe_fixtures.py`.
+  (Dev-only — `fixtures.py` only writes the same plain-JSON DB a user can already edit;
+  it stays in `harness/`, never `src/`, and generated saves are throwaway, never committed.)
 - Hunting bugs/leaks/regressions → fuzz actions, soak for memory, or diff the event
   stream of two branches.
 - Long-horizon: the session is persistent — issue thousands of sequential actions

--- a/harness/README.md
+++ b/harness/README.md
@@ -41,6 +41,7 @@ python3 harness/checks/probe_core.py        # build_core() boots the whole game 
 python3 harness/scenarios/smoke_play.py     # answer cards, catch + defeat
 python3 harness/scenarios/auto_battle.py    # automatic_battle modes 1/2/3
 python3 harness/scenarios/economy.py        # cash + buying items
+python3 harness/checks/probe_fixtures.py    # load a save, seed state, reproduce a bug
 
 # Interactive REPL — one JSON request per line in, one JSON response per line out
 python3 -m harness.server
@@ -130,7 +131,8 @@ d.defeat()                    # or d.catch()  -> spawns the next encounter
 |---|---|
 | `answer(ease)` | answer a card (`1-4` or `again/hard/good/easy`) → runs the battle loop |
 | `catch()` / `defeat()` | resolve a fainted wild Pokemon, then spawn the next |
-| `encounter()` | force a brand-new wild encounter |
+| `encounter()` | force a brand-new (random) wild encounter |
+| `set_enemy(species=, level=, ability=, moves=, …)` | force a **specific** wild encounter (dev fixtures) — for reproducing a reported bug |
 | `set_setting(key, value)` | change a settings key (e.g. `battle.automatic_battle`) |
 | `set_move(move)` | script the move chosen next turn (needs `controls.allow_to_choose_moves`) |
 | `add_cash(n)` / `buy_item(name)` | drive the shop economy |
@@ -140,6 +142,45 @@ d.defeat()                    # or d.catch()  -> spawns the next encounter
 | `drain_events()` | events since the last drain |
 
 Each action returns the events it produced; `get_state()` returns the snapshot.
+
+## Existing progress, custom saves & bug repro (`harness/fixtures.py`)
+
+Sessions don't have to start blank. You can **boot on an existing save** or
+**construct an exact starting state**, then drive a reported bug to its conclusion
+and watch it resolve in the event stream — no Anki, no clicking.
+
+```python
+from harness.driver import Driver
+
+# Load arbitrary existing progress: the given ankimon.db is COPIED into a throwaway
+# profile and booted on, so the source save is never mutated.
+d = Driver(db="reports/issue361.ankimon.db")
+
+# ...or construct a precise state. Pokemon are built from the game's OWN pokedex
+# data (base stats, types, learnset, abilities), so only the fields you pin change.
+d = Driver(seed={
+    "main": {"species": "Gengar", "level": 50, "ability": "Levitate", "moves": ["Shadow Ball"]},
+    "team": [{"species": "Pikachu", "level": 40}],
+    "box":  [{"species": "Bulbasaur", "level": 5}],
+    "items": {"great-ball": 10},
+})
+
+# Force the exact wild Pokemon a bug needs, then battle it:
+d.set_enemy(species="Golem", level=50, moves=["Earthquake"])
+d.answer("again")   # poor answers drop the multiplier < 1, so the wild Pokemon swings
+```
+
+`spec` fields (all optional except a species id): `species`|`id`, `level`, `ability`,
+`moves`, `ivs`/`evs`, `nature`, `shiny`, `gender`, `held_item`, `hp` (pin a low HP to
+reproduce a low-HP bug). Worked example + assertions: `harness/checks/probe_fixtures.py`
+(e.g. it verifies Gengar's Levitate nullifies a forced Golem's Earthquake while a
+non-immune control takes damage).
+
+> **Dev-only, by design.** This lives in `harness/` and is **never shipped** — the
+> add-on adds no "spawn Pokemon" affordance. It only writes the same plain-JSON
+> `ankimon.db` a user can already edit by hand, and only from this unshipped tool.
+> Keep generated saves as throwaway fixtures (temp dirs); never commit one or attach
+> it to a release. Don't move any of this into `src/`.
 
 ## For agents: events, long-horizon runs, and time
 

--- a/harness/checks/probe_fixtures.py
+++ b/harness/checks/probe_fixtures.py
@@ -1,0 +1,82 @@
+"""
+harness/checks/probe_fixtures.py — load-a-save + construct-state + bug-repro.
+
+Demonstrates (and regression-tests) the dev-only fixtures layer:
+  1. seed  — boot on a constructed state (specific main/team/box/items)
+  2. db    — save it, boot a fresh session ON that save (load arbitrary progress)
+  3. set_enemy + a real bug-repro: Gengar(Levitate) is immune to a forced Golem's
+     Earthquake, while a non-immune control takes damage — all observed through the
+     event stream, with no Anki and no clicking.
+
+Run:  python3 harness/checks/probe_fixtures.py
+"""
+
+import os
+import shutil
+import sys
+import tempfile
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+
+from harness.driver import Driver
+
+
+def main():
+    # 1) Seed a precise starting state -----------------------------------------
+    d = Driver(
+        seed={
+            "main": {"species": "Gengar", "level": 50, "ability": "Levitate",
+                     "moves": ["Shadow Ball", "Sludge Bomb"]},
+            "team": [{"species": "Pikachu", "level": 40, "moves": ["Thunderbolt"]}],
+            "box":  [{"species": "Bulbasaur", "level": 5}],
+            "items": {"great-ball": 10},
+        },
+        settings_overrides={"battle.cards_per_round": 1},
+    )
+    st = d.get_state()
+    assert st["main"]["name"] == "Gengar", st["main"]
+    assert d.services.main_pokemon.ability == "Levitate"
+    assert st["collection"]["count"] == 3, st["collection"]
+    assert (d.services.db.get_item("great-ball") or {}).get("quantity") == 10
+    print("seed: main=Gengar(Levitate) Lv%d, team+box=%d caught, 10 great-balls"
+          % (st["main"]["level"], st["collection"]["count"]))
+
+    # 2) Save -> load a fresh session ON that save -----------------------------
+    saved = os.path.join(tempfile.mkdtemp(), "save.db")
+    shutil.copy(os.path.join(d.env.user_path, "ankimon.db"), saved)
+    d2 = Driver(db=saved)
+    st2 = d2.get_state()
+    assert st2["main"]["name"] == "Gengar" and st2["collection"]["count"] == 3, st2
+    assert os.path.exists(saved), "source save must be left untouched"
+    print("db: re-booted on the saved file -> main + collection preserved (source untouched)")
+
+    # 3) set_enemy + bug-repro through the event stream ------------------------
+    def earthquake_damage(species, ability):
+        drv = Driver(
+            seed={"main": {"species": species, "level": 80, "ability": ability, "moves": ["Tackle"]}},
+            settings_overrides={"battle.cards_per_round": 1},
+        )
+        drv.set_enemy(species="Golem", level=50, moves=["Earthquake"])
+        hits = []
+        for _ in range(6):  # poor answers drop the multiplier < 1 so the wild Pokemon swings
+            for e in drv.answer("again"):
+                if e["type"] == "battle" and e.get("enemy_move") == "earthquake":
+                    hits.append(e.get("dmg_to_user"))
+                if e["type"] == "error":
+                    raise RuntimeError("error event during battle: %r" % e)
+            if drv.get_state()["enemy"]["hp"] <= 0:
+                drv.set_enemy(species="Golem", level=50, moves=["Earthquake"])
+        return hits
+
+    immune = earthquake_damage("Gengar", "Levitate")     # Ground-immune
+    control = earthquake_damage("Geodude", "Sturdy")      # not immune
+    assert immune and all(d == 0 for d in immune), ("expected all 0 for Levitate", immune)
+    assert any(d > 0 for d in control), ("expected damage for the control", control)
+    print("set_enemy+repro: Golem's Earthquake -> Gengar(Levitate) took %s, Geodude took %s"
+          % (immune, control))
+
+    print("probe_fixtures: OK")
+
+
+if __name__ == "__main__":
+    main()

--- a/harness/driver.py
+++ b/harness/driver.py
@@ -80,10 +80,25 @@ class Driver:
         return self.drain_events()
 
     def encounter(self):
-        """Force a brand-new wild encounter."""
+        """Force a brand-new (random) wild encounter."""
         s = self.services
         with quiet():
             self.env.new_pokemon(s.enemy_pokemon, s.test_window, s.tracker, s.reviewer)
+        return self.drain_events()
+
+    def set_enemy(self, spec=None, **kw):
+        """Force a SPECIFIC wild encounter — for reproducing a reported bug head-on.
+
+        Accepts a spec dict or keywords (see harness/fixtures.py for all fields):
+            d.set_enemy(species="Golem", level=50, moves=["Earthquake"])
+            d.set_enemy(id=94, ability="Levitate", shiny=True)
+        The Pokemon is built from the game's own pokedex data, so only the fields
+        you pin are overridden. Emits an ``encounter`` event like a real one.
+        """
+        from .fixtures import set_enemy as _set_enemy
+        spec = {**(spec or {}), **kw}
+        with quiet():
+            _set_enemy(self.services, self.events, spec)
         return self.drain_events()
 
     def set_setting(self, key, value):

--- a/harness/fixtures.py
+++ b/harness/fixtures.py
@@ -1,0 +1,245 @@
+"""
+harness/fixtures.py — DEV-ONLY save/state construction for the headless harness.
+
+Lets an agent (1) boot on an EXISTING ``ankimon.db`` (load arbitrary progress)
+and (2) CONSTRUCT a precise starting state — a specific main/team/box, items, and
+a specific wild enemy — so a bug report ("Gengar's Levitate ignores Earthquake",
+"X's move Y does 0 damage") can be reproduced head-on and watched resolve through
+the event stream.
+
+Safety / accessibility (read before extending):
+  * This file lives in ``harness/`` and is NEVER shipped — the ``.ankiaddon`` is
+    built from ``src/Ankimon/`` only. It adds ZERO cheat affordance to the add-on:
+    it only writes the same plain-JSON ``ankimon.db`` a user can already edit by
+    hand with any SQLite tool, and only from this unshipped dev tool. Do NOT move
+    any of this into ``src/``, and do NOT add a "spawn" command to the add-on.
+  * Saves generated here are throwaway fixtures — keep them in temp dirs, never
+    commit one into the repo or attach it to a release (a ready-made save is more
+    convenient to a casual cheater than the capability, which already exists).
+
+Fidelity: Pokemon are built from the game's OWN pokedex helpers (base stats,
+types, abilities, learnset, base exp, growth rate, EV yield, tier), so a
+seeded/forced Pokemon is identical to one the game itself would produce — only the
+fields you pin in the spec are overridden.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+_STAT_KEYS = ("hp", "atk", "def", "spa", "spd", "spe")
+_ZERO_STAGES = {"atk": 0, "def": 0, "spa": 0, "spd": 0, "spe": 0, "accuracy": 0, "evasion": 0}
+
+
+# --- spec -> canonical species data -----------------------------------------
+
+def _stat_dict(val, default):
+    """Coerce a spec stat block (dict or None) into a full 6-stat int dict."""
+    if isinstance(val, dict):
+        return {k: int(val.get(k, default)) for k in _STAT_KEYS}
+    return {k: int(default) for k in _STAT_KEYS}
+
+
+def _name_to_id(name):
+    from Ankimon.functions.pokedex_functions import search_pokedex
+    sid = search_pokedex(name, "id") or search_pokedex(name, "num")
+    if sid:
+        return int(sid)
+    # Fall back to inverting the id->name index the game uses for the reverse map.
+    from Ankimon.functions.pokedex_functions import _load_pokedex_id_index
+    for i, n in (_load_pokedex_id_index() or {}).items():
+        if str(n).lower() == str(name).lower():
+            return int(i)
+    raise ValueError(f"fixtures: could not resolve a pokedex id for {name!r}")
+
+
+def _species_data(spec):
+    """Resolve a compact spec into the field dict the game uses for a Pokemon.
+
+    spec keys (all optional except a species identifier):
+      species|name | id    — which Pokemon (one is required)
+      level                — default 50
+      ability              — default: the species' first listed ability
+      moves|attacks        — default: up to 4 from the level-legal learnset
+      ivs|iv, evs|ev       — dict or scalar; default IV 31, EV 0
+      nature               — default "serious"
+      shiny, gender, held_item, tier
+    """
+    from Ankimon.functions.pokedex_functions import (
+        search_pokedex,
+        search_pokedex_by_id,
+        get_base_experience,
+        get_growth_rate,
+        get_effort_values,
+    )
+    from Ankimon.functions.learnset_retrieval import get_all_pokemon_moves
+    from Ankimon.functions.pokemon_functions import pick_random_gender
+    from Ankimon.utils import get_tier_by_id
+    from Ankimon.poke_engine.helpers import normalize_name
+
+    sid = spec.get("id")
+    name = spec.get("species") or spec.get("name")
+    if sid is not None and not name:
+        name = search_pokedex_by_id(sid)
+    if not name or name == "Pokémon not found":
+        raise ValueError(f"fixtures: unknown species in spec {spec!r}")
+    if sid is None:
+        sid = _name_to_id(name)
+    sid = int(sid)
+    actual_id = search_pokedex(name, "actual_id") or sid
+
+    base_stats = search_pokedex(name, "baseStats")
+    types = search_pokedex(name, "types")
+    if not base_stats or not types:
+        raise ValueError(f"fixtures: pokedex has no data for {name!r}")
+
+    level = int(spec.get("level", 50))
+
+    ability = spec.get("ability")
+    if not ability:
+        abilities = search_pokedex(name, "abilities") or {}
+        numeric = {k: v for k, v in abilities.items() if str(k).isdigit()}
+        ability = numeric.get("0") or next(iter(numeric.values()), None) or "Run Away"
+
+    moves = spec.get("moves") or spec.get("attacks")
+    if not moves:
+        pool = get_all_pokemon_moves(name, level) or ["Tackle"]
+        moves = pool[:4]
+    # The battle loop resolves moves by the game's normalized key ("Shadow Ball" ->
+    # "shadowball"); learnset moves are already normalized, spec-given ones may not be.
+    moves = [normalize_name(m) for m in moves]
+
+    return {
+        "name": name,
+        "id": sid,
+        "level": level,
+        "ability": ability,
+        "type": types,
+        "base_stats": base_stats,
+        "attacks": list(moves),
+        "base_experience": get_base_experience(actual_id) or 0,
+        "growth_rate": get_growth_rate(sid) or "medium",
+        "ev": _stat_dict(spec.get("evs", spec.get("ev")), default=0),
+        "iv": _stat_dict(spec.get("ivs", spec.get("iv")), default=31),
+        "ev_yield": get_effort_values(actual_id) or {k: 0 for k in _STAT_KEYS},
+        "gender": spec.get("gender") or pick_random_gender(name) or "N",
+        "nature": spec.get("nature", "serious"),
+        "shiny": bool(spec.get("shiny", False)),
+        "tier": spec.get("tier") or get_tier_by_id(sid) or "Normal",
+        "held_item": spec.get("held_item"),
+        "battle_status": "fighting",
+        "stat_stages": dict(_ZERO_STAGES),
+    }
+
+
+def build_pokemon(spec):
+    """A faithful PokemonObject from a compact spec (fresh individual_id each call)."""
+    from Ankimon.pyobj.pokemon_obj import PokemonObject
+
+    data = _species_data(spec)
+    data.update({
+        "individual_id": spec.get("individual_id") or str(uuid.uuid4()),
+        "nickname": spec.get("nickname", ""),
+        "friendship": int(spec.get("friendship", 0)),
+        "captured_date": spec.get("captured_date", "2000-01-01 00:00:00"),
+        "xp": int(spec.get("xp", 0)),
+    })
+    pkmn = PokemonObject.from_dict(data)
+    # Full HP unless the spec pins a current hp (e.g. to reproduce a low-HP bug).
+    pkmn.hp = int(spec.get("hp", pkmn.max_hp))
+    pkmn.current_hp = pkmn.hp
+    return pkmn
+
+
+# --- seeding a starting save -------------------------------------------------
+
+def seed_db(seed, db):
+    """Write a constructed starting state into ``db`` (the session ankimon.db).
+
+    seed keys (all optional):
+      main          — a spec; becomes is_main=1 and team slot 1
+      team          — list of specs; appended to the team after main
+      box           — list of specs; captured but not on the team (PC)
+      items         — {item_name: quantity}
+    Returns the individual_ids that were created.
+    """
+    # update_main_pokemon() only reads the DB when is_migrated() is True; a fresh
+    # harness DB is not "migrated", so without this it would ignore a seeded main
+    # and fall back to the default placeholder. is_migrated() checks 'migrated_phase2';
+    # 'migrated' is the phase-1 flag — set both so every code path treats the DB as live.
+    db.execute("INSERT OR REPLACE INTO metadata (key, value) VALUES ('migrated', 'true')")
+    db.execute("INSERT OR REPLACE INTO metadata (key, value) VALUES ('migrated_phase2', 'true')")
+    db._get_connection().commit()
+
+    team = []
+
+    main_spec = seed.get("main")
+    main_obj = None
+    if main_spec:
+        main_obj = build_pokemon(main_spec)
+        db.save_main_pokemon(main_obj.to_dict())  # inserts the row with is_main=1
+        team.append(main_obj)
+
+    for spec in seed.get("team", []):
+        obj = build_pokemon(spec)
+        db.save_pokemon(obj.to_dict())
+        team.append(obj)
+
+    for spec in seed.get("box", []):
+        obj = build_pokemon(spec)
+        db.save_pokemon(obj.to_dict())
+
+    if team:
+        db.save_team([{"individual_id": o.individual_id} for o in team])
+
+    for item_name, qty in (seed.get("items") or {}).items():
+        try:
+            db.add_item(item_name, int(qty))
+        except Exception:
+            pass
+
+    return {
+        "main": main_obj.individual_id if main_obj else None,
+        "team": [o.individual_id for o in team],
+    }
+
+
+# --- forcing a specific wild encounter --------------------------------------
+
+def set_enemy(services, events, spec):
+    """Replace the live wild encounter with a specific species (mirrors new_pokemon).
+
+    The on-screen enemy object is mutated in place (so the battle loop's bound
+    globals keep pointing at it), then an ``encounter`` event is emitted exactly
+    like a normal wild appearance. Use this to reproduce "the enemy's move/ability
+    misbehaves" deterministically.
+    """
+    data = _species_data(spec)
+    ep = services.enemy_pokemon
+    ep.update_stats(**data)
+    max_hp = ep.calculate_max_hp()
+    ep.max_hp = max_hp
+    ep.hp = int(spec.get("hp", max_hp))
+    ep.current_hp = ep.hp
+
+    try:
+        services.tracker.randomize_battle_scene()
+    except Exception:
+        pass
+    if services.test_window is not None:
+        try:
+            services.test_window.display_first_encounter()
+        except Exception:
+            pass
+
+    events.emit(
+        "encounter",
+        pokemon=ep.name, id=ep.id, level=ep.level, tier=ep.tier,
+        shiny=ep.shiny, hp=ep.hp, max_hp=ep.max_hp,
+    )
+    if services.reviewer is not None:
+        try:
+            services.reviewer.refresh_hud()
+        except Exception:
+            pass
+    return ep

--- a/harness/headless_env.py
+++ b/harness/headless_env.py
@@ -25,8 +25,10 @@ def start_session(
     settings_overrides=None,
     evolution_policy: str = "decline",
     event_sink=None,
-    first_encounter: bool = True,
+    first_encounter=None,
     clock_start=None,
+    db=None,
+    seed=None,
 ) -> SimpleNamespace:
     """Boot a headless session and return a namespace of handles for the Driver.
 
@@ -34,10 +36,27 @@ def start_session(
     settings_overrides: dict of settings keys to set (e.g. {"battle.cards_per_round": 1}).
     evolution_policy: "decline" | "ignore" — how FakeEvoWindow answers evolutions.
     event_sink: optional callable(dict) tee'd every event (e.g. JSONL writer).
-    first_encounter: generate a real wild Pokemon up front (vs the placeholder).
+    first_encounter: generate a real wild Pokemon up front. Default: True for a
+        blank session, False when loading a save (so its state isn't disturbed).
+    db: path to an existing ankimon.db to boot on (loads arbitrary progress). It is
+        COPIED into this session's throwaway profile, so the source is never mutated.
+    seed: a dict describing a starting state to construct — main/team/box/items (see
+        harness/fixtures.py:seed_db). Dev-only; written to the throwaway profile DB.
     """
     if user_path is None:
         user_path = tempfile.mkdtemp(prefix="ankimon_session_")
+
+    # Load an existing save: copy the given ankimon.db into THIS session's throwaway
+    # profile (non-destructive — the source file is never touched).
+    if db is not None:
+        import shutil
+        from pathlib import Path as _P
+        shutil.copy(str(db), str(_P(user_path) / "ankimon.db"))
+
+    # Open on a fresh wild encounter for a blank session, but don't disturb a loaded
+    # save's in-progress state unless the caller explicitly asks for one.
+    if first_encounter is None:
+        first_encounter = db is None
 
     bootstrap(user_path=user_path)
 
@@ -64,6 +83,13 @@ def start_session(
     _dbm.user_path = _Path(user_path)
     _dbm.reset_db()
     services.reset()
+
+    # Construct a starting state (specific main/team/box/items) BEFORE build_core,
+    # so the normal boot path (update_main_pokemon) loads it as the live game state.
+    if seed is not None:
+        from .fixtures import seed_db
+        with quiet():
+            seed_db(seed, _dbm.get_db())
 
     # Build core game state and install GUI fakes with events OFF, so none of the
     # setup noise (config save, etc.) lands in the buffer the agent reads.


### PR DESCRIPTION
Stacked on `feat/headless-core-agent-harness` (PR #492). Lets an agent give a
headless session **any progress** and **construct the exact state a bug report
describes**, then drive it to a conclusion through the event stream — no Anki, no
clicking.

## What you can now do

```python
from harness.driver import Driver

# 1. Load arbitrary existing progress (the .db is COPIED into a throwaway profile;
#    the source save is never mutated).
d = Driver(db="reports/issue361.ankimon.db")

# 2. Construct a precise starting state. Pokemon are built from the game's OWN
#    pokedex data, so only the fields you pin are overridden.
d = Driver(seed={
    "main": {"species": "Gengar", "level": 50, "ability": "Levitate", "moves": ["Shadow Ball"]},
    "team": [{"species": "Pikachu", "level": 40}],
    "box":  [{"species": "Bulbasaur", "level": 5}],
    "items": {"great-ball": 10},
})

# 3. Force the exact wild Pokemon a bug needs, then battle it.
d.set_enemy(species="Golem", level=50, moves=["Earthquake"])
d.answer("again")   # poor answers drop the multiplier < 1, so the wild Pokemon swings
```

This directly serves the "someone says X's move/ability won't work" case: reconstruct
the situation and watch the real battle logic resolve it.

## Files (all dev-only — nothing in `src/`)
- **`harness/fixtures.py`** (new) — `build_pokemon`, `seed_db`, `set_enemy`. Species data
  from the game's pokedex helpers; move names normalized via the engine's `normalize_name`.
- `harness/headless_env.py` — `start_session(db=…, seed=…)`; loading a save defaults to
  not disturbing its in-progress state.
- `harness/driver.py` — `Driver.set_enemy(...)`.
- **`harness/checks/probe_fixtures.py`** (new) — demonstrates + asserts the flow.
- `harness/README.md`, `AGENTS.md` — docs.

## Verification
- `probe_fixtures.py`: seed loads the right main/team/box/items; save→load round-trip
  preserves state (source untouched); and a **real repro** — Gengar (Levitate) takes
  **0** from a forced Golem's Earthquake across turns while Geodude (control) takes 87/91.
- No regressions: `probe_foundations`, `probe_leaves` (26 modules aqt-free), `probe_core`,
  `smoke_play`, and `tests/test_headless_harness.py` all still pass.

## Safety / "as accessible as it is now"
Adds **no** new cheat surface. It lives entirely in `harness/` (never shipped — the
`.ankiaddon` is built from `src/` only), adds **no** spawn affordance to the add-on, and
only writes the same plain-JSON `ankimon.db` a user can already edit by hand with any
SQLite tool — and only from this unshipped dev tool. `git status` confirms zero `src/`
changes. Generated saves are throwaway fixtures (temp dirs); don't commit one or ship it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)