### PR TITLE
fix: resolve silent leaderboard sync failure by using service registry

### DIFF
--- a/src/Ankimon/pyobj/ankimon_leaderboard.py
+++ b/src/Ankimon/pyobj/ankimon_leaderboard.py
@@ -5,7 +5,7 @@ from aqt.utils import showInfo
 from ..resources import user_path_credentials, mypokemon_path
 import json
 import requests
-from aqt import mw # import setting values direct from init file
+from ..services import services
 
 #ANKIMON_LEADERBOARD_API_URL = "https://ankimon.com/api/leaderboard"  # Replace with the actual API URL
 ANKIMON_LEADERBOARD_API_URL = "https://leaderboard-api.ankimon.com/update_stats"  # Replace with the actual API URL
@@ -60,7 +60,7 @@ class ApiKeyDialog(QDialog):
         try:
             # Save the new credentials to the database
             for key, value in credentials.items():
-                mw.ankimon_db.set_user_data(key, value)
+                services.db.set_user_data(key, value)
             showInfo("Credentials saved successfully!")
         except Exception as e:
             showInfo(f"Error saving credentials: {e}")
@@ -68,16 +68,16 @@ class ApiKeyDialog(QDialog):
 def sync_data_to_leaderboard(data):
 
         # First check if leaderboard is enabled in config
-        if not mw.settings_obj.get("misc.leaderboard"):
+        if not services.settings.get("misc.leaderboard"):
             return
 
         try:
             # Load credentials from the database
-            username = mw.ankimon_db.get_user_data("username")
-            api_key = mw.ankimon_db.get_user_data("api_key")
+            username = services.db.get_user_data("username")
+            api_key = services.db.get_user_data("api_key")
 
             # Validate credentials
-            if (not username or not api_key) and mw.ankimon_db.is_migrated():
+            if (not username or not api_key) and services.db.is_migrated():
                 showInfo("Error: Missing credentials for Ankimon leaderboard. Please set up leaderboard from Ankimon menu or turn off in Settings.")
                 return
 

--- a/src/Ankimon/pyobj/trainer_card.py
+++ b/src/Ankimon/pyobj/trainer_card.py
@@ -214,6 +214,7 @@ class TrainerCard:
         print(f"Gained {xp_gained} XP from defeating a {tier} Pokémon!")
         self.check_level_up()
 
+
     def check_level_up(self):
         """Update level based on XP."""
         xp_needed = self.xp_for_next_level()


### PR DESCRIPTION
Resolves an issue where Ankimon leaderboard stats failed to sync on startup because the code still relied on the deprecated `mw.ankimon_db` and `mw.settings_obj` instead of the new `services` registry.

* Updated `ankimon_leaderboard.py` to import and use the new `services` object.

---
*PR created automatically by Jules for task [9742001580518963995](https://jules.google.com/task/9742001580518963995) started by @h0tp-ftw*