### PR TITLE
fix(harness): make smoke_play / the headless gate deterministic (kill ~12% flake)

### DIFF
--- a/harness/scenarios/smoke_play.py
+++ b/harness/scenarios/smoke_play.py
@@ -17,7 +17,15 @@ sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[2]))
 from harness.driver import Driver
 
 
-def run(max_answers: int = 60, target_resolutions: int = 4, verbose: bool = True):
+def run(max_answers: int = 120, target_resolutions: int = 4, verbose: bool = True, seed=7):
+    # Deterministic by default: wild encounters + battles use the global `random`,
+    # and the weak starter sometimes rolls its 0-damage move, so an unseeded run can
+    # fail to faint enough enemies in time (~12% flake). Seeding makes this a stable
+    # CI gate; pass seed=None to fuzz with fresh randomness instead.
+    if seed is not None:
+        import random
+        random.seed(seed)
+
     # cards_per_round=1 → a battle turn on every answer; manual mode → we decide
     # whether to catch or defeat each fainted Pokemon.
     d = Driver(settings_overrides={


### PR DESCRIPTION
Stacked on `feat/headless-core-agent-harness` (PR #492). Removes a **pre-existing ~12%
flake** in `smoke_play` — which matters because that scenario is both the headless
regression test and the Tier-1 CI gate (PR #499). A gate that false-fails erodes trust.

## Root cause
`smoke_play` drives "good" answers against the weak default starter (`Please Restart
Anki`). On a "good" answer the main attacks, but it sometimes rolls its **0-damage move
(Transform)** — so with unseeded RNG it occasionally fails to faint enough wild Pokemon
within `max_answers`, raising `AssertionError: nothing fainted`.

I confirmed it's **pre-existing**, not caused by any logic change, with a 20-run A/B on
unmodified vs the (separate) settings fix: 18/20 vs 17/20 — statistically identical.

## Fix
- **Seed the global RNG by default** (`seed=7`) so the run is deterministic and reliably
  reaches its target resolutions. Pass `seed=None` to fuzz with fresh randomness (the old
  behavior, still available for ad-hoc exploration).
- Raise `max_answers` 60 → 120 for headroom.

## Verified
- **25/25 green** (was ~12% flaky).
- Still runs as a script (`python3 harness/scenarios/smoke_play.py`).
- `seed=None` still fuzzes.

Found while fixing the per-battle config-write bug (#500) — the harness surfacing a
weakness in its own gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
