### PR TITLE
fix: allow all special forms to fall back to base learnset

### DIFF
--- a/src/Ankimon/functions/learnset_retrieval.py
+++ b/src/Ankimon/functions/learnset_retrieval.py
@@ -41,8 +41,8 @@ def _get_learnset_moves(pokemon_name, pokemon_level, generation=9):
     pokemon_name = pokemon_name.lower().replace("-", "").replace(" ", "").replace("'", "").replace(".", "")
     pokemon_learnset = learnsets.get(pokemon_name, {}).get("learnset", {})
     
-    # Fallback to base form for Mega/Gigantamax/Primal if no learnset found
-    if not pokemon_learnset and any(x in pokemon_name for x in ["mega", "gmax", "primal"]):
+    # Fallback to base form if no learnset is found
+    if not pokemon_learnset:
         # Use pokedex to find the base form via species_id
         from .pokedex_functions import _load_pokedex_cache, search_pokedex_by_id, search_pokedex
         pokedex_data = _load_pokedex_cache()


### PR DESCRIPTION
Fixes an issue where certain special forms (like Ogerpon-Hearthflame and Silvally-Bug) would not learn any moves upon leveling up and were stuck with only Struggle. This was due to a restrictive fallback check in `learnset_retrieval.py` that only permitted base-learnset fallback if the pokemon's name contained "mega", "gmax", or "primal". This condition has been removed to allow any form missing an explicit learnset to gracefully fall back to its base species.

---
*PR created automatically by Jules for task [1530795619197465645](https://jules.google.com/task/1530795619197465645) started by @h0tp-ftw*