### PR TITLE
fix(ui): hide confusing fighting status badge and display actual elemental types

### DIFF
--- a/src/Ankimon/functions/create_gui_functions.py
+++ b/src/Ankimon/functions/create_gui_functions.py
@@ -29,7 +29,7 @@ def create_status_label(status_name):
 
     return label
 
-def create_status_html(status_name, settings_obj, is_pokemon_owned=False, addon_package=""):
+def create_status_html(status_name, settings_obj, is_pokemon_owned=False, addon_package="", pokemon_types=None):
     xp_bar_spacer = settings_obj.compute_special_variable('xp_bar_spacer')
     hp_bar_thickness = settings_obj.get("gui.review_hp_bar_thickness") * 4
     show_mainpkmn_in_reviewer = int(settings_obj.get("gui.show_mainpkmn_in_reviewer"))
@@ -43,10 +43,16 @@ def create_status_html(status_name, settings_obj, is_pokemon_owned=False, addon_
             pokeball_url = f"/_addons/{addon_package}/web/images/pokeball.png"
             badge_html = f'<img id="owned-indicator-badge" src="{pokeball_url}" style="margin-right: 8px; width: 22px; height: 22px; background-color: var(--ankimon-outline); border-radius: 50%; padding: 2px; box-sizing: border-box; flex-shrink: 0;">'
 
-        if show_mainpkmn_in_reviewer == 2:
-            html = f"""
-            <div id=pokestatus-container class="Ankimon" style="display: flex; align-items: center; position: fixed; bottom: {140 + xp_bar_spacer + hp_bar_thickness}px; right: 1%; z-index: 9999;">
-            {badge_html}
+        type_html = ''
+        if pokemon_types:
+            for ptype in pokemon_types:
+                type_url = f"/_addons/{addon_package}/addon_sprites/Types/{ptype.lower()}.png"
+                type_html += f'<img src="{type_url}" style="margin-right: 4px; height: 16px; object-fit: contain;">'
+
+        if status_name.lower() == 'fighting':
+            status_div = ''
+        else:
+            status_div = f'''
             <div id=pokestatus class="Ankimon" style="
                 background-color: {colors['background']};
                 border: 2px solid {colors['outline']};
@@ -61,46 +67,30 @@ def create_status_html(status_name, settings_obj, is_pokemon_owned=False, addon_
                 margin: 4px;
                 font-family: Arial, sans-serif;
             ">{colors['name']}</div>
+            '''
+
+        if show_mainpkmn_in_reviewer == 2:
+            html = f"""
+            <div id=pokestatus-container class="Ankimon" style="display: flex; align-items: center; position: fixed; bottom: {140 + xp_bar_spacer + hp_bar_thickness}px; right: 1%; z-index: 9999;">
+            {badge_html}
+            {type_html}
+            {status_div}
             </div>
             """
         elif show_mainpkmn_in_reviewer == 1:
             html = f"""
             <div id=pokestatus-container class="Ankimon" style="display: flex; align-items: center; position: fixed; bottom: {40 + hp_bar_thickness + xp_bar_spacer}px; right: 15%; z-index: 9999;">
             {badge_html}
-            <div id=pokestatus class="Ankimon" style="
-                background-color: {colors['background']};
-                border: 2px solid {colors['outline']};
-                border-radius: 5px;
-                padding: 5px 10px;
-                font-size: 8px;
-                font-weight: bold !important;
-                display: inline-block;
-                color: {colors.get('text_color', '#000000')};
-                text-transform: uppercase;
-                text-align: center;
-                margin: 4px;
-                font-family: Arial, sans-serif;
-            ">{colors['name']}</div>
+            {type_html}
+            {status_div}
             </div>
             """
         elif show_mainpkmn_in_reviewer == 0:
             html = f"""
             <div id=pokestatus-container class="Ankimon" style="display: flex; align-items: center; position: fixed; bottom: {40 + hp_bar_thickness}px; left: 160px; z-index: 9999;">
             {badge_html}
-            <div id=pokestatus class="Ankimon" style="
-                background-color: {colors['background']};
-                border: 2px solid {colors['outline']};
-                border-radius: 5px;
-                padding: 5px 10px;
-                font-size: 8px;
-                font-weight: bold !important;
-                display: inline-block;
-                color: {colors.get('text_color', '#000000')};
-                text-transform: uppercase;
-                text-align: center;
-                margin: 4px;
-                font-family: Arial, sans-serif;
-            ">{colors['name']}</div>
+            {type_html}
+            {status_div}
             </div>
             """
     else:

--- a/src/Ankimon/functions/pokedex_functions.py
+++ b/src/Ankimon/functions/pokedex_functions.py
@@ -17,7 +17,7 @@ import json
 import random
 import csv
 from ..pyobj.error_handler import show_warning_with_traceback
-from ..pyobj.pokemon_obj import PokemonObject
+
 
 GROWTH_RATES = {
     1: "slow",
@@ -756,6 +756,7 @@ def check_evolution_for_pokemon(
                             if evo_defeated > 0:
                                 pokemon_data = mw.ankimon_db.get_pokemon(individual_id)
                                 if pokemon_data:
+                                    from ..pyobj.pokemon_obj import PokemonObject
                                     pokemon_obj = PokemonObject.from_dict(pokemon_data)
                                     if (pokemon_obj.pokemon_defeated or 0) >= evo_defeated:
                                         evo_id = safe_int(target_data.get("actual_id") or target_data.get("species_id"))

--- a/src/Ankimon/pyobj/pokemon_obj.py
+++ b/src/Ankimon/pyobj/pokemon_obj.py
@@ -9,7 +9,7 @@ from ..functions.sprite_functions import get_sprite_path
 
 from ..poke_engine.objects import Pokemon
 from ..resources import pkmnimgfolder, mainpokemon_path, mypokemon_path
-from ..utils import give_item
+
 
 class PokemonObject:
     def __init__(
@@ -464,6 +464,8 @@ class PokemonObject:
 
         db = mw.ankimon_db
 
+
+        from ..utils import give_item
         give_item(self.held_item)  # We put the item back in the item bag
         self.held_item = None
 

--- a/src/Ankimon/pyobj/reviewer_obj.py
+++ b/src/Ankimon/pyobj/reviewer_obj.py
@@ -135,9 +135,9 @@ class Reviewer_Manager:
                     break
 
         if self.enemy_pokemon.hp > 0:
-            hud_html += create_status_html(f"{self.enemy_pokemon.battle_status}", self.settings, is_pokemon_owned, addon_package)
+            hud_html += create_status_html(f"{self.enemy_pokemon.battle_status}", self.settings, is_pokemon_owned, addon_package, pokemon_types=self.enemy_pokemon.type)
         else:
-            hud_html += create_status_html("fainted", self.settings, is_pokemon_owned, addon_package)
+            hud_html += create_status_html("fainted", self.settings, is_pokemon_owned, addon_package, pokemon_types=self.enemy_pokemon.type)
 
         hud_html += f'<div id="hp-display" class="Ankimon">HP: {int(self.enemy_pokemon.hp)}/{int(self.enemy_pokemon.max_hp)}</div>'
 


### PR DESCRIPTION
This PR resolves an issue where the default battle status ("fighting") was rendered as a text badge on the reviewer screen, confusing users into thinking the opposing Pokémon was a Fighting-type. 

**Changes:**
- Updates `create_status_html` to accept a `pokemon_types` argument.
- Injects HTML `img` tags for the actual elemental type icons (e.g. `fire.png`, `water.png`) into the `pokestatus-container`.
- Explicitly hides the text badge if the `status_name` is exactly `'fighting'`, avoiding the misleading text while still allowing status ailments like 'Burned' or 'Asleep' to render.
- Modifies `Reviewer_Manager` to pass `self.enemy_pokemon.type` down to `create_status_html`.

These changes make the battle interface much clearer and more informative.

---
*PR created automatically by Jules for task [16294762151297655186](https://jules.google.com/task/16294762151297655186) started by @h0tp-ftw*