### PR TITLE
chore: SQLite WAL/updater/simulator gitignore entries (F08)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ src/Ankimon/user_files/backups
 *.pyc
 .vscode
 .gemini
+.agents
 debug_console.py
 src/Ankimon/user_files/todays_shop.json
 src/Ankimon/user_files/meta.json
@@ -29,10 +30,20 @@ src/Ankimon/updateinfos.md
 cycle_keys.py
 src/Ankimon/user_files/download_complete.flag
 src/Ankimon/user_files/ankimon.db
+src/Ankimon/user_files/ankimon.db-shm
+src/Ankimon/user_files/ankimon.db-wal
+src/Ankimon/user_files/ankimonDEV.db
+src/Ankimon/user_files/ankimonDEV.db-shm
+src/Ankimon/user_files/ankimonDEV.db-wal
+src/Ankimon/user_files/ankimon - Copy.db
+src/Ankimon/user_files/ankimonDEV - Copy.db
 src/Ankimon/user_files/json/*
 # Sprites are downloaded on first run, not tracked in git.
 # Source of truth: https://github.com/h0tp-ftw/ankimon-sprites
 src/Ankimon/user_files/sprites/
+src/Ankimon/user_files/update_state.json
+tests/encounter_weighting_simulations/simulation_report.txt
+tests/encounter_weighting_simulations/simulation_results.json
 venv/
 # Tier-2 agent-harness env (venv + locally-extracted Qt libs); recreate with
 # harness/setup_tier2.sh. Large + machine-specific, never committed.

--- a/.gitignore
+++ b/.gitignore
@@ -29,14 +29,19 @@ src/Ankimon/updateinfos.md
 *.env
 cycle_keys.py
 src/Ankimon/user_files/download_complete.flag
+# SQLite databases + sidecars (-journal from default rollback mode; -shm/-wal when WAL is opted in)
 src/Ankimon/user_files/ankimon.db
+src/Ankimon/user_files/ankimon.db-journal
 src/Ankimon/user_files/ankimon.db-shm
 src/Ankimon/user_files/ankimon.db-wal
 src/Ankimon/user_files/ankimonDEV.db
+src/Ankimon/user_files/ankimonDEV.db-journal
 src/Ankimon/user_files/ankimonDEV.db-shm
 src/Ankimon/user_files/ankimonDEV.db-wal
 src/Ankimon/user_files/ankimon - Copy.db
+src/Ankimon/user_files/ankimon - Copy.db-journal
 src/Ankimon/user_files/ankimonDEV - Copy.db
+src/Ankimon/user_files/ankimonDEV - Copy.db-journal
 src/Ankimon/user_files/json/*
 # Sprites are downloaded on first run, not tracked in git.
 # Source of truth: https://github.com/h0tp-ftw/ankimon-sprites


### PR DESCRIPTION
## Inventory row
Implements **F08 — .gitignore infra ignore entries** (SCAFFOLDING; DEFERRED-TO-STAGE-B).

## What / re-fit
Adds BRRRR_Experimental's infra ignores surgically onto main's `.gitignore` (new-org target = same path):
- SQLite DB sidecars: `ankimon.db(-journal/-shm/-wal)`, `ankimonDEV.db(-journal/-shm/-wal)`, `ankimon - Copy.db(-journal)`, `ankimonDEV - Copy.db(-journal)` (support the thread-safe DB / WAL layer, NR-05; `-journal` covers the default rollback-journal mode since WAL is opt-in per Gemini review r3506830518)
- Updater state: `user_files/update_state.json` (self-updater leaf)
- Encounter-simulator outputs: `tests/encounter_weighting_simulations/simulation_report.txt`, `simulation_results.json`
- `.agents`

No `aqt.mw.*` / seam surface (data-only infra file).

## Guard preserved (GUARDS-TO-REAPPLY)
- **Dropped exp's `.claude/` ignore line** — main tracks `.claude/` skills as infra; ignoring it would untrack them (regression against main's guard). Verified: `git check-ignore .claude/settings.json` → not ignored.
- Skipped exp's duplicate `__pycache__/` (already present on the base at line 40).

## Verification (real output)
- `git check-ignore` confirms `.claude/` NOT ignored; WAL/updater/sim paths ARE ignored.
- `compileall -q src/Ankimon` → PASS (no code touched; baseline unaffected).
- Only `.gitignore` modified; no `user_files/` staged.

## Parity oracle
OBSERVABLE — `git check-ignore` behavior (guard: `.claude/` tracked; new sidecar/state files ignored).

## Context7
N/A (no library API surface).

## Residual concerns
None. Infra-only; harmless to land ahead of the WAL/updater/simulator leaves it supports.



## Attribution
The feature ported here was originally implemented on the `BRRRR_Experimental` branch by @hakimh2 (also commits as BrAk909) with contributions by @AIbrahimv2. Authorship credit is recorded via a `Co-authored-by` trailer on this branch.
