### PR TITLE
feat: add setting to disable item popups

### DIFF
--- a/src/Ankimon/battle_loop.py
+++ b/src/Ankimon/battle_loop.py
@@ -98,7 +98,11 @@ def on_review_card(*args):
         s.item_receive_value -= 1
         if s.item_receive_value <= 0:
             s.item_receive_value = random.randint(3, 385)
-            test_window.display_item()
+            if settings_obj.get("gui.pop_up_dialog_message_on_item"):
+                test_window.display_item()
+            else:
+                from .utils import random_item
+                random_item()
             if not check_for_badge(achievements, 6):
                 receive_badge(6, achievements)
 

--- a/src/Ankimon/config.json
+++ b/src/Ankimon/config.json
@@ -15,6 +15,7 @@
     "gui.styling_in_reviewer": true,
     "gui.hp_bar_config": true,
     "gui.pop_up_dialog_message_on_defeat": false,
+    "gui.pop_up_dialog_message_on_item": true,
     "gui.review_hp_bar_thickness": 2,
     "gui.reviewer_image_gif": false,
     "gui.reviewer_text_message_box": true,

--- a/src/Ankimon/config.md
+++ b/src/Ankimon/config.md
@@ -37,6 +37,9 @@ Reviewer Pop Up Messages:
 Decide if you would like to see the anki popup messages in the anki reviewer when your pokemon levels up or when a wild pokemon is defeated
 - `pop_up_dialog_message_on_defeat` [True/False]
 
+Decide if you would like to see the anki popup messages when receiving an item from a wild pokemon
+- `pop_up_dialog_message_on_item` [True/False]
+
 Sounds:
 You can decide if you want Pokemon Battle Cries in the anki reviewer once a pokemon appears.
 - `sounds` [True/False]

--- a/src/Ankimon/lang/setting_description.json
+++ b/src/Ankimon/lang/setting_description.json
@@ -19,6 +19,7 @@
     "gui.styling_in_reviewer": "Apply custom CSS styles to enhance reviewer visuals.",
     "gui.hp_bar_config": "Enable display HP bar for wild Pokémon.",
     "gui.pop_up_dialog_message_on_defeat": "Show a pop-up message when a wild Pokémon is defeated.",
+    "gui.pop_up_dialog_message_on_item": "Show a pop-up message when receiving an item from wild Pokémon.",
     "gui.review_hp_bar_thickness": "Set the HP bar thickness for reviews [2: 8px, 3: 12px, 4: 16px, 5: 20px].",
     "gui.reviewer_image_gif": "Display Pokémon GIFs in the reviewer window.",
     "gui.reviewer_text_message_box": "Enable colorful pop-up messages in the reviewer.",

--- a/src/Ankimon/lang/setting_name.json
+++ b/src/Ankimon/lang/setting_name.json
@@ -20,6 +20,7 @@
     "gui.styling_in_reviewer": "Styling in Reviewer",
     "gui.hp_bar_config": "HP Bar Configuration",
     "gui.pop_up_dialog_message_on_defeat": "Pop-Up on Defeat",
+    "gui.pop_up_dialog_message_on_item": "Pop-Up on Item Receive",
     "gui.review_hp_bar_thickness": "HP Bar Thickness",
     "gui.reviewer_image_gif": "Reviewer Image as GIF",
     "gui.reviewer_text_message_box": "Show Text Message Box in Reviewer",

--- a/src/Ankimon/pyobj/settings.py
+++ b/src/Ankimon/pyobj/settings.py
@@ -26,6 +26,7 @@ DEFAULT_CONFIG = {
     "gui.styling_in_reviewer": True,
     "gui.hp_bar_config": True,
     "gui.pop_up_dialog_message_on_defeat": False,
+    "gui.pop_up_dialog_message_on_item": True,
     "gui.review_hp_bar_thickness": 2,
     "gui.reviewer_image_gif": False,
     "gui.reviewer_text_message_box": True,

--- a/src/Ankimon/pyobj/settings_window.py
+++ b/src/Ankimon/pyobj/settings_window.py
@@ -321,6 +321,7 @@ class SettingsWindow(QMainWindow):
                     "Hide HUD on Reviewer Startup", 
                     "Show Pokémon Buttons",
                     "Pop-Up on Defeat",
+                    "Pop-Up on Item Receive",
                     "Show Text Message Box in Reviewer",
                     "Message Box Display Time",
                     "Review Based Damage",


### PR DESCRIPTION
Adds a configuration setting to toggle whether item popups interrupt Anki reviews. If disabled, the player still receives the item silently.

---
*PR created automatically by Jules for task [3181808767267220203](https://jules.google.com/task/3181808767267220203) started by @h0tp-ftw*