### PR TITLE
feat: Translator.change_language() live language reload (F02)

### DIFF
--- a/src/Ankimon/pyobj/translator.py
+++ b/src/Ankimon/pyobj/translator.py
@@ -93,8 +93,9 @@ class Translator:
         """
         try:
             short_language = LANG_NUMBERS.get(int(language), "en")
-            self.filepath = LANG_PATHS.get(short_language, lang_path_en)
-            with open(self.filepath, "r", encoding="utf-8") as f:
+            filepath = LANG_PATHS.get(short_language, lang_path_en)
+            with open(filepath, "r", encoding="utf-8") as f:
                 self.translations = json.load(f)
+            self.filepath = filepath
         except Exception as e:
             print(f"Ankimon: Error reloading language {language}: {e}")

--- a/src/Ankimon/pyobj/translator.py
+++ b/src/Ankimon/pyobj/translator.py
@@ -85,10 +85,15 @@ class Translator:
             )
 
     def change_language(self, language):
-        """Reloads the translation file for a new language."""
-        short_language = LANG_NUMBERS.get(int(language), "en")
-        self.filepath = LANG_PATHS.get(short_language, lang_path_en)
+        """Reloads the translation file for a new language.
+
+        Any error — an unparsable ``language`` id or a failed file reload —
+        is swallowed (printed, not raised), leaving the previous language
+        intact, so a bad setting can never crash the caller.
+        """
         try:
+            short_language = LANG_NUMBERS.get(int(language), "en")
+            self.filepath = LANG_PATHS.get(short_language, lang_path_en)
             with open(self.filepath, "r", encoding="utf-8") as f:
                 self.translations = json.load(f)
         except Exception as e:

--- a/src/Ankimon/pyobj/translator.py
+++ b/src/Ankimon/pyobj/translator.py
@@ -1,5 +1,17 @@
 import json
-from ..resources import lang_path_de, lang_path_ch, lang_path_en, lang_path_fr, lang_path_jp, lang_path_sp, lang_path_kr, lang_path_it, lang_path_cz, lang_path_po, lang_path_es_latam
+from ..resources import (
+    lang_path_de,
+    lang_path_ch,
+    lang_path_en,
+    lang_path_fr,
+    lang_path_jp,
+    lang_path_sp,
+    lang_path_kr,
+    lang_path_it,
+    lang_path_cz,
+    lang_path_po,
+    lang_path_es_latam,
+)
 
 LANG_PATHS = {
     "de": lang_path_de,
@@ -12,32 +24,33 @@ LANG_PATHS = {
     "it": lang_path_it,
     "cz": lang_path_cz,
     "po": lang_path_po,
-    "es_latam": lang_path_es_latam
+    "es_latam": lang_path_es_latam,
 }
 
 LANG_NUMBERS = {
-    1: 'jp',
-    2: 'jp',
-    3: 'kr',
-    4: 'ch',
-    5: 'fr',
-    6: 'de',
-    7: 'sp',
-    8: 'it',
-    9: 'en',
-    10: 'cz',
-    11: 'jp',
-    12: 'ch',
-    13: 'po',
-    14: 'es_latam',
+    1: "jp",
+    2: "jp",
+    3: "kr",
+    4: "ch",
+    5: "fr",
+    6: "de",
+    7: "sp",
+    8: "it",
+    9: "en",
+    10: "cz",
+    11: "jp",
+    12: "ch",
+    13: "po",
+    14: "es_latam",
 }
+
 
 class Translator:
     def __init__(self, language):
-        short_language = LANG_NUMBERS.get(int(language), 'en')
+        short_language = LANG_NUMBERS.get(int(language), "en")
         self.filepath = LANG_PATHS.get(short_language, lang_path_en)
         try:
-            with open(self.filepath, 'r', encoding='utf-8') as f:
+            with open(self.filepath, "r", encoding="utf-8") as f:
                 self.translations = json.load(f)
         except FileNotFoundError:
             raise Exception(f"Translation file not found: {self.filepath}")
@@ -52,7 +65,7 @@ class Translator:
         # Fallback to English if key not found
         if template is None:
             try:
-                with open(lang_path_en, 'r', encoding='utf-8') as f:
+                with open(lang_path_en, "r", encoding="utf-8") as f:
                     fallback_translations = json.load(f)
                 template = fallback_translations.get(key, key)
                 source_file = lang_path_en  # Now using fallback file
@@ -71,3 +84,12 @@ class Translator:
                 f"• Available arguments: {available}"
             )
 
+    def change_language(self, language):
+        """Reloads the translation file for a new language."""
+        short_language = LANG_NUMBERS.get(int(language), "en")
+        self.filepath = LANG_PATHS.get(short_language, lang_path_en)
+        try:
+            with open(self.filepath, "r", encoding="utf-8") as f:
+                self.translations = json.load(f)
+        except Exception as e:
+            print(f"Ankimon: Error reloading language {language}: {e}")

--- a/tests/test_translator_change_language.py
+++ b/tests/test_translator_change_language.py
@@ -6,8 +6,9 @@ BRRRR_Experimental onto main's ``pyobj/translator.py``:
 * ``change_language(n)`` re-points ``self.filepath`` to the ``LANG_PATHS`` entry
   for ``LANG_NUMBERS[int(n)]`` and reloads ``self.translations`` from that file.
 * An unknown language id falls back to English (``lang_path_en``).
-* A load error is swallowed (printed, not raised) so a bad language setting can
-  never crash the caller.
+* Any error — an unparsable id (non-numeric / ``None``) or a load failure — is
+  swallowed (printed, not raised) and the previous language is kept, so a bad
+  language setting can never crash the caller.
 
 ``translator.py`` is aqt-free (pure file I/O + ``json.load``), so it runs in the
 Qt-free Tier-1 env. It is loaded here under a *private* module namespace
@@ -102,3 +103,27 @@ def test_change_language_swallows_load_error(monkeypatch, capsys):
     t.change_language(6)
     out = capsys.readouterr().out
     assert "Error reloading language" in out
+
+
+def test_change_language_swallows_non_numeric_input(capsys):
+    t = Translator(9)
+    before_filepath = t.filepath
+    before_translations = t.translations
+
+    # Must not raise; the previous language must stay intact.
+    t.change_language("not-a-number")
+    assert t.filepath == before_filepath
+    assert t.translations is before_translations
+    assert "Error reloading language" in capsys.readouterr().out
+
+
+def test_change_language_swallows_none_input(capsys):
+    t = Translator(9)
+    before_filepath = t.filepath
+    before_translations = t.translations
+
+    # Must not raise; the previous language must stay intact.
+    t.change_language(None)
+    assert t.filepath == before_filepath
+    assert t.translations is before_translations
+    assert "Error reloading language" in capsys.readouterr().out

--- a/tests/test_translator_change_language.py
+++ b/tests/test_translator_change_language.py
@@ -94,13 +94,18 @@ def test_change_language_accepts_string_numeric_like_init():
 
 def test_change_language_swallows_load_error(monkeypatch, capsys):
     t = Translator(9)
+    before_filepath = t.filepath
+    before_translations = t.translations
 
     def _boom(*args, **kwargs):
         raise OSError("simulated read failure")
 
     monkeypatch.setattr("builtins.open", _boom)
-    # Must not raise even though the reload open() fails.
+    # Must not raise even though the reload open() fails, and the previous
+    # language must stay fully intact (no torn filepath/translations state).
     t.change_language(6)
+    assert t.filepath == before_filepath
+    assert t.translations is before_translations
     out = capsys.readouterr().out
     assert "Error reloading language" in out
 

--- a/tests/test_translator_change_language.py
+++ b/tests/test_translator_change_language.py
@@ -1,0 +1,104 @@
+"""Characterization test for ``Translator.change_language()`` (feature F02).
+
+Pins the observable contract of the live-language-reload helper ported from
+BRRRR_Experimental onto main's ``pyobj/translator.py``:
+
+* ``change_language(n)`` re-points ``self.filepath`` to the ``LANG_PATHS`` entry
+  for ``LANG_NUMBERS[int(n)]`` and reloads ``self.translations`` from that file.
+* An unknown language id falls back to English (``lang_path_en``).
+* A load error is swallowed (printed, not raised) so a bad language setting can
+  never crash the caller.
+
+``translator.py`` is aqt-free (pure file I/O + ``json.load``), so it runs in the
+Qt-free Tier-1 env. It is loaded here under a *private* module namespace
+(``_f02_ankimon``) rather than the shared ``Ankimon.*`` names, because sibling
+test modules (``test_encounter_functions``, ``test_cp_formula``) replace
+``Ankimon.pyobj.translator`` / ``Ankimon.resources`` in ``sys.modules`` with
+MagicMocks. The private namespace makes this test order-independent.
+"""
+
+import importlib.util
+import json
+import sys
+import types
+from pathlib import Path
+
+_ANK = Path(__file__).parent.parent / "src" / "Ankimon"
+_PKG = "_f02_ankimon"
+
+
+def _ensure_pkg(name, path):
+    if name not in sys.modules:
+        mod = types.ModuleType(name)
+        mod.__path__ = [str(path)]
+        mod.__package__ = name
+        sys.modules[name] = mod
+
+
+def _load(modname, filepath, package):
+    spec = importlib.util.spec_from_file_location(modname, filepath)
+    module = importlib.util.module_from_spec(spec)
+    module.__package__ = package
+    sys.modules[modname] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+_ensure_pkg(_PKG, _ANK)
+_ensure_pkg(_PKG + ".pyobj", _ANK / "pyobj")
+_resources = _load(_PKG + ".resources", _ANK / "resources.py", _PKG)
+_translator = _load(
+    _PKG + ".pyobj.translator", _ANK / "pyobj" / "translator.py", _PKG + ".pyobj"
+)
+
+Translator = _translator.Translator
+LANG_PATHS = _translator.LANG_PATHS
+lang_path_en = _resources.lang_path_en
+lang_path_de = _resources.lang_path_de
+
+
+def test_change_language_switches_filepath_and_reloads_translations():
+    t = Translator(9)  # English
+    assert t.filepath == lang_path_en
+
+    t.change_language(6)  # German
+    assert t.filepath == LANG_PATHS["de"] == lang_path_de
+
+    with open(lang_path_de, "r", encoding="utf-8") as f:
+        expected = json.load(f)
+    assert t.translations == expected
+
+
+def test_change_language_round_trip_restores_english():
+    t = Translator(9)
+    original = dict(t.translations)
+    t.change_language(6)
+    assert t.translations != original
+    t.change_language(9)
+    assert t.filepath == lang_path_en
+    assert t.translations == original
+
+
+def test_change_language_unknown_id_falls_back_to_english():
+    t = Translator(6)  # German
+    t.change_language(999)  # id not in LANG_NUMBERS -> "en"
+    assert t.filepath == lang_path_en
+
+
+def test_change_language_accepts_string_numeric_like_init():
+    t = Translator(9)
+    t.change_language("6")  # int() coercion, mirroring __init__
+    assert t.filepath == LANG_PATHS["de"]
+
+
+def test_change_language_swallows_load_error(monkeypatch, capsys):
+    t = Translator(9)
+
+    def _boom(*args, **kwargs):
+        raise OSError("simulated read failure")
+
+    monkeypatch.setattr("builtins.open", _boom)
+    # Must not raise even though the reload open() fails.
+    t.change_language(6)
+    out = capsys.readouterr().out
+    assert "Error reloading language" in out


### PR DESCRIPTION
## F02 — `Translator.change_language()` live language reload

Stage-B port of exactly one BRRRR_Experimental feature onto main's architecture.

### (a) Inventory row
- **ID:** F02 — Translator.change_language() live language reload
- **Source location(s):** `src/Ankimon/pyobj/translator.py`
- **Class:** SCAFFOLDING · **Stage-A disposition:** DEFERRED-TO-STAGE-B (ref **NR-03**: single-consumer, deferred, low risk)
- **Harness tier:** UI-ONLY · **Parity strategy:** OBSERVABLE (characterization / import+construct)
- **Notes/guards:** "Small additive reload helper (10 lines), no-newline-at-EOF … Safe, low-risk to port. Missing trailing newline should be fixed on adoption."

### (b) Source → target re-fit + MERGE_ARCH_MAP rules applied
- **Manifest** (`git diff a8abbd66..origin/BRRRR_Experimental -- src/Ankimon/pyobj/translator.py`) is a single additive hunk introduced by exp commit `180bcf29`: a new `Translator.change_language(self, language)` method. Nothing outside the row's Source path is referenced → partition is complete, no post-snapshot extra hunks.
- The file **exists in base** and base HEAD is byte-identical to the merge-base blob (`git diff a8abbd66..HEAD -- …/translator.py` is empty), so per the recipe (§"How to re-fit", step 2) I **ported only the feature's hunk onto the base version** (append the method) — **no wholesale checkout**.
- **Guard re-applied:** exp shipped the method with a trailing-whitespace line and **no newline at EOF**; the row explicitly requires "Missing trailing newline should be fixed on adoption." Fixed on adoption (file now ends with a single newline).

### (c) Seam re-expression
- **None required.** The method is pure file I/O + `json.load` over the existing module-level `LANG_NUMBERS` / `LANG_PATHS` / `lang_path_*` — **zero `aqt.mw.*` access** (confirmed against §2.1). No seam entrypoint added, no existing seam signature touched.
- The single consumer (the Language-setting handler) lives in settings plumbing on the seam and is **out of scope for this row** (NR-03); this PR ships only the additive helper on `translator.py`, exactly as the row's Target specifies.

### (d) Main guards / improvements preserved
- `translator.py` is not an immutable/seam file (`src/Ankimon/pyobj/…`), so editing it needs no §6 authorization.
- Main's `__init__`/`translate` behavior is unchanged; the port is purely additive (one new method).
- The file carried pre-existing whole-tree `ruff format` debt (it is one of the baseline's 78). Because this PR legitimately edits the file, `ruff format` was applied to it (import wrapping, quote normalization, trailing commas) so the changed file is format-clean per gate discipline — **semantics-preserving**, and it does not increase the 78/10 baseline for any file I did not touch. No untouched file was reformatted.

### (e) Parity oracle + gate commands with REAL output
**Parity oracle:** `tests/test_translator_change_language.py` — a characterization test pinning the observable contract (filepath switch + `translations` dict reloaded from the target JSON; unknown-id → English fallback; `int()` string coercion like `__init__`; load-error is swallowed+printed, never raised). Loaded under a private `_f02_ankimon` namespace so it is order-independent of sibling tests that MagicMock `Ankimon.pyobj.translator`/`Ankimon.resources` in `sys.modules`.

Environment (A) Qt-free `venv_t1` (UI-ONLY tier → env (B) GAMEPLAY probes not required):

```
$ python -m compileall -q src/Ankimon            → exit 0

$ ruff check  --config ci_ruff_check.toml src/Ankimon/pyobj/translator.py tests/test_translator_change_language.py
All checks passed!                               → exit 0

$ ruff format --check --config ci_ruff_check.toml src/Ankimon/pyobj/translator.py tests/test_translator_change_language.py
2 files already formatted                         → exit 0

$ python harness/check.py
PASS — all 9 Tier-1 checks green.
  [PASS] probe_contract (~65 seams intact), probe_core, probe_fixtures, probe_foundations,
  probe_leaves (26 modules imported aqt-free), probe_migration, probe_persistence,
  smoke_play, test_headless_harness

$ python -m pytest tests/ --ignore=tests/test_addon_integrity.py --ignore=tests/test_scaffolding_smoke.py -q
154 passed in 1.00s          # 149 baseline + 5 new parity tests, no regressions

$ python -m pytest tests/test_translator_change_language.py -q
5 passed in 0.01s
```

### (f) Context7 APIs verified
None needed — stdlib `json` + `open()` only; no PyQt6/aqt/sqlite3 API re-authoring.

### (g) Residual concerns
- **NR-03 (unchanged):** the helper still has a single intended consumer (the Language setting). This PR ships the helper only; wiring the settings handler to call it is a separate settings-plumbing leaf.
- The whole-file `ruff format` normalization of `translator.py` enlarges the diff beyond the 10 functional lines, but is required to satisfy the format gate on an edited file and is semantics-preserving.

### Post-review amendments (Gemini review + polish dive)
- **Review comment 3506899878 — fixed:** `int(language)` ran outside the `try` in `change_language`, so a non-numeric or `None` language id raised instead of being swallowed like other reload errors. The language resolution now lives inside the `try` (still defaulting unknown numeric ids to English via `LANG_NUMBERS.get`); conversion errors are printed and the previous language is kept.
- **Polish:** the reload is now transactional — `self.filepath` is committed only after the new JSON loads, so a failed reload can no longer leave the object torn (filepath pointing at the new language while `translations` still holds the old one, which previously made `translate()`'s error messages report the wrong source file).
- **Parity oracle updated:** `tests/test_translator_change_language.py` now carries **7** tests (adds non-numeric/`None` swallow tests; strengthens the load-error test to pin no-torn-state). Gate re-run at HEAD: full suite **156 passed** (149 baseline + 7 parity), `harness/check.py` 9/9, compileall clean, ruff check/format clean on touched files.
- Exp-delta check: `origin/BRRRR_Experimental`'s last commit touching `translator.py` is `180bcf29` (the ported commit) — no post-port exp fixes to fold.

---
Row: F02 · Base: `integration/brrr-into-main`

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>



## Attribution
The feature ported here was originally implemented on the `BRRRR_Experimental` branch by @hakimh2 (also commits as BrAk909). Authorship credit is recorded via a `Co-authored-by` trailer on this branch.
