### PR TITLE
fix(tracker): language-agnostic review count + faint guard (#04adddd9)

### DIFF
--- a/src/Ankimon/pyobj/ankimon_tracker.py
+++ b/src/Ankimon/pyobj/ankimon_tracker.py
@@ -117,13 +117,21 @@ class AnkimonTracker:
             )
         except Exception:
             # Fall back to parsing the localized "studied today" string if the
-            # database query fails (e.g. a stub/mock collection). Grabbing the
-            # first integer keeps this language-agnostic too.
+            # database query fails (e.g. a stub/mock collection). The review
+            # count is the first number in every locale's phrasing (decimals
+            # like "1.5 minutes" only appear later), but locales group large
+            # counts with thousands separators ("1,234" / "1.234" / "1 234" /
+            # no-break spaces), so match the whole first numeric token and
+            # strip the separators before converting.
             try:
                 text = col.studied_today()
-                nums = re.findall(r"\d+", text)
-                if nums:
-                    return int(nums[0])
+                # Separators: space, no-break space (U+00A0), narrow
+                # no-break space (U+202F), period and comma, grouping
+                # digits in threes.
+                sep = r"[ \u00a0\u202f.,]"
+                match = re.search(rf"\d+(?:{sep}\d{{3}})*", text)
+                if match:
+                    return int(re.sub(sep, "", match.group(0)))
             except Exception:
                 pass
         return 0

--- a/src/Ankimon/pyobj/ankimon_tracker.py
+++ b/src/Ankimon/pyobj/ankimon_tracker.py
@@ -86,6 +86,7 @@ class AnkimonTracker:
             0  # count for general card count for battle
         )
         self.caught = 0  # check if pokemon is caught
+        self.faint_processed = False  # guard against duplicate faint processing
 
         # Start the session timer when the object is initialized
         self.start_session_timer()
@@ -97,22 +98,35 @@ class AnkimonTracker:
             # count is always current (services.col may be unset at addon load).
             try:
                 from aqt import mw
+
                 col = mw.col
             except Exception:
                 col = None
         if col is None:
             return 0
         try:
-            studied = col.studied_today()
-            match = re.search(r'Studied\s+[^\d]*(\d+)(?=[^\n]*card)', studied)
+            # Query Anki's database directly for review logs since today's
+            # scheduler cutoff. This is language-agnostic, robust, and honours
+            # custom day boundaries. ``day_cutoff`` is tomorrow's rollover, so
+            # subtract 24h (86400s) to reach the start of today; revlog ids are
+            # epoch milliseconds. (Subtracting the day fixes the runaway
+            # cash-reward bug from counting against tomorrow's boundary.)
+            cutoff = col.sched.day_cutoff
+            return col.db.scalar(
+                "SELECT count() FROM revlog WHERE id > ?", (cutoff - 86400) * 1000
+            )
         except Exception:
-            # e.g. a stub/mock collection whose studied_today() isn't a string.
-            return 0
-        if match is None:
-            # Empty-study session or localized Anki whose "Studied N cards"
-            # text doesn't match the English regex.
-            return 0
-        return int(match.group(1))
+            # Fall back to parsing the localized "studied today" string if the
+            # database query fails (e.g. a stub/mock collection). Grabbing the
+            # first integer keeps this language-agnostic too.
+            try:
+                text = col.studied_today()
+                nums = re.findall(r"\d+", text)
+                if nums:
+                    return int(nums[0])
+            except Exception:
+                pass
+        return 0
 
     def set_main_pokemon(self, pokemon):
         """Set the main Pokémon being used."""

--- a/tests/test_ankimon_tracker.py
+++ b/tests/test_ankimon_tracker.py
@@ -1,0 +1,167 @@
+"""Characterization tests for ``Ankimon.pyobj.ankimon_tracker.get_total_reviews``.
+
+Ported from BRRRR_Experimental's shipped ``tests/test_ankimon_tracker.py`` and
+re-fitted onto main's service-seam architecture. The experimental feature made
+the daily review count *language-agnostic* by querying Anki's ``revlog`` table
+directly (``col.sched.day_cutoff`` + ``col.db.scalar``) instead of regex-scraping
+the English-only ``studied_today()`` string, and corrected the ``day_cutoff``
+subtraction that caused runaway cash rewards. The ``faint_processed`` guard flag
+is a separate net-new bit of gameplay state also carried by this feature.
+
+Re-fit vs. the experimental original:
+
+* Experimental code read ``mw.col`` directly and the shipped test patched
+  ``Ankimon.pyobj.ankimon_tracker.mw``. On main the collection is resolved
+  through the ``services`` registry (``services.col``), with a lazy ``mw.col``
+  fallback for the addon-load window. So these tests drive ``services.col``
+  (the seam) rather than a module-level ``mw``.
+* The module is loaded in isolation with stubbed ``aqt`` / ``PyQt6`` / ``anki``
+  so the pure-logic method can be exercised Qt-free (Tier-1), matching the base
+  test suite's convention.
+"""
+
+import sys
+import types
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+class DynamicMockModule(types.ModuleType):
+    """A module stub that dynamically returns MagicMocks for any attribute
+    requests, preventing PyQt/Anki module import and lookup errors."""
+
+    def __getattr__(self, name):
+        mock = MagicMock()
+        setattr(self, name, mock)
+        return mock
+
+
+_SRC = Path(__file__).parent.parent / "src"
+
+
+@pytest.fixture
+def tracker_module():
+    """Load ``AnkimonTracker`` in isolation with stubbed Anki/Qt modules and
+    restore ``sys.modules`` afterwards so the rest of the suite is unaffected."""
+    original_modules = dict(sys.modules)
+
+    # Parent packages so the module's relative imports resolve against the real
+    # source tree without executing ``Ankimon/__init__.py`` (mirrors conftest).
+    parent_pkgs = {}
+    for _pkg in ("Ankimon", "Ankimon.pyobj", "Ankimon.functions"):
+        _mod = types.ModuleType(_pkg)
+        _mod.__path__ = [str(_SRC / _pkg.replace(".", "/"))]
+        _mod.__package__ = _pkg
+        parent_pkgs[_pkg] = _mod
+
+    mocks = {
+        "aqt": DynamicMockModule("aqt"),
+        "aqt.qt": DynamicMockModule("aqt.qt"),
+        "aqt.utils": DynamicMockModule("aqt.utils"),
+        "PyQt6": DynamicMockModule("PyQt6"),
+        "PyQt6.QtWidgets": DynamicMockModule("PyQt6.QtWidgets"),
+        "PyQt6.QtCore": DynamicMockModule("PyQt6.QtCore"),
+        "PyQt6.QtMultimedia": DynamicMockModule("PyQt6.QtMultimedia"),
+        "anki": DynamicMockModule("anki"),
+        "anki.buildinfo": DynamicMockModule("anki.buildinfo"),
+    }
+    mocks.update(parent_pkgs)
+
+    with patch.dict(sys.modules, mocks):
+        import importlib.util
+
+        spec = importlib.util.spec_from_file_location(
+            "Ankimon.pyobj.ankimon_tracker",
+            _SRC / "Ankimon" / "pyobj" / "ankimon_tracker.py",
+        )
+        mod = importlib.util.module_from_spec(spec)
+        sys.modules["Ankimon.pyobj.ankimon_tracker"] = mod
+        spec.loader.exec_module(mod)
+
+        # Start every test from a clean registry so ``services.col`` is the only
+        # thing steering ``get_total_reviews``.
+        mod.services.reset()
+        yield mod
+
+    # Restore sys.modules to EXACTLY its pre-test state, resolving side effects.
+    for key in list(sys.modules):
+        if key not in original_modules:
+            del sys.modules[key]
+        else:
+            sys.modules[key] = original_modules[key]
+
+
+def _make_tracker(mod):
+    return mod.AnkimonTracker(MagicMock())
+
+
+def test_faint_processed_guard_defaults_false(tracker_module):
+    """The net-new duplicate-faint guard initialises to ``False``."""
+    tracker = _make_tracker(tracker_module)
+    assert tracker.faint_processed is False
+
+
+def test_get_total_reviews_database_success(tracker_module):
+    """``get_total_reviews`` queries the revlog and returns the scalar count,
+    filtering from the start of today (``day_cutoff`` minus 24h, in ms)."""
+    tracker = _make_tracker(tracker_module)
+
+    mock_col = MagicMock()
+    mock_col.sched.day_cutoff = 1716800000
+    mock_col.db.scalar.return_value = 42
+    tracker_module.services.col = mock_col
+
+    reviews = tracker.get_total_reviews()
+
+    assert reviews == 42
+    mock_col.db.scalar.assert_called_once_with(
+        "SELECT count() FROM revlog WHERE id > ?", (1716800000 - 86400) * 1000
+    )
+
+
+def test_get_total_reviews_database_failure_fallback_english(tracker_module):
+    """When the DB query fails, fall back to parsing ``studied_today`` (EN)."""
+    tracker = _make_tracker(tracker_module)
+
+    mock_col = MagicMock()
+    mock_col.sched.day_cutoff = 1716800000
+    mock_col.db.scalar.side_effect = Exception("Database is locked")
+    mock_col.studied_today.return_value = "Studied 15 cards in 3.2 minutes today."
+    tracker_module.services.col = mock_col
+
+    reviews = tracker.get_total_reviews()
+
+    assert reviews == 15
+    mock_col.studied_today.assert_called_once()
+
+
+def test_get_total_reviews_database_failure_fallback_localized(tracker_module):
+    """The fallback grabs the first integer, so it works on localized strings."""
+    tracker = _make_tracker(tracker_module)
+
+    mock_col = MagicMock()
+    mock_col.sched.day_cutoff = 1716800000
+    mock_col.db.scalar.side_effect = Exception("Database is locked")
+    mock_col.studied_today.return_value = "Heute 27 Karten in 5.4 Minuten gelernt."
+    tracker_module.services.col = mock_col
+
+    reviews = tracker.get_total_reviews()
+
+    assert reviews == 27
+
+
+def test_get_total_reviews_no_collection(tracker_module):
+    """Returns 0 when neither ``services.col`` nor the ``mw.col`` fallback has a
+    live collection."""
+    tracker = _make_tracker(tracker_module)
+
+    tracker_module.services.col = None
+    # Force the lazy ``from aqt import mw`` fallback to yield no collection too.
+    sys.modules["aqt"].mw = MagicMock()
+    sys.modules["aqt"].mw.col = None
+
+    reviews = tracker.get_total_reviews()
+
+    assert reviews == 0

--- a/tests/test_ankimon_tracker.py
+++ b/tests/test_ankimon_tracker.py
@@ -138,7 +138,8 @@ def test_get_total_reviews_database_failure_fallback_english(tracker_module):
 
 
 def test_get_total_reviews_database_failure_fallback_localized(tracker_module):
-    """The fallback grabs the first integer, so it works on localized strings."""
+    """The fallback grabs the first numeric token, so it works on localized
+    strings."""
     tracker = _make_tracker(tracker_module)
 
     mock_col = MagicMock()
@@ -150,6 +151,43 @@ def test_get_total_reviews_database_failure_fallback_localized(tracker_module):
     reviews = tracker.get_total_reviews()
 
     assert reviews == 27
+
+
+@pytest.mark.parametrize(
+    ("studied_text", "expected"),
+    [
+        # Comma thousands separator (English-style grouping).
+        ("Studied 1,234 cards in 12.5 minutes today.", 1234),
+        # Period thousands separator (German-style; the decimal is a comma).
+        ("Heute 1.234 Karten in 12,5 Minuten gelernt.", 1234),
+        # Plain-space grouping.
+        ("Studied 1 234 cards in 12.5 minutes today.", 1234),
+        # No-break space (U+00A0), classic French grouping.
+        ("1\u00a0234 cartes étudiées en 12,5 minutes aujourd'hui.", 1234),
+        # Narrow no-break space (U+202F), modern CLDR French grouping.
+        ("1\u202f234 cartes étudiées en 12,5 minutes aujourd'hui.", 1234),
+        # Multiple groups.
+        ("Studied 1,234,567 cards in 999.9 minutes today.", 1234567),
+        # An ungrouped count must not swallow the following word or the
+        # decimal minutes that appear later in the string.
+        ("Studied 30 cards in 1.5 minutes today.", 30),
+    ],
+)
+def test_get_total_reviews_fallback_thousands_separators(
+    tracker_module, studied_text, expected
+):
+    """The fallback parses grouped thousands separators (comma, period, space,
+    NBSP, narrow NBSP) as one number instead of stopping at the first digit
+    run — ``"1,234"`` must yield 1234, not 1."""
+    tracker = _make_tracker(tracker_module)
+
+    mock_col = MagicMock()
+    mock_col.sched.day_cutoff = 1716800000
+    mock_col.db.scalar.side_effect = Exception("Database is locked")
+    mock_col.studied_today.return_value = studied_text
+    tracker_module.services.col = mock_col
+
+    assert tracker.get_total_reviews() == expected
 
 
 def test_get_total_reviews_no_collection(tracker_module):


### PR DESCRIPTION
## F35 — AnkimonTracker robustness (faint guard + language-agnostic review count)

Stage-B port of BRRRR_Experimental inventory row **F35** onto main's service-seam architecture.

### (a) Inventory row
- **ID:** F35 — *AnkimonTracker robustness (faint guard + language-agnostic review count)*
- **Source location(s):** `src/Ankimon/pyobj/ankimon_tracker.py`, `tests/test_ankimon_tracker.py`
- **Class:** MIXED · **Harness tier:** GAMEPLAY
- **Parity strategy:** DETERMINISTIC/SEEDED — pin the observable `get_total_reviews` contract.
- **Notes/collision:** Edit-vs-edit with main on `get_total_reviews`. Exp made the daily review
  count language-agnostic via a direct `revlog` SQL query; main had a hardened English-regex parse of
  `studied_today()`. The `faint_processed` guard is net-new state on top.

### (b) Source → target re-fit + MERGE_ARCH_MAP rules applied
Manifest (two-dot, `a8abbd66..origin/BRRRR_Experimental` over the row's Source paths) = **2 commits, 2 hunks**:
- `180bcf29` (overhaul): adds `self.faint_processed = False` in `__init__`.
- `04adddd9` (**post-snapshot**, dated 2026-05-27): rewrites `get_total_reviews` to a direct
  `revlog` query and ships `tests/test_ankimon_tracker.py`. Commit title:
  *"fix: infinite cash rewards on card review by correcting day_cutoff subtraction"*.

Both hunks touch only F35's Source paths and reference no symbols outside them → partition complete
(no partial-port / leak). The post-snapshot `04adddd9` hunk was verified against base: it is the final,
correct form of exp's `get_total_reviews` (subtracts 24h from `day_cutoff` to filter from the start of
today rather than tomorrow's boundary — the infinite-cash fix). It belongs to this row (same file/feature),
so it is carried here, not left for another row.

Re-fit target = `pyobj/ankimon_tracker.py` on main (MERGE_ARCH_MAP §3: `pyobj/ankimon_tracker.py
mw.* -> services.tracker/state`). The file **exists in base**, so hunks were re-authored **onto** main's
seam version (no wholesale checkout). **Behavior = exp's** (revlog query + language-agnostic fallback +
day_cutoff fix); **architecture = main's**.

### (c) Seam re-expression done (which mw.* → which entrypoint)
- `mw.col` (exp read it directly) → resolved through **main's seam**: `col = services.col`, with main's
  lazy `from aqt import mw` / `mw.col` fallback kept intact for the addon-load window. Per §2.1, `mw.col`
  is a **genuine Anki API** and stays via `aqt` in that fallback branch (it is Anki, not addon state).
- `col.sched.day_cutoff` / `col.db.scalar(...)` are called on the resolved `col`, so they run against
  `services.col` in-Anki and against the `mw.col` fallback otherwise — no new direct-`mw` state coupling.
- **No new seam method added**; no existing seam signature/behavior touched.

### (d) Main guards preserved
- Main's `col = services.col` resolution **with** the `mw.col` fallback ("services.col may be unset at
  addon load") is kept — not regressed to exp's bare `mw.col`.
- Main's stub/mock-collection safety is preserved: the whole body is wrapped so a stub `col` whose
  `sched.day_cutoff`/`db.scalar` (or `studied_today`) raises falls through to `return 0` instead of
  throwing. Exp's own outer/inner `try/except` structure provides the same guarantee and is retained.
- `faint_processed` is added purely additively (net-new gameplay state; no consumer in this file — its
  consumers live in other rows' files and are out of scope here).

### (e) Parity oracle + gate commands with REAL output
**Oracle:** `tests/test_ankimon_tracker.py` — ported from exp's shipped test, re-fitted to drive
`services.col` (main's seam) instead of patching a module-level `mw`. It pins: (1) `faint_processed`
defaults `False`; (2) DB success returns the scalar count and calls
`scalar("SELECT count() FROM revlog WHERE id > ?", (day_cutoff-86400)*1000)`; (3) EN fallback = 15 from
`"Studied 15 cards…"`; (4) localized fallback = 27 from `"Heute 27 Karten…"`; (5) no-collection = 0.

```
# (A) Qt-FREE (venv_t1)
$ python -m compileall -q src/Ankimon                 -> exit 0
$ ruff check  --config ci_ruff_check.toml src/Ankimon/pyobj/ankimon_tracker.py tests/test_ankimon_tracker.py
  All checks passed!
$ ruff format --check --config ci_ruff_check.toml <same two files>
  2 files already formatted
$ python harness/check.py
  PASS — all 9 Tier-1 checks green.
$ python -m pytest tests/ --ignore=tests/test_addon_integrity.py --ignore=tests/test_scaffolding_smoke.py -q
  154 passed in 1.19s        # 149 base + 5 new
$ python -m pytest tests/test_ankimon_tracker.py -v
  5 passed in 0.30s

# (B) GAMEPLAY
$ python harness/scenarios/economy.py                 -> economy: OK
$ python harness/scenarios/longrun.py 3000            -> longrun: OK (3000 answers)
$ python -m harness.checks.probe_real_boot   (venv_qt, offscreen) -> probe_real_boot: OK
$ python -m harness.checks.probe_real_play   (venv_qt, offscreen) -> probe_real_play: OK
```
No new failures vs MERGE_BASELINE (ruff 10-error / 78-file whole-tree debt unchanged; the two files
touched are both check- and format-clean).

### (f) Context7 APIs verified
None required — no library signatures re-authored. `col.sched.day_cutoff`, `col.db.scalar(...)` and
`col.studied_today()` are pre-existing Anki calls carried verbatim from exp; the SQLite `revlog` query is
a string literal unchanged from exp's `04adddd9`.

### (g) Residual concerns
- `faint_processed` has no consumer in this file; the battle/encounter code that reads/resets it lives in
  other inventory rows (e.g. battle_loop / encounter). Landing it here is additive and inert until those
  rows arrive.
- The DB-query fallback grabs the first integer in `studied_today()` (exp behavior), slightly looser than
  main's English-anchored regex; it only fires if the primary `revlog` query raises.

### (h) Review follow-up (commit fb934f5b)
Gemini comments 3506923622/3506923644 addressed. The `studied_today()` fallback no longer grabs the
first digit run; it matches the full first numeric token including grouped thousands separators (space,
U+00A0, U+202F, period, comma — groups of exactly 3 digits) and strips the separators before `int()`, so
localized counts like `1,234` / `1.234` / `1 234` parse as 1234 instead of 1, while an ungrouped
`30 cards` still yields 30 and later decimals (`1.5 minutes`) are unaffected. A new parametrized test
(7 cases) pins comma/period/space/NBSP/narrow-NBSP grouping, multi-group counts, and the no-separator
case. Gate delta: Tier-1 pytest is now 161 passed (149 base + 12 new); all other gates unchanged (ruff
10-error known debt only, both touched files format-clean, harness 9/9). Residual concern (g) about the
fallback "grabbing the first integer" is resolved: the fallback is now separator-aware and stricter than
exp's naive first-digit-run parse.

Row: F35. Oracle: `tests/test_ankimon_tracker.py`.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)



## Attribution
The feature ported here was originally implemented on the `BRRRR_Experimental` branch by @hakimh2 (also commits as BrAk909). Authorship credit is recorded via a `Co-authored-by` trailer on this branch.
