### PR TITLE
fix: gracefully handle missing backup_info.txt in backup logic

### DIFF
--- a/src/Ankimon/pyobj/backup_files.py
+++ b/src/Ankimon/pyobj/backup_files.py
@@ -38,11 +38,20 @@ def is_backup_needed():
     if not os.path.exists(backup_folders[0]):
         return True  # No backups exist, so we need one
 
-    with open(os.path.join(backup_folders[0], "backup_info.txt"), "r") as f:
-        date_str = f.readline().replace("Backup created on: ", "").strip()
-        last_backup_date = datetime.strptime(date_str, "%Y-%m-%d %H:%M:%S")
+    backup_info_path = os.path.join(backup_folders[0], "backup_info.txt")
+    if not os.path.exists(backup_info_path):
+        return True  # The text file is missing, do a backup to be safe and restore state
 
-    return (datetime.now() - last_backup_date).days >= 14  # Check if 2 weeks have passed
+    try:
+        with open(backup_info_path, "r") as f:
+            date_str = f.readline().replace("Backup created on: ", "").strip()
+            last_backup_date = datetime.strptime(date_str, "%Y-%m-%d %H:%M:%S")
+
+        return (datetime.now() - last_backup_date).days >= 14  # Check if 2 weeks have passed
+    except Exception as e:
+        # If there's an issue reading or parsing the date, just take a backup
+        mw.logger.log("error", f"Could not read backup_info.txt: {e}")
+        return True
 
 def run_backup():
     """Main function to run the backup process."""


### PR DESCRIPTION
This resolves an issue where users manually manipulating the backup folders would trigger a hard crash upon opening Anki because the `backup_info.txt` file was not found but the first backup directory existed.

---
*PR created automatically by Jules for task [13884932515170570640](https://jules.google.com/task/13884932515170570640) started by @h0tp-ftw*