### PR TITLE
fix: handle legacy string and integer formats during mypokemon.json migration

### DIFF
--- a/src/Ankimon/pyobj/migration_dialog.py
+++ b/src/Ankimon/pyobj/migration_dialog.py
@@ -21,6 +21,7 @@ from typing import Dict, Any
 import csv
 from ..utils import show_warning_with_traceback
 from ..resources import csv_file_items_cost, user_path
+from ..functions.pokedex_functions import search_pokedex_by_id
 
 
 class MigrationDialog(QDialog):
@@ -154,6 +155,21 @@ class MigrationDialog(QDialog):
                     total = len(pokemon_list)
                     for i, pokemon in enumerate(pokemon_list):
                         if self.cancelled: break
+                        if isinstance(pokemon, (int, str)):
+                            # Convert string/int to dict
+                            if isinstance(pokemon, int) or (isinstance(pokemon, str) and pokemon.isdigit()):
+                                poke_name = search_pokedex_by_id(int(pokemon))
+                                if poke_name == "Pokémon not found":
+                                    continue
+                            else:
+                                poke_name = str(pokemon)
+
+                            pokemon = {
+                                "name": poke_name.capitalize(),
+                                "individual_id": str(uuid.uuid4()),
+                                "level": 1,
+                                "xp": 0
+                            }
                         if not isinstance(pokemon, dict):
                             continue
                         if not pokemon.get("individual_id"):


### PR DESCRIPTION
Fixes an issue where users migrating from older JSON files would have their Pokémon skipped if they were stored as simple string names or integer Pokédex IDs instead of dictionary profiles. 

The migration loop now checks for these types and dynamically constructs a `PokemonObject`-compliant dictionary before continuing the save process.

Closes #xyz

---
*PR created automatically by Jules for task [11970519625669595753](https://jules.google.com/task/11970519625669595753) started by @h0tp-ftw*