### PR TITLE
perf(settings): persist only the changed key on set (63x fewer config writes/battle)

### DIFF
--- a/src/Ankimon/pyobj/database_manager.py
+++ b/src/Ankimon/pyobj/database_manager.py
@@ -722,6 +722,19 @@ class AnkimonDB:
         conn.commit()
         return True
 
+    def set_config_value(self, key: str, value: Any) -> bool:
+        """Upsert a SINGLE config key (incremental). Avoids rewriting all ~60 config
+        rows on every Settings.set — the battle loop awards cash per review, so the
+        old save_all_config path rewrote the whole table dozens of times per battle."""
+        str_value = json.dumps(value) if isinstance(value, (dict, list, bool)) else str(value)
+        conn = self._get_connection()
+        conn.execute(
+            "INSERT OR REPLACE INTO config (key, value) VALUES (?, ?)",
+            (key, str_value),
+        )
+        conn.commit()
+        return True
+
     def has_config(self) -> bool:
         """Checks if config data exists in the database."""
         cursor = self.execute("SELECT COUNT(*) FROM config")

--- a/src/Ankimon/pyobj/settings.py
+++ b/src/Ankimon/pyobj/settings.py
@@ -176,31 +176,49 @@ class Settings:
                 print(f"Ankimon: Failed to save config to database: {e}")
 
         # 2. Also save to obfuscated file if it exists (legacy support)
-        # Note: Once moved to the archive folder, this will no longer be found here.
-        obfuscated_config_path = user_path / "config.obf"
-        if obfuscated_config_path.is_file():
-            try:
-                # Imported lazily, and only when a legacy config.obf is present, so
-                # this module never drags in ankimon_sync (and thus aqt) at import.
-                from ..pyobj.ankimon_sync import AnkimonDataSync
-                sync_handler = AnkimonDataSync()  # Re-use the obfuscation logic
-                obfuscated_str = sync_handler._obfuscate_data(config)
-                warning_message = "WARNING: This file contains important user data. Do not delete or modify this file. Deleting or modifying this file can lead to data loss in the Ankimon addon.\n---"
-                file_content = warning_message + obfuscated_str
-                with open(obfuscated_config_path, "w", encoding="utf-8") as f:
-                    f.write(file_content)
-            except Exception as e:
-                print(f"Ankimon: Could not save obfuscated config: {e}")
-
         self.config = config
+        self._save_legacy_obf_if_present()
         self.compute_gui_config()
+
+    def _save_legacy_obf_if_present(self):
+        """Mirror self.config into a legacy config.obf, only if one still exists
+        (pre-migration profiles). Migrated profiles archived it, so this is a no-op.
+        Note: once moved to the archive folder this file is no longer found here."""
+        obfuscated_config_path = user_path / "config.obf"
+        if not obfuscated_config_path.is_file():
+            return
+        try:
+            # Imported lazily, and only when a legacy config.obf is present, so this
+            # module never drags in ankimon_sync (and thus aqt) at import time.
+            from ..pyobj.ankimon_sync import AnkimonDataSync
+            sync_handler = AnkimonDataSync()  # Re-use the obfuscation logic
+            obfuscated_str = sync_handler._obfuscate_data(self.config)
+            warning_message = "WARNING: This file contains important user data. Do not delete or modify this file. Deleting or modifying this file can lead to data loss in the Ankimon addon.\n---"
+            file_content = warning_message + obfuscated_str
+            with open(obfuscated_config_path, "w", encoding="utf-8") as f:
+                f.write(file_content)
+        except Exception as e:
+            print(f"Ankimon: Could not save obfuscated config: {e}")
 
     def get(self, key, default=None):
         return self.config.get(key, default)
 
     def set(self, key, value):
         self.config[key] = value
-        self.save_config(self.config)
+        # Persist ONLY the changed key. The previous implementation re-saved the
+        # entire config (~60 rows + a commit) on every set; the battle loop awards
+        # cash per review, so a single battle rewrote all of config dozens of times.
+        if services.db is not None:
+            try:
+                services.db.set_config_value(key, value)
+            except Exception as e:
+                print(f"Ankimon: Failed to save config key '{key}': {e}")
+        else:
+            # No DB yet (very early boot / legacy) — fall back to the full save.
+            self.save_config(self.config)
+            return
+        self._save_legacy_obf_if_present()
+        self.compute_gui_config()
 
     def compute_gui_config(self):
         # Manage conditional GUI settings


### PR DESCRIPTION
Stacked on `feat/headless-core-agent-harness` (PR #492). **A real perf bug the harness
found, fixed, and verified** — the full find → fix → prove loop the harness exists for.

## The bug
`Settings.set(key, value)` → `save_config()` → `save_all_config(config)`, which rewrites
**every** config row (~60) and commits — on **every single `set()`**. The battle loop
awards cash per review (`battle_loop.py`: sets `trainer.cash` + `trainer.cash_earned_today`
each card), so one battle rewrote the entire config table dozens of times.

## Measured (headless profiler + sqlite trace)
10 battles → 21 `set()` calls × 63 keys = **1,323 `INSERT OR REPLACE INTO config`**.
**After: 21** (one per changed key) — a **63× reduction** in config-row writes per battle.
Per-set commit count is unchanged, so durability semantics are preserved.

## The fix
- `database_manager.set_config_value(key, value)` — single-key upsert.
- `Settings.set()` persists just the changed key via it; the legacy `config.obf` mirror is
  factored into `_save_legacy_obf_if_present()` (kept for pre-migration profiles) and
  `compute_gui_config()` still runs. Falls back to the full `save_config()` if the DB isn't
  up yet. No behavior change beyond *how much* gets written.

## Verified
- config writes **1,323 → 21** over 10 battles.
- `trainer.cash` still accrues correctly (400) and **persists** (in-memory == on-disk).
- Tier-1 probes + smoke + headless test green (the `test_headless_harness` ~12% flake is
  pre-existing and unrelated — it's unseeded-RNG "nothing fainted", confirmed by 20-run A/B
  on unmodified vs fixed code: 18/20 vs 17/20. Fixing that flake is a separate PR).

## ⚠️ Also live on `main`
`main`'s `Settings.set` is identical, so **every current user pays this** (every cash-earning
review rewrites all config + commits — real disk churn, worse on a Pi or a synced profile).
Recommend a backport to `main` (same logic, via main's `mw.ankimon_db` idiom). I kept this PR
on the verified headless branch rather than ship an unverified change straight to production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
