### PR TITLE
fix(mobile): repair 4 regressions from the #496 resolve refactor (+ full review)

### DIFF
--- a/src/Ankimon/functions/mobile_sync.py
+++ b/src/Ankimon/functions/mobile_sync.py
@@ -863,17 +863,13 @@ def run_mobile_battles(
     from ..pyobj.pokemon_obj import PokemonObject
     from ..singletons import get_evo_window
 
-    print(">>> run_mobile_battles: before _compute_initial_reviews", flush=True)
     initial_reviews = _compute_initial_reviews(
         db,
         tracker,
         day_cutoff
     )
-    print(">>> run_mobile_battles: before TempTracker", flush=True)
     temp_tracker = TempTracker(initial_reviews)
-    print(">>> run_mobile_battles: before load_active_team_clones", flush=True)
     team_clones = load_active_team_clones(db, settings_obj, main_pokemon)
-    print(">>> run_mobile_battles: after load_active_team_clones", flush=True)
     main_pokemon_clone = team_clones[0] if team_clones else None
 
     main_pokemon_level = 5
@@ -1042,6 +1038,7 @@ def run_mobile_battles(
                                 if isinstance(_collected_pokemon_ids, set): _collected_pokemon_ids.add(current_enemy_pokemon.id)
                             except Exception: pass
                             caught_pokemon_list.append(pkmn_info)
+                            caught_count += 1  # else resolveAll/the UI report "0 caught"
                             last_outcome = "caught"
                         else:
                             caught_pokemon.append(pkmn_info)
@@ -1402,16 +1399,9 @@ def commit_replay_outcome(choice: str, outcome_data: dict, db, settings_obj, tra
             if companion_id and (total_xp > 0 or any(accumulated_evs.values())):
                 _attribute_xp_and_evs_to_companion(companion_id, total_xp, accumulated_evs, settings_obj, db=db, logger=logger)
 
-            if total_xp > 0 and main_pokemon and companion_id == main_pokemon.individual_id:
-                # Add main_pokemon.pokemon_defeated increment
-                main_pokemon.pokemon_defeated += 1
-                try:
-                    mp_data = db.get_main_pokemon()
-                    if mp_data:
-                        mp_data["pokemon_defeated"] = main_pokemon.pokemon_defeated
-                        db.save_main_pokemon(mp_data)
-                except Exception:
-                    pass
+            # NOTE: pokemon_defeated is already incremented (DB row + in-memory
+            # singleton) by _attribute_xp_and_evs_to_companion above. Incrementing it
+            # again here double-counted the active companion's defeats on replay.
 
             if total_trainer_xp > 0 and trainer_card:
                 new_txp = int(settings_obj.get("trainer.xp", 0) + total_trainer_xp)
@@ -1553,7 +1543,13 @@ def _resolve_internal(mode="all", companion_id="", limit=None, db=None, settings
     finally:
         if use_transaction:
             conn._disable_commit = False
+            # Reset the bulk-resolve flag. If this is dropped, in_bulk_resolve
+            # stays True for the rest of the session and silently suppresses
+            # level-up tooltips, evolution prompts and learn-move dialogs in
+            # normal desktop play (encounter_functions / pokedex_functions gate
+            # those on `not in_bulk_resolve`).
             from .. import utils
+            utils.in_bulk_resolve = False
 
 
 def _attribute_xp_and_evs_to_companion(companion_id: str, xp_gained: int, ev_yield_gained: dict, settings_obj, battles_fought=1, db=None, logger=None) -> None:


### PR DESCRIPTION
Takes on **issue #496**: a comprehensive correctness review of the mobile-resolve
refactor (steps 1-5) **+ fixes for the real regressions it found.** Targets this branch
directly so the fixes land where the refactor lives.

## TL;DR
The refactor itself is **sound** — the dedup/relocation/unification preserved behavior
in almost every dimension (verified below). But four regressions slipped in from lines
dropped during the move; this PR fixes them. A handful of smaller items are flagged for
your call (not changed here).

## ✅ Fixed in this PR (`functions/mobile_sync.py`)
| # | Sev | Bug |
|---|-----|-----|
| 1 | **HIGH** | `in_bulk_resolve` was set True but **never reset** (the `finally` imported `utils` then dropped `utils.in_bulk_resolve = False`). After one mobile auto-resolve it stays True all session, **silently suppressing level-up tooltips, evolution prompts and learn-move dialogs in normal desktop play** (gated on `not in_bulk_resolve` in encounter_functions/pokedex_functions). Restored the reset. |
| 2 | **HIGH** | `caught_count` never incremented in the commit path → auto-resolve always reported **"0 caught"** while the caught list was populated (contradictory UI; mons were actually caught). Restored `caught_count += 1`. |
| 3 | MED | `pokemon_defeated` **double-counted** for the active companion on replay-defeat (`commit_replay_outcome` incremented it after `_attribute_xp_and_evs_to_companion` already did, on both the DB row and the in-memory main). Removed the redundant block. |
| 4 | LOW | Removed 4 leftover `print(">>> run_mobile_battles…")` debug lines that spammed stdout on every resolve/estimate. |

## 🔎 Flagged for your call (NOT changed here)
- **MED — lost catch-all error handling.** The old resolve path wrapped its body in `try/except → {"success": False, "error": …}`; the unified `run_mobile_battles`/`_resolve_internal` only have `try/finally`, so an exception now propagates out of the `@pyqtSlot` and the QWebChannel call returns null to JS (no error shown) instead of an error dict.
- **MED — `utils.limit_ev_yield` can now raise** (`ValueError`/`KeyError`) on a companion whose stored `ev` dict has a stray/missing key (the old local copy used `.get(...,0)` and never raised). Combined with the item above, one malformed companion aborts the whole batch. (The switch to the canonical helper is otherwise the intended alignment with desktop.)
- **MED — dry-run "encounters" estimate drift** (estimate-only, real rewards unaffected): the estimate now bases on `resolved_encounters` and stopped accumulating `current_encounter_reviews`, skewing the >100-review extrapolation.
- **MED (test quality) — two tests downgraded** from real `PokemonObject` to `FakePokemon` (`test_commit_replay_outcome_override_companion`, `test_auto_resolve_xp_attribution_multi_companion`), weakening coverage vs the commit's "real fakes" goal.
- **LOW — mock-detection guards relocated, not removed**: `singletons.py` `FakeEvoWindow` gated on `PYTEST_CURRENT_TEST`/`"mock" in mw.__class__` and `menu_buttons.py` similar. Gated so no runtime bug, but it's the "test scaffolding in production" pattern #496 aimed to remove.
- **LOW (perf) — `sync_resolutions_to_other_db` per-review** instead of per-batch (opens N connections to the other DB). Idempotent, just inefficient.

## Verified faithful (no regression) — reassurance
XP/EV/cash math (the old 3-way rounding drift is genuinely unified; multiplication is
associative), catch-vs-defeat + `auto_battle_setting` (Manual→mode 3) + wishlist/legendary/shiny,
**commit-gating** (dry-run mutates nothing; real path writes), deterministic seeding
(preview == committed result), the 100-review cap/extrapolation, companion selection +
multi-companion XP/EV attribution, faint/HP/revive parity, DB SQL (parameterized, safe) +
transactions, the Python-3.9 annotation fix (correct **and** complete), step-5 import hoisting
(no new cycle), `FakeEvoWindow`/`menu_buttons` (safe), and the MagicMock-guard removals (all
purely test scaffolding — no new production crash).

## Verification & limits
Verified on this headless ARM box: `py_compile` OK, `ruff check` clean, and the
WebEngine-free test subset unchanged (no new failures from these edits). The **full mobile
suite needs QtWebEngine**, which can't load here (no Chromium native libs; `apt` unavailable)
— and `integrity_tests.yml` only runs on PRs **to main**, so it won't run on this PR either.
**Please run `pytest tests/test_mobile_*.py` once on a desktop / x86 CI** to confirm the green
baseline (the failures here are 100% the WebEngine import wall, identical before and after the
refactor — not logic). The review above is static + the 6 Qt-free tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
