### PR TITLE
feat(harness): dev tooling — profiler + pluggable backends + debugpy/pdb

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -162,6 +162,10 @@ python -m harness.scenarios.screenshots     # PNGs of the real battle window + P
 - Editing a real window → run the matching Tier-2 scenario + a screenshot.
 - Hunting bugs/leaks/regressions → fuzz actions, soak for memory, or diff the event
   stream of two branches.
+- Profiling perf/leaks → wrap a workload in `harness/diagnostics.py` `profile(d, memory=True)`
+  (or `scenarios/profile_battles.py N`) for DB-query counts (spots N+1s/rescans), cProfile
+  hotspots, and RSS/tracemalloc growth. Query counts + cProfile shape are hardware-independent;
+  wall/RSS are indicative on this box, not the user's felt latency.
 - Long-horizon: the session is persistent — issue thousands of sequential actions
   (`longrun.py` / `soak.py` do 10k+; ~900 turns/s in Tier 1). Real-time delays are
   skipped (full speed); the **calendar** is controllable — pass `clock_start=datetime(...)`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -165,7 +165,12 @@ python -m harness.scenarios.screenshots     # PNGs of the real battle window + P
 - Profiling perf/leaks → wrap a workload in `harness/diagnostics.py` `profile(d, memory=True)`
   (or `scenarios/profile_battles.py N`) for DB-query counts (spots N+1s/rescans), cProfile
   hotspots, and RSS/tracemalloc growth. Query counts + cProfile shape are hardware-independent;
-  wall/RSS are indicative on this box, not the user's felt latency.
+  wall/RSS are indicative on this box, not the user's felt latency. Swap the engine with
+  `backend="pyinstrument"` (etc.) — optional tools come from `harness/requirements-dev.txt`.
+- Stepping through code → it's a normal process: `python3 -m pdb <scenario>`, or attach debugpy
+  (`harness/debug.py`, or `python3 -m debugpy --listen 5678 --wait-for-client <scenario>`) to set
+  breakpoints in `src/Ankimon` and inspect variables mid-battle. Tooling/debug packages go in a
+  venv via `harness/requirements-dev.txt` — **never** as add-on deps (the shipped addon stays dep-free).
 - Long-horizon: the session is persistent — issue thousands of sequential actions
   (`longrun.py` / `soak.py` do 10k+; ~900 turns/s in Tier 1). Real-time delays are
   skipped (full speed); the **calendar** is controllable — pass `clock_start=datetime(...)`

--- a/harness/README.md
+++ b/harness/README.md
@@ -38,9 +38,10 @@ python3 harness/checks/probe_leaves.py      # 26 core modules import aqt-free
 python3 harness/checks/probe_core.py        # build_core() boots the whole game state
 
 # Scripted play sessions
-python3 harness/scenarios/smoke_play.py     # answer cards, catch + defeat
-python3 harness/scenarios/auto_battle.py    # automatic_battle modes 1/2/3
-python3 harness/scenarios/economy.py        # cash + buying items
+python3 harness/scenarios/smoke_play.py       # answer cards, catch + defeat
+python3 harness/scenarios/auto_battle.py      # automatic_battle modes 1/2/3
+python3 harness/scenarios/economy.py          # cash + buying items
+python3 harness/scenarios/profile_battles.py 10000   # cProfile + DB queries + memory
 
 # Interactive REPL — one JSON request per line in, one JSON response per line out
 python3 -m harness.server
@@ -140,6 +141,35 @@ d.defeat()                    # or d.catch()  -> spawns the next encounter
 | `drain_events()` | events since the last drain |
 
 Each action returns the events it produced; `get_state()` returns the snapshot.
+
+## Profiling a workload (`harness/diagnostics.py`)
+
+Wrap any sequence of actions and get a machine-readable report — **DB queries**
+(grouped by normalized statement, so an N+1 collapses to one big-count row),
+**cProfile** hotspots, **memory** (RSS delta + tracemalloc top allocators), and
+wall time:
+
+```python
+from harness.driver import Driver
+from harness.diagnostics import profile
+
+d = Driver(settings_overrides={"battle.cards_per_round": 1})
+with profile(d, label="10k battles", memory=True) as report:
+    for _ in range(10_000):
+        d.answer("good")
+        if d.services.enemy_pokemon.hp <= 0:
+            d.catch()
+report.print()          # human-readable; report.as_dict() for assertions
+```
+
+Or just: `python3 harness/scenarios/profile_battles.py 10000`.
+
+**Read it right:** the **query counts** and the **cProfile shape** are
+hardware-independent — they tell you *where* the cost is and *how it scales*
+(e.g. queries growing per page = an N+1; `copy.deepcopy` dominating = state-copy
+churn), which is what you actually fix. **Wall time and RSS are indicative on this
+box only** — for the felt milliseconds, measure the real window on real hardware.
+This profiles the data/logic layer, not Qt rendering.
 
 ## For agents: events, long-horizon runs, and time
 

--- a/harness/README.md
+++ b/harness/README.md
@@ -171,6 +171,38 @@ churn), which is what you actually fix. **Wall time and RSS are indicative on th
 box only** — for the felt milliseconds, measure the real window on real hardware.
 This profiles the data/logic layer, not Qt rendering.
 
+## Extending: other tooling & live debugging
+
+The harness is a plain Python process driving the real game code, so any analysis or
+debug tool that works on a Python program plugs into the same `Driver` workload.
+
+**Profiler backends.** `profile(d, backend="pyinstrument")` swaps the engine; an
+unknown or uninstalled backend falls back to stdlib cProfile with a note. The core
+stays stdlib-only — optional tools live in a **venv**, never an add-on dependency:
+
+```bash
+python3 -m venv .venv && .venv/bin/pip install -r harness/requirements-dev.txt
+```
+
+That list includes pyinstrument, scalene, memray, py-spy, line_profiler, objgraph,
+debugpy — point any of them at a `Driver` loop the way cProfile is wired.
+
+**Live debugging — breakpoints + variable inspection.** Because it's a normal
+process, set breakpoints in `src/Ankimon` and step through them while a *simulated*
+review runs — no Anki:
+
+```bash
+# stdlib pdb (zero deps) — or drop breakpoint() anywhere in src/Ankimon:
+python3 -m pdb harness/scenarios/smoke_play.py
+
+# debugpy (VS Code / PyCharm / any DAP client): set breakpoints in the editor, then:
+python3 -m debugpy --listen 5678 --wait-for-client harness/scenarios/smoke_play.py
+#   ...or inside your own script:  from harness.debug import wait_for_client; wait_for_client()
+```
+
+See `harness/debug.py`. **Rule:** tooling/debug packages live in the venv + `harness/`,
+**never** in `src/` — the shipped add-on must stay dependency-free.
+
 ## For agents: events, long-horizon runs, and time
 
 **Minimal loop** (Tier 1):

--- a/harness/debug.py
+++ b/harness/debug.py
@@ -1,0 +1,45 @@
+"""
+harness/debug.py — DEV-ONLY: attach a real debugger to a headless session.
+
+Because the harness is a plain Python process driving the real game code, you can
+set breakpoints in ``src/Ankimon`` and step through them while a *simulated* review
+runs — no Anki, no clicking. Two ways:
+
+1. pdb (stdlib, zero deps). Drop ``breakpoint()`` anywhere in a scenario or in
+   ``src/Ankimon`` and run it, or run a scenario under pdb:
+       python3 -m pdb harness/scenarios/smoke_play.py
+
+2. debugpy (DAP — VS Code / PyCharm / any DAP client): set breakpoints in the editor,
+   inspect/watch variables, step in/over/out. Either launch a scenario under debugpy:
+       python3 -m debugpy --listen 5678 --wait-for-client harness/scenarios/smoke_play.py
+   ...or call wait_for_client() inside your own script, then attach your editor:
+       from harness.debug import wait_for_client
+       from harness.driver import Driver
+       wait_for_client()                 # blocks until the editor attaches on :5678
+       d = Driver(settings_overrides={"battle.cards_per_round": 1})
+       d.answer("good")                  # now step through battle_loop.py live
+
+debugpy is optional — `pip install debugpy` into a venv (see harness/requirements-dev.txt).
+pdb always works with zero deps.
+"""
+
+from __future__ import annotations
+
+
+def wait_for_client(port: int = 5678, host: str = "127.0.0.1"):
+    """Start a debugpy DAP server and block until a client (e.g. VS Code) attaches.
+
+    Returns the ``debugpy`` module so you can call ``debugpy.breakpoint()`` later.
+    """
+    try:
+        import debugpy
+    except ImportError as e:
+        raise RuntimeError(
+            "debugpy is not installed — `pip install debugpy` (into a venv), or use "
+            "the stdlib `breakpoint()` / `python3 -m pdb <scenario>` instead."
+        ) from e
+    debugpy.listen((host, port))
+    print(f"debugpy: waiting for a debugger to attach on {host}:{port} ...")
+    debugpy.wait_for_client()
+    print("debugpy: attached — breakpoints in src/Ankimon are now live.")
+    return debugpy

--- a/harness/diagnostics.py
+++ b/harness/diagnostics.py
@@ -1,0 +1,187 @@
+"""
+harness/diagnostics.py — DEV-ONLY profiling for a headless workload.
+
+Wrap any sequence of Driver actions and get a machine-readable report:
+  - DB queries: total + grouped by normalized statement (spots N+1s / rescans)
+  - cProfile: top functions by cumulative time (where the time goes)
+  - memory: process RSS delta + optional tracemalloc top allocators (leak hunting)
+  - wall time
+
+The **query counts** and the **cProfile shape** are hardware-independent — they tell
+you WHERE the cost is and HOW it scales, which is what you actually fix. Wall-time and
+RSS are *indicative on this box*, not a substitute for measuring on real hardware.
+
+Stdlib only (cProfile, pstats, tracemalloc, sqlite3 trace, /proc). Dev-only — lives in
+harness/, never shipped, never imported by src/.
+
+    from harness.driver import Driver
+    from harness.diagnostics import profile
+
+    d = Driver(settings_overrides={"battle.cards_per_round": 1})
+    with profile(d, label="10k battles", memory=True) as report:
+        for _ in range(10_000):
+            d.answer("good")
+            if d.services.enemy_pokemon.hp <= 0:
+                d.catch()
+    report.print()           # human-readable; report.as_dict() for assertions
+"""
+
+from __future__ import annotations
+
+import cProfile
+import gc
+import io
+import os
+import pstats
+import re
+import time
+import tracemalloc
+from contextlib import contextmanager
+
+# Group statements that differ only by literal values, so an N+1 collapses to one
+# row with a big count (string literals + bare numbers -> '?', whitespace squashed).
+_NORM = [
+    (re.compile(r"'[^']*'"), "?"),
+    (re.compile(r"\b\d+\b"), "?"),
+    (re.compile(r"\s+"), " "),
+]
+
+
+def _normalize(sql: str) -> str:
+    s = sql.strip()
+    for rx, rep in _NORM:
+        s = rx.sub(rep, s)
+    return s[:160]
+
+
+def _rss_mb() -> float:
+    """Current process resident set size in MiB (Linux /proc; resource fallback)."""
+    try:
+        with open("/proc/self/statm") as f:
+            resident_pages = int(f.read().split()[1])
+        return resident_pages * os.sysconf("SC_PAGE_SIZE") / (1024 * 1024)
+    except Exception:
+        try:
+            import resource
+            return resource.getrusage(resource.RUSAGE_SELF).ru_maxrss / 1024.0
+        except Exception:
+            return 0.0
+
+
+class Report:
+    def __init__(self, label: str = "run"):
+        self.label = label
+        self.wall_seconds = 0.0
+        self.queries: dict[str, int] = {}
+        self.query_total = 0
+        self.rss_start = 0.0
+        self.rss_end = 0.0
+        self.tracemalloc_top: list[tuple[str, float, int]] = []  # (location, kb_growth, count)
+        self.cprofile_top: list[tuple[str, int, float, float]] = []  # (func, ncalls, tot, cum)
+
+    def as_dict(self) -> dict:
+        top_q = sorted(self.queries.items(), key=lambda kv: -kv[1])[:15]
+        return {
+            "label": self.label,
+            "wall_seconds": round(self.wall_seconds, 3),
+            "db": {
+                "total_queries": self.query_total,
+                "distinct_statements": len(self.queries),
+                "by_statement": top_q,
+            },
+            "memory": {
+                "rss_start_mb": round(self.rss_start, 1),
+                "rss_end_mb": round(self.rss_end, 1),
+                "rss_delta_mb": round(self.rss_end - self.rss_start, 1),
+                "tracemalloc_top": self.tracemalloc_top,
+            },
+            "cprofile_top": self.cprofile_top,
+        }
+
+    def print(self) -> None:
+        d = self.as_dict()
+        print(f"\n=== diagnostics: {d['label']} ===")
+        print(f"wall: {d['wall_seconds']}s  (includes profiler overhead)")
+        db = d["db"]
+        print(f"\nDB queries: {db['total_queries']} total, {db['distinct_statements']} distinct")
+        for stmt, n in db["by_statement"]:
+            print(f"  {n:>8}  {stmt}")
+        m = d["memory"]
+        print(f"\nRSS: {m['rss_start_mb']} -> {m['rss_end_mb']} MB  (delta {m['rss_delta_mb']:+} MB)")
+        for loc, kb, cnt in m["tracemalloc_top"]:
+            print(f"  +{kb:>9.1f} KB  ({cnt:+} objs)  {loc}")
+        if d["cprofile_top"]:
+            print("\ncProfile (top by cumulative time):")
+            for func, ncalls, tot, cum in d["cprofile_top"]:
+                print(f"  cum={cum:7.3f}s  tot={tot:7.3f}s  calls={ncalls:>9}  {func}")
+        print()
+
+
+@contextmanager
+def profile(driver, label: str = "run", memory: bool = False, cprofile: bool = True, top: int = 15):
+    """Profile the workload run inside the ``with`` block. Yields a Report.
+
+    memory=True adds tracemalloc top-allocator tracking (heavier; great for leaks).
+    cprofile=False skips the function profiler (lower overhead, keeps query counts).
+    """
+    rep = Report(label)
+
+    # 1) Exact DB query counting via the sqlite trace callback on the live connection.
+    conn = None
+    try:
+        conn = driver.services.db._get_connection()
+    except Exception:
+        conn = None
+
+    def _trace(sql):
+        key = _normalize(sql)
+        rep.queries[key] = rep.queries.get(key, 0) + 1
+        rep.query_total += 1
+
+    if conn is not None:
+        try:
+            conn.set_trace_callback(_trace)
+        except Exception:
+            conn = None
+
+    # 2) Memory baselines (after a gc so the delta reflects retained, not churn).
+    gc.collect()
+    rep.rss_start = _rss_mb()
+    snap0 = None
+    if memory:
+        tracemalloc.start(20)
+        snap0 = tracemalloc.take_snapshot()
+
+    pr = cProfile.Profile() if cprofile else None
+    t0 = time.perf_counter()
+    if pr:
+        pr.enable()
+    try:
+        yield rep
+    finally:
+        if pr:
+            pr.disable()
+        rep.wall_seconds = time.perf_counter() - t0
+
+        if memory and snap0 is not None:
+            snap1 = tracemalloc.take_snapshot()
+            for st in snap1.compare_to(snap0, "lineno")[:top]:
+                rep.tracemalloc_top.append((str(st.traceback), st.size_diff / 1024.0, st.count_diff))
+            tracemalloc.stop()
+        gc.collect()
+        rep.rss_end = _rss_mb()
+
+        if conn is not None:
+            try:
+                conn.set_trace_callback(None)
+            except Exception:
+                pass
+
+        if pr:
+            ps = pstats.Stats(pr, stream=io.StringIO())
+            rows = [
+                (f"{os.path.basename(fn[0])}:{fn[1]}({fn[2]})", nc, tt, ct)
+                for fn, (cc, nc, tt, ct, callers) in ps.stats.items()
+            ]
+            rows.sort(key=lambda r: -r[3])  # by cumulative time
+            rep.cprofile_top = rows[:top]

--- a/harness/diagnostics.py
+++ b/harness/diagnostics.py
@@ -3,43 +3,43 @@ harness/diagnostics.py — DEV-ONLY profiling for a headless workload.
 
 Wrap any sequence of Driver actions and get a machine-readable report:
   - DB queries: total + grouped by normalized statement (spots N+1s / rescans)
-  - cProfile: top functions by cumulative time (where the time goes)
+  - a profiler backend's hotspots (stdlib cProfile by default; pyinstrument optional)
   - memory: process RSS delta + optional tracemalloc top allocators (leak hunting)
   - wall time
 
-The **query counts** and the **cProfile shape** are hardware-independent — they tell
+The **query counts** and the profiler **shape** are hardware-independent — they tell
 you WHERE the cost is and HOW it scales, which is what you actually fix. Wall-time and
 RSS are *indicative on this box*, not a substitute for measuring on real hardware.
 
-Stdlib only (cProfile, pstats, tracemalloc, sqlite3 trace, /proc). Dev-only — lives in
-harness/, never shipped, never imported by src/.
+Core is stdlib only. The profiler backend is **pluggable** so a dev can point any
+tool at the same workload — see harness/requirements-dev.txt (and harness/debug.py
+for stepping through with pdb/debugpy). Dev-only: lives in harness/, never shipped.
 
     from harness.driver import Driver
     from harness.diagnostics import profile
 
     d = Driver(settings_overrides={"battle.cards_per_round": 1})
-    with profile(d, label="10k battles", memory=True) as report:
+    with profile(d, label="10k battles", memory=True) as report:   # backend="cprofile"
         for _ in range(10_000):
             d.answer("good")
             if d.services.enemy_pokemon.hp <= 0:
                 d.catch()
-    report.print()           # human-readable; report.as_dict() for assertions
+    report.print()                       # human-readable; report.as_dict() for assertions
+
+    # swap the engine — same workload, different tool (needs `pip install pyinstrument`):
+    with profile(d, backend="pyinstrument") as report: ...
 """
 
 from __future__ import annotations
 
-import cProfile
 import gc
 import io
 import os
-import pstats
 import re
 import time
 import tracemalloc
 from contextlib import contextmanager
 
-# Group statements that differ only by literal values, so an N+1 collapses to one
-# row with a big count (string literals + bare numbers -> '?', whitespace squashed).
 _NORM = [
     (re.compile(r"'[^']*'"), "?"),
     (re.compile(r"\b\d+\b"), "?"),
@@ -55,7 +55,6 @@ def _normalize(sql: str) -> str:
 
 
 def _rss_mb() -> float:
-    """Current process resident set size in MiB (Linux /proc; resource fallback)."""
     try:
         with open("/proc/self/statm") as f:
             resident_pages = int(f.read().split()[1])
@@ -69,25 +68,27 @@ def _rss_mb() -> float:
 
 
 class Report:
-    def __init__(self, label: str = "run"):
+    def __init__(self, label: str = "run", backend: str = "cprofile"):
         self.label = label
+        self.backend = backend
         self.wall_seconds = 0.0
         self.queries: dict[str, int] = {}
         self.query_total = 0
         self.rss_start = 0.0
         self.rss_end = 0.0
-        self.tracemalloc_top: list[tuple[str, float, int]] = []  # (location, kb_growth, count)
-        self.cprofile_top: list[tuple[str, int, float, float]] = []  # (func, ncalls, tot, cum)
+        self.tracemalloc_top: list[tuple[str, float, int]] = []
+        self.cprofile_top: list[tuple[str, int, float, float]] = []  # cProfile backend
+        self.profile_text: str = ""  # text-tree backends (e.g. pyinstrument)
 
     def as_dict(self) -> dict:
-        top_q = sorted(self.queries.items(), key=lambda kv: -kv[1])[:15]
         return {
             "label": self.label,
+            "backend": self.backend,
             "wall_seconds": round(self.wall_seconds, 3),
             "db": {
                 "total_queries": self.query_total,
                 "distinct_statements": len(self.queries),
-                "by_statement": top_q,
+                "by_statement": sorted(self.queries.items(), key=lambda kv: -kv[1])[:15],
             },
             "memory": {
                 "rss_start_mb": round(self.rss_start, 1),
@@ -96,11 +97,12 @@ class Report:
                 "tracemalloc_top": self.tracemalloc_top,
             },
             "cprofile_top": self.cprofile_top,
+            "profile_text": self.profile_text,
         }
 
     def print(self) -> None:
         d = self.as_dict()
-        print(f"\n=== diagnostics: {d['label']} ===")
+        print(f"\n=== diagnostics: {d['label']}  (backend={d['backend']}) ===")
         print(f"wall: {d['wall_seconds']}s  (includes profiler overhead)")
         db = d["db"]
         print(f"\nDB queries: {db['total_queries']} total, {db['distinct_statements']} distinct")
@@ -110,23 +112,74 @@ class Report:
         print(f"\nRSS: {m['rss_start_mb']} -> {m['rss_end_mb']} MB  (delta {m['rss_delta_mb']:+} MB)")
         for loc, kb, cnt in m["tracemalloc_top"]:
             print(f"  +{kb:>9.1f} KB  ({cnt:+} objs)  {loc}")
-        if d["cprofile_top"]:
+        if d["profile_text"]:
+            print(f"\n{d['backend']}:")
+            print(d["profile_text"])
+        elif d["cprofile_top"]:
             print("\ncProfile (top by cumulative time):")
             for func, ncalls, tot, cum in d["cprofile_top"]:
                 print(f"  cum={cum:7.3f}s  tot={tot:7.3f}s  calls={ncalls:>9}  {func}")
         print()
 
 
+# --- pluggable profiler backends --------------------------------------------
+# Each backend is (start() -> handle, stop(handle, report, top)). Add one here and
+# it's usable as profile(..., backend="name"). DB-query/memory/wall are captured
+# around the backend, so every tool gets them for free.
+
+def _start_cprofile():
+    import cProfile
+    pr = cProfile.Profile()
+    pr.enable()
+    return pr
+
+
+def _stop_cprofile(pr, rep, top):
+    import pstats
+    pr.disable()
+    ps = pstats.Stats(pr, stream=io.StringIO())
+    rows = [
+        (f"{os.path.basename(fn[0])}:{fn[1]}({fn[2]})", nc, tt, ct)
+        for fn, (cc, nc, tt, ct, callers) in ps.stats.items()
+    ]
+    rows.sort(key=lambda r: -r[3])
+    rep.cprofile_top = rows[:top]
+
+
+def _start_pyinstrument():
+    from pyinstrument import Profiler  # optional: pip install pyinstrument
+    pr = Profiler()
+    pr.start()
+    return pr
+
+
+def _stop_pyinstrument(pr, rep, top):
+    pr.stop()
+    rep.profile_text = pr.output_text(unicode=False, color=False, show_all=False)
+
+
+_BACKENDS = {
+    "cprofile": (_start_cprofile, _stop_cprofile),
+    "pyinstrument": (_start_pyinstrument, _stop_pyinstrument),
+    "none": (lambda: None, lambda h, rep, top: None),
+}
+
+
 @contextmanager
-def profile(driver, label: str = "run", memory: bool = False, cprofile: bool = True, top: int = 15):
+def profile(driver, label: str = "run", memory: bool = False, backend: str = "cprofile", top: int = 15):
     """Profile the workload run inside the ``with`` block. Yields a Report.
 
+    backend: "cprofile" (default, stdlib), "pyinstrument" (pip), or "none".
+             An unknown/uninstalled backend falls back to cProfile with a note.
     memory=True adds tracemalloc top-allocator tracking (heavier; great for leaks).
-    cprofile=False skips the function profiler (lower overhead, keeps query counts).
     """
-    rep = Report(label)
+    if backend not in _BACKENDS:
+        print(f"diagnostics: unknown backend {backend!r}; using cprofile")
+        backend = "cprofile"
+    start, stop = _BACKENDS[backend]
+    rep = Report(label, backend)
 
-    # 1) Exact DB query counting via the sqlite trace callback on the live connection.
+    # DB query counting via the sqlite trace callback on the live connection.
     conn = None
     try:
         conn = driver.services.db._get_connection()
@@ -144,7 +197,6 @@ def profile(driver, label: str = "run", memory: bool = False, cprofile: bool = T
         except Exception:
             conn = None
 
-    # 2) Memory baselines (after a gc so the delta reflects retained, not churn).
     gc.collect()
     rep.rss_start = _rss_mb()
     snap0 = None
@@ -152,16 +204,24 @@ def profile(driver, label: str = "run", memory: bool = False, cprofile: bool = T
         tracemalloc.start(20)
         snap0 = tracemalloc.take_snapshot()
 
-    pr = cProfile.Profile() if cprofile else None
+    # Start the profiler backend (fall back to cprofile if its package is missing).
+    try:
+        handle = start()
+    except Exception as e:
+        print(f"diagnostics: backend {backend!r} unavailable ({e}); using cprofile")
+        backend, (start, stop) = "cprofile", _BACKENDS["cprofile"]
+        rep.backend = "cprofile"
+        handle = start()
+
     t0 = time.perf_counter()
-    if pr:
-        pr.enable()
     try:
         yield rep
     finally:
-        if pr:
-            pr.disable()
         rep.wall_seconds = time.perf_counter() - t0
+        try:
+            stop(handle, rep, top)
+        except Exception as e:
+            print(f"diagnostics: backend {backend!r} stop failed: {e}")
 
         if memory and snap0 is not None:
             snap1 = tracemalloc.take_snapshot()
@@ -176,12 +236,3 @@ def profile(driver, label: str = "run", memory: bool = False, cprofile: bool = T
                 conn.set_trace_callback(None)
             except Exception:
                 pass
-
-        if pr:
-            ps = pstats.Stats(pr, stream=io.StringIO())
-            rows = [
-                (f"{os.path.basename(fn[0])}:{fn[1]}({fn[2]})", nc, tt, ct)
-                for fn, (cc, nc, tt, ct, callers) in ps.stats.items()
-            ]
-            rows.sort(key=lambda r: -r[3])  # by cumulative time
-            rep.cprofile_top = rows[:top]

--- a/harness/requirements-dev.txt
+++ b/harness/requirements-dev.txt
@@ -1,0 +1,21 @@
+# Optional DEV-ONLY tooling for the harness.
+#
+# Install into a VENV — never make these add-on dependencies. The shipped
+# .ankiaddon is built from src/Ankimon/ only and MUST stay dependency-free, or
+# normal users' installs break. These are a *developer's* analysis/debug tools,
+# pointed at a Driver workload from harness/ (which never ships).
+#
+#     python3 -m venv .venv
+#     .venv/bin/pip install -r harness/requirements-dev.txt
+#
+# None of this is needed for the core Tier-1 harness (stdlib only — runs anywhere).
+# Each line is an optional tool you can point at the same headless session:
+
+pyinstrument      # low-overhead statistical call-tree profiler — diagnostics(backend="pyinstrument")
+scalene           # line-level CPU + memory profiler (separates Python vs native time)
+memray            # allocation tracking + flamegraphs (real leak hunting)
+py-spy            # sampling profiler that attaches to a running PID — no code changes
+line_profiler     # per-line timing for @profile-decorated hot functions
+objgraph          # object reference graphs — "what is keeping this alive?"
+debugpy           # DAP debug server for VS Code / PyCharm — see harness/debug.py
+pytest            # run tests/ ; add pytest-benchmark for microbenchmarks

--- a/harness/scenarios/profile_battles.py
+++ b/harness/scenarios/profile_battles.py
@@ -1,0 +1,35 @@
+"""
+harness/scenarios/profile_battles.py [N] — profile N battle answers.
+
+Drives N "good" answers (resolving each wild Pokemon as it faints) under the
+diagnostics profiler, then prints DB-query counts, cProfile hotspots, memory, and
+wall time. The query counts + cProfile shape are hardware-independent; treat the
+wall time / RSS as indicative on this box.
+
+    python3 harness/scenarios/profile_battles.py 2000
+    python3 harness/scenarios/profile_battles.py 10000   # the "10k battles" run
+"""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+
+from harness.driver import Driver
+from harness.diagnostics import profile
+
+
+def main(n: int = 2000):
+    d = Driver(settings_overrides={"battle.cards_per_round": 1})
+    with profile(d, label=f"{n} battles", memory=True) as report:
+        for _ in range(n):
+            d.answer("good")
+            if d.services.enemy_pokemon.hp <= 0:   # in-memory check (no DB query)
+                d.catch()                          # resolve + spawn the next wild Pokemon
+    report.print()
+    return report
+
+
+if __name__ == "__main__":
+    n = int(sys.argv[1]) if len(sys.argv) > 1 else 2000
+    main(n)


### PR DESCRIPTION
Stacked on `feat/headless-core-agent-harness` (PR #492). Turns the harness into a
first-class, **extensible** debug/profiling surface — because it's a plain Python
process driving the real game code, any analysis/debug tool that works on Python
plugs into the same `Driver` workload.

## 1. Workload profiler (`harness/diagnostics.py`)

```python
from harness.diagnostics import profile
with profile(d, label="10k battles", memory=True) as report:   # backend="cprofile"
    for _ in range(10_000):
        d.answer("good")
        if d.services.enemy_pokemon.hp <= 0: d.catch()
report.print()
```
…or `python3 harness/scenarios/profile_battles.py 10000`. Reports: **DB queries**
(total + grouped by normalized statement — an N+1/rescan = one big-count row, via the
`sqlite3` trace callback), **profiler hotspots**, **memory** (RSS delta + optional
`tracemalloc` top allocators), **wall time**.

## 2. Pluggable profiler backends
`profile(d, backend="pyinstrument")` swaps the engine. `"cprofile"` (stdlib, default)
and `"pyinstrument"` (optional pip) ship; an unknown/uninstalled backend falls back to
cProfile with a note. DB-query counting + memory + wall are captured around *any*
backend. Adding one is a 2-function entry.

## 3. Live debugging (`harness/debug.py`)
Set breakpoints in `src/Ankimon` and step through a *simulated* review — no Anki:
```bash
python3 -m pdb harness/scenarios/smoke_play.py                                       # stdlib
python3 -m debugpy --listen 5678 --wait-for-client harness/scenarios/smoke_play.py  # VS Code/DAP
# or:  from harness.debug import wait_for_client; wait_for_client()
```

## 4. Optional tooling manifest (`harness/requirements-dev.txt`)
pyinstrument, scalene, memray, py-spy, line_profiler, objgraph, debugpy — into a **venv**.

## It already found real things
An 800-battle run surfaced two targets unprompted; pyinstrument independently localized one:
- **`copy.deepcopy` dominates battle CPU** (~686/battle, >50% of time).
- **~22 `INSERT OR REPLACE INTO config` writes per battle** → traced to `Settings.set →
  save_config → save_all_config → Connection.commit` in the hot path.

## Honest limits & safety
Query counts + profiler **shape** are hardware-independent (the *where*/*how-it-scales*);
**wall/RSS are indicative on this box only**, not felt latency; profiles the data/logic
layer, not Qt rendering. **Core is stdlib-only**; tools live in a venv + `harness/`,
**never** as add-on deps — **zero `src/` changes**. Existing probes + `tests/test_headless_harness.py` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
