### PR TITLE
feat: add shared MovePickerDialog (F41)

### DIFF
--- a/src/Ankimon/pyobj/move_picker.py
+++ b/src/Ankimon/pyobj/move_picker.py
@@ -1,0 +1,372 @@
+import json
+from PyQt6.QtWidgets import (
+    QDialog,
+    QVBoxLayout,
+    QHBoxLayout,
+    QLabel,
+    QPushButton,
+    QLineEdit,
+    QTableWidget,
+    QTableWidgetItem,
+    QHeaderView,
+    QAbstractItemView,
+    QStyledItemDelegate,
+    QStyleOptionViewItem,
+    QFrame,
+)
+from PyQt6.QtCore import Qt, QSize, QRect
+from PyQt6.QtGui import QIcon, QPainter, QColor, QFont, QLinearGradient
+
+from ..functions.pokedex_functions import find_details_move
+from ..functions.gui_functions import type_icon_path, move_category_path
+from ..utils import format_move_name
+
+
+class NumericTableWidgetItem(QTableWidgetItem):
+    def __lt__(self, other):
+        try:
+            t1 = (
+                self.text()
+                .replace("--", "0")
+                .replace("---", "0")
+                .replace("None", "0")
+                .strip()
+            )
+            t2 = (
+                other.text()
+                .replace("--", "0")
+                .replace("---", "0")
+                .replace("None", "0")
+                .strip()
+            )
+            if not t1:
+                t1 = "0"
+            if not t2:
+                t2 = "0"
+            return float(t1) < float(t2)
+        except ValueError:
+            return super().__lt__(other)
+
+
+class SortableIconTableWidgetItem(QTableWidgetItem):
+    """Custom item for sorting columns that only display icons, by using their tooltip text."""
+
+    def __lt__(self, other):
+        return self.toolTip().lower() < other.toolTip().lower()
+
+
+class IconDelegate(QStyledItemDelegate):
+    def paint(self, painter, option, index):
+        option.widget.style().drawControl(
+            option.widget.style().ControlElement.CE_ItemViewItem, option, painter
+        )
+        icon = index.data(Qt.ItemDataRole.DecorationRole)
+        if icon:
+            icon_size = option.decorationSize
+            if icon_size.width() <= 0:
+                icon_size = QSize(50, 30)
+            rect = option.rect
+            x = rect.x() + (rect.width() - icon_size.width()) // 2
+            y = rect.y() + (rect.height() - icon_size.height()) // 2
+            icon.paint(
+                painter,
+                QRect(x, y, icon_size.width(), icon_size.height()),
+                Qt.AlignmentFlag.AlignCenter,
+            )
+
+
+class MovePickerDialog(QDialog):
+    def __init__(
+        self,
+        pokemon_name,
+        all_moves,
+        current_moves,
+        parent=None,
+        force_show_current=False,
+    ):
+        super().__init__(parent)
+        self.setWindowTitle("Move Selection & Details")
+        self.setMinimumSize(1000, 650)
+
+        # Main dark theme with glassy effects
+        self.setStyleSheet("""
+            QDialog {
+                background-color: #0f172a;
+                color: #f8fafc;
+            }
+            QLabel#HeaderLabel {
+                font-size: 26px;
+                font-weight: 900;
+                color: #60a5fa;
+                letter-spacing: 0.5px;
+                margin-bottom: 5px;
+            }
+            QLineEdit {
+                background-color: #1e293b;
+                border: 1px solid #334155;
+                border-radius: 8px;
+                padding: 8px 12px;
+                color: #f1f5f9;
+                font-size: 14px;
+                selection-background-color: #3b82f6;
+            }
+            QLineEdit:focus {
+                border-color: #60a5fa;
+                background-color: #0f172a;
+            }
+            QTableWidget {
+                background-color: #0f172a;
+                alternate-background-color: #161e33;
+                gridline-color: #1e293b;
+                border: 1px solid #334155;
+                border-radius: 8px;
+                font-size: 14px;
+                color: #e2e8f0;
+            }
+            QTableWidget::item {
+                padding-left: 10px;
+            }
+            QTableWidget::item:selected {
+                background-color: #1e40af;
+                color: white;
+            }
+            QHeaderView::section {
+                background-color: #1e293b;
+                color: #94a3b8;
+                font-weight: bold;
+                font-size: 12px;
+                padding: 10px;
+                border: none;
+                text-transform: uppercase;
+            }
+            QPushButton#ActionBtn {
+                font-weight: bold;
+                border-radius: 6px;
+                padding: 8px 20px;
+                font-size: 14px;
+            }
+            QPushButton#LearnBtn {
+                background: qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 #2563eb, stop:1 #1d4ed8);
+                color: white;
+                border: 1px solid #1e40af;
+            }
+            QPushButton#LearnBtn:hover {
+                background: qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 #3b82f6, stop:1 #2563eb);
+            }
+            QPushButton#LearnBtn:disabled {
+                background: #334155;
+                color: #94a3b8;
+                border-color: #1e293b;
+            }
+            QPushButton#CancelBtn {
+                background-color: transparent;
+                color: #94a3b8;
+                border: 1px solid #334155;
+            }
+            QPushButton#CancelBtn:hover {
+                background-color: #1e293b;
+                color: #f1f5f9;
+            }
+            QScrollBar:vertical {
+                border: none;
+                background: #0f172a;
+                width: 10px;
+                margin: 0px;
+            }
+            QScrollBar::handle:vertical {
+                background: #334155;
+                min-height: 20px;
+                border-radius: 5px;
+            }
+            QScrollBar::handle:vertical:hover {
+                background: #475569;
+            }
+        """)
+
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(20, 20, 20, 20)
+        layout.setSpacing(15)
+
+        header_label = QLabel(pokemon_name)
+        header_label.setObjectName("HeaderLabel")
+        layout.addWidget(header_label)
+
+        self.search_bar = QLineEdit()
+        self.search_bar.setPlaceholderText("Search moves by name...")
+        self.search_bar.setClearButtonEnabled(True)
+        self.search_bar.textChanged.connect(self.filter_moves)
+        layout.addWidget(self.search_bar)
+
+        self.table = QTableWidget()
+        self.table.setColumnCount(7)
+        self.table.setHorizontalHeaderLabels(
+            ["Name", "Type", "Category", "Power", "Accuracy", "PP", "Details"]
+        )
+        self.table.setIconSize(QSize(50, 30))
+        self.table.setSelectionBehavior(QAbstractItemView.SelectionBehavior.SelectRows)
+        self.table.setSelectionMode(QAbstractItemView.SelectionMode.SingleSelection)
+        self.table.setEditTriggers(QAbstractItemView.EditTrigger.NoEditTriggers)
+        self.table.verticalHeader().setVisible(False)
+        self.table.verticalHeader().setDefaultSectionSize(50)
+        self.table.setAlternatingRowColors(True)
+
+        self.icon_delegate = IconDelegate()
+        self.table.setItemDelegateForColumn(1, self.icon_delegate)
+        self.table.setItemDelegateForColumn(2, self.icon_delegate)
+
+        header = self.table.horizontalHeader()
+        header.setSectionResizeMode(QHeaderView.ResizeMode.Interactive)
+        header.setSectionResizeMode(0, QHeaderView.ResizeMode.ResizeToContents)
+        for i, width in [(1, 60), (2, 60), (3, 75), (4, 85), (5, 55)]:
+            header.setSectionResizeMode(i, QHeaderView.ResizeMode.Fixed)
+            self.table.setColumnWidth(i, width)
+        header.setSectionResizeMode(6, QHeaderView.ResizeMode.Stretch)
+
+        self.table.setSortingEnabled(True)
+
+        self.current_moves = current_moves
+        self.all_moves = list(all_moves)
+
+        # Only add current moves if explicitly requested (e.g. from clicking a move name)
+        # or if they are already present in the learnable list.
+        if force_show_current:
+            for m in self.current_moves:
+                if m not in self.all_moves:
+                    self.all_moves.append(m)
+
+        self.move_data_cache = {}
+        for move_name in self.all_moves:
+            self.move_data_cache[move_name] = find_details_move(move_name)
+
+        layout.addWidget(self.table)
+
+        self.buttons = QHBoxLayout()
+        self.learn_btn = QPushButton("Learn Move")
+        self.learn_btn.setObjectName("LearnBtn")
+        self.learn_btn.setProperty("class", "ActionBtn")
+        self.learn_btn.setEnabled(False)
+        self.learn_btn.setFixedSize(140, 38)
+        self.learn_btn.setCursor(Qt.CursorShape.PointingHandCursor)
+        self.learn_btn.clicked.connect(self.accept)
+
+        self.cancel_btn = QPushButton("Close")
+        self.cancel_btn.setObjectName("CancelBtn")
+        self.cancel_btn.setFixedSize(100, 38)
+        self.cancel_btn.setCursor(Qt.CursorShape.PointingHandCursor)
+        self.cancel_btn.clicked.connect(self.reject)
+
+        self.buttons.addStretch()
+        self.buttons.addWidget(self.cancel_btn)
+        self.buttons.addWidget(self.learn_btn)
+        layout.addLayout(self.buttons)
+
+        self.table.itemSelectionChanged.connect(self.update_btn_state)
+        self.populate_moves()
+
+    def update_btn_state(self):
+        selected_move = self.get_selected_move()
+        if not selected_move:
+            self.learn_btn.setEnabled(False)
+            self.learn_btn.setText("Select a Move")
+            return
+
+        is_known = selected_move in self.current_moves
+        self.learn_btn.setEnabled(not is_known)
+
+        if is_known:
+            self.learn_btn.setText("Already Known")
+            self.learn_btn.setToolTip("Pokémon already knows this move")
+        else:
+            self.learn_btn.setText("Learn Move")
+            self.learn_btn.setToolTip("")
+
+    def populate_moves(self, filter_text=""):
+        self.table.setSortingEnabled(False)
+        self.table.setRowCount(0)
+        filter_text = filter_text.lower()
+
+        row_idx = 0
+        for move_name in self.all_moves:
+            if filter_text and filter_text not in move_name.lower():
+                continue
+
+            move = self.move_data_cache.get(move_name)
+            if not move:
+                continue
+
+            self.table.insertRow(row_idx)
+
+            is_known = move_name in self.current_moves
+            name_text = format_move_name(move_name)
+
+            # Name Item
+            name_item = QTableWidgetItem(name_text)
+            name_item.setData(Qt.ItemDataRole.UserRole, move_name)
+
+            if is_known:
+                name_item.setForeground(QColor("#4ade80"))
+                name_item.setFont(QFont("", -1, QFont.Weight.Black))
+                name_item.setText(f"{name_text}  ●")
+
+            # Type Icon
+            m_type = move.get("type", "Normal")
+            type_item = SortableIconTableWidgetItem("")
+            t_icon_path = type_icon_path(m_type.lower())
+            if t_icon_path.exists():
+                type_item.setIcon(QIcon(str(t_icon_path)))
+            type_item.setToolTip(m_type)
+
+            self.table.setItem(row_idx, 0, name_item)
+            self.table.setItem(row_idx, 1, type_item)
+
+            # Category Icon
+            cat = move.get("category", "Status")
+            cat_item = SortableIconTableWidgetItem("")
+            c_icon_path = move_category_path(cat)
+            if c_icon_path.exists():
+                cat_item.setIcon(QIcon(str(c_icon_path)))
+            cat_item.setToolTip(cat)
+            self.table.setItem(row_idx, 2, cat_item)
+
+            # BP
+            bp = str(move.get("basePower", "0"))
+            bp_item = NumericTableWidgetItem(bp if bp != "0" else "--")
+            bp_item.setTextAlignment(Qt.AlignmentFlag.AlignCenter)
+            self.table.setItem(row_idx, 3, bp_item)
+
+            # Accuracy
+            acc = move.get("accuracy")
+            acc_str = str(acc) if isinstance(acc, int) else "100"
+            acc_item = NumericTableWidgetItem(acc_str if acc_str != "True" else "---")
+            acc_item.setTextAlignment(Qt.AlignmentFlag.AlignCenter)
+            self.table.setItem(row_idx, 4, acc_item)
+
+            # PP
+            pp_item = NumericTableWidgetItem(str(move.get("pp", "5")))
+            pp_item.setTextAlignment(Qt.AlignmentFlag.AlignCenter)
+            self.table.setItem(row_idx, 5, pp_item)
+
+            # Description
+            desc_item = QTableWidgetItem(move.get("shortDesc", ""))
+            self.table.setItem(row_idx, 6, desc_item)
+
+            if is_known:
+                for col in range(self.table.columnCount()):
+                    item = self.table.item(row_idx, col)
+                    if item:
+                        item.setBackground(QColor("#0f172a"))
+
+            row_idx += 1
+
+        self.table.setSortingEnabled(True)
+        self.table.sortByColumn(0, Qt.SortOrder.AscendingOrder)
+
+    def filter_moves(self, text):
+        self.populate_moves(text)
+
+    def get_selected_move(self):
+        selected_rows = self.table.selectionModel().selectedRows()
+        if not selected_rows:
+            return None
+        row = selected_rows[0].row()
+        return self.table.item(row, 0).data(Qt.ItemDataRole.UserRole)

--- a/src/Ankimon/pyobj/move_picker.py
+++ b/src/Ankimon/pyobj/move_picker.py
@@ -1,5 +1,5 @@
-import json
 from PyQt6.QtWidgets import (
+    QApplication,
     QDialog,
     QVBoxLayout,
     QHBoxLayout,
@@ -11,11 +11,9 @@ from PyQt6.QtWidgets import (
     QHeaderView,
     QAbstractItemView,
     QStyledItemDelegate,
-    QStyleOptionViewItem,
-    QFrame,
 )
 from PyQt6.QtCore import Qt, QSize, QRect
-from PyQt6.QtGui import QIcon, QPainter, QColor, QFont, QLinearGradient
+from PyQt6.QtGui import QIcon, QColor, QFont
 
 from ..functions.pokedex_functions import find_details_move
 from ..functions.gui_functions import type_icon_path, move_category_path
@@ -23,19 +21,23 @@ from ..utils import format_move_name
 
 
 class NumericTableWidgetItem(QTableWidgetItem):
+    """Table item whose placeholder tokens ("--"/"---"/"None") sort as 0."""
+
     def __lt__(self, other):
         try:
+            # "---" must be replaced before "--" (its own prefix), or it
+            # degrades to "0-" and silently falls back to string comparison.
             t1 = (
                 self.text()
-                .replace("--", "0")
                 .replace("---", "0")
+                .replace("--", "0")
                 .replace("None", "0")
                 .strip()
             )
             t2 = (
                 other.text()
-                .replace("--", "0")
                 .replace("---", "0")
+                .replace("--", "0")
                 .replace("None", "0")
                 .strip()
             )
@@ -44,7 +46,9 @@ class NumericTableWidgetItem(QTableWidgetItem):
             if not t2:
                 t2 = "0"
             return float(t1) < float(t2)
-        except ValueError:
+        except (ValueError, AttributeError):
+            # Non-numeric text, or an operand without ``text()`` (e.g. None):
+            # defer to the base-class comparison.
             return super().__lt__(other)
 
 
@@ -52,14 +56,22 @@ class SortableIconTableWidgetItem(QTableWidgetItem):
     """Custom item for sorting columns that only display icons, by using their tooltip text."""
 
     def __lt__(self, other):
-        return self.toolTip().lower() < other.toolTip().lower()
+        try:
+            return self.toolTip().lower() < other.toolTip().lower()
+        except AttributeError:
+            # Operand without ``toolTip()`` (e.g. None): defer to the base class.
+            return super().__lt__(other)
 
 
 class IconDelegate(QStyledItemDelegate):
     def paint(self, painter, option, index):
-        option.widget.style().drawControl(
-            option.widget.style().ControlElement.CE_ItemViewItem, option, painter
-        )
+        # ``option.widget`` can be None (e.g. offscreen or custom rendering).
+        widget = option.widget
+        style = widget.style() if widget is not None else QApplication.style()
+        if style is not None:
+            style.drawControl(
+                style.ControlElement.CE_ItemViewItem, option, painter, widget
+            )
         icon = index.data(Qt.ItemDataRole.DecorationRole)
         if icon:
             icon_size = option.decorationSize
@@ -308,8 +320,8 @@ class MovePickerDialog(QDialog):
                 name_item.setFont(QFont("", -1, QFont.Weight.Black))
                 name_item.setText(f"{name_text}  ●")
 
-            # Type Icon
-            m_type = move.get("type", "Normal")
+            # Type Icon (``or`` also covers a key present with a None value)
+            m_type = move.get("type") or "Normal"
             type_item = SortableIconTableWidgetItem("")
             t_icon_path = type_icon_path(m_type.lower())
             if t_icon_path.exists():
@@ -320,7 +332,7 @@ class MovePickerDialog(QDialog):
             self.table.setItem(row_idx, 1, type_item)
 
             # Category Icon
-            cat = move.get("category", "Status")
+            cat = move.get("category") or "Status"
             cat_item = SortableIconTableWidgetItem("")
             c_icon_path = move_category_path(cat)
             if c_icon_path.exists():
@@ -328,26 +340,34 @@ class MovePickerDialog(QDialog):
             cat_item.setToolTip(cat)
             self.table.setItem(row_idx, 2, cat_item)
 
-            # BP
-            bp = str(move.get("basePower", "0"))
-            bp_item = NumericTableWidgetItem(bp if bp != "0" else "--")
+            # BP ("--" placeholder when absent or zero, e.g. status moves)
+            bp = move.get("basePower")
+            bp_item = NumericTableWidgetItem("--" if bp in (None, 0, "0") else str(bp))
             bp_item.setTextAlignment(Qt.AlignmentFlag.AlignCenter)
             self.table.setItem(row_idx, 3, bp_item)
 
-            # Accuracy
+            # Accuracy (Showdown data uses ``true`` for moves that bypass
+            # accuracy checks; bool must be tested before int — bool is an
+            # int subclass)
             acc = move.get("accuracy")
-            acc_str = str(acc) if isinstance(acc, int) else "100"
-            acc_item = NumericTableWidgetItem(acc_str if acc_str != "True" else "---")
+            if isinstance(acc, bool):
+                acc_str = "---"
+            elif isinstance(acc, int):
+                acc_str = str(acc)
+            else:
+                acc_str = "100"
+            acc_item = NumericTableWidgetItem(acc_str)
             acc_item.setTextAlignment(Qt.AlignmentFlag.AlignCenter)
             self.table.setItem(row_idx, 4, acc_item)
 
             # PP
-            pp_item = NumericTableWidgetItem(str(move.get("pp", "5")))
+            pp = move.get("pp")
+            pp_item = NumericTableWidgetItem(str(pp) if pp is not None else "5")
             pp_item.setTextAlignment(Qt.AlignmentFlag.AlignCenter)
             self.table.setItem(row_idx, 5, pp_item)
 
             # Description
-            desc_item = QTableWidgetItem(move.get("shortDesc", ""))
+            desc_item = QTableWidgetItem(move.get("shortDesc") or "")
             self.table.setItem(row_idx, 6, desc_item)
 
             if is_known:
@@ -369,4 +389,5 @@ class MovePickerDialog(QDialog):
         if not selected_rows:
             return None
         row = selected_rows[0].row()
-        return self.table.item(row, 0).data(Qt.ItemDataRole.UserRole)
+        item = self.table.item(row, 0)
+        return item.data(Qt.ItemDataRole.UserRole) if item is not None else None

--- a/tests/test_move_picker.py
+++ b/tests/test_move_picker.py
@@ -1,0 +1,269 @@
+"""Characterization tests for the shared MovePickerDialog (inventory row F41).
+
+``pyobj/move_picker.py`` is an exp-only NEW module: a pure-Qt move-selection
+dialog shared by three leaves (PC-box move manager, pokemon-details
+remember-attack, evolution learn-move). It has no ``aqt.mw``/``services`` usage
+at all -- callers pass data in -- so this pins the dialog's OBSERVABLE contract
+(rows built from resolvable moves, current-move marking, learn-button state,
+selection round-trip, search filtering, and the two custom sort-item ``__lt__``
+semantics) against a stubbed data layer.
+
+These need real PyQt6 (a QApplication), so they run in the Qt / Tier-2 env; the
+whole module skips cleanly where PyQt6 is absent OR has been mocked in
+``sys.modules`` by another (Tier-1) test file -- mirroring
+``test_scaffolding_smoke.py``. Run standalone with::
+
+    pytest tests/test_move_picker.py
+"""
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("PyQt6")  # Qt env only; skipped in the aqt-free Tier-1 env.
+
+
+_MODULE_NAME = "Ankimon.pyobj.move_picker"
+
+# Deterministic stub move table for the stubbed ``find_details_move``.
+_STUB_MOVES = {
+    "tackle": {
+        "type": "Normal",
+        "category": "Physical",
+        "basePower": 40,
+        "accuracy": 100,
+        "pp": 35,
+        "shortDesc": "A physical attack.",
+    },
+    "thunderbolt": {
+        "type": "Electric",
+        "category": "Special",
+        "basePower": 90,
+        "accuracy": 100,
+        "pp": 15,
+        "shortDesc": "May paralyze the target.",
+    },
+    "growl": {
+        "type": "Normal",
+        "category": "Status",
+        "basePower": 0,
+        "accuracy": True,  # non-int accuracy -> displayed as "---"
+        "pp": 40,
+        "shortDesc": "Lowers the target's Attack.",
+    },
+    "swift": {
+        "type": "Normal",
+        "category": "Special",
+        "basePower": 60,
+        "accuracy": True,
+        "pp": 20,
+        "shortDesc": "Never misses.",
+    },
+}
+
+
+class _NoIconPath:
+    """Stand-in for ``type_icon_path``/``move_category_path`` results.
+
+    The dialog only calls ``.exists()`` before loading an icon; returning False
+    keeps the test independent of on-disk sprite assets.
+    """
+
+    def exists(self):
+        return False
+
+
+@pytest.fixture(autouse=True)
+def _env_guard():
+    """Skip gracefully when another test file has mocked PyQt6 in this run.
+
+    Several base test files mock ``PyQt6``/``aqt`` in ``sys.modules``; un-mocking
+    a compiled Qt extension mid-process is not reliable, so we skip rather than
+    fail when real Qt is not active. Matches ``test_scaffolding_smoke.py``.
+    """
+    from PyQt6.QtWidgets import QDialog
+
+    if not isinstance(QDialog, type):  # PyQt6 was mocked by another test
+        pytest.skip(
+            "real PyQt6 not active (mocked by another test); "
+            "run tests/test_move_picker.py standalone"
+        )
+
+    src = Path(__file__).parent.parent / "src"
+    if str(src) not in sys.path:
+        sys.path.insert(0, str(src))
+    yield
+
+
+@pytest.fixture
+def move_picker(qapp):
+    """Load ``move_picker`` in isolation with its three deps stubbed.
+
+    Mirrors the base-suite idiom (see ``test_learnset_retrieval.py``): stub the
+    modules the target imports at module level, then load the single file via
+    ``spec_from_file_location`` so ``Ankimon/__init__.py`` never runs.
+    """
+    saved = {
+        name: sys.modules.get(name)
+        for name in (
+            "Ankimon",
+            "Ankimon.functions",
+            "Ankimon.pyobj",
+            "Ankimon.functions.pokedex_functions",
+            "Ankimon.functions.gui_functions",
+            "Ankimon.utils",
+            _MODULE_NAME,
+        )
+    }
+    src = Path(__file__).parent.parent / "src"
+
+    for pkg in ("Ankimon", "Ankimon.functions", "Ankimon.pyobj"):
+        mod = types.ModuleType(pkg)
+        mod.__path__ = [str(src / pkg.replace(".", "/"))]
+        mod.__package__ = pkg
+        sys.modules[pkg] = mod
+
+    pf = types.ModuleType("Ankimon.functions.pokedex_functions")
+    pf.find_details_move = lambda name: _STUB_MOVES.get(name)
+    sys.modules["Ankimon.functions.pokedex_functions"] = pf
+
+    gf = types.ModuleType("Ankimon.functions.gui_functions")
+    gf.type_icon_path = lambda t: _NoIconPath()
+    gf.move_category_path = lambda c: _NoIconPath()
+    sys.modules["Ankimon.functions.gui_functions"] = gf
+
+    ut = types.ModuleType("Ankimon.utils")
+    ut.format_move_name = lambda s: s.replace("-", " ").title()
+    sys.modules["Ankimon.utils"] = ut
+
+    spec = importlib.util.spec_from_file_location(
+        _MODULE_NAME, src / "Ankimon" / "pyobj" / "move_picker.py"
+    )
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[_MODULE_NAME] = module
+    spec.loader.exec_module(module)
+
+    try:
+        yield module
+    finally:
+        for name, val in saved.items():
+            if val is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = val
+
+
+def _rows_by_userrole(dialog):
+    """Map each visible row's stored move key (UserRole) -> row index."""
+    from PyQt6.QtCore import Qt
+
+    out = {}
+    for row in range(dialog.table.rowCount()):
+        item = dialog.table.item(row, 0)
+        out[item.data(Qt.ItemDataRole.UserRole)] = row
+    return out
+
+
+def test_only_resolvable_moves_become_rows(move_picker):
+    dialog = move_picker.MovePickerDialog(
+        "Pikachu",
+        all_moves=["tackle", "thunderbolt", "growl", "does-not-exist"],
+        current_moves=["tackle"],
+    )
+    # "does-not-exist" has no move data -> skipped by ``if not move: continue``.
+    assert set(_rows_by_userrole(dialog)) == {"tackle", "thunderbolt", "growl"}
+
+
+def test_current_move_is_marked(move_picker):
+    dialog = move_picker.MovePickerDialog(
+        "Pikachu",
+        all_moves=["tackle", "thunderbolt"],
+        current_moves=["tackle"],
+    )
+    rows = _rows_by_userrole(dialog)
+    known_text = dialog.table.item(rows["tackle"], 0).text()
+    unknown_text = dialog.table.item(rows["thunderbolt"], 0).text()
+    assert "●" in known_text  # known move gets the ● badge
+    assert "●" not in unknown_text
+
+
+def test_learn_button_starts_disabled(move_picker):
+    dialog = move_picker.MovePickerDialog(
+        "Pikachu", all_moves=["thunderbolt"], current_moves=[]
+    )
+    assert dialog.learn_btn.isEnabled() is False
+
+
+def test_button_state_tracks_selection(move_picker):
+    dialog = move_picker.MovePickerDialog(
+        "Pikachu",
+        all_moves=["tackle", "thunderbolt"],
+        current_moves=["tackle"],
+    )
+    rows = _rows_by_userrole(dialog)
+
+    dialog.table.selectRow(rows["tackle"])  # already known
+    assert dialog.learn_btn.isEnabled() is False
+    assert dialog.learn_btn.text() == "Already Known"
+
+    dialog.table.selectRow(rows["thunderbolt"])  # learnable
+    assert dialog.learn_btn.isEnabled() is True
+    assert dialog.learn_btn.text() == "Learn Move"
+    assert dialog.get_selected_move() == "thunderbolt"
+
+
+def test_search_filter_narrows_rows(move_picker):
+    dialog = move_picker.MovePickerDialog(
+        "Pikachu",
+        all_moves=["tackle", "thunderbolt", "growl"],
+        current_moves=[],
+    )
+    assert dialog.table.rowCount() == 3
+
+    dialog.filter_moves("thunder")
+    assert set(_rows_by_userrole(dialog)) == {"thunderbolt"}
+
+    dialog.filter_moves("")  # cleared -> all resolvable rows return
+    assert dialog.table.rowCount() == 3
+
+
+def test_force_show_current_toggles_extra_row(move_picker):
+    with_current = move_picker.MovePickerDialog(
+        "Eevee",
+        all_moves=["tackle"],
+        current_moves=["swift"],
+        force_show_current=True,
+    )
+    assert set(_rows_by_userrole(with_current)) == {"tackle", "swift"}
+
+    without_current = move_picker.MovePickerDialog(
+        "Eevee",
+        all_moves=["tackle"],
+        current_moves=["swift"],
+        force_show_current=False,
+    )
+    assert set(_rows_by_userrole(without_current)) == {"tackle"}
+
+
+def test_numeric_item_sort_semantics(move_picker):
+    numeric = move_picker.NumericTableWidgetItem
+    # placeholder tokens collapse to 0, then numeric comparison
+    assert (numeric("--") < numeric("40")) is True
+    assert (numeric("90") < numeric("40")) is False
+    assert (numeric("---") < numeric("5")) is True
+    # non-numeric text falls back to the default (string) comparison
+    assert (numeric("abc") < numeric("bcd")) == ("abc" < "bcd")
+
+
+def test_icon_item_sorts_by_lowercased_tooltip(move_picker):
+    icon_item = move_picker.SortableIconTableWidgetItem
+    electric = icon_item("")
+    electric.setToolTip("Electric")
+    normal = icon_item("")
+    normal.setToolTip("normal")
+    # case-insensitive: "electric" < "normal"
+    assert (electric < normal) is True
+    assert (normal < electric) is False

--- a/tests/test_move_picker.py
+++ b/tests/test_move_picker.py
@@ -62,6 +62,14 @@ _STUB_MOVES = {
         "pp": 20,
         "shortDesc": "Never misses.",
     },
+    "mystery": {  # every key present but None: populate_moves must stay None-safe
+        "type": None,
+        "category": None,
+        "basePower": None,
+        "accuracy": None,
+        "pp": None,
+        "shortDesc": None,
+    },
 }
 
 
@@ -267,3 +275,93 @@ def test_icon_item_sorts_by_lowercased_tooltip(move_picker):
     # case-insensitive: "electric" < "normal"
     assert (electric < normal) is True
     assert (normal < electric) is False
+
+
+def test_sort_items_tolerate_non_item_operands(move_picker):
+    """Comparing against None / non-items must not raise AttributeError.
+
+    Both ``__lt__`` overrides defer to the base class, whose rich-compare
+    returns ``NotImplemented`` for foreign operands, so Python's operator
+    machinery raises its standard ``TypeError`` instead of an
+    ``AttributeError`` escaping mid-sort.
+    """
+    numeric = move_picker.NumericTableWidgetItem("40")
+    assert numeric.__lt__(None) is NotImplemented
+    assert numeric.__lt__(object()) is NotImplemented
+
+    icon_item = move_picker.SortableIconTableWidgetItem("")
+    icon_item.setToolTip("Electric")
+    assert icon_item.__lt__(None) is NotImplemented
+    assert icon_item.__lt__(object()) is NotImplemented
+
+
+def test_numeric_item_triple_dash_sorts_as_zero(move_picker):
+    numeric = move_picker.NumericTableWidgetItem
+    # "---" collapses to 0 *numerically* (it must be replaced before its own
+    # prefix "--"): it is neither less nor greater than "0".
+    assert (numeric("---") < numeric("0")) is False
+    assert (numeric("0") < numeric("---")) is False
+    assert (numeric("100") < numeric("---")) is False
+
+
+def test_stat_columns_display_contract(move_picker):
+    dialog = move_picker.MovePickerDialog(
+        "Pikachu", all_moves=["tackle", "growl"], current_moves=[]
+    )
+    rows = _rows_by_userrole(dialog)
+    growl, tackle = rows["growl"], rows["tackle"]
+    assert dialog.table.item(growl, 3).text() == "--"  # basePower 0
+    assert dialog.table.item(growl, 4).text() == "---"  # accuracy True (sure-hit)
+    assert dialog.table.item(tackle, 3).text() == "40"
+    assert dialog.table.item(tackle, 4).text() == "100"
+    assert dialog.table.item(tackle, 5).text() == "35"
+
+
+def test_populate_survives_none_valued_move_fields(move_picker):
+    """A move whose keys exist but hold None renders placeholders, not a crash."""
+    dialog = move_picker.MovePickerDialog(
+        "Porygon", all_moves=["mystery"], current_moves=[]
+    )
+    row = _rows_by_userrole(dialog)["mystery"]
+    assert dialog.table.item(row, 1).toolTip() == "Normal"  # type default
+    assert dialog.table.item(row, 2).toolTip() == "Status"  # category default
+    assert dialog.table.item(row, 3).text() == "--"  # basePower None
+    assert dialog.table.item(row, 4).text() == "100"  # accuracy None
+    assert dialog.table.item(row, 5).text() == "5"  # pp None
+    assert dialog.table.item(row, 6).text() == ""  # shortDesc None
+
+
+def test_get_selected_move_survives_missing_name_item(move_picker):
+    dialog = move_picker.MovePickerDialog(
+        "Pikachu", all_moves=["tackle"], current_moves=[]
+    )
+    dialog.table.selectRow(0)
+    assert dialog.get_selected_move() == "tackle"
+    dialog.table.takeItem(0, 0)  # name cell cleared out from under the selection
+    assert dialog.get_selected_move() is None
+
+
+def test_icon_delegate_paints_without_widget(move_picker):
+    """``option.widget`` is None under offscreen/custom rendering; paint must
+    fall back to ``QApplication.style()`` instead of crashing."""
+    from PyQt6.QtGui import QIcon, QPainter, QPixmap
+    from PyQt6.QtWidgets import QStyleOptionViewItem, QTableWidget, QTableWidgetItem
+
+    table = QTableWidget(1, 1)
+    icon_pixmap = QPixmap(10, 10)
+    icon_pixmap.fill()
+    cell = QTableWidgetItem("")
+    cell.setIcon(QIcon(icon_pixmap))
+    table.setItem(0, 0, cell)
+    index = table.model().index(0, 0)
+
+    option = QStyleOptionViewItem()  # default-constructed: no widget attached
+    assert option.widget is None
+
+    target = QPixmap(60, 40)
+    target.fill()
+    painter = QPainter(target)
+    try:
+        move_picker.IconDelegate().paint(painter, option, index)
+    finally:
+        painter.end()


### PR DESCRIPTION
## F41 — Move learning UI (`MovePickerDialog`)

Stage-B port of exactly one BRRRR_Experimental feature (inventory row **F41**) onto
`main`'s architecture. Base: `integration/brrr-into-main`.

### (a) Inventory row
- **ID:** F41 — Move learning UI (`MovePickerDialog`)
- **Source location(s):** `src/Ankimon/pyobj/move_picker.py`
- **Class:** SCAFFOLDING · **Stage-A disposition:** DEFERRED-TO-STAGE-B (ref **NR-03**)
- **Target:** `src/Ankimon/pyobj/move_picker.py` (new module), importable by the PC-box
  move manager, `pokemon_details` remember-attack, and the evolution learn-move leaf.
- **Harness tier:** UI-ONLY · **Parity strategy:** OBSERVABLE — characterization / import+construct smoke
- **Dependencies:** `pokedex_functions.find_details_move`, `gui_functions.type_icon_path` /
  `move_category_path`, `utils.format_move_name` — all present in base.

### (b) Source → target re-fit + MERGE_ARCH_MAP rules applied
- **Manifest (git is ground truth):**
  `git diff a8abbd66..origin/BRRRR_Experimental -- src/Ankimon/pyobj/move_picker.py` is a single
  `new file` hunk (+328). `--name-only` confirms the diff touches **only** this path; the git log
  shows one exp commit (`180bcf29`). No references to files/symbols outside the row's Source path →
  partition is complete (no partial-port).
- **File is exp-only NEW** (`git cat-file -e HEAD:src/Ankimon/pyobj/move_picker.py` → absent in base),
  so per STEP 3 a **wholesale checkout is authorized** for this file (it does not revert any base
  seam/guard). Brought in via `git checkout origin/BRRRR_Experimental -- <path>`, then `ruff format`
  applied (my added file). The three dependency symbols were verified to exist in base at their
  expected import paths (`functions/pokedex_functions.py`, `functions/gui_functions.py`, and
  `format_move_name` re-exported by `utils.py` — the exact `from ..utils import format_move_name`
  form is already used by `pyobj/attack_dialog.py`).
- **MERGE_ARCH_MAP rules applied:** §6 "purely-additive NEW file / shared scaffolding pulled forward
  ahead of its leaf callers" (NR-03). No entry in §3's shared-module reversion set; not a §7 hotspot;
  no §2.1 translation needed (see (c)).

### (c) Seam re-expression
- **None required.** The module has **zero** `aqt.mw.*` / `services.*` / `aqt` usage
  (`grep -nE '\bmw\b|services\.|from aqt|import aqt' src/Ankimon/pyobj/move_picker.py` → clean). It is
  pure PyQt6; callers pass `pokemon_name`, `all_moves`, `current_moves` in. §2.1 dictionary therefore
  has nothing to translate.
- **No new/edited seam method.** Nothing under `src/Ankimon/{core,services,events,ui_port,
  gui_presenter,hooks}.py` or any other immutable/seam file was touched — no additive seam method
  was needed or added.

### (d) Main guards preserved
- No base file was modified, so all of main's seam wiring and guards are untouched by definition. The
  only base-repo change is the addition of this new module + its test. The module does not import
  `poke_engine`, does not reach `aqt.mw`, and reverts none of main's seams.

### (e) Parity oracle + gate commands (REAL output)
**Oracle:** `tests/test_move_picker.py` — a hermetic characterization test (mirrors the base-suite
`test_learnset_retrieval.py` file-isolation idiom + the `test_scaffolding_smoke.py` Qt-env-guard
pattern). It loads `move_picker` via `spec_from_file_location` with its three deps stubbed to a
deterministic move table, then pins the dialog's OBSERVABLE contract: only resolvable moves become
rows (unknown move skipped), current-move ● marking, learn-button initial disabled + selection-driven
state ("Already Known" vs "Learn Move"), `get_selected_move` UserRole round-trip, search-filter
narrowing, `force_show_current` toggling the extra row, and the two custom sort-item `__lt__`
semantics (`NumericTableWidgetItem` placeholder→0/float compare with ValueError string fallback;
`SortableIconTableWidgetItem` case-insensitive tooltip). It `importorskip`s PyQt6 and skips when
another Tier-1 test has mocked PyQt6 in `sys.modules`, so it runs for real only in the Qt env.

Two-environment discipline (never mixed). GREEN = no NEW failures vs `MERGE_BASELINE.md`.

**(A) Qt-FREE (venv_t1):**
```
$ python -m compileall -q src/Ankimon            # exit 0
$ ruff check  --config ci_ruff_check.toml src/Ankimon/pyobj/move_picker.py tests/test_move_picker.py
All checks passed!
$ ruff format --check --config ci_ruff_check.toml src/Ankimon/pyobj/move_picker.py tests/test_move_picker.py
2 files already formatted
$ python harness/check.py
PASS — all 9 Tier-1 checks green.
$ python -m pytest tests/ --ignore=tests/test_addon_integrity.py --ignore=tests/test_scaffolding_smoke.py -q
149 passed, 8 skipped in 1.12s
```
(The 8 skips are this file's tests skipping gracefully in the Qt-free env, exactly as
`test_scaffolding_smoke.py` does — baseline `149 passed` is preserved, zero new ruff errors, and no
untouched file was reformatted so the 10/78 baseline debt is unchanged.)

**Parity test (venv_qt, offscreen, standalone):**
```
$ QT_QPA_PLATFORM=offscreen QTWEBENGINE_DISABLE_SANDBOX=1 \
  python -m pytest tests/test_move_picker.py -q
8 passed in 0.05s
```

Harness tier is **UI-ONLY**, so the GAMEPLAY-only Tier-2 gates (economy / longrun /
`probe_real_boot` / `probe_real_play`) are out of scope for this row. The new module is orphan-additive
(no base caller imports it yet — it is shared scaffolding pulled forward ahead of its leaves per
NR-03), so it cannot affect the boot/play paths.

### (f) Context7 APIs verified
None required — no unfamiliar/re-authored library API. The module uses only stable PyQt6 widget APIs
already exercised across the codebase, and the parity test asserts the observable behavior directly.

### (g) Residual concerns
- The module carries an unused top-level `import json` as shipped by exp. It is intentionally left
  as-is for exact behavior parity; CI ruff (`select = ["PLE","UP018"]`) does not flag F401, so it adds
  no gate error. A future cleanup wave may drop it.
- This is shared scaffolding with **no caller on main yet**; its three leaf consumers (F42 PC-box,
  F43 pokemon-details, evolution learn-move) land in later waves and will import it then.

Row-only port; no other inventory row's files touched.

### (h) Post-review hardening (commit 879764ce)
All five Gemini robustness comments applied on their merits — sort-item `__lt__` overrides now fall
back to the base-class comparison for operands without `text()`/`toolTip()` (base rich-compare
returns `NotImplemented`, yielding standard `TypeError` semantics instead of `AttributeError`
mid-sort); `IconDelegate.paint` falls back to `QApplication.style()` when `option.widget` is None and
passes the widget to `drawControl`; `populate_moves` is None-safe for
type/category/basePower/pp/shortDesc values and branches accuracy explicitly bool-before-int
(accuracy `None` still renders `"100"` for exact behavior parity); `get_selected_move` guards a
missing name item. An independent dive also fixed a real exp-inherited sort bug: `"---"` was replaced
after its own prefix `"--"`, degrading to `"0-"` → `ValueError` → silent string-comparison fallback,
so the triple-dash placeholder now genuinely sorts as 0.

**Section (e) counts update:** `tests/test_move_picker.py` is now 14 tests (14 passed in venv_qt;
Tier-1 run is `149 passed, 14 skipped` — the 6 extra skips are the new Qt-only cases).
**Section (g) update:** the unused `import json` (and other dead exp imports: `QFrame`, `QPainter`,
`QLinearGradient`, `QStyleOptionViewItem`) have now been dropped, so that residual concern is
resolved; module behavior parity is instead pinned by the expanded characterization suite, five of
whose six new cases fail against the pre-fix module.


Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>



## Attribution
The feature ported here was originally implemented on the `BRRRR_Experimental` branch by @hakimh2 (also commits as BrAk909). Authorship credit is recorded via a `Co-authored-by` trailer on this branch.
