### PR TITLE
PC Box V2 (3/3): pc_box V2 + Trade V2

### DIFF
--- a/src/Ankimon/functions/sprite_functions.py
+++ b/src/Ankimon/functions/sprite_functions.py
@@ -57,26 +57,90 @@ def _try_back(back: bool, id: int, gif: bool, shiny: bool, female: bool):
             return path
 
 
-def get_sprite_path(side: str, sprite_type: str, id: int, shiny: bool, gender: str):
-    """Return the path to the sprite of the Pokémon with robust fallbacks."""
+def _get_pokemon_id_from_pokedex(pokemon_name):
+    """Get the sprite ID for a Pokémon form from pokedex (handles Mega/Gmax forms)."""
+    from .pokedex_functions import _load_pokedex_cache, safe_int
+    try:
+        pokedex = _load_pokedex_cache()
+        pokemon_key = pokemon_name.lower().replace(" ", "").replace("-", "")
+        if pokemon_key in pokedex:
+            pdata = pokedex[pokemon_key]
+            # Ensure we return an integer ID
+            return safe_int(pdata.get("actual_id")) or safe_int(pdata.get("num"))
+    except Exception as e:
+        services.logger.log("debug", f"Error looking up pokemon ID in pokedex: {e}")
+    return None
+
+
+def get_sprite_path(side: str, sprite_type: str, id: int, shiny: bool, gender: str, pokemon_name: str = None):
+    """Return the path to the sprite of the Pokémon with robust fallbacks.
+
+    Args:
+        side: "front" or "back"
+        sprite_type: "gif" or "png"
+        id: Pokémon ID (base form)
+        shiny: Whether the Pokémon is shiny
+        gender: "M" or "F"
+        pokemon_name: Optional Pokémon name (used for Mega/Gmax forms to lookup correct sprite ID)
+    """
 
     gif = sprite_type == "gif"
     female = gender == "F"
     back = side == "back"
 
-    path = _try_back(back, id, gif, shiny, female)
+    lookup_id = id
+
+    # For Mega/Gmax forms, try to get the form-specific ID from pokedex
+    base_species_id = None
+    if pokemon_name and any(form in pokemon_name.lower() for form in ["mega", "gmax", "gigantamax"]):
+        forme_id = _get_pokemon_id_from_pokedex(pokemon_name)
+        if forme_id:
+            lookup_id = forme_id
+            services.logger.log("debug", f"Using Mega/Gmax form ID {lookup_id} for {pokemon_name}")
+        # Also get the base species_id for fallback
+        try:
+            from .pokedex_functions import _load_pokedex_cache
+            pokedex = _load_pokedex_cache()
+            pokemon_key = pokemon_name.lower().replace(" ", "").replace("-", "")
+            if pokemon_key in pokedex:
+                base_species_id = pokedex[pokemon_key].get("species_id")
+        except Exception:
+            pass
+
+    # Try requested format first
+    path = _try_back(back, lookup_id, gif, shiny, female)
     if path:
         return path
 
+    # If GIF requested but not found, try PNG
     if gif:
-        # requested gif but not found, try png
-        path = _try_back(back, id, False, shiny, female)
+        path = _try_back(back, lookup_id, False, shiny, female)
         if path:
             return path
+
+    # If we used a forme ID and still found nothing, fallback to base form ID
+    if lookup_id != id:
+        path = _try_back(back, id, gif, shiny, female)
+        if path:
+            return path
+        if gif:
+            path = _try_back(back, id, False, shiny, female)
+            if path:
+                return path
+
+    # Final fallback: try species_id (base form) for Mega/Gmax
+    if base_species_id and base_species_id != id and base_species_id != lookup_id:
+        path = _try_back(back, base_species_id, gif, shiny, female)
+        if path:
+            return path
+        if gif:
+            path = _try_back(back, base_species_id, False, shiny, female)
+            if path:
+                return path
 
     # Fallback to the generic substitute image
     services.logger.log(
         "warning",
-        f"Unable to find sprite for ID {id} (Side: {side} Sprite: {sprite_type} Shiny: {shiny}, Gender: {gender}). Returning substitute.",
+        f"Unable to find sprite for {pokemon_name} ID {id} (Side: {side} Sprite: {sprite_type} Shiny: {shiny}, Gender: {gender}). Returning substitute.",
     )
     return SUBSTITUTE_PATH

--- a/src/Ankimon/pyobj/pc_box.py
+++ b/src/Ankimon/pyobj/pc_box.py
@@ -26,6 +26,7 @@ from PyQt6.QtWidgets import (
     QFrame,
     QRadioButton,
     QButtonGroup,
+    QStyle,
 )
 from PyQt6.QtCore import QSize, pyqtSignal, QTimer
 from PyQt6.QtGui import QIcon, QFont, QAction, QMovie, QCloseEvent, QResizeEvent
@@ -35,15 +36,409 @@ from ..pyobj.reviewer_obj import Reviewer_Manager
 from ..pyobj.test_window import TestWindow
 from ..pyobj.translator import Translator
 from ..pyobj.collection_dialog import MainPokemon
-from ..gui_classes.pokemon_details import PokemonCollectionDetails
+from ..gui_classes.pokemon_details import PokemonCollectionDetails, remember_attack
 from ..pyobj.InfoLogger import ShowInfoLogger
+from ..pyobj.move_picker import MovePickerDialog
+from ..pyobj.evolution_window import EvoWindow
 
 from ..pyobj.settings import Settings
 from ..functions.friendship_evolution import evolution_readiness, current_time_label
 from ..functions.sprite_functions import get_sprite_path
-from ..utils import load_custom_font, get_tier_by_id
-from ..resources import icon_path, items_path, csv_file_items_cost, poke_evo_path
+from ..utils import load_custom_font, get_tier_by_id, is_alive, format_move_name, format_pokemon_name
+from ..resources import icon_path, items_path, csv_file_items_cost, poke_evo_path, pokemon_tm_learnset_path, addon_dir
 from ..business import calculate_cp_from_dict
+from ..functions.pokedex_functions import find_details_move, get_all_pokemon_moves, format_lore_name, get_pretty_name_for_name, search_pokedex_by_id
+from ..functions.gui_functions import type_icon_path, move_category_path
+
+MOVE_TYPE_COLORS = {
+    "Normal":"#A8A878","Fire":"#F08030","Water":"#6890F0","Electric":"#F8D030",
+    "Grass":"#78C850","Ice":"#98D8D8","Fighting":"#C03028","Poison":"#A040A0",
+    "Ground":"#E0C068","Flying":"#A890F0","Psychic":"#F85888","Bug":"#A8B820",
+    "Rock":"#B8A038","Ghost":"#705898","Dragon":"#7038F8","Dark":"#705848",
+    "Steel":"#B8B8D0","Fairy":"#EE99AC",
+}
+
+NATURE_EFFECTS = {
+    "Hardy":    ("", ""),       "Docile":  ("", ""),
+    "Serious":  ("", ""),       "Bashful": ("", ""),
+    "Quirky":   ("", ""),       # neutral natures
+    "Lonely":   ("attack", "defense"),
+    "Brave":    ("attack", "speed"),
+    "Adamant":  ("attack", "special-attack"),
+    "Naughty":  ("attack", "special-defense"),
+    "Bold":     ("defense", "attack"),
+    "Relaxed":  ("defense", "speed"),
+    "Impish":   ("defense", "special-attack"),
+    "Lax":      ("defense", "special-defense"),
+    "Timid":    ("speed", "attack"),
+    "Hasty":    ("speed", "defense"),
+    "Jolly":    ("speed", "special-attack"),
+    "Naive":    ("speed", "special-defense"),
+    "Modest":   ("special-attack", "attack"),
+    "Mild":     ("special-attack", "defense"),
+    "Quiet":    ("special-attack", "speed"),
+    "Rash":     ("special-attack", "special-defense"),
+    "Calm":     ("special-defense", "attack"),
+    "Gentle":   ("special-defense", "defense"),
+    "Sassy":    ("special-defense", "speed"),
+    "Careful":  ("special-defense", "special-attack"),
+}
+
+STAT_KEY_TO_DISPLAY = {
+    "hp": "HP", "attack": "Attack", "defense": "Defense",
+    "special-attack": "Sp. Atk", "special-defense": "Sp. Def", "speed": "Speed",
+}
+DISPLAY_TO_STAT_KEY = {v: k for k, v in STAT_KEY_TO_DISPLAY.items()}
+
+from PyQt6.QtWidgets import QListWidget, QListWidgetItem, QTableWidget, QTableWidgetItem, QHeaderView, QAbstractItemView, QTabWidget
+from PyQt6.QtGui import QColor
+
+
+class MoveManagerWidget(QWidget):
+    def __init__(self, individual_id, pkmn_id, logger, save_fn, parent=None):
+        super().__init__(parent)
+        self.individual_id = individual_id
+        self.pkmn_id = pkmn_id
+        self.logger = logger
+        self.save_fn = save_fn
+        self.full_data = None
+        self.setup_ui()
+        self.refresh()
+
+    def setup_ui(self):
+        self.layout = QVBoxLayout(self)
+        self.layout.setSpacing(6)
+        self.layout.setContentsMargins(0, 0, 0, 0)
+        
+        self.header = QLabel("MOVES")
+        self.header.setStyleSheet("color: #94a3b8; font-size: 10px; font-weight: bold; letter-spacing: 1px;")
+        self.layout.addWidget(self.header)
+        
+        self.slots = []
+        for i in range(4):
+            slot_container = QWidget()
+            slot_layout = QHBoxLayout(slot_container)
+            slot_layout.setContentsMargins(0, 2, 0, 2)
+            
+            type_chip = QLabel("---")
+            type_chip.setFixedSize(42, 18)
+            type_chip.setAlignment(Qt.AlignmentFlag.AlignCenter)
+            type_chip.setStyleSheet("border-radius: 4px; font-size: 9px; font-weight: bold; color: white;")
+            
+            name_label = QPushButton("— empty —")
+            name_label.setFlat(True)
+            name_label.setCursor(Qt.CursorShape.PointingHandCursor)
+            name_label.setStyleSheet("""
+                QPushButton { 
+                    text-align: left; 
+                    font-size: 12px; 
+                    color: #475569; 
+                    font-style: italic; 
+                    border: none; 
+                    padding: 4px 8px; 
+                    border-radius: 4px;
+                }
+                QPushButton:hover {
+                    background-color: #1e293b;
+                }
+            """)
+            
+            forget_btn = QPushButton("✕")
+            forget_btn.setFixedSize(24, 24)
+            forget_btn.setFlat(True)
+            
+            learn_btn = QPushButton("＋")
+            learn_btn.setFixedSize(24, 24)
+            learn_btn.setFlat(True)
+            
+            slot_layout.addWidget(type_chip)
+            slot_layout.addWidget(name_label)
+            slot_layout.addStretch()
+            slot_layout.addWidget(forget_btn)
+            slot_layout.addWidget(learn_btn)
+            
+            self.layout.addWidget(slot_container)
+            self.slots.append({
+                "container": slot_container,
+                "layout": slot_layout,
+                "type_chip": type_chip,
+                "name_label": name_label,
+                "forget_btn": forget_btn,
+                "learn_btn": learn_btn,
+                "move": None
+            })
+            
+            forget_btn.clicked.connect(lambda checked, idx=i: self.on_forget_clicked(idx))
+            learn_btn.clicked.connect(lambda checked, idx=i: self.on_learn_clicked(idx))
+            name_label.clicked.connect(lambda checked, idx=i: self.on_learn_clicked(idx))
+
+        # Add TM button
+        self.tm_btn = QPushButton(" LEARN FROM TMs")
+        tm_icon_path = items_path / "Bag_TM_normal_SV_Sprite.png"
+        if tm_icon_path.exists():
+            self.tm_btn.setIcon(QIcon(str(tm_icon_path)))
+            self.tm_btn.setIconSize(QSize(18, 18))
+            
+        self.tm_btn.setMinimumHeight(32)
+        self.tm_btn.setCursor(Qt.CursorShape.PointingHandCursor)
+        self.tm_btn.setStyleSheet("""
+            QPushButton {
+                background: qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 #2563eb, stop:1 #1d4ed8);
+                color: #f8fafc;
+                font-size: 11px;
+                font-weight: 800;
+                letter-spacing: 0.5px;
+                border: 1px solid #1e40af;
+                border-radius: 6px;
+                margin-top: 12px;
+                padding: 4px 8px;
+                text-align: center;
+            }
+            QPushButton:hover {
+                background: qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 #3b82f6, stop:1 #2563eb);
+                border-color: #3b82f6;
+                margin-top: 12px;
+                padding: 4px 8px;
+                text-align: center;
+            }
+            QPushButton:pressed {
+                background: #1e40af;
+                margin-top: 12px;
+                padding: 5px 8px 3px 8px;
+                text-align: center;
+            }
+        """)
+        self.tm_btn.clicked.connect(self.on_tm_clicked)
+        self.layout.addWidget(self.tm_btn)
+
+    def _fetch_full(self, individual_id):
+        try:
+            cursor = mw.ankimon_db.execute("SELECT data FROM captured_pokemon WHERE individual_id = ?", (individual_id,))
+            row = cursor.fetchone()
+            if row:
+                data = json.loads(row[0])
+                # Ensure all_attacks is fetched
+                if "all_attacks" not in data:
+                    from ..functions.pokedex_functions import get_all_pokemon_moves
+                    data["all_attacks"] = get_all_pokemon_moves(data.get("name"), data.get("level"))
+                return data
+        except Exception:
+            pass
+        return {}
+
+    def refresh(self):
+        self.full_data = self._fetch_full(self.individual_id)
+        attacks = self.full_data.get("attacks", [])
+        all_moves = self.full_data.get("all_attacks", []) or self.full_data.get("learnable_moves", [])
+        
+        for i in range(4):
+            slot = self.slots[i]
+            if i < len(attacks):
+                move = attacks[i]
+                slot["move"] = move
+                slot["name_label"].setText(format_move_name(move))
+                slot["name_label"].setStyleSheet("""
+                    QPushButton { 
+                        text-align: left; 
+                        font-size: 12px; 
+                        color: #e6edf3; 
+                        font-weight: 600; 
+                        border: none; 
+                        padding: 4px 8px; 
+                        border-radius: 4px;
+                    } 
+                    QPushButton:hover { 
+                        color: #60a5fa; 
+                        background-color: #1e293b;
+                    }
+                """)
+                slot["forget_btn"].setVisible(len(attacks) > 1)
+                slot["learn_btn"].setText("⤵")
+                slot["learn_btn"].setVisible(bool(all_moves))
+                
+                move_data = find_details_move(move)
+                m_type = move_data.get("type", "Normal")
+                color = MOVE_TYPE_COLORS.get(m_type, "#777")
+                slot["type_chip"].setText(m_type.upper())
+                slot["type_chip"].setStyleSheet(f"background-color: {color}; border-radius: 4px; font-size: 9px; font-weight: bold; color: white;")
+                slot["type_chip"].show()
+            else:
+                slot["move"] = None
+                slot["name_label"].setText("— empty —")
+                slot["name_label"].setStyleSheet("QPushButton { text-align: left; font-size: 12px; color: #475569; font-style: italic; border: none; padding: 0; }")
+                slot["forget_btn"].hide()
+                slot["learn_btn"].setText("＋")
+                slot["learn_btn"].setVisible(bool(all_moves))
+                slot["type_chip"].hide()
+
+        if not all_moves:
+            if not hasattr(self, "no_moves_label"):
+                self.no_moves_label = QLabel("No learnable moves data")
+                self.no_moves_label.setStyleSheet("color: #64748b; font-size: 11px; font-style: italic;")
+                self.layout.addWidget(self.no_moves_label)
+        elif hasattr(self, "no_moves_label"):
+            self.no_moves_label.setParent(None)
+            del self.no_moves_label
+
+    def on_forget_clicked(self, idx):
+        move = self.slots[idx]["move"]
+        if not move: return
+        
+        # Confirmation UI
+        slot_container = self.slots[idx]["container"]
+        old_layout = self.slots[idx]["layout"]
+        
+        conf_widget = QWidget()
+        conf_layout = QHBoxLayout(conf_widget)
+        conf_layout.setContentsMargins(0, 0, 0, 0)
+        
+        label = QLabel(f"Forget {move.capitalize()}?")
+        label.setStyleSheet("font-size: 11px; font-weight: bold;")
+        
+        yes_btn = QPushButton("Yes")
+        yes_btn.setFixedSize(40, 22)
+        yes_btn.setStyleSheet("font-size: 10px;")
+        
+        no_btn = QPushButton("No")
+        no_btn.setFixedSize(40, 22)
+        no_btn.setStyleSheet("font-size: 10px;")
+        
+        conf_layout.addWidget(label)
+        conf_layout.addStretch()
+        conf_layout.addWidget(yes_btn)
+        conf_layout.addWidget(no_btn)
+        
+        # Swap layouts
+        slot_container.hide()
+        self.layout.insertWidget(idx + 1, conf_widget) # +1 because of header
+        
+        def on_yes():
+            attacks = self.full_data.get("attacks", [])
+            if move in attacks:
+                attacks.remove(move)
+                self.full_data["attacks"] = attacks
+                self.save_fn(self.full_data)
+                self.refresh()
+            conf_widget.setParent(None)
+            slot_container.show()
+            
+        def on_no():
+            conf_widget.setParent(None)
+            slot_container.show()
+            
+        yes_btn.clicked.connect(on_yes)
+        no_btn.clicked.connect(on_no)
+
+    def on_learn_clicked(self, idx):
+        all_moves = self.full_data.get("all_attacks", []) or self.full_data.get("learnable_moves", [])
+        current_moves = self.full_data.get("attacks", [])
+        
+        nickname = self.full_data.get("nickname")
+        raw_name = self.full_data.get("name")
+        species_name = get_pretty_name_for_name(raw_name)
+        
+        def normalize_n(s):
+            if not s: return ""
+            return "".join(c for c in str(s).lower() if c.isalnum())
+            
+        is_redundant = (
+            not nickname or 
+            not str(nickname).strip() or 
+            normalize_n(nickname) == normalize_n(species_name) or
+            normalize_n(nickname) == normalize_n(raw_name)
+        )
+        
+        pretty_name = species_name if is_redundant else f"{nickname} ({species_name})"
+        
+        dialog = MovePickerDialog(pretty_name, all_moves, current_moves, self, force_show_current=True)
+        if dialog.exec():
+            new_move = dialog.get_selected_move()
+            if new_move:
+                attacks = self.full_data.get("attacks", [])
+                if idx < len(attacks):
+                    attacks[idx] = new_move
+                else:
+                    attacks.append(new_move)
+                self.full_data["attacks"] = attacks
+                self.save_fn(self.full_data)
+                self.refresh()
+
+    def on_tm_clicked(self):
+        # 1. Get species/base name for TM lookup
+        internal_name = search_pokedex_by_id(self.pkmn_id)
+        if not internal_name:
+            self.logger.log_and_showinfo("error", f"Could not find Pokémon data for ID: {self.pkmn_id}")
+            return
+            
+        # Normalize: strip hyphens and everything after the first hyphen to try base species
+        # e.g. "venusaur-mega" -> "venusaur"
+        base_name = internal_name.split("-")[0].lower()
+        internal_name = internal_name.lower()
+        
+        # 2. Load TM learnsets
+        try:
+            with open(pokemon_tm_learnset_path, "r", encoding="utf-8") as f:
+                tm_learnsets = json.load(f)
+        except Exception as e:
+            self.logger.log_and_showinfo("error", f"Failed to load TM learnsets: {e}")
+            return
+
+        # 3. Get valid TMs for this species (check specific form then base species)
+        valid_tms = tm_learnsets.get(internal_name) or tm_learnsets.get(base_name)
+        if not valid_tms:
+            self.logger.log_and_showinfo("info", f"This Pokémon cannot learn any moves from TMs.")
+            return
+            
+        # 4. Get owned TMs from DB
+        all_items = mw.ankimon_db.get_all_items()
+        owned_tm_moves = [
+            item["item_name"] 
+            for item in all_items 
+            if (item.get("extra_data") or {}).get("type") == "TM"
+        ]
+        
+        # 5. Filter valid TMs by ownership
+        learnable_tm_moves = [move for move in valid_tms if move in owned_tm_moves]
+        if not learnable_tm_moves:
+            self.logger.log_and_showinfo("info", "You don't own any TMs that this Pokémon can learn.")
+            return
+            
+        # 6. UI: Use MovePickerDialog
+        nickname = self.full_data.get("nickname")
+        raw_name = self.full_data.get("name")
+        species_name = get_pretty_name_for_name(raw_name)
+        
+        def normalize_n(s):
+            if not s: return ""
+            return "".join(c for c in str(s).lower() if c.isalnum())
+            
+        is_redundant = (
+            not nickname or 
+            not str(nickname).strip() or 
+            normalize_n(nickname) == normalize_n(species_name) or
+            normalize_n(nickname) == normalize_n(raw_name)
+        )
+        
+        pretty_name = species_name if is_redundant else f"{nickname} ({species_name})"
+        title = f"TM Learning: {pretty_name}"
+        
+        current_moves = self.full_data.get("attacks", [])
+        dialog = MovePickerDialog(title, learnable_tm_moves, current_moves, self)
+        dialog.setWindowTitle("Learn from TMs")
+        
+        if dialog.exec():
+            new_move = dialog.get_selected_move()
+            if new_move:
+                self.learn_move_from_tm(new_move)
+
+    def learn_move_from_tm(self, move_name):
+        remember_attack(
+            self.individual_id,
+            self.full_data.get("attacks", []),
+            move_name,
+            self.logger,
+            refresh_callback=lambda: self.save_fn(mw.ankimon_db.get_pokemon(self.individual_id))
+        )
 
 
 def format_item_name(item_name: str) -> str:
@@ -60,11 +455,12 @@ def clear_layout(layout):
     Args:
         layout (QLayout): The layout to be cleared. Can contain widgets and/or nested layouts.
     """
+    if not is_alive(layout):
+        return
     while layout.count():
         item = layout.takeAt(0)
         widget = item.widget()
         if widget is not None:
-            widget.setParent(None)
             widget.deleteLater()
         elif item.layout():
             clear_layout(item.layout())
@@ -80,14 +476,21 @@ class PokemonSlotButton(QPushButton):
 
 
 class ScaledMovieLabel(QLabel):
-    def __init__(self, gif_path, width, height):
-        super().__init__()
+    def __init__(self, gif_path, width, height, parent=None):
+        super().__init__(parent)
         self.target_width = width
         self.target_height = height
-        self.movie = QMovie(gif_path)
+        self.movie = QMovie(gif_path, parent=self)
         self.movie.frameChanged.connect(self.on_frame_changed)
-        self.movie.start()
         self.setFixedSize(width, height)
+
+    def showEvent(self, event):
+        super().showEvent(event)
+        self.movie.start()
+
+    def hideEvent(self, event):
+        super().hideEvent(event)
+        self.movie.stop()
 
     def on_frame_changed(self, frame_number):
         # Get current frame pixmap
@@ -113,6 +516,7 @@ class PokemonPC(QDialog):
         test_window: TestWindow,
         settings: Settings,
         main_pokemon: PokemonObject,
+        achievements: dict,
         parent=mw,
     ):
         super().__init__(parent)
@@ -122,6 +526,8 @@ class PokemonPC(QDialog):
         self.reviewer_obj = reviewer_obj
         self.test_window = test_window
         self.settings = settings
+        self.main_pokemon = main_pokemon
+        self.achievements = achievements
         self.main_pokemon_function_callback = lambda _pokemon_data: MainPokemon(
             _pokemon_data, main_pokemon, logger, translator, reviewer_obj, test_window
         )
@@ -138,6 +544,15 @@ class PokemonPC(QDialog):
         self.resize_timer.timeout.connect(
             self.on_resize_timeout
         )  # Debounce resize events to avoid excessive refreshes during window resizing
+
+        # PERFORMANCE: Database result caching
+        self._pokemon_cache = None
+        self._last_filter_state = None
+        
+        # LIVE SEARCH: Timer for debouncing
+        self.search_timer = QTimer()
+        self.search_timer.setSingleShot(True)
+        self.search_timer.timeout.connect(lambda: self.go_to_box(0))
 
         self.main_layout = QHBoxLayout()  # Main horizontal layout for split panels
         self.details_layout = QVBoxLayout()  # Layout for details panel
@@ -158,9 +573,21 @@ class PokemonPC(QDialog):
         self.sort_by_friendship = None
         self.sort_by_date = None
         self.sort_group = None
-        self.selected_sort_key = "Date"
+        self.selected_sort_key = "CP"
+        self.sort_combo = None
         self.desc_sort = None  # Sort by descending order
         self.current_stats_tab_index = 0  # Remember selected tab (Stats/IV/EV)
+        
+        self._selected_individual_id = None
+        self._total_pokemon_count = 0
+        
+        self._bff_id = None
+        self._bff_dirty = True
+        self.time_label = None
+        
+        # Splitter persistence keys
+        self.GEOMETRY_KEY = "ankimon.pc_box.geometry"
+        self.SPLITTER_KEY = "ankimon.pc_box.splitter"
 
         # Subscribe to theme change hook to update UI dynamically
         gui_hooks.theme_did_change.append(self.on_theme_change)
@@ -180,7 +607,13 @@ class PokemonPC(QDialog):
         self._bff_dirty = True
 
         self.create_gui()
+        self._restore_geometry()
         self.refresh_pokemon_grid()
+        
+        # Real-time clock for friendship evolutions
+        self.time_timer = QTimer(self)
+        self.time_timer.timeout.connect(self._update_time_display)
+        self.time_timer.start(60000) # Every minute
 
     def showEvent(self, event):
         """Refresh the grid whenever the PC is (re)opened.
@@ -228,6 +661,10 @@ class PokemonPC(QDialog):
             - Connects UI elements to their corresponding interaction handlers.
         """
         self.setWindowTitle("Pokémon PC")
+        
+        # Make the window non-modal (floating) and add maximize/minimize buttons
+        self.setWindowFlags(self.windowFlags() | Qt.WindowType.WindowMaximizeButtonHint | Qt.WindowType.WindowMinimizeButtonHint)
+        self.setWindowModality(Qt.WindowModality.NonModal)
 
         # Determine theme based on Anki's night mode
         is_dark_mode = theme_manager.night_mode  # Correctly checks Anki's theme
@@ -240,8 +677,8 @@ class PokemonPC(QDialog):
             button_bg = "#3B4CCA"
             button_border = "#6A73D9"
             hover_color = "#6A73D9"
-            favorite_color = "#B3A125"
-            favorite_hover_color = "#AF8308"
+            favorite_color = "#998A3D"  # Muted antique brass/gold (classy, low-luminance)
+            favorite_hover_color = "#8A7C36"
             input_bg = "#002B5A"  # Slightly lighter than background for input fields
             slot_bg_color = "#002B5A"
         else:
@@ -251,8 +688,8 @@ class PokemonPC(QDialog):
             button_bg = "#3D7DCA"
             button_border = "#003A70"
             hover_color = "#A8D8FF"
-            favorite_color = "#FFDE00"
-            favorite_hover_color = "#FFA600"
+            favorite_color = "#EAD180"  # Soft honey-gold / desaturated sand gold (warm, mild brightness)
+            favorite_hover_color = "#D9BF70"
             input_bg = "#FFFFFF"  # White background for input fields
             slot_bg_color = "#CCE5FF"
 
@@ -330,7 +767,13 @@ class PokemonPC(QDialog):
         if self.layout():
             clear_layout(self.layout())
         else:
-            self.setLayout(self.main_layout)
+            self.main_layout = QHBoxLayout(self)
+        
+        self.main_container = QWidget()
+        self.main_container_layout = QHBoxLayout(self.main_container)
+        self.main_container_layout.setContentsMargins(0, 0, 0, 0)
+        self.main_layout.addWidget(self.main_container)
+        
         pokemon_list = self.fetch_filtered_pokemon()
         max_box_idx = (len(pokemon_list) - 1) // (self.n_rows * self.n_cols)
 
@@ -409,14 +852,73 @@ class PokemonPC(QDialog):
         self.pokemon_grid.setAlignment(Qt.AlignmentFlag.AlignCenter)
         self.scroll_area.setWidget(self.grid_container)
 
+        self.count_label = QLabel("", self)
+        self.count_label.setObjectName("countLabel")
+        self.count_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        collection_layout.addWidget(self.count_label)
+        
         collection_layout.addWidget(self.scroll_area, 1)
         self.setup_filters_layout(collection_layout)
 
         collection_widget = QWidget()
         collection_widget.setLayout(collection_layout)
-        self.main_layout.addWidget(collection_widget, 1)
-
+        self.main_container_layout.addWidget(collection_widget, 3) # Grid takes 3/5
+        
         self.setup_details_panel(background_color)
+        
+        self._apply_qss()
+
+    def _apply_qss(self):
+        self.setStyleSheet(self.styleSheet() + """
+            #countLabel {
+                font-size: 11px;
+                color: #94a3b8;
+                padding: 2px 8px 4px 8px;
+                letter-spacing: 0.3px;
+            }
+            
+            /* Unselected slot */
+            QPushButton#pokemonSlot {
+                border-radius: 5px;
+            }
+
+            /* Selected slot */
+            QPushButton#pokemonSlot[selected="true"] {
+                border: 2px solid #60a5fa;
+                background: rgba(96, 165, 250, 0.12);
+                border-radius: 8px;
+            }
+
+            /* Selected slot hover */
+            QPushButton#pokemonSlot[selected="true"]:hover {
+                background: rgba(96, 165, 250, 0.20);
+                border-color: #93c5fd;
+            }
+        """)
+
+    def _restore_geometry(self):
+        import base64
+        try:
+            geo = mw.pm.profile.get(self.GEOMETRY_KEY)
+            if geo:
+                self.restoreGeometry(QByteArray(base64.b64decode(geo)))
+        except Exception:
+            pass
+
+    def closeEvent(self, event: QCloseEvent):
+        import base64
+        try:
+            mw.pm.profile[self.GEOMETRY_KEY] = base64.b64encode(bytes(self.saveGeometry())).decode()
+        except Exception:
+            pass
+        
+        for attr in ("resize_timer", "search_timer"):
+            t = getattr(self, attr, None)
+            if t and t.isActive():
+                t.stop()
+        
+        self.on_window_close()
+        event.accept()
 
     def setup_filters_layout(self, parent_layout):
         """
@@ -436,7 +938,11 @@ class PokemonPC(QDialog):
         self.search_edit = QLineEdit()
         self.search_edit.setPlaceholderText("Search Pokémon (by nickname, name)")
         self.search_edit.setText(prev_text)
+        
+        # LIVE SEARCH: Trigger refresh after 300ms of inactivity
+        self.search_edit.textChanged.connect(lambda: self.search_timer.start(300))
         self.search_edit.returnPressed.connect(lambda: self.go_to_box(0))
+        
         search_button = QPushButton("Search")
         search_button.clicked.connect(lambda: self.go_to_box(0))
         # Type filtering
@@ -483,7 +989,7 @@ class PokemonPC(QDialog):
         self.tier_combo = QComboBox()
         self.tier_combo.addItem("All tiers")
         self.tier_combo.addItems(
-            ["Normal", "Legendary", "Mythical", "Baby", "Ultra", "Fossil", "Starter"]
+            ["Normal", "Legendary", "Mythical", "Baby", "Ultra", "Fossil", "Starter", "Mega", "Gmax"]
         )
         self.tier_combo.setCurrentIndex(prev_idx)
         self.tier_combo.currentIndexChanged.connect(lambda: self.go_to_box(0))
@@ -514,62 +1020,46 @@ class PokemonPC(QDialog):
         self.filter_shiny.stateChanged.connect(lambda: self.go_to_box(0))
         # Sorting options
         sort_label = QLabel("Sort by:")
+        
+        prev_sort = self.selected_sort_key if hasattr(self, 'selected_sort_key') else "Date"
+        self.sort_combo = QComboBox()
+        sort_options = [
+            self.translator.translate("Date"),
+            self.translator.translate("ID"),
+            self.translator.translate("Name"),
+            self.translator.translate("Level"),
+            self.translator.translate("cp_label"),
+            self.translator.translate("friendship_label"),
+            "IV (Total)",
+            "EV (Total)",
+            "HP",
+            self.translator.translate("Attack"),
+            self.translator.translate("Defense"),
+            "Sp. Atk",
+            "Sp. Def",
+            self.translator.translate("Speed"),
+        ]
+        self.sort_combo.addItems(sort_options)
+        
+        # Set current index based on previous selection
+        index = self.sort_combo.findText(prev_sort)
+        if index >= 0:
+            self.sort_combo.setCurrentIndex(index)
+        else:
+            self.sort_combo.setCurrentText("Date")
+            
+        self.sort_combo.currentTextChanged.connect(self.on_sort_changed)
 
-        # Radio buttons for mutually exclusive sorting
-        self.sort_group = QButtonGroup(self)
-        self.sort_by_id = QRadioButton("ID")
-        self.sort_by_name = QRadioButton("Name")
-        self.sort_by_level = QRadioButton("Level")
-        self.sort_by_cp = QRadioButton("CP")
-        self.sort_by_iv = QRadioButton("IV")
-        self.sort_by_ev = QRadioButton("EV")
-        self.sort_by_friendship = QRadioButton("Friendship")
-        self.sort_by_date = QRadioButton("Date")
-
-        self.sort_group.addButton(self.sort_by_id)
-        self.sort_group.addButton(self.sort_by_name)
-        self.sort_group.addButton(self.sort_by_level)
-        self.sort_group.addButton(self.sort_by_cp)
-        self.sort_group.addButton(self.sort_by_iv)
-        self.sort_group.addButton(self.sort_by_ev)
-        self.sort_group.addButton(self.sort_by_friendship)
-        self.sort_group.addButton(self.sort_by_date)
-
-        if self.selected_sort_key == "ID":
-            self.sort_by_id.setChecked(True)
-        elif self.selected_sort_key == "Name":
-            self.sort_by_name.setChecked(True)
-        elif self.selected_sort_key == "Level":
-            self.sort_by_level.setChecked(True)
-        elif self.selected_sort_key == "CP":
-            self.sort_by_cp.setChecked(True)
-        elif self.selected_sort_key == "IV":
-            self.sort_by_iv.setChecked(True)
-        elif self.selected_sort_key == "EV":
-            self.sort_by_ev.setChecked(True)
-        elif self.selected_sort_key == "Friendship":
-            self.sort_by_friendship.setChecked(True)
-        else:  # Date is the default
-            self.sort_by_date.setChecked(True)
-
-        # Connect signals
-        self.sort_group.buttonClicked.connect(self.on_sort_button_clicked)
-
-        sort_radio_layout = QHBoxLayout()
-        sort_radio_layout.addWidget(sort_label)
-        sort_radio_layout.addWidget(self.sort_by_id)
-        sort_radio_layout.addWidget(self.sort_by_name)
-        sort_radio_layout.addWidget(self.sort_by_level)
-        sort_radio_layout.addWidget(self.sort_by_cp)
-        sort_radio_layout.addWidget(self.sort_by_iv)
-        sort_radio_layout.addWidget(self.sort_by_ev)
-        sort_radio_layout.addWidget(self.sort_by_friendship)
-        sort_radio_layout.addWidget(self.sort_by_date)
-        sort_radio_widget = QWidget()
-        sort_radio_widget.setLayout(sort_radio_layout)
+        # Sort control: V2 combo-box (writes selected_sort_key via on_sort_changed).
+        # Covers Date/ID/Name/Level/CP/Friendship/IV/EV and individual stats.
+        sort_combo_layout = QHBoxLayout()
+        sort_combo_layout.addWidget(QLabel("Sort by:"))
+        sort_combo_layout.addWidget(self.sort_combo)
+        sort_combo_widget = QWidget()
+        sort_combo_widget.setLayout(sort_combo_layout)
 
         # Checkboxes for other options
-        is_checked = self.desc_sort.isChecked() if self.desc_sort is not None else False
+        is_checked = self.desc_sort.isChecked() if self.desc_sort is not None else True
         self.desc_sort = QCheckBox("Descending")
         self.desc_sort.setChecked(is_checked)
         self.desc_sort.stateChanged.connect(lambda: self.go_to_box(0))
@@ -590,21 +1080,108 @@ class PokemonPC(QDialog):
         checkboxes_widget.setLayout(checkboxes_layout)
 
         filters_layout.addWidget(checkboxes_widget, 2, 0, 1, 5)
-        filters_layout.addWidget(sort_radio_widget, 3, 0, 1, 5)
+        filters_layout.addWidget(sort_combo_widget, 4, 0, 1, 5)
         parent_layout.addLayout(filters_layout)
 
     def setup_details_panel(self, background_color):
-        if self.pokemon_details_layout is not None:
-            self.details_widget = QWidget()
-            self.details_widget.setLayout(self.pokemon_details_layout)
-            self.details_widget.setMinimumWidth(470)  # Ensure it's visible
-            self.details_widget.setStyleSheet(f"background-color: {background_color};")
-            self.main_layout.addWidget(self.details_widget, 2)
-        else:
-            # Ensure the panel is collapsed if no pokemon is selected
-            self.details_widget = QWidget()
-            self.details_widget.hide()
-            self.main_layout.addWidget(self.details_widget, 0)
+        """Initializes the details panel with a persistent stack to avoid window flickering/resizing."""
+        from PyQt6.QtWidgets import QStackedWidget
+        
+        self.details_panel_stack = QStackedWidget()
+        self.details_panel_stack.setMinimumWidth(470)
+        self.main_container_layout.addWidget(self.details_panel_stack, 2)
+        
+        # Index 0: Placeholder
+        self._placeholder_widget = self._create_placeholder_widget()
+        self.details_panel_stack.addWidget(self._placeholder_widget)
+        
+        # Index 1: Actual Details View (Container for header/stats/footer stacks)
+        self.details_widget = QWidget()
+        self.details_widget.setObjectName("persistentDetails")
+        self.details_container_layout = QVBoxLayout(self.details_widget)
+        self.details_container_layout.setContentsMargins(0, 0, 0, 0)
+        self.details_container_layout.setSpacing(0)
+        
+        from PyQt6.QtWidgets import QGraphicsOpacityEffect
+        self.header_stack = QStackedWidget()
+        self.stats_stack = QStackedWidget()
+        self.footer_stack = QStackedWidget()
+        
+        # Lock the heights to prevent window jumping
+        self.header_stack.setMinimumHeight(420)
+        self.stats_stack.setFixedHeight(220)
+        self.footer_stack.setMinimumHeight(90)
+        
+        self.details_container_layout.addWidget(self.header_stack)
+        self.details_container_layout.addWidget(self.stats_stack)
+        self.details_container_layout.addWidget(self.footer_stack)
+        
+        # Setup opacity effects for header
+        self.header_opacity = QGraphicsOpacityEffect(self.header_stack)
+        self.header_stack.setGraphicsEffect(self.header_opacity)
+        
+        self.details_panel_stack.addWidget(self.details_widget)
+        
+        # Initial state: Show placeholder
+        self.details_panel_stack.setCurrentIndex(0)
+
+    def _create_placeholder_widget(self):
+        """Creates and returns the beautiful placeholder widget."""
+        widget = QWidget()
+        widget.setMinimumHeight(700)
+        widget.setObjectName("detailsPlaceholder")
+
+        # Theme-aware styling
+        is_dark_mode = theme_manager.night_mode
+        bg_color = "#002B5A" if is_dark_mode else "#CCE5FF"
+        text_color = "#94a3b8" if is_dark_mode else "#003A70"
+            
+        widget.setStyleSheet(f"""
+            #detailsPlaceholder {{
+                background-color: {bg_color};
+                border-left: 1px solid {self.theme_vars.get("button_border", "#6A73D9")};
+                border-radius: 12px;
+                margin: 8px;
+            }}
+        """)
+        
+        layout = QVBoxLayout(widget)
+        layout.setContentsMargins(40, 20, 40, 20)
+        layout.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        
+        # Pokéball Icon
+        icon_label = QLabel()
+        pixmap = QPixmap(str(icon_path))
+        if not pixmap.isNull():
+            scaled_pixmap = pixmap.scaled(180, 180, Qt.AspectRatioMode.KeepAspectRatio, Qt.TransformationMode.SmoothTransformation)
+            icon_label.setPixmap(scaled_pixmap)
+        icon_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        
+        # Main Prompt
+        prompt_label = QLabel("Choose a Pokémon to view its stats")
+        prompt_label.setWordWrap(True)
+        prompt_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        prompt_label.setStyleSheet(f"color: {text_color}; font-size: 20px; font-weight: 800; margin-top: 25px;")
+        
+        # Subtext
+        count = getattr(self, "_total_pokemon_count", 0)
+        summary_label = QLabel(f"PC Inventory: {count} Pokémon")
+        summary_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        summary_label.setStyleSheet("color: #64748b; font-size: 13px; font-style: italic; margin-top: 10px;")
+        
+        layout.addStretch(1)
+        layout.addWidget(icon_label)
+        layout.addWidget(prompt_label)
+        layout.addWidget(summary_label)
+        layout.addStretch(1)
+        return widget
+
+    def _show_placeholder_details(self):
+        """Switches the details panel to placeholder mode."""
+        if hasattr(self, "details_panel_stack"):
+            self.details_panel_stack.setCurrentIndex(0)
+        self._selected_individual_id = None
+        self._refresh_slot_selection()
 
     def refresh_pokemon_grid(self, recompute_bff: bool = True):
         """
@@ -619,9 +1196,10 @@ class PokemonPC(QDialog):
                 ``json_extract`` query. A pending dirty flag forces a recompute
                 regardless (e.g. after the window is shown).
         """
-        if self.pokemon_grid is None:
+        if not is_alive(self.pokemon_grid):
             return
 
+        self._pokemon_cache = None  # Invalidate database cache
         clear_layout(self.pokemon_grid)
         self.gif_in_collection = self.settings.get("gui.gif_in_collection")
         # The day/night clock and the friendship-specific evolution badges are
@@ -630,7 +1208,8 @@ class PokemonPC(QDialog):
             "evolution.friendship_time_enabled", True
         )
 
-        pokemon_list = self.fetch_filtered_pokemon()
+        self._filtered_pokemon = self.fetch_filtered_pokemon()
+        pokemon_list = self._filtered_pokemon
         max_box_idx = max(0, (len(pokemon_list) - 1) // (self.n_rows * self.n_cols))
 
         if self.current_box_idx > max_box_idx:
@@ -644,6 +1223,21 @@ class PokemonPC(QDialog):
                     total=max_box_idx + 1,
                 )
             )
+        
+        # Update day/night label
+        if self.time_label is not None:
+            if friendship_time_enabled:
+                self.time_label.setText(current_time_label())
+                self.time_label.show()
+            else:
+                self.time_label.hide()
+
+        # Resolve the BFF (highest-friendship Pokémon)
+        if recompute_bff or self._bff_dirty:
+            self._update_bff()
+        bff_id = self._bff_id
+        
+        self._update_count_label()
 
         # Keep the day/night indicator current on every render, but only when
         # the friendship/time feature is enabled — otherwise hide it.
@@ -675,7 +1269,7 @@ class PokemonPC(QDialog):
             for col in range(self.n_cols):
                 pokemon_idx = row * self.n_cols + col
                 if pokemon_idx >= len(pokemon_list_slice):
-                    empty_label = QLabel()
+                    empty_label = QLabel(self.grid_container)
                     empty_label.setFixedSize(self.slot_size, self.slot_size)
                     self.pokemon_grid.addWidget(
                         empty_label, row, col, alignment=Qt.AlignmentFlag.AlignCenter
@@ -689,8 +1283,10 @@ class PokemonPC(QDialog):
                     pokemon["id"],
                     pokemon.get("shiny", False),
                     pokemon["gender"],
+                    pokemon.get("name"),
                 )
-                pokemon_button = PokemonSlotButton("")
+                pokemon_button = PokemonSlotButton("", self.grid_container)
+                pokemon_button.setObjectName("pokemonSlot")
                 pokemon_button.setFixedSize(self.slot_size, self.slot_size)
 
                 # BFF (highest friendship) takes visual precedence over Favorite.
@@ -699,7 +1295,7 @@ class PokemonPC(QDialog):
                     and pokemon.get("individual_id") == bff_id
                 )
                 if is_bff:
-                    bg = "#FF69B4"  # Hot pink
+                    bg = "#FF69B4"  # Hot pink for BFF
                     h_bg = "#FF8DC7"
                 elif pokemon.get("is_favorite"):
                     bg = theme_vars["favorite_color"]
@@ -707,8 +1303,14 @@ class PokemonPC(QDialog):
                 else:
                     bg = theme_vars["slot_bg_color"]
                     h_bg = theme_vars["hover_color"]
+
+                # Store base colours so _refresh_slot_selection can build the full sheet
+                pokemon_button._base_bg = bg
+                pokemon_button._hover_bg = h_bg
+                pokemon_button._border = border
                 pokemon_button.setStyleSheet(
-                    f"QPushButton {{ background-color: {bg}; border: 1px solid {border}; border-radius: 5px; }} QPushButton:hover {{ background-color: {h_bg}; }}"
+                    f"QPushButton {{ background-color: {bg}; border: 1px solid {border}; border-radius: 5px; }}"
+                    f" QPushButton:hover {{ background-color: {h_bg}; }}"
                 )
 
                 # Connect signals
@@ -722,13 +1324,14 @@ class PokemonPC(QDialog):
                         pb, pkmn
                     )
                 )
+                pokemon_button._individual_id = pokemon["individual_id"]
                 self.pokemon_grid.addWidget(
                     pokemon_button, row, col, alignment=Qt.AlignmentFlag.AlignCenter
                 )
 
                 if self.gif_in_collection:
                     scaled_movie_label = ScaledMovieLabel(
-                        pkmn_image_path, self.slot_size - 10, self.slot_size - 10
+                        pkmn_image_path, self.slot_size - 10, self.slot_size - 10, self.grid_container
                     )
                     scaled_movie_label.setAttribute(
                         Qt.WidgetAttribute.WA_TransparentForMouseEvents
@@ -750,59 +1353,71 @@ class PokemonPC(QDialog):
                 # slot stays clickable), which means *their* tooltips never fire —
                 # we mirror the explanation onto the slot button, which does
                 # receive hover events.
+                # Overlays (Heart for BFF, Star/Moon/Sun for Evolution), added
+                # last so they paint on top of the sprite. V2 renders them as
+                # styled QLabels / a PNG asset; the dynamic status_text from
+                # MAIN's friendship UI is preferred for the hover tooltip when
+                # available, falling back to the translated label.
                 badge_tooltips = []
+                readiness = evolution_readiness(pokemon)
 
-                # Badge overlays, added last so they paint on top of the sprite.
                 # Heart on the BFF slot (top-left corner).
                 if is_bff:
-                    heart_badge = QLabel("💖")
-                    heart_badge.setAttribute(
-                        Qt.WidgetAttribute.WA_TransparentForMouseEvents
+                    heart_badge = QLabel("💖", self.grid_container)
+                    heart_badge.setAttribute(Qt.WidgetAttribute.WA_TransparentForMouseEvents)
+                    heart_badge.setStyleSheet(
+                        "QLabel {"
+                        "  margin-top: 5px;"
+                        "  margin-left: 5px;"
+                        "  background: transparent;"
+                        "}"
                     )
-                    heart_badge.setStyleSheet("background: transparent;")
                     self.pokemon_grid.addWidget(
-                        heart_badge,
-                        row,
-                        col,
-                        alignment=Qt.AlignmentFlag.AlignTop
-                        | Qt.AlignmentFlag.AlignLeft,
+                        heart_badge, row, col,
+                        alignment=Qt.AlignmentFlag.AlignTop | Qt.AlignmentFlag.AlignLeft
                     )
-                    badge_tooltips.append("💖 Your best friend (highest friendship)")
+                    badge_tooltips.append(self.translator.translate("bff_tooltip"))
 
-                # Sparkle on Pokémon ready to evolve (friendship or level-up) —
-                # top-right. The level-up case mostly surfaces rejected/Everstone/
-                # caught-high mons (a plain level-ready mon auto-evolves on level
-                # up). The 🌙/☀️ wait badge below stays friendship-only because
-                # required_time is None for level evolutions.
-                readiness = evolution_readiness(
-                    {
-                        "id": pokemon["id"],
-                        "friendship": pokemon.get("friendship", 0),
-                        "everstone": pokemon.get("everstone", False),
-                        "evolution_rejected": pokemon.get("evolution_rejected", False),
-                        "level": pokemon.get("level", 1),
-                    }
-                )
-                # Friendship/time evolution is behind a master toggle; its badges
-                # only show when enabled. Level-up evolution is base-game and
-                # always shows its ✨ badge.
-                if readiness["ready"] and (
-                    readiness["method"] == "level" or friendship_time_enabled
-                ):
-                    evo_badge = QLabel("✨")
-                    evo_badge.setAttribute(
-                        Qt.WidgetAttribute.WA_TransparentForMouseEvents
-                    )
-                    evo_badge.setStyleSheet("background: transparent;")
-                    evo_badge.setToolTip(readiness["status_text"])
+                # Evolution-ready badge (friendship or level-up). The level-up case
+                # mostly surfaces rejected/Everstone/caught-high mons (a plain
+                # level-ready mon auto-evolves on level up).
+                if readiness["ready"] and (readiness["method"] == "level" or friendship_time_enabled):
+                    evo_badge = QLabel(self.grid_container)
+                    evo_badge.setAttribute(Qt.WidgetAttribute.WA_TransparentForMouseEvents)
+                    evo_badge.setFixedSize(23, 23) # Slightly larger size to accommodate margins cleanly
+
+                    # Load the generated high-quality PNG asset
+                    badge_path = addon_dir / "addon_sprites" / "evolution_indicator.png"
+                    if badge_path.exists():
+                        pixmap = QPixmap(str(badge_path))
+                        scaled_pixmap = pixmap.scaled(
+                            18, 18,
+                            Qt.AspectRatioMode.KeepAspectRatio,
+                            Qt.TransformationMode.SmoothTransformation
+                        )
+                        evo_badge.setPixmap(scaled_pixmap)
+                        evo_badge.setStyleSheet("margin-top: 2px; margin-right: 1px; background: transparent;")
+                    else:
+                        # Fallback to plain text ⇈ if asset is not found
+                        evo_badge.setText("⇈")
+                        evo_badge.setStyleSheet(
+                            "QLabel {"
+                            "  color: #3b82f6;"
+                            "  font-weight: bold;"
+                            "  margin-top: 2px;"
+                            "  margin-right: 1px;"
+                            "  background: transparent;"
+                            "}"
+                        )
+
+                    evo_badge.setAlignment(Qt.AlignmentFlag.AlignCenter)
+                    evo_tip = readiness["status_text"] or self.translator.translate("badge_ready")
+                    evo_badge.setToolTip(evo_tip)
                     self.pokemon_grid.addWidget(
-                        evo_badge,
-                        row,
-                        col,
-                        alignment=Qt.AlignmentFlag.AlignTop
-                        | Qt.AlignmentFlag.AlignRight,
+                        evo_badge, row, col,
+                        alignment=Qt.AlignmentFlag.AlignTop | Qt.AlignmentFlag.AlignRight
                     )
-                    badge_tooltips.append(f"✨ {readiness['status_text']}")
+                    badge_tooltips.append(evo_tip)
                 elif (
                     friendship_time_enabled
                     and readiness["evolvable"]
@@ -814,50 +1429,59 @@ class PokemonPC(QDialog):
                     # blocking. Show a sun/moon so the player knows to come back
                     # during the day / at night (full text is in the details
                     # panel and the day/night label at the top of the PC).
-                    wait_icon = (
-                        "🌙" if readiness["required_time"] == "night" else "☀️"
+                    wait_icon = "🌙" if readiness["required_time"] == "night" else "☀️"
+                    wait_badge = QLabel(wait_icon, self.grid_container)
+                    wait_badge.setAttribute(Qt.WidgetAttribute.WA_TransparentForMouseEvents)
+                    wait_badge.setStyleSheet(
+                        "QLabel {"
+                        "  margin-top: 5px;"
+                        "  margin-right: 5px;"
+                        "  background: transparent;"
+                        "}"
                     )
-                    wait_badge = QLabel(wait_icon)
-                    wait_badge.setAttribute(
-                        Qt.WidgetAttribute.WA_TransparentForMouseEvents
-                    )
-                    wait_badge.setStyleSheet("background: transparent;")
-                    wait_badge.setToolTip(readiness["status_text"])
                     self.pokemon_grid.addWidget(
-                        wait_badge,
-                        row,
-                        col,
-                        alignment=Qt.AlignmentFlag.AlignTop
-                        | Qt.AlignmentFlag.AlignRight,
+                        wait_badge, row, col,
+                        alignment=Qt.AlignmentFlag.AlignTop | Qt.AlignmentFlag.AlignRight
                     )
-                    badge_tooltips.append(f"{wait_icon} {readiness['status_text']}")
+                    # Prefer MAIN's dynamic status_text; fall back to the V2
+                    # translated wait label so the tooltip is always populated.
+                    key = "badge_wait_night" if readiness["required_time"] == "night" else "badge_wait_day"
+                    wait_tip = readiness["status_text"] or self.translator.translate(key)
+                    wait_badge.setToolTip(wait_tip)
+                    badge_tooltips.append(wait_tip)
 
                 # Mirror the badge meaning(s) onto the (hover-capable) slot button
                 # so the otherwise-unreachable badge tooltips become discoverable.
                 if badge_tooltips:
                     pokemon_button.setToolTip("\n".join(badge_tooltips))
+        self._update_count_label()
+        self._refresh_slot_selection()
 
-    def _compute_bff_id(self):
-        """Return the individual_id of the highest-friendship Pokémon.
-
-        The BFF is computed (not stored): the single Pokémon with the highest
-        friendship across the whole collection, ignoring any with friendship 0.
-        Ties are broken deterministically by ``rowid`` (oldest wins). Returns
-        ``None`` if every Pokémon has 0 friendship or on query failure.
-        """
-        try:
-            cursor = mw.ankimon_db.execute(
-                "SELECT individual_id FROM captured_pokemon "
-                "WHERE CAST(json_extract(data, '$.friendship') AS INTEGER) > 0 "
-                "ORDER BY CAST(json_extract(data, '$.friendship') AS INTEGER) DESC, "
-                "rowid ASC LIMIT 1"
-            )
-            row = cursor.fetchone()
-            return row["individual_id"] if row else None
-        except Exception as e:
-            if self.logger:
-                self.logger.log("error", f"Error computing BFF: {e}")
-            return None
+    def _refresh_slot_selection(self):
+        for i in range(self.pokemon_grid.count()):
+            item = self.pokemon_grid.itemAt(i)
+            if not item: continue
+            widget = item.widget()
+            if isinstance(widget, PokemonSlotButton):
+                pkmn_id = getattr(widget, "_individual_id", None)
+                is_selected = (pkmn_id == self._selected_individual_id)
+                bg     = getattr(widget, "_base_bg",  "transparent")
+                h_bg   = getattr(widget, "_hover_bg", "transparent")
+                border = getattr(widget, "_border",   "#888")
+                if is_selected:
+                    sheet = (
+                        f"QPushButton {{ background-color: {bg}; border: 3px solid #ffffff;"
+                        f" border-radius: 8px; }}"
+                        f" QPushButton:hover {{ background-color: rgba(255,255,255,0.15);"
+                        f" border-color: #f0f0f0; }}"
+                    )
+                else:
+                    sheet = (
+                        f"QPushButton {{ background-color: {bg}; border: 1px solid {border};"
+                        f" border-radius: 5px; }}"
+                        f" QPushButton:hover {{ background-color: {h_bg}; }}"
+                    )
+                widget.setStyleSheet(sheet)
 
     def navigate_box(self, delta):
         """
@@ -910,8 +1534,11 @@ class PokemonPC(QDialog):
 
     def refresh_gui(self, recompute_bff: bool = True):
         """
-        Refreshes the entire graphical user interface by rebuilding its structure
-        and then populating the grid.
+        Refreshes the user interface by populating the grid.
+
+        V2 avoids calling create_gui() when a layout already exists, to prevent
+        full layout rebuilds (and the associated flicker). It only builds the
+        layout from scratch the first time.
 
         Args:
             recompute_bff (bool): Forwarded to :meth:`refresh_pokemon_grid`.
@@ -920,8 +1547,14 @@ class PokemonPC(QDialog):
                 via ``refresh_callback``) need a fresh BFF. Non-mutating callers
                 (theme change, selecting a Pokémon) pass ``False``.
         """
-        self.create_gui()
-        self.refresh_pokemon_grid(recompute_bff=recompute_bff)
+        self._pokemon_cache = None  # Invalidate database cache
+        if not self.layout():
+            self.create_gui()
+        else:
+            self.refresh_pokemon_grid(recompute_bff=recompute_bff)
+            # If no Pokémon is selected (e.g. after account swap), refresh the placeholder
+            if self._selected_individual_id is None:
+                self._show_placeholder_details()
         self.layout().invalidate()
         self.layout().activate()
 
@@ -989,17 +1622,48 @@ class PokemonPC(QDialog):
         return pixmap
 
     def fetch_filtered_pokemon(self) -> list:
-        """Dynamically builds a SQL query to filter and sort Pokemon, fetching only the lightweight stub data needed for the grid."""
+        """
+        Dynamically builds a SQL query to filter and sort Pokemon, fetching only the lightweight stub data needed for the grid.
+        Results are cached to improve performance when navigating boxes or selecting Pokémon.
+        """
+        # Always fetch latest count to detect DB changes
+        try:
+            cursor = mw.ankimon_db.execute("SELECT COUNT(*) FROM captured_pokemon")
+            self._total_pokemon_count = cursor.fetchone()[0]
+        except Exception:
+            pass
+
+        # Build current filter state for cache check
+        current_state = {
+            "db": mw.ankimon_db.db_path.name,
+            "search": self.search_edit.text() if self.search_edit else "",
+            "type": self.type_combo.currentText() if self.type_combo else "All types",
+            "gen": self.generation_combo.currentText() if self.generation_combo else "All gens",
+            "tier": self.tier_combo.currentText() if self.tier_combo else "All tiers",
+            "shiny": self.filter_shiny.isChecked() if self.filter_shiny else False,
+            "favorite": self.filter_favorites.isChecked() if self.filter_favorites else False,
+            "holding": self.filter_is_holding_item.isChecked() if self.filter_is_holding_item else False,
+            "sort": self.sort_combo.currentText() if self.sort_combo else "Date",
+            "desc": self.desc_sort.isChecked() if self.desc_sort else False,
+            "count": self._total_pokemon_count # Force refresh if count changes
+        }
+
+        if self._pokemon_cache is not None and self._last_filter_state == current_state:
+            return self._pokemon_cache
+
         # Base query mapping direct virtual columns where available
         query_parts = [
             "SELECT individual_id, name, level, pokedex_id as id, shiny as shiny, "
             "rowid as original_index, json_extract(data, '$.nickname') as nickname, "
             "json_extract(data, '$.gender') as gender, json_extract(data, '$.is_favorite') as is_favorite, "
             "json_extract(data, '$.held_item') as held_item, "
+            "json_extract(data, '$.captured_date') as captured_date, "
             "json_extract(data, '$.friendship') as friendship, "
             "json_extract(data, '$.everstone') as everstone, "
             "json_extract(data, '$.evolution_rejected') as evolution_rejected, "
-            "json_extract(data, '$.iv') as iv_json, json_extract(data, '$.ev') as ev_json "
+            "json_extract(data, '$.iv') as iv_json, json_extract(data, '$.ev') as ev_json, "
+            "json_extract(data, '$.base_stats') as base_stats_json, json_extract(data, '$.stats') as stats_json, json_extract(data, '$.nature') as nature, "
+            "json_extract(data, '$.attacks') as attacks_json "
             "FROM captured_pokemon WHERE 1=1"
         ]
         params = []
@@ -1054,9 +1718,23 @@ class PokemonPC(QDialog):
                     params.extend([start_id, end_id])
 
         # Sorting
-        sort_key_str = self.selected_sort_key.lower() if hasattr(self, 'selected_sort_key') else "date"
+        sort_key_raw = self.selected_sort_key if hasattr(self, 'selected_sort_key') else "Date"
+        sort_key_str = sort_key_raw.lower()
         reverse = self.desc_sort is not None and self.desc_sort.isChecked()
         direction = "DESC" if reverse else "ASC"
+
+        # Determine if we use SQL sorting or Python sorting
+        use_python_sort = False
+        stat_map = {
+            "hp": "hp",
+            "attack": "atk",
+            "defense": "def",
+            "sp. atk": "spa",
+            "sp. def": "spd",
+            "speed": "spe"
+        }
+        
+        target_stat = stat_map.get(sort_key_str)
 
         if sort_key_str == "date":
             order_clause = f"ORDER BY original_index {direction}"
@@ -1067,15 +1745,27 @@ class PokemonPC(QDialog):
         elif sort_key_str == "id":
             order_clause = f"ORDER BY pokedex_id {direction}"
         elif sort_key_str == "cp":
-            order_clause = f"ORDER BY CAST(json_extract(data, '$.cp') AS REAL) {direction}"
-        elif sort_key_str == "friendship":
-            # COALESCE so a missing/NULL friendship sorts as 0 (grouped with the
-            # zero-friendship Pokémon) instead of NULL drifting to an extreme
-            # end of the list under ASC/DESC.
-            order_clause = f"ORDER BY CAST(COALESCE(json_extract(data, '$.friendship'), 0) AS INTEGER) {direction}"
-        else:
-            # For IV/EV or default, sort by original_index first, then override in Python if needed
+            # V2 sorts CP in Python so it uses the current CP formula
+            # (calculate_cp_from_dict) rather than a possibly-stale stored value.
+            use_python_sort = True
             order_clause = f"ORDER BY original_index {direction}"
+        elif sort_key_str in ["iv (total)", "ev (total)", "iv", "ev"]:
+            # Fallback for legacy keys if they appear
+            use_python_sort = True
+            order_clause = f"ORDER BY original_index {direction}"
+        elif target_stat:
+            use_python_sort = True
+            order_clause = f"ORDER BY original_index {direction}"
+        elif sort_key_str == "friendship":
+            # Friendship sort is done in Python (the _sort_value is the raw
+            # friendship, missing/NULL coerced to 0) so it integrates with the
+            # shared results.sort tail below.
+            use_python_sort = True
+            order_clause = f"ORDER BY original_index {direction}"
+        else:
+            # Default to Date
+            order_clause = f"ORDER BY original_index {direction}"
+            
 
         query = " ".join(query_parts) + " " + order_clause
 
@@ -1094,22 +1784,65 @@ class PokemonPC(QDialog):
                     "gender": row["gender"],
                     "is_favorite": bool(row["is_favorite"]),
                     "held_item": row["held_item"],
-                    "friendship": row["friendship"] or 0,
+                    "friendship": int(row["friendship"] or 0),
                     "everstone": bool(row["everstone"]),
                     "evolution_rejected": bool(row["evolution_rejected"]),
+                    "attacks": json.loads(row["attacks_json"]) if row["attacks_json"] else [],
                 }
 
-                # Pre-calculate sums for sorting if needed
-                if sort_key_str in ["iv", "ev"]:
-                    stats_json = row[f"{sort_key_str}_json"]
-                    stats_dict = json.loads(stats_json) if stats_json else {}
-                    p["_sort_value"] = sum(stats_dict.values()) if isinstance(stats_dict, dict) else sum(stats_dict) if isinstance(stats_dict, list) else 0
-                
+                # Pre-calculate sums/stats for sorting if needed
+                if use_python_sort:
+                    if sort_key_str == "friendship":
+                        p["_sort_value"] = row["friendship"] or 0
+                    elif "iv" in sort_key_str or "ev" in sort_key_str:
+                        key = "iv" if "iv" in sort_key_str else "ev"
+                        stats_json = row[f"{key}_json"]
+                        stats_dict = json.loads(stats_json) if stats_json else {}
+                        p["_sort_value"] = sum(stats_dict.values()) if isinstance(stats_dict, dict) else sum(stats_dict) if isinstance(stats_dict, list) else 0
+                    elif target_stat:
+                        # Individual Stat sorting
+                        level = row["level"]
+                        nature = row["nature"] or "serious"
+
+                        iv_dict = json.loads(row["iv_json"]) if row["iv_json"] else {}
+                        ev_dict = json.loads(row["ev_json"]) if row["ev_json"] else {}
+                        base_stats_dict = json.loads(row["base_stats_json"]) if row["base_stats_json"] else {}
+                        stats_dict = json.loads(row["stats_json"]) if row["stats_json"] else {}
+
+                        # Use PokemonObject's calculation logic (with fallback for legacy stats)
+                        base_val = (base_stats_dict or stats_dict).get(target_stat, 1)
+                        iv_val = iv_dict.get(target_stat, 0)
+                        ev_val = ev_dict.get(target_stat, 0)
+
+                        p["_sort_value"] = PokemonObject.calc_stat(target_stat, base_val, level, iv_val, ev_val, nature)
+                    elif sort_key_str == "cp":
+                        # Re-calculate CP for sorting to ensure it uses the new formula
+                        iv_dict = json.loads(row["iv_json"]) if row["iv_json"] else {}
+                        ev_dict = json.loads(row["ev_json"]) if row["ev_json"] else {}
+                        base_stats_dict = json.loads(row["base_stats_json"]) if row["base_stats_json"] else {}
+                        stats_dict = json.loads(row["stats_json"]) if row["stats_json"] else {}
+
+                        # Mirror calculate_cp_from_dict's contract: prefer base_stats, else stats fallback
+                        cp_dict = {
+                            "level": row["level"],
+                            "iv": iv_dict,
+                            "ev": ev_dict
+                        }
+                        if base_stats_dict:
+                            cp_dict["base_stats"] = base_stats_dict
+                        else:
+                            cp_dict["stats"] = stats_dict
+                        p["_sort_value"] = calculate_cp_from_dict(cp_dict)
+
                 results.append(p)
                 
-            # Perform Python sorting for IV/EV
-            if sort_key_str in ["iv", "ev"]:
+            # Perform Python sorting
+            if use_python_sort:
                 results.sort(key=lambda x: x.get("_sort_value", 0), reverse=reverse)
+            
+            # Cache the result
+            self._pokemon_cache = results
+            self._last_filter_state = current_state
             
             return results
         except Exception as e:
@@ -1117,8 +1850,8 @@ class PokemonPC(QDialog):
                 self.logger.log("error", f"Error fetching filtered pokemon: {e}")
             return []
 
-    def on_sort_button_clicked(self, button):
-        self.selected_sort_key = button.text()
+    def on_sort_changed(self, text):
+        self.selected_sort_key = text
         self.go_to_box(0)
 
     def show_actions_submenu(self, button: QPushButton, pokemon: dict[str, Any]):
@@ -1188,14 +1921,12 @@ class PokemonPC(QDialog):
     def show_pokemon_details(self, pokemon_stub):
         """
         Displays detailed information about a specific Pokémon in the right-hand details panel.
-
-        The method prepares detailed stats by merging base stats or stats with experience points,
-        then updates the `self.details_layout` with a `PokemonCollectionDetails` layout.
-
-        Args:
-            pokemon_stub (dict): A lightweight dictionary containing the pokemon's `individual_id`.
+        Only the header and footer parts animate; the stats box stays persistent for smooth bar sliding.
         """
-        pokemon = mw.ankimon_db.get_pokemon(pokemon_stub['individual_id'])
+        individual_id = pokemon_stub.get('individual_id')
+        is_same_pokemon = (individual_id is not None and individual_id == getattr(self, "_selected_individual_id", None))
+        
+        pokemon = mw.ankimon_db.get_pokemon(individual_id)
         if not pokemon:
             return
 
@@ -1206,7 +1937,32 @@ class PokemonPC(QDialog):
         else:
             raise ValueError("Could not get the stats information of the Pokémon")
 
-        self.pokemon_details_layout = PokemonCollectionDetails(
+        # Switch to details view if not already there
+        if hasattr(self, "details_panel_stack"):
+            self.details_panel_stack.setCurrentIndex(1)
+
+        # Get previous stats for sliding bar animation
+        old_stats = getattr(self, "_last_pokemon_stats", None)
+
+        def trigger_evo(method):
+            """Manual evolution trigger from the PC Details panel."""
+            readiness = evolution_readiness(pokemon)
+            if readiness["ready"]:
+                evo_window = EvoWindow(
+                    self.logger,
+                    self.settings,
+                    self.main_pokemon,
+                    self.translator,
+                    self.reviewer_obj,
+                    self.test_window,
+                    self.achievements,
+                )
+                evo_window.ask_pokemon_evo(
+                    pokemon["individual_id"], pokemon["id"], readiness["evo_id"]
+                )
+
+        # Build new widgets from components
+        h_widget, stats_tabs, f_widget, current_stats = PokemonCollectionDetails(
             name=pokemon["name"],
             level=pokemon["level"],
             id=pokemon["id"],
@@ -1230,24 +1986,216 @@ class PokemonPC(QDialog):
             gif_in_collection=self.gif_in_collection,
             remove_levelcap=self.settings.get("misc.remove_level_cap"),
             logger=self.logger,
-            refresh_callback=self.refresh_gui,
+            refresh_callback=lambda: (self.refresh_gui(), self.show_pokemon_details(pokemon_stub)),
             initial_tab_index=self.current_stats_tab_index,
             tab_changed_callback=self.on_stats_tab_changed,
             nature=pokemon.get("nature", "serious"),
             base_stats=pokemon.get("base_stats"),
+            old_stats=old_stats,
             friendship=pokemon.get("friendship", 0),
             friendship_time_enabled=self.settings.get(
                 "evolution.friendship_time_enabled", True
             ),
+            trigger_evo_callback=trigger_evo,
         )
-        # Selecting a Pokémon only opens the details panel — no data change, so
-        # reuse the cached BFF. (The refresh_callback above keeps the default
-        # recompute=True for mutating actions like release/trade/rename/evolve.)
-        self.refresh_gui(recompute_bff=False)
+
+        self._last_pokemon_stats = current_stats
+        
+        # Update Stacks (Zero Flicker Swap)
+        def swap_stack_widget(stack, new_widget):
+            old_widget = stack.currentWidget()
+            stack.addWidget(new_widget)
+            stack.setCurrentWidget(new_widget)
+            if old_widget:
+                stack.removeWidget(old_widget)
+                old_widget.deleteLater()
+
+        # 1. Update Header
+        swap_stack_widget(self.header_stack, h_widget)
+        
+        # 2. Update Stats (No fade)
+        swap_stack_widget(self.stats_stack, stats_tabs)
+        
+        # 3. Update Footer
+        swap_stack_widget(self.footer_stack, f_widget)
+        
+        # --- Post-processing: Move Manager (Improvement B) ---
+        self._integrate_move_manager(pokemon)
+        
+        # --- Post-processing: Nature Indicators (Improvement G) ---
+        self._apply_nature_indicators(pokemon)
+
+        # Set initial state for animation
+        if not is_same_pokemon:
+            self.header_opacity.setOpacity(0.0)
+            
+        self.details_widget.show()
+
+        # Force layout recalculation
+        self.details_container_layout.activate()
+
+        # Animation Handling
+        from PyQt6.QtCore import QPropertyAnimation, QEasingCurve
+        
+        if not is_same_pokemon:
+            # Header Animation
+            self.header_fade = QPropertyAnimation(self.header_opacity, b"opacity")
+            self.header_fade.setDuration(400)
+            self.header_fade.setStartValue(0.0)
+            self.header_fade.setEndValue(1.0)
+            self.header_fade.setEasingCurve(QEasingCurve.Type.OutCubic)
+            self.header_fade.start()
+        else:
+            self.header_opacity.setOpacity(1.0)
+
+            
+        # Selection indicator
+        self._selected_individual_id = pokemon.get("individual_id")
+        self._refresh_slot_selection()
+
+    def _integrate_move_manager(self, pokemon):
+        # Traverse layout to find TopR_layout_Box
+        try:
+            # NEW STRUCTURE: header_stack -> currentWidget (h_widget) -> layout -> first_layout -> TopR_layout_Box
+            h_widget = self.header_stack.currentWidget()
+            if h_widget:
+                h_layout = h_widget.layout()
+                # h_layout -> name_label (index 0), first_layout (index 1)
+                if h_layout and h_layout.count() > 1:
+                    first_layout_item = h_layout.itemAt(1)
+                    if first_layout_item and first_layout_item.layout():
+                        first_layout = first_layout_item.layout()
+                        # TopR_widget is at index 1 of first_layout (a QWidget wrapping TopR_layout_Box)
+                        top_r_item = first_layout.itemAt(1)
+                        if top_r_item and top_r_item.widget():
+                            top_r_layout = top_r_item.widget().layout()
+
+                    
+                    # Add new Move Manager
+                    def _save_pokemon(data):
+                        mw.ankimon_db.save_pokemon(data)
+                        self.show_pokemon_details(pokemon)
+
+                    # Initialize FIRST (this might be slightly heavy)
+                    new_move_manager = MoveManagerWidget(
+                        individual_id=pokemon["individual_id"],
+                        pkmn_id=pokemon["id"],
+                        logger=self.logger,
+                        save_fn=_save_pokemon,
+                        parent=self.details_widget
+                    )
+                    self.move_manager = new_move_manager
+
+                    # Hide old buttons and label ONLY after the new one is ready
+                    evo_btn = None
+                    for i in range(top_r_layout.count()):
+                        item = top_r_layout.itemAt(i)
+                        if item and item.widget():
+                            if item.widget().objectName() == "evolveNowButton":
+                                evo_btn = item.widget()
+                                continue
+                            item.widget().hide()
+                    
+                    top_r_layout.addWidget(self.move_manager)
+                    if evo_btn:
+                        top_r_layout.removeWidget(evo_btn)
+                        top_r_layout.addWidget(evo_btn)
+
+        except Exception as e:
+            self.logger.log("error", f"Error integrating move manager: {e}")
+
+    def _apply_nature_indicators(self, pokemon):
+        # Normalize to Title Case so lowercase DB values (e.g. "adamant") match
+        raw_nature = pokemon.get("nature", "serious") or "serious"
+        nature = raw_nature.strip().title()
+        boosted, lowered = NATURE_EFFECTS.get(nature, ("", ""))
+        if not boosted and not lowered:
+            return
+
+        try:
+            # Use the persistent stack to find the active stats tab widget
+            stats_tabs = self.stats_stack.currentWidget()
+            if stats_tabs and isinstance(stats_tabs, QTabWidget):
+                # The first tab is typically the "Base Stats" or "Stats" page
+                stats_widget = stats_tabs.widget(0)
+                labels = stats_widget.findChildren(QLabel)
+
+                for label in labels:
+                    # Strip any previously applied indicators before matching
+                    raw_text = label.text()
+                    clean_text = raw_text.replace(" ▲", "").replace(" ▼", "").replace(":", "").strip()
+                    clean_text_lower = clean_text.lower()
+                    
+                    stat_key = None
+                    # First try exact match in lower case
+                    for k, v in DISPLAY_TO_STAT_KEY.items():
+                        if k.lower() == clean_text_lower:
+                            stat_key = v
+                            break
+                    
+                    if not stat_key:
+                        # Fallback for substring match (e.g. "Sp. Atk" in "Special-attack" or vice versa)
+                        for k, v in DISPLAY_TO_STAT_KEY.items():
+                            kl = k.lower()
+                            if kl in clean_text_lower or clean_text_lower in kl:
+                                stat_key = v
+                                break
+
+
+                    if stat_key:
+                        if stat_key == boosted:
+                            label.setText(f"{clean_text} ▲")
+                            label.setStyleSheet("color: #4ade80; font-weight: bold;")
+                        elif stat_key == lowered:
+                            label.setText(f"{clean_text} ▼")
+                            label.setStyleSheet("color: #f87171; font-weight: bold;")
+        except Exception as e:
+            self.logger.log("error", f"Error applying nature indicators: {e}")
+            
+    def _update_count_label(self):
+        if not hasattr(self, "count_label") or not is_alive(self.count_label):
+            return
+        
+        shown = len(self._filtered_pokemon) if hasattr(self, "_filtered_pokemon") else 0
+        
+        # Get total count
+        try:
+            cursor = mw.ankimon_db.execute("SELECT COUNT(*) FROM captured_pokemon")
+            total = cursor.fetchone()[0]
+        except Exception:
+            total = shown
+            
+        self.count_label.setText(f"Showing {shown} / {total} Pokémon")
 
     def on_stats_tab_changed(self, index: int):
         """Callback to remember which tab (Stats/IV/EV) is selected."""
         self.current_stats_tab_index = index
+
+    def _update_bff(self):
+        """Resolve the BFF (highest-friendship Pokémon) and update state."""
+        self._bff_id = self._compute_bff_id()
+        self._bff_dirty = False
+
+    def _compute_bff_id(self):
+        """Return the individual_id of the highest-friendship Pokémon."""
+        try:
+            cursor = mw.ankimon_db.execute(
+                "SELECT individual_id FROM captured_pokemon "
+                "WHERE CAST(json_extract(data, '$.friendship') AS INTEGER) > 0 "
+                "ORDER BY CAST(json_extract(data, '$.friendship') AS INTEGER) DESC, "
+                "rowid ASC LIMIT 1"
+            )
+            row = cursor.fetchone()
+            return row["individual_id"] if row else None
+        except Exception as e:
+            if self.logger:
+                self.logger.log("error", f"Error computing BFF: {e}")
+            return None
+
+    def _update_time_display(self):
+        """Update the day/night label with current time."""
+        if self.time_label is not None and is_alive(self.time_label):
+            self.time_label.setText(current_time_label())
 
     def toggle_favorite(self, pokemon: dict[list, Any]):
         """
@@ -1318,6 +2266,12 @@ class PokemonPC(QDialog):
             )
             self.refresh_gui()
 
+            # Refresh open item/bag/shop windows
+            if hasattr(mw, "item_window") and is_alive(mw.item_window):
+                mw.item_window.renewWidgets()
+            if hasattr(mw, "items_web_window") and is_alive(mw.items_web_window):
+                mw.items_web_window.update_ui_data()
+
         give_item_window = GiveItemWindow(
             item_list=items_names,
             give_item_func=lambda item_name: func(item_name),
@@ -1363,6 +2317,12 @@ class PokemonPC(QDialog):
         # Refreshing the PC after giving the item is important in order to update the pokemon information without the held item
         self.refresh_gui()
 
+        # Refresh open item/bag/shop windows
+        if hasattr(mw, "item_window") and is_alive(mw.item_window):
+            mw.item_window.renewWidgets()
+        if hasattr(mw, "items_web_window") and is_alive(mw.items_web_window):
+            mw.items_web_window.update_ui_data()
+
     def ensure_data_integrity(self):
         """
         Iterates through all Pokémon to ensure they have required non-stat fields,
@@ -1401,6 +2361,7 @@ class PokemonPC(QDialog):
 
         is_migration_needed = any(
             key not in pokemon
+
             for pokemon in pokemon_list
             if isinstance(pokemon, dict)
             for key in default_keys
@@ -1439,6 +2400,13 @@ class PokemonPC(QDialog):
             if not isinstance(pokemon, dict):
                 continue
 
+            # Always recalculate CP to ensure it matches the current formula in business.py
+            old_cp = pokemon.get("cp")
+            new_cp = calculate_cp_from_dict(pokemon)
+            if old_cp != new_cp:
+                needs_update = True
+                pokemon_list[i]["cp"] = new_cp
+
             for key, default_generator in default_values.items():
                 if key not in pokemon:
                     needs_update = True
@@ -1457,10 +2425,6 @@ class PokemonPC(QDialog):
             clear_layout(self.pokemon_details_layout)
             self.details_widget.setFixedSize(0, 0)
             self.pokemon_details_layout = None
-
-    def closeEvent(self, event: QCloseEvent):
-        self.on_window_close()
-        event.accept()  # Accept the close event
 
     def reject(self):  # Called when pressing Escape
         self.on_window_close()

--- a/src/Ankimon/pyobj/pokemon_trade.py
+++ b/src/Ankimon/pyobj/pokemon_trade.py
@@ -1,7 +1,7 @@
 import json
 import hashlib
 import requests
-from PyQt6.QtWidgets import QDialog, QVBoxLayout, QLabel, QLineEdit, QPushButton, QHBoxLayout, QFrame
+from PyQt6.QtWidgets import QDialog, QVBoxLayout, QLabel, QLineEdit, QPushButton, QHBoxLayout, QFrame, QCheckBox
 from PyQt6.QtGui import QPixmap, QFont, QIcon, QColor
 from PyQt6.QtCore import QSize, Qt
 from aqt.utils import showWarning, showInfo
@@ -56,7 +56,9 @@ def add_pokemon_to_collection(new_pokemon, refresh_callback=None, parent_window=
             refresh_callback()
 
         from ..singletons import pokemon_pc
-        pokemon_pc.refresh_pokemon_grid()
+        from ..utils import is_alive
+        if is_alive(pokemon_pc):
+            pokemon_pc.refresh_pokemon_grid()
     except Exception as e:
         show_warning_with_traceback(parent=parent_window, exception=e, message="Error adding Pokemon to collection")
 
@@ -140,11 +142,50 @@ def check_and_award_monthly_pokemon(logger):
         # Still failing silently on the user's end, but with more detailed logs for debugging.
         pass
 
+def parse_to_canonical(code_str):
+    if not code_str:
+        return None
+    parts = [p.strip() for p in code_str.strip().split(',') if p.strip()]
+    if not parts:
+        return None
+    try:
+        if parts[0] == "-200":
+            if len(parts) < 18:
+                return None
+            species_id = int(parts[1])
+            level = int(parts[2])
+            gender = int(parts[3])
+            shiny = int(parts[4])
+            evs = [int(x) for x in parts[5:11]]
+            ivs = [int(x) for x in parts[11:17]]
+            nature = int(parts[17])
+            attacks = [int(x) for x in parts[18:]]
+        else:
+            if len(parts) < 16:
+                return None
+            species_id = int(parts[0])
+            level = int(parts[1])
+            gender = int(parts[2])
+            shiny = int(parts[3])
+            evs = [int(x) for x in parts[4:10]]
+            ivs = [int(x) for x in parts[10:16]]
+            nature = 12  # Default to Serious
+            attacks = [int(x) for x in parts[16:]]
+            
+        while len(attacks) < 4:
+            attacks.append(33)
+        attacks = attacks[:4]
+        
+        canonical = [species_id, level, gender, shiny] + evs + ivs + [nature] + attacks
+        return ",".join(map(str, canonical))
+    except Exception:
+        return None
+
 
 class PokemonTrade:
     TRADE_VERSION = "02"
 
-    def __init__(self, name, id, level, ability, iv, ev, gender, attacks, individual_id, shiny, logger, refresh_callback, parent_window=None):
+    def __init__(self, name, id, level, ability, iv, ev, gender, attacks, individual_id, shiny, logger, refresh_callback, parent_window=None, nature="serious"):
         self.name = name
         self.id = id
         self.level = level
@@ -155,6 +196,7 @@ class PokemonTrade:
         self.attacks = attacks
         self.individual_id = individual_id
         self.shiny = shiny
+        self.nature = nature
         self.refresh_callback = refresh_callback
         self.logger = logger
         self.parent_window = parent_window
@@ -214,7 +256,7 @@ class PokemonTrade:
         sprite_size = QSize(64, 64)
         your_pokemon_sprite_label.setMaximumSize(sprite_size)
         your_pokemon_sprite_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
-        your_pokemon_gif_path = get_sprite_path(side="front", sprite_type="gif", id=self.id, shiny=getattr(self, "shiny", False), gender=self.gender)
+        your_pokemon_gif_path = get_sprite_path(side="front", sprite_type="gif", id=self.id, shiny=getattr(self, "shiny", False), gender=self.gender, pokemon_name=self.name)
         
         your_pokemon_movie = QMovie(your_pokemon_gif_path)
         def set_bw_frame():
@@ -265,22 +307,39 @@ class PokemonTrade:
         self.trade_code_layout = QVBoxLayout()
         self.trade_code_layout.setSpacing(5)
 
+        self.legacy_checkbox = QCheckBox("Legacy Mode (Trade with Official Release)")
+        self.legacy_checkbox.setFont(QFont("Arial", 10))
+        self.trade_code_layout.addWidget(self.legacy_checkbox)
+
         self.your_code_label = QLabel("Your Trade Code:")
         self.your_code_label.setFont(QFont("Arial", 11, QFont.Weight.Bold))
         self.trade_code_layout.addWidget(self.your_code_label)
 
         self.code_display_layout = QHBoxLayout()
-        clipboard_info = f"{self.id},{self.level},{self.format_gender()},{self.format_shiny()},{self.ev_string()},{self.iv_string()},{self.attack_ids()}"
-        self.trade_code_display = QLineEdit(clipboard_info)
+        self.trade_code_display = QLineEdit()
         self.trade_code_display.setReadOnly(True)
         self.trade_code_display.setFont(QFont("Courier New", 10))
         self.code_display_layout.addWidget(self.trade_code_display)
 
         self.copy_button = QPushButton("Copy")
         self.copy_button.setToolTip("Copy the trade code to your clipboard")
-        self.copy_button.clicked.connect(lambda: self.copy_to_clipboard(clipboard_info))
         self.code_display_layout.addWidget(self.copy_button)
         self.trade_code_layout.addLayout(self.code_display_layout)
+
+        def update_my_trade_code():
+            if self.legacy_checkbox.isChecked():
+                code = f"{self.id},{self.level},{self.format_gender()},{self.format_shiny()},{self.ev_string()},{self.iv_string()},{self.attack_ids()}"
+            else:
+                code = f"-200,{self.id},{self.level},{self.format_gender()},{self.format_shiny()},{self.ev_string()},{self.iv_string()},{self.format_nature()},{self.attack_ids()}"
+            self.trade_code_display.setText(code)
+            try:
+                self.copy_button.clicked.disconnect()
+            except TypeError:
+                pass
+            self.copy_button.clicked.connect(lambda: self.copy_to_clipboard(code))
+
+        self.legacy_checkbox.stateChanged.connect(lambda _: update_my_trade_code())
+        update_my_trade_code()
 
         main_layout.addLayout(self.trade_code_layout)
 
@@ -304,16 +363,23 @@ class PokemonTrade:
     def generate_and_show_passwords(self, window):
         code1 = self.trade_code_display.text().strip()
         code2 = self.trade_code_input.text().strip()
-        if not code1 or not code2 or len(code2) < 16:
+        if not code1 or not code2:
             showWarning("Please enter a valid trade code from the other user.")
             return
 
-        parts = code2.split(',')
-        if len(parts) > 0 and parts[0].isdigit():
-            incoming_id = int(parts[0])
-            if incoming_id == self.id:
-                showWarning("You cannot trade with a Pokémon of the same species (ID) as the one you're trading away!")
-                return
+        canonical1 = parse_to_canonical(code1)
+        canonical2 = parse_to_canonical(code2)
+
+        if not canonical1 or not canonical2:
+            showWarning("Invalid trade code format. Please check the code.")
+            return
+
+        # Same species check using canonical species IDs
+        id1 = int(canonical1.split(',')[0])
+        id2 = int(canonical2.split(',')[0])
+        if id1 == id2:
+            showWarning("You cannot trade with a Pokémon of the same species (ID) as the one you're trading away!")
+            return
 
         self.your_code_label.hide()
         self.trade_code_display.hide()
@@ -322,18 +388,35 @@ class PokemonTrade:
         self.trade_code_input.hide()
         self.trade_button.hide()
 
-        codes = sorted([code1, code2])
-        combo = codes[0] + "|" + codes[1]
-        hash_digest = hashlib.sha256(combo.encode()).hexdigest()
-        part1 = hash_digest[:len(hash_digest) // 2]
-        part2 = hash_digest[len(hash_digest) // 2:]
+        # Check if we should use legacy hashing (checkbox checked OR either code is unversioned)
+        is_legacy = self.legacy_checkbox.isChecked() or (not code1.startswith("-200")) or (not code2.startswith("-200"))
 
-        if code1 < code2:
-            my_part = part1
-            self._their_password_part = part2
+        if is_legacy:
+            codes = sorted([code1, code2])
+            combo = codes[0] + "|" + codes[1]
+            hash_digest = hashlib.sha256(combo.encode()).hexdigest()
+            part1 = hash_digest[:len(hash_digest) // 2]
+            part2 = hash_digest[len(hash_digest) // 2:]
+
+            if code1 < code2:
+                my_part = part1
+                self._their_password_part = part2
+            else:
+                my_part = part2
+                self._their_password_part = part1
         else:
-            my_part = part2
-            self._their_password_part = part1
+            codes = sorted([canonical1, canonical2])
+            combo = codes[0] + "|" + codes[1]
+            hash_digest = hashlib.sha256(combo.encode()).hexdigest()
+            part1 = hash_digest[:len(hash_digest) // 2]
+            part2 = hash_digest[len(hash_digest) // 2:]
+
+            if canonical1 < canonical2:
+                my_part = part1
+                self._their_password_part = part2
+            else:
+                my_part = part2
+                self._their_password_part = part1
 
         my_part += self.TRADE_VERSION
         self._their_password_part += self.TRADE_VERSION
@@ -391,9 +474,9 @@ class PokemonTrade:
 
         if their_part_entered == self._their_password_part:
             code = self.trade_code_input.text().strip()
-            parts = code.split(',')
-            if len(parts) > 0 and parts[0].isdigit():
-                incoming_id = int(parts[0])
+            canonical = parse_to_canonical(code)
+            if canonical:
+                incoming_id = int(canonical.split(',')[0])
                 if incoming_id == self.id:
                     showWarning("You cannot trade with a Pokémon of the same species (ID) as the one you're trading away!")
                     return
@@ -407,22 +490,27 @@ class PokemonTrade:
         showInfo("Trade code copied to clipboard!")
 
     def update_other_pokemon_sprite(self, code):
-        from PyQt6.QtGui import QMovie
+        from PyQt6.QtGui import QMovie, QPixmap
         try:
             sprite_size = QSize(64, 64)
-            parts = code.split(',')
             self.other_pokemon_sprite_label.clear()
             self.other_pokemon_sprite_label.setPixmap(QPixmap())
             self.other_pokemon_name_label.setText("")
-            if len(parts) > 0 and parts[0].isdigit():
+            
+            canonical = parse_to_canonical(code)
+            if canonical:
+                parts = canonical.split(',')
                 pokemon_id = int(parts[0])
-                other_gender = "M"
-                other_shiny = False
-                if len(parts) > 2:
-                    gender_map = {"0": "M", "1": "F", "2": "N"}
-                    other_gender = gender_map.get(parts[2], "M")
+                gender_id = parts[2]
+                shiny_val = int(parts[3])
                 
-                sprite_path = get_sprite_path(side="front", sprite_type="gif", id=pokemon_id, shiny=other_shiny, gender=other_gender)
+                gender_map = {"0": "M", "1": "F", "2": "N"}
+                other_gender = gender_map.get(gender_id, "M")
+                other_shiny = (shiny_val == 1)
+                
+                other_name = self.get_pokemon_name_by_id(pokemon_id)
+                self.other_pokemon_name_label.setText(other_name)
+                sprite_path = get_sprite_path(side="front", sprite_type="gif", id=pokemon_id, shiny=other_shiny, gender=other_gender, pokemon_name=other_name)
                 
                 if hasattr(self, '_other_pokemon_movie') and self._other_pokemon_movie is not None:
                     self._other_pokemon_movie.stop()
@@ -440,8 +528,6 @@ class PokemonTrade:
                 self.other_pokemon_sprite_label.setMovie(other_pokemon_movie)
                 other_pokemon_movie.start()
                 set_other_frame()
-                name = self.get_pokemon_name_by_id(pokemon_id)
-                self.other_pokemon_name_label.setText(name if name else "Unknown Pokémon")
             else:
                 self.other_pokemon_sprite_label.setPixmap(QPixmap(":/icons/pokeball.png").scaled(QSize(64, 64), Qt.AspectRatioMode.KeepAspectRatio, Qt.TransformationMode.SmoothTransformation))
                 self.other_pokemon_name_label.setText("")
@@ -453,6 +539,11 @@ class PokemonTrade:
         try:
             with open(self.pokedex_path, 'r', encoding='utf-8') as file:
                 pokedex = json.load(file)
+                # First pass: check actual_id for precise form match (e.g. Mega Diancie)
+                for details in pokedex.values():
+                    if details.get('actual_id') == pokemon_id:
+                        return details.get('name', str(pokemon_id))
+                # Second pass fallback: check species_id
                 for details in pokedex.values():
                     if details.get('species_id') == pokemon_id:
                         return details.get('name', str(pokemon_id))
@@ -464,10 +555,15 @@ class PokemonTrade:
         from PyQt6.QtWidgets import QMessageBox
         code = self.trade_code_input.text()
         name = "the other Pokémon"
-        parts = code.split(',')
-        if len(parts) > 0 and parts[0].isdigit():
-            pokemon_id = int(parts[0])
-            name = self.get_pokemon_name_by_id(pokemon_id)
+        parts = [p.strip() for p in code.split(',')]
+        if len(parts) > 0:
+            if parts[0] == "-200":
+                if len(parts) > 1 and parts[1].isdigit():
+                    pokemon_id = int(parts[1])
+                    name = self.get_pokemon_name_by_id(pokemon_id)
+            elif parts[0].isdigit():
+                pokemon_id = int(parts[0])
+                name = self.get_pokemon_name_by_id(pokemon_id)
         msg = QMessageBox(parent_window)
         msg.setIcon(QMessageBox.Icon.Question)
         msg.setWindowTitle("Confirm Trade")
@@ -485,6 +581,11 @@ class PokemonTrade:
                 showWarning("Code is incomplete.")
                 return
             incoming_id = numbers[0]
+            if incoming_id == -200:
+                if len(numbers) < 18:
+                    showWarning("Code is incomplete.")
+                    return
+                incoming_id = numbers[1]
             if incoming_id == self.id:
                 showWarning("You cannot trade with a Pokémon of the same species (ID) as the one you're trading away!")
                 return
@@ -496,10 +597,19 @@ class PokemonTrade:
         from ..functions.pokedex_functions import search_pokedex, get_all_pokemon_moves
         import random
         try:
-            pokemon_id, level, gender_id, shiny = numbers[0], numbers[1], numbers[2], numbers[3]
-            ev_stats = dict(zip(['hp', 'atk', 'def', 'spa', 'spd', 'spe'], numbers[4:10]))
-            iv_stats = dict(zip(['hp', 'atk', 'def', 'spa', 'spd', 'spe'], numbers[10:16]))
-            attacks = [self.find_move_by_num(attack_id)['name'] for attack_id in numbers[16:]]
+            if len(numbers) > 0 and numbers[0] == -200:
+                pokemon_id, level, gender_id, shiny = numbers[1], numbers[2], numbers[3], numbers[4]
+                ev_stats = dict(zip(['hp', 'atk', 'def', 'spa', 'spd', 'spe'], numbers[5:11]))
+                iv_stats = dict(zip(['hp', 'atk', 'def', 'spa', 'spd', 'spe'], numbers[11:17]))
+                nature_id = numbers[17]
+                nature = self.nature_from_id(nature_id)
+                attacks = [self.find_move_by_num(attack_id)['name'] for attack_id in numbers[18:]]
+            else:
+                pokemon_id, level, gender_id, shiny = numbers[0], numbers[1], numbers[2], numbers[3]
+                ev_stats = dict(zip(['hp', 'atk', 'def', 'spa', 'spd', 'spe'], numbers[4:10]))
+                iv_stats = dict(zip(['hp', 'atk', 'def', 'spa', 'spd', 'spe'], numbers[10:16]))
+                nature = "serious"
+                attacks = [self.find_move_by_num(attack_id)['name'] for attack_id in numbers[16:]]
 
             details = self.find_pokemon_by_id(pokemon_id)
             if not details:
@@ -533,13 +643,14 @@ class PokemonTrade:
                 "ev": ev_stats,
                 "iv": iv_stats,
                 "attacks": attacks,
-                "growth_rate": get_growth_rate(pokemon_id),
+                "growth_rate": get_growth_rate(details["species_id"]),
                 "current_hp": self.calculate_max_hp(details["baseStats"]["hp"], level, ev_stats, iv_stats),
                 "base_experience": base_experience,
                 "friendship": 0,
                 "pokemon_defeated": 0,
                 "everstone": False,
                 "shiny": bool(shiny),
+                "nature": nature,
                 "mega": False,
                 "special_form": None,
                 "capture_date": datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
@@ -573,6 +684,11 @@ class PokemonTrade:
         try:
             with open(self.pokedex_path, 'r', encoding='utf-8') as file:
                 pokedex = json.load(file)
+                # First pass: check actual_id for precise form match (e.g. Mega Diancie)
+                for details in pokedex.values():
+                    if details.get('actual_id') == pokemon_id:
+                        return details
+                # Second pass fallback: check species_id
                 for details in pokedex.values():
                     if details.get('species_id') == pokemon_id:
                         return details
@@ -615,6 +731,32 @@ class PokemonTrade:
     
     def format_shiny(self):
         return 1 if self.shiny else 0
+
+    def format_nature(self):
+        nature_name = getattr(self, 'nature', 'serious').lower()
+        natures = [
+            "hardy", "lonely", "brave", "adamant", "naughty",
+            "bold", "docile", "relaxed", "impish", "lax",
+            "timid", "hasty", "serious", "jolly", "naive",
+            "modest", "mild", "quiet", "bashful", "rash",
+            "calm", "gentle", "sassy", "careful", "quirky"
+        ]
+        try:
+            return natures.index(nature_name)
+        except ValueError:
+            return 12  # "serious"
+
+    def nature_from_id(self, nature_id):
+        natures = [
+            "hardy", "lonely", "brave", "adamant", "naughty",
+            "bold", "docile", "relaxed", "impish", "lax",
+            "timid", "hasty", "serious", "jolly", "naive",
+            "modest", "mild", "quiet", "bashful", "rash",
+            "calm", "gentle", "sassy", "careful", "quirky"
+        ]
+        if 0 <= nature_id < len(natures):
+            return natures[nature_id]
+        return "serious"
 
     def ev_string(self):
         return ','.join(str(value) for value in self.ev.values())

--- a/src/Ankimon/singletons.py
+++ b/src/Ankimon/singletons.py
@@ -144,6 +144,7 @@ pokemon_pc = PokemonPC(
     test_window=test_window,
     settings=settings_obj,
     main_pokemon=main_pokemon,
+    achievements=achievements,
 )
 
 # --- Register the GUI windows + the Qt UI presenter in the registry, so the

--- a/src/Ankimon/utils.py
+++ b/src/Ankimon/utils.py
@@ -71,6 +71,17 @@ with open(pokedex_path, "r", encoding="utf-8") as f:
     POKEMON_NAME_LOOKUP = {x: data[x]["name"] for x in data}
 
 
+def is_alive(obj):
+    """Check if a QObject/QWidget's C++ part is still alive."""
+    if obj is None:
+        return False
+    try:
+        obj.objectName()
+        return True
+    except (RuntimeError, AttributeError):
+        return False
+
+
 def format_pokemon_name(name: str) -> str:
     """
     Look up the official Pokémon name using the normalized key.


### PR DESCRIPTION
**PR 3 of 3** — the main feature of the PC Box V2 + Trade V2 port from `BRRRR_Experimental`. Stacked on #515 (pokemon_details V2) → #514 (move picker). Original author: **@hakimh2**.

This is the `pc_box` slice of the big `180bcf29` mega-commit, preserving BOTH feature sets:

- **`pc_box.py`** — 3-way merge of main's friendship/evolution UI (BFF heart/pink slot, evo-ready + day/night wait badges, friendship sort, day/night label, refresh-on-reopen, robust geometry-saving `closeEvent`) with **BRRRR's V2** (persistent stacked details panel, move manager via `MovePickerDialog`, nature indicators, Python CP/IV/EV/stat sorting, `trigger_evo_callback`, action buttons). I deduped the `showEvent`/`closeEvent` that both sides added (kept main's richer versions, which call the merged refresh/`on_window_close`) and kept a **single** sort control (BRRRR's combo — it already includes Friendship).
- **`pokemon_trade.py`** — Trade V2 (clean 3-way auto-merge, **0 conflicts**).

Seam adaptations / additive helpers (logic preserved):
- `utils.py`: `is_alive()` (QObject liveness) — used 8× by `pc_box`, absent on main (the evolutions PR adds the identical helper).
- `sprite_functions.py`: form-aware `get_sprite_path(pokemon_name=…)` + `_get_pokemon_id_from_pokedex`, so Mega/Gmax forms resolve their own sprite (`mw.logger` → `services.logger` seam).
- `singletons.py`: pass the existing `achievements` singleton to the V2 `PokemonPC` constructor.

## Validation
- Tier-1 gate **9/9**, `pytest` **150**, `ruff check` clean
- Tier-2 real boot + play — **OK**
- **Real PC-box open** under offscreen Qt: `create_gui` + `go_to_box` (grid renders) + V2 `show_pokemon_details` + `show()` — **0 errors**, with 2 caught Pokémon

> Review/merge order: #514 → #515 → this.
> Not in this slice (separate concerns from the mega-commit): `reviewer_obj`/`pokedex.json`/lang changes bundled in 180bcf29 that PC Box V2 doesn't require.

🤖 Generated with [Claude Code](https://claude.com/claude-code)