### PR TITLE
Encounter Overhaul + Special Forms + Rate Simulator (port from BRRRR_Experimental)

### DIFF
--- a/docs/encounter_overhaul_spec.md
+++ b/docs/encounter_overhaul_spec.md
@@ -1,0 +1,217 @@
+# Ankimon Encounter Overhaul: Technical Specification
+
+This document details the architecture, mathematical models, and balancing variables behind the **Ankimon Encounter Overhaul**. It serves as an authoritative reference for game systems designers and core developers.
+
+---
+
+## 1. Design Philosophy & Goals
+
+In the legacy Ankimon spawn economy, late-game players faced an inflated rare encounter rate exceeding **35%**. While initially engaging, this abundance trivialized high-tier Pokémon (Legendaries, Megas, Mythicals), saturating the player's collection and undermining the progression loop.
+
+The Overhaul transitions the game into a structured, lore-accurate progression economy by:
+1.  **Introducing the Mastery Index (EP):** A dynamic float between `0.0` and `100.0` that acts as the core multiplier for all rare encounter weights.
+2.  **Exponential Rarity Scaling ("Soft Landing"):** Compressing the aggregate late-game rare spawn chance to a balanced **~10-12%** while scaling seamlessly based on progress.
+3.  **Independent Pity Trackers ($P_i$):** Shielding players from long dry spells by implementing 6 distinct bad-luck protection curves, completely decoupled from one another.
+
+```mermaid
+graph TD
+    A[Card Flip in Anki] --> B[Query DB: Trainer Lvl, Dex %, Daily Progress, Team CP]
+    B --> C[Calculate Unified EP Mastery Index]
+    C --> D[Generate Base Exponential Weights]
+    D --> E[Check Main Pokémon Level Thresholds]
+    E --> F[Apply 6 Independent Pity Multipliers]
+    F --> G[Normalize Weights to 100%]
+    G --> H[Roll Encounter & Initialize Battle]
+    H --> I[Update Persistent Pity Trackers in SQLite]
+```
+
+---
+
+## 2. Mastery Index & EP Calculation ($EP$)
+
+The core of the new system is the **Encounter Potential ($EP$)**, which weights collection breadth, combat depth, study consistency, and leveling to reward overall game mastery while preventing early-game exploitation.
+
+$$EP = (W_{trainer} \times T_{norm}) + (W_{dex} \times D_{norm}) + (W_{session} \times S_{norm}) + (W_{team} \times C_{norm})$$
+
+### The Configurable Weights & Caps
+These parameters are defined as module-level constants at the top of `encounter_functions.py`:
+
+| Parameter | Default Value | Description |
+| --- | --- | --- |
+| `EP_WEIGHT_TRAINER_LEVEL` | `0.25` (25%) | Impact of overall Trainer XP level on EP. |
+| `EP_WEIGHT_DEX_COMPLETION` | `0.25` (25%) | Impact of unique caught species percentage. |
+| `EP_WEIGHT_SESSION_PROGRESS` | `0.25` (25%) | Impact of card flips done relative to daily goal. |
+| `EP_WEIGHT_CORE_TEAM_POWER` | `0.25` (25%) | Impact of average CP of the top 6 Pokémon. |
+| `TRAINER_LEVEL_CAP` | `50.0` | Trainer level at which $T_{norm}$ reaches 100%. |
+| `CORE_TEAM_POWER_CAP` | `16000.0` | Average Top 6 CP at which $C_{norm}$ reaches 100%. |
+
+### Normalized Components
+*   **Trainer Progress ($T_{norm}$):** $\min\left(\frac{TrainerLevel}{TRAINER\_LEVEL\_CAP} \times 100, 100\right)$
+*   **Dex Progress ($D_{norm}$):** The percentage of unique captured base species (resolving Megas and Gigantamax forms >= 10000 to their base species IDs to prevent duplicate exploitation).
+*   **Session Progress ($S_{norm}$):** $\min\left(\frac{DailyReviewsDone}{DailyGoal} \times 100, 100\right)$.
+*   **Core Team Power ($C_{norm}$):** $\min\left(\frac{AverageTop6CP}{CORE\_TEAM\_POWER\_CAP} \times 100, 100\right)$.
+
+---
+
+## 3. Rarity Curves & The Soft Landing
+
+To scale each category smoothly from beginner configurations to late-game levels, each Tier $i$ utilizes an exponential growth curve relative to the player's current $EP$:
+
+$$Rate_i(EP) = Base_i \times \left( \frac{Max_i}{Base_i} \right)^{\frac{EP}{100}}$$
+
+### Rarity Parameters Table (`OVERHAUL_TIER_PARAMS`)
+
+| Tier | Base Rate ($EP = 0$) | Max Rate ($EP = 100$) | Scaling Description |
+| --- | --- | --- | --- |
+| **Normal** | 96.98% | 84.70% | Compresses smoothly to make room for rare categories. |
+| **Baby** | 2.30% | 3.00% | Slightly expands, maintaining a steady early/late-game presence. |
+| **Ultra Beast** | 0.35% | 4.50% | The most accessible high-tier rare group. |
+| **Gmax** | 0.15% | 2.50% | Highly coveted boss forms. |
+| **Starter** | 0.10% | 1.80% | Locked to 0% in active code (activated via comment toggle). |
+| **Mega** | 0.05% | 1.50% | Endgame standard legendary tier scaling. |
+| **Legendary** | 0.05% | 1.50% | Endgame standard legendary tier scaling. |
+| **Mythical** | 0.02% | 0.50% | The ultimate, hyper-rare endgame stretch goal. |
+
+### Main Pokémon Level Locks (`OVERHAUL_LEVEL_THRESHOLDS`)
+Regardless of a player's $EP$, a tier's weight is immediately set to `0.0` before normalization if the player's **Main Pokémon Level** is below the lock threshold:
+*   **Ultra / Starter:** Level 30+ (Starter has an updated threshold of Level 80+ in this configuration)
+*   **Legendary:** Level 50+
+*   **Mega:** Level 60+
+*   **Gmax:** Level 65+
+*   **Mythical:** Level 75+
+
+---
+
+## 4. The Independent Pity System
+
+In the legacy system, a single rare roll reset the global counter, "stealing" bad-luck protection from other tiers. The Overhaul introduces **6 Independent Pity Trackers ($P_i$)** stored in SQLite under the `"ankimon_pity_trackers"` JSON key.
+
+For each Rare Tier $i$, the pity multiplier is calculated quadratically:
+
+$$M_{pity\_i} = 1 + \left( \max\left(0, \frac{P_i - T_i}{OVERHAUL\_PITY\_DIVISOR}\right) \right)^2$$
+
+### Dry Spell Thresholds (`OVERHAUL_PITY_THRESHOLDS`)
+*   **Ultra Beast ($T_{ultra}$):** 100 reviews
+*   **Gmax ($T_{gmax}$):** 150 reviews
+*   **Starter ($T_{starter}$):** 200 reviews
+*   **Mega ($T_{mega}$):** 250 reviews
+*   **Legendary ($T_{leg}$):** 250 reviews
+*   **Mythical ($T_{myth}$):** 600 reviews
+*   *Pity Divisor (`OVERHAUL_PITY_DIVISOR`):* `50.0` reviews.
+
+If the selected encounter tier matches a Rare Tier, **only that tier's pity counter is reset to 0**. All other counters are incremented by 1.
+
+---
+
+## 5. Legay vs. Overhaul: Scenario Comparisons
+
+Here is how the calculations diverge across three typical stages of player progression.
+
+---
+
+### Scenario A: The Beginner Player
+*   **Trainer Level:** 1
+*   **Dex Completion:** 0%
+*   **Session Progress:** 0 reviews completed (out of 100 daily goal)
+*   **Core Team Power:** average CP of 10
+*   **Main Pokémon Level:** 5
+
+#### Legacy Calculations
+*   Review progress ratio = $0 / 100 = 0.0$ (< 0.4).
+*   All categories except Normal are locked (Normal gets their rates added).
+*   **Encounter Odds:**
+    *   **Normal:** 100.0%
+    *   **All Others:** 0.0%
+
+#### Overhaul Calculations
+*   $T_{norm} = \min\left(\frac{1}{50.0} \times 100, 100\right) = 2.0\%$
+*   $D_{norm} = 0.0\%$, $S_{norm} = 0.0\%$, $C_{norm} = \min\left(\frac{10}{16000.0} \times 100, 100\right) = 0.06\%$
+*   $EP = 0.25(2.0) + 0.25(0.0) + 0.25(0.0) + 0.25(0.06) = 0.515\%$
+*   Main level is 5, locking Ultra, Legendary, Mega, Gmax, Mythical, and Starter.
+*   Weights:
+    *   Normal: $96.98 \times (84.70 / 96.98)^{0.00515} \approx 96.91$
+    *   Baby: $2.30 \times (3.00 / 2.30)^{0.00515} \approx 2.303$
+*   **Encounter Odds (Normalized):**
+    *   **Normal:** 97.68%
+    *   **Baby:** 2.32%
+    *   **Rares:** 0.0% (locked)
+
+> **Key takeaway:** The Overhaul unlocks Baby Pokémon immediately, making early reviews more engaging, whereas Legacy strictly limits early reviews to Normal spawns.
+
+---
+
+### Scenario B: The Mid-Game Player
+*   **Trainer Level:** 20
+*   **Dex Completion:** 20%
+*   **Session Progress:** 60 reviews completed (out of 100 daily goal)
+*   **Core Team Power:** average CP of 1,200
+*   **Main Pokémon Level:** 35
+
+#### Legacy Calculations
+*   Review progress ratio = $60 / 100 = 0.60$ (between 0.6 and 0.8).
+*   Ultra rate increases by +3% (Normal rate decreases by -3%).
+*   Main level is 35 (Starter and Ultra unlocked; Legendary/Mega/Gmax/Mythical locked).
+*   **Encounter Odds (Normalized):**
+    *   **Normal:** 89.54%
+    *   **Baby:** 2.09%
+    *   **Ultra:** 8.37%
+
+#### Overhaul Calculations
+*   $T_{norm} = \min\left(\frac{20}{50.0} \times 100, 100\right) = 40.0\%$
+*   $D_{norm} = 20.0\%$, $S_{norm} = 60.0\%$, $C_{norm} = \min\left(\frac{1200}{16000.0} \times 100, 100\right) = 7.5\%$
+*   $EP = 0.25(40.0 + 20.0 + 60.0 + 7.5) = 31.875\%$
+*   Main level is 35 (locks Legendary, Mega, Gmax, Mythical, and Starter).
+*   Weights:
+    *   Normal: $96.98 \times (84.70 / 96.98)^{0.31875} \approx 92.87$
+    *   Baby: $2.30 \times (3.00 / 2.30)^{0.31875} \approx 2.50$
+    *   Ultra: $0.35 \times (4.50 / 0.35)^{0.31875} \approx 0.79$
+*   **Encounter Odds (Normalized):**
+    *   **Normal:** 96.58%
+    *   **Baby:** 2.60%
+    *   **Ultra:** 0.82%
+
+> **Key takeaway:** In Legacy, the Ultra spawn rate inflates to an unearned **8.37%** immediately at card 60. Under the Overhaul, the Ultra rate stays at a balanced **0.82%**, preserving their value and scaling seamlessly with team power and dex completion.
+
+---
+
+### Scenario C: The Endgame Master (Zero Pity active)
+*   **Trainer Level:** 50
+*   **Dex Completion:** 85%
+*   **Session Progress:** 100 reviews completed (out of 100 daily goal)
+*   **Core Team Power:** average CP of 8,000
+*   **Main Pokémon Level:** 85
+
+#### Legacy Calculations
+*   Review progress ratio = $100 / 100 = 1.0$ (>= 0.8).
+*   All level locks cleared. Flat +5% bonus applied to all non-normal tiers for Trainer Level > 10.
+*   **Encounter Odds (Normalized):**
+    *   **Normal:** 61.31%
+    *   **Ultra:** 10.61%
+    *   **Mega:** 6.29%
+    *   **Legendary:** 6.12%
+    *   **Gmax / Baby:** 5.71% each
+    *   **Mythical:** 4.24%
+    *   *Aggregate Rare Chance:* **38.69%**
+
+#### Overhaul Calculations
+*   $T_{norm} = 100.0\%$, $D_{norm} = 85.0\%$, $S_{norm} = 100.0\%$, $C_{norm} = \min\left(\frac{8000}{16000.0} \times 100, 100\right) = 50.0\%$
+*   $EP = 0.25(100.0 + 85.0 + 100.0 + 50.0) = 83.75\%$
+*   All level locks cleared (Starter is locked at 80+ but currently set to 0.0 weight in active code).
+*   Weights:
+    *   Normal: $96.98 \times (84.70 / 96.98)^{0.8375} \approx 86.55$
+    *   Baby: $2.30 \times (3.00 / 2.30)^{0.8375} \approx 2.87$
+    *   Ultra: $0.35 \times (4.50 / 0.35)^{0.8375} \approx 2.93$
+    *   Gmax: $0.15 \times (2.50 / 0.15)^{0.8375} \approx 1.57$
+    *   Mega: $0.05 \times (1.50 / 0.05)^{0.8375} \approx 0.86$
+    *   Legendary: $0.05 \times (1.50 / 0.05)^{0.8375} \approx 0.86$
+    *   Mythical: $0.02 \times (0.50 / 0.02)^{0.8375} \approx 0.30$
+*   **Encounter Odds (Normalized):**
+    *   **Normal:** 90.21%
+    *   **Baby:** 2.99%
+    *   **Ultra:** 3.05%
+    *   **Gmax:** 1.64%
+    *   **Mega / Legendary:** 0.90% each
+    *   **Mythical:** 0.31%
+    *   *Aggregate Rare Chance:* **9.79%**
+
+> **Key takeaway:** The endgame aggregate rare rate is compressed from an inflated **38.69%** down to a healthy **9.79%** (with absolute maximums hitting 12.3% at 100% EP). This restores prestige to endgame catches. If a dry spell occurs, the independent pity system will dynamically multiply these weights to guarantee exciting encounters.

--- a/src/Ankimon/data_files/pokedex.json
+++ b/src/Ankimon/data_files/pokedex.json
@@ -4782,7 +4782,7 @@
   "farfetchd": {
     "species_id": 83,
     "actual_id": 83,
-    "name": "Farfetch\u2019d",
+    "name": "Farfetch’d",
     "types": [
       "Normal",
       "Flying"
@@ -4808,11 +4808,11 @@
       "Field"
     ],
     "otherFormes": [
-      "Farfetch\u2019d-Galar"
+      "Farfetch’d-Galar"
     ],
     "formeOrder": [
-      "Farfetch\u2019d",
-      "Farfetch\u2019d-Galar"
+      "Farfetch’d",
+      "Farfetch’d-Galar"
     ],
     "tier": "Illegal",
     "isNonstandard": "Past"
@@ -4820,8 +4820,8 @@
   "farfetchdgalar": {
     "species_id": 83,
     "actual_id": 10166,
-    "name": "Farfetch\u2019d-Galar",
-    "baseSpecies": "Farfetch\u2019d",
+    "name": "Farfetch’d-Galar",
+    "baseSpecies": "Farfetch’d",
     "forme": "Galar",
     "types": [
       "Fighting"
@@ -4842,7 +4842,7 @@
     "weightkg": 42,
     "color": "Brown",
     "evos": [
-      "Sirfetch\u2019d"
+      "Sirfetch’d"
     ],
     "eggGroups": [
       "Flying",
@@ -29675,7 +29675,7 @@
   "flabebe": {
     "species_id": 669,
     "actual_id": 669,
-    "name": "Flab\u00e9b\u00e9",
+    "name": "Flabébé",
     "baseForme": "Red",
     "types": [
       "Fairy"
@@ -29703,17 +29703,17 @@
       "Fairy"
     ],
     "cosmeticFormes": [
-      "Flab\u00e9b\u00e9-Blue",
-      "Flab\u00e9b\u00e9-Orange",
-      "Flab\u00e9b\u00e9-White",
-      "Flab\u00e9b\u00e9-Yellow"
+      "Flabébé-Blue",
+      "Flabébé-Orange",
+      "Flabébé-White",
+      "Flabébé-Yellow"
     ],
     "formeOrder": [
-      "Flab\u00e9b\u00e9",
-      "Flab\u00e9b\u00e9-Yellow",
-      "Flab\u00e9b\u00e9-Orange",
-      "Flab\u00e9b\u00e9-Blue",
-      "Flab\u00e9b\u00e9-White"
+      "Flabébé",
+      "Flabébé-Yellow",
+      "Flabébé-Orange",
+      "Flabébé-Blue",
+      "Flabébé-White"
     ],
     "tier": "LC"
   },
@@ -29741,7 +29741,7 @@
     "heightm": 0.2,
     "weightkg": 0.9,
     "color": "White",
-    "prevo": "Flab\u00e9b\u00e9",
+    "prevo": "Flabébé",
     "evoLevel": 19,
     "evos": [
       "Florges"
@@ -39223,7 +39223,7 @@
   "sirfetchd": {
     "species_id": 865,
     "actual_id": 865,
-    "name": "Sirfetch\u2019d",
+    "name": "Sirfetch’d",
     "types": [
       "Fighting"
     ],
@@ -39242,7 +39242,7 @@
     "heightm": 0.8,
     "weightkg": 117,
     "color": "White",
-    "prevo": "Farfetch\u2019d-Galar",
+    "prevo": "Farfetch’d-Galar",
     "evoType": "other",
     "evoCondition": "Land 3 critical hits in 1 battle",
     "eggGroups": [
@@ -45707,5 +45707,820 @@
       "Undiscovered"
     ],
     "tier": "OU"
+  },
+  "raichumegax": {
+    "species_id": 26,
+    "actual_id": 10304,
+    "name": "Raichu-Mega-X",
+    "baseSpecies": "Raichu",
+    "forme": "Mega-X",
+    "types": [
+      "Electric"
+    ],
+    "baseStats": {
+      "hp": 60,
+      "atk": 135,
+      "def": 95,
+      "spa": 90,
+      "spd": 95,
+      "spe": 110
+    },
+    "abilities": {
+      "0": "Surge Surfer"
+    },
+    "heightm": 1.2,
+    "weightkg": 38,
+    "color": "Yellow",
+    "eggGroups": [
+      "Field",
+      "Fairy"
+    ],
+    "requiredItem": "Raichunite X",
+    "gen": 9,
+    "tier": "Illegal",
+    "isNonstandard": "Past"
+  },
+  "raichumegay": {
+    "species_id": 26,
+    "actual_id": 10305,
+    "name": "Raichu-Mega-Y",
+    "baseSpecies": "Raichu",
+    "forme": "Mega-Y",
+    "types": [
+      "Electric"
+    ],
+    "baseStats": {
+      "hp": 60,
+      "atk": 100,
+      "def": 55,
+      "spa": 160,
+      "spd": 80,
+      "spe": 130
+    },
+    "abilities": {
+      "0": "Surge Surfer"
+    },
+    "heightm": 1,
+    "weightkg": 26,
+    "color": "Yellow",
+    "eggGroups": [
+      "Field",
+      "Fairy"
+    ],
+    "requiredItem": "Raichunite Y",
+    "gen": 9,
+    "tier": "Illegal",
+    "isNonstandard": "Past"
+  },
+  "chimechomega": {
+    "species_id": 358,
+    "actual_id": 10306,
+    "name": "Chimecho-Mega",
+    "baseSpecies": "Chimecho",
+    "forme": "Mega",
+    "types": [
+      "Psychic",
+      "Steel"
+    ],
+    "baseStats": {
+      "hp": 75,
+      "atk": 50,
+      "def": 110,
+      "spa": 135,
+      "spd": 120,
+      "spe": 65
+    },
+    "abilities": {
+      "0": "Levitate"
+    },
+    "heightm": 1.2,
+    "weightkg": 8,
+    "color": "Blue",
+    "eggGroups": [
+      "Amorphous"
+    ],
+    "requiredItem": "Chimechite",
+    "gen": 9,
+    "tier": "Illegal",
+    "isNonstandard": "Past"
+  },
+  "absolmegaz": {
+    "species_id": 359,
+    "actual_id": 10307,
+    "name": "Absol-Mega-Z",
+    "baseSpecies": "Absol",
+    "forme": "Mega-Z",
+    "types": [
+      "Dark",
+      "Ghost"
+    ],
+    "baseStats": {
+      "hp": 65,
+      "atk": 154,
+      "def": 60,
+      "spa": 75,
+      "spd": 60,
+      "spe": 151
+    },
+    "abilities": {
+      "0": "Magic Bounce"
+    },
+    "heightm": 1.2,
+    "weightkg": 49,
+    "color": "Black",
+    "eggGroups": [
+      "Field"
+    ],
+    "requiredItem": "Absolite Z",
+    "gen": 9,
+    "tier": "Illegal",
+    "isNonstandard": "Past"
+  },
+  "staraptormega": {
+    "species_id": 398,
+    "actual_id": 10308,
+    "name": "Staraptor-Mega",
+    "baseSpecies": "Staraptor",
+    "forme": "Mega",
+    "types": [
+      "Fighting",
+      "Flying"
+    ],
+    "baseStats": {
+      "hp": 85,
+      "atk": 140,
+      "def": 100,
+      "spa": 60,
+      "spd": 90,
+      "spe": 110
+    },
+    "abilities": {
+      "0": "Intimidate",
+      "H": "Reckless"
+    },
+    "heightm": 1.9,
+    "weightkg": 50,
+    "color": "Gray",
+    "eggGroups": [
+      "Flying"
+    ],
+    "requiredItem": "Staraptite",
+    "gen": 9,
+    "tier": "Illegal",
+    "isNonstandard": "Past"
+  },
+  "garchompmegaz": {
+    "species_id": 445,
+    "actual_id": 10309,
+    "name": "Garchomp-Mega-Z",
+    "baseSpecies": "Garchomp",
+    "forme": "Mega-Z",
+    "types": [
+      "Dragon"
+    ],
+    "baseStats": {
+      "hp": 108,
+      "atk": 130,
+      "def": 85,
+      "spa": 141,
+      "spd": 85,
+      "spe": 151
+    },
+    "abilities": {
+      "0": "Sand Force"
+    },
+    "heightm": 1.9,
+    "weightkg": 99,
+    "color": "Blue",
+    "eggGroups": [
+      "Monster",
+      "Dragon"
+    ],
+    "requiredItem": "Garchompite Z",
+    "gen": 9,
+    "tier": "Illegal",
+    "isNonstandard": "Past"
+  },
+  "lucariomegaz": {
+    "species_id": 448,
+    "actual_id": 10310,
+    "name": "Lucario-Mega-Z",
+    "baseSpecies": "Lucario",
+    "forme": "Mega-Z",
+    "types": [
+      "Fighting",
+      "Steel"
+    ],
+    "genderRatio": {
+      "M": 0.875,
+      "F": 0.125
+    },
+    "baseStats": {
+      "hp": 70,
+      "atk": 100,
+      "def": 70,
+      "spa": 164,
+      "spd": 70,
+      "spe": 151
+    },
+    "abilities": {
+      "0": "Adaptability"
+    },
+    "heightm": 1.3,
+    "weightkg": 49.4,
+    "color": "Gray",
+    "eggGroups": [
+      "Field",
+      "Human-Like"
+    ],
+    "requiredItem": "Lucarionite Z",
+    "gen": 9,
+    "tier": "Illegal",
+    "isNonstandard": "Past"
+  },
+  "heatranmega": {
+    "species_id": 485,
+    "actual_id": 10311,
+    "name": "Heatran-Mega",
+    "baseSpecies": "Heatran",
+    "forme": "Mega",
+    "types": [
+      "Fire",
+      "Steel"
+    ],
+    "baseStats": {
+      "hp": 91,
+      "atk": 120,
+      "def": 106,
+      "spa": 175,
+      "spd": 141,
+      "spe": 67
+    },
+    "abilities": {
+      "0": "Flash Fire",
+      "H": "Flame Body"
+    },
+    "heightm": 2.8,
+    "weightkg": 570,
+    "color": "Brown",
+    "tags": [
+      "Sub-Legendary"
+    ],
+    "eggGroups": [
+      "Undiscovered"
+    ],
+    "requiredItem": "Heatranite",
+    "gen": 9,
+    "tier": "Illegal",
+    "isNonstandard": "Past"
+  },
+  "darkraimega": {
+    "species_id": 491,
+    "actual_id": 10312,
+    "name": "Darkrai-Mega",
+    "baseSpecies": "Darkrai",
+    "forme": "Mega",
+    "types": [
+      "Dark"
+    ],
+    "gender": "N",
+    "baseStats": {
+      "hp": 70,
+      "atk": 120,
+      "def": 130,
+      "spa": 165,
+      "spd": 130,
+      "spe": 85
+    },
+    "abilities": {
+      "0": "Bad Dreams"
+    },
+    "heightm": 3,
+    "weightkg": 240,
+    "color": "Black",
+    "tags": [
+      "Mythical"
+    ],
+    "eggGroups": [
+      "Undiscovered"
+    ],
+    "requiredItem": "Darkranite",
+    "gen": 9,
+    "tier": "Illegal",
+    "isNonstandard": "Past"
+  },
+  "golurkmega": {
+    "species_id": 623,
+    "actual_id": 10313,
+    "name": "Golurk-Mega",
+    "baseSpecies": "Golurk",
+    "forme": "Mega",
+    "types": [
+      "Ground",
+      "Ghost"
+    ],
+    "gender": "N",
+    "baseStats": {
+      "hp": 89,
+      "atk": 159,
+      "def": 105,
+      "spa": 70,
+      "spd": 105,
+      "spe": 55
+    },
+    "abilities": {
+      "0": "Unseen Fist"
+    },
+    "heightm": 4,
+    "weightkg": 330,
+    "color": "Green",
+    "eggGroups": [
+      "Mineral"
+    ],
+    "requiredItem": "Golurkite",
+    "gen": 9,
+    "tier": "Illegal",
+    "isNonstandard": "Past"
+  },
+  "crabominablemega": {
+    "species_id": 740,
+    "actual_id": 10315,
+    "name": "Crabominable-Mega",
+    "baseSpecies": "Crabominable",
+    "forme": "Mega",
+    "types": [
+      "Fighting",
+      "Ice"
+    ],
+    "baseStats": {
+      "hp": 97,
+      "atk": 157,
+      "def": 122,
+      "spa": 62,
+      "spd": 107,
+      "spe": 33
+    },
+    "abilities": {
+      "0": "Iron Fist"
+    },
+    "heightm": 2.6,
+    "weightkg": 252.8,
+    "color": "White",
+    "eggGroups": [
+      "Water 3"
+    ],
+    "requiredItem": "Crabominite",
+    "gen": 9,
+    "tier": "Illegal",
+    "isNonstandard": "Past"
+  },
+  "golisopodmega": {
+    "species_id": 768,
+    "actual_id": 10316,
+    "name": "Golisopod-Mega",
+    "baseSpecies": "Golisopod",
+    "forme": "Mega",
+    "types": [
+      "Bug",
+      "Steel"
+    ],
+    "baseStats": {
+      "hp": 75,
+      "atk": 150,
+      "def": 175,
+      "spa": 70,
+      "spd": 120,
+      "spe": 40
+    },
+    "abilities": {
+      "0": "Emergency Exit"
+    },
+    "heightm": 2.3,
+    "weightkg": 148,
+    "color": "Gray",
+    "eggGroups": [
+      "Bug",
+      "Water 3"
+    ],
+    "requiredItem": "Golisopite",
+    "gen": 9,
+    "tier": "Illegal",
+    "isNonstandard": "Past"
+  },
+  "miniororange": {
+    "species_id": 774,
+    "actual_id": 10137,
+    "isCosmeticForme": true,
+    "name": "Minior-Orange",
+    "baseSpecies": "Minior",
+    "forme": "Orange",
+    "color": "Red",
+    "tier": "ZU"
+  },
+  "minioryellow": {
+    "species_id": 774,
+    "actual_id": 10138,
+    "isCosmeticForme": true,
+    "name": "Minior-Yellow",
+    "baseSpecies": "Minior",
+    "forme": "Yellow",
+    "color": "Yellow",
+    "tier": "ZU"
+  },
+  "miniorgreen": {
+    "species_id": 774,
+    "actual_id": 10139,
+    "isCosmeticForme": true,
+    "name": "Minior-Green",
+    "baseSpecies": "Minior",
+    "forme": "Green",
+    "color": "Green",
+    "tier": "ZU"
+  },
+  "miniorblue": {
+    "species_id": 774,
+    "actual_id": 10140,
+    "isCosmeticForme": true,
+    "name": "Minior-Blue",
+    "baseSpecies": "Minior",
+    "forme": "Blue",
+    "color": "Blue",
+    "tier": "ZU"
+  },
+  "miniorindigo": {
+    "species_id": 774,
+    "actual_id": 10141,
+    "isCosmeticForme": true,
+    "name": "Minior-Indigo",
+    "baseSpecies": "Minior",
+    "forme": "Indigo",
+    "color": "Blue",
+    "tier": "ZU"
+  },
+  "miniorviolet": {
+    "species_id": 774,
+    "actual_id": 10142,
+    "isCosmeticForme": true,
+    "name": "Minior-Violet",
+    "baseSpecies": "Minior",
+    "forme": "Violet",
+    "color": "Purple",
+    "tier": "ZU"
+  },
+  "magearnamega": {
+    "species_id": 801,
+    "actual_id": 10317,
+    "name": "Magearna-Mega",
+    "baseSpecies": "Magearna",
+    "forme": "Mega",
+    "types": [
+      "Steel",
+      "Fairy"
+    ],
+    "gender": "N",
+    "baseStats": {
+      "hp": 80,
+      "atk": 125,
+      "def": 115,
+      "spa": 170,
+      "spd": 115,
+      "spe": 95
+    },
+    "abilities": {
+      "0": "Soul-Heart"
+    },
+    "heightm": 1.3,
+    "weightkg": 248.1,
+    "color": "Gray",
+    "eggGroups": [
+      "Undiscovered"
+    ],
+    "requiredItem": "Magearnite",
+    "gen": 9,
+    "tier": "Illegal",
+    "isNonstandard": "Past"
+  },
+  "magearnaoriginalmega": {
+    "species_id": 801,
+    "actual_id": 10318,
+    "name": "Magearna-Original-Mega",
+    "baseSpecies": "Magearna",
+    "forme": "Original-Mega",
+    "types": [
+      "Steel",
+      "Fairy"
+    ],
+    "gender": "N",
+    "baseStats": {
+      "hp": 80,
+      "atk": 125,
+      "def": 115,
+      "spa": 170,
+      "spd": 115,
+      "spe": 95
+    },
+    "abilities": {
+      "0": "Soul-Heart"
+    },
+    "heightm": 1.3,
+    "weightkg": 248.1,
+    "color": "Red",
+    "eggGroups": [
+      "Undiscovered"
+    ],
+    "requiredItem": "Magearnite",
+    "battleOnly": "Magearna-Original",
+    "gen": 9,
+    "tier": "Illegal",
+    "isNonstandard": "Past"
+  },
+  "zeraoramega": {
+    "species_id": 807,
+    "actual_id": 10319,
+    "name": "Zeraora-Mega",
+    "baseSpecies": "Zeraora",
+    "forme": "Mega",
+    "types": [
+      "Electric"
+    ],
+    "gender": "N",
+    "baseStats": {
+      "hp": 88,
+      "atk": 157,
+      "def": 75,
+      "spa": 147,
+      "spd": 80,
+      "spe": 153
+    },
+    "abilities": {
+      "0": "Volt Absorb"
+    },
+    "heightm": 1.5,
+    "weightkg": 44.5,
+    "color": "Yellow",
+    "tags": [
+      "Mythical"
+    ],
+    "eggGroups": [
+      "Undiscovered"
+    ],
+    "requiredItem": "Zeraorite",
+    "gen": 9,
+    "tier": "Illegal",
+    "isNonstandard": "Past"
+  },
+  "scovillainmega": {
+    "species_id": 952,
+    "actual_id": 10320,
+    "name": "Scovillain-Mega",
+    "baseSpecies": "Scovillain",
+    "forme": "Mega",
+    "types": [
+      "Grass",
+      "Fire"
+    ],
+    "baseStats": {
+      "hp": 65,
+      "atk": 138,
+      "def": 85,
+      "spa": 138,
+      "spd": 85,
+      "spe": 75
+    },
+    "abilities": {
+      "0": "Spicy Spray"
+    },
+    "heightm": 1.2,
+    "weightkg": 22,
+    "color": "Green",
+    "eggGroups": [
+      "Grass"
+    ],
+    "requiredItem": "Scovillainite",
+    "tier": "Illegal",
+    "isNonstandard": "Past"
+  },
+  "glimmoramega": {
+    "species_id": 970,
+    "actual_id": 10321,
+    "name": "Glimmora-Mega",
+    "baseSpecies": "Glimmora",
+    "forme": "Mega",
+    "types": [
+      "Rock",
+      "Poison"
+    ],
+    "baseStats": {
+      "hp": 83,
+      "atk": 90,
+      "def": 105,
+      "spa": 150,
+      "spd": 96,
+      "spe": 101
+    },
+    "abilities": {
+      "0": "Adaptability"
+    },
+    "heightm": 2.8,
+    "weightkg": 77,
+    "color": "Blue",
+    "eggGroups": [
+      "Mineral"
+    ],
+    "requiredItem": "Glimmoranite",
+    "tier": "Illegal",
+    "isNonstandard": "Past"
+  },
+  "tatsugiridroopy": {
+    "species_id": 978,
+    "actual_id": 10258,
+    "name": "Tatsugiri-Droopy",
+    "baseSpecies": "Tatsugiri",
+    "forme": "Droopy",
+    "types": [
+      "Dragon",
+      "Water"
+    ],
+    "baseStats": {
+      "hp": 68,
+      "atk": 50,
+      "def": 60,
+      "spa": 120,
+      "spd": 95,
+      "spe": 82
+    },
+    "abilities": {
+      "0": "Commander",
+      "H": "Storm Drain"
+    },
+    "heightm": 0.3,
+    "weightkg": 8,
+    "color": "Pink",
+    "eggGroups": [
+      "Water 2"
+    ],
+    "tier": "PU"
+  },
+  "tatsugiristretchy": {
+    "species_id": 978,
+    "actual_id": 10259,
+    "name": "Tatsugiri-Stretchy",
+    "baseSpecies": "Tatsugiri",
+    "forme": "Stretchy",
+    "types": [
+      "Dragon",
+      "Water"
+    ],
+    "baseStats": {
+      "hp": 68,
+      "atk": 50,
+      "def": 60,
+      "spa": 120,
+      "spd": 95,
+      "spe": 82
+    },
+    "abilities": {
+      "0": "Commander",
+      "H": "Storm Drain"
+    },
+    "heightm": 0.3,
+    "weightkg": 8,
+    "color": "Yellow",
+    "eggGroups": [
+      "Water 2"
+    ],
+    "tier": "PU"
+  },
+  "tatsugiricurlymega": {
+    "species_id": 978,
+    "actual_id": 10322,
+    "name": "Tatsugiri-Curly-Mega",
+    "baseSpecies": "Tatsugiri",
+    "forme": "Curly-Mega",
+    "types": [
+      "Dragon",
+      "Water"
+    ],
+    "baseStats": {
+      "hp": 68,
+      "atk": 65,
+      "def": 90,
+      "spa": 135,
+      "spd": 125,
+      "spe": 92
+    },
+    "abilities": {
+      "0": "Commander",
+      "H": "Storm Drain"
+    },
+    "heightm": 0.3,
+    "weightkg": 24,
+    "color": "Red",
+    "eggGroups": [
+      "Water 2"
+    ],
+    "requiredItem": "Tatsugirinite",
+    "battleOnly": "Tatsugiri",
+    "tier": "Illegal",
+    "isNonstandard": "Past"
+  },
+  "tatsugiridroopymega": {
+    "species_id": 978,
+    "actual_id": 10323,
+    "name": "Tatsugiri-Droopy-Mega",
+    "baseSpecies": "Tatsugiri",
+    "forme": "Droopy-Mega",
+    "types": [
+      "Dragon",
+      "Water"
+    ],
+    "baseStats": {
+      "hp": 68,
+      "atk": 65,
+      "def": 90,
+      "spa": 135,
+      "spd": 125,
+      "spe": 92
+    },
+    "abilities": {
+      "0": "Commander",
+      "H": "Storm Drain"
+    },
+    "heightm": 0.3,
+    "weightkg": 24,
+    "color": "Pink",
+    "eggGroups": [
+      "Water 2"
+    ],
+    "requiredItem": "Tatsugirinite",
+    "battleOnly": "Tatsugiri-Droopy",
+    "tier": "Illegal",
+    "isNonstandard": "Past"
+  },
+  "tatsugiristretchymega": {
+    "species_id": 978,
+    "actual_id": 10324,
+    "name": "Tatsugiri-Stretchy-Mega",
+    "baseSpecies": "Tatsugiri",
+    "forme": "Stretchy-Mega",
+    "types": [
+      "Dragon",
+      "Water"
+    ],
+    "baseStats": {
+      "hp": 68,
+      "atk": 65,
+      "def": 90,
+      "spa": 135,
+      "spd": 125,
+      "spe": 92
+    },
+    "abilities": {
+      "0": "Commander",
+      "H": "Storm Drain"
+    },
+    "heightm": 0.3,
+    "weightkg": 24,
+    "color": "Yellow",
+    "eggGroups": [
+      "Water 2"
+    ],
+    "requiredItem": "Tatsugirinite",
+    "battleOnly": "Tatsugiri-Stretchy",
+    "tier": "Illegal",
+    "isNonstandard": "Past"
+  },
+  "baxcaliburmega": {
+    "species_id": 998,
+    "actual_id": 10325,
+    "name": "Baxcalibur-Mega",
+    "baseSpecies": "Baxcalibur",
+    "forme": "Mega",
+    "types": [
+      "Dragon",
+      "Ice"
+    ],
+    "baseStats": {
+      "hp": 115,
+      "atk": 175,
+      "def": 117,
+      "spa": 105,
+      "spd": 101,
+      "spe": 87
+    },
+    "abilities": {
+      "0": "Thermal Exchange",
+      "H": "Ice Body"
+    },
+    "heightm": 2.1,
+    "weightkg": 315,
+    "color": "Blue",
+    "eggGroups": [
+      "Dragon",
+      "Mineral"
+    ],
+    "requiredItem": "Baxcalibrite",
+    "tier": "Illegal",
+    "isNonstandard": "Past"
   }
 }

--- a/src/Ankimon/encounter_simulator/simulator.html
+++ b/src/Ankimon/encounter_simulator/simulator.html
@@ -1,0 +1,792 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Ankimon Encounter Rate Simulator</title>
+    <!-- We try to load Outfit font, fallback to standard sleek sans-serif -->
+    <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+    <style>
+        :root {
+            --bg-gradient: radial-gradient(135deg, #0d0f19 0%, #151829 100%);
+            --panel-bg: rgba(255, 255, 255, 0.025);
+            --panel-border: rgba(255, 255, 255, 0.05);
+            --panel-border-hover: rgba(255, 255, 255, 0.1);
+            --text-primary: #f1f3f9;
+            --text-secondary: #8f9cae;
+            --accent-cyan: #00e5ff;
+            --accent-glow: rgba(0, 229, 255, 0.35);
+            
+            /* Tier Colors */
+            --color-normal: #8a93a5;
+            --color-baby: #ff7597;
+            --color-ultra: #00e5ff;
+            --color-gmax: #bd00ff;
+            --color-starter: #00ff88;
+            --color-mega: #ff0055;
+            --color-legendary: #ffaa00;
+            --color-mythical: #7b2cff;
+        }
+
+        * {
+            box-sizing: border-box;
+            margin: 0;
+            padding: 0;
+            user-select: none;
+        }
+
+        body {
+            background: #0b0c16; /* Solid deep premium dark background to fix compositor flickering */
+            color: var(--text-primary);
+            font-family: 'Outfit', system-ui, -apple-system, sans-serif;
+            min-height: 100vh;
+            display: flex;
+            flex-direction: column;
+            overflow-x: hidden;
+            padding: 24px;
+        }
+
+        /* Scrollbar styling */
+        ::-webkit-scrollbar {
+            width: 8px;
+            height: 8px;
+        }
+        ::-webkit-scrollbar-track {
+            background: rgba(0,0,0,0.1);
+        }
+        ::-webkit-scrollbar-thumb {
+            background: rgba(255,255,255,0.05);
+            border-radius: 4px;
+        }
+        ::-webkit-scrollbar-thumb:hover {
+            background: rgba(255,255,255,0.15);
+        }
+
+        header {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            margin-bottom: 24px;
+            padding-bottom: 16px;
+            border-bottom: 1px solid var(--panel-border);
+        }
+
+        .header-title h1 {
+            font-size: 24px;
+            font-weight: 600;
+            letter-spacing: -0.5px;
+            background: linear-gradient(90deg, #ffffff 0%, var(--accent-cyan) 100%);
+            -webkit-background-clip: text;
+            -webkit-text-fill-color: transparent;
+            display: flex;
+            align-items: center;
+            gap: 8px;
+        }
+
+        .header-title p {
+            font-size: 13px;
+            color: var(--text-secondary);
+            margin-top: 4px;
+        }
+
+        .dev-badge {
+            background: rgba(0, 229, 255, 0.1);
+            border: 1px solid rgba(0, 229, 255, 0.2);
+            color: var(--accent-cyan);
+            font-size: 11px;
+            font-weight: 600;
+            padding: 4px 10px;
+            border-radius: 20px;
+            letter-spacing: 0.5px;
+            text-transform: uppercase;
+            box-shadow: 0 0 10px rgba(0, 229, 255, 0.05);
+        }
+
+        .dashboard {
+            display: grid;
+            grid-template-columns: 360px 1fr;
+            gap: 24px;
+            flex-grow: 1;
+        }
+
+        /* Premium Solid Panel base (removes backdrop-filter to prevent hover flickering) */
+        .panel {
+            background: #111422;
+            border: 1px solid var(--panel-border);
+            border-radius: 16px;
+            padding: 24px;
+            display: flex;
+            flex-direction: column;
+            gap: 20px;
+        }
+
+        .panel:hover {
+            border-color: var(--panel-border-hover);
+        }
+
+        /* Left controls panel */
+        .controls-panel {
+            max-height: calc(100vh - 100px);
+            overflow-y: auto;
+        }
+
+        .panel-title {
+            font-size: 16px;
+            font-weight: 600;
+            color: var(--text-primary);
+            letter-spacing: -0.2px;
+            display: flex;
+            align-items: center;
+            gap: 8px;
+            border-bottom: 1px solid rgba(255,255,255,0.03);
+            padding-bottom: 12px;
+        }
+
+        .panel-subtitle {
+            font-size: 12px;
+            color: var(--text-secondary);
+            font-weight: 400;
+        }
+
+        /* Slider Controls */
+        .slider-group {
+            display: flex;
+            flex-direction: column;
+            gap: 8px;
+        }
+
+        .slider-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            font-size: 13px;
+        }
+
+        .slider-label {
+            color: var(--text-secondary);
+            font-weight: 500;
+        }
+
+        .slider-value-container {
+            display: flex;
+            align-items: center;
+            gap: 4px;
+        }
+
+        .slider-value {
+            font-weight: 600;
+            color: var(--accent-cyan);
+            background: rgba(0, 229, 255, 0.08);
+            padding: 2px 6px;
+            border-radius: 6px;
+            font-size: 12px;
+            min-width: 36px;
+            text-align: center;
+        }
+
+        .slider-input-wrapper {
+            position: relative;
+            display: flex;
+            align-items: center;
+        }
+
+        .slider-input {
+            -webkit-appearance: none;
+            width: 100%;
+            height: 6px;
+            border-radius: 3px;
+            background: rgba(255,255,255,0.06);
+            outline: none;
+        }
+
+        .slider-input::-webkit-slider-thumb {
+            -webkit-appearance: none;
+            width: 16px;
+            height: 16px;
+            border-radius: 50%;
+            background: var(--accent-cyan);
+            cursor: pointer;
+            box-shadow: 0 0 10px var(--accent-glow);
+        }
+
+        .slider-input::-webkit-slider-thumb:hover {
+            background: #ffffff;
+        }
+
+        /* Right Dashboard Columns */
+        .stats-area {
+            display: flex;
+            flex-direction: column;
+            gap: 24px;
+        }
+
+        .upper-stats {
+            display: grid;
+            grid-template-columns: 240px 1fr;
+            gap: 24px;
+        }
+
+        /* EP Gauge Circular Styling */
+        .ep-gauge-container {
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            justify-content: center;
+            gap: 16px;
+            min-height: 240px;
+        }
+
+        .gauge-svg-container {
+            position: relative;
+            width: 160px;
+            height: 160px;
+        }
+
+        .gauge-circle-bg {
+            fill: none;
+            stroke: rgba(255, 255, 255, 0.025);
+            stroke-width: 10px;
+        }
+
+        .gauge-circle-fill {
+            fill: none;
+            stroke: url(#cyanGrad);
+            stroke-width: 10px;
+            stroke-linecap: round;
+            transform: rotate(-90deg);
+            transform-origin: 50% 50%;
+            stroke-dasharray: 440;
+            stroke-dashoffset: 440;
+            transition: stroke-dashoffset 0.4s ease-out;
+        }
+
+        .gauge-center-text {
+            position: absolute;
+            top: 50%;
+            left: 50%;
+            transform: translate(-50%, -50%);
+            text-align: center;
+        }
+
+        .gauge-value {
+            font-size: 32px;
+            font-weight: 700;
+            color: var(--text-primary);
+            line-height: 1;
+        }
+
+        .gauge-unit {
+            font-size: 11px;
+            color: var(--text-secondary);
+            text-transform: uppercase;
+            letter-spacing: 1px;
+            margin-top: 4px;
+        }
+
+        /* Exponential Graph Canvas */
+        .graph-container {
+            flex-grow: 1;
+            position: relative;
+            display: flex;
+            flex-direction: column;
+            gap: 8px;
+        }
+
+        .canvas-wrapper {
+            position: relative;
+            width: 100%;
+            height: 100%;
+            min-height: 200px;
+            background: rgba(0, 0, 0, 0.15);
+            border-radius: 8px;
+            border: 1px solid rgba(255, 255, 255, 0.02);
+            overflow: hidden;
+        }
+
+        canvas {
+            display: block;
+            width: 100%;
+            height: 100%;
+        }
+
+        /* Matrix Table View */
+        .matrix-panel {
+            flex-grow: 1;
+        }
+
+        table {
+            width: 100%;
+            border-collapse: collapse;
+            text-align: left;
+        }
+
+        th {
+            font-size: 12px;
+            color: var(--text-secondary);
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.5px;
+            padding: 12px 16px;
+            border-bottom: 1px solid rgba(255,255,255,0.05);
+        }
+
+        td {
+            padding: 14px 16px;
+            font-size: 14px;
+            border-bottom: 1px solid rgba(255,255,255,0.02);
+            vertical-align: middle;
+        }
+
+        tr:hover td {
+            background-color: rgba(255,255,255,0.01);
+        }
+
+        .tier-cell {
+            display: flex;
+            align-items: center;
+            gap: 8px;
+            font-weight: 600;
+        }
+
+        .tier-indicator {
+            width: 8px;
+            height: 8px;
+            border-radius: 50%;
+        }
+
+        .lock-indicator {
+            color: #ff3b30;
+            font-size: 12px;
+            margin-left: 6px;
+            display: inline-flex;
+            align-items: center;
+            opacity: 0.8;
+        }
+
+        /* Specific neon glow elements */
+        .color-normal { color: var(--color-normal); }
+        .color-baby { color: var(--color-baby); }
+        .color-ultra { color: var(--color-ultra); }
+        .color-gmax { color: var(--color-gmax); }
+        .color-starter { color: var(--color-starter); }
+        .color-mega { color: var(--color-mega); }
+        .color-legendary { color: var(--color-legendary); }
+        .color-mythical { color: var(--color-mythical); }
+
+        .bg-normal { background: var(--color-normal); box-shadow: 0 0 6px var(--color-normal); }
+        .bg-baby { background: var(--color-baby); box-shadow: 0 0 6px var(--color-baby); }
+        .bg-ultra { background: var(--color-ultra); box-shadow: 0 0 6px var(--color-ultra); }
+        .bg-gmax { background: var(--color-gmax); box-shadow: 0 0 6px var(--color-gmax); }
+        .bg-starter { background: var(--color-starter); box-shadow: 0 0 6px var(--color-starter); }
+        .bg-mega { background: var(--color-mega); box-shadow: 0 0 6px var(--color-mega); }
+        .bg-legendary { background: var(--color-legendary); box-shadow: 0 0 6px var(--color-legendary); }
+        .bg-mythical { background: var(--color-mythical); box-shadow: 0 0 6px var(--color-mythical); }
+
+        .percentage-value {
+            font-family: monospace;
+            font-weight: 600;
+            font-size: 14px;
+        }
+
+        .live-value {
+            color: var(--text-primary);
+        }
+
+        .overhaul-value {
+            color: var(--accent-cyan);
+            font-weight: 700;
+        }
+
+        .legacy-value {
+            color: var(--text-secondary);
+        }
+
+        .legend-container {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 12px;
+            font-size: 11px;
+            color: var(--text-secondary);
+            padding: 8px 12px;
+            background: rgba(0,0,0,0.1);
+            border-radius: 6px;
+        }
+
+        .legend-item {
+            display: flex;
+            align-items: center;
+            gap: 4px;
+        }
+
+        .legend-color {
+            width: 8px;
+            height: 8px;
+            border-radius: 2px;
+        }
+
+        .action-btn {
+            background: rgba(0, 229, 255, 0.08);
+            border: 1px solid rgba(0, 229, 255, 0.2);
+            color: var(--accent-cyan);
+            font-family: 'Outfit', sans-serif;
+            font-size: 13px;
+            font-weight: 600;
+            padding: 8px 16px;
+            border-radius: 8px;
+            cursor: pointer;
+            width: 100%;
+            text-align: center;
+            box-shadow: 0 0 10px rgba(0, 229, 255, 0.02);
+        }
+
+        .action-btn:hover {
+            background: rgba(0, 229, 255, 0.15);
+            border-color: rgba(0, 229, 255, 0.35);
+            color: #ffffff;
+        }
+
+        .action-btn:active {
+            transform: translateY(1px);
+        }
+
+        /* Custom Dropdown Styling */
+        .custom-dropdown-container {
+            position: relative;
+            width: 100%;
+        }
+
+        .custom-dropdown-trigger {
+            background: #151829;
+            border: 1px solid var(--panel-border);
+            color: var(--text-primary);
+            font-family: 'Outfit', sans-serif;
+            padding: 10px 14px;
+            border-radius: 8px;
+            cursor: pointer;
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            font-size: 14px;
+            transition: border-color 0.2s, background 0.2s;
+        }
+
+        .custom-dropdown-trigger:hover {
+            border-color: var(--panel-border-hover);
+            background: #1a1d32;
+        }
+
+        .custom-dropdown-options {
+            display: none;
+            position: absolute;
+            top: calc(100% + 6px);
+            left: 0;
+            width: 100%;
+            background: #151829;
+            border: 1px solid var(--panel-border);
+            border-radius: 8px;
+            box-shadow: 0 10px 25px rgba(0, 0, 0, 0.4);
+            z-index: 1000;
+            overflow: hidden;
+        }
+
+        .custom-dropdown-options.active {
+            display: block;
+        }
+
+        .dropdown-option {
+            padding: 11px 14px;
+            cursor: pointer;
+            font-size: 14px;
+            color: var(--text-primary);
+            transition: background 0.15s, color 0.15s;
+        }
+
+        .dropdown-option:hover {
+            background: rgba(0, 229, 255, 0.08);
+            color: var(--accent-cyan);
+        }
+
+        .dropdown-option.selected {
+            background: rgba(0, 229, 255, 0.15);
+            color: var(--accent-cyan);
+            font-weight: 600;
+        }
+    </style>
+</head>
+<body>
+    <header>
+        <div class="header-title">
+            <h1><span>⚡</span> Encounter Rate Simulator</h1>
+            <p>Ankimon Developer Tool for Modeling Wild Pokémon Spawn Weights</p>
+        </div>
+        <div class="badge-container" style="display: flex; gap: 8px;">
+            <div class="dev-badge" id="system-badge" style="border-color: rgba(255, 255, 255, 0.1); background: rgba(255, 255, 255, 0.03); color: var(--text-secondary);">Active System: ...</div>
+            <div class="dev-badge" style="background: rgba(168, 85, 247, 0.1); border-color: rgba(168, 85, 247, 0.2); color: #a855f7;">Developer Mode</div>
+        </div>
+    </header>
+
+    <div class="dashboard">
+        <!-- Control Panel -->
+        <div class="panel controls-panel">
+            <div class="panel-title" style="flex-direction: column; align-items: stretch; gap: 12px; border: none; padding-bottom: 0;">
+                <div style="display: flex; align-items: center; gap: 8px;">
+                    <span>🔧</span>
+                    <div>
+                        Simulation Variables
+                        <div class="panel-subtitle">Adjust sliding factors to recalculate weight distribution</div>
+                    </div>
+                </div>
+                <button id="btn-reset" class="action-btn">Reset to Live Save</button>
+            </div>
+
+            <!-- Trainer Level Slider -->
+            <div class="slider-group">
+                <div class="slider-header">
+                    <span class="slider-label">Trainer Level (T<sub>norm</sub>)</span>
+                    <div class="slider-value-container">
+                        <span class="slider-value" id="val-trainer-level">1</span>
+                    </div>
+                </div>
+                <div class="slider-input-wrapper">
+                    <input type="range" class="slider-input" id="slide-trainer-level" min="1" max="100" value="1">
+                </div>
+            </div>
+
+            <!-- Dex Completion Slider -->
+            <div class="slider-group">
+                <div class="slider-header">
+                    <span class="slider-label">Dex Completion (D<sub>norm</sub>)</span>
+                    <div class="slider-value-container">
+                        <span class="slider-value" id="val-dex-completion">0%</span>
+                    </div>
+                </div>
+                <div class="slider-input-wrapper">
+                    <input type="range" class="slider-input" id="slide-dex-completion" min="0" max="100" value="0">
+                </div>
+            </div>
+
+            <!-- Reviews Done Slider -->
+            <div class="slider-group">
+                <div class="slider-header">
+                    <span class="slider-label">Session Reviews Done</span>
+                    <div class="slider-value-container">
+                        <span class="slider-value" id="val-reviews-done">0</span>
+                    </div>
+                </div>
+                <div class="slider-input-wrapper">
+                    <input type="range" class="slider-input" id="slide-reviews-done" min="0" max="300" value="0">
+                </div>
+            </div>
+
+            <!-- Daily Review Goal Slider -->
+            <div class="slider-group">
+                <div class="slider-header">
+                    <span class="slider-label">Daily Review Goal</span>
+                    <div class="slider-value-container">
+                        <span class="slider-value" id="val-daily-goal">100</span>
+                    </div>
+                </div>
+                <div class="slider-input-wrapper">
+                    <input type="range" class="slider-input" id="slide-daily-goal" min="10" max="200" value="100">
+                </div>
+            </div>
+
+            <!-- Top 6 CP Slider -->
+            <div class="slider-group">
+                <div class="slider-header">
+                    <span class="slider-label">Avg. CP of Top 6 (C<sub>norm</sub>)</span>
+                    <div class="slider-value-container">
+                        <span class="slider-value" id="val-avg-cp">10</span>
+                    </div>
+                </div>
+                <div class="slider-input-wrapper">
+                    <input type="range" class="slider-input" id="slide-avg-cp" min="10" max="4000" step="50" value="10">
+                </div>
+            </div>
+
+            <!-- Main Pokemon Level Slider -->
+            <div class="slider-group">
+                <div class="slider-header">
+                    <span class="slider-label">Main Pokémon Level (Gating)</span>
+                    <div class="slider-value-container">
+                        <span class="slider-value" id="val-main-level">1</span>
+                    </div>
+                </div>
+                <div class="slider-input-wrapper">
+                    <input type="range" class="slider-input" id="slide-main-level" min="1" max="100" value="1">
+                </div>
+            </div>
+        </div>
+
+        <!-- Right Stats Area -->
+        <div class="stats-area">
+            <!-- Upper Area (EP Circular Gauge & Exponential Graph) -->
+            <div class="upper-stats">
+                <!-- Circular EP Gauge -->
+                <div class="panel ep-gauge-container">
+                    <div class="panel-title" style="width: 100%; border: none; padding: 0;">Encounter Potential</div>
+                    <div class="gauge-svg-container">
+                        <svg width="160" height="160" viewBox="0 0 160 160">
+                            <defs>
+                                <linearGradient id="cyanGrad" x1="0%" y1="0%" x2="100%" y2="100%">
+                                    <stop offset="0%" stop-color="#ffffff" />
+                                    <stop offset="100%" stop-color="#00e5ff" />
+                                </linearGradient>
+                            </defs>
+                            <circle class="gauge-circle-bg" cx="80" cy="80" r="70" />
+                            <circle class="gauge-circle-fill" id="gauge-fill" cx="80" cy="80" r="70" />
+                        </svg>
+                        <div class="gauge-center-text">
+                            <div class="gauge-value" id="ep-value">0.0</div>
+                            <div class="gauge-unit">EP</div>
+                        </div>
+                    </div>
+                    <div class="panel-subtitle" style="text-align: center;">Mastery Index (0.0 - 100.0)</div>
+                </div>
+
+                <!-- Interactive Exponential Curve Graph -->
+                <div class="panel graph-container">
+                    <div class="panel-title" style="border: none; padding-bottom: 0;">
+                        <div>
+                            Exponential Rarity Curves
+                            <div class="panel-subtitle">Base Weight Gating as a Function of EP</div>
+                        </div>
+                    </div>
+                    <div class="canvas-wrapper">
+                        <canvas id="curves-graph"></canvas>
+                    </div>
+                    <div class="legend-container">
+                        <div class="legend-item"><span class="legend-color bg-normal"></span><span>Normal</span></div>
+                        <div class="legend-item"><span class="legend-color bg-baby"></span><span>Baby</span></div>
+                        <div class="legend-item"><span class="legend-color bg-ultra"></span><span>Ultra</span></div>
+                        <div class="legend-item"><span class="legend-color bg-gmax"></span><span>Gmax</span></div>
+                        <div class="legend-item"><span class="legend-color bg-starter"></span><span>Starter</span></div>
+                        <div class="legend-item"><span class="legend-color bg-mega"></span><span>Mega</span></div>
+                        <div class="legend-item"><span class="legend-color bg-legendary"></span><span>Legendary</span></div>
+                        <div class="legend-item"><span class="legend-color bg-mythical"></span><span>Mythical</span></div>
+                    </div>
+                </div>
+            </div>
+
+            <!-- Lower Area (Matrix Table View) -->
+            <div class="panel matrix-panel">
+                <div class="panel-title">
+                    <span>📊</span>
+                    <div>
+                        Rarity Weighting Matrix
+                        <div class="panel-subtitle">Comparison of active database vs simulated distributions</div>
+                    </div>
+                </div>
+                <table>
+                    <thead>
+                        <tr>
+                            <th>Rarity Tier</th>
+                            <th style="text-align: right; color: #a5b4fc;">Live Overhaul</th>
+                            <th style="text-align: right; color: rgba(255,255,255,0.4);">Live Legacy</th>
+                            <th style="text-align: right; color: var(--accent-cyan);">Simulated Overhaul</th>
+                            <th style="text-align: right; color: rgba(255,255,255,0.6);">Simulated Legacy</th>
+                        </tr>
+                    </thead>
+                    <tbody id="matrix-tbody">
+                        <!-- Tiers are injected dynamically -->
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+
+    <!-- Pity and Dry Spell Simulator Panel -->
+    <div class="panel pity-panel" style="margin-top: 24px;">
+        <div class="panel-title" style="border: none; padding-bottom: 0;">
+            <span>🍀</span>
+            <div>
+                Pity & Dry Spell Simulator
+                <div class="panel-subtitle">Model quadratic pity multipliers and boosted encounter rates for dry review spells</div>
+            </div>
+        </div>
+        
+        <div class="pity-grid" style="display: grid; grid-template-columns: 360px 1fr; gap: 24px;">
+            <!-- Pity Inputs -->
+            <div class="pity-controls" style="display: flex; flex-direction: column; gap: 20px;">
+                <!-- Selected Tier Dropdown -->
+                <div class="slider-group">
+                    <div class="slider-header">
+                        <span class="slider-label">Select Pokémon Tier</span>
+                    </div>
+                <div class="custom-dropdown-container">
+                    <div id="pity-tier-trigger" class="custom-dropdown-trigger">
+                        <span id="selected-tier-label">Ultra</span>
+                        <span style="font-size: 10px; color: var(--text-secondary); transition: transform 0.2s; transform-origin: center;" id="dropdown-arrow">▼</span>
+                    </div>
+                    <div id="pity-tier-options" class="custom-dropdown-options">
+                        <div class="dropdown-option" data-value="Ultra">Ultra</div>
+                        <div class="dropdown-option" data-value="Gmax">Gmax</div>
+                        <div class="dropdown-option" data-value="Starter">Starter</div>
+                        <div class="dropdown-option" data-value="Mega">Mega</div>
+                        <div class="dropdown-option" data-value="Legendary">Legendary</div>
+                        <div class="dropdown-option" data-value="Mythical">Mythical</div>
+                    </div>
+                </div>
+                </div>
+
+                <!-- Dry Encounters Slider -->
+                <div class="slider-group">
+                    <div class="slider-header">
+                        <span class="slider-label">Dry Encounters (Reviews without Spawn)</span>
+                        <div class="slider-value-container">
+                            <span class="slider-value" id="val-pity-dry">0</span>
+                        </div>
+                    </div>
+                    <div class="slider-input-wrapper">
+                        <input type="range" class="slider-input" id="slide-pity-dry" min="0" max="1000" value="0">
+                    </div>
+                </div>
+
+                <!-- Param Info Board -->
+                <div class="info-board" style="background: rgba(255,255,255,0.01); border: 1px solid var(--panel-border); border-radius: 8px; padding: 14px; display: flex; flex-direction: column; gap: 8px; font-size: 13px; color: var(--text-secondary);">
+                    <div style="display: flex; justify-content: space-between;">
+                        <span>Pity Threshold (T<sub>i</sub>):</span>
+                        <span id="info-pity-threshold" style="color: var(--text-primary); font-weight: 600;">100</span>
+                    </div>
+                    <div style="display: flex; justify-content: space-between;">
+                        <span>Pity Divisor:</span>
+                        <span id="info-pity-divisor" style="color: var(--text-primary); font-weight: 600;">50.0</span>
+                    </div>
+                    <div style="display: flex; justify-content: space-between; border-top: 1px solid rgba(255,255,255,0.03); padding-top: 8px;">
+                        <span>Multiplier Formula:</span>
+                        <span style="font-family: monospace; color: var(--accent-cyan);">1 + (Excess / 50)²</span>
+                    </div>
+                </div>
+            </div>
+
+            <!-- Pity Visualization & Stats -->
+            <div class="pity-viz-container" style="display: grid; grid-template-columns: 240px 1fr; gap: 24px;">
+                <!-- Pity Factor Display -->
+                <div style="display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 16px; background: rgba(0,0,0,0.1); border-radius: 12px; padding: 20px; text-align: center;">
+                    <div class="slider-label" style="font-size: 12px; text-transform: uppercase; letter-spacing: 0.5px;">Pity Multiplier</div>
+                    <div id="pity-multiplier-value" style="font-size: 36px; font-weight: 700; color: #00ff88; text-shadow: 0 0 10px rgba(0,255,136,0.2);">1.00x</div>
+                    <div class="info-board" style="width: 100%; border: none; padding: 0; background: transparent; display: flex; flex-direction: column; gap: 6px; font-size: 12px;">
+                        <div style="display: flex; justify-content: space-between;">
+                            <span>Base Rate:</span>
+                            <span id="pity-base-rate" style="color: var(--text-primary); font-weight: 600;">0.00%</span>
+                        </div>
+                        <div style="display: flex; justify-content: space-between; border-top: 1px solid rgba(255,255,255,0.05); padding-top: 6px;">
+                            <span>Boosted Rate:</span>
+                            <span id="pity-boosted-rate" style="color: #00ff88; font-weight: 700;">0.00%</span>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- Pity Multiplier Chart -->
+                <div class="canvas-wrapper" style="position: relative; min-height: 180px;">
+                    <canvas id="pity-graph"></canvas>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <!-- Qt WebChannel Integration -->
+    <script src="qrc:///qtwebchannel/qwebchannel.js"></script>
+    <script src="simulator.js"></script>
+</body>
+</html>

--- a/src/Ankimon/encounter_simulator/simulator.js
+++ b/src/Ankimon/encounter_simulator/simulator.js
@@ -1,0 +1,834 @@
+(function() {
+    // Rarity Tier color mapping & configuration
+    const TIERS_CONFIG = {
+        "Normal": { name: "Normal", color: "#8a93a5", key: "Normal" },
+        "Baby": { name: "Baby", color: "#ff7597", key: "Baby" },
+        "Ultra": { name: "Ultra", color: "#00e5ff", key: "Ultra" },
+        "Gmax": { name: "Gmax", color: "#bd00ff", key: "Gmax" },
+        "Starter": { name: "Starter", color: "#00ff88", key: "Starter" },
+        "Mega": { name: "Mega", color: "#ff0055", key: "Mega" },
+        "Legendary": { name: "Legendary", color: "#ffaa00", key: "Legendary" },
+        "Mythical": { name: "Mythical", color: "#7b2cff", key: "Mythical" }
+    };
+
+    // Exponential curve parameters (loaded dynamically from python OVERHAUL_TIER_PARAMS)
+    let TIER_PARAMS = {
+        "Normal": { base: 97.08, max_val: 85.20 },
+        "Baby": { base: 2.30, max_val: 2.50 },
+        "Ultra": { base: 0.25, max_val: 4.50 },
+        "Gmax": { base: 0.15, max_val: 2.50 },
+        "Starter": { base: 0.10, max_val: 1.80 },
+        "Mega": { base: 0.05, max_val: 1.50 },
+        "Legendary": { base: 0.05, max_val: 1.50 },
+        "Mythical": { base: 0.02, max_val: 0.50 }
+    };
+
+    let LEVEL_THRESHOLDS = {
+        "Starter": 30,
+        "Ultra": 30,
+        "Legendary": 50,
+        "Mega": 60,
+        "Gmax": 65,
+        "Mythical": 75
+    };
+
+    // EP mastery weights and caps (loaded dynamically from python)
+    let EP_WEIGHTS = {
+        trainerLevel: 0.25,
+        dexCompletion: 0.25,
+        reviewsDone: 0.25,
+        avgCp: 0.25
+    };
+
+    let CAPS = {
+        trainerLevel: 50.0,
+        avgCp: 16000.0
+    };
+
+    // Pity dynamic config values (loaded dynamically from python)
+    let TIER_PITY_THRESHOLDS = {
+        "Ultra": 100,
+        "Gmax": 150,
+        "Starter": 200,
+        "Mega": 250,
+        "Legendary": 250,
+        "Mythical": 600
+    };
+    let PITY_DIVISOR = 50.0;
+
+    // DOM Elements
+    const sliders = {
+        trainerLevel: document.getElementById('slide-trainer-level'),
+        dexCompletion: document.getElementById('slide-dex-completion'),
+        reviewsDone: document.getElementById('slide-reviews-done'),
+        dailyGoal: document.getElementById('slide-daily-goal'),
+        avgCp: document.getElementById('slide-avg-cp'),
+        mainLevel: document.getElementById('slide-main-level')
+    };
+
+    const bubbles = {
+        trainerLevel: document.getElementById('val-trainer-level'),
+        dexCompletion: document.getElementById('val-dex-completion'),
+        reviewsDone: document.getElementById('val-reviews-done'),
+        dailyGoal: document.getElementById('val-daily-goal'),
+        avgCp: document.getElementById('val-avg-cp'),
+        mainLevel: document.getElementById('val-main-level')
+    };
+
+    let selectedPityTier = "Ultra";
+
+    const pitySliders = {
+        get tierValue() { return selectedPityTier; },
+        dry: document.getElementById('slide-pity-dry')
+    };
+
+    const pityDisplays = {
+        dryVal: document.getElementById('val-pity-dry'),
+        threshold: document.getElementById('info-pity-threshold'),
+        divisor: document.getElementById('info-pity-divisor'),
+        multiplier: document.getElementById('pity-multiplier-value'),
+        baseRate: document.getElementById('pity-base-rate'),
+        boostedRate: document.getElementById('pity-boosted-rate')
+    };
+
+    const epValueDisplay = document.getElementById('ep-value');
+    const gaugeFill = document.getElementById('gauge-fill');
+    const matrixTbody = document.getElementById('matrix-tbody');
+    const canvas = document.getElementById('curves-graph');
+    const ctx = canvas.getContext('2d');
+    const pityCanvas = document.getElementById('pity-graph');
+    const pityCtx = pityCanvas ? pityCanvas.getContext('2d') : null;
+
+    let currentEP = 0.0;
+    let ratesData = null;
+    let liveState = null;
+
+    // Set up canvas sizing and high DPI support
+    function resizeAllCanvases() {
+        if (canvas) {
+            const rect = canvas.parentElement.getBoundingClientRect();
+            canvas.width = rect.width * window.devicePixelRatio;
+            canvas.height = rect.height * window.devicePixelRatio;
+            canvas.style.width = rect.width + 'px';
+            canvas.style.height = rect.height + 'px';
+            ctx.setTransform(1, 0, 0, 1, 0, 0);
+            ctx.scale(window.devicePixelRatio, window.devicePixelRatio);
+            drawGraph();
+        }
+
+        if (pityCanvas) {
+            const rect = pityCanvas.parentElement.getBoundingClientRect();
+            pityCanvas.width = rect.width * window.devicePixelRatio;
+            pityCanvas.height = rect.height * window.devicePixelRatio;
+            pityCanvas.style.width = rect.width + 'px';
+            pityCanvas.style.height = rect.height + 'px';
+            pityCtx.setTransform(1, 0, 0, 1, 0, 0);
+            pityCtx.scale(window.devicePixelRatio, window.devicePixelRatio);
+            drawPityGraph();
+        }
+    }
+
+    // Set initial canvas dimension and bind window resize
+    window.addEventListener('resize', resizeAllCanvases);
+    setTimeout(resizeAllCanvases, 100);
+
+    // Dynamic Graph Renderer
+    function drawGraph() {
+        if (!canvas.width || !canvas.height) return;
+        
+        const width = canvas.width / window.devicePixelRatio;
+        const height = canvas.height / window.devicePixelRatio;
+        
+        ctx.clearRect(0, 0, width, height);
+
+        // Chart Area Boundaries
+        const padding = { top: 20, right: 30, bottom: 30, left: 40 };
+        const chartWidth = width - padding.left - padding.right;
+        const chartHeight = height - padding.top - padding.bottom;
+
+        // 1. Draw Grid Lines and Labels
+        ctx.strokeStyle = 'rgba(255, 255, 255, 0.04)';
+        ctx.fillStyle = '#8f9cae';
+        ctx.font = '10px "Outfit", sans-serif';
+        ctx.lineWidth = 1;
+
+        // X-Axis Grid & Labels (EP)
+        for (let i = 0; i <= 10; i++) {
+            const epX = i * 10;
+            const x = padding.left + (i / 10) * chartWidth;
+            
+            ctx.beginPath();
+            ctx.moveTo(x, padding.top);
+            ctx.lineTo(x, padding.top + chartHeight);
+            ctx.stroke();
+
+            ctx.textAlign = 'center';
+            ctx.fillText(epX, x, padding.top + chartHeight + 15);
+        }
+
+        // Define the tiers we want to focus on and scale on the graph
+        const rareTiers = ["Baby", "Ultra", "Gmax", "Starter", "Mega", "Legendary", "Mythical"];
+
+        // Get simulated levels for threshold checks
+        const simulatedMainLevel = parseInt(sliders.mainLevel.value);
+
+        // Helper: calculate percentages for all tiers at any given EP
+        function getRatesAtEP(epVal) {
+            const weights = {};
+            for (const tier in TIER_PARAMS) {
+                const param = TIER_PARAMS[tier];
+                weights[tier] = param.base * Math.pow((param.max_val / param.base), (epVal / 100.0));
+                
+                // Gating threshold check
+                if (LEVEL_THRESHOLDS[tier] && simulatedMainLevel < LEVEL_THRESHOLDS[tier]) {
+                    weights[tier] = 0.0;
+                }
+            }
+
+            const sum = Object.values(weights).reduce((a, b) => a + b, 0);
+            const rates = {};
+            for (const tier in weights) {
+                rates[tier] = sum > 0 ? (weights[tier] / sum) * 100.0 : 0.0;
+            }
+            return rates;
+        }
+
+        // Calculate curves and find max percentage among active rare tiers to scale the chart dynamically
+        const points = 100;
+        const curvePaths = {};
+        let maxPlottedPercent = 0.1; // Baseline safety floor
+
+        for (const tier of rareTiers) {
+            curvePaths[tier] = [];
+        }
+
+        for (let i = 0; i <= points; i++) {
+            const epVal = (i / points) * 100;
+            const rates = getRatesAtEP(epVal);
+            const x = padding.left + (i / points) * chartWidth;
+
+            for (const tier of rareTiers) {
+                const pct = rates[tier] || 0.0;
+                if (pct > maxPlottedPercent) {
+                    maxPlottedPercent = pct;
+                }
+                curvePaths[tier].push({ x, rate: pct });
+            }
+        }
+
+        // Determine Y-axis max with 15% headroom, capped at a minimum of 0.5% for visual scaling
+        const yMax = Math.max(0.5, Math.ceil(maxPlottedPercent * 1.15 * 10) / 10);
+
+        // Y-Axis Grid & Labels (Percentage dynamically scaled to yMax)
+        const ySteps = 5;
+        for (let i = 0; i <= ySteps; i++) {
+            const pctY = (i / ySteps) * yMax;
+            const y = padding.top + chartHeight - (i / ySteps) * chartHeight;
+
+            ctx.beginPath();
+            ctx.moveTo(padding.left, y);
+            ctx.lineTo(padding.left + chartWidth, y);
+            ctx.stroke();
+
+            ctx.textAlign = 'right';
+            ctx.fillText(pctY.toFixed(2) + '%', padding.left - 8, y + 3);
+        }
+
+        // Label axis names
+        ctx.fillStyle = 'rgba(255, 255, 255, 0.3)';
+        ctx.font = '9px "Outfit", sans-serif';
+        ctx.textAlign = 'right';
+        ctx.fillText("EP (Encounter Potential) →", padding.left + chartWidth, padding.top + chartHeight + 28);
+
+        // 2. Stroke Curves (Rare encounters only)
+        for (const tier of rareTiers) {
+            const path = curvePaths[tier];
+            // Check if this tier has any non-zero points plotted (skip fully gated curves)
+            const isZero = path.every(pt => pt.rate === 0.0);
+            if (isZero) continue;
+
+            ctx.beginPath();
+            ctx.strokeStyle = TIERS_CONFIG[tier].color;
+            ctx.lineWidth = 2.5; // Thicker lines for clear rare visibility
+            ctx.lineJoin = 'round';
+            
+            const startY = padding.top + chartHeight - (path[0].rate / yMax) * chartHeight;
+            ctx.moveTo(path[0].x, startY);
+            for (let i = 1; i < path.length; i++) {
+                const y = padding.top + chartHeight - (path[i].rate / yMax) * chartHeight;
+                ctx.lineTo(path[i].x, y);
+            }
+            ctx.stroke();
+        }
+
+        // 3. Mark Current EP Line
+        const currentX = padding.left + (currentEP / 100.0) * chartWidth;
+        
+        ctx.beginPath();
+        ctx.strokeStyle = 'rgba(0, 229, 255, 0.4)';
+        ctx.lineWidth = 1.5;
+        ctx.setLineDash([4, 4]);
+        ctx.moveTo(currentX, padding.top);
+        ctx.lineTo(currentX, padding.top + chartHeight);
+        ctx.stroke();
+        ctx.setLineDash([]); // Reset dash
+
+        // Draw text box indicator for current EP
+        ctx.fillStyle = '#00e5ff';
+        ctx.beginPath();
+        ctx.arc(currentX, padding.top, 4, 0, 2 * Math.PI);
+        ctx.fill();
+
+        ctx.font = 'bold 9px "Outfit", sans-serif';
+        ctx.textAlign = 'center';
+        ctx.fillStyle = '#00e5ff';
+        ctx.fillText("EP: " + currentEP.toFixed(1), currentX, padding.top - 8);
+
+        // 4. Draw Current Value Dot on each Curve
+        const currentRates = getRatesAtEP(currentEP);
+        for (const tier of rareTiers) {
+            const pct = currentRates[tier] || 0.0;
+            const y = padding.top + chartHeight - (pct / yMax) * chartHeight;
+            
+            // Only draw dots for tiers that have a positive presence
+            if (pct > 0.0) {
+                ctx.beginPath();
+                ctx.fillStyle = TIERS_CONFIG[tier].color;
+                ctx.arc(currentX, y, 4.5, 0, 2 * Math.PI);
+                ctx.fill();
+                
+                ctx.beginPath();
+                ctx.strokeStyle = '#ffffff';
+                ctx.lineWidth = 1.2;
+                ctx.arc(currentX, y, 4.5, 0, 2 * Math.PI);
+                ctx.stroke();
+            }
+        }
+    }
+
+    // Update range bubbles locally for responsiveness
+    function updateBubbles() {
+        bubbles.trainerLevel.innerText = sliders.trainerLevel.value;
+        bubbles.dexCompletion.innerText = sliders.dexCompletion.value + '%';
+        bubbles.reviewsDone.innerText = sliders.reviewsDone.value;
+        bubbles.dailyGoal.innerText = sliders.dailyGoal.value;
+        bubbles.avgCp.innerText = sliders.avgCp.value;
+        bubbles.mainLevel.innerText = sliders.mainLevel.value;
+    }
+
+    // Collect slider values to form the state packet
+    function getSliderState() {
+        return {
+            trainer_level: parseInt(sliders.trainerLevel.value),
+            dex_completion: parseFloat(sliders.dexCompletion.value),
+            reviews_done: parseInt(sliders.reviewsDone.value),
+            daily_goal: parseInt(sliders.dailyGoal.value),
+            avg_cp: parseFloat(sliders.avgCp.value),
+            main_level: parseInt(sliders.mainLevel.value)
+        };
+    }
+
+    // Call Python backend and update page
+    function triggerCalculation() {
+        updateBubbles();
+        const state = getSliderState();
+
+        if (window.getRatesFromPython) {
+            window.getRatesFromPython(state, function(result) {
+                ratesData = result;
+                currentEP = result.ep;
+                updateUIElements(result);
+            });
+        } else {
+            // Fallback for visual local prototyping in standard browser
+            // Compute EP locally using dynamic weights and caps
+            const t_norm = Math.min((state.trainer_level / CAPS.trainerLevel) * 100.0, 100.0);
+            const d_norm = state.dex_completion;
+            const s_norm = Math.min((state.reviews_done / state.daily_goal) * 100.0, 100.0);
+            const c_norm = Math.min((state.avg_cp / CAPS.avgCp) * 100.0, 100.0);
+            currentEP = (EP_WEIGHTS.trainerLevel * t_norm) + 
+                        (EP_WEIGHTS.dexCompletion * d_norm) + 
+                        (EP_WEIGHTS.reviewsDone * s_norm) + 
+                        (EP_WEIGHTS.avgCp * c_norm);
+            currentEP = Math.max(0.0, Math.min(currentEP, 100.0));
+            
+            const localLocks = {};
+            for (const tier in LEVEL_THRESHOLDS) {
+                localLocks[tier] = state.main_level < LEVEL_THRESHOLDS[tier];
+            }
+            
+            updateUIElements({
+                ep: currentEP,
+                locks: localLocks,
+                live_overhaul: { "Normal": 90, "Baby": 10, "Ultra": 0, "Gmax": 0, "Starter": 0, "Mega": 0, "Legendary": 0, "Mythical": 0 },
+                live_legacy: { "Normal": 91, "Baby": 9, "Ultra": 0, "Gmax": 0, "Starter": 0, "Mega": 0, "Legendary": 0, "Mythical": 0 },
+                overhaul: { "Normal": 85, "Baby": 12, "Ultra": 3, "Gmax": 0, "Starter": 0, "Mega": 0, "Legendary": 0, "Mythical": 0 },
+                legacy: { "Normal": 88, "Baby": 10, "Ultra": 2, "Gmax": 0, "Starter": 0, "Mega": 0, "Legendary": 0, "Mythical": 0 }
+            });
+        }
+    }
+
+    // Refresh UI elements with backend calculation results
+    function updateUIElements(data) {
+        // 1. Update EP Value display and Gauge
+        epValueDisplay.innerText = data.ep.toFixed(1);
+        
+        // Gauge stroke dashoffset math: circle perimeter is 2 * PI * r = 2 * 3.14159 * 70 = ~440px
+        const perimeter = 440;
+        const offset = perimeter - (data.ep / 100.0) * perimeter;
+        gaugeFill.style.strokeDashoffset = offset;
+
+        // 2. Clear and Render Table Matrix
+        matrixTbody.innerHTML = '';
+        
+        for (const tier in TIERS_CONFIG) {
+            const config = TIERS_CONFIG[tier];
+            const liveOverhaulVal = data.live_overhaul[tier] !== undefined ? data.live_overhaul[tier].toFixed(3) + '%' : '0.000%';
+            const liveLegacyVal = data.live_legacy[tier] !== undefined ? data.live_legacy[tier].toFixed(3) + '%' : '0.000%';
+            const overhaulVal = data.overhaul[tier] !== undefined ? data.overhaul[tier].toFixed(3) + '%' : '0.000%';
+            const legacyVal = data.legacy[tier] !== undefined ? data.legacy[tier].toFixed(3) + '%' : '0.000%';
+            
+            const isLocked = data.locks[tier] === true;
+            const lockHtml = isLocked ? `<span class="lock-indicator" title="Locked: Main Pokémon below level threshold">🔒 Lvl ${LEVEL_THRESHOLDS[tier]}</span>` : '';
+
+            const tr = document.createElement('tr');
+            tr.innerHTML = `
+                <td>
+                    <div class="tier-cell">
+                        <span class="tier-indicator bg-${config.key.toLowerCase()}"></span>
+                        <span class="color-${config.key.toLowerCase()}">${config.name}</span>
+                        ${lockHtml}
+                    </div>
+                </td>
+                <td style="text-align: right; color: #a5b4fc;" class="percentage-value">${liveOverhaulVal}</td>
+                <td style="text-align: right; color: rgba(255,255,255,0.4);" class="percentage-value">${liveLegacyVal}</td>
+                <td style="text-align: right; color: var(--accent-cyan);" class="percentage-value">${overhaulVal}</td>
+                <td style="text-align: right; color: rgba(255,255,255,0.6);" class="percentage-value">${legacyVal}</td>
+            `;
+            matrixTbody.appendChild(tr);
+        }
+
+        // 3. Re-render graph curves and value markers
+        drawGraph();
+
+        // 4. Update Pity Simulator display
+        updatePitySimulator();
+    }
+
+    // =========================================================================
+    // Pity & Dry Spell Simulator Logic
+    // =========================================================================
+
+    function getOverhaulRatesWithPity(selectedPityTier, dryEncounters) {
+        const weights = {};
+        const simulatedMainLevel = parseInt(sliders.mainLevel.value);
+        
+        // 1. Calculate base weights
+        for (const tier in TIER_PARAMS) {
+            const param = TIER_PARAMS[tier];
+            weights[tier] = param.base * Math.pow((param.max_val / param.base), (currentEP / 100.0));
+            
+            // Gating threshold check
+            if (LEVEL_THRESHOLDS[tier] && simulatedMainLevel < LEVEL_THRESHOLDS[tier]) {
+                weights[tier] = 0.0;
+            }
+        }
+
+        // 2. Calculate pity multiplier for the selected tier
+        let pityMultiplier = 1.0;
+        if (selectedPityTier && TIER_PARAMS[selectedPityTier]) {
+            const t_i = TIER_PITY_THRESHOLDS[selectedPityTier] || 100;
+            const divisor = PITY_DIVISOR;
+            pityMultiplier = 1.0 + Math.pow(Math.max(0, (dryEncounters - t_i) / divisor), 2);
+            weights[selectedPityTier] *= pityMultiplier;
+        }
+
+        // 3. Re-normalize to get rates
+        const sum = Object.values(weights).reduce((a, b) => a + b, 0);
+        const rates = {};
+        for (const tier in weights) {
+            rates[tier] = sum > 0 ? (weights[tier] / sum) * 100.0 : 0.0;
+        }
+        return {
+            rates: rates,
+            multiplier: pityMultiplier
+        };
+    }
+
+    function updatePitySimulator() {
+        if (!pitySliders.dry) return;
+        
+        const tier = pitySliders.tierValue;
+        const dry = parseInt(pitySliders.dry.value);
+        
+        // Update DOM labels
+        pityDisplays.dryVal.innerText = dry;
+        
+        const threshold = TIER_PITY_THRESHOLDS[tier] || 100;
+        pityDisplays.threshold.innerText = threshold;
+        pityDisplays.divisor.innerText = PITY_DIVISOR.toFixed(1);
+        
+        // Calculate base rate (0 dry encounters)
+        const baseResult = getOverhaulRatesWithPity(tier, 0);
+        const baseRate = baseResult.rates[tier] || 0.0;
+        pityDisplays.baseRate.innerText = baseRate.toFixed(3) + "%";
+        
+        // Calculate boosted rate
+        const boostedResult = getOverhaulRatesWithPity(tier, dry);
+        const boostedRate = boostedResult.rates[tier] || 0.0;
+        pityDisplays.boostedRate.innerText = boostedRate.toFixed(3) + "%";
+        pityDisplays.multiplier.innerText = boostedResult.multiplier.toFixed(2) + "x";
+        
+        // Draw the pity curve graph
+        drawPityGraph();
+    }
+
+    function drawPityGraph() {
+        if (!pityCanvas || !pityCtx) return;
+        
+        const width = pityCanvas.width / window.devicePixelRatio;
+        const height = pityCanvas.height / window.devicePixelRatio;
+        
+        pityCtx.clearRect(0, 0, width, height);
+        
+        const padding = { top: 20, right: 30, bottom: 30, left: 40 };
+        const chartWidth = width - padding.left - padding.right;
+        const chartHeight = height - padding.top - padding.bottom;
+        
+        const tier = pitySliders.tierValue;
+        const currentDry = parseInt(pitySliders.dry.value);
+        const threshold = TIER_PITY_THRESHOLDS[tier] || 100;
+        const divisor = PITY_DIVISOR;
+        
+        const tierColor = TIERS_CONFIG[tier]?.color || '#00ff88';
+        
+        // Scale X-axis from 0 to 1000
+        const maxDry = 1000;
+        const maxMult = 1.0 + Math.pow(Math.max(0, (maxDry - threshold) / divisor), 2);
+        
+        const yMin = 1.0;
+        const yMax = Math.max(5.0, Math.ceil(maxMult * 1.05));
+        
+        // 1. Draw Grid Lines and Labels
+        pityCtx.strokeStyle = 'rgba(255, 255, 255, 0.04)';
+        pityCtx.fillStyle = '#8f9cae';
+        pityCtx.font = '9px "Outfit", sans-serif';
+        pityCtx.lineWidth = 1;
+        
+        // X-Axis Grid & Labels (Dry encounters from 0 to 1000, step 200)
+        for (let i = 0; i <= 5; i++) {
+            const xVal = i * 200;
+            const x = padding.left + (xVal / maxDry) * chartWidth;
+            
+            pityCtx.beginPath();
+            pityCtx.moveTo(x, padding.top);
+            pityCtx.lineTo(x, padding.top + chartHeight);
+            pityCtx.stroke();
+            
+            pityCtx.textAlign = 'center';
+            pityCtx.fillText(xVal, x, padding.top + chartHeight + 14);
+        }
+        
+        // Y-Axis Grid & Labels (Multiplier, step 4)
+        const ySteps = 4;
+        for (let i = 0; i <= ySteps; i++) {
+            const yVal = 1.0 + (i / ySteps) * (yMax - 1.0);
+            const y = padding.top + chartHeight - (i / ySteps) * chartHeight;
+            
+            pityCtx.beginPath();
+            pityCtx.moveTo(padding.left, y);
+            pityCtx.lineTo(padding.left + chartWidth, y);
+            pityCtx.stroke();
+            
+            pityCtx.textAlign = 'right';
+            pityCtx.fillText(yVal.toFixed(0) + 'x', padding.left - 8, y + 3);
+        }
+        
+        // Draw Axis Names
+        pityCtx.fillStyle = 'rgba(255, 255, 255, 0.3)';
+        pityCtx.font = '9px "Outfit", sans-serif';
+        pityCtx.textAlign = 'right';
+        pityCtx.fillText("Dry Encounters →", padding.left + chartWidth, padding.top + chartHeight + 26);
+        
+        // 2. Stroke Pity Curve
+        pityCtx.beginPath();
+        pityCtx.strokeStyle = tierColor;
+        pityCtx.lineWidth = 2.5;
+        pityCtx.lineJoin = 'round';
+        
+        const points = 100;
+        for (let i = 0; i <= points; i++) {
+            const xVal = (i / points) * maxDry;
+            const mult = 1.0 + Math.pow(Math.max(0, (xVal - threshold) / divisor), 2);
+            
+            const x = padding.left + (xVal / maxDry) * chartWidth;
+            const y = padding.top + chartHeight - ((mult - yMin) / (yMax - yMin)) * chartHeight;
+            
+            if (i === 0) {
+                pityCtx.moveTo(x, y);
+            } else {
+                pityCtx.lineTo(x, y);
+            }
+        }
+        pityCtx.stroke();
+        
+        // 3. Draw Threshold Marker Line (dashed vertical)
+        const threshX = padding.left + (threshold / maxDry) * chartWidth;
+        pityCtx.beginPath();
+        pityCtx.strokeStyle = 'rgba(255, 255, 255, 0.15)';
+        pityCtx.lineWidth = 1;
+        pityCtx.setLineDash([3, 3]);
+        pityCtx.moveTo(threshX, padding.top);
+        pityCtx.lineTo(threshX, padding.top + chartHeight);
+        pityCtx.stroke();
+        pityCtx.setLineDash([]);
+        
+        // Add threshold text label
+        pityCtx.fillStyle = 'rgba(255, 255, 255, 0.4)';
+        pityCtx.font = '9px "Outfit", sans-serif';
+        pityCtx.textAlign = 'center';
+        pityCtx.fillText(`Threshold: ${threshold}`, threshX, padding.top - 6);
+        
+        // 4. Mark Current Selected Value Point on Curve
+        const currentMult = 1.0 + Math.pow(Math.max(0, (currentDry - threshold) / divisor), 2);
+        const currentX = padding.left + (currentDry / maxDry) * chartWidth;
+        const currentY = padding.top + chartHeight - ((currentMult - yMin) / (yMax - yMin)) * chartHeight;
+        
+        // Draw vertical guide line for current value
+        pityCtx.beginPath();
+        pityCtx.strokeStyle = 'rgba(0, 255, 136, 0.25)';
+        pityCtx.lineWidth = 1;
+        pityCtx.setLineDash([2, 2]);
+        pityCtx.moveTo(currentX, currentY);
+        pityCtx.lineTo(currentX, padding.top + chartHeight);
+        pityCtx.stroke();
+        pityCtx.setLineDash([]);
+        
+        // Highlight active dot
+        pityCtx.beginPath();
+        pityCtx.fillStyle = '#00ff88';
+        pityCtx.arc(currentX, currentY, 5, 0, 2 * Math.PI);
+        pityCtx.fill();
+        
+        pityCtx.beginPath();
+        pityCtx.strokeStyle = '#ffffff';
+        pityCtx.lineWidth = 1.5;
+        pityCtx.arc(currentX, currentY, 5, 0, 2 * Math.PI);
+        pityCtx.stroke();
+        
+        // Draw bubble with current stats at active dot
+        pityCtx.fillStyle = '#00ff88';
+        pityCtx.font = 'bold 9px "Outfit", sans-serif';
+        pityCtx.textAlign = 'center';
+        pityCtx.fillText(`${currentMult.toFixed(2)}x`, currentX, currentY - 8);
+    }
+
+    let calcTimeout = null;
+
+    function handleSliderInput() {
+        // Instantly update local slider text bubbles for ultra-smooth feedback
+        updateBubbles();
+        
+        // Debounce the heavy PyQt/WebEngine evaluation calculations to prevent flickering
+        if (calcTimeout) {
+            clearTimeout(calcTimeout);
+        }
+        calcTimeout = setTimeout(triggerCalculation, 50);
+    }
+
+    function handleSliderChange() {
+        if (calcTimeout) {
+            clearTimeout(calcTimeout);
+        }
+        triggerCalculation();
+    }
+
+    // Bind event listeners to all sliders
+    for (const key in sliders) {
+        sliders[key].addEventListener('input', handleSliderInput);
+        sliders[key].addEventListener('change', handleSliderChange);
+    }
+
+    // Bind event listeners to pity simulator controls
+    if (pitySliders.dry) {
+        pitySliders.dry.addEventListener('input', function() {
+            pityDisplays.dryVal.innerText = pitySliders.dry.value;
+            updatePitySimulator();
+        });
+        pitySliders.dry.addEventListener('change', function() {
+            updatePitySimulator();
+        });
+    }
+
+    // Custom Styled Dropdown Click Interactivity (replaces native selects to prevent crashes)
+    const dropdownTrigger = document.getElementById('pity-tier-trigger');
+    const dropdownOptionsContainer = document.getElementById('pity-tier-options');
+    const dropdownArrow = document.getElementById('dropdown-arrow');
+    const selectedLabel = document.getElementById('selected-tier-label');
+    const optionElements = document.querySelectorAll('.dropdown-option');
+
+    if (dropdownTrigger && dropdownOptionsContainer) {
+        dropdownTrigger.addEventListener('click', function(e) {
+            e.stopPropagation();
+            dropdownOptionsContainer.classList.toggle('active');
+            if (dropdownArrow) {
+                dropdownArrow.style.transform = dropdownOptionsContainer.classList.contains('active') ? 'rotate(180deg)' : 'rotate(0deg)';
+            }
+        });
+
+        // Close dropdown when clicking outside
+        document.addEventListener('click', function() {
+            dropdownOptionsContainer.classList.remove('active');
+            if (dropdownArrow) {
+                dropdownArrow.style.transform = 'rotate(0deg)';
+            }
+        });
+
+        optionElements.forEach(option => {
+            option.addEventListener('click', function(e) {
+                e.stopPropagation();
+                selectedPityTier = this.getAttribute('data-value');
+                
+                // Update active highlighted classes
+                optionElements.forEach(opt => opt.classList.remove('selected'));
+                this.classList.add('selected');
+                
+                // Update selection label text
+                if (selectedLabel) {
+                    selectedLabel.innerText = selectedPityTier;
+                }
+                
+                // Collapse menu
+                dropdownOptionsContainer.classList.remove('active');
+                if (dropdownArrow) {
+                    dropdownArrow.style.transform = 'rotate(0deg)';
+                }
+                
+                // Trigger calculation / update
+                updatePitySimulator();
+            });
+        });
+        
+        // Mark default selection on startup
+        optionElements.forEach(option => {
+            if (option.getAttribute('data-value') === selectedPityTier) {
+                option.classList.add('selected');
+            }
+        });
+    }
+
+    // 5. PyQt6 QWebChannel Connection Wires
+    document.addEventListener("DOMContentLoaded", function() {
+        if (typeof qt !== "undefined" && qt.webChannelTransport) {
+            new QWebChannel(qt.webChannelTransport, function(channel) {
+                window.pyBridge = channel.objects.pyBridge;
+                
+                // Wire up the expected window helper
+                window.getRatesFromPython = function(sliderState, callback) {
+                    window.pyBridge.calculate_rates_js(JSON.stringify(sliderState)).then(function(resultJson) {
+                        callback(JSON.parse(resultJson));
+                    });
+                };
+
+                // Trigger initial load calculations from real python database values
+                // Python can query active save settings and update sliders on load
+                window.pyBridge.get_initial_state().then(function(stateJson) {
+                    const state = JSON.parse(stateJson);
+                    liveState = state;
+                    
+                    // Load dynamic config coefficients from Python dynamically!
+                    if (state.config) {
+                        const cfg = state.config;
+                        EP_WEIGHTS.trainerLevel = cfg.ep_weight_trainer_level;
+                        EP_WEIGHTS.dexCompletion = cfg.ep_weight_dex_completion;
+                        EP_WEIGHTS.reviewsDone = cfg.ep_weight_session_progress;
+                        EP_WEIGHTS.avgCp = cfg.ep_weight_core_team_power;
+                        
+                        CAPS.trainerLevel = cfg.trainer_level_cap;
+                        CAPS.avgCp = cfg.core_team_power_cap;
+                        
+                        if (cfg.tier_params) {
+                            for (const tier in cfg.tier_params) {
+                                const val = cfg.tier_params[tier];
+                                if (Array.isArray(val)) {
+                                    TIER_PARAMS[tier] = { base: val[0], max_val: val[1] };
+                                } else {
+                                    TIER_PARAMS[tier] = val;
+                                }
+                            }
+                        }
+                        if (cfg.level_thresholds) LEVEL_THRESHOLDS = cfg.level_thresholds;
+                        if (cfg.pity_thresholds) TIER_PITY_THRESHOLDS = cfg.pity_thresholds;
+                        if (cfg.pity_divisor) PITY_DIVISOR = cfg.pity_divisor;
+                    }
+
+                    // Dynamically adjust slider limits based on dynamic config caps from Python
+                    if (CAPS.trainerLevel) {
+                        sliders.trainerLevel.max = CAPS.trainerLevel;
+                    }
+                    if (CAPS.avgCp) {
+                        sliders.avgCp.min = 0; // Fix slider step alignment clamp bug!
+                        sliders.avgCp.max = CAPS.avgCp;
+                        // Set a step size that makes sense for the scale (e.g. 1/100 of the max, at least 50)
+                        sliders.avgCp.step = Math.max(50, Math.floor(CAPS.avgCp / 100));
+                    }
+
+                    // Render active system badge dynamically
+                    const systemBadge = document.getElementById('system-badge');
+                    if (systemBadge && state.active_system) {
+                        systemBadge.innerText = "Active System: " + state.active_system;
+                        if (state.active_system === "Overhaul") {
+                            systemBadge.style.borderColor = "rgba(0, 255, 136, 0.2)";
+                            systemBadge.style.background = "rgba(0, 255, 136, 0.1)";
+                            systemBadge.style.color = "#00ff88";
+                        } else {
+                            systemBadge.style.borderColor = "rgba(255, 170, 0, 0.2)";
+                            systemBadge.style.background = "rgba(255, 170, 0, 0.1)";
+                            systemBadge.style.color = "#ffaa00";
+                        }
+                    }
+                    
+                    sliders.trainerLevel.value = state.trainer_level;
+                    sliders.dexCompletion.value = state.dex_completion;
+                    sliders.reviewsDone.value = state.reviews_done;
+                    sliders.dailyGoal.value = state.daily_goal;
+                    sliders.avgCp.value = state.avg_cp;
+                    sliders.mainLevel.value = state.main_level;
+                    
+                    // Wire up the Reset to Live button
+                    const btnReset = document.getElementById("btn-reset");
+                    if (btnReset) {
+                        btnReset.addEventListener("click", function() {
+                            if (liveState) {
+                                sliders.trainerLevel.value = liveState.trainer_level;
+                                sliders.dexCompletion.value = liveState.dex_completion;
+                                sliders.reviewsDone.value = liveState.reviews_done;
+                                sliders.dailyGoal.value = liveState.daily_goal;
+                                sliders.avgCp.value = liveState.avg_cp;
+                                sliders.mainLevel.value = liveState.main_level;
+                                
+                                if (pitySliders.dry) pitySliders.dry.value = 0;
+                                selectedPityTier = "Ultra";
+                                if (selectedLabel) selectedLabel.innerText = "Ultra";
+                                optionElements.forEach(opt => {
+                                    opt.classList.remove('selected');
+                                    if (opt.getAttribute('data-value') === "Ultra") {
+                                        opt.classList.add('selected');
+                                    }
+                                });
+                                
+                                triggerCalculation();
+                            }
+                        });
+                    }
+                    
+                    triggerCalculation();
+                });
+            });
+        } else {
+            // Standard web prototyping load trigger
+            triggerCalculation();
+        }
+    });
+
+})();

--- a/src/Ankimon/functions/encounter_data.py
+++ b/src/Ankimon/functions/encounter_data.py
@@ -2,72 +2,103 @@
 # This is not a list of *ALL* pokemon
 
 LEGENDARY = [
+    # Generation 1
+    144, 145, 146,  # articuno, zapdos, moltres
+    150,            # mewtwo
+    # Generation 2
+    243, 244, 245,  # raikou, entei, suicune
+    249, 250,       # lugia, ho-oh
+    # Generation 3
+    377, 378, 379,  # regirock, regice, registeel
+    380, 381,       # latias, latios
+    382, 383, 384,  # kyogre, groudon, rayquaza
     # Generation 4
-    480, 481, 482,	# uxie, mesprit, azelf
-    485, 488,	# heatran, cresselia
+    480, 481, 482,  # uxie, mesprit, azelf
+    483, 484,       # dialga, palkia
+    10245, 10246,   # dialgaorigin, palkiaorigin
+    485, 486, 487,  # heatran, regigigas, giratina
+    10007,          # giratinaorigin
+    488,            # cresselia
     # Generation 5
-    638, 639, 640,	# cobalion, terrakion, virizion
-    641, 642, 643,	# tornadus-incarnate, thundurus-incarnate, reshiram
-    644, 645, 646,	# zekrom, landorus-incarnate, kyurem
+    638, 639, 640,  # cobalion, terrakion, virizion
+    641, 642, 643,  # tornadus-incarnate, thundurus-incarnate, reshiram
+    10019, 10020,   # tornadustherian, thundurustherian
+    644, 645, 646,  # zekrom, landorus-incarnate, kyurem
+    10021,          # landorustherian
     # Generation 6
-    716, 717, 718,	# xerneas, yveltal, zygarde-50
+    716, 717, 10119,  # xerneas, yveltal, zygarde-50 (actual_id=10119)
+    10181,          # zygarde10
     # Generation 7
-    772, 773, 785,	# type-null, silvally, tapu-koko
-    786, 787, 788,	# tapu-lele, tapu-bulu, tapu-fini
-    789, 790, 791,	# cosmog, cosmoem, solgaleo
-    792, 800,	# lunala, necrozma
+    772, 773, 785,  # type-null, silvally, tapu-koko
+    786, 787, 788,  # tapu-lele, tapu-bulu, tapu-fini
+    789, 790, 791,  # cosmog, cosmoem, solgaleo
+    792, 800,       # lunala, necrozma
     # Generation 8
-    888, 889, 890,	# zacian, zamazenta, eternatus
-    891, 892, 894,	# kubfu, urshifu-single-strike, regieleki
-    895, 896, 897,	# regidrago, glastrier, spectrier
-    898,	# calyrex
+    888, 889, 890,  # zacian, zamazenta, eternatus
+    891, 892, 894,  # kubfu, urshifu-single-strike, regieleki
+    10191,          # urshifurapidstrike
+    895, 896, 897,  # regidrago, glastrier, spectrier
+    898, 905,       # calyrex, enamorus-incarnate
+    10249,          # enamorustherian
     # Generation 9
-    1001, 1002, 1003,   # wo-chien, chien-pao, ting-lu
-    1004, 1007, 1008,   # chi-yu, koraidon, miraidon
-    1009, 1010, 1014,   # walking-wake, iron-leaves, okidogi
-    1015, 1016, 1017,   # munkidori, fezandipiti, ogerpon
-    1020, 1021, 1022,	# gouging-fire, raging-bolt, iron-boulder
-    1023, 1024, 1025,   # iron-crown, terapagos, pecharunt
+    1001, 1002, 1003,  # wo-chien, chien-pao, ting-lu
+    1004, 1007, 1008,  # chi-yu, koraidon, miraidon
+    1009, 1010, 1014,  # walking-wake, iron-leaves, okidogi  [Paradox Legendary]
+    1015, 1016, 1017,  # munkidori, fezandipiti, ogerpon
+    1020, 1021, 1022,  # gouging-fire, raging-bolt, iron-boulder  [Paradox Legendary]
+    1023, 1024,        # iron-crown, terapagos
 ]
 
 MYTHICAL = [
+    # Generation 1
+    151,            # mew  [from encounter.txt]
+    # Generation 2
+    251,            # celebi  [from encounter.txt]
     # Generation 3
-    385,	# jirachi
+    385,            # jirachi
+    386,            # deoxys  [from encounter.txt]
+    10001, 10002, 10003, # deoxysattack, deoxysdefense, deoxysspeed
     # Generation 4
-    489, 490, 491,	# phione, manaphy, darkrai
-    492,	# shaymin-land
+    489, 490, 491,  # phione, manaphy, darkrai
+    492,            # shaymin-land
+    10006,          # shayminsky
+    493,            # arceus  [from encounter.txt]
     # Generation 5
-    494, 647, 648,	# victini, keldeo-ordinary, meloetta-aria
+    494, 647, 648,  # victini, keldeo-ordinary, meloetta-aria
+    10024, 10018,   # keldeoresolute, meloettapirouette
+    649,            # genesect  [from encounter.txt]
     # Generation 6
-    719, 720, 721,	# diancie, hoopa, volcanion
+    719, 720, 721,  # diancie, hoopa, volcanion
     # Generation 7
-    801, 802, 807,	# magearna, marshadow, zeraora
-    808, 809,	# meltan, melmetal
+    801, 802, 807,  # magearna, marshadow, zeraora
+    808, 809,       # meltan, melmetal
     # Generation 8
-    893,	# zarude
+    893,            # zarude
+    # Generation 9
+    1025,           # pecharunt
 ]
 
 BABY = [
     # Generation 2
-    172, 173, 174,	# pichu, cleffa, igglybuff
-    175, 236, 238,	# togepi, tyrogue, smoochum
-    239, 240,	# elekid, magby
+    172, 173, 174,  # pichu, cleffa, igglybuff
+    175, 236, 238,  # togepi, tyrogue, smoochum
+    239, 240,       # elekid, magby
     # Generation 3
-    298, 360,	# azurill, wynaut
+    298, 360,       # azurill, wynaut
     # Generation 4
-    406, 433, 438,	# budew, chingling, bonsly
-    439, 440, 446,	# mime-jr, happiny, munchlax
-    447, 458,	# riolu, mantyke
+    406, 433, 438,  # budew, chingling, bonsly
+    439, 440, 446,  # mime-jr, happiny, munchlax
+    447, 458,       # riolu, mantyke
     # Generation 8
-    848,	# toxel
+    848,            # toxel
 ]
 
 ULTRA = [
     # Generation 7
-    793, 794, 795,	# nihilego, buzzwole, pheromosa
-    796, 797, 798,	# xurkitree, celesteela, kartana
-    799, 803, 804,	# guzzlord, poipole, naganadel
-    805, 806,	# stakataka, blacephalon
+    793, 794, 795,  # nihilego, buzzwole, pheromosa
+    796, 797, 798,  # xurkitree, celesteela, kartana
+    799, 803, 804,  # guzzlord, poipole, naganadel
+    805, 806,       # stakataka, blacephalon
 ]
 
 NORMAL = [
@@ -313,7 +344,7 @@ NORMAL = [
     884, 885, 886,	# duraludon, dreepy, drakloak
     887, 899, 900,	# dragapult, wyrdeer, kleavor
     901, 902, 903,	# ursaluna, basculegion-male, sneasler
-    904, 905,	# overqwil, enamorus-incarnate
+    904,	        # overqwil
     # Generation 9
     915, 916, 917,	# lechonk, oinkologne, tarountula
     918, 919, 920,	# spidops, nymble, lokix
@@ -347,3 +378,434 @@ NORMAL = [
     1006, 1011, 1012,   # iron-valiant, dipplin, poltchageist
     1013, 1018, 1019,	# sinistcha, archaludon, hydrapple
 ]
+
+STARTERS = [
+    # Generation 1
+    1, 2, 3,         # bulbasaur, ivysaur, venusaur
+    4, 5, 6,         # charmander, charmeleon, charizard
+    7, 8, 9,         # squirtle, wartortle, blastoise
+    # Generation 2
+    152, 153, 154,   # chikorita, bayleef, meganium
+    155, 156, 157,   # cyndaquil, quilava, typhlosion
+    158, 159, 160,   # totodile, croconaw, feraligatr
+    # Generation 3
+    252, 253, 254,   # treecko, grovyle, sceptile
+    255, 256, 257,   # torchic, combusken, blaziken
+    258, 259, 260,   # mudkip, marshtomp, swampert
+    # Generation 4
+    387, 388, 389,   # turtwig, grotle, torterra
+    390, 391, 392,   # chimchar, monferno, infernape
+    393, 394, 395,   # piplup, prinplup, empoleon
+    # Generation 5
+    495, 496, 497,   # snivy, servine, serperior
+    498, 499, 500,   # tepig, pignite, emboar
+    501, 502, 503,   # oshawott, dewott, samurott
+    # Generation 6
+    650, 651, 652,   # chespin, quilladin, chesnaught
+    653, 654, 655,   # fennekin, braixen, delphox
+    656, 657, 658,   # froakie, frogadier, greninja
+    # Generation 7
+    722, 723, 724,   # rowlet, dartrix, decidueye
+    725, 726, 727,   # litten, torracat, incineroar
+    728, 729, 730,   # popplio, brionne, primarina
+    # Generation 8
+    810, 811, 812,   # grookey, thwackey, rillaboom
+    813, 814, 815,   # scorbunny, raboot, cinderace
+    816, 817, 818,   # sobble, drizzile, inteleon
+    # Generation 9
+    906, 907, 908,   # sprigatito, floragato, meowscarada
+    909, 910, 911,   # fuecoco, crocalor, skeledirge
+    912, 913, 914,   # quaxly, quaxwell, quaquaval
+]
+
+# =============================================================
+# HARD-CODED MEGA / GMAX LISTS
+# Generated from pokedex.json forme field — 95 Mega, 34 Gmax.
+# =============================================================
+MEGA_AND_SPECIAL = [
+    # =============================================================
+    # 1. TRUE MEGAS
+    # =============================================================
+    10033,  # venusaurmega           (species=3)
+    10034,  # charizardmegax         (species=6)
+    10035,  # charizardmegay         (species=6)
+    10036,  # blastoisemega          (species=9)
+    10037,  # alakazammega           (species=65)
+    10038,  # gengarmega             (species=94)
+    10039,  # kangaskhanmega         (species=115)
+    10040,  # pinsirmega             (species=127)
+    10041,  # gyaradosmega           (species=130)
+    10042,  # aerodactylmega         (species=142)
+    10043,  # mewtwomegax            (species=150)
+    10044,  # mewtwomegay            (species=150)
+    10045,  # ampharosmega           (species=181)
+    10046,  # scizormega             (species=212)
+    10047,  # heracrossmega          (species=214)
+    10048,  # houndoommega           (species=229)
+    10049,  # tyranitarmega          (species=248)
+    10050,  # blazikenmega           (species=257)
+    10051,  # gardevoirmega          (species=282)
+    10052,  # mawilemega             (species=303)
+    10053,  # aggronmega             (species=306)
+    10054,  # medichammega           (species=308)
+    10055,  # manectricmega          (species=310)
+    10056,  # banettemega            (species=354)
+    10057,  # absolmega              (species=359)
+    10058,  # garchompmega           (species=445)
+    10059,  # lucariomega            (species=448)
+    10060,  # abomasnowmega          (species=460)
+    10062,  # latiasmega             (species=380)
+    10063,  # latiosmega             (species=381)
+    10064,  # swampertmega           (species=260)
+    10065,  # sceptilemega           (species=254)
+    10066,  # sableyemega            (species=302)
+    10067,  # altariamega            (species=334)
+    10068,  # gallademega            (species=475)
+    10069,  # audinomega             (species=531)
+    10070,  # sharpedomega           (species=319)
+    10071,  # slowbromega            (species=80)
+    10072,  # steelixmega            (species=208)
+    10073,  # pidgeotmega            (species=18)
+    10074,  # glaliemega             (species=362)
+    10075,  # dianciemega            (species=719)
+    10076,  # metagrossmega          (species=376)
+    10079,  # rayquazamega           (species=384)
+    10087,  # cameruptmega           (species=323)
+    10088,  # lopunnymega            (species=428)
+    10089,  # salamencemega          (species=373)
+    10090,  # beedrillmega           (species=15)
+    10278,  # clefablemega           (species=36)
+    10279,  # victreebelmega         (species=71)
+    10280,  # starmiemega            (species=121)
+    10281,  # dragonitemega          (species=149)
+    10282,  # meganiummega           (species=154)
+    10283,  # feraligatrmega         (species=160)
+    10284,  # skarmorymega           (species=227)
+    10285,  # froslassmega           (species=478)
+    10286,  # emboarmega             (species=500)
+    10287,  # excadrillmega          (species=530)
+    10288,  # scolipedemega          (species=545)
+    10289,  # scraftymega            (species=560)
+    10290,  # eelektrossmega         (species=604)
+    10291,  # chandeluremega         (species=609)
+    10292,  # chesnaughtmega         (species=652)
+    10293,  # delphoxmega            (species=655)
+    10294,  # greninjamega           (species=658)
+    10295,  # pyroarmega             (species=668)
+    10296,  # floettemega            (species=670)
+    10297,  # malamarmega            (species=687)
+    10298,  # barbaraclemega         (species=689)
+    10299,  # dragalgemega           (species=691)
+    10300,  # hawluchamega           (species=701)
+    10301,  # zygardemega            (species=718)
+    10302,  # drampamega             (species=780)
+    10303,  # falinksmega            (species=870)
+    10304,  # raichumegax            (species=26)
+    10305,  # raichumegay            (species=26)
+    10306,  # chimechomega           (species=358)
+    10307,  # absolmegaz             (species=359)
+    10308,  # staraptormega          (species=398)
+    10309,  # garchompmegaz          (species=445)
+    10310,  # lucariomegaz           (species=448)
+    10311,  # heatranmega            (species=485)  [Sub-Legendary tag — still Mega]
+    10312,  # darkraimega            (species=491)  [Mythical tag — still Mega]
+    10313,  # golurkmega             (species=623)
+    10315,  # crabominablemega       (species=740)
+    10316,  # golisopodmega          (species=768)
+    10317,  # magearnamega           (species=801)
+    10318,  # magearnaoriginalmega   (species=801)
+    10319,  # zeraoramega            (species=807)  [Mythical tag — still Mega]
+    10320,  # scovillainmega         (species=952)
+    10321,  # glimmoramega           (species=970)
+    10322,  # tatsugiricurlymega     (species=978)
+    10323,  # tatsugiridroopymega    (species=978)
+    10324,  # tatsugiristretchymega  (species=978)
+    10325,  # baxcaliburmega         (species=998)
+
+    # =============================================================
+    # 2. PHASE 1 SPECIAL FORMS (LEGENDARY & MYTHICAL FUSIONS, ORIGINS, ETC.)
+    # =============================================================
+    # Primal Reversions & Eternamax (Not true Megas)
+    10077,  # kyogreprimal           (species=382)
+    10078,  # groudonprimal          (species=383)
+
+    10190,  # eternatuseternamax     (species=890)
+
+    # Zygarde Forms
+    10120,  # zygardecomplete        (species=718)
+
+    # Necrozma Forms & Fusions
+    10155,  # necrozmaduskmane       (species=800)
+    10156,  # necrozmadawnwings      (species=800)
+    10157,  # necrozmaultra          (species=800)
+
+    # Kyurem Fusions
+    10022,  # kyuremblack            (species=646)
+    10023,  # kyuremwhite            (species=646)
+
+    # Zacian & Zamazenta Crowned Forms
+    10188,  # zaciancrowned          (species=888)
+    10189,  # zamazentacrowned       (species=889)
+
+    # Calyrex Fusions
+    10193,  # calyrexice             (species=898)
+    10194,  # calyrexshadow          (species=898)
+
+    # Terapagos Forms
+    10276,  # terapagosterastal      (species=1024)
+    10277,  # terapagosstellar       (species=1024)
+
+    # Other Mythical/Legendary Special Forms
+    10086,  # hoopaunbound           (species=720)
+]
+
+MEGA = MEGA_AND_SPECIAL
+
+GMAX = [
+    10195,  # venusaurgmax              (species=3)
+    10196,  # charizardgmax             (species=6)
+    10197,  # blastoisegmax             (species=9)
+    10198,  # butterfreegmax            (species=12)
+    10199,  # pikachugmax               (species=25)
+    10200,  # meowthgmax                (species=52)
+    10201,  # machampgmax               (species=68)
+    10202,  # gengargmax                (species=94)
+    10203,  # kinglergmax               (species=99)
+    10204,  # laprasgmax                (species=131)
+    10205,  # eeveegmax                 (species=133)
+    10206,  # snorlaxgmax               (species=143)
+    10207,  # garbodorgmax              (species=569)
+    10208,  # melmetalgmax              (species=809)
+    10209,  # rillaboomgmax             (species=812)
+    10210,  # cinderacegmax             (species=815)
+    10211,  # inteleongmax              (species=818)
+    10212,  # corviknightgmax           (species=823)
+    10213,  # orbeetlegmax              (species=826)
+    10214,  # drednawgmax               (species=834)
+    10215,  # coalossalgmax             (species=839)
+    10216,  # flapplegmax               (species=841)
+    10217,  # appletungmax              (species=842)
+    10218,  # sandacondagmax            (species=844)
+    10219,  # toxtricitygmax            (species=849)
+    10220,  # centiskorchgmax           (species=851)
+    10221,  # hatterenegmax             (species=858)
+    10222,  # grimmsnarlgmax            (species=861)
+    10223,  # alcremiegmax              (species=869)
+    10224,  # copperajahgmax            (species=879)
+    10225,  # duraludongmax             (species=884)
+    10226,  # urshifugmax               (species=892)
+    10227,  # urshifurapidstrikegmax    (species=892)
+    10228,  # toxtricitylowkeygmax      (species=849)
+]
+
+UNAVAILABLE = [
+    # Fossil Pokemon & Evolutions
+    138, 139, 140,   # omanyte, omastar, kabuto
+    141, 142, 345,   # kabutops, aerodactyl, lileep
+    346, 347, 348,   # cradily, anorith, armaldo
+    408, 409, 410,   # cranidos, rampardos, shieldon
+    411, 564, 565,   # bastiodon, tirtouga, carracosta
+    566, 567, 696,   # archen, archeops, tyrunt
+    697, 698, 699,   # tyrantrum, amaura, aurorus
+    880, 881, 882,   # dracozolt, arctozolt, dracovish
+    883,             # arctovish
+    # Alolan Forms (10093 = raticatealolatotem, 10149 = marowakalolatotem: stay UNAVAILABLE)
+    10093, 10149, 10099, # raticatealolatotem, marowakalolatotem, pikachualola
+    # Special & Battle-Only Forms
+    10117, 10121,        # greninjaash, gumshoostotem
+    10122, 10128, 10129, # vikavolttotem, lurantistotem, salazzletotem
+    10144, 10145, 10146, # mimikyutotem, mimikyubustedtotem, kommoototem
+    10150, 10153, 10154, # ribombeetotem, araquanidtotem, togedemarutotem
+    10256,           # palafinhero
+    # Alternate Species Forms
+    10004, 10005,        # wormadamsandy, wormadamtrash 
+    10008, 10009,        # rotomheat, rotomwash
+    10010, 10011, 10012, # rotomfrost, rotomfan, rotommow
+    10013, 10014, 10015, # castform sunny, castformrainy, castformsnowy
+    10016, 10017,        # basculinbluestriped, darmanitanzen 
+    10025, 10027,        # meowsticf, aegislashblade, pumpkaboosmall 
+    10028, 10029, 10030, # pumpkaboolarge, pumpkaboosuper, gourgeistsmall
+    10031, 10032, 10061, # gourgeistlarge, gourgeistsuper, floetteeternal
+    10080,               # pikachurockstar
+    10081, 10082, 10083, # pikachubelle, pikachupopstar, pikachuphd
+    10084, 10085,        # pikachulibre, pikachucosplay 
+    10094, 10095, 10096, # pikachuoriginal, pikachuhoenn, pikachusinnoh
+    10097, 10098, 10116, # pikachuunova, pikachukalos, greninjabond
+    10123, 10124, 10125, # oricoriopompom, oricoriopau, oricoriosensu
+    10126, 10127, 10136, # lycanrocmidnight, wishiwashischool, minior
+    10137, 10138, 10139, # miniororange, minioryellow, miniorgreen
+    10140, 10141, 10142, # miniorblue, miniorindigo, miniorviolet
+    10143, 10148,        # mimikyubusted, pikachupartner
+    10152,               # lycanrocdusk 
+    10158, 10159, 10160, # pikachustarter, eeveestarter, pikachuworld
+    10182, 10183, 10184, # cramorantgulping, cramorantgorging, toxtricitylowkey
+    10185, 10186, 10187, # eiscuenoice, indeedeef, morpekohangry
+    10191,               # urshifurapidstrike 
+    10192,               # zarudedada
+    10247,               # basculinwhitestriped
+    10248, 10254,        # basculegionf, oinkolognef
+    10255, 10257, 10258, # dudunsparcethreesegment, maushold, tatsugiridroopy
+    10259, 10260, 10261, # tatsugiristretchy, squawkabillyblue, squawkabillyyellow
+    10262, 10263, 10272, # squawkabillywhite, gimmighoulroaming, ursalunabloodmoon
+    10273, 10274, 10275, # ogerponwellspringtera, ogerponhearthflametera, ogerponcornerstonetera
+    10178,               # darmanitan-galar-zen
+]
+
+# =============================================================
+# REGIONAL FORMS
+# Maps region name -> list of encounterable regional form actual_ids.
+# Totem variants (10093, 10149) are intentionally excluded.
+# =============================================================
+REGIONAL_FORMS: dict[str, list[int]] = {
+    "alola": [
+        10091, 10092,  # rattata-alola, raticate-alola
+        10100, 10101, 10102,  # raichu-alola, sandshrew-alola, sandslash-alola
+        10103, 10104, 10105,  # vulpix-alola, ninetales-alola, diglett-alola
+        10106, 10107, 10108,  # dugtrio-alola, meowth-alola, persian-alola
+        10109, 10110, 10111,  # geodude-alola, graveler-alola, golem-alola
+        10112, 10113, 10114,  # grimer-alola, muk-alola, exeggutor-alola
+        10115,                # marowak-alola
+    ],
+    "galar": [
+        10161, 10162, 10163,  # meowth-galar, ponyta-galar, rapidash-galar
+        10164, 10165, 10166,  # slowpoke-galar, slowbro-galar, farfetchd-galar
+        10167, 10168, 10169,  # weezing-galar, mr-mime-galar, articuno-galar
+        10170, 10171, 10172,  # zapdos-galar, moltres-galar, slowking-galar
+        10173, 10174, 10175,  # corsola-galar, zigzagoon-galar, linoone-galar
+        10176, 10177, 10179,  # darumaka-galar, darmanitan-galar-standard, yamask-galar
+        10180,                # stunfisk-galar
+    ],
+    "hisui": [
+        10229, 10230, 10231,  # growlithe-hisui, arcanine-hisui, voltorb-hisui
+        10232, 10233, 10234,  # electrode-hisui, typhlosion-hisui, qwilfish-hisui
+        10235, 10236, 10237,  # sneasel-hisui, samurott-hisui, lilligant-hisui
+        10238, 10239, 10240,  # zorua-hisui, zoroark-hisui, braviary-hisui
+        10241, 10242, 10243,  # sliggoo-hisui, goodra-hisui, avalugg-hisui
+        10244,                # decidueye-hisui
+    ],
+    "paldea": [
+        10250, 10251, 10252,  # tauros-paldea-combat-breed, tauros-paldea-blaze-breed, tauros-paldea-aqua-breed
+        10253,                # wooper-paldea
+    ],
+}
+
+# Maps forme string (as it appears in pokedex.json) -> required intro gen number
+REGIONAL_FORME_GEN: dict[str, int] = {
+    "Alola":  7,
+    "Galar":  8,
+    "Hisui":  8,
+    "Paldea": 9,
+}
+
+# Flat reverse map: actual_id -> region string
+REGIONAL_FORM_REGION: dict[int, str] = {
+    aid: region for region, aids in REGIONAL_FORMS.items() for aid in aids
+}
+
+# species_id -> {region_name -> [actual_id, ...]}
+# Multiple variants per species+region supported (e.g. Tauros-Paldea x3).
+# Built once at module load by _build_regional_lookup().
+REGIONAL_FORM_LOOKUP: dict[int, dict[str, list[int]]] = {}
+
+
+# REGIONAL_FORM_LOOKUP is populated at import time by
+# _build_regional_lookup() in functions/encounter_functions.py.
+
+
+# =============================================================
+# PREREQUISITE CHAINS (partly from encounter.txt)
+# Key   = Pokémon species_id that requires prerequisites.
+# Value = set of species_ids that must ALL be in the player's collection.
+# =============================================================
+PREREQUISITES = {
+    # Generation 1
+    150: {151},            # Mewtwo requires Mew
+    
+    # Generation 2
+    249: {144, 145, 146},  # Lugia requires Articuno + Zapdos + Moltres
+    250: {243, 244, 245},  # Ho-Oh requires Raikou + Entei + Suicune
+    
+    # Generation 3
+    384: {382, 383},       # Rayquaza requires Kyogre + Groudon
+    10001: {386},          # Deoxys Attack requires Deoxys
+    10002: {386},          # Deoxys Defense requires Deoxys
+    10003: {386},          # Deoxys Speed requires Deoxys
+    
+    # Generation 4
+    487: {483, 484},       # Giratina requires Dialga + Palkia
+    483: {480, 481, 482},  # Dialga requires Uxie + Mesprit + Azelf
+    484: {480, 481, 482},  # Palkia requires Uxie + Mesprit + Azelf
+    10245: {483},          # Dialga Origin requires Dialga
+    10246: {484},          # Palkia Origin requires Palkia
+    10007: {487},          # Giratina Origin requires Giratina
+    10006: {492},          # Shaymin Sky requires Shaymin
+    493: {487},            # Arceus requires Lake Trio + Dialga + Palkia + Giratina
+    490: {489},            # Phione requires Manaphy
+    486: {894, 895, 377, 378, 379}, # Regigigas requires Eleki + Drago + Regi Trio
+    
+    # Generation 5
+    647: {638, 639, 640},  # Keldeo requires Swords of Justice
+    10024: {647},          # Keldeo Resolute requires Keldeo
+    645: {641, 642},       # Landorus requires Tornadus + Thundurus
+    646: {643, 644},       # Kyurem requires Reshiram + Zekrom
+    10022: {646, 644},     # Kyurem-Black requires Kyurem + Zekrom
+    10023: {646, 643},     # Kyurem-White requires Kyurem + Reshiram
+    10019: {641},          # Tornadus Therian requires Tornadus
+    10020: {642},          # Thundurus Therian requires Thundurus
+    10021: {645},          # Landorus Therian requires Landorus
+    10018: {648},          # Meloetta Pirouette requires Meloetta
+    
+    # Generation 6
+    718: {716, 717},       # Zygarde requires Xerneas + Yveltal
+    10181: {10119},        # Zygarde 10% requires Zygarde 50%
+    
+    # Generation 7
+    800: {791, 792},       # Necrozma requires Solgaleo + Lunala
+    773: {772},            # Silvally requires Type: Null
+    10155: {800, 791},     # Necrozma-Dusk-Mane requires Necrozma + Solgaleo
+    10156: {800, 792},     # Necrozma-Dawn-Wings requires Necrozma + Lunala
+    10157: {800, 791, 792},# Necrozma-Ultra requires Necrozma + Solgaleo + Lunala
+    
+    # Generation 8
+    890: {888, 889},       # Eternatus requires Zacian + Zamazenta
+    896: {898},            # Glastrier requires Calyrex
+    897: {898},            # Spectrier requires Calyrex
+    905: {645},            # Enamorus requires Tornadus + Thundurus + Landorus
+    10249: {905},          # Enamorus Therian requires Enamorus
+    10193: {898, 896},     # Calyrex-Ice requires Calyrex + Glastrier
+    10194: {898, 897},     # Calyrex-Shadow requires Calyrex + Spectrier
+    10191: {892},          # Urshifu Rapid Strike requires Urshifu Single Strike
+    
+    # Generation 9
+    1025: {1014, 1015, 1016}, # Pecharunt requires Loyal Three
+    1024: {1007, 1008}, # Terapagos requires Koraidon OR Miraidon
+
+    # Starter Evolutions
+    2: {1}, 3: {2},     # Ivysaur requires Bulbasaur, Venusaur requires Ivysaur
+    5: {4}, 6: {5},     # Charmeleon requires Charmander, Charizard requires Charmeleon
+    8: {7}, 9: {8},     # Wartortle requires Squirtle, Blastoise requires Wartortle
+    153: {152}, 154: {153}, # Chikorita family
+    156: {155}, 157: {156}, # Cyndaquil family
+    159: {158}, 160: {159}, # Totodile family
+    253: {252}, 254: {253}, # Treecko family
+    256: {255}, 257: {256}, # Torchic family
+    259: {258}, 260: {259}, # Mudkip family
+    388: {387}, 389: {388}, # Turtwig family
+    391: {390}, 392: {391}, # Chimchar family
+    394: {393}, 395: {394}, # Piplup family
+    496: {495}, 497: {496}, # Snivy family
+    499: {498}, 500: {499}, # Tepig family
+    502: {501}, 503: {502}, # Oshawott family
+    651: {650}, 652: {651}, # Chespin family
+    654: {653}, 655: {654}, # Fennekin family
+    657: {656}, 658: {657}, # Froakie family
+    723: {722}, 724: {723}, # Rowlet family
+    726: {725}, 727: {726}, # Litten family
+    729: {728}, 730: {729}, # Popplio family
+    811: {810}, 812: {811}, # Grookey family
+    814: {813}, 815: {814}, # Scorbunny family
+    817: {816}, 818: {817}, # Sobble family
+    907: {906}, 908: {907}, # Sprigatito family
+    910: {909}, 911: {910}, # Fuecoco family
+    913: {912}, 914: {913}, # Quaxly family
+}

--- a/src/Ankimon/functions/encounter_functions.py
+++ b/src/Ankimon/functions/encounter_functions.py
@@ -69,11 +69,195 @@ _percentages_cache = {
     'main_pokemon_level': None,
 }
 
+# ==============================================================================
+# ENCOUNTER OVERHAUL CONFIGURATION (DEVELOPER TOGGLES & BALANCING COEFFICIENTS)
+# ==============================================================================
+USE_OVERHAUL_ENCOUNTER_SYSTEM = False
+
+# EP Mastery Index Components Weights
+EP_WEIGHT_TRAINER_LEVEL = 0.25     # T_norm weight
+EP_WEIGHT_DEX_COMPLETION = 0.25    # D_norm weight
+EP_WEIGHT_SESSION_PROGRESS = 0.25  # S_norm weight
+EP_WEIGHT_CORE_TEAM_POWER = 0.25   # C_norm weight
+
+# Scale limits for EP components
+TRAINER_LEVEL_CAP = 50.0
+CORE_TEAM_POWER_CAP = 16000.0
+
+# Master Rarity Parameters: (Beginner Base Rate, Master Max Rate)
+OVERHAUL_TIER_PARAMS = {
+    "Normal": (96.98, 84.70),
+    "Baby": (2.30, 3.0),
+    "Ultra": (0.35, 4.50),
+    "Gmax": (0.15, 2.50),
+    "Starter": (0.10, 1.80),
+    "Mega": (0.05, 1.50),
+    "Legendary": (0.05, 1.50),
+    "Mythical": (0.02, 0.50)
+}
+
+# Main Pokémon level thresholds for unlocking tiers
+OVERHAUL_LEVEL_THRESHOLDS = {
+    "Ultra": 30,
+    "Legendary": 50,
+    "Mega": 60,
+    "Gmax": 65,
+    "Mythical": 75,
+    "Starter": 80,
+}
+
+# Dry spell thresholds for independent pity (Pi reviews)
+OVERHAUL_PITY_THRESHOLDS = {
+    "Ultra": 100,
+    "Gmax": 150,
+    "Starter": 175,
+    "Mega": 200,
+    "Legendary": 200,
+    "Mythical": 400
+}
+
+# Pity divisor/scaling factor (the quadratic denominator)
+OVERHAUL_PITY_DIVISOR = 50.0
+# ==============================================================================
+
+
+def calculate_mastery_index_ep(total_reviews, daily_average, trainer_level):
+    """
+    Calculate the Encounter Potential (EP) Mastery Index (0.0 to 100.0).
+    EP = 0.30 * T_norm + 0.30 * D_norm + 0.25 * S_norm + 0.15 * C_norm
+    """
+    # 1. T_norm (Trainer Level)
+    level_val = trainer_level if trainer_level is not None else 1
+    t_norm = min((level_val / TRAINER_LEVEL_CAP) * 100.0, 100.0)
+
+    # 2. D_norm (Pokedex Completion)
+    d_norm = 0.0
+    try:
+        from ..functions.pokedex_functions import _load_pokedex_cache
+        pokedex_data = _load_pokedex_cache()
+        if pokedex_data and hasattr(mw, 'ankimon_db') and mw.ankimon_db:
+            caught_ids = mw.ankimon_db.get_all_pokemon_ids()
+            caught_species = set()
+            for pid in caught_ids:
+                if pid >= 10000:
+                    name = search_pokedex_by_id(pid)
+                    if name and name != "Pokémon not found":
+                        base_id = safe_int(search_pokedex(name, "species_id"))
+                        if base_id:
+                            caught_species.add(base_id)
+                else:
+                    caught_species.add(pid)
+                    
+            unique_species_in_game = {safe_int(v.get("species_id")) for v in pokedex_data.values() if v.get("species_id")}
+            unique_species_in_game.discard(0)
+            total_species_count = len(unique_species_in_game) if unique_species_in_game else 1
+            d_norm = (len(caught_species & unique_species_in_game) / total_species_count) * 100.0
+    except Exception as e:
+        print(f"[Ankimon] Warning: Error calculating Dex Completion for EP: {e}")
+
+    # 3. S_norm (Session Progress)
+    daily_goal = daily_average if daily_average and daily_average > 0 else 100.0
+    s_norm = min((total_reviews / daily_goal) * 100.0, 100.0)
+
+    # 4. C_norm (Core Team Power)
+    c_norm = 0.0
+    try:
+        if hasattr(mw, 'ankimon_db') and mw.ankimon_db:
+            all_pkmn = mw.ankimon_db.get_all_pokemon()
+            if all_pkmn:
+                cps = []
+                for p in all_pkmn:
+                    try:
+                        cp = calculate_cp_from_dict(p)
+                        cps.append(cp)
+                    except Exception:
+                        pass
+                cps.sort(reverse=True)
+                top_6 = cps[:6]
+                avg_top_6_cp = sum(top_6) / len(top_6) if top_6 else 0.0
+                c_norm = min((avg_top_6_cp / CORE_TEAM_POWER_CAP) * 100.0, 100.0)
+    except Exception as e:
+        print(f"[Ankimon] Warning: Error calculating Core Team Power for EP: {e}")
+
+    ep = (EP_WEIGHT_TRAINER_LEVEL * t_norm) + \
+         (EP_WEIGHT_DEX_COMPLETION * d_norm) + \
+         (EP_WEIGHT_SESSION_PROGRESS * s_norm) + \
+         (EP_WEIGHT_CORE_TEAM_POWER * c_norm)
+    return max(0.0, min(ep, 100.0))
+
+def load_pity_trackers() -> dict:
+    default_pity = {
+        "Ultra": 0,
+        "Gmax": 0,
+        "Starter": 0,
+        "Mega": 0,
+        "Legendary": 0,
+        "Mythical": 0
+    }
+    try:
+        if hasattr(mw, 'ankimon_db') and mw.ankimon_db:
+            stored = mw.ankimon_db.get_user_data("ankimon_pity_trackers")
+            if isinstance(stored, dict):
+                for k in default_pity:
+                    if k in stored:
+                        default_pity[k] = int(stored[k])
+    except Exception as e:
+        print(f"[Ankimon] Warning: Error loading pity trackers: {e}")
+    return default_pity
+
+def save_pity_trackers(trackers: dict):
+    try:
+        if hasattr(mw, 'ankimon_db') and mw.ankimon_db:
+            mw.ankimon_db.set_user_data("ankimon_pity_trackers", trackers)
+    except Exception as e:
+        print(f"[Ankimon] Warning: Error saving pity trackers: {e}")
+
+def _modify_percentages_overhaul(total_reviews, daily_average, trainer_level):
+    """
+    Overhaul calculation for encounter percentages based on the Mastery Index (EP),
+    Exponential Rarity Scaling, and Independent Pity systems.
+    """
+    ep = calculate_mastery_index_ep(total_reviews, daily_average, trainer_level)
+
+    # Generate base weights
+    weights = {}
+    for tier, (base, max_val) in OVERHAUL_TIER_PARAMS.items():
+        weights[tier] = base * ((max_val / base) ** (ep / 100.0))
+
+    # Apply level thresholds
+    level_val = main_pokemon.level if main_pokemon and hasattr(main_pokemon, 'level') and main_pokemon.level is not None else 1
+    for tier, limit in OVERHAUL_LEVEL_THRESHOLDS.items():
+        if level_val < limit:
+            weights[tier] = 0.0
+
+    # Apply pity multipliers
+    pity_trackers = load_pity_trackers()
+    for tier in OVERHAUL_PITY_THRESHOLDS:
+        p_i = pity_trackers.get(tier, 0)
+        t_i = OVERHAUL_PITY_THRESHOLDS[tier]
+        multiplier = 1.0 + (max(0, (p_i - t_i) / OVERHAUL_PITY_DIVISOR)) ** 2
+        weights[tier] = weights[tier] * multiplier
+
+    # Force Starter to 0 (Comment to activate starters)
+    #weights["Starter"] = 0.0
+
+    total_sum = sum(weights.values())
+    percentages = {}
+    for tier in weights:
+        percentages[tier] = (weights[tier] / total_sum) * 100.0 if total_sum > 0.0 else 0.0
+
+    return percentages
+
 def modify_percentages(total_reviews, daily_average, trainer_level):
     """
     Modify Pokémon encounter percentages based on total reviews, trainer level, and main Pokémon level.
     """
+    if USE_OVERHAUL_ENCOUNTER_SYSTEM:
+        return _modify_percentages_overhaul(total_reviews, daily_average, trainer_level)
+
+    # Legacy System
     # Performance Guard: Skip recalculation if inputs haven't changed
+    # Check if cache is valid
     if (_percentages_cache['percentages'] is not None and
         _percentages_cache['total_reviews'] == total_reviews and
         _percentages_cache['trainer_level'] == trainer_level and
@@ -291,8 +475,128 @@ def generate_random_pokemon(
     if main_pokemon_level == 100:
         wild_pokemon_lvl = 100
 
-    # First, we draw a random, valid pokemon id.
-    pokemon_id, tier = choose_random_pkmn_from_tier()
+    from ..utils import load_collected_pokemon_ids
+    collected_ids = load_collected_pokemon_ids()
+
+    # FALLBACK HIERARCHY
+    # If a rolled tier fails, try the next one in the list.
+    TIER_ORDER = ["Mythical", "Mega", "Legendary", "Gmax", "Ultra", "Starter", "Normal", "Baby"]
+    
+    selected_pokemon_id = None
+    selected_tier = None
+    
+    # 1. Select the initial tier based on probabilities
+    initial_tier = get_tier(ankimon_tracker_obj.get_total_reviews(), trainer_card.level)
+    
+    # Find starting point in fallback order
+    try:
+        start_idx = TIER_ORDER.index(initial_tier)
+    except ValueError:
+        start_idx = TIER_ORDER.index("Normal")
+        
+    # Iterate through tiers starting from the rolled one
+    for i in range(start_idx, len(TIER_ORDER)):
+        current_tier = TIER_ORDER[i]
+        
+        tier_ids = get_all_pokemon_in_tier(current_tier)
+        full_pool = []
+        for pokemon_id in tier_ids:
+            name = search_pokedex_by_id(pokemon_id)
+            if not name or name == "Pokémon not found":
+                continue
+                
+            # Guard 1: Generation check
+            if not check_id_ok(pokemon_id):
+                continue
+
+            # Guard 2: Level check
+            min_allowed_pokemon_lvl = check_min_generate_level(str(name.lower()))
+            if wild_pokemon_lvl < min_allowed_pokemon_lvl:
+                continue
+
+            # Guard 3: Mega/Gmax base ownership
+            if current_tier in ("Mega", "Gmax") and not _player_owns_base_form(pokemon_id, collected_ids):
+                continue
+
+            # Guard 4: Prerequisite check
+            if not _meets_prerequisites(pokemon_id, collected_ids):
+                continue
+                
+            full_pool.append(pokemon_id)
+            
+        if not full_pool:
+            continue
+
+        active_region = settings_obj.get("misc.active_region")
+        boosted_pool = []
+
+        if active_region:
+            boosted_gens = get_boosted_gens_for_region(active_region)
+            
+            for pid in full_pool:
+                if get_base_species_gen(pid) in boosted_gens:
+                    if pid not in boosted_pool:
+                        boosted_pool.append(pid)
+                
+                # Add eligible regional variants for the active region
+                options = encounter_data.REGIONAL_FORM_LOOKUP.get(pid, {}).get(active_region, [])
+                for opt in options:
+                    if check_id_ok(opt) and opt not in boosted_pool:
+                        boosted_pool.append(opt)
+
+        if active_region and boosted_pool:
+            chance = get_boosted_pool_chance(active_region)
+            if random.random() < chance:
+                selected_pokemon_id = random.choice(boosted_pool)
+            else:
+                selected_pokemon_id = random.choice(full_pool)
+        else:
+            selected_pokemon_id = random.choice(full_pool)
+
+        selected_tier = current_tier
+        break
+            
+    # Final fallback if somehow everything failed (e.g. settings restrict all IDs)
+    if not selected_pokemon_id:
+        selected_pokemon_id = 19 # Rattata
+        selected_tier = "Normal"
+
+    # --- Regional form resolution ---
+    # Apply 7%-per-variant resolution for base species.
+    if selected_pokemon_id < 10000:
+        region_forms = encounter_data.REGIONAL_FORM_LOOKUP.get(selected_pokemon_id, {})
+        num_eligible = 0
+        for variants in region_forms.values():
+            for v in variants:
+                if check_id_ok(v):
+                    num_eligible += 1
+        
+        if num_eligible > 0:
+            if random.random() < 0.07 * num_eligible:
+                sub = get_regional_substitute(selected_pokemon_id)
+                if sub:
+                    selected_pokemon_id = sub
+    # --- End form resolution ---
+
+    pokemon_id = selected_pokemon_id
+    tier = selected_tier
+
+    # Update pity trackers if overhaul system is active
+    if USE_OVERHAUL_ENCOUNTER_SYSTEM:
+        try:
+            pity_trackers = load_pity_trackers()
+            rare_tiers = ["Ultra", "Gmax", "Starter", "Mega", "Legendary", "Mythical"]
+            if tier in rare_tiers:
+                pity_trackers[tier] = 0
+                for rt in rare_tiers:
+                    if rt != tier:
+                        pity_trackers[rt] += 1
+            else:
+                for rt in rare_tiers:
+                    pity_trackers[rt] += 1
+            save_pity_trackers(pity_trackers)
+        except Exception as e:
+            print(f"[Ankimon] Warning: Error updating pity trackers in generate_random_pokemon: {e}")
     name = search_pokedex_by_id(pokemon_id)
     min_allowed_pokemon_lvl = check_min_generate_level(
         str(name.lower())

--- a/src/Ankimon/functions/encounter_functions.py
+++ b/src/Ankimon/functions/encounter_functions.py
@@ -22,6 +22,7 @@ from ..functions.pokedex_functions import (
     get_effort_values,
     get_growth_rate,
     return_name_for_id,
+    safe_int,
     search_pokedex,
     search_pokedex_by_id,
 )
@@ -35,6 +36,7 @@ from ..functions.drawing_utils import tooltipWithColour
 from ..utils import limit_ev_yield, play_effect_sound, get_ev_spread
 from ..business import calc_experience, calculate_cp_from_dict
 from ..const import gen_ids
+from . import encounter_data
 
 if TYPE_CHECKING:
     # Type-hint-only imports (several pull in Qt). `from __future__ import
@@ -135,8 +137,8 @@ def calculate_mastery_index_ep(total_reviews, daily_average, trainer_level):
     try:
         from ..functions.pokedex_functions import _load_pokedex_cache
         pokedex_data = _load_pokedex_cache()
-        if pokedex_data and hasattr(mw, 'ankimon_db') and mw.ankimon_db:
-            caught_ids = mw.ankimon_db.get_all_pokemon_ids()
+        if pokedex_data and ankimon_db:
+            caught_ids = ankimon_db.get_all_pokemon_ids()
             caught_species = set()
             for pid in caught_ids:
                 if pid >= 10000:
@@ -162,8 +164,8 @@ def calculate_mastery_index_ep(total_reviews, daily_average, trainer_level):
     # 4. C_norm (Core Team Power)
     c_norm = 0.0
     try:
-        if hasattr(mw, 'ankimon_db') and mw.ankimon_db:
-            all_pkmn = mw.ankimon_db.get_all_pokemon()
+        if ankimon_db:
+            all_pkmn = ankimon_db.get_all_pokemon()
             if all_pkmn:
                 cps = []
                 for p in all_pkmn:
@@ -195,8 +197,8 @@ def load_pity_trackers() -> dict:
         "Mythical": 0
     }
     try:
-        if hasattr(mw, 'ankimon_db') and mw.ankimon_db:
-            stored = mw.ankimon_db.get_user_data("ankimon_pity_trackers")
+        if ankimon_db:
+            stored = ankimon_db.get_user_data("ankimon_pity_trackers")
             if isinstance(stored, dict):
                 for k in default_pity:
                     if k in stored:
@@ -207,8 +209,8 @@ def load_pity_trackers() -> dict:
 
 def save_pity_trackers(trackers: dict):
     try:
-        if hasattr(mw, 'ankimon_db') and mw.ankimon_db:
-            mw.ankimon_db.set_user_data("ankimon_pity_trackers", trackers)
+        if ankimon_db:
+            ankimon_db.set_user_data("ankimon_pity_trackers", trackers)
     except Exception as e:
         print(f"[Ankimon] Warning: Error saving pity trackers: {e}")
 

--- a/src/Ankimon/functions/encounter_functions.py
+++ b/src/Ankimon/functions/encounter_functions.py
@@ -423,6 +423,169 @@ def check_id_ok(id_num: Union[int, list[int]]):
     return False
 
 
+
+# === Encounter Overhaul helpers (ported from BRRRR_Experimental @hakimh2) ===
+def _build_regional_lookup() -> None:
+    """Populates encounter_data.REGIONAL_FORM_LOOKUP from pokedex.json.
+
+    Maps species_id -> {region -> [actual_id, ...]} for all encounterable
+    regional forms. Called once at module import. Silently no-ops if
+    pokedex.json is unavailable (e.g. first-run before data files exist).
+    """
+    import os
+
+    try:
+        pokedex_path = os.path.join(
+            os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+            "data_files",
+            "pokedex.json",
+        )
+        with open(pokedex_path, "r", encoding="utf-8") as f:
+            pokedex = json.load(f)
+        aid_to_sid: dict[int, int] = {
+            v["actual_id"]: v["species_id"]
+            for v in pokedex.values()
+            if "actual_id" in v and "species_id" in v
+        }
+        for region, aids in encounter_data.REGIONAL_FORMS.items():
+            for aid in aids:
+                sid = aid_to_sid.get(aid)
+                if sid is None:
+                    continue
+                region_map = encounter_data.REGIONAL_FORM_LOOKUP.setdefault(sid, {})
+                region_map.setdefault(region, []).append(aid)
+    except Exception as e:
+        print(f"[Ankimon] Warning: Could not build regional form lookup: {e}")
+
+
+_build_regional_lookup()
+
+def clear_encounter_cache():
+    """Clear cache when needed"""
+    global _percentages_cache
+    _percentages_cache = {
+        "percentages": None,
+        "total_reviews": None,
+        "trainer_level": None,
+        "main_pokemon_level": None,
+    }
+
+def _player_owns_base_form(actual_id: int, collected_ids: set) -> bool:
+    """Return True if the player owns the base species of this Mega/Gmax form."""
+    name = search_pokedex_by_id(actual_id)
+    if not name or name == "Pokémon not found":
+        return True  # can't determine — allow through
+    species_id = safe_int(search_pokedex(name, "species_id"))
+    if not species_id:
+        return True
+    return species_id in collected_ids
+
+
+def _meets_prerequisites(pokemon_id: int, collected_ids: set) -> bool:
+    """Return True if all prerequisite Pokémon for this ID are collected.
+
+    Prerequisite chains are defined in encounter_data.PREREQUISITES.
+    Handles forms by checking the species_id prerequisites.
+    """
+
+    check_id = pokemon_id
+    if pokemon_id not in encounter_data.PREREQUISITES:
+        if pokemon_id >= 10000:
+            name = search_pokedex_by_id(pokemon_id)
+            species_id = safe_int(search_pokedex(name, "species_id"))
+            if species_id:
+                check_id = species_id
+
+    required = encounter_data.PREREQUISITES.get(check_id)
+    if not required:
+        return True
+
+    if isinstance(required, tuple) and len(required) == 2 and required[0] == "OR":
+        # Any of these must be present
+        return any(rid in collected_ids for rid in required[1])
+
+    # All must be present (default behavior for sets)
+    return required.issubset(collected_ids)
+
+def get_regional_substitute(species_id: int, region: str = None) -> "int | None":
+    """
+    Returns a regional form actual_id for the given species and region, or None.
+    If region is None, returns any valid regional variant from any region.
+    """
+
+    eligible = []
+    lookup = encounter_data.REGIONAL_FORM_LOOKUP.get(species_id, {})
+
+    if region:
+        options = lookup.get(region, [])
+        for v in options:
+            if check_id_ok(v):
+                eligible.append(v)
+    else:
+        for reg_variants in lookup.values():
+            for v in reg_variants:
+                if check_id_ok(v):
+                    eligible.append(v)
+
+    if eligible:
+        return random.choice(eligible)
+    return None
+
+
+def get_boosted_gens_for_region(region: str) -> list[int]:
+    mapping = {
+        "kanto": [1],
+        "johto": [2],
+        "hoenn": [3],
+        "sinnoh": [4],
+        "unova": [5],
+        "kalos": [6],
+        "alola": [7],
+        "galar": [8],
+        "paldea": [9],
+        "hisui": [4, 8],
+    }
+    return mapping.get(region, [])
+
+
+def get_boosted_pool_chance(region: str) -> float:
+    return 0.40 if region == "hisui" else 0.30
+
+
+def get_base_species_gen(actual_id: int) -> int:
+    species_id = actual_id
+    if actual_id >= 10000:
+        name = search_pokedex_by_id(actual_id)
+        if name and name != "Pokémon not found":
+            species_id = safe_int(search_pokedex(name, "species_id")) or actual_id
+
+    for gen, max_id in gen_ids.items():
+        if species_id <= max_id:
+            return int(gen.split("_")[1])
+    return 0
+
+
+def get_all_pokemon_in_tier(tier: str) -> list[int]:
+    if tier == "Normal":
+        return encounter_data.NORMAL
+    if tier == "Baby":
+        return encounter_data.BABY
+    if tier == "Ultra":
+        return encounter_data.ULTRA
+    if tier == "Legendary":
+        return encounter_data.LEGENDARY
+    if tier == "Mythical":
+        return encounter_data.MYTHICAL
+    if tier == "Mega":
+        return encounter_data.MEGA
+    if tier == "Gmax":
+        return encounter_data.GMAX
+    # if tier == "Starter": return encounter_data.STARTERS #Uncomment to activate starters
+    if tier == "Starter":
+        return []
+    return []
+
+
 def generate_random_pokemon(
     main_pokemon_level: int, ankimon_tracker_obj: AnkimonTracker
 ):

--- a/src/Ankimon/functions/encounter_functions.py
+++ b/src/Ankimon/functions/encounter_functions.py
@@ -480,7 +480,7 @@ def generate_random_pokemon(
 
     # FALLBACK HIERARCHY
     # If a rolled tier fails, try the next one in the list.
-    TIER_ORDER = ["Mythical", "Mega", "Legendary", "Gmax", "Ultra", "Starter", "Normal", "Baby"]
+    TIER_ORDER = ["Mythical", "Mega", "Legendary", "Gmax", "Ultra", "Starter", "Baby", "Normal"]
     
     selected_pokemon_id = None
     selected_tier = None

--- a/src/Ankimon/functions/learnset_retrieval.py
+++ b/src/Ankimon/functions/learnset_retrieval.py
@@ -41,8 +41,8 @@ def _get_learnset_moves(pokemon_name, pokemon_level, generation=9):
     pokemon_name = pokemon_name.lower().replace("-", "").replace(" ", "").replace("'", "").replace(".", "")
     pokemon_learnset = learnsets.get(pokemon_name, {}).get("learnset", {})
     
-    # Fallback to base form for Mega/Gigantamax/Primal if no learnset found
-    if not pokemon_learnset and any(x in pokemon_name for x in ["mega", "gmax", "primal"]):
+    # Fallback to base form for Mega/Gigantamax/Primal/Eternamax if no learnset found
+    if not pokemon_learnset and any(x in pokemon_name for x in ["mega", "gmax", "primal", "eternamax"]):
         # Use pokedex to find the base form via species_id
         from .pokedex_functions import _load_pokedex_cache, search_pokedex_by_id, search_pokedex
         pokedex_data = _load_pokedex_cache()

--- a/src/Ankimon/functions/pokedex_functions.py
+++ b/src/Ankimon/functions/pokedex_functions.py
@@ -386,6 +386,9 @@ def format_lore_name(name: str) -> str:
     if not name or not isinstance(name, str):
         return name
         
+    if name.lower() == "eternatus-eternamax":
+        return "Eternamax"
+
     # Order matters: check more specific ones first
     if "-Mega-X" in name:
         return "Mega " + name.replace("-Mega-X", " X")

--- a/src/Ankimon/menu_buttons.py
+++ b/src/Ankimon/menu_buttons.py
@@ -264,10 +264,16 @@ def create_menu_actions(
 
     # Encounter Rate Simulator (dev tool — ported from BRRRR_Experimental)
     if debug is True:
-        from .pyobj.encounter_simulator_dialog import EncounterSimulatorDialog
         simulator_action = QAction("Encounter Rate Simulator", mw)
         simulator_action.setMenuRole(QAction.MenuRole.NoRole)
-        simulator_action.triggered.connect(lambda: EncounterSimulatorDialog(addon_dir).show())
+
+        def _open_encounter_simulator():
+            # Lazy import: EncounterSimulatorDialog pulls in QtWebEngine, which
+            # must not load at boot (keeps the addon importable without WebEngine).
+            from .pyobj.encounter_simulator_dialog import EncounterSimulatorDialog
+            EncounterSimulatorDialog(addon_dir).show()
+
+        simulator_action.triggered.connect(lambda: _open_encounter_simulator())
         help_menu.addAction(simulator_action)
     if debug is True:
         tracker_window_action = QAction(mw.translator.translate("ankimon_tracker_button"), mw)

--- a/src/Ankimon/menu_buttons.py
+++ b/src/Ankimon/menu_buttons.py
@@ -262,6 +262,13 @@ def create_menu_actions(
     # Show the Settings window
     mw.pokemenu.addAction(config_action)
 
+    # Encounter Rate Simulator (dev tool — ported from BRRRR_Experimental)
+    if debug is True:
+        from .pyobj.encounter_simulator_dialog import EncounterSimulatorDialog
+        simulator_action = QAction("Encounter Rate Simulator", mw)
+        simulator_action.setMenuRole(QAction.MenuRole.NoRole)
+        simulator_action.triggered.connect(lambda: EncounterSimulatorDialog(addon_dir).show())
+        help_menu.addAction(simulator_action)
     if debug is True:
         tracker_window_action = QAction(mw.translator.translate("ankimon_tracker_button"), mw)
         tracker_window_action.setMenuRole(QAction.MenuRole.NoRole)

--- a/src/Ankimon/pyobj/encounter_simulator_dialog.py
+++ b/src/Ankimon/pyobj/encounter_simulator_dialog.py
@@ -1,0 +1,301 @@
+import json
+import os
+from pathlib import Path
+from PyQt6.QtWidgets import QDialog, QVBoxLayout
+from PyQt6.QtWebEngineWidgets import QWebEngineView
+from PyQt6.QtWebChannel import QWebChannel
+from PyQt6.QtCore import QUrl, QObject, pyqtSlot, Qt
+from PyQt6.QtGui import QColor
+
+from aqt import mw
+from ..functions import encounter_functions as ef
+from .. import business
+from ..singletons import (
+    main_pokemon,
+    ankimon_tracker_obj,
+    settings_obj,
+    trainer_card
+)
+from ..functions.pokedex_functions import (
+    search_pokedex,
+    search_pokedex_by_id,
+    safe_int
+)
+
+
+class SimulatorBridge(QObject):
+    """
+    Exposes slots to JavaScript via QWebChannel for retrieving initial state
+    and running real-time encounter rate calculations.
+    """
+    def __init__(self, dialog):
+        super().__init__()
+        self.dialog = dialog
+
+    @pyqtSlot(result=str)
+    def get_initial_state(self) -> str:
+        """
+        Fetches the player's active live data state to pre-populate simulator sliders.
+        """
+        # 1. Trainer Level
+        t_level = trainer_card.level if trainer_card and hasattr(trainer_card, 'level') else 1
+
+        # 2. Dex Completion Percentage
+        d_pct = 0.0
+        try:
+            from ..functions.pokedex_functions import _load_pokedex_cache
+            pokedex_data = _load_pokedex_cache()
+            if pokedex_data and hasattr(mw, 'ankimon_db') and mw.ankimon_db:
+                caught_ids = mw.ankimon_db.get_all_pokemon_ids()
+                caught_species = set()
+                for pid in caught_ids:
+                    if pid >= 10000:
+                        name = search_pokedex_by_id(pid)
+                        if name and name != "Pokémon not found":
+                            base_id = safe_int(search_pokedex(name, "species_id"))
+                            if base_id:
+                                caught_species.add(base_id)
+                    else:
+                        caught_species.add(pid)
+                        
+                unique_species_in_game = {safe_int(v.get("species_id")) for v in pokedex_data.values() if v.get("species_id")}
+                unique_species_in_game.discard(0)
+                total_species_count = len(unique_species_in_game) if unique_species_in_game else 1
+                d_pct = (len(caught_species & unique_species_in_game) / total_species_count) * 100.0
+        except Exception as e:
+            print(f"[Ankimon Bridge] Warning: Could not calculate live Dex Completion: {e}")
+
+        # 3. Reviews Done
+        reviews = ankimon_tracker_obj.get_total_reviews() if ankimon_tracker_obj else 0
+
+        # 4. Daily Goal
+        daily_goal = 100
+        try:
+            if settings_obj:
+                daily_goal = int(settings_obj.get("battle.daily_average"))
+        except Exception:
+            pass
+
+        # 5. Average CP
+        avg_cp = 10.0
+        try:
+            if hasattr(mw, 'ankimon_db') and mw.ankimon_db:
+                all_pkmn = mw.ankimon_db.get_all_pokemon()
+                if all_pkmn:
+                    cps = []
+                    for p in all_pkmn:
+                        try:
+                            cp = business.calculate_cp_from_dict(p)
+                            cps.append(cp)
+                        except Exception:
+                            pass
+                    cps.sort(reverse=True)
+                    top_6 = cps[:6]
+                    avg_cp = sum(top_6) / len(top_6) if top_6 else 10.0
+        except Exception as e:
+            print(f"[Ankimon Bridge] Warning: Could not calculate live top-6 CP: {e}")
+
+        # 6. Main Pokémon Level
+        main_lvl = main_pokemon.level if main_pokemon and hasattr(main_pokemon, 'level') and main_pokemon.level is not None else 1
+
+        # Check which system is currently active in the Ankimon add-on
+        active_system = "Overhaul" if ef.USE_OVERHAUL_ENCOUNTER_SYSTEM else "Legacy"
+
+        # Package Overhaul Configuration constants dynamically from encounter_functions
+        overhaul_config = {
+            "ep_weight_trainer_level": float(ef.EP_WEIGHT_TRAINER_LEVEL),
+            "ep_weight_dex_completion": float(ef.EP_WEIGHT_DEX_COMPLETION),
+            "ep_weight_session_progress": float(ef.EP_WEIGHT_SESSION_PROGRESS),
+            "ep_weight_core_team_power": float(ef.EP_WEIGHT_CORE_TEAM_POWER),
+            "trainer_level_cap": float(ef.TRAINER_LEVEL_CAP),
+            "core_team_power_cap": float(ef.CORE_TEAM_POWER_CAP),
+            "tier_params": ef.OVERHAUL_TIER_PARAMS,
+            "level_thresholds": ef.OVERHAUL_LEVEL_THRESHOLDS,
+            "pity_thresholds": ef.OVERHAUL_PITY_THRESHOLDS,
+            "pity_divisor": float(ef.OVERHAUL_PITY_DIVISOR)
+        }
+
+        state = {
+            "trainer_level": int(t_level),
+            "dex_completion": round(d_pct, 1),
+            "reviews_done": int(reviews),
+            "daily_goal": int(daily_goal),
+            "avg_cp": int(avg_cp),
+            "main_level": int(main_lvl),
+            "config": overhaul_config,
+            "active_system": active_system
+        }
+        return json.dumps(state)
+
+    @pyqtSlot(str, result=str)
+    def calculate_rates_js(self, slider_state_json: str) -> str:
+        """
+        Receives slider values, executes backend calculations, and returns JSON weights.
+        """
+        slider_state = json.loads(slider_state_json)
+        result = self.dialog.calculate_rates(slider_state)
+        return json.dumps(result)
+
+
+class EncounterSimulatorDialog(QDialog):
+    """
+    Modern PyQt6 dialog housing the Encounter Rate Simulator web view.
+    Exposes simulated mathematical weighting without code duplication.
+    """
+    def __init__(self, addon_dir: Path):
+        super().__init__()
+        self.addon_dir = addon_dir
+        self.setWindowTitle("Ankimon Encounter Rate Simulator")
+        self.resize(1100, 800)
+
+        # Allow minimizing/maximizing cleanly
+        self.setWindowFlags(self.windowFlags() | Qt.WindowType.WindowMinMaxButtonsHint)
+
+        # Setup Layout
+        layout = QVBoxLayout()
+        layout.setContentsMargins(0, 0, 0, 0)
+        self.setLayout(layout)
+
+        # Setup QWebEngineView
+        self.webview = QWebEngineView()
+        # Prevent white background loading flash
+        self.webview.page().setBackgroundColor(QColor(13, 15, 25))
+        
+        # Configure WebChannel communication
+        self.channel = QWebChannel(self.webview)
+        self.bridge = SimulatorBridge(self)
+        self.channel.registerObject("pyBridge", self.bridge)
+        self.webview.page().setWebChannel(self.channel)
+
+        layout.addWidget(self.webview)
+
+        # Load Local HTML file
+        html_path = self.addon_dir / "encounter_simulator" / "simulator.html"
+        self.webview.setUrl(QUrl.fromLocalFile(html_path.as_posix()))
+
+    def calculate_rates(self, slider_state: dict) -> dict:
+        """
+        Temporarily monkeypatches active settings and database references to run
+        live math formulas directly from encounter_functions.py, then restores state.
+        """
+        # 1. Clear caches first
+        ef.clear_encounter_cache()
+
+        # 2. Preserve original global references before simulation override
+        orig_use_overhaul = ef.USE_OVERHAUL_ENCOUNTER_SYSTEM
+        orig_main_pokemon_level = getattr(main_pokemon, "level", 1)
+        orig_trainer_card_level = getattr(trainer_card, "level", 1)
+        orig_db = getattr(mw, "ankimon_db", None)
+        orig_calc_cp = getattr(business, "calculate_cp_from_dict", None)
+        orig_ef_calc_cp = getattr(ef, "calculate_cp_from_dict", None)
+
+        # 3. Calculate "Current Live Rates" under both systems based on absolute active save database values
+        live_reviews = ankimon_tracker_obj.get_total_reviews() if ankimon_tracker_obj else 0
+        live_goal = 100
+        try:
+            live_goal = int(settings_obj.get("battle.daily_average"))
+        except Exception:
+            pass
+        live_trainer_lvl = trainer_card.level if trainer_card and hasattr(trainer_card, 'level') else 1
+
+        # Calculate Live Overhaul Rates
+        ef.USE_OVERHAUL_ENCOUNTER_SYSTEM = True
+        ef.clear_encounter_cache()
+        live_overhaul_rates = ef.modify_percentages(live_reviews, live_goal, live_trainer_lvl)
+
+        # Calculate Live Legacy Rates
+        ef.USE_OVERHAUL_ENCOUNTER_SYSTEM = False
+        ef.clear_encounter_cache()
+        live_legacy_rates = ef.modify_percentages(live_reviews, live_goal, live_trainer_lvl)
+
+        # 4. Perform simulation override swaps
+        # A. Swap Main Pokemon Level
+        if main_pokemon:
+            main_pokemon.level = slider_state["main_level"]
+        if trainer_card:
+            trainer_card.level = slider_state["trainer_level"]
+
+        # B. Swap Database with a mock containing matching length and CP outputs
+        class MockDB:
+            def get_all_pokemon_ids(self):
+                try:
+                    from ..functions.pokedex_functions import _load_pokedex_cache
+                    pokedex_data = _load_pokedex_cache()
+                    unique_species = {ef.safe_int(v.get("species_id")) for v in pokedex_data.values() if v.get("species_id")}
+                    unique_species.discard(0)
+                    total_count = len(unique_species) if unique_species else 151
+                except Exception:
+                    total_count = 151
+
+                target_count = int((slider_state["dex_completion"] / 100.0) * total_count)
+                return list(range(1, target_count + 1))
+
+            def get_all_pokemon(self):
+                # Returns 6 elements to feed average top-6 CP calculation
+                return [{"cp": slider_state["avg_cp"]}] * 6
+
+            def get_user_data(self, key):
+                # Fallback to active pity values inside database so pity boosts display correctly
+                if orig_db and hasattr(orig_db, "get_user_data"):
+                    return orig_db.get_user_data(key)
+                return None
+
+        mw.ankimon_db = MockDB()
+
+        # C. Monkeypatch both business and ef calculate_cp_from_dict to return simulated avg CP directly
+        business.calculate_cp_from_dict = lambda p: slider_state["avg_cp"]
+        ef.calculate_cp_from_dict = lambda p: slider_state["avg_cp"]
+
+        # D. Calculate Simulated Overhaul Rates
+        ef.USE_OVERHAUL_ENCOUNTER_SYSTEM = True
+        ef.clear_encounter_cache()
+        overhaul_rates = ef.modify_percentages(
+            slider_state["reviews_done"],
+            slider_state["daily_goal"],
+            slider_state["trainer_level"]
+        )
+
+        # E. Calculate Simulated Legacy Rates
+        ef.USE_OVERHAUL_ENCOUNTER_SYSTEM = False
+        ef.clear_encounter_cache()
+        legacy_rates = ef.modify_percentages(
+            slider_state["reviews_done"],
+            slider_state["daily_goal"],
+            slider_state["trainer_level"]
+        )
+
+        # 5. Restore original references
+        ef.USE_OVERHAUL_ENCOUNTER_SYSTEM = orig_use_overhaul
+        if main_pokemon and hasattr(main_pokemon, "level"):
+            main_pokemon.level = orig_main_pokemon_level
+        if trainer_card and hasattr(trainer_card, "level"):
+            trainer_card.level = orig_trainer_card_level
+        mw.ankimon_db = orig_db
+        if orig_calc_cp:
+            business.calculate_cp_from_dict = orig_calc_cp
+        if orig_ef_calc_cp:
+            ef.calculate_cp_from_dict = orig_ef_calc_cp
+        ef.clear_encounter_cache()
+
+        # 6. Compute EP Mastery Index component values dynamically using constants from encounter_functions
+        t_norm = min((slider_state["trainer_level"] / ef.TRAINER_LEVEL_CAP) * 100.0, 100.0)
+        d_norm = slider_state["dex_completion"]
+        s_norm = min((slider_state["reviews_done"] / slider_state["daily_goal"]) * 100.0, 100.0)
+        c_norm = min((slider_state["avg_cp"] / ef.CORE_TEAM_POWER_CAP) * 100.0, 100.0)
+        simulated_ep = (ef.EP_WEIGHT_TRAINER_LEVEL * t_norm) + \
+                       (ef.EP_WEIGHT_DEX_COMPLETION * d_norm) + \
+                       (ef.EP_WEIGHT_SESSION_PROGRESS * s_norm) + \
+                       (ef.EP_WEIGHT_CORE_TEAM_POWER * c_norm)
+        simulated_ep = max(0.0, min(simulated_ep, 100.0))
+
+        # Check Active Locks dynamically from OVERHAUL_LEVEL_THRESHOLDS
+        locks = {tier: (slider_state["main_level"] < limit) for tier, limit in ef.OVERHAUL_LEVEL_THRESHOLDS.items()}
+
+        return {
+            "live_overhaul": live_overhaul_rates,
+            "live_legacy": live_legacy_rates,
+            "overhaul": overhaul_rates,
+            "legacy": legacy_rates,
+            "ep": simulated_ep,
+            "locks": locks
+        }

--- a/src/Ankimon/resources.py
+++ b/src/Ankimon/resources.py
@@ -427,6 +427,11 @@ POKEMON_TIERS = {
   1022,  # iron-boulder
   1023,  # iron-crown
   1024,  # terapagos
+  10245, 10246,  # dialgaorigin, palkiaorigin
+  10007,         # giratinaorigin
+  10019, 10020, 10021, 10249, # tornadustherian, thundurustherian, landorustherian, enamorustherian
+  10181,         # zygarde10
+  10191,         # urshifurapidstrike
 ]
 ,
   "Mythical": [
@@ -436,10 +441,13 @@ POKEMON_TIERS = {
   251,        # Celebi
   # Gen 3
   385, 386,   # Jirachi, Deoxys
+  10001, 10002, 10003,       # deoxysattack, deoxysdefense, deoxysspeed
   # Gen 4
   489, 490, 491, 492, 493,   # Phione, Manaphy, Darkrai, Shaymin, Arceus
+  10006,                     # shayminsky
   # Gen 5
   494, 647, 648, 649,        # Victini, Keldeo, Meloetta, Genesect
+  10024, 10018,              # keldeoresolute, meloettapirouette
   # Gen 6
   719, 720, 721,             # Diancie, Hoopa, Volcanion
   # Gen 7

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,3 +17,10 @@ for _pkg in ("Ankimon", "Ankimon.functions"):
         _mod.__path__ = [str(_src / _pkg.replace(".", "/"))]
         _mod.__package__ = _pkg
         sys.modules[_pkg] = _mod
+
+# The encounter-weighting simulations are heavyweight, *unseeded* statistical
+# dev tools (one is a bare script with no test functions). They mutate sys.modules
+# globally at import time, which pollutes the deterministic unit suite, and their
+# random sampling is unsuited to a CI gate. Skip them by default — run manually
+# with `pytest tests/encounter_weighting_simulations/`.
+collect_ignore_glob = ["encounter_weighting_simulations/*"]

--- a/tests/encounter_weighting_simulations/test_encounter_simulation.py
+++ b/tests/encounter_weighting_simulations/test_encounter_simulation.py
@@ -1,0 +1,898 @@
+import sys
+import os
+import json
+import random
+from unittest.mock import MagicMock
+import importlib.util
+
+# --- CONFIGURATION ---
+SCENARIOS_TO_RUN = [21, 22]
+N = {
+    1: 200000,
+    2: 50000,
+    3: 50000,
+    4: 200000,
+    5: 200000,
+    6: 200000,
+    7: 50000,
+    8: 50000,
+    11: 50000,
+    12: 50000,
+    13: 50000,
+    14: 50000,
+    15: 200000,
+    16: 400000,
+    17: 10000,
+    18: 100000,
+    19: 100000,
+    20: 500000,
+    21: 10000,
+    22: 10000,
+}
+
+# --- SIMULATION SETTINGS ---
+MAIN_POKEMON_LEVEL = 50
+BYPASS_PREREQUISITES = True
+BYPASS_MIN_LEVEL_CHECK = False
+BYPASS_BASE_FORM_CHECK = True
+# ---------------------------
+
+import types
+class MockModule(MagicMock):
+    pass
+
+# Initialize addon, addon.pyobj and addon.functions as packages so relative imports resolve
+for pkg in ("addon", "addon.pyobj", "addon.functions"):
+    mod = types.ModuleType(pkg)
+    mod.__path__ = []
+    sys.modules[pkg] = mod
+
+modules_to_mock = [
+    "aqt", "aqt.qt", "aqt.utils", "anki", "anki.hooks",
+    "addon.pyobj.ankimon_tracker", "addon.pyobj.pokemon_obj",
+    "addon.pyobj.reviewer_obj", "addon.pyobj.test_window", "addon.pyobj.trainer_card",
+    "addon.pyobj.InfoLogger", "addon.pyobj.evolution_window", "addon.pyobj.attack_dialog",
+    "addon.pyobj.translator", "addon.pyobj.error_handler",
+    "addon.functions.pokemon_functions", "addon.functions.pokedex_functions",
+    "addon.functions.trainer_functions", "addon.functions.badges_functions",
+    "addon.functions.drawing_utils", "addon.utils", "addon.business", "addon.const",
+    "addon.singletons", "addon.functions.encounter_data", "addon.functions.friendship_evolution"
+]
+for mod in modules_to_mock:
+    sys.modules[mod] = MockModule()
+
+sys.modules["addon.pyobj.ankimon_tracker"].AnkimonTracker = MockModule
+sys.modules["addon.pyobj.pokemon_obj"].PokemonObject = MockModule
+sys.modules["addon.pyobj.reviewer_obj"].Reviewer_Manager = MockModule
+sys.modules["addon.pyobj.test_window"].TestWindow = MockModule
+sys.modules["addon.pyobj.trainer_card"].TrainerCard = MockModule
+sys.modules["addon.pyobj.InfoLogger"].ShowInfoLogger = MockModule
+sys.modules["addon.pyobj.evolution_window"].EvoWindow = MockModule
+sys.modules["addon.pyobj.attack_dialog"].AttackDialog = MockModule
+sys.modules["addon.pyobj.translator"].Translator = MockModule
+sys.modules["addon.pyobj.error_handler"].show_warning_with_traceback = lambda *args, **kwargs: None
+
+sys.modules["addon.functions.pokemon_functions"].find_experience_for_level = lambda *args: 0
+sys.modules["addon.functions.pokemon_functions"].get_levelup_move_for_pokemon = lambda *args: None
+sys.modules["addon.functions.pokemon_functions"].pick_random_gender = lambda *args: "Male"
+sys.modules["addon.functions.pokemon_functions"].shiny_chance = lambda *args: False
+
+base_dir = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+pokedex_path = os.path.join(base_dir, "src", "Ankimon", "data_files", "pokedex.json")
+with open(pokedex_path, "r", encoding="utf-8") as f:
+    pokedex_data = json.load(f)
+
+id_to_name = {}
+for name, data in pokedex_data.items():
+    if "actual_id" in data:
+        id_to_name[data["actual_id"]] = name
+
+def search_pokedex_by_id(pkmn_id):
+    return id_to_name.get(pkmn_id, "Pokémon not found")
+
+def search_pokedex(name, key):
+    if not isinstance(name, str):
+        return None
+    # Normalize name to match JSON keys (e.g., "Darumaka-Galar" -> "darumakagalar")
+    name_key = name.lower().replace("-", "").replace(" ", "").replace("'", "")
+    if name_key in pokedex_data:
+        return pokedex_data[name_key].get(key)
+    return None
+
+def safe_int(val):
+    try:
+        return int(val)
+    except:
+        return 0
+
+sys.modules["addon.functions.pokedex_functions"].check_evolution_for_pokemon = lambda *args: None
+sys.modules["addon.functions.pokedex_functions"].get_all_pokemon_moves = lambda *args: []
+sys.modules["addon.functions.pokedex_functions"].get_base_experience = lambda *args: 100
+sys.modules["addon.functions.pokedex_functions"].get_effort_values = lambda *args: {}
+sys.modules["addon.functions.pokedex_functions"].get_growth_rate = lambda *args: "Medium Fast"
+sys.modules["addon.functions.pokedex_functions"].return_name_for_id = search_pokedex_by_id
+sys.modules["addon.functions.pokedex_functions"].search_pokedex = search_pokedex
+sys.modules["addon.functions.pokedex_functions"].search_pokedex_by_id = search_pokedex_by_id
+sys.modules["addon.functions.pokedex_functions"].safe_int = safe_int
+sys.modules["addon.functions.pokedex_functions"].get_pretty_name_for_name = lambda name: name
+
+sys.modules["addon.functions.trainer_functions"].xp_share_gain_exp = lambda *args: None
+sys.modules["addon.functions.badges_functions"].check_for_badge = lambda *args: False
+sys.modules["addon.functions.badges_functions"].receive_badge = lambda *args: None
+sys.modules["addon.functions.drawing_utils"].tooltipWithColour = lambda *args: None
+
+collected_ids_mock = set(range(1, 11000))
+sys.modules["addon.utils"].limit_ev_yield = lambda *args: None
+sys.modules["addon.utils"].play_effect_sound = lambda *args: None
+sys.modules["addon.utils"].get_ev_spread = lambda *args: {}
+sys.modules["addon.utils"].is_alive = lambda *args: True
+sys.modules["addon.utils"].load_collected_pokemon_ids = lambda: collected_ids_mock
+
+sys.modules["addon.business"].calc_experience = lambda *args: 0
+sys.path.insert(0, os.path.join(base_dir, "src", "Ankimon"))
+import const
+import functions.encounter_data as ed
+
+sys.modules["addon.const"].gen_ids = const.gen_ids
+sys.modules["addon.functions.encounter_data"] = ed
+sys.modules["addon.functions"].encounter_data = ed
+
+class MockPokemon:
+    def __init__(self):
+        self.level = MAIN_POKEMON_LEVEL
+class MockTrainerCard:
+    def __init__(self):
+        self.level = 10
+class MockSettings:
+    def __init__(self):
+        self.config = {}
+        self.config["battle.daily_average"] = 100
+    def get(self, key, default=None):
+        return self.config.get(key, default)
+    def set_config(self, cfg):
+        self.config.update(cfg)
+
+sys.modules["addon.singletons"].main_pokemon = MockPokemon()
+sys.modules["addon.singletons"].ankimon_tracker_obj = MockModule()
+sys.modules["addon.singletons"].ankimon_tracker_obj.get_total_reviews = lambda: 100
+sys.modules["addon.singletons"].trainer_card = MockTrainerCard()
+mock_settings = MockSettings()
+sys.modules["addon.singletons"].settings_obj = mock_settings
+sys.modules["addon.singletons"].translator = MockModule()
+sys.modules["addon.singletons"].ankimon_db = MockModule()
+sys.modules["addon.singletons"].pokemon_pc = MockModule()
+
+spec = importlib.util.spec_from_file_location("addon.functions.encounter_functions", os.path.join(base_dir, "src", "Ankimon", "functions", "encounter_functions.py"))
+ef = importlib.util.module_from_spec(spec)
+sys.modules["addon.functions.encounter_functions"] = ef
+spec.loader.exec_module(ef)
+
+if BYPASS_PREREQUISITES:
+    ef._meets_prerequisites = lambda pokemon_id, collected_ids: True
+if BYPASS_MIN_LEVEL_CHECK:
+    ef.check_min_generate_level = lambda name: 1
+if BYPASS_BASE_FORM_CHECK:
+    ef._player_owns_base_form = lambda actual_id, collected_ids: True
+
+from functools import lru_cache
+# Cache the heavy utility lookups
+ef.search_pokedex = lru_cache(maxsize=None)(ef.search_pokedex)
+ef.check_min_generate_level = lru_cache(maxsize=None)(ef.check_min_generate_level)
+
+# Special handling for functions with unhashable 'set' arguments
+original_meets = ef._meets_prerequisites
+@lru_cache(maxsize=None)
+def cached_meets(pid):
+    return original_meets(pid, collected_ids_mock)
+ef._meets_prerequisites = lambda pid, coll: cached_meets(pid)
+
+original_owns = ef._player_owns_base_form
+@lru_cache(maxsize=None)
+def cached_owns(pid):
+    return original_owns(pid, collected_ids_mock)
+ef._player_owns_base_form = lambda pid, coll: cached_owns(pid)
+
+original_check_id_ok = ef.check_id_ok
+ef.check_id_ok = lru_cache(maxsize=None)(original_check_id_ok)
+
+def set_config(cfg):
+    # Clear all caches for the new configuration
+    ef.check_id_ok.cache_clear()
+    ef.search_pokedex.cache_clear()
+    ef.check_min_generate_level.cache_clear()
+    cached_meets.cache_clear()
+    cached_owns.cache_clear()
+    
+    mock_settings.config = {"battle.daily_average": 100}
+    mock_settings.set_config(cfg)
+    ef.settings_obj = mock_settings
+    ef.clear_encounter_cache()
+
+def run_simulation(config, N=200000, force_tier=None):
+    set_config(config)
+    original_get_tier = ef.get_tier
+    if force_tier:
+        ef.get_tier = lambda *args, **kwargs: force_tier
+    
+    encounters = []
+    for count in range(N):
+        if count % 1000 == 0:
+            print(f"  ...generated {count} encounters", flush=True)
+        res = ef.generate_random_pokemon(MAIN_POKEMON_LEVEL, sys.modules["addon.singletons"].ankimon_tracker_obj)
+        name, pokemon_id, tier = res[0], res[1], res[14]
+        
+        forme = search_pokedex(name, "forme")
+        generation = ef.get_base_species_gen(pokemon_id)
+        is_regional = pokemon_id >= 10000 and forme in ["Alola", "Galar", "Hisui", "Paldea"]
+        
+        encounters.append({
+            "pokemon_id": pokemon_id,
+            "name": name,
+            "tier": tier,
+            "forme": forme,
+            "generation": generation,
+            "is_regional": is_regional
+        })
+        
+    if force_tier:
+        ef.get_tier = original_get_tier
+        
+    return encounters
+
+def analyze_encounters(encounters):
+    stats = {
+        "total": len(encounters),
+        "by_id": {},
+        "by_generation": {},
+        "by_tier": {},
+        "by_forme": {},
+        "regional_count": 0,
+    }
+    for e in encounters:
+        pid = str(e["pokemon_id"])
+        gen = e["generation"]
+        tier = e["tier"]
+        forme = e["forme"] or "Base"
+        name = e["name"]
+        
+        if pid not in stats["by_id"]:
+            stats["by_id"][pid] = {
+                "count": 0,
+                "name": name,
+                "generation": gen,
+                "tier": tier
+            }
+        stats["by_id"][pid]["count"] += 1
+        
+        stats["by_generation"][gen] = stats["by_generation"].get(gen, 0) + 1
+        stats["by_tier"][tier] = stats["by_tier"].get(tier, 0) + 1
+        stats["by_forme"][forme] = stats["by_forme"].get(forme, 0) + 1
+        if e["is_regional"]:
+            stats["regional_count"] += 1
+    return stats
+
+results_json = {}
+report_lines = []
+
+def log(msg):
+    print(msg)
+    report_lines.append(msg)
+
+def log_test(scenario, passed, msgs):
+    status = "PASS" if passed else "FAIL"
+    log(f"[{status}] {scenario}")
+    for m in msgs:
+        log(f"  - {m}")
+    log("")
+
+def should_run(n):
+    return not SCENARIOS_TO_RUN or n in SCENARIOS_TO_RUN
+
+def run_all():
+    print("====================================================")
+    print("Ankimon Encounter Weighting System - Phase 2 Test Report")
+    print("====================================================")
+    print(f"SETTINGS: Level={MAIN_POKEMON_LEVEL}, BypassLvl={BYPASS_MIN_LEVEL_CHECK}, BypassPre={BYPASS_PREREQUISITES}, BypassOwn={BYPASS_BASE_FORM_CHECK}")
+    print("----------------------------------------------------")
+
+    # Base config
+    base_config = {f"misc.gen{i}": True for i in range(1, 10)}
+    base_config["misc.active_region"] = None
+    
+    def get_count(stats, pid):
+        return stats["by_id"].get(str(pid), {}).get("count", 0)
+
+    # We always need stats1 for comparisons in 4, 5, 6
+    stats1 = None
+    encs1 = None
+
+    # ----------------------------------------------------
+    # SCENARIO 1 — BASELINE: No region, all gens enabled
+    # ----------------------------------------------------
+    if should_run(1) or should_run(4) or should_run(5) or should_run(6):
+        sc1_cfg = dict(base_config)
+        encs1 = run_simulation(sc1_cfg, N=N[1])
+        stats1 = analyze_encounters(encs1)
+        results_json["scenario_1"] = stats1
+        
+        msgs1 = []
+        passed1 = True
+        
+        if stats1["regional_count"] == 0:
+            msgs1.append("FAIL: No regional forms ever appear.")
+            passed1 = False
+        else:
+            msgs1.append(f"PASS: Regional forms appear ({stats1['regional_count']}/{stats1['total']})")
+            
+        # --- MEOWTH CHECK ---
+        meowth_base = 52
+        meowth_alola = 10107
+        meowth_galar = 10161
+        m_total = get_count(stats1, meowth_base) + get_count(stats1, meowth_alola) + get_count(stats1, meowth_galar)
+        if m_total > 0:
+            br = get_count(stats1, meowth_base) / m_total
+            ar = get_count(stats1, meowth_alola) / m_total
+            gr = get_count(stats1, meowth_galar) / m_total
+            msgs1.append(f"Meowth: Base {br:.1%}, Alola {ar:.1%}, Galar {gr:.1%} (target ~7% each)")
+            if not (0.04 <= ar <= 0.10 and 0.04 <= gr <= 0.10):
+                passed1 = False
+                msgs1.append("FAIL: Meowth variance too high")
+
+        # --- TAUROS CHECK ---
+        tauros_base = 128
+        paldea_tauros = [10250, 10251, 10252]
+        t_total = get_count(stats1, tauros_base) + sum(get_count(stats1, tid) for tid in paldea_tauros)
+        if t_total > 0:
+            for tid in paldea_tauros:
+                rate = get_count(stats1, tid) / t_total
+                msgs1.append(f"Tauros {tid}: {rate:.1%} (target ~7%)")
+                if not (0.04 <= rate <= 0.10):
+                    passed1 = False
+        
+        # --- WOOPER CHECK ---
+        wooper_base = 194
+        wooper_paldea = 10253
+        w_total = get_count(stats1, wooper_base) + get_count(stats1, wooper_paldea)
+        if w_total > 0:
+            wr = get_count(stats1, wooper_paldea) / w_total
+            msgs1.append(f"Wooper Paldea: {wr:.1%} (target ~7%)")
+            if not (0.04 <= wr <= 0.10):
+                passed1 = False
+
+        # --- TAUROS CHECK ---
+        tauros_base = 128
+        paldea_tauros = [10250, 10251, 10252]
+        t_total = get_count(stats1, tauros_base) + sum(get_count(stats1, tid) for tid in paldea_tauros)
+        if t_total > 0:
+            for tid in paldea_tauros:
+                rate = get_count(stats1, tid) / t_total
+                msgs1.append(f"Tauros {tid}: {rate:.1%} (target ~7%)")
+                if not (0.04 <= rate <= 0.10):
+                    passed1 = False
+        
+        # --- WOOPER CHECK ---
+        wooper_base = 194
+        wooper_paldea = 10253
+        w_total = get_count(stats1, wooper_base) + get_count(stats1, wooper_paldea)
+        if w_total > 0:
+            wr = get_count(stats1, wooper_paldea) / w_total
+            msgs1.append(f"Wooper Paldea: {wr:.1%} (target ~7%)")
+            if not (0.04 <= wr <= 0.10):
+                passed1 = False
+
+        if should_run(1):
+            log_test("SCENARIO 1 — BASELINE", passed1, msgs1)
+
+    # ----------------------------------------------------
+    # SCENARIO 2 — No region, gens 7/8/9 disabled
+    # ----------------------------------------------------
+    if should_run(2):
+        sc2_cfg = dict(base_config)
+        sc2_cfg["misc.gen7"] = False
+        sc2_cfg["misc.gen8"] = False
+        sc2_cfg["misc.gen9"] = False
+        encs2 = run_simulation(sc2_cfg, N=N[2])
+        stats2 = analyze_encounters(encs2)
+        results_json["scenario_2"] = stats2
+        msgs2 = []
+        passed2 = True
+        
+        if stats2["regional_count"] > 0:
+            passed2 = False
+            msgs2.append(f"FAIL: Regional forms appeared when gens 7/8/9 disabled ({stats2['regional_count']})")
+        else:
+            msgs2.append("PASS: No regional forms appeared")
+            
+        if sum(stats2["by_generation"].get(g, 0) for g in [7, 8, 9]) > 0:
+            passed2 = False
+            msgs2.append("FAIL: Gen 7/8/9 Pokemon appeared")
+        else:
+            msgs2.append("PASS: No Gen 7/8/9 Pokemon appeared")
+            
+        log_test("SCENARIO 2 — No region, gens 7/8/9 disabled", passed2, msgs2)
+
+    # ----------------------------------------------------
+    # SCENARIO 3 — No region, only gen1 + gen7 enabled
+    # ----------------------------------------------------
+    if should_run(3):
+        sc3_cfg = {f"misc.gen{i}": False for i in range(1, 10)}
+        sc3_cfg["misc.gen1"] = True
+        sc3_cfg["misc.gen7"] = True
+        sc3_cfg["misc.active_region"] = None
+        encs3 = run_simulation(sc3_cfg, N=N[3])
+        stats3 = analyze_encounters(encs3)
+        results_json["scenario_3"] = stats3
+        msgs3 = []
+        passed3 = True
+        
+        if sum(stats3["by_generation"].get(g, 0) for g in [2,3,4,5,6,8,9]) > 0:
+            passed3 = False
+            msgs3.append("FAIL: Unauthorized gens appeared")
+        else:
+            msgs3.append("PASS: Only Gen 1 and Gen 7 appeared")
+            
+        if stats3["by_forme"].get("Alola", 0) == 0:
+            passed3 = False
+            msgs3.append("FAIL: No Alolan forms appeared")
+        else:
+            msgs3.append(f"PASS: Alolan forms appeared ({stats3['by_forme'].get('Alola')})")
+            
+        log_test("SCENARIO 3 — No region, gen1+gen7 only", passed3, msgs3)
+
+    # ----------------------------------------------------
+    # SCENARIO 4 — Region = kanto, all gens enabled
+    # ----------------------------------------------------
+    if should_run(4):
+        sc4_cfg = dict(base_config)
+        sc4_cfg["misc.active_region"] = "kanto"
+        encs4 = run_simulation(sc4_cfg, N=N[4])
+        stats4 = analyze_encounters(encs4)
+        results_json["scenario_4"] = stats4
+        
+        msgs4 = []
+        passed4 = True
+        
+        gen1_s1 = stats1["by_generation"].get(1, 0) / stats1["total"]
+        gen1_s4 = stats4["by_generation"].get(1, 0) / stats4["total"]
+        
+        if gen1_s4 <= gen1_s1 + 0.05:
+            msgs4.append(f"FAIL: Gen 1 rate in Scenario 4 ({gen1_s4:.1%}) not meaningfully higher than Scenario 1 ({gen1_s1:.1%})")
+            passed4 = False
+        else:
+            msgs4.append(f"PASS: Gen 1 rate increased from {gen1_s1:.1%} to {gen1_s4:.1%}")
+            
+        log_test("SCENARIO 4 — Region = kanto", passed4, msgs4)
+
+    # ----------------------------------------------------
+    # SCENARIO 5 — Region = alola, all gens enabled
+    # ----------------------------------------------------
+    if should_run(5):
+        meowth_alola = 10107
+        meowth_galar = 10161
+        sc5_cfg = dict(base_config)
+        sc5_cfg["misc.active_region"] = "alola"
+        encs5 = run_simulation(sc5_cfg, N=N[5])
+        stats5 = analyze_encounters(encs5)
+        results_json["scenario_5"] = stats5
+        
+        msgs5 = []
+        passed5 = True
+        vulpix_alola = 10103
+        valola_s1 = get_count(stats1, vulpix_alola)
+        valola_s5 = get_count(stats5, vulpix_alola)
+        
+        if valola_s5 <= valola_s1:
+            msgs5.append(f"FAIL: Alolan Vulpix rate didn't increase ({valola_s1} -> {valola_s5})")
+            passed5 = False
+        else:
+            msgs5.append(f"PASS: Alolan Vulpix increased ({valola_s1} -> {valola_s5})")
+            
+        alola_m = get_count(stats5, meowth_alola)
+        galar_m = get_count(stats5, meowth_galar)
+        if alola_m <= galar_m:
+            msgs5.append(f"FAIL: Alolan Meowth ({alola_m}) not strictly > Galarian Meowth ({galar_m})")
+            passed5 = False
+        else:
+            msgs5.append(f"PASS: Alolan Meowth ({alola_m}) > Galarian Meowth ({galar_m})")
+            
+        log_test("SCENARIO 5 — Region = alola", passed5, msgs5)
+
+    # ----------------------------------------------------
+    # SCENARIO 6 — Region = hisui, all gens enabled
+    # ----------------------------------------------------
+    if should_run(6):
+        sc6_cfg = dict(base_config)
+        sc6_cfg["misc.active_region"] = "hisui"
+        encs6 = run_simulation(sc6_cfg, N=N[6])
+        stats6 = analyze_encounters(encs6)
+        results_json["scenario_6"] = stats6
+        
+        msgs6 = []
+        passed6 = True
+        
+        gen4_s1 = stats1["by_generation"].get(4, 0) / stats1["total"]
+        gen4_s6 = stats6["by_generation"].get(4, 0) / stats6["total"]
+        
+        gen8_s1 = stats1["by_generation"].get(8, 0) / stats1["total"]
+        gen8_s6 = stats6["by_generation"].get(8, 0) / stats6["total"]
+        
+        msgs6.append(f"Gen 4 rate: {gen4_s1:.1%} -> {gen4_s6:.1%}")
+        msgs6.append(f"Gen 8 rate: {gen8_s1:.1%} -> {gen8_s6:.1%}")
+        
+        hisui_ids = ef.encounter_data.REGIONAL_FORMS.get("hisui", [])
+        hisui_s1 = sum(get_count(stats1, aid) for aid in hisui_ids)
+        hisui_s6 = sum(get_count(stats6, aid) for aid in hisui_ids)
+        msgs6.append(f"Hisui forms: {hisui_s1} -> {hisui_s6}")
+        
+        if hisui_s6 <= hisui_s1: passed6 = False; msgs6.append("FAIL: Hisui forms not boosted")
+        
+        log_test("SCENARIO 6 — Region = hisui", passed6, msgs6)
+    
+    # ----------------------------------------------------
+    # SCENARIO 7 — Region = hisui, gen4 disabled
+    # ----------------------------------------------------
+    if should_run(7):
+        sc7_cfg = dict(base_config)
+        sc7_cfg["misc.active_region"] = "hisui"
+        sc7_cfg["misc.gen4"] = False
+        encs7 = run_simulation(sc7_cfg, N=N[7])
+        stats7 = analyze_encounters(encs7)
+        results_json["scenario_7"] = stats7
+        msgs7 = []
+        passed7 = True
+        if stats7["by_generation"].get(4, 0) > 0:
+            passed7 = False
+            msgs7.append("FAIL: Gen 4 Pokemon appeared when disabled")
+        else:
+            msgs7.append("PASS: No Gen 4 Pokemon appeared")
+        log_test("SCENARIO 7 — Region = hisui, gen4 disabled", passed7, msgs7)
+
+    # ----------------------------------------------------
+    # SCENARIO 8 — Region = alola, gen7 disabled
+    # ----------------------------------------------------
+    if should_run(8):
+        sc8_cfg = dict(base_config)
+        sc8_cfg["misc.active_region"] = "alola"
+        sc8_cfg["misc.gen7"] = False
+        encs8 = run_simulation(sc8_cfg, N=N[8])
+        stats8 = analyze_encounters(encs8)
+        results_json["scenario_8"] = stats8
+        msgs8 = []
+        passed8 = True
+        if stats8["by_forme"].get("Alola", 0) > 0:
+            passed8 = False
+            msgs8.append("FAIL: Alolan forms appeared despite gen7 disabled")
+        else:
+            msgs8.append("PASS: No Alolan forms appeared")
+        log_test("SCENARIO 8 — Region = alola, gen7 disabled", passed8, msgs8)
+
+    # ----------------------------------------------------
+    # SCENARIO 11 — All gens disabled except gen1
+    # ----------------------------------------------------
+    if should_run(11):
+        sc11_cfg = {f"misc.gen{i}": False for i in range(1, 10)}
+        sc11_cfg["misc.gen1"] = True
+        sc11_cfg["misc.active_region"] = None
+        encs11 = run_simulation(sc11_cfg, N=N[11])
+        stats11 = analyze_encounters(encs11)
+        results_json["scenario_11"] = stats11
+        msgs11 = []
+        passed11 = True
+        if sum(stats11["by_generation"].get(g, 0) for g in range(2, 10)) > 0:
+            passed11 = False
+            msgs11.append("FAIL: Non-gen1 pokemon appeared")
+        else:
+            msgs11.append("PASS: Only Gen 1 appeared")
+        if stats11["regional_count"] > 0:
+            passed11 = False
+            msgs11.append("FAIL: Regional forms appeared")
+        else:
+            msgs11.append("PASS: No regional forms appeared")
+        log_test("SCENARIO 11 — All gens disabled except gen1", passed11, msgs11)
+
+    # ----------------------------------------------------
+    # SCENARIO 12 — Mega/Gmax tier with region = kanto
+    # ----------------------------------------------------
+    if should_run(12):
+        sc12_cfg = dict(base_config)
+        sc12_cfg["misc.active_region"] = "kanto"
+        encs12 = run_simulation(sc12_cfg, N=N[12], force_tier="Mega")
+        stats12 = analyze_encounters(encs12)
+        results_json["scenario_12"] = stats12
+        msgs12 = []
+        passed12 = True
+        if stats12["by_generation"].get(1, 0) == 0:
+            passed12 = False
+            msgs12.append("FAIL: No Gen 1 Megas appeared")
+        else:
+            msgs12.append(f"PASS: Gen 1 Megas appeared ({stats12['by_generation'].get(1, 0)} times)")
+        log_test("SCENARIO 12 — Mega/Gmax tier with region = kanto", passed12, msgs12)
+
+    # ----------------------------------------------------
+    # SCENARIO 13 — Legendary tier with region = kanto
+    # ----------------------------------------------------
+    if should_run(13):
+        sc13_cfg = dict(base_config)
+        sc13_cfg["misc.active_region"] = "kanto"
+        encs13 = run_simulation(sc13_cfg, N=N[13], force_tier="Legendary")
+        stats13 = analyze_encounters(encs13)
+        results_json["scenario_13"] = stats13
+        msgs13 = []
+        passed13 = True
+        gen1_leg_rate = stats13["by_generation"].get(1, 0) / stats13["total"]
+        msgs13.append(f"Gen 1 Legendary Rate: {gen1_leg_rate:.1%}")
+        if gen1_leg_rate < 0.30:
+            passed13 = False
+            msgs13.append("FAIL: Gen 1 legendaries not boosted enough (expected > 30%)")
+        log_test("SCENARIO 13 — Legendary tier with region = kanto", passed13, msgs13)
+
+    # ----------------------------------------------------
+    # SCENARIO 14 — Galarian birds with region = galar, gen1+gen8 enabled
+    # ----------------------------------------------------
+    if should_run(14):
+        sc14_cfg = {f"misc.gen{i}": False for i in range(1, 10)}
+        sc14_cfg["misc.gen1"] = True
+        sc14_cfg["misc.gen8"] = True
+        sc14_cfg["misc.active_region"] = "galar"
+        encs14 = run_simulation(sc14_cfg, N=N[14], force_tier="Legendary")
+        stats14 = analyze_encounters(encs14)
+        results_json["scenario_14"] = stats14
+        msgs14 = []
+        passed14 = True
+        if stats14["by_forme"].get("Galar", 0) == 0:
+            passed14 = False
+            msgs14.append("FAIL: No Galarian legendaries appeared")
+        else:
+            msgs14.append(f"PASS: Galarian legendaries appeared ({stats14['by_forme'].get('Galar')} times)")
+        log_test("SCENARIO 14 — Galarian birds", passed14, msgs14)
+
+    # ----------------------------------------------------
+    # SCENARIO 15 — Full-pool fairness check (no region, all gens)
+    # ----------------------------------------------------
+    if should_run(15):
+        encs15 = run_simulation(base_config, N=N[15], force_tier="Normal")
+        stats15 = analyze_encounters(encs15)
+        results_json["scenario_15"] = stats15
+        msgs15 = []
+        passed15 = True
+        zero_count = 0
+        for pid in ed.NORMAL:
+            if get_count(stats15, pid) == 0 and ef.check_id_ok(pid):
+                zero_count += 1
+        if zero_count > 0:
+            msgs15.append(f"WARN: {zero_count} eligible Normal pokemon never appeared.")
+        else:
+            msgs15.append("PASS: All eligible Normal pokemon appeared at least once.")
+        log_test("SCENARIO 15 — Full-pool fairness check", passed15, msgs15)
+    
+    # ----------------------------------------------------
+    # SCENARIO 16 — Tauros (3 Paldean forms) fairness check
+    # ----------------------------------------------------
+    if should_run(16):
+        encs16 = run_simulation(base_config, N=N[16], force_tier="Normal")
+        stats16 = analyze_encounters(encs16)
+        results_json["scenario_16"] = stats16
+        msgs16 = []
+        passed16 = True
+        tauros_id = 128
+        paldea_tauros = [10250, 10251, 10252]
+        
+        t_counts = {tid: get_count(stats16, tid) for tid in [tauros_id] + paldea_tauros}
+        t_total = sum(t_counts.values())
+        if t_total > 0:
+            for tid in paldea_tauros:
+                rate = t_counts[tid] / t_total
+                msgs16.append(f"Tauros {tid} rate: {rate:.1%} (expected ~7%)")
+                if not (0.04 <= rate <= 0.10):
+                    passed16 = False
+        log_test("SCENARIO 16 — Tauros fairness check", passed16, msgs16)
+
+    # ----------------------------------------------------
+    # SCENARIO 17 — Region switching mid-session
+    # ----------------------------------------------------
+    if should_run(17):
+        # We switch regions and see if the cache/state leaks
+        msgs17 = []
+        passed17 = True
+        
+        set_config(base_config)
+        ef.generate_random_pokemon(100, sys.modules["addon.singletons"].ankimon_tracker_obj) # Warm up
+        
+        cfg_k = dict(base_config); cfg_k["misc.active_region"] = "kanto"
+        encs_k = run_simulation(cfg_k, N=N[17])
+        
+        cfg_a = dict(base_config); cfg_a["misc.active_region"] = "alola"
+        encs_a = run_simulation(cfg_a, N=N[17])
+        
+        k_in_a = sum(1 for e in encs_a if e["generation"] == 1) / N[17]
+        a_in_a = sum(1 for e in encs_a if e["generation"] == 7) / N[17]
+        if k_in_a > a_in_a:
+            passed17 = False
+            msgs17.append(f"FAIL: Kanto rate ({k_in_a:.1%}) > Alola rate ({a_in_a:.1%}) in Alola session")
+        else:
+            msgs17.append("PASS: No obvious state leak from Kanto to Alola")
+        log_test("SCENARIO 17 — Region switching state leak", passed17, msgs17)
+
+    # ----------------------------------------------------
+    # SCENARIO 18 — Paldea region scenario
+    # ----------------------------------------------------
+    if should_run(18):
+        sc18_cfg = dict(base_config)
+        sc18_cfg["misc.active_region"] = "paldea"
+        encs18 = run_simulation(sc18_cfg, N=N[18])
+        stats18 = analyze_encounters(encs18)
+        results_json["scenario_18"] = stats18
+        msgs18 = []
+        passed18 = True
+        
+        gen9_rate = stats18["by_generation"].get(9, 0) / stats18["total"]
+        msgs18.append(f"Gen 9 rate in Paldea: {gen9_rate:.1%}")
+        if gen9_rate < 0.30:
+            passed18 = False
+            msgs18.append("FAIL: Gen 9 not boosted in Paldea")
+            
+        paldea_tauros = [10250, 10251, 10252]
+        p_tauros_count = sum(get_count(stats18, tid) for tid in paldea_tauros)
+        if p_tauros_count == 0:
+            passed18 = False
+            msgs18.append("FAIL: No Paldean Tauros in Paldea region")
+        log_test("SCENARIO 18 — Region = paldea", passed18, msgs18)
+
+    # ----------------------------------------------------
+    # SCENARIO 19 — Cross-gen gating: gen2+gen9 only
+    # ----------------------------------------------------
+    if should_run(19):
+        sc19_cfg = {f"misc.gen{i}": False for i in range(1, 10)}
+        sc19_cfg["misc.gen2"] = True
+        sc19_cfg["misc.gen9"] = True
+        sc19_cfg["misc.active_region"] = None
+        encs19 = run_simulation(sc19_cfg, N=N[19])
+        stats19 = analyze_encounters(encs19)
+        results_json["scenario_19"] = stats19
+        msgs19 = []
+        passed19 = True
+        
+        # Wooper Paldea: Base Gen 2, Form Gen 9 -> SHOULD appear
+        w_p_count = get_count(stats19, 10253)
+        if w_p_count == 0:
+            passed19 = False
+            msgs19.append("FAIL: Paldean Wooper (Gen 2+9) did not appear")
+        else:
+            msgs19.append(f"PASS: Paldean Wooper appeared ({w_p_count} times)")
+            
+        # Tauros Paldea: Base Gen 1, Form Gen 9 -> SHOULD NOT appear (Gen 1 disabled)
+        paldea_tauros = [10250, 10251, 10252]
+        t_p_count = sum(get_count(stats19, tid) for tid in paldea_tauros)
+        if t_p_count > 0:
+            passed19 = False
+            msgs19.append(f"FAIL: Paldean Tauros appeared despite Gen 1 disabled ({t_p_count} times)")
+        else:
+            msgs19.append("PASS: Paldean Tauros (Gen 1+9) correctly gated out")
+            
+        log_test("SCENARIO 19 — Cross-gen gating (Wooper vs Tauros)", passed19, msgs19)
+
+    # ----------------------------------------------------
+    # SCENARIO 20 — All variants check: gen 1+7+8+9
+    # ----------------------------------------------------
+    if should_run(20):
+        sc20_cfg = {f"misc.gen{i}": False for i in range(1, 10)}
+        for g in [1, 7, 8, 9]: sc20_cfg[f"misc.gen{g}"] = True
+        sc20_cfg["misc.active_region"] = None
+        encs20 = run_simulation(sc20_cfg, N=N[20])
+        stats20 = analyze_encounters(encs20)
+        results_json["scenario_20"] = stats20
+        msgs20 = []
+        passed20 = True
+        
+        # --- MEOWTH (Base, Alola, Galar) ---
+        m_base, m_alola, m_galar = 52, 10107, 10161
+        m_total = get_count(stats20, m_base) + get_count(stats20, m_alola) + get_count(stats20, m_galar)
+        if m_total > 0:
+            br = get_count(stats20, m_base) / m_total
+            ar = get_count(stats20, m_alola) / m_total
+            gr = get_count(stats20, m_galar) / m_total
+            msgs20.append(f"Meowth: Base {br:.1%}, Alola {ar:.1%}, Galar {gr:.1%}")
+            if not (0.04 <= ar <= 0.10 and 0.04 <= gr <= 0.10):
+                passed20 = False
+        
+        # --- TAUROS (Base, Paldea x3) ---
+        t_base = 128
+        p_tauros = [10250, 10251, 10252]
+        t_total = get_count(stats20, t_base) + sum(get_count(stats20, tid) for tid in p_tauros)
+        if t_total > 0:
+            tr = get_count(stats20, t_base) / t_total
+            msgs20.append(f"Tauros: Base {tr:.1%}")
+            for tid in p_tauros:
+                rate = get_count(stats20, tid) / t_total
+                msgs20.append(f"  - Paldea {tid}: {rate:.1%}")
+                if not (0.04 <= rate <= 0.10):
+                    passed20 = False
+                    
+        log_test("SCENARIO 20 — All variants (Meowth/Tauros) check", passed20, msgs20)
+
+    # ----------------------------------------------------
+    # SCENARIO 21 — Galarian Darmanitan region = galar, gen5+gen8 enabled
+    # ----------------------------------------------------
+    if should_run(21):
+        sc21_cfg = {f"misc.gen{i}": False for i in range(1, 10)}
+        sc21_cfg["misc.gen5"] = True
+        sc21_cfg["misc.gen8"] = True
+        sc21_cfg["misc.active_region"] = "galar"
+        encs21 = run_simulation(sc21_cfg, N=N[21], force_tier="Normal")
+        stats21 = analyze_encounters(encs21)
+        results_json["scenario_21"] = stats21
+        msgs21 = []
+        passed21 = True
+        
+        # Darumaka variants
+        d_base, d_galar = 554, 10176
+        dn_base, dn_galar = 555, 10177
+        
+        c_d_base = get_count(stats21, d_base)
+        c_d_galar = get_count(stats21, d_galar)
+        c_dn_base = get_count(stats21, dn_base)
+        c_dn_galar = get_count(stats21, dn_galar)
+        
+        msgs21.append(f"Darumaka: Base {c_d_base}, Galar {c_d_galar}")
+        msgs21.append(f"Darmanitan: Base {c_dn_base}, Galar {c_dn_galar}")
+        
+        if c_d_galar == 0 or c_dn_galar == 0:
+            passed21 = False
+            msgs21.append("FAIL: Galarian variants did not appear")
+        else:
+            msgs21.append("PASS: Galarian variants appeared")
+            
+        log_test("SCENARIO 21 — Darumaka/Darmanitan check in Galar", passed21, msgs21)
+
+    # ----------------------------------------------------
+    # SCENARIO 22 — Starter tier: gen 1+2, region = kanto
+    # ----------------------------------------------------
+    if should_run(22):
+        sc22_cfg = {f"misc.gen{i}": False for i in range(1, 10)}
+        sc22_cfg["misc.gen1"] = True
+        sc22_cfg["misc.gen2"] = True
+        sc22_cfg["misc.active_region"] = "kanto"
+        encs22 = run_simulation(sc22_cfg, N=N[22], force_tier="Starter")
+        stats22 = analyze_encounters(encs22)
+        results_json["scenario_22"] = stats22
+        msgs22 = []
+        passed22 = True
+        
+        gen1_starters = [1,2,3, 4,5,6, 7,8,9]
+        gen2_starters = [152,153,154, 155,156,157, 158,159,160]
+        
+        msgs22.append("Gen 1 Individual Counts:")
+        for sid in gen1_starters:
+            count = get_count(stats22, sid)
+            name = ef.search_pokedex_by_id(sid)
+            msgs22.append(f"  - {name} ({sid}): {count} ({count/N[22]:.1%})")
+            
+        msgs22.append("Gen 2 Individual Counts:")
+        for sid in gen2_starters:
+            count = get_count(stats22, sid)
+            name = ef.search_pokedex_by_id(sid)
+            msgs22.append(f"  - {name} ({sid}): {count} ({count/N[22]:.1%})")
+        
+        c1 = sum(get_count(stats22, sid) for sid in gen1_starters)
+        c2 = sum(get_count(stats22, sid) for sid in gen2_starters)
+        
+        # In Kanto, Gen 1 should be boosted (30% pool chance + 70% shared)
+        if c1 <= c2:
+            passed22 = False
+            msgs22.append(f"FAIL: Gen 1 total ({c1}) <= Gen 2 total ({c2}) in Kanto")
+        else:
+            msgs22.append(f"PASS: Gen 1 total ({c1}) > Gen 2 total ({c2}) in Kanto")
+            
+        log_test("SCENARIO 22 — Starter family individual counts", passed22, msgs22)
+    
+if __name__ == "__main__":
+    base_dir = os.path.dirname(os.path.abspath(__file__))
+    results_path = os.path.join(base_dir, "simulation_results.json")
+    report_path = os.path.join(base_dir, "simulation_report.txt")
+    try:
+        run_all()
+    finally:
+        with open(results_path, "w") as f:
+            json.dump(results_json, f, indent=2)
+        with open(report_path, "w") as f:
+            f.write("\n".join(report_lines))

--- a/tests/encounter_weighting_simulations/test_encounter_simulation.py
+++ b/tests/encounter_weighting_simulations/test_encounter_simulation.py
@@ -56,7 +56,8 @@ modules_to_mock = [
     "addon.functions.pokemon_functions", "addon.functions.pokedex_functions",
     "addon.functions.trainer_functions", "addon.functions.badges_functions",
     "addon.functions.drawing_utils", "addon.utils", "addon.business", "addon.const",
-    "addon.singletons", "addon.functions.encounter_data", "addon.functions.friendship_evolution"
+    "addon.singletons", "addon.functions.encounter_data", "addon.functions.friendship_evolution",
+    "addon.services", "addon.events"
 ]
 for mod in modules_to_mock:
     sys.modules[mod] = MockModule()

--- a/tests/encounter_weighting_simulations/test_overhaul_simulation.py
+++ b/tests/encounter_weighting_simulations/test_overhaul_simulation.py
@@ -1,0 +1,420 @@
+import sys
+import os
+import json
+import random
+from unittest.mock import MagicMock
+import importlib.util
+from pathlib import Path
+
+# --- DIRECTORY RESOLUTION ---
+base_dir = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.insert(0, base_dir)
+
+# --- MOCK LIFECYCLE ---
+class MockModule(MagicMock):
+    pass
+
+# We use the standard Ankimon namespace so relative imports resolve through conftest packages
+modules_to_mock = [
+    "aqt", "aqt.qt", "aqt.utils", "anki", "anki.hooks",
+    "Ankimon.pyobj.ankimon_tracker", "Ankimon.pyobj.pokemon_obj",
+    "Ankimon.pyobj.reviewer_obj", "Ankimon.pyobj.test_window", "Ankimon.pyobj.trainer_card",
+    "Ankimon.pyobj.InfoLogger", "Ankimon.pyobj.evolution_window", "Ankimon.pyobj.attack_dialog",
+    "Ankimon.pyobj.translator", "Ankimon.pyobj.error_handler",
+    "Ankimon.functions.pokemon_functions", "Ankimon.functions.pokedex_functions",
+    "Ankimon.functions.trainer_functions", "Ankimon.functions.badges_functions",
+    "Ankimon.functions.drawing_utils", "Ankimon.utils",
+    "Ankimon.singletons", "Ankimon.functions.encounter_data", "Ankimon.functions.friendship_evolution"
+]
+for mod in modules_to_mock:
+    sys.modules[mod] = MockModule()
+
+# Stub out standard loaders and helpers
+sys.modules["Ankimon.pyobj.error_handler"].show_warning_with_traceback = lambda *args, **kwargs: None
+sys.modules["Ankimon.functions.pokemon_functions"].pick_random_gender = lambda *args: "Female"
+sys.modules["Ankimon.functions.pokemon_functions"].shiny_chance = lambda *args: False
+
+pokedex_path = os.path.join(base_dir, "src", "Ankimon", "data_files", "pokedex.json")
+pokedex_data = {}
+try:
+    with open(pokedex_path, "r", encoding="utf-8") as f:
+        pokedex_data = json.load(f)
+except Exception as e:
+    # If not found during headless runs, create a mock minimal pokedex
+    pokedex_data = {str(i): {"species_id": i, "actual_id": i} for i in range(1, 1000)}
+
+id_to_name = {}
+for name, data in pokedex_data.items():
+    if "actual_id" in data:
+        id_to_name[data["actual_id"]] = name
+
+def search_pokedex_by_id(pkmn_id):
+    return id_to_name.get(pkmn_id, "Pokémon not found")
+
+def search_pokedex(name, key):
+    if not isinstance(name, str):
+        return None
+    name_key = name.lower().replace("-", "").replace(" ", "").replace("'", "")
+    if key == "abilities":
+        return {"1": "pressure"}
+    if name_key in pokedex_data:
+        return pokedex_data[name_key].get(key)
+    return None
+
+def safe_int(val):
+    try: return int(val)
+    except: return 0
+
+sys.modules["Ankimon.functions.pokedex_functions"].search_pokedex = search_pokedex
+sys.modules["Ankimon.functions.pokedex_functions"].search_pokedex_by_id = search_pokedex_by_id
+sys.modules["Ankimon.functions.pokedex_functions"].safe_int = safe_int
+sys.modules["Ankimon.functions.pokedex_functions"]._load_pokedex_cache = lambda: pokedex_data
+
+# Stub database manager to mock state variables
+class MockAnkimonDB:
+    def __init__(self):
+        self.pokemon_list = []
+        self.caught_ids = set()
+        self.user_data = {}
+        
+    def get_all_pokemon(self):
+        return self.pokemon_list
+        
+    def get_all_pokemon_ids(self):
+        return self.caught_ids
+        
+    def get_user_data(self, key, default=None):
+        return self.user_data.get(key, default)
+        
+    def set_user_data(self, key, value):
+        self.user_data[key] = value
+
+mock_db = MockAnkimonDB()
+class MockPokemon:
+    def __init__(self):
+        self.level = 5
+class MockTrainerCard:
+    def __init__(self):
+        self.level = 1
+class MockSettings:
+    def __init__(self):
+        self.daily_average = 100
+    def get(self, key, default=None):
+        if key == "battle.daily_average":
+            return self.daily_average
+        return default
+
+mock_pokemon = MockPokemon()
+mock_trainer = MockTrainerCard()
+mock_settings = MockSettings()
+
+# Ensure both Ankimon.singletons and aqt.mw point to the same mock database
+sys.modules["aqt"].mw = MockModule()
+sys.modules["aqt"].mw.ankimon_db = mock_db
+sys.modules["aqt"].mw.settings_obj = mock_settings
+
+sys.modules["Ankimon.singletons"].mw = sys.modules["aqt"].mw
+sys.modules["Ankimon.singletons"].main_pokemon = mock_pokemon
+sys.modules["Ankimon.singletons"].trainer_card = mock_trainer
+sys.modules["Ankimon.singletons"].settings_obj = mock_settings
+sys.modules["Ankimon.singletons"].ankimon_tracker_obj = MockModule()
+sys.modules["Ankimon.singletons"].ankimon_tracker_obj.get_total_reviews = lambda: 0
+
+# --- DYNAMIC SPEC LOAD ---
+_src = Path(base_dir) / "src"
+spec = importlib.util.spec_from_file_location(
+    "Ankimon.functions.encounter_functions",
+    _src / "Ankimon" / "functions" / "encounter_functions.py"
+)
+ef = importlib.util.module_from_spec(spec)
+sys.modules["Ankimon.functions.encounter_functions"] = ef
+spec.loader.exec_module(ef)
+
+# Bypass long prerequisite recursion checks during rollout
+ef._meets_prerequisites = lambda *args: True
+ef._player_owns_base_form = lambda *args: True
+ef.check_id_ok = lambda *args: True
+ef.check_min_generate_level = lambda name: 1
+ef.load_collected_pokemon_ids = lambda: set(range(1, 1000))
+
+# --- TEST SUITE DEFINITIONS ---
+report_lines = []
+results_json = {}
+
+def log(msg):
+    print(msg)
+    report_lines.append(msg)
+
+def log_header(title):
+    border = "=" * 60
+    log(border)
+    log(title)
+    log(border)
+
+def run_scenario_sim(name, N=5000):
+    counts = {tier: 0 for tier in ef.OVERHAUL_TIER_PARAMS}
+    for _ in range(N):
+        tier = ef.get_tier(
+            total_reviews=ef.ankimon_tracker_obj.get_total_reviews(),
+            trainer_level=ef.trainer_card.level
+        )
+        counts[tier] = counts.get(tier, 0) + 1
+    return counts
+
+# ------------------------------------------------------------------------------
+# 1. SCENARIO A: The Beginner Player
+# ------------------------------------------------------------------------------
+def simulate_scenario_a():
+    log_header("SCENARIO A: The Beginner Player (Level 5 Main, 0% Progress)")
+    
+    # Configure beginner environment
+    ef.USE_OVERHAUL_ENCOUNTER_SYSTEM = True
+    mock_pokemon.level = 5
+    mock_trainer.level = 1
+    mock_settings.daily_average = 100
+    ef.ankimon_tracker_obj.get_total_reviews = lambda: 0
+    mock_db.caught_ids = set()
+    mock_db.pokemon_list = []
+    mock_db.user_data["ankimon_pity_trackers"] = {k: 0 for k in ef.OVERHAUL_PITY_THRESHOLDS}
+    
+    # Calculate EP mathematically
+    ep = ef.calculate_mastery_index_ep(total_reviews=0, daily_average=100, trainer_level=1)
+    log(f"Calculated EP: {ep:.4f}% (Expected ~0.50%)")
+    
+    # Run roll simulation
+    counts = run_scenario_sim("Scenario A", N=5000)
+    
+    # Analyze
+    log("Simulation Spawn Rates (5,000 rolls):")
+    passed = True
+    errors = []
+    
+    for tier, count in counts.items():
+        rate = (count / 5000) * 100
+        log(f"  - {tier}: {rate:.2f}% (Count: {count})")
+        
+        # Verify locks
+        if tier in ["Ultra", "Legendary", "Mega", "Gmax", "Mythical", "Starter"]:
+            if count > 0:
+                passed = False
+                errors.append(f"Locked tier '{tier}' spawned under Level 30 threshold!")
+                
+    if counts["Normal"] < 4500:
+        passed = False
+        errors.append("Normal spawn rate abnormally low for a beginner!")
+        
+    status = "PASS" if passed else "FAIL"
+    log(f"Result: {status}")
+    if errors:
+        for err in errors: log(f"  [ERROR] {err}")
+    return passed, counts
+
+# ------------------------------------------------------------------------------
+# 2. SCENARIO B: Mid-Game Progression
+# ------------------------------------------------------------------------------
+def simulate_scenario_b():
+    log_header("SCENARIO B: Mid-Game Progression (Level 35 Main, EP ~25)")
+    
+    mock_pokemon.level = 35  # locks Legendary, Mega, Gmax, Mythical, Starter; unlocks Ultra
+    mock_trainer.level = 20
+    mock_settings.daily_average = 100
+    ef.ankimon_tracker_obj.get_total_reviews = lambda: 60  # 60% session progress
+    
+    # 20% pokedex completion out of a mock 100 species
+    mock_db.caught_ids = set(range(1, 21))
+    pokedex_data.clear()
+    pokedex_data.update({str(i): {"species_id": i, "actual_id": i} for i in range(1, 101)})
+    
+    # Top 6 pokemon each with 1200 CP -> Core team CP = 1200
+    mock_db.pokemon_list = [{"level": 30, "stats": {}, "individual_id": str(i)} for i in range(6)]
+    ef.calculate_cp_from_dict = lambda p: 1200
+    
+    mock_db.user_data["ankimon_pity_trackers"] = {k: 0 for k in ef.OVERHAUL_PITY_THRESHOLDS}
+    
+    ep = ef.calculate_mastery_index_ep(total_reviews=60, daily_average=100, trainer_level=20)
+    log(f"Calculated EP: {ep:.4f}% (Expected ~25.00%)")
+    
+    counts = run_scenario_sim("Scenario B", N=5000)
+    
+    log("Simulation Spawn Rates (5,000 rolls):")
+    passed = True
+    errors = []
+    
+    for tier, count in counts.items():
+        rate = (count / 5000) * 100
+        log(f"  - {tier}: {rate:.2f}% (Count: {count})")
+        
+        # Verify level locks
+        if tier in ["Legendary", "Mega", "Gmax", "Mythical", "Starter"]:
+            if count > 0:
+                passed = False
+                errors.append(f"Locked tier '{tier}' spawned under level lock thresholds!")
+                
+    if counts["Ultra"] == 0:
+        passed = False
+        errors.append("Unlocked Ultra Beast tier failed to spawn any encounters!")
+        
+    status = "PASS" if passed else "FAIL"
+    log(f"Result: {status}")
+    if errors:
+        for err in errors: log(f"  [ERROR] {err}")
+    return passed, counts
+
+# ------------------------------------------------------------------------------
+# 3. SCENARIO C: Endgame Master
+# ------------------------------------------------------------------------------
+def simulate_scenario_c():
+    log_header("SCENARIO C: Endgame Master (Level 85 Main, EP ~48)")
+    
+    mock_pokemon.level = 85  # All locks cleared
+    mock_trainer.level = 50  # Maxed Trainer norm (Trainer cap = 50)
+    mock_settings.daily_average = 100
+    ef.ankimon_tracker_obj.get_total_reviews = lambda: 50  # 50% session progress
+    
+    # 30% pokedex completion
+    mock_db.caught_ids = set(range(1, 31))
+    pokedex_data.clear()
+    pokedex_data.update({str(i): {"species_id": i, "actual_id": i} for i in range(1, 101)})
+    
+    # Top 6 average CP = 2000 -> Core Team norm = 12.5% (cap = 16000)
+    mock_db.pokemon_list = [{"level": 80, "stats": {}, "individual_id": str(i)} for i in range(6)]
+    ef.calculate_cp_from_dict = lambda p: 2000
+    
+    mock_db.user_data["ankimon_pity_trackers"] = {k: 0 for k in ef.OVERHAUL_PITY_THRESHOLDS}
+    
+    ep = ef.calculate_mastery_index_ep(total_reviews=50, daily_average=100, trainer_level=50)
+    log(f"Calculated EP: {ep:.4f}% (Expected ~48.125%)")
+    
+    counts = run_scenario_sim("Scenario C", N=5000)
+    
+    log("Simulation Spawn Rates (5,000 rolls):")
+    passed = True
+    errors = []
+    total_rares = 0
+    
+    for tier, count in counts.items():
+        rate = (count / 5000) * 100
+        log(f"  - {tier}: {rate:.2f}% (Count: {count})")
+        if tier not in ["Normal", "Baby"]:
+            total_rares += count
+            
+    aggregate_rare_rate = (total_rares / 5000) * 100
+    log(f"Aggregate Rare Spawn Rate: {aggregate_rare_rate:.2f}% (Expected under 13% Soft Landing cap)")
+    
+    if aggregate_rare_rate > 13.0:
+        passed = False
+        errors.append(f"Aggregate rare spawn economy inflated! Got {aggregate_rare_rate:.2f}% (Max allowed: 13%)")
+    elif aggregate_rare_rate < 1.0:
+        passed = False
+        errors.append("Aggregate rare spawn rate heavily throttled below baseline expectations!")
+        
+    status = "PASS" if passed else "FAIL"
+    log(f"Result: {status}")
+    if errors:
+        for err in errors: log(f"  [ERROR] {err}")
+    return passed, counts
+
+# ------------------------------------------------------------------------------
+# 4. SCENARIO D: Pity Tracking & Bad-Luck Protection
+# ------------------------------------------------------------------------------
+def simulate_scenario_d():
+    log_header("SCENARIO D: Pity Tracking & Reset Simulation")
+    
+    # Establish Endgame Master environment
+    mock_pokemon.level = 85
+    mock_trainer.level = 50
+    ef.ankimon_tracker_obj.get_total_reviews = lambda: 50
+    mock_db.caught_ids = set(range(1, 31))
+    pokedex_data.clear()
+    pokedex_data.update({str(i): {"species_id": i, "actual_id": i} for i in range(1, 101)})
+    ef.calculate_cp_from_dict = lambda p: 2000
+    
+    # Simulate a deep dry spell for Legendary: Counter = 400 reviews (150 above 250 threshold)
+    pity_data = {
+        "Ultra": 10,
+        "Gmax": 20,
+        "Starter": 30,
+        "Mega": 40,
+        "Legendary": 400, # Large dry spell
+        "Mythical": 50
+    }
+    mock_db.user_data["ankimon_pity_trackers"] = pity_data
+    
+    # Run 5,000 rolls with inflated Legendary pity
+    counts = run_scenario_sim("Scenario D (High Pity)", N=5000)
+    
+    passed = True
+    errors = []
+    
+    legendary_rate = (counts.get("Legendary", 0) / 5000) * 100
+    log(f"Legendary Spawn Rate under Pity: {legendary_rate:.2f}% (Normal: ~0.90%)")
+    
+    if legendary_rate < 1.0:
+        passed = False
+        errors.append(f"Independent pity multiplier failed to boost Legendary spawn rate! Rate: {legendary_rate:.2f}%")
+    else:
+        log("PASS: Independent pity counter successfully boosted Legendary spawn rates!")
+        
+    # --- PITY RESET LOGIC VERIFICATION ---
+    ef.get_tier = lambda *args, **kwargs: "Legendary"
+    ef.get_all_pokemon_in_tier = lambda tier: [150] # Mewtwo
+    ef.search_pokedex_by_id = lambda pid: "mewtwo"
+    
+    # Run one generation to trigger the pity tracker updates
+    res = ef.generate_random_pokemon(85, sys.modules["Ankimon.singletons"].ankimon_tracker_obj)
+    log(f"DEBUG: generate_random_pokemon returned name={res[0]}, id={res[1]}, tier={res[14]}")
+    
+    # Retrieve updated trackers from mock database
+    updated_pity = mock_db.get_user_data("ankimon_pity_trackers")
+    log("Updated Pity Trackers after Legendary spawn:")
+    for tier, p_val in updated_pity.items():
+        log(f"  - {tier}: {p_val}")
+        
+    if updated_pity["Legendary"] != 0:
+        passed = False
+        errors.append("Legendary pity counter failed to reset to 0 after Legendary spawn!")
+    else:
+        log("PASS: Legendary pity counter successfully reset to 0!")
+        
+    if updated_pity["Ultra"] != 11 or updated_pity["Gmax"] != 21:
+        passed = False
+        errors.append("Other rare pity counters failed to increment by 1!")
+    else:
+        log("PASS: Non-selected rare pity counters successfully incremented by 1!")
+        
+    status = "PASS" if passed else "FAIL"
+    log(f"Result: {status}")
+    if errors:
+        for err in errors: log(f"  [ERROR] {err}")
+    return passed, counts
+
+# --- RUN LIFECYCLE ---
+def test_simulation_suite():
+    # Setup conftest stubs to allow proper resolution inside ef
+    import types
+    _src = Path(base_dir) / "src"
+    for _pkg in ("Ankimon", "Ankimon.functions"):
+        if _pkg not in sys.modules:
+            _mod = types.ModuleType(_pkg)
+            _mod.__path__ = [str(_src / _pkg.replace(".", "/"))]
+            _mod.__package__ = _pkg
+            sys.modules[_pkg] = _mod
+
+    passed_a, _ = simulate_scenario_a()
+    passed_b, _ = simulate_scenario_b()
+    passed_c, _ = simulate_scenario_c()
+    passed_d, _ = simulate_scenario_d()
+    
+    assert passed_a is True
+    assert passed_b is True
+    assert passed_c is True
+    assert passed_d is True
+
+if __name__ == "__main__":
+    log("Starting Encounter Overhaul Simulation Suite...")
+    try:
+        test_simulation_suite()
+        log("\n[SUCCESS] All 4 progression simulation scenarios passed successfully!")
+    except AssertionError:
+        log("\n[FAILURE] One or more simulation validation assertions failed!")
+        sys.exit(1)

--- a/tests/test_encounter_overhaul.py
+++ b/tests/test_encounter_overhaul.py
@@ -1,0 +1,159 @@
+import sys
+import unittest.mock as mock
+from pathlib import Path
+import importlib.util
+
+# Mock necessary modules
+sys.modules["aqt"] = mock.MagicMock()
+sys.modules["aqt.qt"] = mock.MagicMock()
+sys.modules["aqt.utils"] = mock.MagicMock()
+
+# Mock internal dependencies of encounter_functions
+for module in [
+    "Ankimon.pyobj.ankimon_tracker", "Ankimon.pyobj.pokemon_obj", 
+    "Ankimon.pyobj.reviewer_obj", "Ankimon.pyobj.test_window", 
+    "Ankimon.pyobj.trainer_card", "Ankimon.pyobj.InfoLogger", 
+    "Ankimon.pyobj.evolution_window", "Ankimon.pyobj.attack_dialog",
+    "Ankimon.pyobj.translator", "Ankimon.pyobj.error_handler",
+    "Ankimon.functions.pokemon_functions", "Ankimon.functions.pokedex_functions",
+    "Ankimon.functions.trainer_functions", "Ankimon.functions.badges_functions",
+    "Ankimon.functions.drawing_utils", "Ankimon.utils", "Ankimon.business", 
+    "Ankimon.const", "Ankimon.singletons", "Ankimon.resources"
+]:
+    sys.modules[module] = mock.MagicMock()
+
+# Import the module under test
+_src = Path(__file__).parent.parent / "src"
+spec = importlib.util.spec_from_file_location(
+    "Ankimon.functions.encounter_functions",
+    _src / "Ankimon" / "functions" / "encounter_functions.py",
+)
+ef = importlib.util.module_from_spec(spec)
+
+# Pre-patch singletons and dependencies used in the module
+ef.main_pokemon = mock.MagicMock()
+ef.settings_obj = mock.MagicMock()
+ef.ankimon_tracker_obj = mock.MagicMock()
+ef.trainer_card = mock.MagicMock()
+
+# Patch mw in both places
+ef.mw = mock.MagicMock()
+sys.modules["aqt"].mw = ef.mw
+
+# Execute the module
+spec.loader.exec_module(ef)
+
+def test_legacy_mode_works_when_toggle_is_false():
+    # Force legacy mode
+    ef.USE_OVERHAUL_ENCOUNTER_SYSTEM = False
+    ef.main_pokemon.level = 50
+    ef.settings_obj.get.return_value = 100
+
+    percentages = ef.modify_percentages(total_reviews=50, daily_average=100, trainer_level=5)
+    assert "Normal" in percentages
+    assert percentages["Starter"] == 0.0
+    assert abs(sum(percentages.values()) - 100.0) < 0.001
+
+
+def test_ep_mastery_index_bounds_and_components():
+    # Setup mocks to achieve specific components
+    ef.trainer_card.level = 50  # T_norm = 50%
+    ef.settings_obj.get.return_value = 100  # DailyGoal
+
+    # Mock Pokedex Completion D_norm
+    ef.mw.ankimon_db.get_all_pokemon_ids.return_value = {1, 2, 3}
+    sys.modules["aqt"].mw.ankimon_db.get_all_pokemon_ids.return_value = {1, 2, 3}
+    
+    ef.search_pokedex_by_id = lambda pid: "Bulbasaur"
+    ef.search_pokedex = lambda name, key: 1 if key == "species_id" else None
+    ef.safe_int = lambda x: int(x) if x is not None else 0
+
+    # 3 unique species out of a mock 10 species -> D_norm = 30%
+    # We patch _load_pokedex_cache to return 10 species keys
+    with mock.patch("Ankimon.functions.pokedex_functions._load_pokedex_cache") as mock_cache:
+        mock_cache.return_value = {str(i): {"species_id": i} for i in range(1, 11)}
+        
+        # Mock Core Team Power C_norm
+        ef.mw.ankimon_db.get_all_pokemon.return_value = [{"level": 50, "stats": {}} for _ in range(6)]
+        sys.modules["aqt"].mw.ankimon_db.get_all_pokemon.return_value = [{"level": 50, "stats": {}} for _ in range(6)]
+        
+        # Patch calculate_cp_from_dict directly on ef to return 2000
+        ef.calculate_cp_from_dict = mock.MagicMock(return_value=2000)
+            
+        # Run calculate_mastery_index_ep
+        ep = ef.calculate_mastery_index_ep(total_reviews=50, daily_average=100, trainer_level=50)
+        
+        # New Overhaul Config:
+        # T_norm = min((50/50)*100, 100) = 100.0 -> 0.25 * 100.0 = 25.0
+        # D_norm = 30.0 -> 0.25 * 30.0 = 7.5
+        # S_norm = min((50/100)*100, 100) = 50.0 -> 0.25 * 50.0 = 12.5
+        # C_norm = min((2000/16000)*100, 100) = 12.5 -> 0.25 * 12.5 = 3.125
+        # Total EP = 25.0 + 7.5 + 12.5 + 3.125 = 48.125
+        assert abs(ep - 48.125) < 0.001
+
+
+def test_overhaul_pity_multipliers_and_level_locks():
+    # Enable overhaul system
+    ef.USE_OVERHAUL_ENCOUNTER_SYSTEM = True
+    ef.main_pokemon.level = 45  # locks Legendary (50), Mega (60), Gmax (65), Mythical (75)
+    
+    # Mock pity trackers to trigger custom multipliers
+    ef.mw.ankimon_db.get_user_data.return_value = {
+        "Ultra": 150,  # exceeds threshold (150 - 100)/50 = 1 -> multiplier = 1 + 1^2 = 2.0
+        "Gmax": 200,   # exceeds threshold but Gmax is locked by level 45, so its weight must remain 0.0
+        "Starter": 0,
+        "Mega": 0,
+        "Legendary": 0,
+        "Mythical": 0
+    }
+    
+    # Mock calculate_mastery_index_ep to return EP = 50.0
+    with mock.patch("Ankimon.functions.encounter_functions.calculate_mastery_index_ep") as mock_ep:
+        mock_ep.return_value = 50.0
+        
+        percentages = ef.modify_percentages(total_reviews=50, daily_average=100, trainer_level=50)
+        
+        # Verify that locked categories have 0% rate
+        assert percentages["Legendary"] == 0.0
+        assert percentages["Mega"] == 0.0
+        assert percentages["Gmax"] == 0.0
+        assert percentages["Mythical"] == 0.0
+        
+        # Starter is locked under the new overhaul config (threshold 80 > 45)
+        assert percentages["Starter"] == 0.0
+        
+        # Normal, Baby, and Ultra should have > 0% rates
+        assert percentages["Normal"] > 0.0
+        assert percentages["Baby"] > 0.0
+        assert percentages["Ultra"] > 0.0
+        assert abs(sum(percentages.values()) - 100.0) < 0.001
+
+
+def test_pity_trackers_increment_and_reset_in_generation():
+    ef.USE_OVERHAUL_ENCOUNTER_SYSTEM = True
+    
+    # Setup mock pity trackers in database
+    pity_data = {
+        "Ultra": 10,
+        "Gmax": 20,
+        "Starter": 30,
+        "Mega": 40,
+        "Legendary": 50,
+        "Mythical": 60
+    }
+    ef.mw.ankimon_db.get_user_data.return_value = pity_data
+    
+    pity_trackers = ef.load_pity_trackers()
+    selected_tier = "Ultra"
+    
+    rare_tiers = ["Ultra", "Gmax", "Starter", "Mega", "Legendary", "Mythical"]
+    if selected_tier in rare_tiers:
+        pity_trackers[selected_tier] = 0
+        for rt in rare_tiers:
+            if rt != selected_tier:
+                pity_trackers[rt] += 1
+                
+    assert pity_trackers["Ultra"] == 0
+    assert pity_trackers["Gmax"] == 21
+    assert pity_trackers["Legendary"] == 51
+    assert pity_trackers["Mythical"] == 61

--- a/tests/test_encounter_overhaul.py
+++ b/tests/test_encounter_overhaul.py
@@ -30,18 +30,17 @@ spec = importlib.util.spec_from_file_location(
 )
 ef = importlib.util.module_from_spec(spec)
 
-# Pre-patch singletons and dependencies used in the module
+# Execute the module first. It declares its runtime-wired seam globals as
+# `= None` (main_pokemon, ankimon_db, settings_obj, ...), bound at runtime by
+# core.bind_runtime_globals(), so any pre-exec patch would be clobbered. Patch
+# them AFTER exec to drive the functions under test.
+spec.loader.exec_module(ef)
+
 ef.main_pokemon = mock.MagicMock()
 ef.settings_obj = mock.MagicMock()
 ef.ankimon_tracker_obj = mock.MagicMock()
 ef.trainer_card = mock.MagicMock()
-
-# Patch mw in both places
-ef.mw = mock.MagicMock()
-sys.modules["aqt"].mw = ef.mw
-
-# Execute the module
-spec.loader.exec_module(ef)
+ef.ankimon_db = mock.MagicMock()
 
 def test_legacy_mode_works_when_toggle_is_false():
     # Force legacy mode
@@ -51,7 +50,9 @@ def test_legacy_mode_works_when_toggle_is_false():
 
     percentages = ef.modify_percentages(total_reviews=50, daily_average=100, trainer_level=5)
     assert "Normal" in percentages
-    assert percentages["Starter"] == 0.0
+    # Starters are disabled as a wild tier on main's legacy system, so the key
+    # may be absent — either way its encounter rate must be zero.
+    assert percentages.get("Starter", 0.0) == 0.0
     assert abs(sum(percentages.values()) - 100.0) < 0.001
 
 
@@ -61,8 +62,7 @@ def test_ep_mastery_index_bounds_and_components():
     ef.settings_obj.get.return_value = 100  # DailyGoal
 
     # Mock Pokedex Completion D_norm
-    ef.mw.ankimon_db.get_all_pokemon_ids.return_value = {1, 2, 3}
-    sys.modules["aqt"].mw.ankimon_db.get_all_pokemon_ids.return_value = {1, 2, 3}
+    ef.ankimon_db.get_all_pokemon_ids.return_value = {1, 2, 3}
     
     ef.search_pokedex_by_id = lambda pid: "Bulbasaur"
     ef.search_pokedex = lambda name, key: 1 if key == "species_id" else None
@@ -74,8 +74,7 @@ def test_ep_mastery_index_bounds_and_components():
         mock_cache.return_value = {str(i): {"species_id": i} for i in range(1, 11)}
         
         # Mock Core Team Power C_norm
-        ef.mw.ankimon_db.get_all_pokemon.return_value = [{"level": 50, "stats": {}} for _ in range(6)]
-        sys.modules["aqt"].mw.ankimon_db.get_all_pokemon.return_value = [{"level": 50, "stats": {}} for _ in range(6)]
+        ef.ankimon_db.get_all_pokemon.return_value = [{"level": 50, "stats": {}} for _ in range(6)]
         
         # Patch calculate_cp_from_dict directly on ef to return 2000
         ef.calculate_cp_from_dict = mock.MagicMock(return_value=2000)
@@ -98,7 +97,7 @@ def test_overhaul_pity_multipliers_and_level_locks():
     ef.main_pokemon.level = 45  # locks Legendary (50), Mega (60), Gmax (65), Mythical (75)
     
     # Mock pity trackers to trigger custom multipliers
-    ef.mw.ankimon_db.get_user_data.return_value = {
+    ef.ankimon_db.get_user_data.return_value = {
         "Ultra": 150,  # exceeds threshold (150 - 100)/50 = 1 -> multiplier = 1 + 1^2 = 2.0
         "Gmax": 200,   # exceeds threshold but Gmax is locked by level 45, so its weight must remain 0.0
         "Starter": 0,
@@ -141,7 +140,7 @@ def test_pity_trackers_increment_and_reset_in_generation():
         "Legendary": 50,
         "Mythical": 60
     }
-    ef.mw.ankimon_db.get_user_data.return_value = pity_data
+    ef.ankimon_db.get_user_data.return_value = pity_data
     
     pity_trackers = ef.load_pity_trackers()
     selected_tier = "Ultra"

--- a/tests/test_encounter_simulator.py
+++ b/tests/test_encounter_simulator.py
@@ -1,0 +1,119 @@
+import sys
+import unittest.mock as mock
+from pathlib import Path
+import importlib.util
+import pytest
+
+# 1. Back up sys.modules to prevent pollution
+orig_modules = dict(sys.modules)
+
+# 2. Mock PyQt6 and other external modules before import
+sys.modules["aqt"] = mock.MagicMock()
+sys.modules["aqt.qt"] = mock.MagicMock()
+sys.modules["aqt.utils"] = mock.MagicMock()
+
+# Mock dependencies
+for module in [
+    "Ankimon.functions.encounter_functions",
+    "Ankimon.functions.pokedex_functions",
+    "Ankimon.business",
+    "Ankimon.singletons",
+    "Ankimon.resources",
+    "PyQt6.QtWebEngineWidgets",
+    "PyQt6.QtWebChannel"
+]:
+    sys.modules[module] = mock.MagicMock()
+
+# 3. Import the module under test dynamically
+_src = Path(__file__).parent.parent / "src"
+spec = importlib.util.spec_from_file_location(
+    "Ankimon.pyobj.encounter_simulator_dialog",
+    _src / "Ankimon" / "pyobj" / "encounter_simulator_dialog.py",
+)
+esd = importlib.util.module_from_spec(spec)
+
+# Mock required module-level imports
+esd.QDialog = mock.MagicMock
+esd.QVBoxLayout = mock.MagicMock
+esd.QWebEngineView = mock.MagicMock
+esd.QWebChannel = mock.MagicMock
+esd.QObject = mock.MagicMock
+
+spec.loader.exec_module(esd)
+
+# 4. Restore sys.modules immediately after executing the module loader
+sys.modules.clear()
+sys.modules.update(orig_modules)
+
+def test_calculate_rates_mocked():
+    """
+    Verifies that calculate_rates runs without exceptions when given slider states,
+    and returns a structured output containing live, overhaul, legacy, ep, and locks.
+    """
+    # Create the dialog instance with a mocked Path
+    dialog = mock.MagicMock()
+    
+    # Configure mock calculation outputs from encounter_functions
+    esd.ef.modify_percentages = mock.MagicMock(return_value={
+        "Normal": 90.0, "Baby": 10.0, "Ultra": 0.0, "Gmax": 0.0,
+        "Starter": 0.0, "Mega": 0.0, "Legendary": 0.0, "Mythical": 0.0
+    })
+    esd.ef.USE_OVERHAUL_ENCOUNTER_SYSTEM = False
+    esd.ef.TRAINER_LEVEL_CAP = 50.0
+    esd.ef.CORE_TEAM_POWER_CAP = 16000.0
+    esd.ef.EP_WEIGHT_TRAINER_LEVEL = 0.25
+    esd.ef.EP_WEIGHT_DEX_COMPLETION = 0.25
+    esd.ef.EP_WEIGHT_SESSION_PROGRESS = 0.25
+    esd.ef.EP_WEIGHT_CORE_TEAM_POWER = 0.25
+    esd.ef.OVERHAUL_LEVEL_THRESHOLDS = {
+        "Starter": 30,
+        "Ultra": 30,
+        "Legendary": 50,
+        "Mega": 60,
+        "Gmax": 65,
+        "Mythical": 75,
+    }
+    
+    esd.main_pokemon = mock.MagicMock()
+    esd.main_pokemon.level = 50
+    esd.trainer_card = mock.MagicMock()
+    esd.trainer_card.level = 20
+    esd.ankimon_tracker_obj = mock.MagicMock()
+    esd.ankimon_tracker_obj.get_total_reviews.return_value = 100
+    esd.settings_obj = mock.MagicMock()
+    esd.settings_obj.get.return_value = 100
+
+    # Define standard slider input state
+    slider_state = {
+        "trainer_level": 25,
+        "dex_completion": 50.0,
+        "reviews_done": 120,
+        "daily_goal": 100,
+        "avg_cp": 1500,
+        "main_level": 45
+    }
+
+    # Call calculate_rates via class method directly to test logic
+    result = esd.EncounterSimulatorDialog.calculate_rates(dialog, slider_state)
+    
+    # Assert return structure
+    assert "live_overhaul" in result
+    assert "live_legacy" in result
+    assert "overhaul" in result
+    assert "legacy" in result
+    assert "ep" in result
+    assert "locks" in result
+    
+    # Verify calculated EP matches formula under the new weights/caps:
+    # t_norm = min((25 / 50.0) * 100.0, 100.0) = 50.0 -> 0.25 * 50 = 12.5
+    # d_norm = 50.0 -> 0.25 * 50 = 12.5
+    # s_norm = min((120 / 100.0) * 100.0, 100.0) = 100.0 -> 0.25 * 100 = 25.0
+    # c_norm = min((1500 / 16000.0) * 100.0, 100.0) = 9.375 -> 0.25 * 9.375 = 2.34375
+    # ep = 12.5 + 12.5 + 25.0 + 2.34375 = 52.34375
+    assert abs(result["ep"] - 52.34375) < 0.001
+    
+    # Verify lock states at main_level = 45:
+    # "Legendary" gating limit is 50, so locked = True
+    # "Ultra" gating limit is 30, so locked = False
+    assert result["locks"]["Legendary"] is True
+    assert result["locks"]["Ultra"] is False


### PR DESCRIPTION
Ports the **Encounter Overhaul + Special Forms** gameplay system and the **Encounter Rate Simulator** dev tool from `BRRRR_Experimental` onto `main`, preserving the original code/data and adapting only the seams to main's #492 aqt-free architecture.

Original author: **@hakimh2** (all feature commits authored to them).

## What's included
- **Special-forms encounter data** (`encounter_data.py`, taken wholesale — main made zero post-divergence changes, so it's purely additive): full `MEGA`/`MEGA_AND_SPECIAL`, `GMAX`, `UNAVAILABLE`, `STARTERS` lists; regional-form data (`REGIONAL_FORMS`, `REGIONAL_FORM_LOOKUP`, `REGIONAL_FORM_REGION`, `REGIONAL_FORME_GEN`, `PREREQUISITES`); and the comprehensive legendary/mythical tiers with form variants.
- **Overhaul selection engine** (`encounter_functions.py`): tier fallback hierarchy, base-form ownership + prerequisite guards, regional boosting, regional-form resolution, pity tracking and the EP "mastery index" rarity curve — plus the 9 selection helpers it relies on. `get_tier()` remains the probability entry point, so base tier rates are preserved; regional features stay dormant unless an `active_region` is set. The `USE_OVERHAUL_ENCOUNTER_SYSTEM` toggle (default off) gates the pity/percentage layer.
- **Eternamax** encounter + learnset fallback + lore name.
- **`POKEMON_TIERS` redistribution** (`resources.py`) of stat-redistribution special forms to Legendary/Mythical, matching `encounter_data`.
- **Encounter Rate Simulator** (`encounter_simulator_dialog.py` + web assets), wired into the menu behind the existing `debug` flag, imported lazily so QtWebEngine never loads at boot.

## Seam adaptations (logic preserved, access rewired to main)
- Module-level `encounter_data` / `safe_int` imports for the grafted helpers.
- Overhaul EP/pity functions moved off BRRRR's `mw.ankimon_db` onto main's runtime-wired `ankimon_db` global (`core.bind_runtime_globals`).
- Test shims updated for main's `= None` seam globals; heavyweight unseeded simulation scripts excluded from the default unit gate (runnable via `pytest tests/encounter_weighting_simulations/`).

## Deferred to follow-ups (avoid 3-way conflicts now)
- Learnset Relearn/Special-move support + `DEOXYS_EXCLUSIONS` (depends on the 3-tier learnset fallback shipping in the evolutions PR).
- The PC-box evolution-button layout tweak (belongs with the PC Box V2 port).

## Validation
- Tier-1 harness gate: **9/9 PASS**
- `pytest tests/`: **155 passed**
- Tier-2 real-Qt `probe_real_boot` + `probe_real_play`: **OK** (full gameplay with the overhaul engine)
- **15,000-encounter stress** across levels 5–100, 5 regions, both toggle states: **0 errors**, 763 distinct species

🤖 Generated with [Claude Code](https://claude.com/claude-code)