### PR TITLE
fix(mobile): restore relative imports + per-encounter heal (4 resolve regressions)

### DIFF
--- a/src/Ankimon/functions/mobile_sync.py
+++ b/src/Ankimon/functions/mobile_sync.py
@@ -1576,8 +1576,8 @@ def _attribute_xp_and_evs_to_companion(companion_id: str, xp_gained: int, ev_yie
     if not pkmndata:
         return
 
-    from Ankimon.functions.pokemon_functions import find_experience_for_level, get_levelup_move_for_pokemon
-    from Ankimon.functions.drawing_utils import tooltipWithColour
+    from .pokemon_functions import find_experience_for_level, get_levelup_move_for_pokemon
+    from .drawing_utils import tooltipWithColour
     from ..pyobj.pokemon_obj import PokemonObject
     from .. import utils
 
@@ -1639,7 +1639,7 @@ def _attribute_xp_and_evs_to_companion(companion_id: str, xp_gained: int, ev_yie
                         tooltipWithColour(msg_learn, color)
                 elif new_attack not in attacks:
                     if is_active and not in_bulk:
-                        from Ankimon.pyobj.reviewer_obj import AttackDialog
+                        from ..pyobj.attack_dialog import AttackDialog
                         from PyQt6.QtWidgets import QDialog
                         dialog = AttackDialog(attacks, new_attack)
                         if dialog.exec() == QDialog.DialogCode.Accepted:

--- a/src/Ankimon/functions/mobile_sync.py
+++ b/src/Ankimon/functions/mobile_sync.py
@@ -151,6 +151,29 @@ def _normalize_ev_yield(raw: dict) -> dict:
     }
     return {mapping.get(k.lower(), k.lower()): v for k, v in raw.items()}
 
+def _heal_to_full(p) -> None:
+    """Restore a companion clone to full HP and clear its battle bonuses.
+
+    Run after every resolved encounter so each encounter begins with the
+    companion at full health — exactly the way manual replay behaves (it reloads
+    the team fresh on every call). Without this heal, damage carries across
+    encounters, so battle length (and therefore the encounter count and the seed
+    of every subsequent encounter) starts to depend on how many companions are
+    active and on the odd/even fainting-revival cycle, and the preview /
+    auto-resolve / manual-replay sequences drift apart.
+    """
+    if p is None:
+        return
+    max_hp_val = getattr(p, "max_hp", 100)
+    if isinstance(max_hp_val, (int, float)):
+        p.hp = max_hp_val
+        if hasattr(p, "current_hp"):
+            p.current_hp = max_hp_val
+    try:
+        p.reset_bonuses()
+    except Exception:
+        pass
+
 def detect_mobile_reviews(col, watermark_ms: int, desktop_revlog_ids: frozenset[int]) -> list[dict]:
     """
     Returns revlog rows that are:
@@ -1100,9 +1123,7 @@ def run_mobile_battles(
                     reviews_spent_for_resolved += current_encounter_reviews
                     resolved_encounters += 1
                     current_enemy_pokemon = None
-                    if main_pokemon_clone:
-                        try: main_pokemon_clone.reset_bonuses()
-                        except Exception: pass
+                    _heal_to_full(main_pokemon_clone)
 
                 elif isinstance(companion_hp, (int, float)) and companion_hp <= 0:
                     if commit:
@@ -1130,9 +1151,7 @@ def run_mobile_battles(
                     reviews_spent_for_resolved += current_encounter_reviews
                     resolved_encounters += 1
                     current_enemy_pokemon = None
-                    if main_pokemon_clone:
-                        try: main_pokemon_clone.reset_bonuses()
-                        except Exception: pass
+                    _heal_to_full(main_pokemon_clone)
         
         if commit and current_enemy_pokemon is not None:
             # Insert history for escaped / unfinished battle


### PR DESCRIPTION
## What

Restores the Mobile & Web Reviews feature to its behaviour at the last known-good commit `b5c80084`. The #496 resolve-engine refactor (and follow-ups) introduced **two** regressions that account for **all four** smoke-test symptoms. One commit per fix.

## Regression 1 — absolute imports (`16403933`)

Moving `_attribute_xp_and_evs_to_companion` from `shop_obj.py` into `functions/mobile_sync.py` converted three imports to absolute form:

```python
from Ankimon.functions.pokemon_functions import …
from Ankimon.functions.drawing_utils  import tooltipWithColour
from Ankimon.pyobj.reviewer_obj       import AttackDialog
```

Anki loads the addon under its install-folder package name, **not** `Ankimon`, so each raised `ModuleNotFoundError: No module named 'Ankimon'`. Restored to relative form; `AttackDialog` repointed at its real module `..pyobj.attack_dialog` (the path every other caller uses — `reviewer_obj` never exported it).

- **Symptom 1** — crash on **Defeat** in manual replay (`commit_replay_outcome` → `_attribute_xp_and_evs_to_companion`).
- **Symptom 4** — **Auto-Resolve All** errored whenever a non-main companion won a battle (the commit path calls the same function).

The test suite can't catch this because `conftest` registers a real `Ankimon` package stub; the failure only manifests inside Anki.

## Regression 2 — dropped per-encounter heal (`fc8260f3`)

The original dry-run estimator reset the companion's HP to full after every encounter; the unify into `run_mobile_battles` dropped it (left only `reset_bonuses()`), so damage carried across encounters in **both** preview and auto-resolve. Restored via a shared `_heal_to_full()` helper.

- **Symptom 2** — the best companion accumulates damage, faints, and weaker members cycle in (revive once all faint), so battle lengths — and therefore the extrapolated encounter count — depend on active-team size/parity. Repro (300 reviews, 1 strong + 2 weak companions): preview count `51 / 57 / 75` for `3 / 2 / 1` active members → stable `75 / 75 / 75` after the fix.
- **Symptom 3** — manual replay reloads the team fresh each call, so preview/auto-resolve drifted from it. After the fix, **preview == auto-resolve == manual replay** produce an identical species/level/shiny sequence (verified across all three modes).

## Deliberately not changed

- Enemy level = `max(active-team)` is canonical (covered by baseline test `test_enemy_level_uses_team_max_not_main_pokemon`); the team-toggle instability the user hit is the HP-cycling count swing, fixed by Regression 2.
- Reward caps `[5,250]` / `[10,2000]` are settings ranges (UI-enforced), never inline — nothing dropped.
- The deferred `sync_resolutions_to_other_db` / `singletons.py` mock-guard items (out of scope).

## Verification

- Test suite unchanged at **223 passed** (mobile: `test_mobile_sync` 28/28, `test_mobile_auto_resolve` 10/10, `test_mobile_replay` 6/6).
- Auto-resolve to a **non-main** best companion completes and awards XP correctly (ace companion XP 0 → 349, all battles resolved, badge → 0).
- End-to-end: preview / auto-resolve / manual replay produce identical encounter sequences; encounter count is stable across active-team size; Defeat/Catch award the correct companion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)