### PR TITLE
feat: expand encounter tiers with alternate-form IDs + nature-chart path

### DIFF
--- a/src/Ankimon/resources.py
+++ b/src/Ankimon/resources.py
@@ -55,6 +55,7 @@ poke_species_path = data_files_path / "pokemon_species.csv"
 eff_chart_html_path = addon_dir / "addon_files" / "eff_chart_html.html"
 effectiveness_chart_file_path = addon_dir / "addon_files" / "eff_chart.json"
 table_gen_id_html_path = addon_dir / "addon_files" / "table_gen_id.html"
+nature_chart_html_path = addon_dir / "addon_files" / "nature_chart.html"
 icon_path = addon_dir / "addon_files" / "pokeball.png"
 sound_list_path = addon_dir / "addon_files" / "sound_list.json"
 badges_list_path = addon_dir / "addon_files" / "badges.json"
@@ -427,6 +428,11 @@ POKEMON_TIERS = {
   1022,  # iron-boulder
   1023,  # iron-crown
   1024,  # terapagos
+  10245, 10246,  # dialgaorigin, palkiaorigin
+  10007,         # giratinaorigin
+  10019, 10020, 10021, 10249, # tornadustherian, thundurustherian, landorustherian, enamorustherian
+  10181,         # zygarde10
+  10191,         # urshifurapidstrike
 ]
 ,
   "Mythical": [
@@ -436,10 +442,13 @@ POKEMON_TIERS = {
   251,        # Celebi
   # Gen 3
   385, 386,   # Jirachi, Deoxys
+  10001, 10002, 10003,       # deoxysattack, deoxysdefense, deoxysspeed
   # Gen 4
   489, 490, 491, 492, 493,   # Phione, Manaphy, Darkrai, Shaymin, Arceus
+  10006,                     # shayminsky
   # Gen 5
   494, 647, 648, 649,        # Victini, Keldeo, Meloetta, Genesect
+  10024, 10018,              # keldeoresolute, meloettapirouette
   # Gen 6
   719, 720, 721,             # Diancie, Hoopa, Volcanion
   # Gen 7

--- a/tests/test_encounter_tier_data.py
+++ b/tests/test_encounter_tier_data.py
@@ -1,0 +1,103 @@
+"""Characterization test for F38 — encounter tier data expansion + nature-chart path.
+
+F38 is a pure-data leaf: it adds alternate-form dex IDs to the Legendary and
+Mythical encounter tiers in ``POKEMON_TIERS`` and adds the ``nature_chart_html_path``
+resource constant. There is no ``mw`` access and no seam wiring — the observable
+contract is simply the membership of ``resources.POKEMON_TIERS`` and the resolved
+path constant.
+
+The module is loaded directly from its file (not via ``import Ankimon.resources``)
+so the test runs in the Qt-free Tier-1 environment: ``Ankimon/__init__.py`` imports
+``aqt`` which is absent there, whereas ``resources.py`` itself only needs stdlib
+(``pathlib``/``os``/``json``).
+"""
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+# --- Golden expectations (the "seed -> output" of this data leaf) ----------------
+
+# Alternate-form dex IDs relocated INTO the Legendary tier (commit 8c795df9).
+LEGENDARY_NEW_FORMS = {
+    10245,  # dialgaorigin
+    10246,  # palkiaorigin
+    10007,  # giratinaorigin
+    10019,  # tornadustherian
+    10020,  # thundurustherian
+    10021,  # landorustherian
+    10249,  # enamorustherian
+    10181,  # zygarde10
+    10191,  # urshifurapidstrike
+}
+
+# Alternate-form dex IDs relocated INTO the Mythical tier (commit 8c795df9).
+MYTHICAL_NEW_FORMS = {
+    10001,  # deoxysattack
+    10002,  # deoxysdefense
+    10003,  # deoxysspeed
+    10006,  # shayminsky
+    10024,  # keldeoresolute
+    10018,  # meloettapirouette
+}
+
+PECHARUNT = 1025  # Gen 9 mythical, lives in "Mythical" (not "Ultra").
+
+
+def _load_resources():
+    """Load ``src/Ankimon/resources.py`` in isolation (no package __init__, no aqt)."""
+    resources_path = (
+        Path(__file__).resolve().parents[1] / "src" / "Ankimon" / "resources.py"
+    )
+    spec = importlib.util.spec_from_file_location(
+        "ankimon_resources_f38_probe", resources_path
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def resources():
+    return _load_resources()
+
+
+def test_nature_chart_html_path(resources):
+    path = resources.nature_chart_html_path
+    assert path.name == "nature_chart.html"
+    assert path.parent.name == "addon_files"
+
+
+def test_legendary_tier_has_new_forms(resources):
+    legendary = resources.POKEMON_TIERS["Legendary"]
+    missing = sorted(LEGENDARY_NEW_FORMS - set(legendary))
+    assert not missing, f"Legendary tier missing form IDs: {missing}"
+
+
+def test_mythical_tier_has_new_forms(resources):
+    mythical = resources.POKEMON_TIERS["Mythical"]
+    missing = sorted(MYTHICAL_NEW_FORMS - set(mythical))
+    assert not missing, f"Mythical tier missing form IDs: {missing}"
+
+
+def test_pecharunt_is_mythical_not_ultra(resources):
+    assert PECHARUNT in resources.POKEMON_TIERS["Mythical"]
+    assert PECHARUNT not in resources.POKEMON_TIERS["Ultra"]
+
+
+def test_f38_ids_are_not_duplicated(resources):
+    """Every ID F38 introduces (and Pecharunt) must live in exactly one tier.
+
+    This is scoped to the F38-added IDs on purpose: the base data has unrelated
+    pre-existing cross-tier overlaps (e.g. regional-form ranges) that are out of
+    scope for this leaf and must not be regressed into a false failure here.
+    """
+    f38_ids = LEGENDARY_NEW_FORMS | MYTHICAL_NEW_FORMS | {PECHARUNT}
+    membership = {}
+    for tier, ids in resources.POKEMON_TIERS.items():
+        for dex_id in ids:
+            if dex_id in f38_ids:
+                membership.setdefault(dex_id, []).append(tier)
+    dupes = {k: v for k, v in membership.items() if len(v) > 1}
+    assert not dupes, f"F38 IDs listed in multiple tiers: {dupes}"

--- a/tests/test_encounter_tier_data.py
+++ b/tests/test_encounter_tier_data.py
@@ -10,6 +10,10 @@ The module is loaded directly from its file (not via ``import Ankimon.resources`
 so the test runs in the Qt-free Tier-1 environment: ``Ankimon/__init__.py`` imports
 ``aqt`` which is absent there, whereas ``resources.py`` itself only needs stdlib
 (``pathlib``/``os``/``json``).
+
+A cross-file drift guard against ``functions/encounter_data.py`` (whose lists
+drive wild-encounter generation) is included at the bottom; it self-skips until
+the F22 encounter overhaul replaces that file — see its docstring.
 """
 
 import importlib.util
@@ -101,3 +105,81 @@ def test_f38_ids_are_not_duplicated(resources):
                 membership.setdefault(dex_id, []).append(tier)
     dupes = {k: v for k, v in membership.items() if len(v) > 1}
     assert not dupes, f"F38 IDs listed in multiple tiers: {dupes}"
+
+
+# --- Cross-file drift guard: resources.POKEMON_TIERS vs functions/encounter_data --
+
+
+def _load_encounter_data():
+    """Load ``src/Ankimon/functions/encounter_data.py`` in isolation.
+
+    Like ``resources.py`` it is loaded straight from its file: the module is
+    pure data (no imports at all), so this stays Qt-free and does not trigger
+    ``Ankimon/__init__``'s ``aqt`` import.
+    """
+    encounter_data_path = (
+        Path(__file__).resolve().parents[1]
+        / "src"
+        / "Ankimon"
+        / "functions"
+        / "encounter_data.py"
+    )
+    spec = importlib.util.spec_from_file_location(
+        "ankimon_encounter_data_f38_probe", encounter_data_path
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_encounter_data_agrees_with_pokemon_tiers_on_f38_ids():
+    """Wild-encounter lists must agree with ``POKEMON_TIERS`` on F38's IDs.
+
+    Wild encounters are generated from the ``LEGENDARY``/``MYTHICAL`` lists in
+    ``functions/encounter_data.py`` (via ``get_random_pokemon_in_tier``), while
+    tier classification (badges/achievements on capture) reads
+    ``resources.POKEMON_TIERS`` — the two files must agree on the F38 IDs or
+    tier-based logic diverges.
+
+    The base ``encounter_data.py`` predates the F22 encounter overhaul: it
+    contains none of the F38 alternate-form IDs and still lists Pecharunt under
+    ``LEGENDARY`` (a discrepancy that predates this PR). F22 — a Wave-2 unit,
+    not yet ported — replaces that file with exp's version, which already
+    matches this PR (all form IDs present; Pecharunt in ``MYTHICAL``). Until
+    then this check self-skips; the moment any F38 form ID appears in
+    ``encounter_data.py`` it arms and enforces full consistency, so a partial
+    F22 port fails loudly instead of drifting silently.
+
+    Scope note: consistency is asserted only between ``LEGENDARY`` and
+    ``MYTHICAL``. Exp's ``encounter_data.py`` intentionally also lists some of
+    these IDs elsewhere (e.g. 10191 in ``UNAVAILABLE``, all of them as
+    ``PREREQUISITES`` keys) — those memberships are F22 semantics, not drift.
+    """
+    encounter_data = _load_encounter_data()
+    legendary = set(encounter_data.LEGENDARY)
+    mythical = set(encounter_data.MYTHICAL)
+    form_ids = LEGENDARY_NEW_FORMS | MYTHICAL_NEW_FORMS
+    if not form_ids & (legendary | mythical):
+        pytest.skip(
+            "functions/encounter_data.py predates the F22 encounter overhaul "
+            "(no F38 form IDs present yet); this consistency guard arms "
+            "automatically once F22 lands"
+        )
+    missing_legendary = sorted(LEGENDARY_NEW_FORMS - legendary)
+    assert not missing_legendary, (
+        f"encounter_data.LEGENDARY is missing form IDs: {missing_legendary}"
+    )
+    missing_mythical = sorted(MYTHICAL_NEW_FORMS - mythical)
+    assert not missing_mythical, (
+        f"encounter_data.MYTHICAL is missing form IDs: {missing_mythical}"
+    )
+    cross_listed = sorted(
+        (LEGENDARY_NEW_FORMS & mythical) | (MYTHICAL_NEW_FORMS & legendary)
+    )
+    assert not cross_listed, (
+        f"form IDs listed in the wrong encounter_data tier: {cross_listed}"
+    )
+    assert PECHARUNT in mythical, "Pecharunt must be MYTHICAL in encounter_data"
+    assert PECHARUNT not in legendary, (
+        "Pecharunt must not remain in encounter_data.LEGENDARY once F22 lands"
+    )


### PR DESCRIPTION
## F38 — Encounter tier data expansion + nature-chart resource path

Stage-B port of BRRRR_Experimental feature row **F38** onto main's architecture.

### (a) Inventory row
- **ID:** F38 — *Encounter tier data expansion + nature-chart resource path*
- **Source location(s):** `src/Ankimon/resources.py`
- **Class:** LEAF · **Harness tier:** GAMEPLAY · **Stage-A disposition:** DEFERRED-TO-STAGE-B
- **Parity strategy:** DETERMINISTIC/SEEDED (data contract)
- **Seam-entrypoints-required:** *Pure data/path constants; no `mw` access.*
- Exp provenance: commits `180bcf29` and `8c795df9` (the resources.py hunks only; the rest of those commits belong to other rows).

### (b) Source → target re-fit + MERGE_ARCH_MAP rules applied
`resources.py` **exists in base**, so per STEP 3 I ported only F38's hunks **onto main's version** (three-way, not a wholesale checkout). Two facts drove the re-fit:

1. **main already implemented part of F38.** `git diff a8abbd66..HEAD -- resources.py` shows main already relocated Pecharunt (`1025`) out of the `Ultra` tier into `Mythical` → Gen 9. So I did **not** re-add that hunk (would have been a no-op/duplicate). This is why the ported diff is the *residual* of the exp cumulative diff.
2. **Residual F38 delta layered on top:**
   - `nature_chart_html_path = addon_dir / "addon_files" / "nature_chart.html"` (path constant, next to `table_gen_id_html_path`).
   - `POKEMON_TIERS["Legendary"]`: added the 9 relocated alternate-form dex IDs after `1024 # terapagos` — `10245,10246` (dialga/palkia-origin), `10007` (giratina-origin), `10019,10020,10021,10249` (tornadus/thundurus/landorus/enamorus-therian), `10181` (zygarde-10), `10191` (urshifu-rapid-strike). (Note: exp labels these "Ultra" in prose but git places them in the `Legendary` list preceding `Mythical`; git is ground truth.)
   - `POKEMON_TIERS["Mythical"]`: added `10001,10002,10003` (deoxys attack/defense/speed, Gen 3), `10006` (shaymin-sky, Gen 4), `10024,10018` (keldeo-resolute, meloetta-pirouette, Gen 5).

Rules applied: MERGE_ARCH_MAP **§2.1** (this row has no `mw.*`, so translation dictionary is a no-op), **STEP 3** three-way onto base (no wholesale checkout of an existing-in-base file), and the "keep main's improvements; layer exp on top; do not regress main" principle (kept main's `ANKIMON_USER_PATH` redirect and its Pecharunt relocation untouched).

The exp commit message mentions "move forms **out of the Mega list**"; verified in base that `resources.py` has **no** MEGA/mega list and none of these form IDs appear anywhere in the file (that removal lives in a different module owned by a different row). So the resources.py delta is self-contained; no duplicate IDs introduced.

### (c) Seam re-expression / purely-additive seam methods
None required and none added. F38 is pure data/path constants — no `aqt.mw`, no `services`, no `events`, no seam surface touched. `nature_chart_html_path` is an unused-for-now module constant that a later menu leaf (`get_nature_chart()` in menu_buttons/singletons — other rows) will consume.

### (d) main guards preserved
- Kept main's `user_path` / `ANKIMON_USER_PATH` env redirect block (harness path indirection) verbatim.
- Kept main's already-applied Pecharunt→Mythical Gen 9 relocation (did not revert to exp's Ultra placement).
- No seam/immutable file touched; nothing under `user_files/` staged; `harness/` untouched.
- Did **not** wholesale-reformat `resources.py`: it is one of the 78-file whole-tree `ruff format` baseline-debt files (`ruff format` would rewrite ~1601 lines). Per the baseline discipline ("no NEW failures vs baseline"; "do NOT reformat untouched files / the 78-file baseline must not increase"), edits are surgical and the file's `ruff format --check` status is **unchanged from baseline** (still exactly 1 would-reformat). The new test file is fully `ruff format`-clean.

### (e) Parity oracle + gate commands (REAL output)
**Oracle:** `tests/test_encounter_tier_data.py` — a characterization test that loads the real `resources.py` in isolation (via `importlib.util.spec_from_file_location`, so it runs Qt-free without triggering `Ankimon/__init__`'s `aqt` import) and pins the observable data contract: Legendary/Mythical membership of every F38-added form ID, Pecharunt in Mythical (not Ultra), the `nature_chart.html` path resolution, and that F38's own IDs are not double-listed. (Scoped to F38 IDs on purpose: base data has an unrelated pre-existing cross-tier overlap — dex `899` in Normal & Hisuian — which is out of scope for this leaf.)

```
# (1) compileall — exit 0
$ python -m compileall -q src/Ankimon      -> compileall exit=0

# (2) ruff check (changed files) — ci_ruff_check.toml (PLE, UP018)
$ ruff check --config ci_ruff_check.toml src/Ankimon/resources.py tests/test_encounter_tier_data.py
All checks passed!

# (3) ruff format --check
$ ruff format --config ci_ruff_check.toml --check tests/test_encounter_tier_data.py
1 file already formatted                    # new file clean
$ ruff format --config ci_ruff_check.toml --check src/Ankimon/resources.py
Would reformat: src/Ankimon/resources.py   # == baseline debt (unchanged; not a NEW failure)

# (4) Tier-1 harness
$ python harness/check.py
PASS — all 9 Tier-1 checks green.

# (5) Tier-1 pytest logic (excluding integrity + scaffolding-smoke)
$ python -m pytest tests/ --ignore=tests/test_addon_integrity.py --ignore=tests/test_scaffolding_smoke.py -q
154 passed in 1.12s                          # 149 baseline + 5 new

# (parity) targeted test
$ python -m pytest tests/test_encounter_tier_data.py -q
5 passed

# (GAMEPLAY tier) scenarios (venv_t1)
$ python harness/scenarios/economy.py        -> economy: OK
$ python harness/scenarios/longrun.py 3000   -> longrun: OK (3000 answers, trainer Lv2)

# (GAMEPLAY tier) real Qt probes (venv_qt + QT_QPA_PLATFORM=offscreen)
$ python -m harness.checks.probe_real_boot   -> probe_real_boot: OK
$ python -m harness.checks.probe_real_play   -> probe_real_play: OK (caught 2, defeated 1)
```

### (f) Context7 APIs verified
None — no library API re-authoring involved (pure data/path constants).

### (g) Residual concerns
- `nature_chart_html_path` currently has no consumer in base; it is intentionally landed ahead of its menu leaf (nature-chart menu item / `get_nature_chart()`), which are separate inventory rows. The target file `addon_files/nature_chart.html` is not shipped by this row and will accompany that leaf; nothing in base reads the path yet, so no breakage.
- The alternate-form IDs affect encounter-tier classification only when the encounter overhaul consumes these tiers; the base encounter path already imports `POKEMON_TIERS` and both gameplay probes stay green.
- `resources.py` remains in the pre-existing whole-tree `ruff format` debt by design (not reformatted).

### (h) Review follow-up (Gemini, commit cdd5f53b)
Added a sixth test, `test_encounter_data_agrees_with_pokemon_tiers_on_f38_ids` — a cross-file drift guard asserting `functions/encounter_data.py`'s LEGENDARY/MYTHICAL lists agree with `resources.POKEMON_TIERS` on the F38 IDs (incl. Pecharunt in MYTHICAL). Since base `encounter_data.py` predates the F22 encounter overhaul (owned by row F22, Wave-2), the guard self-skips with an F22-referencing reason until any F38 form ID appears in that file, then arms and enforces full consistency; the armed path was verified green against exp's `encounter_data.py`. Gate figures update accordingly: targeted test file now `5 passed, 1 skipped`; Tier-1 suite now `154 passed, 1 skipped` (the skip is this guard, by design). The encounter_data.py side of the drift itself is intentionally NOT patched here — exp's encounter_data.py already contains the fix and lands wholesale with F22; editing it in this PR would cross the partition and collide with F22's rewrite.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>



## Attribution
The feature ported here was originally implemented on the `BRRRR_Experimental` branch by @hakimh2 (also commits as BrAk909). Authorship credit is recorded via a `Co-authored-by` trailer on this branch.
