### PR TITLE
feat(learnset): suffix-cleaning, L/R/S methods, Deoxys/eternamax + gen fallbacks

### DIFF
--- a/src/Ankimon/functions/learnset_retrieval.py
+++ b/src/Ankimon/functions/learnset_retrieval.py
@@ -6,6 +6,7 @@ from ..resources import learnset_path
 # === Cache learnset data ===
 _learnset_cache = None
 
+
 def _load_learnset_cache():
     """Load learnset JSON once and cache it in memory"""
     global _learnset_cache
@@ -18,68 +19,214 @@ def _load_learnset_cache():
             _learnset_cache = {}
     return _learnset_cache
 
+
 def clear_learnset_cache():
     """Clear the learnset cache if data is updated"""
     global _learnset_cache
     _learnset_cache = None
 
+
+def clean_pokeapi_name(name: str) -> str:
+    name_lower = name.lower()
+
+    # Handle female forms (PokéAPI "-female" -> Smogon "f")
+    if name_lower.endswith("-female"):
+        return name[:-7] + "f"
+
+    suffixes_to_strip = [
+        "-standard",
+        "-normal",
+        "-altered",
+        "-land",
+        "-red-striped",
+        "-male",
+        "-ordinary",
+        "-aria",
+        "-average",
+        "-disguised",
+        "-amped",
+        "-ice",
+        "-single-strike",
+        "-zero",
+        "-curly",
+        "-two-segment",
+        "-green-plumage",
+        "-plant",
+        "-mask",
+    ]
+    for suffix in suffixes_to_strip:
+        if name_lower.endswith(suffix):
+            return name[: -len(suffix)]
+
+    return name
+
+
+DEOXYS_EXCLUSIONS = {
+    "deoxys": {
+        "spikes",
+        "superpower",
+        "extremespeed",
+        "zapcannon",
+        "irondefense",
+        "amnesia",
+        "agility",
+        "counter",
+        "mirrorcoat",
+    },
+    "deoxysattack": {
+        "spikes",
+        "extremespeed",
+        "cosmicpower",
+        "irondefense",
+        "amnesia",
+        "agility",
+        "recover",
+        "counter",
+        "mirrorcoat",
+        "doubleteam",
+    },
+    "deoxysdefense": {
+        "superpower",
+        "extremespeed",
+        "cosmicpower",
+        "zapcannon",
+        "agility",
+        "doubleteam",
+    },
+    "deoxysspeed": {
+        "spikes",
+        "superpower",
+        "cosmicpower",
+        "zapcannon",
+        "irondefense",
+        "amnesia",
+        "counter",
+        "mirrorcoat",
+    },
+}
+
+
 def _get_learnset_moves(pokemon_name, pokemon_level, generation=9):
     """
     Return all moves a Pokémon can know at *pokemon_level* in a single *generation*.
-
-    Args:
-        pokemon_name: Pokémon name (case-insensitive).
-        pokemon_level: Current level of the Pokémon.
-        generation: Generation to filter learn_codes by (default 9).
-
-    Returns:
-        dict mapping move_name -> learn_level for every move learnable
-        at or below *pokemon_level* within the specified generation.
+    Falls back to earlier generations if no moves are found.
+    Handles Mega/Gigantamax forms by falling back to base form learnset.
     """
     learnsets = _load_learnset_cache()
 
-    pokemon_name = pokemon_name.lower().replace("-", "").replace(" ", "").replace("'", "").replace(".", "")
-    pokemon_learnset = learnsets.get(pokemon_name, {}).get("learnset", {})
-    
-    # Fallback to base form for Mega/Gigantamax/Primal if no learnset found
-    if not pokemon_learnset and any(x in pokemon_name for x in ["mega", "gmax", "primal"]):
+    # Try standard key normalization first
+    norm_name = (
+        pokemon_name.lower()
+        .replace("-", "")
+        .replace(" ", "")
+        .replace("'", "")
+        .replace(".", "")
+    )
+    pokemon_learnset = learnsets.get(norm_name, {}).get("learnset", {})
+
+    # Fallback 1: clean PokéAPI suffix mismatches (e.g. "darmanitan-galar-standard" -> "darmanitangalar")
+    if not pokemon_learnset:
+        cleaned_name = clean_pokeapi_name(pokemon_name)
+        cleaned_norm = (
+            cleaned_name.lower()
+            .replace("-", "")
+            .replace(" ", "")
+            .replace("'", "")
+            .replace(".", "")
+        )
+        pokemon_learnset = learnsets.get(cleaned_norm, {}).get("learnset", {})
+
+    # Fallback 2: reverse lookup canonical key using pokedex ID index
+    if not pokemon_learnset:
+        try:
+            from .pokedex_functions import (
+                search_pokedex,
+                search_pokedex_by_id,
+                safe_int,
+            )
+
+            actual_id = safe_int(search_pokedex(pokemon_name, "actual_id"))
+            if actual_id:
+                canonical_key = search_pokedex_by_id(actual_id)
+                if canonical_key and canonical_key != "Pokémon not found":
+                    pokemon_learnset = learnsets.get(canonical_key, {}).get(
+                        "learnset", {}
+                    )
+        except Exception:
+            pass
+
+    # Fallback 3: base form for Mega/Gigantamax/Special forms if no level-up moves found
+    has_lvl_moves = any(
+        any("L" in code for code in codes) for codes in pokemon_learnset.values()
+    )
+    if not pokemon_learnset or not has_lvl_moves:
         # Use pokedex to find the base form via species_id
-        from .pokedex_functions import _load_pokedex_cache, search_pokedex_by_id, search_pokedex
-        pokedex_data = _load_pokedex_cache()
-        
-        # Use search_pokedex to handle normalized names and fallbacks
-        species_id = search_pokedex(pokemon_name, "species_id")
-        
-        if species_id and not isinstance(species_id, list):
-            base_name = search_pokedex_by_id(species_id)
-            if base_name and base_name != "Pokémon not found":
-                pokemon_learnset = learnsets.get(base_name, {}).get("learnset", {})
+        try:
+            from .pokedex_functions import (
+                _load_pokedex_cache,
+                search_pokedex_by_id,
+                search_pokedex,
+            )
+
+            pokedex_data = _load_pokedex_cache()
+
+            # Use search_pokedex to handle normalized names and fallbacks
+            species_id = search_pokedex(norm_name, "species_id")
+
+            if species_id and not isinstance(species_id, list):
+                base_name = search_pokedex_by_id(species_id)
+                if (
+                    base_name
+                    and base_name != "Pokémon not found"
+                    and base_name != norm_name
+                ):
+                    base_learnset = learnsets.get(base_name, {}).get("learnset", {})
+                    pokemon_learnset = {**base_learnset, **pokemon_learnset}
+        except Exception:
+            pass
 
     moves = {}
-    
+
     # Try the requested generation first, then fallback to all earlier generations
     for gen in range(generation, 0, -1):  # Try from requested gen down to gen 1
         moves = {}
         target_generation = str(gen)
-        
+
         for move, learn_codes in pokemon_learnset.items():
+            if norm_name in DEOXYS_EXCLUSIONS and move in DEOXYS_EXCLUSIONS[norm_name]:
+                continue
             best = -1
             for learn_code in learn_codes:
-                move_generation, _, move_level = learn_code.partition("L")
-                if move_generation != target_generation:
+                if not learn_code or learn_code[0] != target_generation:
                     continue
-                
-                learn_level = int(move_level)
+
+                # Parse method: L (level-up), R (relearn), S (special/event level)
+                method = learn_code[1] if len(learn_code) > 1 else ""
+                if method == "L":
+                    try:
+                        learn_level = int(learn_code[2:])
+                    except ValueError:
+                        continue
+                elif method == "R":
+                    learn_level = 1  # Relearn moves can be learned at any level >= 1
+                elif method == "S":
+                    try:
+                        learn_level = int(learn_code[2:])
+                    except ValueError:
+                        continue
+                else:
+                    continue
+
                 if pokemon_level >= learn_level > best:
                     best = learn_level
-            
+
             if best >= 0:
                 moves[move] = best
-        
+
         # If we found moves, return them
         if moves:
             break
-    
+
     return moves
 
 
@@ -100,4 +247,6 @@ def get_levelup_move_for_pokemon(pokemon_name, pokemon_level, generation=9):
     """Return a list of moves learned at exactly *pokemon_level* (never None)."""
     all_moves = _get_learnset_moves(pokemon_name, pokemon_level, generation)
 
-    return [move for move, learn_level in all_moves.items() if learn_level == pokemon_level]
+    return [
+        move for move, learn_level in all_moves.items() if learn_level == pokemon_level
+    ]

--- a/src/Ankimon/functions/learnset_retrieval.py
+++ b/src/Ankimon/functions/learnset_retrieval.py
@@ -110,7 +110,8 @@ def _get_learnset_moves(pokemon_name, pokemon_level, generation=9):
     """
     Return all moves a Pokémon can know at *pokemon_level* in a single *generation*.
     Falls back to earlier generations if no moves are found.
-    Handles Mega/Gigantamax forms by falling back to base form learnset.
+    Resolves PokéAPI/Smogon name mismatches and handles Mega/Gigantamax/special
+    forms by falling back to the base form learnset.
     """
     learnsets = _load_learnset_cache()
 
@@ -170,12 +171,9 @@ def _get_learnset_moves(pokemon_name, pokemon_level, generation=9):
         # Use pokedex to find the base form via species_id
         try:
             from .pokedex_functions import (
-                _load_pokedex_cache,
                 search_pokedex_by_id,
                 search_pokedex,
             )
-
-            pokedex_data = _load_pokedex_cache()
 
             # Use search_pokedex to handle normalized names and fallbacks
             species_id = search_pokedex(norm_name, "species_id")

--- a/src/Ankimon/functions/learnset_retrieval.py
+++ b/src/Ankimon/functions/learnset_retrieval.py
@@ -135,6 +135,10 @@ def _get_learnset_moves(pokemon_name, pokemon_level, generation=9):
             .replace(".", "")
         )
         pokemon_learnset = learnsets.get(cleaned_norm, {}).get("learnset", {})
+        if pokemon_learnset:
+            # Adopt the resolved key so form-specific exclusions and later
+            # fallbacks operate on the name that actually matched.
+            norm_name = cleaned_norm
 
     # Fallback 2: reverse lookup canonical key using pokedex ID index
     if not pokemon_learnset:
@@ -152,6 +156,9 @@ def _get_learnset_moves(pokemon_name, pokemon_level, generation=9):
                     pokemon_learnset = learnsets.get(canonical_key, {}).get(
                         "learnset", {}
                     )
+                    if pokemon_learnset:
+                        # Adopt the canonical key for the same reason as above.
+                        norm_name = canonical_key
         except Exception:
             pass
 

--- a/tests/test_learnset_retrieval.py
+++ b/tests/test_learnset_retrieval.py
@@ -1,7 +1,6 @@
 import json
 import importlib
 import sys
-import types
 
 _orig_modules = {
     name: sys.modules.get(name)

--- a/tests/test_learnset_retrieval.py
+++ b/tests/test_learnset_retrieval.py
@@ -2,15 +2,45 @@ import json
 import importlib
 import sys
 import types
+
+_orig_modules = {
+    name: sys.modules.get(name)
+    for name in [
+        "Ankimon.resources",
+        "Ankimon.pyobj.error_handler",
+        "aqt",
+        "aqt.utils",
+        "aqt.qt",
+    ]
+}
 from pathlib import Path
-from unittest.mock import mock_open, patch
+from unittest.mock import mock_open, patch, MagicMock
 
 import pytest
 
-# Stub resources module with a fake learnset_path
-_resources = types.ModuleType("Ankimon.resources")
-_resources.learnset_path = "/fake/learnsets.json"
-sys.modules["Ankimon.resources"] = _resources
+# Mock aqt modules
+mock_aqt = MagicMock()
+sys.modules["aqt"] = mock_aqt
+sys.modules["aqt.utils"] = mock_aqt.utils
+sys.modules["aqt.qt"] = MagicMock()
+
+# Mock error_handler and pyobj to avoid loading PyQt/Anki dependencies
+sys.modules["Ankimon.pyobj.error_handler"] = MagicMock()
+
+# Stub resources module with a fake learnset_path and fallback attributes
+_src = Path(__file__).parent.parent / "src"
+actual_pokedex_path = _src / "Ankimon" / "data_files" / "pokedex.json"
+
+
+class MockResources:
+    learnset_path = "/fake/learnsets.json"
+    pokedex_path = str(actual_pokedex_path)
+
+    def __getattr__(self, name):
+        return "/fake/dummy"
+
+
+sys.modules["Ankimon.resources"] = MockResources()
 
 # Now load learnset_retrieval from its file
 _src = Path(__file__).parent.parent / "src"
@@ -29,6 +59,13 @@ from Ankimon.functions.learnset_retrieval import (
     get_random_moves_for_pokemon,
 )
 
+# Restore original modules to prevent global mock contamination during test collection
+for name, orig in _orig_modules.items():
+    if orig is None:
+        sys.modules.pop(name, None)
+    else:
+        sys.modules[name] = orig
+
 
 FAKE_LEARNSET = {
     "slowpoke": {
@@ -39,15 +76,65 @@ FAKE_LEARNSET = {
             "yawn": ["9L15"],
             "surf": ["9M"],  # TM, no level entry
         }
-    }
+    },
+    "eternatus": {
+        "learnset": {
+            "dynamaxcannon": ["9L56"],
+        }
+    },
+    "necrozma": {
+        "learnset": {
+            "photongeyser": ["9L1"],
+        }
+    },
+    "necrozmaultra": {
+        "learnset": {
+            "moongeistbeam": ["9R"],
+            "sunsteelstrike": ["9R"],
+        }
+    },
+    "deoxys": {
+        "learnset": {
+            "spikes": ["9L20"],
+            "superpower": ["9L37"],
+            "extremespeed": ["9L73"],
+            "cosmicpower": ["9L35"],
+            "recover": ["9L40"],
+            "teleport": ["9L1"],
+            "zapcannon": ["9L61"],
+        }
+    },
 }
 
 _FAKE_JSON = json.dumps(FAKE_LEARNSET)
 
+original_open = open
+
 
 @pytest.fixture(autouse=True)
 def _mock_learnset_file():
-    with patch("builtins.open", mock_open(read_data=_FAKE_JSON)):
+    res = sys.modules.get("Ankimon.resources")
+    if res is not None:
+        res.learnset_path = "/fake/learnsets.json"
+        res.pokedex_path = str(actual_pokedex_path)
+
+    # Clear pokedex functions cache if it was already loaded to avoid test pollution
+    pokedex_funcs = sys.modules.get("Ankimon.functions.pokedex_functions")
+    if pokedex_funcs is not None:
+        pokedex_funcs.pokedex_path = str(actual_pokedex_path)
+        try:
+            pokedex_funcs.clear_pokedex_caches()
+        except AttributeError:
+            pass
+
+    m = mock_open(read_data=_FAKE_JSON)
+
+    def side_effect(file, *args, **kwargs):
+        if "learnsets.json" in str(file) or "fake" in str(file):
+            return m(file, *args, **kwargs)
+        return original_open(file, *args, **kwargs)
+
+    with patch("builtins.open", side_effect):
         yield
 
 
@@ -121,3 +208,79 @@ class TestGetLevelupMove:
     def test_no_match_returns_empty_list(self):
         result = get_levelup_move_for_pokemon("slowpoke", 13, 9)
         assert result == []
+
+
+class TestLearnsetMismatches:
+    def test_clean_pokeapi_name_suffixes(self):
+        from Ankimon.functions.learnset_retrieval import clean_pokeapi_name
+
+        assert clean_pokeapi_name("Darmanitan-galar-standard") == "Darmanitan-galar"
+        assert clean_pokeapi_name("meowstic-female") == "meowsticf"
+        assert clean_pokeapi_name("giratina-altered") == "giratina"
+        assert clean_pokeapi_name("ogerpon-wellspring-mask") == "ogerpon-wellspring"
+
+    def test_get_learnset_moves_with_mismatched_pokeapi_names(self):
+        # Even with mocked learnsets, if we pass a name with standard/normal suffix,
+        # it should clean it first and successfully find the moves for the base form.
+        moves = _get_learnset_moves("slowpoke-standard", 12, 9)
+        assert "confusion" in moves
+
+        # Test female suffix mapping
+        from Ankimon.functions.learnset_retrieval import _load_learnset_cache
+
+        cache = _load_learnset_cache()
+        cache["slowpokef"] = cache["slowpoke"]
+        moves_f = _get_learnset_moves("slowpoke-female", 12, 9)
+        assert "confusion" in moves_f
+
+    def test_eternamax_learnset_fallback(self):
+        # Test that eternatuseternamax successfully falls back to eternatus learnset
+        moves = _get_learnset_moves("eternatuseternamax", 60, 9)
+        assert "dynamaxcannon" in moves
+        assert moves["dynamaxcannon"] == 56
+
+    def test_special_form_learnset_merge(self):
+        # Test that necrozmaultra (which only has R/tutor moves) merges necrozma's level-up moves
+        # and correctly resolves its own Relearn (R) moves
+        moves = _get_learnset_moves("necrozmaultra", 50, 9)
+        assert "photongeyser" in moves
+        assert "moongeistbeam" in moves
+        assert "sunsteelstrike" in moves
+
+    def test_deoxys_form_exclusive_moves(self):
+        # 1. Deoxys Normal
+        normal_moves = _get_learnset_moves("deoxys", 100, 9)
+        assert "cosmicpower" in normal_moves
+        assert "recover" in normal_moves
+        assert "teleport" in normal_moves
+        assert "spikes" not in normal_moves
+        assert "superpower" not in normal_moves
+        assert "extremespeed" not in normal_moves
+
+        # 2. Deoxys Attack
+        attack_moves = _get_learnset_moves("deoxysattack", 100, 9)
+        assert "superpower" in attack_moves
+        assert "zapcannon" in attack_moves
+        assert "teleport" in attack_moves
+        assert "recover" not in attack_moves
+        assert "spikes" not in attack_moves
+        assert "extremespeed" not in attack_moves
+        assert "cosmicpower" not in attack_moves
+
+        # 3. Deoxys Defense
+        defense_moves = _get_learnset_moves("deoxysdefense", 100, 9)
+        assert "spikes" in defense_moves
+        assert "recover" in defense_moves
+        assert "teleport" in defense_moves
+        assert "superpower" not in defense_moves
+        assert "extremespeed" not in defense_moves
+        assert "cosmicpower" not in defense_moves
+
+        # 4. Deoxys Speed
+        speed_moves = _get_learnset_moves("deoxysspeed", 100, 9)
+        assert "extremespeed" in speed_moves
+        assert "recover" in speed_moves
+        assert "teleport" in speed_moves
+        assert "spikes" not in speed_moves
+        assert "superpower" not in speed_moves
+        assert "cosmicpower" not in speed_moves

--- a/tests/test_learnset_retrieval.py
+++ b/tests/test_learnset_retrieval.py
@@ -284,3 +284,29 @@ class TestLearnsetMismatches:
         assert "spikes" not in speed_moves
         assert "superpower" not in speed_moves
         assert "cosmicpower" not in speed_moves
+
+    def test_deoxys_suffix_cleaned_form_applies_exclusions(self):
+        # "deoxys-normal" (PokéAPI name) resolves to "deoxys" via Fallback 1
+        # suffix cleaning; the normal-form exclusions must key on the resolved
+        # name, not on the stale "deoxysnormal" normalization.
+        moves = _get_learnset_moves("deoxys-normal", 100, 9)
+        assert "cosmicpower" in moves
+        assert "recover" in moves
+        assert "teleport" in moves
+        assert "spikes" not in moves
+        assert "superpower" not in moves
+        assert "extremespeed" not in moves
+        assert "zapcannon" not in moves
+
+    def test_deoxys_reverse_lookup_applies_exclusions(self):
+        # An unmapped form suffix skips Fallback 1 (not in the suffix table)
+        # and resolves via Fallback 2's pokedex reverse lookup ("deoxys-unknown"
+        # -> actual_id 386 -> canonical key "deoxys"); exclusions must key on
+        # the resolved canonical name as well.
+        moves = _get_learnset_moves("deoxys-unknown", 100, 9)
+        assert "cosmicpower" in moves
+        assert "recover" in moves
+        assert "teleport" in moves
+        assert "spikes" not in moves
+        assert "superpower" not in moves
+        assert "extremespeed" not in moves

--- a/tests/test_learnset_robustness.py
+++ b/tests/test_learnset_robustness.py
@@ -2,6 +2,22 @@ import json
 import importlib
 import sys
 import types
+
+_orig_modules = {
+    name: sys.modules.get(name)
+    for name in [
+        "Ankimon.resources",
+        "Ankimon.singletons",
+        "Ankimon.utils",
+        "Ankimon.pyobj",
+        "Ankimon.pyobj.error_handler",
+        "Ankimon.pyobj.QProgressIndicator",
+        "aqt",
+        "aqt.utils",
+        "Anki",
+        "aqt.qt",
+    ]
+}
 from pathlib import Path
 from unittest.mock import patch, MagicMock
 
@@ -50,6 +66,13 @@ sys.modules[_spec.name] = _pf
 _spec.loader.exec_module(_pf)
 
 from Ankimon.functions.pokedex_functions import get_all_pokemon_moves
+
+# Restore original modules to prevent global mock contamination during test collection
+for name, orig in _orig_modules.items():
+    if orig is None:
+        sys.modules.pop(name, None)
+    else:
+        sys.modules[name] = orig
 
 
 def test_all_pokemon_learnsets_are_valid():


### PR DESCRIPTION
## F44 — Learnset retrieval overhaul (suffix-cleaning, R/S methods, Deoxys/eternamax, gen fallbacks)

Stage-B port of one BRRRR_Experimental feature onto main's architecture.

### (a) Inventory row
- **ID:** F44 · **Class:** LEAF · **Harness tier:** GAMEPLAY
- **Source location(s):** `src/Ankimon/functions/learnset_retrieval.py`, `tests/test_learnset_retrieval.py`, `tests/test_learnset_robustness.py`
- **Dependencies:** `pokedex_functions` (`search_pokedex` / `search_pokedex_by_id` / `safe_int` / `_load_pokedex_cache`) — all present on main.
- **Parity strategy:** DETERMINISTIC/SEEDED + characterization (pure pokedex-backed logic).
- **GUARDS-TO-REAPPLY:** preserve main's in-memory learnset cache / `clear_learnset_cache` behavior.

### (b) Source→target re-fit + MERGE_ARCH_MAP rules applied
`learnset_retrieval.py` is a **pure-logic LEAF** (no `aqt.mw` / no `services`), so per the inventory row and MERGE_ARCH_MAP §2.1 there is **no seam entrypoint to translate** — it is ported as pure logic.

Main (`integration/brrr-into-main`) had already advanced past the Stage-A snapshot (`a8abbd66`): the base file already ships the in-memory cache (`_load_learnset_cache`/`clear_learnset_cache`), the generation-fallback loop, and a Mega/Gmax/Primal base-form fallback. I therefore did a **three-way / re-author onto the base HEAD version** (NOT a wholesale `git checkout`), applying only F44's hunks on top:
- `clean_pokeapi_name()` — PokéAPI suffix stripping (`-standard`, `-normal`, `-altered`, …) + `-female → …f` mapping.
- `DEOXYS_EXCLUSIONS` — per-form move blocklists.
- **3-tier fallback** in `_get_learnset_moves` (generalizes main's narrower mega/gmax/primal fallback):
  1. clean-suffix retry,
  2. reverse-lookup canonical key via `search_pokedex(..,"actual_id") → search_pokedex_by_id`,
  3. base-form learnset **merge** (`{**base_learnset, **pokemon_learnset}`) when a form has no level-up (`L`) moves.
- **Learn-code method parsing** `L` (level-up) / `R` (relearn, level 1) / `S` (special/event level), replacing the old `partition("L")` — this is also strictly more robust (malformed codes are now skipped via `try/except ValueError` instead of raising).
- Deoxys per-form move exclusion inside the move loop.

Exp's `_get_learnset_moves` is a strict superset of main's; the two cache helpers are re-fit **byte-identically** (verified). Non-source symbols referenced are only the F44 dependency `pokedex_functions` (in-base) — nothing outside the row's Source paths, so no partition leak.

### (c) Seam re-expression done + purely-additive seam methods
- **None required.** No `aqt.mw.*`, no `services.*`, no `events.*` in this module (confirmed). MERGE_ARCH_MAP §2.1 translation dictionary is N/A for a pure pokedex-backed helper.
- **No new seam method added.**

### (d) Main guards preserved
- In-memory learnset cache `_load_learnset_cache()` / `clear_learnset_cache()` kept **byte-identical** to main (blank-line-insensitive `diff` = 0). The new fallbacks read exclusively through the cached `learnsets` dict.
- No regression to main's generation-fallback loop (kept) — Fallback 3 only *generalizes* the previous mega/gmax/primal-only branch.

### Post-snapshot manifest note
The two-dot manifest `a8abbd66..origin/BRRRR_Experimental` for these paths spans 5 commits (`617686e6` caching, `67978406` suffix/3-tier fix, `77c8cf2d` eternamax, `8c795df9` special-form tiers, `92acefcc` mobile). Only the learnset-retrieval hunks are ported here; the caching hunk (`617686e6`) is **already in base** and was preserved, not re-applied. No hunk belonging to a different feature/file was pulled in (the mobile commit touched these paths only incidentally; none of its non-learnset content is present in the diff for these three files).

### (e) Parity oracle + exact gate commands with REAL output
**Parity oracle:** ported exp's own shipped tests, re-fit as a strict superset of main's — `tests/test_learnset_retrieval.py::TestLearnsetMismatches` (5 new characterization tests pinning: suffix-clean map, mismatched-name resolution, eternamax base-form fallback, necrozma-ultra R-move + base-form merge, Deoxys per-form exclusive moves) plus the extended robustness sweep in `tests/test_learnset_robustness.py`. All 12 pre-existing learnset tests are preserved verbatim.

Gates (TWO environments; never mixed). Qt-free = `venv_t1`, full-Qt = `venv_qt` + `QT_QPA_PLATFORM=offscreen`:

```
# compileall (venv_t1)                      -> exit 0
python -m compileall -q src/Ankimon          # compileall_rc=0

# ruff check (venv_t1, ci_ruff_check.toml)  -> All checks passed!
ruff check  --config ci_ruff_check.toml src/Ankimon/functions/learnset_retrieval.py tests/test_learnset_retrieval.py tests/test_learnset_robustness.py

# ruff format --check (after apply)         -> 3 files already formatted
ruff format --check --config ci_ruff_check.toml <same 3 files>

# Tier-1 harness (venv_t1)                  -> PASS — all 9 Tier-1 checks green
python harness/check.py

# pytest (venv_t1)                          -> 154 passed in 1.16s   (baseline 149 + 5 new; 0 regressions)
python -m pytest tests/ --ignore=tests/test_addon_integrity.py --ignore=tests/test_scaffolding_smoke.py -q

# targeted parity (venv_t1, standalone)     -> 17 passed in 0.13s
python -m pytest tests/test_learnset_retrieval.py -v

# GAMEPLAY — Qt-free scenarios (venv_t1)
python harness/scenarios/economy.py          # economy: OK
python harness/scenarios/longrun.py 3000      # longrun: OK (3000 answers, 2,700 turns/sec)

# GAMEPLAY — full-Qt probes (venv_qt, offscreen)
python -m harness.checks.probe_real_boot      # probe_real_boot: OK
python -m harness.checks.probe_real_play      # probe_real_play: OK (answers ~29, caught 2, defeated 1)
```

### (f) Context7 APIs verified
None needed — pure stdlib (`json`, `random`) + in-repo `pokedex_functions`. No PyQt6/aqt/sqlite3/orjson API re-authoring in this leaf.

### (g) Residual concerns
- `tests/test_learnset_robustness.py` retains a **pre-existing** base fragility: run in isolation without a prior test importing the real `Ankimon.pyobj.pokemon_obj`, its module-level `exec_module` of `pokedex_functions` fails (`Ankimon.pyobj` mocked → not a package). This reproduces identically on the base file (line 66, before any F44-added code) and does **not** occur in the full suite (154 passed). Not introduced by F44; left as-is to avoid touching unrelated base test scaffolding. My additive `_orig_modules` restore actually *reduces* downstream mock contamination.
- Fallbacks 2/3 depend on the real `data_files/pokedex.json` id↔species mappings; the new tests exercise real entries (eternatuseternamax→eternatus, necrozmaultra→necrozma) and pass.

### (h) Post-review fixes (Gemini)
Post-review fixes (Gemini): after Fallback 1 suffix-cleaning and Fallback 2 reverse-lookup resolution, `norm_name` is now updated to the key that actually matched (guarded on the lookup succeeding), so `DEOXYS_EXCLUSIONS` and Fallback 3 key on the resolved name — previously `"deoxys-normal"` silently leaked all 9 excluded base-form moves. This is a correctness fix beyond BRRRR_Experimental (exp has the same stale-norm_name bug). Fallback 3 intentionally does not adopt the base-form name, so merged forms (e.g. deoxysattack) keep their own exclusion sets. Also removed the dead `_load_pokedex_cache()` preload in Fallback 3 and the orphaned `import types` in tests/test_learnset_retrieval.py. Parity counts update: targeted `tests/test_learnset_retrieval.py` is now 19 passed (17 + 2 new regression tests pinning both resolution points), full Qt-free suite 156 passed (0 regressions).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>



## Attribution
The feature ported here was originally implemented on the `BRRRR_Experimental` branch by @hakimh2 (also commits as BrAk909). Authorship credit is recorded via a `Co-authored-by` trailer on this branch.
