### PR TITLE
fix(pc-box): port reliability fixes from BRRRR_Experimental

### DIFF
--- a/src/Ankimon/gui_classes/pokemon_details.py
+++ b/src/Ankimon/gui_classes/pokemon_details.py
@@ -1,5 +1,4 @@
 import math
-from math import exp
 import json
 from typing import Any
 import re
@@ -545,6 +544,23 @@ def PokemonDetailsStats(
         "friendship": "Friendship",
     }
 
+    # 1. Query the max level in the player's collection to dynamically scale the visual baseline
+    max_level = 100
+    try:
+        cursor = mw.ankimon_db.execute("SELECT MAX(level) FROM captured_pokemon")
+        row = cursor.fetchone()
+        if row and row[0] is not None:
+            max_level = int(row[0])
+    except Exception:
+        pass
+
+    # 2. Get the maximum stat of the currently selected Pokémon (handles manual DB/JSON stat edits)
+    core_stats = ["hp", "atk", "def", "spa", "spd", "spe"]
+    current_max_stat = max(detail_stats.get(s, 0) for s in core_stats) if any(s in detail_stats for s in core_stats) else 0
+
+    # 3. Determine unified global maximum for this database context
+    global_max_stat = max(750, max_level * 7.5, current_max_stat)
+
     for row, (stat, value) in enumerate(detail_stats.items()):
         # Skip unknown stats that are not in stat_colors
         if stat not in stat_colors:
@@ -594,7 +610,7 @@ def PokemonDetailsStats(
                 int((friendship_value / max(1, friendship_bar_max)) * max_width_stat_item),
             )
         else:
-            value = int(max_width_stat_item * (1 - exp(-value / max_width_stat_item)))
+            value = int((math.sqrt(max(0, value)) / math.sqrt(global_max_stat)) * max_width_stat_item)
         pixmap2 = createStatBar(stat_colors.get(stat), value)
         # Convert the QPixmap to an QIcon
         icon = QIcon(pixmap2)

--- a/src/Ankimon/pyobj/item_window.py
+++ b/src/Ankimon/pyobj/item_window.py
@@ -464,7 +464,10 @@ class ItemWindow(QWidget):
             self.delete_item(item_name)
             self.starter_window.display_fossil_pokemon(fossil_id, fossil_poke_name)
             from ..singletons import pokemon_pc
-            pokemon_pc.refresh_pokemon_grid()
+            from ..utils import is_alive
+
+            if is_alive(pokemon_pc):
+                pokemon_pc.refresh_pokemon_grid()
         except Exception as e:
             show_warning_with_traceback(parent=self, exception=e, message=f"Error using fossil item '{item_name}'")
         finally:

--- a/src/Ankimon/pyobj/pc_box.py
+++ b/src/Ankimon/pyobj/pc_box.py
@@ -64,7 +64,6 @@ def clear_layout(layout):
         item = layout.takeAt(0)
         widget = item.widget()
         if widget is not None:
-            widget.setParent(None)
             widget.deleteLater()
         elif item.layout():
             clear_layout(item.layout())
@@ -80,14 +79,21 @@ class PokemonSlotButton(QPushButton):
 
 
 class ScaledMovieLabel(QLabel):
-    def __init__(self, gif_path, width, height):
-        super().__init__()
+    def __init__(self, gif_path, width, height, parent=None):
+        super().__init__(parent)
         self.target_width = width
         self.target_height = height
-        self.movie = QMovie(gif_path)
+        self.movie = QMovie(gif_path, parent=self)
         self.movie.frameChanged.connect(self.on_frame_changed)
-        self.movie.start()
         self.setFixedSize(width, height)
+
+    def showEvent(self, event):
+        super().showEvent(event)
+        self.movie.start()
+
+    def hideEvent(self, event):
+        super().hideEvent(event)
+        self.movie.stop()
 
     def on_frame_changed(self, frame_number):
         # Get current frame pixmap
@@ -675,7 +681,7 @@ class PokemonPC(QDialog):
             for col in range(self.n_cols):
                 pokemon_idx = row * self.n_cols + col
                 if pokemon_idx >= len(pokemon_list_slice):
-                    empty_label = QLabel()
+                    empty_label = QLabel(self.grid_container)
                     empty_label.setFixedSize(self.slot_size, self.slot_size)
                     self.pokemon_grid.addWidget(
                         empty_label, row, col, alignment=Qt.AlignmentFlag.AlignCenter
@@ -690,7 +696,7 @@ class PokemonPC(QDialog):
                     pokemon.get("shiny", False),
                     pokemon["gender"],
                 )
-                pokemon_button = PokemonSlotButton("")
+                pokemon_button = PokemonSlotButton("", self.grid_container)
                 pokemon_button.setFixedSize(self.slot_size, self.slot_size)
 
                 # BFF (highest friendship) takes visual precedence over Favorite.
@@ -728,7 +734,7 @@ class PokemonPC(QDialog):
 
                 if self.gif_in_collection:
                     scaled_movie_label = ScaledMovieLabel(
-                        pkmn_image_path, self.slot_size - 10, self.slot_size - 10
+                        pkmn_image_path, self.slot_size - 10, self.slot_size - 10, self.grid_container
                     )
                     scaled_movie_label.setAttribute(
                         Qt.WidgetAttribute.WA_TransparentForMouseEvents
@@ -755,7 +761,7 @@ class PokemonPC(QDialog):
                 # Badge overlays, added last so they paint on top of the sprite.
                 # Heart on the BFF slot (top-left corner).
                 if is_bff:
-                    heart_badge = QLabel("💖")
+                    heart_badge = QLabel("💖", self.grid_container)
                     heart_badge.setAttribute(
                         Qt.WidgetAttribute.WA_TransparentForMouseEvents
                     )
@@ -789,7 +795,7 @@ class PokemonPC(QDialog):
                 if readiness["ready"] and (
                     readiness["method"] == "level" or friendship_time_enabled
                 ):
-                    evo_badge = QLabel("✨")
+                    evo_badge = QLabel("✨", self.grid_container)
                     evo_badge.setAttribute(
                         Qt.WidgetAttribute.WA_TransparentForMouseEvents
                     )
@@ -817,7 +823,7 @@ class PokemonPC(QDialog):
                     wait_icon = (
                         "🌙" if readiness["required_time"] == "night" else "☀️"
                     )
-                    wait_badge = QLabel(wait_icon)
+                    wait_badge = QLabel(wait_icon, self.grid_container)
                     wait_badge.setAttribute(
                         Qt.WidgetAttribute.WA_TransparentForMouseEvents
                     )

--- a/src/Ankimon/pyobj/pokemon_trade.py
+++ b/src/Ankimon/pyobj/pokemon_trade.py
@@ -56,7 +56,9 @@ def add_pokemon_to_collection(new_pokemon, refresh_callback=None, parent_window=
             refresh_callback()
 
         from ..singletons import pokemon_pc
-        pokemon_pc.refresh_pokemon_grid()
+        from ..utils import is_alive
+        if is_alive(pokemon_pc):
+            pokemon_pc.refresh_pokemon_grid()
     except Exception as e:
         show_warning_with_traceback(parent=parent_window, exception=e, message="Error adding Pokemon to collection")
 

--- a/src/Ankimon/pyobj/starter_window.py
+++ b/src/Ankimon/pyobj/starter_window.py
@@ -159,7 +159,9 @@ class StarterWindow(QWidget):
         self.display_chosen_starter_pokemon(starter_name)
 
         from ..singletons import pokemon_pc
-        pokemon_pc.refresh_pokemon_grid()
+        from ..utils import is_alive
+        if is_alive(pokemon_pc):
+            pokemon_pc.refresh_pokemon_grid()
 
         close_anki()
 


### PR DESCRIPTION
Ports three PC-box reliability fixes from `BRRRR_Experimental` onto `main`, preserving the original code by @hakimh2. All three commits keep his authorship (cherry-picked with `-x`); conflicts were resolved by applying his change onto main's diverged versions of the files.

## What's ported (all authored by @hakimh2)

1. **`fix(pc): prevent AttributeError when refreshing grid before PC Box is initialized`** (`be6f8ff8`)
   Guards `pokemon_pc.refresh_pokemon_grid()` with `is_alive(pokemon_pc)` in `item_window.py`, `pokemon_trade.py`, and `starter_window.py`, so adding a Pokémon (fossil revive / trade / starter pick) before the PC box has ever been opened no longer crashes. `is_alive()` already exists in main's `utils.py`.

2. **`fix: resolve PC Box flashing blank white window popups`** (`729fa96f`)
   Root cause: `widget.setParent(None)` in `clear_layout()` briefly turned animating widgets into top-level windows (white flashes). Fix keeps widgets parented during `deleteLater()`, explicitly parents every grid element to `self.grid_container`, and defers `QMovie` start/stop to `showEvent`/`hideEvent` (no animation while detached).

3. **`fix: implement dynamic global square root scaling for PC Box stat bars`** (`54df8c3e`)
   Replaces the `1 - exp(...)` stat-bar value mapping with sqrt scaling against a dynamic `global_max_stat` (`max(750, max_level*7.5, current_max_stat)`) queried from the collection, so bars stay meaningful for over-levelled / manually-edited mons.

## Adaptations (main had diverged from BRRRR)

- **`pc_box.py`**: main's grid builder is richer than BRRRR's (BFF heart, `evolution_readiness` ✨ badge + tooltips, sun/moon wait badge, `badge_tooltips`). I kept all of main's logic and applied **only** @hakimh2's parenting change (`, self.grid_container`) to each widget constructor. `clear_layout` (drop `setParent(None)`) and `ScaledMovieLabel` (deferred QMovie via showEvent/hideEvent) applied cleanly.
- **`pokemon_details.py`**: BRRRR renders the bar via an `AnimatedStatBar` (old→new animation) that **does not exist on main** — main uses a static `createStatBar` pixmap. Importing the animated path would crash, so I kept main's static-bar structure and ported **only** the sqrt formula. @hakimh2's `global_max_stat` computation block applied cleanly. Removed the now-unused `from math import exp` (it was the only consumer).
- **`item_window.py`**: added a local `from ..utils import is_alive` (main's `item_window.py` didn't already import it), matching the local-import pattern @hakimh2 used in the other two files.

## Harness validation (Tier-2, offscreen Qt)

- `harness/check.py` → PASS (9/9 Tier-1 checks)
- Tier-1 sweeps: `economy.py` OK, `longrun.py 3000` OK
- `probe_real_boot` OK, `probe_real_play` OK
- `feature_check.py` (boots a seeded session, opens the PC box via `pc.show()`, drives `show_pokemon_details` + catch-refresh): **same result as pristine `origin/main`** — the one pre-existing `rename` failure reproduces identically on unmodified main, so this PR introduces **no regression**; `catch_grows_collection` (the refresh path the init-guard protects) passes.
- `pytest tests/` → 150 passed
- `ruff check --config ci_ruff_check.toml` (PLE+UP018) → all checks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)