### PR TITLE
fix: persist main pokemon hp when using healing items

### DIFF
--- a/src/Ankimon/pyobj/item_window.py
+++ b/src/Ankimon/pyobj/item_window.py
@@ -518,6 +518,13 @@ class ItemWindow(QWidget):
         self.main_pokemon.hp += heal_points
         if self.main_pokemon.hp > (self.main_pokemon.max_hp):
             self.main_pokemon.hp = self.main_pokemon.max_hp
+
+        # Save to database using the services registry
+        from ..services import services
+        pokemon_data = self.main_pokemon.to_dict()
+        services.db.save_pokemon(pokemon_data)
+        services.db.save_main_pokemon(pokemon_data)
+
         self.delete_item(item_name)
         play_effect_sound(self.settings_obj, "HpHeal")
         self.logger.log_and_showinfo("info", f"{prevo_name} was healed for {heal_points}")


### PR DESCRIPTION
This pull request fixes a critical bug where healing a Pokémon with an item in the bag (e.g., Soda Pop) would consume the item and visually update the HP, but fail to save the updated HP to the database. Consequently, the Pokémon's health would revert to its previous, low state on the very next turn.

### Changes Made:
- Imported `services` from `..services` inside `Check_Heal_Item` in `item_window.py`.
- Added logic to generate the dictionary representation of the updated `main_pokemon`.
- Called `services.db.save_pokemon` and `services.db.save_main_pokemon` to persist the healed state.

---
*PR created automatically by Jules for task [2887623009379478163](https://jules.google.com/task/2887623009379478163) started by @h0tp-ftw*