### PR TITLE
feat(harness): mega_fuzz + feature_check + extra probes + WebEngine + fidelity

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,8 @@ venv/
 # harness/setup_tier2.sh. Large + machine-specific, never committed.
 .tier2/
 __pycache__/
+# coverage.py artifacts from `harness/check.py --coverage` (dev-only measurement)
+.coverage
+.coverage.*
+htmlcov/
+coverage.xml

--- a/harness/checks/probe_contract.py
+++ b/harness/checks/probe_contract.py
@@ -1,0 +1,110 @@
+"""
+harness/checks/probe_contract.py — the harness's SEAM CONTRACT with Ankimon.
+
+The harness drives the real game code, so it depends on a set of symbols staying
+put: build_core, the service-registry fields, the DB methods, the env functions
+the driver calls, and the pokedex helpers the fixtures build Pokemon from. Those
+are the "fragile edge" — the things an Ankimon refactor (or an Anki API change)
+can move out from under us.
+
+This probe asserts every one of them exists, so drift fails HERE with a clear
+"SEAM MOVED: X" line instead of a deep traceback in the middle of some scenario.
+It's the early-warning the harness needs to stay sturdy across updates.
+
+Run:  python3 harness/checks/probe_contract.py
+"""
+
+import sys
+import os
+
+_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.insert(0, _ROOT)                       # for `harness`
+sys.path.insert(0, os.path.join(_ROOT, "src"))  # for `Ankimon` (before any import)
+
+from harness.driver import Driver
+
+problems = []
+
+
+def need(cond, msg):
+    if not cond:
+        problems.append(msg)
+
+
+def need_methods(obj, names, label):
+    for n in names:
+        need(callable(getattr(obj, n, None)), "SEAM MOVED: %s.%s missing/not callable" % (label, n))
+
+
+def need_attrs(obj, names, label):
+    for n in names:
+        need(hasattr(obj, n), "SEAM MOVED: %s.%s missing" % (label, n))
+
+
+def main():
+    # Boot FIRST: Driver() runs bootstrap() (which installs the Tier-1 import stub)
+    # and build_core(), loading Ankimon's modules into sys.modules — only then do the
+    # introspection imports below resolve (Tier-1 has no real aqt).
+    d = Driver()
+    s, env = d.services, d.env
+
+    # --- core composition (shared with production singletons.py) ---------------
+    from Ankimon import core
+    need_methods(core, ["build_core", "bind_runtime_globals"], "Ankimon.core")
+
+    # --- service registry: the fields core logic + the driver read -------------
+    need_attrs(s, ["db", "settings", "logger", "translator", "main_pokemon",
+                   "enemy_pokemon", "tracker", "trainer_card", "achievements",
+                   "ui", "test_window", "evo_window", "pokemon_pc",
+                   "reviewer"], "services")
+    # the event bus is its own module (not a services field)
+    from Ankimon.events import events as _bus
+    need_methods(_bus, ["emit", "drain", "enable"], "Ankimon.events.events")
+
+    # --- env functions the driver calls (answer/catch/defeat/encounter) --------
+    need_attrs(env, ["catch_pokemon", "kill_pokemon", "new_pokemon",
+                     "on_review_card", "collected_ids"], "env")
+
+    # --- DB methods the harness + fixtures depend on ---------------------------
+    need_methods(s.db, ["get_pokemon", "get_all_pokemon", "get_pokemon_count",
+                        "get_main_pokemon", "save_pokemon", "save_main_pokemon",
+                        "save_team", "get_team", "get_item", "add_item",
+                        "get_all_items", "is_migrated", "migrate_from_json",
+                        "set_config_value", "get_all_config", "execute"], "db")
+
+    # --- settings + tracker surface -------------------------------------------
+    need_methods(s.settings, ["get", "set"], "settings")
+    need_methods(s.tracker, ["review"], "tracker")
+
+    # --- the Driver's own public surface (scenarios/probes call these) ---------
+    need_methods(d, ["answer", "catch", "defeat", "encounter", "set_enemy",
+                     "set_setting", "get_state", "advance_time", "time_of_day"], "Driver")
+
+    # --- pokedex/poke_engine helpers the fixtures build Pokemon from -----------
+    from Ankimon.functions import pokedex_functions as pf
+    need_methods(pf, ["search_pokedex", "search_pokedex_by_id", "get_base_experience",
+                      "get_growth_rate", "get_effort_values", "_load_pokedex_id_index"],
+                 "pokedex_functions")
+    from Ankimon.functions import learnset_retrieval as lr
+    need_methods(lr, ["get_all_pokemon_moves"], "learnset_retrieval")
+    from Ankimon.functions import pokemon_functions as pkf
+    need_methods(pkf, ["pick_random_gender"], "pokemon_functions")
+    from Ankimon import utils as u
+    need_methods(u, ["get_tier_by_id"], "utils")
+    from Ankimon.poke_engine import helpers as h
+    need_methods(h, ["normalize_name"], "poke_engine.helpers")
+    from Ankimon.pyobj.pokemon_obj import PokemonObject
+    need(callable(getattr(PokemonObject, "from_dict", None)), "SEAM MOVED: PokemonObject.from_dict missing")
+    need(callable(getattr(PokemonObject, "to_dict", None)), "SEAM MOVED: PokemonObject.to_dict missing")
+
+    n_checked = 9 + 15 + 5 + 16 + 3 + 9 + 6 + 2  # rough count for the summary line
+    if problems:
+        print("SEAM CONTRACT VIOLATIONS (%d) — the harness's dependencies moved:" % len(problems))
+        for p in problems:
+            print("  - " + p)
+        raise SystemExit(1)
+    print("probe_contract: OK (~%d seams intact)" % n_checked)
+
+
+if __name__ == "__main__":
+    main()

--- a/harness/checks/probe_migration.py
+++ b/harness/checks/probe_migration.py
@@ -1,0 +1,117 @@
+"""
+harness/checks/probe_migration.py — "never lose a save when you UPDATE Ankimon."
+
+Old Ankimon kept progress in JSON files (mypokemon.json, mainpokemon.json,
+items.json, team.json, ...); current Ankimon keeps it in ankimon.db. The one-time
+upgrade that copies JSON -> DB is where silent data loss hurts most — yet it's the
+hardest thing to see, because the harness normally seeds an already-migrated DB.
+
+This probe builds a realistic LEGACY save (JSON files for a box, a main, a team,
+items), runs the JSON->DB migration on a fresh database, and asserts every piece
+of data made it across intact (species, level, moves, item counts) — then re-boots
+a fresh session on the migrated DB to prove the upgraded save is actually playable.
+
+NOTE (finding surfaced 2026-06-23): this exercises DatabaseManager.migrate_from_json(),
+the clean headless migration logic — but that method is currently DEAD CODE. The
+migration real users hit on upgrade is a *duplicate* inlined in the Qt
+MigrationDialog, which can't run headlessly (button-gated inside .exec()).
+Recommended fix: have the dialog call migrate_from_json() so the shipped path
+becomes the tested path. Until then this guards the migration LOGIC, not the exact
+shipped dialog.
+
+Run:  python3 harness/checks/probe_migration.py
+"""
+
+import json
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+
+from harness.driver import Driver
+from harness.fixtures import build_pokemon
+
+
+def _attacks(p):
+    return [str(a).lower() for a in (p.get("attacks") or p.get("moves") or [])]
+
+
+def main():
+    # Boot a fresh (un-migrated) session FIRST: this puts Ankimon on the import
+    # path and gives us an empty database to upgrade INTO.
+    d = Driver()
+    db = d.services.db
+    assert not db.is_migrated(), "a fresh harness DB must start un-migrated"
+
+    # --- Build a realistic LEGACY (pre-DB) save as JSON files ------------------
+    box_specs = [
+        {"species": "Pikachu",   "level": 10, "moves": ["Thunderbolt"]},
+        {"species": "Bulbasaur", "level": 16, "moves": ["Vine Whip", "Tackle"]},
+        {"species": "Squirtle",  "level": 12, "moves": ["Water Gun"]},
+    ]
+    main_spec = {"species": "Gengar", "level": 50, "ability": "Levitate",
+                 "moves": ["Shadow Ball", "Sludge Bomb"]}
+
+    box   = [build_pokemon(s).to_dict() for s in box_specs]
+    main  = [build_pokemon(main_spec).to_dict()]
+    items = [{"item": "great-ball", "quantity": 5}, {"item": "potion", "quantity": 3}]
+    team  = [{"individual_id": main[0]["individual_id"]},
+             {"individual_id": box[0]["individual_id"]}]
+
+    tmp = Path(tempfile.mkdtemp())
+
+    def w(name, obj):
+        p = tmp / name
+        p.write_text(json.dumps(obj), encoding="utf-8")
+        return p
+
+    paths = dict(
+        mypokemon_path=w("mypokemon.json", box),
+        mainpokemon_path=w("mainpokemon.json", main),
+        items_path=w("items.json", items),
+        badges_path=w("badges.json", []),
+        team_path=w("team.json", team),
+    )
+
+    # --- Run the upgrade migration on the fresh database ----------------------
+    stats = db.migrate_from_json(**paths)
+
+    # --- Assert nothing was lost ---------------------------------------------
+    assert db.is_migrated(), "migration must mark the DB migrated"
+    assert stats["pokemon"] == 3 and stats["main"] == 1 and stats["items"] == 2, stats
+    assert db.get_pokemon_count() == 4, ("3 box + 1 main", db.get_pokemon_count())
+
+    loaded_main = db.get_main_pokemon()
+    assert loaded_main and loaded_main.get("name") == "Gengar", loaded_main
+    assert int(loaded_main.get("level")) == 50, loaded_main
+
+    assert (db.get_item("great-ball") or {}).get("quantity") == 5, "great-ball count lost"
+    assert (db.get_item("potion") or {}).get("quantity") == 3, "potion count lost"
+
+    # every box species crossed over with its level + moves intact
+    by_name = {p.get("name"): p for p in db.get_all_pokemon()}
+    for spec in box_specs:
+        got = by_name.get(spec["species"])
+        assert got is not None, ("box Pokemon lost on migration: " + spec["species"], list(by_name))
+        assert int(got.get("level")) == spec["level"], ("level lost", spec["species"], got.get("level"))
+        for mv in spec["moves"]:
+            from Ankimon.poke_engine.helpers import normalize_name
+            assert normalize_name(mv) in _attacks(got), ("move lost", spec["species"], mv, _attacks(got))
+    print("migrated: 3 box + main(Gengar L50) + 2 item stacks + team -> %s" % stats)
+
+    # --- Re-boot on the migrated DB: the upgraded save must be playable --------
+    import shutil
+    saved = os.path.join(tempfile.mkdtemp(), "save.db")
+    shutil.copy(os.path.join(d.env.user_path, "ankimon.db"), saved)
+    st = Driver(db=saved).get_state()
+    assert st["main"]["name"] == "Gengar", ("upgraded save did not boot with the main", st["main"])
+    assert st["collection"]["count"] == 4, ("upgraded save lost collection", st["collection"])
+    print("re-boot on upgraded save -> main=Gengar, collection=4 (playable)")
+
+    print("probe_migration: OK")
+
+
+if __name__ == "__main__":
+    main()

--- a/harness/checks/probe_persistence.py
+++ b/harness/checks/probe_persistence.py
@@ -1,0 +1,90 @@
+"""
+harness/checks/probe_persistence.py — "never lose a save when you restart Anki."
+
+The harness runs ONE session per process, which hides the single biggest class of
+real bug: progress that lives only in memory and vanishes when Anki is closed and
+reopened. This probe PLAYS a session (earns XP + cash, catches Pokemon, defeats
+Pokemon), then copies the ``ankimon.db`` and BOOTS A FRESH SESSION on it — exactly
+what reopening Anki does — and asserts every gameplay change survived the round
+trip. If anything a player earned is lost on reload, it fails loudly and names
+what was lost.
+
+This currently PASSES (persistence works); its job is to keep it that way — any
+future change that drops progress on restart turns this red.
+
+Run:  python3 harness/checks/probe_persistence.py
+"""
+
+import os
+import shutil
+import sys
+import tempfile
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+
+from harness.driver import Driver
+
+# The slice of state a player would be furious to lose on a restart.
+TRACKED = ("count", "cash", "trainer_level", "trainer_xp", "main_xp", "main_level")
+
+
+def _snap(drv):
+    s = drv.get_state()
+    return {
+        "count": s["collection"]["count"],
+        "cash": s["trainer"]["cash"],
+        "trainer_level": s["trainer"]["level"],
+        "trainer_xp": s["trainer"]["xp"],
+        "main_xp": s["main"]["xp"],
+        "main_level": s["main"]["level"],
+    }
+
+
+def _drive(events, what):
+    for e in events:
+        if e["type"] == "error":
+            raise RuntimeError("error event during %s: %r" % (what, e))
+
+
+def main():
+    d = Driver(
+        seed={"main": {"species": "Gengar", "level": 50, "moves": ["Shadow Ball"]}},
+        settings_overrides={"battle.cards_per_round": 1},
+    )
+    before = _snap(d)
+    assert before["count"] == 1, ("expected just the seeded main", before)
+
+    # --- Play: earn XP/cash, then catch 3 and defeat 2 wild Pokemon -----------
+    for _ in range(12):
+        _drive(d.answer("good"), "answer")
+    for sp in ("Pikachu", "Bulbasaur", "Charmander"):
+        d.set_enemy(species=sp, level=5, hp=0)   # force an already-fainted wild
+        _drive(d.catch(), "catch")
+    for sp in ("Rattata", "Pidgey"):
+        d.set_enemy(species=sp, level=5, hp=0)
+        _drive(d.defeat(), "defeat")
+
+    after = _snap(d)
+    # Real, persistent progress actually happened (else the test is vacuous).
+    assert after["count"] == before["count"] + 3, ("expected +3 caught", before, after)
+    assert after["main_xp"] > 0 or after["trainer_xp"] > 0, ("expected XP from defeats", after)
+    print("played: caught 3, defeated 2 -> %s" % after)
+
+    # --- Restart: copy the save, boot a brand-new session on it ---------------
+    saved = os.path.join(tempfile.mkdtemp(), "save.db")
+    shutil.copy(os.path.join(d.env.user_path, "ankimon.db"), saved)
+    reloaded = _snap(Driver(db=saved))
+
+    lost = {k: (after[k], reloaded[k]) for k in TRACKED if after[k] != reloaded[k]}
+    if lost:
+        raise AssertionError(
+            "DATA LOST ON RESTART: "
+            + ", ".join("%s had %r, reloaded %r" % (k, a, b) for k, (a, b) in lost.items())
+        )
+    assert os.path.exists(saved), "source save must be left untouched"
+    print("restart: re-booted on the saved file -> all progress survived %s" % reloaded)
+    print("probe_persistence: OK")
+
+
+if __name__ == "__main__":
+    main()

--- a/harness/fake_aqt.py
+++ b/harness/fake_aqt.py
@@ -284,7 +284,8 @@ def _make_fake_mw(app, user_path):
             self.reviewer = SimpleNamespace(web=_Web(), card=None, mw=self)
             self.taskman = _Taskman()
             self.addonManager = _AddonManager()
-            self.pm = SimpleNamespace(name="headless", profileFolder=lambda: str(user_path))
+            self.pm = SimpleNamespace(name="headless", profileFolder=lambda: str(user_path),
+                                      night_mode=lambda: False)
             self.progress = SimpleNamespace(
                 timer=lambda *a, **k: SimpleNamespace(stop=lambda: None, start=lambda *a, **k: None),
                 start=lambda *a, **k: None, finish=lambda: None, update=lambda *a, **k: None,
@@ -303,8 +304,14 @@ def _make_fake_mw(app, user_path):
 
 # --- top-level install -----------------------------------------------------
 
-def install(app, user_path):
-    """Install the fake aqt/anki into sys.modules. Call before `import Ankimon`."""
+def install(app, user_path, real_webengine=False):
+    """Install the fake aqt/anki into sys.modules. Call before `import Ankimon`.
+
+    real_webengine=True wires the REAL QWebEngineView (so the Pokedex / HUD render
+    for real) instead of the lightweight stub — requires WebEngine to be importable
+    and already imported before the QApplication (real_env handles that). Falls back
+    to the stub if the real one isn't available.
+    """
     import PyQt6.QtCore
     import PyQt6.QtGui
     import PyQt6.QtWidgets
@@ -316,7 +323,15 @@ def install(app, user_path):
     def qconnect(signal, func):
         signal.connect(func)
 
-    web_view, web_page, web_settings = _make_webengine_stubs(QWidget)
+    web_view = web_page = web_settings = None
+    if real_webengine:
+        try:
+            from PyQt6.QtWebEngineWidgets import QWebEngineView as web_view
+            from PyQt6.QtWebEngineCore import QWebEnginePage as web_page, QWebEngineSettings as web_settings
+        except Exception:
+            web_view = web_page = web_settings = None
+    if web_view is None:
+        web_view, web_page, web_settings = _make_webengine_stubs(QWidget)
 
     # aqt.qt — faithful re-export of real PyQt6 (+ qconnect, sip, webengine stubs).
     qt = ModuleType("aqt.qt")

--- a/harness/real_env.py
+++ b/harness/real_env.py
@@ -79,8 +79,16 @@ def _seed_assets(user_path):
         img.save(str(substitute), "PNG")
 
 
-def start_real_session(user_path=None, settings_overrides=None, neuter_network=True):
-    """Boot the real add-on and return handles (app, aqt, services, events)."""
+def start_real_session(user_path=None, settings_overrides=None, neuter_network=True,
+                       first_run=False, webengine=False):
+    """Boot the real add-on and return handles (app, aqt, services, events).
+
+    first_run=True seeds the sprite assets BEFORE the import, so startup's
+    _check_assets passes (database_complete=True) and a blank profile gets the
+    genuine new-user path: the full menu populates and the starter-selection
+    window opens — the state a real user is in once sprites are present. (Default
+    False keeps the lean "assets incomplete" boot for fast play tests.)
+    """
     if user_path is None:
         user_path = tempfile.mkdtemp(prefix="ankimon_real_")
     os.environ["ANKIMON_USER_PATH"] = str(user_path)
@@ -103,16 +111,31 @@ def start_real_session(user_path=None, settings_overrides=None, neuter_network=T
         except Exception:
             pass
 
+    # Real WebEngine (to render the Pokedex / HUD) MUST be imported before the
+    # QApplication exists. Only when requested + importable; else fall back to the stub.
+    if webengine:
+        os.environ.setdefault("QTWEBENGINE_DISABLE_SANDBOX", "1")
+        os.environ.setdefault("QTWEBENGINE_CHROMIUM_FLAGS",
+                              "--no-sandbox --disable-gpu --disable-dev-shm-usage "
+                              "--in-process-gpu --single-process")
+        try:
+            import PyQt6.QtWebEngineWidgets  # noqa: F401  (must precede QApplication)
+        except Exception:
+            webengine = False
+
     # Real PyQt6 first (needs the offscreen platform + native libs already loadable).
-    from PyQt6.QtWidgets import QApplication, QDialog, QMessageBox
+    from PyQt6.QtWidgets import QApplication, QDialog, QMessageBox, QInputDialog
 
     app = QApplication.instance() or QApplication(["ankimon-harness"])
 
-    # NOTE: assets are seeded AFTER boot (by the driver), not here. Seeding the
-    # sprite dirs makes startup's _check_assets pass, which would trigger the
-    # first-run starter window on an empty profile. Booting with no sprite dirs
-    # keeps startup on its "assets incomplete" path (no first-run UI); the driver
-    # seeds the placeholder sprite before it starts play.
+    # Assets: by default seeded AFTER boot (by the driver), so startup stays on its
+    # "assets incomplete" path and skips the first-run UI. With first_run=True we
+    # seed them BEFORE the import — startup's _check_assets then passes
+    # (database_complete=True), the menu fully populates, and a blank profile gets
+    # the genuine new-user flow (starter selection). _seed_assets symlinks to the
+    # real sprite cache if present, so this renders with genuine art.
+    if first_run:
+        _seed_assets(user_path)
 
     # Neuter blocking dialogs so a real boot can never hang on a modal .exec().
     QDialog.exec = lambda self: 0
@@ -125,13 +148,39 @@ def start_real_session(user_path=None, settings_overrides=None, neuter_network=T
     except Exception:
         pass
 
+    # QInputDialog.* are blocking static modals too (e.g. item_window's "Select
+    # Pokemon" getItem). Auto-accept with a valid default so a real boot / a GUI
+    # fuzzer can't hang on them (mirrors the QMessageBox auto-answers above).
+    def _fuzz_get_item(parent, title, label, items, current=0, editable=True, *a, **k):
+        items = list(items)
+        chosen = items[current] if 0 <= current < len(items) else (items[0] if items else "")
+        return chosen, True
+    try:
+        QInputDialog.getItem = staticmethod(_fuzz_get_item)
+        QInputDialog.getText = staticmethod(lambda *a, **k: ("Ankimon", True))
+        QInputDialog.getMultiLineText = staticmethod(lambda *a, **k: ("Ankimon", True))
+        QInputDialog.getInt = staticmethod(lambda *a, **k: (1, True))
+        QInputDialog.getDouble = staticmethod(lambda *a, **k: (1.0, True))
+    except Exception:
+        pass
+
     # Install the fake Anki host (mw, gui_hooks, aqt.* ) BEFORE importing Ankimon.
     from . import fake_aqt
 
-    aqt = fake_aqt.install(app, user_path)
+    aqt = fake_aqt.install(app, user_path, real_webengine=webengine)
 
     # REAL boot — runs Ankimon/__init__.py just as Anki would.
     import Ankimon  # noqa: F401
+
+    # Anki fires "profileLoaded" after the add-on imports; the harness must too, or
+    # mw.catchpokemon / mw.defeatpokemon (set by profile_hooks.on_profile_loaded) stay
+    # unset and the test_window catch/defeat buttons AttributeError-crash. (This is the
+    # faithful boot order — the same hook the real client runs on profile open.)
+    try:
+        from anki.hooks import runHook
+        runHook("profileLoaded")
+    except Exception:
+        pass
 
     # Turn on event capture (emits are no-ops until enabled).
     from Ankimon.events import events

--- a/harness/scenarios/feature_check.py
+++ b/harness/scenarios/feature_check.py
@@ -1,0 +1,154 @@
+"""
+harness/scenarios/feature_check.py — validate a FEATURE works as intended (Tier 2).
+
+mega_fuzz proves a feature doesn't *crash*. This proves it does the *right thing*:
+drive the real feature the way a user would, then assert the intended OUTCOME (the
+DB / game state / event changed exactly as it should) — and that no error fired.
+
+This is the TEMPLATE for "an agent, given guidance, validates a new feature." When
+someone adds a menu/button/action and says "it should do Y", you write a check():
+
+    def check_my_feature(d, app, db, pc, pool):
+        before = <observe state>
+        <drive the feature: open a window, find the widget, click/type, or fire the
+         exact callback the menu wires>
+        after = <observe state>
+        return ("my_feature", after == expected, "before=%s after=%s" % (before, after))
+
+The runner boots ONE real seeded session (real Qt windows offscreen), runs every
+check, drains error events after each, and prints PASS/FAIL + a final verdict. Each
+check operates on its own box Pokemon so they don't interfere. Add a check to CHECKS
+and it joins the suite — so this doubles as a regression gate for existing features.
+
+    source .tier2/env.sh
+    python3 harness/scenarios/feature_check.py
+"""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+
+SEED = {
+    "main": {"species": "Gengar", "level": 50},
+    "box": [{"species": s, "level": 10 + i}
+            for i, s in enumerate(["Pikachu", "Bulbasaur", "Squirtle", "Eevee", "Snorlax", "Lapras"])],
+    "items": {"Pokeball": 25, "Potion": 10},
+}
+
+
+def _find(app, cls, **match):
+    """First visible widget of `cls` whose getter() text contains a substring."""
+    for w in app.allWidgets():
+        if not isinstance(w, cls) or not w.isVisible():
+            continue
+        for getter, sub in match.items():
+            try:
+                val = getattr(w, getter)() or ""
+            except Exception:
+                val = ""
+            if sub.lower() in str(val).lower():
+                return w
+    return None
+
+
+# --- feature checks (each: drive the real feature, assert the intended outcome) ---
+
+def check_rename(d, app, db, pc, pool):
+    """The 'Rename Pokémon' feature (full real GUI drive): open a Pokemon's details,
+    type a nickname into the real field, click the real button → DB nickname updates."""
+    from PyQt6.QtWidgets import QLineEdit, QPushButton
+    from PyQt6.QtTest import QTest
+    iid = pool.pop()
+    pkmn = db.get_pokemon(iid)
+    before = pkmn.get("nickname", "")
+    pc.show_pokemon_details(pkmn)
+    app.processEvents()
+    edit = _find(app, QLineEdit, placeholderText="Nickname")
+    btn = _find(app, QPushButton, text="Rename")
+    if not edit or not btn:
+        return ("rename (full GUI)", False, "could not find the rename field/button in the details window")
+    edit.clear()
+    QTest.keyClicks(edit, "Sparky")
+    btn.click()
+    app.processEvents()
+    after = (db.get_pokemon(iid) or {}).get("nickname", "")
+    return ("rename (full GUI)", after == "Sparky", "nickname %r -> %r (intended 'Sparky')" % (before, after))
+
+
+def check_make_favorite(d, app, db, pc, pool):
+    """The right-click 'Make favorite' context action (its real wired callback):
+    toggling flips is_favorite in the DB, and toggling again flips it back."""
+    iid = pool.pop()
+    start = bool((db.get_pokemon(iid) or {}).get("is_favorite", False))
+    pc.toggle_favorite(db.get_pokemon(iid))
+    on = bool((db.get_pokemon(iid) or {}).get("is_favorite", False))
+    pc.toggle_favorite(db.get_pokemon(iid))
+    back = bool((db.get_pokemon(iid) or {}).get("is_favorite", False))
+    ok = (on == (not start)) and (back == start)
+    return ("make_favorite (context action)", ok,
+            "is_favorite %s -> %s -> %s (intended: flip then flip back)" % (start, on, back))
+
+
+def check_catch_grows_collection(d, app, db, pc, pool):
+    """The catch feature (real reviewer catch path): when the wild Pokemon has
+    fainted, catching it adds exactly one to the collection."""
+    before = db.get_pokemon_count()
+    d.services.enemy_pokemon.hp = 0          # catch is only valid on a fainted wild
+    d.services.enemy_pokemon.current_hp = 0
+    d.catch()
+    app.processEvents()
+    after = db.get_pokemon_count()
+    return ("catch_grows_collection", after == before + 1,
+            "collection %d -> %d (intended +1)" % (before, after))
+
+
+CHECKS = [check_rename, check_make_favorite, check_catch_grows_collection]
+
+
+def _boot():
+    from harness.real_driver import RealDriver
+    from harness.fixtures import seed_db
+    from PyQt6.QtWidgets import QApplication
+
+    d = RealDriver(first_run=True, first_encounter=True)
+    import Ankimon.singletons as S          # import AFTER boot (RealDriver sets up the path)
+    import Ankimon.utils as u
+    u.close_anki = lambda *a, **k: None
+    seed_db(SEED, d.services.db)
+    app = QApplication.instance()
+    pc = S.pokemon_pc
+    # Open the PC box (exactly what the menu action does: qconnect(..., pokemon_pc.show))
+    # so its grid + details panel are live and visible, like a user opening it.
+    pc.show()
+    app.processEvents()
+    return d, app, d.services.db, pc
+
+
+def run(verbose=True):
+    d, app, db, pc = _boot()
+    pool = [r[0] for r in db.execute(
+        "SELECT individual_id FROM captured_pokemon WHERE is_main = 0").fetchall()]
+    results = []
+    for chk in CHECKS:
+        db_events = d.events.drain()                      # clear before
+        try:
+            name, ok, detail = chk(d, app, db, pc, pool)
+        except Exception as e:
+            name, ok, detail = chk.__name__, False, "raised %s: %s" % (type(e).__name__, e)
+        errs = [e for e in d.events.drain() if isinstance(e, dict) and e.get("type") == "error"]
+        if errs:
+            ok = False
+            detail += " | ERROR event: %s" % (errs[0].get("message") or errs[0].get("exception"))
+        results.append((name, ok, detail))
+        if verbose:
+            print("  [%s] %-32s %s" % ("PASS" if ok else "FAIL", name, detail))
+    n_ok = sum(1 for _, ok, _ in results if ok)
+    if verbose:
+        print("\nfeature_check: %d/%d features behave as intended" % (n_ok, len(results)))
+    return results
+
+
+if __name__ == "__main__":
+    res = run()
+    sys.exit(0 if all(ok for _, ok, _ in res) else 1)

--- a/harness/scenarios/fuzz.py
+++ b/harness/scenarios/fuzz.py
@@ -1,0 +1,192 @@
+"""
+harness/scenarios/fuzz.py — property/fuzz testing for Ankimon's real game logic.
+
+Throws MANY random configurations at the real code and reports any that crash,
+emit an `error` event, or break an invariant — each with an exact, reproducible
+seed. What it randomizes:
+  * the main + wild Pokemon: random species (all ~1300), level, moves (incl. the
+    occasional bogus move name), IVs/EVs (incl. out-of-range), nature, shiny,
+    gender, and weird nicknames (unicode/emoji/empty/very long/injection-y)
+  * settings overrides (boundary values + the occasional wrong type)
+  * a random action sequence (answer/catch/defeat/encounter/set_enemy/set_setting)
+Invariants checked after every action: HP within [0, max], non-negative cash and
+collection count.
+
+    python3 harness/scenarios/fuzz.py 500          # 500 random iterations
+    python3 harness/scenarios/fuzz.py --seed 12345 # reproduce ONE case, verbose
+
+This catches the "bad code merged, some edge case errors out" class before a user
+does. Tier 1 (no Qt) — fast, runs anywhere. Deterministic per seed.
+"""
+
+import os
+import random
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+
+from harness.driver import Driver
+
+NATURES = ["hardy", "lonely", "brave", "adamant", "bold", "relaxed", "impish",
+           "timid", "hasty", "serious", "jolly", "modest", "quiet", "calm", "careful"]
+WEIRD_NICKS = ["", "A" * 200, "Ž★🔥", "'; DROP TABLE x;--", "<b>x</b>", "💀💀💀",
+               "  ", "\n\t", "Ünïçödé", "名前", "%s%d{}", "../../etc/passwd"]
+BOGUS_MOVES = ["notamove", "", "Hyper Beam!!!", "移动", "z" * 40]
+NUM_KEYS = ["battle.cards_per_round", "battle.daily_average", "gui.xp_bar_location",
+            "evolution.day_start_hour", "evolution.night_start_hour", "trainer.cash_reward_amount"]
+BOOL_KEYS = ["misc.remove_level_cap", "misc.gen9", "misc.gen1", "audio.sounds"]
+
+_POOL = None
+_CONFIG = None
+_warm = False
+
+
+def _warmup():
+    """Boot one throwaway Driver so the Ankimon pokedex/learnset modules are
+    initialised before we build random specs from them — and capture the FULL
+    settings dict so fuzzing covers every key, not a hardcoded few."""
+    global _warm, _CONFIG
+    if not _warm:
+        d = Driver()
+        _CONFIG = dict(d.services.settings.config)   # ALL ~63 settings + their defaults
+        _warm = True
+
+
+def _pool():
+    global _POOL
+    if _POOL is None:
+        from Ankimon.functions.pokedex_functions import _load_pokedex_id_index
+        _POOL = list((_load_pokedex_id_index() or {}).values()) or ["bulbasaur"]
+    return _POOL
+
+
+def _moves(rng, name, level):
+    from Ankimon.functions.learnset_retrieval import get_all_pokemon_moves
+    pool = list(get_all_pokemon_moves(name, level) or [])
+    rng.shuffle(pool)
+    moves = pool[:rng.randint(1, 4)] or ["tackle"]
+    if rng.random() < 0.12:
+        moves[rng.randrange(len(moves))] = rng.choice(BOGUS_MOVES)
+    return moves
+
+
+def random_spec(rng):
+    name = rng.choice(_pool())
+    level = rng.choice([rng.randint(1, 100), 1, 100, 5])
+    spec = {
+        "species": name, "level": level, "moves": _moves(rng, name, level),
+        "ivs": {k: rng.randint(0, 31) for k in ("hp", "atk", "def", "spa", "spd", "spe")},
+        "evs": {k: rng.choice([0, rng.randint(0, 252), rng.randint(0, 999)])
+                for k in ("hp", "atk", "def", "spa", "spd", "spe")},
+        "nature": rng.choice(NATURES),
+        "shiny": rng.random() < 0.1,
+        "gender": rng.choice(["M", "F", "N"]),
+    }
+    if rng.random() < 0.3:
+        spec["nickname"] = rng.choice(WEIRD_NICKS)
+    return spec
+
+
+def _fuzz_value(rng, default):
+    """A random value for a setting, typed from its default + boundary picks."""
+    if isinstance(default, bool):                # bool BEFORE int (bool is an int subclass)
+        return rng.random() < 0.5
+    if isinstance(default, int):
+        return rng.choice([0, 1, 2, -1, -5, rng.randint(0, 9999), 999999])
+    if isinstance(default, float):
+        return rng.choice([0.0, -1.0, rng.random(), rng.uniform(0, 1000), 1e9])
+    return rng.choice(["", "x" * 100, "Ž★🔥", "999", "-1", str(default)])  # string
+
+
+def random_settings(rng):
+    # Fuzz a random subset of ALL real settings keys, each typed from its default.
+    keys = list(_CONFIG or {})
+    out = {k: _fuzz_value(rng, _CONFIG[k]) for k in rng.sample(keys, rng.randint(1, 6))} if keys else {}
+    if keys and rng.random() < 0.1:             # occasional wrong type → robustness
+        out[rng.choice(keys)] = rng.choice(["x", "", None, [], -1])
+    return out
+
+
+ACTIONS = ["answer", "answer", "answer", "catch", "defeat", "encounter",
+           "set_enemy", "set_setting"]
+
+
+def _scan(events, where):
+    for e in events or []:
+        if e.get("type") == "error":
+            raise AssertionError("error event during %s: %r"
+                                 % (where, {k: e.get(k) for k in ("type", "exception", "message")}))
+
+
+def _invariants(d):
+    st = d.get_state()
+    mp, ep = st["main"], st["enemy"]
+    assert 0 <= mp["hp"] <= mp["max_hp"], "main HP out of range: %s/%s" % (mp["hp"], mp["max_hp"])
+    assert ep["hp"] >= 0 and (ep["max_hp"] == 0 or ep["hp"] <= ep["max_hp"]), \
+        "enemy HP out of range: %s/%s" % (ep["hp"], ep["max_hp"])
+    assert st["collection"]["count"] >= 0, "negative collection count"
+    cash = st["trainer"]["cash"]
+    assert cash is None or cash >= 0, "negative cash: %s" % cash
+
+
+def one(seed, verbose=False):
+    _warmup()
+    rng = random.Random(seed)
+    main_spec = random_spec(rng)
+    settings = random_settings(rng)
+    if verbose:
+        print("seed %d\n  main: %s\n  settings: %s" % (seed, main_spec, settings))
+    d = Driver(seed={"main": main_spec}, settings_overrides=settings)
+    for a in [rng.choice(ACTIONS) for _ in range(rng.randint(5, 25))]:
+        if verbose:
+            print("  action:", a)
+        if a == "answer":
+            _scan(d.answer(rng.choice([1, 2, 3, 4, "again", "good"])), "answer")
+        elif a == "catch":
+            _scan(d.catch(), "catch")
+        elif a == "defeat":
+            _scan(d.defeat(), "defeat")
+        elif a == "encounter":
+            _scan(d.encounter(), "encounter")
+        elif a == "set_enemy":
+            _scan(d.set_enemy(random_spec(rng)), "set_enemy")
+        elif a == "set_setting":
+            k = rng.choice(list(_CONFIG or NUM_KEYS))     # any real setting, mid-play
+            d.set_setting(k, _fuzz_value(rng, (_CONFIG or {}).get(k, 0)))
+        _invariants(d)
+
+
+def run(n=300, master=20260623):
+    crashes = []
+    for i in range(n):
+        seed = master * 100000 + i
+        try:
+            one(seed)
+        except Exception as e:
+            crashes.append((seed, type(e).__name__, str(e)[:200]))
+        if (i + 1) % 100 == 0:
+            print("  %d/%d run, %d crashes so far" % (i + 1, n, len(crashes)))
+
+    print("\nfuzz: %d iterations, %d crashed/errored" % (n, len(crashes)))
+    distinct = {}
+    for seed, kind, msg in crashes:
+        distinct.setdefault((kind, msg.split(":")[0][:70]), (seed, kind, msg))
+    if distinct:
+        print("distinct failures (%d) — each reproducible:" % len(distinct))
+        for (_k, _m), (seed, kind, msg) in list(distinct.items())[:25]:
+            print("  [seed %d] %s: %s" % (seed, kind, msg))
+        print("\nreproduce any with:  python3 harness/scenarios/fuzz.py --seed <seed>")
+    else:
+        print("fuzz: CLEAN — no crashes, error events, or invariant breaks.")
+    return len(crashes)
+
+
+if __name__ == "__main__":
+    args = sys.argv[1:]
+    if "--seed" in args:
+        s = int(args[args.index("--seed") + 1])
+        one(s, verbose=True)
+        print("seed %d: completed with no detected problem" % s)
+    else:
+        n = int(args[0]) if args and args[0].isdigit() else 300
+        sys.exit(1 if run(n) else 0)

--- a/harness/scenarios/gui_fuzz.py
+++ b/harness/scenarios/gui_fuzz.py
@@ -1,0 +1,187 @@
+"""
+harness/scenarios/gui_fuzz.py — isolated, REPRODUCIBLE GUI monkey-fuzzer (Tier 2).
+
+Random GUI actions on the real windows: click a random visible button, type a
+weird string into a random field, or trigger a random menu item — wandering
+wherever the GUI leads. The catch (learned the hard way): a bad GUI action can
+HARD-crash the process (a C++ Qt abort, uncatchable in Python). So this is built
+for reproducibility:
+
+  * Every action is journaled to disk and FLUSHED *before* it runs — so if the
+    process dies, the journal's last line is exactly the action that killed it.
+  * Each seed runs in its own CHILD process — a hard crash kills the child, not
+    the sweep; the parent reads the journal and reports the culprit + how to replay.
+
+    source .tier2/env.sh
+    python3 harness/scenarios/gui_fuzz.py                  # parent: sweep seeds, report crashers
+    python3 harness/scenarios/gui_fuzz.py --replay 7 40    # re-run one seed, verbose, to watch it
+    # (--run SEED STEPS JOURNAL is the internal child entrypoint)
+"""
+
+import os
+import subprocess
+import sys
+import tempfile
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+
+WEIRD = ["", "💀", "Ž★🔥", "x" * 60, "'; DROP TABLE x;--", "999", "../../etc/passwd"]
+SEED_TEAM = {"main": {"species": "Gengar", "level": 50},
+             "box": [{"species": s, "level": 10}
+                     for s in ["Pikachu", "Bulbasaur", "Squirtle", "Eevee", "Snorlax"]]}
+
+
+def _describe(w):
+    try:
+        win = w.window().windowTitle() or type(w.window()).__name__
+    except Exception:
+        win = "?"
+    txt = ""
+    for getter in ("text", "placeholderText", "objectName"):
+        try:
+            txt = getattr(w, getter)() or txt
+        except Exception:
+            pass
+        if txt:
+            break
+    return "%s '%s' in [%s]" % (type(w).__name__, str(txt)[:30], win)
+
+
+def _candidates(app):
+    from PyQt6.QtWidgets import QPushButton, QLineEdit
+    btns = [w for w in app.allWidgets() if isinstance(w, QPushButton) and w.isVisible() and w.isEnabled()]
+    edits = [w for w in app.allWidgets() if isinstance(w, QLineEdit) and w.isVisible() and w.isEnabled()]
+    # sort for best-effort determinism (the journal is the real repro)
+    btns.sort(key=lambda w: (w.text(), w.objectName()))
+    edits.sort(key=lambda w: (w.placeholderText(), w.objectName()))
+    return btns, edits
+
+
+def _menu_actions(mw):
+    out = []
+
+    def walk(m):
+        for a in m.actions():
+            if a.menu():
+                walk(a.menu())
+            elif a.text():
+                out.append(a)
+    walk(mw.pokemenu)
+    out.sort(key=lambda a: a.text())
+    return out
+
+
+def _run(seed, steps, journal_path, verbose=False):
+    """CHILD: run one seeded monkey, journaling each action (flushed) before it runs."""
+    import random
+    from harness.real_env import start_real_session
+    from harness.fixtures import seed_db
+    from PyQt6.QtWidgets import QApplication
+    from PyQt6.QtTest import QTest
+
+    h = start_real_session(first_run=True)           # FAITHFUL state: sprites present, full menu
+    import Ankimon.utils as u
+    u.close_anki = lambda *a, **k: None              # so the monkey can't quit the process
+    seed_db(SEED_TEAM, h.services.db)
+    app = QApplication.instance()
+    rng = random.Random(seed)
+
+    j = open(journal_path, "w", buffering=1)
+
+    def log(line):
+        j.write(line + "\n")
+        j.flush()
+        os.fsync(j.fileno())                         # survive a hard abort
+        if verbose:
+            print(line)
+
+    log("SEED %d STEPS %d" % (seed, steps))
+    for i in range(steps):
+        btns, edits = _candidates(app)
+        acts = _menu_actions(h.aqt.mw)
+        kind = rng.choice(["menu", "menu", "button", "button", "type", "close"])
+        try:
+            if kind == "menu" and acts:
+                a = rng.choice(acts)
+                log("step %d: TRIGGER menu '%s'" % (i, a.text()))     # journaled BEFORE doing it
+                a.trigger()
+            elif kind == "button" and btns:
+                b = rng.choice(btns)
+                log("step %d: CLICK %s" % (i, _describe(b)))
+                b.click()
+            elif kind == "type" and edits:
+                e = rng.choice(edits)
+                txt = rng.choice(WEIRD)
+                log("step %d: TYPE %r into %s" % (i, txt, _describe(e)))
+                e.clear()
+                if txt.isascii():
+                    QTest.keyClicks(e, txt)         # realistic keystrokes for ASCII
+                else:
+                    e.setText(txt)                  # QTest.keyClicks is ASCII-only; setText for unicode
+            elif kind == "close":
+                wins = [w for w in app.topLevelWidgets()
+                        if w.isVisible() and w is not h.aqt.mw and w.windowTitle()]
+                if wins:
+                    w = rng.choice(wins)
+                    log("step %d: CLOSE window '%s'" % (i, w.windowTitle()))
+                    w.close()
+                else:
+                    log("step %d: noop (nothing open to close)" % i)
+                    continue
+            else:
+                log("step %d: noop" % i)
+                continue
+            app.processEvents()
+            for ev in h.events.drain():
+                if ev.get("type") == "error":
+                    log("  CAUGHT error event: %s" % (ev.get("message") or ev.get("exception")))
+        except Exception as ex:
+            log("  CAUGHT exception: %s: %s" % (type(ex).__name__, str(ex)[:120]))
+    log("SURVIVED all %d steps" % steps)
+    j.close()
+
+
+def sweep(n_seeds=12, steps=40):
+    """PARENT: run each seed in a child process; report any that hard-crash."""
+    crashers = []
+    for seed in range(n_seeds):
+        fd, jp = tempfile.mkstemp(prefix="guifuzz_%d_" % seed, suffix=".log")
+        os.close(fd)
+        try:
+            proc = subprocess.run([sys.executable, __file__, "--run", str(seed), str(steps), jp],
+                                  capture_output=True, text=True, timeout=180)
+            rc = proc.returncode
+        except subprocess.TimeoutExpired:
+            rc = -99
+        lines = []
+        try:
+            lines = [l for l in open(jp).read().splitlines() if l.strip()]
+        except Exception:
+            pass
+        survived = bool(lines) and lines[-1].startswith("SURVIVED")
+        if survived:
+            print("  seed %2d: survived %d steps" % (seed, steps))
+        else:
+            culprit = lines[-1] if lines else "(no journal written)"
+            crashers.append((seed, rc, culprit))
+            print("  seed %2d: HARD CRASH (exit %d) — last action before death:\n           %s"
+                  % (seed, rc, culprit))
+
+    print("\ngui_fuzz: %d seeds x %d steps | %d hard-crashed" % (n_seeds, steps, len(crashers)))
+    for seed, rc, culprit in crashers:
+        print("  [seed %d] %s   →  replay: python3 harness/scenarios/gui_fuzz.py --replay %d %d"
+              % (seed, culprit, seed, steps))
+    return crashers
+
+
+if __name__ == "__main__":
+    if "--run" in sys.argv:
+        i = sys.argv.index("--run")
+        _run(int(sys.argv[i + 1]), int(sys.argv[i + 2]), sys.argv[i + 3])
+    elif "--replay" in sys.argv:
+        i = sys.argv.index("--replay")
+        fd, jp = tempfile.mkstemp(suffix=".log")
+        os.close(fd)
+        _run(int(sys.argv[i + 1]), int(sys.argv[i + 2]), jp, verbose=True)
+    else:
+        sys.exit(1 if sweep() else 0)

--- a/harness/scenarios/hud_render.py
+++ b/harness/scenarios/hud_render.py
@@ -1,0 +1,113 @@
+"""
+harness/scenarios/hud_render.py — RENDER the reviewer HUD overlay in real WebEngine
+and measure its memory over many refreshes.
+
+The in-card HUD is HTML/CSS/JS the add-on injects into Anki's reviewer webview.
+The harness captures the exact JS it would inject (self-contained — sprite inlined
+as base64), so this loads it into a REAL QWebEngineView, renders it, and re-injects
+it N times measuring RSS — the leak-hunt for the per-card overlay (it repaints every
+single review, so a leak there compounds fastest of all).
+
+Needs WebEngine. On CI (x86) it's built in. On this aarch64 Pi, the native deps
+were fetched sudo-free into .tier2/we-libs; run with:
+
+    source .tier2/env.sh
+    export LD_LIBRARY_PATH=$PWD/.tier2/we-libs/extract/usr/lib/aarch64-linux-gnu:$LD_LIBRARY_PATH
+    python3 harness/scenarios/hud_render.py 200
+"""
+
+import os
+import sys
+
+# Headless Chromium flags BEFORE importing WebEngine.
+os.environ.setdefault("QTWEBENGINE_DISABLE_SANDBOX", "1")
+os.environ.setdefault(
+    "QTWEBENGINE_CHROMIUM_FLAGS",
+    "--no-sandbox --disable-gpu --disable-dev-shm-usage --in-process-gpu "
+    "--disable-software-rasterizer --single-process",
+)
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+
+# WebEngine must be imported before any QApplication exists.
+from PyQt6.QtWebEngineWidgets import QWebEngineView          # noqa: E402
+from PyQt6.QtCore import QTimer, QEventLoop                  # noqa: E402
+
+
+def _capture_hud(h):
+    """One HUD refresh -> (portal_setup_js, hud_content_js)."""
+    calls = []
+    web = h.aqt.mw.reviewer.web
+    web.eval = lambda js, *a, **k: calls.append(js)
+    web.evalWithCallback = lambda js, cb=None, *a, **k: (calls.append(js), cb(None) if cb else None)
+    h.services.reviewer.refresh_hud()
+    if not calls:
+        return "", ""
+    content = max(calls, key=len)
+    setup = "\n".join(c for c in calls if c is not content)
+    return setup, content
+
+
+def _rss():
+    for line in open("/proc/self/status"):
+        if line.startswith("VmRSS"):
+            return int(line.split()[1]) // 1024
+    return 0
+
+
+def _pump(app, ms):
+    loop = QEventLoop()
+    QTimer.singleShot(ms, loop.quit)
+    loop.exec()
+
+
+def run(n=200):
+    from harness.real_env import start_real_session
+    from PyQt6.QtWidgets import QApplication
+
+    h = start_real_session(first_run=True)
+    app = QApplication.instance()
+
+    setup, content = _capture_hud(h)
+    print("captured HUD: setup %d chars, content %d chars | self-contained base64: %s"
+          % (len(setup), len(content), "base64," in content))
+    if not content:
+        print("no HUD content captured — aborting"); return
+
+    # Real WebEngine view; load a blank page, then inject the real portal + HUD.
+    view = QWebEngineView()
+    view.resize(520, 340)
+    q = QEventLoop()
+    view.loadFinished.connect(lambda ok: q.quit())
+    view.setHtml("<html><body style='margin:0;background:#111'></body></html>")
+    QTimer.singleShot(30000, q.quit)
+    q.exec()
+
+    page = view.page()
+    page.runJavaScript(setup)
+    page.runJavaScript(content)
+    _pump(app, 1500)
+
+    shot = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", ".tier2", "hud.png"))
+    try:
+        view.grab().save(shot)
+        print("rendered HUD -> screenshot:", shot, "(WebEngine grabs may be blank offscreen)")
+    except Exception as e:
+        print("screenshot skipped:", e)
+
+    # Leak hunt: re-inject a fresh HUD N times, watch RSS.
+    import gc
+    gc.collect()
+    base = _rss()
+    print("baseline RSS after first render: %d MB" % base)
+    for i in range(1, n + 1):
+        _, content = _capture_hud(h)            # fresh HUD markup each "review"
+        page.runJavaScript(content)
+        _pump(app, 15)
+        if i in (50, 100, 200, n):
+            gc.collect()
+            print("  after %3d HUD renders: RSS %d MB  (Δ +%d)" % (i, _rss(), _rss() - base))
+
+
+if __name__ == "__main__":
+    run(int(sys.argv[1]) if len(sys.argv) > 1 and sys.argv[1].isdigit() else 200)

--- a/harness/scenarios/mega_fuzz.py
+++ b/harness/scenarios/mega_fuzz.py
@@ -1,0 +1,450 @@
+"""
+harness/scenarios/mega_fuzz.py — the unified "do EVERYTHING" fuzzer (Tier 2).
+
+One fuzzer that exercises the WHOLE add-on the way a chaotic human would: it boots
+the genuine Ankimon (real Qt windows, offscreen) into a random *starting world*,
+then loops random *actions* drawn from the complete surface — gameplay AND GUI —
+over auto-discovered targets, until something breaks or N steps pass.
+
+  initial WORLD  (rng per seed)
+    first_run  — sprites present, empty box, full menu       (fresh post-download)
+    blank      — NO sprites (download denied), gated menu     ("I said no to sprites")
+    seeded     — sprites + a full team/box                    (established player)
+    corrupt    — seeded, then ONE saved Pokemon mangled       (corrupt save file)
+
+  ACTION space  (rng per step, weighted) — every verb a user has:
+    gameplay : answer(ease) · catch · defeat · encounter · set_setting
+    GUI      : open-menu · click-button · type-weird · close-window
+    RIGHT-CLICK → context-menu   (PC box: favorite/give-item/release/trade/rename/evolve)
+  Targets auto-discover from live widgets — a window that opens mid-run is fuzzed for
+  free; a PokemonSlotButton that appears becomes right-clickable.
+
+Built for reproducibility, because a bad GUI action can HARD-crash the process (a
+C++ Qt abort uncatchable from Python):
+  * every action is journaled + flushed + fsync'd BEFORE it runs — the journal's
+    last line is exactly the action (and world) that killed the process;
+  * each seed runs in its own CHILD process — a hard crash kills the child, the
+    parent reads the journal and reports the culprit + an exact replay command.
+
+This FINDS bugs; it does not fix them. Expect a lot — that's the point.
+
+    source .tier2/env.sh
+    python3 harness/scenarios/mega_fuzz.py                    # sweep seeds (random worlds), report crashers
+    python3 harness/scenarios/mega_fuzz.py --world corrupt    # sweep, forcing the corrupt-save world
+    python3 harness/scenarios/mega_fuzz.py --replay 7 80      # re-run one seed, verbose, to watch it
+    python3 harness/scenarios/mega_fuzz.py --replay 7 80 seeded   # ...forcing a world
+    # (--run SEED STEPS JOURNAL [WORLD] is the internal child entrypoint)
+"""
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+
+WORLDS = ["first_run", "blank", "seeded", "corrupt"]
+
+WEIRD = ["", "💀", "Ž★🔥", "x" * 80, "'; DROP TABLE captured_pokemon;--", "999", "-1", "../../etc/passwd"]
+EASES = ["again", "hard", "good", "easy"]
+
+# A populated save for the seeded/corrupt worlds — a main + a teamful + a boxful, so
+# the PC box has plenty of slots to right-click and plenty of data to render.
+BIG_TEAM = {
+    "main": {"species": "Gengar", "level": 50, "nickname": "Spooky"},
+    "team": [{"species": s, "level": 40} for s in ["Charizard", "Blastoise", "Venusaur"]],
+    "box": [{"species": s, "level": 10 + i}
+            for i, s in enumerate(["Pikachu", "Bulbasaur", "Squirtle", "Eevee", "Snorlax",
+                                   "Mew", "Dragonite", "Gyarados", "Lapras", "Ditto"])],
+    "items": {"Pokeball": 25, "Potion": 10, "Rare Candy": 5},
+}
+
+
+# --- footprint ---------------------------------------------------------------
+
+def _rss_mb():
+    """Current resident set size in MB (Linux /proc) — for organic leak flagging."""
+    try:
+        with open("/proc/self/statm") as f:
+            pages = int(f.read().split()[1])
+        return pages * os.sysconf("SC_PAGE_SIZE") / 1e6
+    except Exception:
+        return 0.0
+
+
+# --- target auto-discovery ---------------------------------------------------
+
+def _describe(w):
+    try:
+        win = w.window().windowTitle() or type(w.window()).__name__
+    except Exception:
+        win = "?"
+    txt = ""
+    for getter in ("text", "placeholderText", "objectName"):
+        try:
+            txt = getattr(w, getter)() or txt
+        except Exception:
+            pass
+        if txt:
+            break
+    return "%s '%s' in [%s]" % (type(w).__name__, str(txt)[:30], win)
+
+
+def _candidates(app):
+    from PyQt6.QtWidgets import QPushButton, QLineEdit
+    btns = [w for w in app.allWidgets() if isinstance(w, QPushButton) and w.isVisible() and w.isEnabled()]
+    edits = [w for w in app.allWidgets() if isinstance(w, QLineEdit) and w.isVisible() and w.isEnabled()]
+    btns.sort(key=lambda w: (w.text(), w.objectName()))       # best-effort determinism; journal is the real repro
+    edits.sort(key=lambda w: (w.placeholderText(), w.objectName()))
+    return btns, edits
+
+
+def _rightclickables(app):
+    """Any live widget exposing a ``rightClicked`` signal — PC box slots, etc."""
+    out = [w for w in app.allWidgets()
+           if w.isVisible() and w.isEnabled() and hasattr(type(w), "rightClicked")]
+    out.sort(key=lambda w: (w.objectName(), _describe(w)))
+    return out
+
+
+def _menu_actions(mw):
+    out = []
+
+    def walk(m):
+        for a in m.actions():
+            if a.menu():
+                walk(a.menu())
+            elif a.text():
+                out.append(a)
+    menu = getattr(mw, "pokemenu", None)
+    if menu is not None:
+        walk(menu)
+    out.sort(key=lambda a: a.text())
+    return out
+
+
+# --- the corrupt world -------------------------------------------------------
+
+def _corrupt_one(db, rng, log):
+    """Mangle ONE saved Pokemon to valid-JSON-but-broken-values — the realistic
+    'part of my save is corrupt' a normal user can hit (a half-finished write, a
+    bad migration). Stays valid JSON so it passes the generated virtual columns;
+    the damage surfaces when the game LOADS/renders it (PC box, battle, HUD)."""
+    rows = db.execute("SELECT individual_id, data FROM captured_pokemon").fetchall()
+    if not rows:
+        log("  (corrupt: no rows to mangle)")
+        return
+    row = rng.choice(rows)
+    iid, data = row[0], json.loads(row[1])
+    mangles = [
+        ("level=garbage", lambda x: x.__setitem__("level", rng.choice([-5, 0, 99999, "fifty", None]))),
+        ("hp=garbage",    lambda x: x.__setitem__("hp", rng.choice(["lots", -1, None]))),
+        ("stats={}",      lambda x: x.__setitem__("stats", {})),
+        ("no attacks",    lambda x: x.__setitem__("attacks", [])),
+        ("type=broken",   lambda x: x.__setitem__("type", rng.choice([None, [], ["???"]]))),
+        ("drop name",     lambda x: x.pop("name", None)),
+        ("ability=null",  lambda x: x.__setitem__("ability", None)),
+        ("ev=broken",     lambda x: x.__setitem__("ev", "broken")),
+        ("id=garbage",    lambda x: x.__setitem__("id", rng.choice([-1, 0, 999999]))),
+    ]
+    label, fn = rng.choice(mangles)
+    fn(data)
+    db.execute("UPDATE captured_pokemon SET data = ? WHERE individual_id = ?", (json.dumps(data), iid))
+    db._get_connection().commit()
+    log("  CORRUPT row %s -> %s" % (str(iid)[:8], label))
+
+
+# --- the child ---------------------------------------------------------------
+
+def _run(seed, steps, journal_path, world=None, verbose=False):
+    """CHILD: one seeded run in a random world; journals each action before it runs."""
+    import random
+    from harness.real_driver import RealDriver
+    from harness.fixtures import seed_db
+    from PyQt6.QtWidgets import QApplication, QMenu
+    from PyQt6.QtTest import QTest
+
+    rng = random.Random(seed)
+    world = world or rng.choice(WORLDS)
+
+    j = open(journal_path, "w", buffering=1)
+
+    def log(line):
+        j.write(line + "\n")
+        j.flush()
+        os.fsync(j.fileno())                         # survive a hard abort
+        if verbose:
+            print(line)
+
+    log("SEED %d STEPS %d WORLD %s" % (seed, steps, world))
+
+    # Boot the genuine add-on into the chosen world.
+    has_assets = world != "blank"                    # blank = the user who denied the sprite download
+    d = RealDriver(first_run=has_assets, first_encounter=has_assets)
+    import Ankimon.utils as u
+    u.close_anki = lambda *a, **k: None              # the monkey must not quit the process
+    app = QApplication.instance()
+    mw = d.aqt.mw
+
+    if world in ("seeded", "corrupt"):
+        seed_db(BIG_TEAM, d.services.db)             # PC box reads the DB live, so this populates it
+    if world == "corrupt":
+        _corrupt_one(d.services.db, rng, log)
+
+    # Right-click pops a QMenu via menu.exec() (blocks). Neuter it to AUTO-pick and
+    # trigger a random context action (its actions are pre-wired via .triggered) and
+    # journal the choice — so favorite/give-item/release/trade/rename/evolve all fire.
+    def _fuzz_menu_exec(self, *a, **k):
+        acts = [x for x in self.actions() if x.isEnabled() and x.text() and not x.isSeparator()]
+        if acts:
+            c = rng.choice(acts)
+            log("    CONTEXT-ACTION '%s'" % c.text())
+            c.trigger()
+        return None
+    QMenu.exec = _fuzz_menu_exec
+    QMenu.exec_ = _fuzz_menu_exec
+
+    config = dict(d.services.settings.config)        # all ~63 real setting keys + defaults
+
+    # Weighted action menu: gameplay-heavy, with the full GUI surface mixed in.
+    KINDS = (["answer"] * 5 + ["catch"] * 2 + ["defeat"] * 2 + ["encounter"] * 1 + ["setting"] * 1
+             + ["menu"] * 4 + ["click"] * 3 + ["type"] * 2 + ["close"] * 1 + ["rightclick"] * 3)
+
+    def check(ret):
+        app.processEvents()
+        for ev in list(ret or []) + d.events.drain():
+            if isinstance(ev, dict) and ev.get("type") == "error":
+                log("  CAUGHT error event: %s" % (ev.get("message") or ev.get("exception")))
+
+    # Worlds with a populated box: open the PC box once up front so its slots are
+    # live for right-click AND so a corrupt row is actually LOADED/rendered — else
+    # the mangled row sits dormant in the DB and the corrupt world tests nothing.
+    # (If rendering a corrupt row hard-crashes, this warm-up line is the culprit.)
+    if world in ("seeded", "corrupt"):
+        pc = [a for a in _menu_actions(mw) if a.text() == "Pokémon PC"]
+        if pc:
+            log("warmup: open 'Pokémon PC' (load the seeded/corrupt box)")
+            try:
+                pc[0].trigger()
+                check(None)
+            except Exception as ex:
+                log("  CAUGHT exception in warmup: %s: %s" % (type(ex).__name__, str(ex)[:160]))
+
+    rss0 = _rss_mb()
+    log("RSS start: %.1f MB" % rss0)
+    for i in range(steps):
+        if i and i % 15 == 0:
+            log("RSS step %d: %.1f MB" % (i, _rss_mb()))
+        kind = rng.choice(KINDS)
+        ret = None
+        try:
+            if kind == "answer":
+                e = rng.choice(EASES)
+                log("step %d: ANSWER %s" % (i, e)); ret = d.answer(e)
+            elif kind == "catch":
+                log("step %d: CATCH" % i); ret = d.catch()
+            elif kind == "defeat":
+                log("step %d: DEFEAT" % i); ret = d.defeat()
+            elif kind == "encounter":
+                log("step %d: ENCOUNTER" % i); ret = d.encounter()
+            elif kind == "setting":
+                k = rng.choice(list(config))
+                v = _fuzz_value(rng, config[k])
+                log("step %d: SET %s=%r" % (i, k, v)); d.set_setting(k, v)
+            elif kind == "menu":
+                acts = _menu_actions(mw)
+                if not acts:
+                    log("step %d: noop (menu gated/empty)" % i); continue
+                a = rng.choice(acts)
+                log("step %d: MENU '%s'" % (i, a.text())); a.trigger()
+            elif kind == "click":
+                btns, _ = _candidates(app)
+                if not btns:
+                    log("step %d: noop (no buttons)" % i); continue
+                b = rng.choice(btns)
+                log("step %d: CLICK %s" % (i, _describe(b))); b.click()
+            elif kind == "type":
+                _, edits = _candidates(app)
+                if not edits:
+                    log("step %d: noop (no fields)" % i); continue
+                ed = rng.choice(edits); txt = rng.choice(WEIRD)
+                log("step %d: TYPE %r into %s" % (i, txt, _describe(ed)))
+                ed.clear()
+                if txt.isascii():
+                    QTest.keyClicks(ed, txt)
+                else:
+                    ed.setText(txt)                  # QTest.keyClicks is ASCII-only
+            elif kind == "close":
+                wins = [w for w in app.topLevelWidgets()
+                        if w.isVisible() and w is not mw and w.windowTitle()]
+                if not wins:
+                    log("step %d: noop (nothing to close)" % i); continue
+                w = rng.choice(wins)
+                log("step %d: CLOSE window '%s'" % (i, w.windowTitle())); w.close()
+            elif kind == "rightclick":
+                rc = _rightclickables(app)
+                if not rc:
+                    log("step %d: noop (nothing right-clickable — PC box not open yet)" % i); continue
+                w = rng.choice(rc)
+                log("step %d: RIGHT-CLICK %s" % (i, _describe(w)))
+                w.rightClicked.emit()                # -> context menu -> _fuzz_menu_exec triggers an action
+            check(ret)
+        except Exception as ex:
+            log("  CAUGHT exception: %s: %s" % (type(ex).__name__, str(ex)[:160]))
+    rssN = _rss_mb()
+    log("RSS final: %.1f MB (delta %+.1f over %d steps)" % (rssN, rssN - rss0, steps))
+    log("SURVIVED all %d steps" % steps)
+    j.close()
+
+
+def _fuzz_value(rng, default):
+    """A random value for a setting, typed from its default + boundary picks."""
+    if isinstance(default, bool):                    # bool BEFORE int (bool is an int subclass)
+        return rng.random() < 0.5
+    if isinstance(default, int):
+        return rng.choice([0, 1, 2, -1, -5, rng.randint(0, 9999), 999999])
+    if isinstance(default, float):
+        return rng.choice([0.0, -1.0, rng.random(), rng.uniform(0, 1000), 1e9])
+    return rng.choice(["", "x" * 100, "Ž★🔥", "999", "-1", str(default)])
+
+
+# --- the parent --------------------------------------------------------------
+
+def _signature(caught_line):
+    """Collapse a 'CAUGHT ...' journal line to a dedup key (drop the variable tail)."""
+    s = caught_line.strip()
+    for cut in (" at ", " in <", "': ", ": '"):
+        if cut in s:
+            s = s.split(cut)[0]
+    return s[:90]
+
+
+def _run_one(seed, steps, world):
+    """Run ONE child subprocess and return (seed, rc, journal-lines)."""
+    fd, jp = tempfile.mkstemp(prefix="megafuzz_%d_" % seed, suffix=".log")
+    os.close(fd)
+    cmd = [sys.executable, __file__, "--run", str(seed), str(steps), jp]
+    if world:
+        cmd.append(world)
+    try:
+        proc = subprocess.run(cmd, capture_output=True, text=True, timeout=300)
+        rc = proc.returncode
+    except subprocess.TimeoutExpired:
+        rc = -99
+    try:
+        lines = [l for l in open(jp).read().splitlines() if l.strip()]
+    except Exception:
+        lines = []
+    return seed, rc, lines
+
+
+def sweep(n_seeds=12, steps=80, world=None, parallel=1):
+    """PARENT: run each seed in a child process (up to `parallel` at once) and
+    aggregate hard crashes, soft error events, AND footprint into one ranked
+    findings report. `world` may be None (random/child), a str (forced), or a
+    LIST that is cycled across seeds (e.g. ['corrupt','blank'] to mine the edge
+    worlds hard)."""
+    crashers = []                 # (seed, world, rc, culprit-action)
+    soft = {}                     # signature -> {"count", "seeds": set, "example", "world"}
+    footprints = []               # (seed, world, delta_mb) for survived runs
+
+    def world_for(seed):
+        if isinstance(world, (list, tuple)):
+            return world[seed % len(world)]
+        return world
+
+    def handle(seed, rc, lines):
+        w = lines[0].split("WORLD")[-1].strip() if lines else "?"
+        caught = [l for l in lines if "CAUGHT" in l]
+        for c in caught:
+            sig = _signature(c)
+            rec = soft.setdefault(sig, {"count": 0, "seeds": set(), "example": c.strip(), "world": w})
+            rec["count"] += 1
+            rec["seeds"].add(seed)
+        delta = None
+        for l in lines:
+            if l.startswith("RSS final") and "delta" in l:
+                try:
+                    delta = float(l.split("delta")[1].split("over")[0])
+                except Exception:
+                    pass
+        survived = bool(lines) and lines[-1].startswith("SURVIVED")
+        if survived:
+            rc_count = sum(1 for l in lines if "RIGHT-CLICK" in l)
+            ctx_count = sum(1 for l in lines if "CONTEXT-ACTION" in l)
+            if delta is not None:
+                footprints.append((seed, w, delta))
+            mem = (" | RSS %+.0f MB" % delta) if delta is not None else ""
+            print("  seed %3d [%-9s]: survived %d steps  (%d right-clicks, %d context-actions, %d soft errors)%s"
+                  % (seed, w, steps, rc_count, ctx_count, len(caught), mem))
+        else:
+            culprit = next((l for l in reversed(lines) if not l.startswith("RSS")), lines[-1] if lines else "(no journal written)")
+            crashers.append((seed, w, rc, culprit))
+            print("  seed %3d [%-9s]: HARD CRASH (exit %d) — last action before death:\n           %s"
+                  % (seed, w, rc, culprit))
+
+    if parallel > 1:
+        from concurrent.futures import ThreadPoolExecutor, as_completed
+        with ThreadPoolExecutor(max_workers=parallel) as ex:
+            futs = [ex.submit(_run_one, s, steps, world_for(s)) for s in range(n_seeds)]
+            for f in as_completed(futs):
+                handle(*f.result())
+    else:
+        for s in range(n_seeds):
+            handle(*_run_one(s, steps, world_for(s)))
+
+    wlabel = ("|".join(world) if isinstance(world, (list, tuple)) else world) or "random"
+    print("\nmega_fuzz: %d seeds x %d steps (worlds=%s, parallel=%d) | %d hard-crashed | %d distinct soft errors"
+          % (n_seeds, steps, wlabel, parallel, len(crashers), len(soft)))
+    if crashers:
+        print("\nHARD CRASHES (process aborted — uncatchable in Python):")
+        for seed, w, rc, culprit in crashers:
+            wpart = (" %s" % w) if w and w != "?" else ""
+            print("  [seed %d %s] %s\n      replay: python3 harness/scenarios/mega_fuzz.py --replay %d %d%s"
+                  % (seed, w, culprit, seed, steps, wpart))
+    if soft:
+        print("\nSOFT ERRORS (caught mid-run — error events / handled exceptions):")
+        for sig, rec in sorted(soft.items(), key=lambda kv: -kv[1]["count"]):
+            ex = next(iter(sorted(rec["seeds"])))
+            print("  x%-3d [%s] %s\n      e.g. replay: python3 harness/scenarios/mega_fuzz.py --replay %d %d %s"
+                  % (rec["count"], rec["world"], rec["example"][:110], ex, steps, rec["world"]))
+    if footprints:
+        by_world = {}
+        for seed, w, d in footprints:
+            by_world.setdefault(w, []).append(d)
+        print("\nFOOTPRINT (RSS growth over the run — leak signal; high+linear = investigate):")
+        for w in sorted(by_world):
+            ds = by_world[w]
+            print("  %-9s avg %+.0f MB / run  (max %+.0f MB, n=%d)"
+                  % (w, sum(ds) / len(ds), max(ds), len(ds)))
+        worst = max(footprints, key=lambda t: t[2])
+        if worst[2] >= 100:
+            print("  ! biggest grower: seed %d [%s] %+.0f MB — replay: "
+                  "python3 harness/scenarios/mega_fuzz.py --replay %d %d %s"
+                  % (worst[0], worst[1], worst[2], worst[0], steps, worst[1]))
+    return crashers
+
+
+if __name__ == "__main__":
+    if "--run" in sys.argv:
+        i = sys.argv.index("--run")
+        extra = sys.argv[i + 4] if len(sys.argv) > i + 4 and not sys.argv[i + 4].startswith("-") else None
+        _run(int(sys.argv[i + 1]), int(sys.argv[i + 2]), sys.argv[i + 3], world=extra)
+    elif "--replay" in sys.argv:
+        i = sys.argv.index("--replay")
+        w = sys.argv[i + 3] if len(sys.argv) > i + 3 and not sys.argv[i + 3].startswith("-") else None
+        fd, jp = tempfile.mkstemp(suffix=".log")
+        os.close(fd)
+        _run(int(sys.argv[i + 1]), int(sys.argv[i + 2]), jp, world=w, verbose=True)
+    else:
+        def _opt(flag, default, cast=int):
+            return cast(sys.argv[sys.argv.index(flag) + 1]) if flag in sys.argv else default
+        world = None
+        if "--world" in sys.argv:
+            raw = sys.argv[sys.argv.index("--world") + 1]
+            world = raw.split(",") if "," in raw else raw     # comma list -> cycle worlds
+        n_seeds = _opt("--seeds", 12)
+        steps = _opt("--steps", 80)
+        parallel = _opt("--parallel", 1)
+        sys.exit(1 if sweep(n_seeds=n_seeds, steps=steps, world=world, parallel=parallel) else 0)

--- a/harness/scenarios/move_sweep.py
+++ b/harness/scenarios/move_sweep.py
@@ -1,0 +1,95 @@
+"""
+harness/scenarios/move_sweep.py — run EVERY move through a real battle, list crashers.
+
+The fuzzer *samples* moves; this is the exhaustive version for the move dimension.
+It takes every move poke_engine knows (~885), gives it to the main Pokemon, and
+makes the main attack with it in a real battle — surfacing any move whose
+implementation (in poke_engine or Ankimon's bridge to it) throws or emits an
+`error` event. Output is a clean per-move pass/fail: exactly which moves break.
+
+    python3 harness/scenarios/move_sweep.py        # sweep all ~885 moves
+    python3 harness/scenarios/move_sweep.py 200     # first 200 (quick check)
+
+Not a gate probe — it's an exhaustive audit you run on demand.
+"""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+
+from harness.driver import Driver
+
+
+def _test_move(mv):
+    """Give the MAIN this move, attack with it a few times, report any crash."""
+    try:
+        d = Driver(seed={"main": {"species": "Mew", "level": 50, "moves": [mv]}},
+                   settings_overrides={"battle.cards_per_round": 1})
+        d.set_enemy(species="Snorlax", level=50)        # tanky, survives so the move fires
+        for _ in range(3):
+            for e in d.answer("good"):                   # main attacks WITH `mv`
+                if e.get("type") == "error":
+                    return "error: " + str(e.get("message") or e.get("exception") or "")[:90]
+        return None
+    except Exception as ex:
+        return "%s: %s" % (type(ex).__name__, str(ex)[:90])
+
+
+def _test_enemy_move(mv):
+    """Give the WILD this move and make it attack with it (poor answers drop the
+    multiplier so the wild swings); a tanky main survives so it keeps attacking."""
+    try:
+        d = Driver(seed={"main": {"species": "Blissey", "level": 90, "moves": ["softboiled"]}},
+                   settings_overrides={"battle.cards_per_round": 1})
+        d.set_enemy(species="Gengar", level=50, moves=[mv])
+        attacked = False
+        for _ in range(8):
+            for e in d.answer("again"):
+                if e.get("type") == "error":
+                    return "error: " + str(e.get("message") or e.get("exception") or "")[:90]
+                if e.get("type") == "battle" and e.get("enemy_move"):
+                    attacked = True
+            if attacked:
+                break                                    # move fired cleanly -> done
+        return None
+    except Exception as ex:
+        return "%s: %s" % (type(ex).__name__, str(ex)[:90])
+
+
+def run(limit=None, verbose=True, side="main"):
+    Driver()                                             # warmup: make Ankimon importable
+    import Ankimon.poke_engine.data as ped
+    moves = sorted(ped.all_move_json.keys())
+    if limit:
+        moves = moves[:limit]
+    tester = _test_enemy_move if side == "enemy" else _test_move
+    print("move sweep (%s side): %d moves" % (side, len(moves)))
+
+    crashers = []
+    for i, mv in enumerate(moves):
+        why = tester(mv)
+        if why:
+            crashers.append((mv, why))
+        if verbose and (i + 1) % 150 == 0:
+            print("  %d/%d swept, %d crashers so far" % (i + 1, len(moves), len(crashers)))
+
+    print("\nmove sweep: %d moves, %d crashed" % (len(moves), len(crashers)))
+    if crashers:
+        # group by the error signature to show distinct failure modes
+        from collections import defaultdict
+        groups = defaultdict(list)
+        for mv, why in crashers:
+            groups[why.split(":")[0][:40]].append(mv)
+        print("by failure mode:")
+        for sig, mvs in sorted(groups.items(), key=lambda kv: -len(kv[1])):
+            print("  [%3d moves] %s  e.g. %s" % (len(mvs), sig, ", ".join(mvs[:8])))
+    else:
+        print("CLEAN — every move ran without a crash.")
+    return crashers
+
+
+if __name__ == "__main__":
+    side = "enemy" if "--enemy" in sys.argv else "main"          # default: main side
+    lim = next((int(a) for a in sys.argv[1:] if a.isdigit()), None)
+    sys.exit(1 if run(lim, side=side) else 0)

--- a/harness/scenarios/pokedex_render.py
+++ b/harness/scenarios/pokedex_render.py
@@ -1,0 +1,88 @@
+"""
+harness/scenarios/pokedex_render.py — open the REAL Pokedex (WebEngine) repeatedly
+and measure memory. Reproduces user issue #4 ("lagspikes / memory when opening the
+Pokedex and going past pages").
+
+The Pokedex loads pokedex.html (all ~1300 Pokemon) into a real QWebEngineView. This
+opens it once, then re-opens it (load_html + reload) N times, sampling RSS — the
+per-open memory cost. Needs real WebEngine (CI, or this aarch64 Pi via
+harness/setup_webengine.sh + the env below).
+
+    source .tier2/env.sh
+    export LD_LIBRARY_PATH=$PWD/.tier2/we-libs/extract/usr/lib/aarch64-linux-gnu:$LD_LIBRARY_PATH
+    export ANKIMON_SPRITE_CACHE=$PWD/.tier2/sprites-cache
+    python3 harness/scenarios/pokedex_render.py 80
+
+Finding (this Pi, single-process Chromium): ~2.6 MB leaked per re-open, linear, no
+plateau over 60 opens (326 -> 481 MB). Root not yet pinned (Ankimon page not freed
+vs Chromium image cache vs single-process) — but it reproduces the reported symptom.
+"""
+
+import os
+import sys
+
+os.environ.setdefault("QTWEBENGINE_DISABLE_SANDBOX", "1")
+os.environ.setdefault(
+    "QTWEBENGINE_CHROMIUM_FLAGS",
+    "--no-sandbox --disable-gpu --disable-dev-shm-usage --in-process-gpu --single-process",
+)
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+
+from PyQt6.QtWebEngineWidgets import QWebEngineView          # before QApplication
+from PyQt6.QtCore import QTimer, QEventLoop
+
+
+def _rss():
+    for line in open("/proc/self/status"):
+        if line.startswith("VmRSS"):
+            return int(line.split()[1]) // 1024
+    return 0
+
+
+def _pump(ms):
+    loop = QEventLoop()
+    QTimer.singleShot(ms, loop.quit)
+    loop.exec()
+
+
+def run(n=80):
+    from harness.real_env import start_real_session
+    from harness.fixtures import seed_db
+    from PyQt6.QtWidgets import QApplication
+
+    h = start_real_session(first_run=True, webengine=True)
+    seed_db({"main": {"species": "Gengar", "level": 50},
+             "box": [{"species": s, "level": 10}
+                     for s in ["Pikachu", "Bulbasaur", "Squirtle", "Eevee", "Snorlax",
+                               "Mew", "Onix", "Magikarp", "Ditto", "Lapras"]]}, h.services.db)
+    app = QApplication.instance()
+    import Ankimon.singletons as S
+    pd = S.pokedex_window
+
+    if not pd.webview.__class__.__module__.startswith("PyQt6"):
+        print("Pokedex is on the WebEngine STUB — run setup_webengine.sh + set the env "
+              "(LD_LIBRARY_PATH, Chromium flags) so it uses real WebEngine. Aborting.")
+        return
+
+    done = {}
+    pd.webview.loadFinished.connect(lambda ok: done.update(ok=ok))
+    pd.load_html()
+    _pump(5000)
+    base = _rss()
+    print("first Pokedex render: loadFinished=%s | baseline RSS %d MB" % (done.get("ok"), base))
+
+    for i in range(1, n + 1):
+        pd.load_html()
+        pd.webview.reload()
+        _pump(180)
+        if i % max(1, n // 4) == 0 or i == n:
+            print("  after %3d re-opens: RSS %d MB  (Δ +%d)" % (i, _rss(), _rss() - base))
+
+    slope = (_rss() - base) / n
+    print("\npokedex re-open memory: %d -> %d MB over %d opens (~%.2f MB/open)"
+          % (base, _rss(), n, slope))
+    print("VERDICT:", "LEAK — climbs without plateau" if slope > 0.5 else "bounded")
+
+
+if __name__ == "__main__":
+    run(int(sys.argv[1]) if len(sys.argv) > 1 and sys.argv[1].isdigit() else 80)

--- a/harness/setup_webengine.sh
+++ b/harness/setup_webengine.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# harness/setup_webengine.sh — fetch QtWebEngine's native deps, sudo-free.
+#
+# QtWebEngine (the reviewer HUD + the Pokedex/help windows) needs a pile of
+# Chromium native libs. On a box that has them (x86 CI), nothing to do. On a
+# minimal/aarch64 box (e.g. this Pi) they're missing, so — exactly like
+# setup_tier2.sh does for the base Qt libs — this downloads the .debs WITHOUT
+# sudo and extracts them locally; you reach them via LD_LIBRARY_PATH.
+#
+#   bash harness/setup_webengine.sh
+#   source .tier2/env.sh
+#   export LD_LIBRARY_PATH="$PWD/.tier2/we-libs/extract/usr/lib/aarch64-linux-gnu:$LD_LIBRARY_PATH"
+#   export QTWEBENGINE_DISABLE_SANDBOX=1
+#   export QTWEBENGINE_CHROMIUM_FLAGS="--no-sandbox --disable-gpu --disable-dev-shm-usage --in-process-gpu --single-process"
+#   python3 harness/scenarios/hud_render.py 150
+#
+# (Headless Chromium needs --no-sandbox + software GL; the flags above are the set
+# that gets it rendering offscreen on this Pi.)
+set -u
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+WE="$ROOT/.tier2/we-libs"
+mkdir -p "$WE/debs" "$WE/extract"
+cd "$WE/debs" || exit 1
+
+# libs reported missing by `ldd libQt6WebEngineCore.so` (+ their transitive deps).
+PKGS="libxcomposite1 libxdamage1 libxfixes3 libxrandr2 libxtst6 liblcms2-2 \
+      libopus0 libsnappy1v5 libwebp7 libwebpdemux2 libwebpmux3 libxcb-dri3-0 \
+      libxkbfile1 libasound2t64 libminizip1t64 libxrender1 libsharpyuv0"
+
+for p in $PKGS; do
+  apt-get download "$p" 2>/dev/null || echo "warn: could not fetch $p (name may differ on your release)"
+done
+
+n=0
+for d in *.deb; do
+  [ -f "$d" ] && dpkg-deb -x "$d" "$WE/extract" && n=$((n + 1))
+done
+echo "extracted $n debs -> $WE/extract"
+echo "libs at: $WE/extract/usr/lib/aarch64-linux-gnu"
+echo "Re-run ldd on libQt6WebEngineCore.so to check for any further 'not found' deps."


### PR DESCRIPTION
Stacked on #492 (targets its branch, like the other harness siblings). Lands the session's headline harness work so the skill (already on #492 via #503) has real code behind it.

## What this adds
- **`mega_fuzz.py`** — the do-EVERYTHING fuzzer: random **world** (`first_run`/`blank`/`seeded`/`corrupt`) × random **action** (gameplay + GUI + **right-click context menus**) over auto-discovered targets. Journaled + fsync'd before each action, each seed in its own child process (a C++ Qt abort → reproducible finding), parallel, with a ranked report of **hard crashes + soft error-events + footprint (RSS/world)** and `--replay`.
- **`feature_check.py`** — validate a feature behaves **as intended** (drive the real feature, assert the intended outcome). 3 worked checks: rename / make-favorite / catch-grows-collection — the template for new-menu acceptance checks.
- **`gui_fuzz.py` / `fuzz.py` / `move_sweep.py`** — GUI monkey, Tier-1 logic fuzz, every-move-through-a-real-battle.
- **`hud_render.py` / `pokedex_render.py` + `setup_webengine.sh`** — real `QtWebEngine` offscreen (reproduces the Pokédex memory leak, #4).
- **`probe_contract` / `probe_persistence` / `probe_migration`** — Tier-1 gate probes (auto-join `check.py`; gate now 9/9).
- **`real_env.py` / `fake_aqt.py`** — faithful-boot upgrades: `first_run` (seed sprites pre-import), `webengine` wiring, and the two fidelity fixes the fuzzer surfaced (neuter `QInputDialog`, fire `profileLoaded` so the catch/defeat buttons work).

## Verified on this branch
- Tier-1 gate: **9/9 green**
- `feature_check`: **3/3** features behave as intended
- `mega_fuzz`: runs (survives a smoke sweep)

## Notes
- `--coverage` on the gate is intentionally **deferred to its own PR** — it's entangled with `check.py`/`harness.yml`, which the enriched #499 already updated.
- The bugs `mega_fuzz` found (Item Shop `random.sample`, Pokédex leak, etc.) are **logged, not fixed** here — that's the follow-up fix queue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)