### PR TITLE
fix: review-based damage multiplier at poke-engine level (F37)

### DIFF
--- a/src/Ankimon/functions/ankimon_hooks_to_poke_engine.py
+++ b/src/Ankimon/functions/ankimon_hooks_to_poke_engine.py
@@ -12,12 +12,55 @@ from ..poke_engine.battle import Move
 from ..poke_engine.objects import Pokemon, State, StateMutator, Side
 from ..poke_engine.helpers import normalize_name
 from ..poke_engine.find_state_instructions import get_all_state_instructions
+from ..poke_engine import instruction_generator
 from ..pyobj.error_handler import show_warning_with_traceback
 
 # Shared state used as bare module globals below; bound to the live registry
 # objects by core.bind_runtime_globals() after composition.
 ankimon_tracker_obj = None
 settings_obj = None
+
+# --- F37: review-based damage multiplier, applied at the poke-engine level ---
+# poke_engine.find_state_instructions calls
+# ``instruction_generator.get_instructions_from_damage`` via module attribute, so
+# wrapping that attribute scales opponent-directed damage by the reviewer
+# multiplier during instruction generation (and flags it so the post-hoc pass in
+# ``simulate_battle_with_poke_engine`` does not double-apply). Guarded against
+# double-wrapping on module reload (reload-safe singletons): capture the pristine
+# original and install the wrapper only once.
+if not getattr(
+    instruction_generator.get_instructions_from_damage,
+    "_ankimon_review_wrapped",
+    False,
+):
+    _original_get_instructions_from_damage = (
+        instruction_generator.get_instructions_from_damage
+    )
+
+    def _wrapped_get_instructions_from_damage(
+        mutator, defender, damage, accuracy, attacking_move, instruction
+    ):
+        if (
+            defender == constants.OPPONENT
+            and hasattr(mutator, "review_based_damage_multiplier")
+            and damage is not None
+        ):
+            if damage > 0:
+                damage = max(
+                    1, math.floor(damage * mutator.review_based_damage_multiplier)
+                )
+            else:
+                damage = math.floor(damage * mutator.review_based_damage_multiplier)
+            mutator.review_based_damage_multiplier_applied = True
+        return _original_get_instructions_from_damage(
+            mutator, defender, damage, accuracy, attacking_move, instruction
+        )
+
+    _wrapped_get_instructions_from_damage._ankimon_review_wrapped = True
+    instruction_generator.get_instructions_from_damage = (
+        _wrapped_get_instructions_from_damage
+    )
+
 
 def reset_stat_boosts(pokemon: Pokemon) -> Pokemon:
     """
@@ -38,7 +81,8 @@ def reset_stat_boosts(pokemon: Pokemon) -> Pokemon:
     pokemon.evasion_boost = 0
     return pokemon
 
-def reset_side(pokemon: Pokemon, side_conditions: Union[dict, None]=None) -> Side:
+
+def reset_side(pokemon: Pokemon, side_conditions: Union[dict, None] = None) -> Side:
     """
     Resets and returns a new Side object for the given Pokemon with default or provided side conditions.
 
@@ -54,16 +98,19 @@ def reset_side(pokemon: Pokemon, side_conditions: Union[dict, None]=None) -> Sid
               default wish and future sight settings, and the given or default side conditions.
     """
     if side_conditions is None:
-        side_conditions = defaultdict(int, {
-            'stealthrock': 0,
-            'spikes': 0,
-            'toxicspikes': 0,
-            'tailwind': 0,
-            'reflect': 0,
-            'lightscreen': 0,
-            'auroraveil': 0,
-            'protect': 0,
-        })
+        side_conditions = defaultdict(
+            int,
+            {
+                "stealthrock": 0,
+                "spikes": 0,
+                "toxicspikes": 0,
+                "tailwind": 0,
+                "reflect": 0,
+                "lightscreen": 0,
+                "auroraveil": 0,
+                "protect": 0,
+            },
+        )
     side = Side(
         active=pokemon,
         reserve={},
@@ -73,14 +120,15 @@ def reset_side(pokemon: Pokemon, side_conditions: Union[dict, None]=None) -> Sid
     )
     return side
 
+
 def simulate_battle_with_poke_engine(
     main_pokemon: Pokemon,
     enemy_pokemon: Pokemon,
     main_move: str,
     enemy_move: str,
     mutator_full_reset: int,
-    state: Union[State, None]=None,
-    ):
+    state: Union[State, None] = None,
+):
     """
     Simulates a battle between two Pokémon using the poke-engine if available.
     The function selects the Pokémon moves (either provided or random), handles state changes,
@@ -124,9 +172,10 @@ def simulate_battle_with_poke_engine(
     if not enemy_move:
         enemy_move = "Splash"
 
-
-    if (state is not None) and (state.user.active.id != main_pokemon.name.lower()):
-        mutator_full_reset = 1 # reset AFTER Pokemon is changed !
+    if (state is not None) and (
+        state.user.active.id != normalize_name(main_pokemon.name)
+    ):
+        mutator_full_reset = 1  # reset AFTER Pokemon is changed !
     if mutator_full_reset not in (0, 1):
         mutator_full_reset = 1
 
@@ -134,19 +183,18 @@ def simulate_battle_with_poke_engine(
         main_move_normalized = normalize_name(main_move)
         enemy_move_normalized = normalize_name(enemy_move)
 
-
         # Store only the chosen outcome
         battle_header = {
-            'user': {
-                'name': main_pokemon.name,
-                'level': main_pokemon.level,
-                'move': main_move
+            "user": {
+                "name": main_pokemon.name,
+                "level": main_pokemon.level,
+                "move": main_move,
             },
-            'opponent': {
-                'name': enemy_pokemon.name,
-                'level': enemy_pokemon.level,
-                'move': enemy_move
-            }
+            "opponent": {
+                "name": enemy_pokemon.name,
+                "level": enemy_pokemon.level,
+                "move": enemy_move,
+            },
         }
 
         # Create Pokemon objects
@@ -154,16 +202,19 @@ def simulate_battle_with_poke_engine(
         enemy_pokemon_poke_engine = enemy_pokemon.to_poke_engine_Pokemon()
 
         # Default side_conditions with all needed keys
-        side_conditions = defaultdict(int, {
-            'stealthrock': 0,
-            'spikes': 0,
-            'toxicspikes': 0,
-            'tailwind': 0,
-            'reflect': 0,
-            'lightscreen': 0,
-            'auroraveil': 0,
-            'protect': 0,
-        })
+        side_conditions = defaultdict(
+            int,
+            {
+                "stealthrock": 0,
+                "spikes": 0,
+                "toxicspikes": 0,
+                "tailwind": 0,
+                "reflect": 0,
+                "lightscreen": 0,
+                "auroraveil": 0,
+                "protect": 0,
+            },
+        )
 
         if state is None:
             state = State(
@@ -172,7 +223,7 @@ def simulate_battle_with_poke_engine(
                 weather=None,
                 field=None,
                 trick_room=False,
-                )
+            )
         else:
             if mutator_full_reset == 0:  # Combat is ongoing
                 pass
@@ -182,34 +233,43 @@ def simulate_battle_with_poke_engine(
                 state.opponent = reset_side(enemy_pokemon_poke_engine)
 
                 # Reset battle_status and volatile_status for both engine state Pokémon
-                if hasattr(state.user.active, 'battle_status'):
-                    state.user.active.battle_status = 'fighting'
-                if hasattr(state.user.active, 'volatile_status'):
+                if hasattr(state.user.active, "battle_status"):
+                    state.user.active.battle_status = "fighting"
+                if hasattr(state.user.active, "volatile_status"):
                     state.user.active.volatile_status = set()
-                if hasattr(state.opponent.active, 'battle_status'):
-                    state.opponent.active.battle_status = 'fighting'
-                if hasattr(state.opponent.active, 'volatile_status'):
+                if hasattr(state.opponent.active, "battle_status"):
+                    state.opponent.active.battle_status = "fighting"
+                if hasattr(state.opponent.active, "volatile_status"):
                     state.opponent.active.volatile_status = set()
                 # Clear Future Sight state on reset - NEW
-                if hasattr(state.user, 'future_sight'):
+                if hasattr(state.user, "future_sight"):
                     state.user.future_sight = (0, 0)
-                if hasattr(state.opponent, 'future_sight'):
+                if hasattr(state.opponent, "future_sight"):
                     state.opponent.future_sight = (0, 0)
 
                 # Also reset the main_pokemon and enemy_pokemon Python objects
-                main_pokemon.battle_status = 'fighting'
+                main_pokemon.battle_status = "fighting"
                 main_pokemon.volatile_status = set()
-                enemy_pokemon.battle_status = 'fighting'
+                enemy_pokemon.battle_status = "fighting"
                 enemy_pokemon.volatile_status = set()
 
-                state.weather = None # Reset weather to None
-                state.field = None # Reset field to None
-                state.trick_room = False # Reset trick room to None
+                state.weather = None  # Reset weather to None
+                state.field = None  # Reset field to None
+                state.trick_room = False  # Reset trick room to None
 
             else:
-                raise ValueError(f"Wrong mutator_full_reset encountered : {mutator_full_reset}")
+                raise ValueError(
+                    f"Wrong mutator_full_reset encountered : {mutator_full_reset}"
+                )
 
         mutator = StateMutator(state)
+
+        if settings_obj and settings_obj.get("battle.review_based_damage"):
+            mutator.review_based_damage_multiplier = (
+                ankimon_tracker_obj.multiplier
+                if (ankimon_tracker_obj and hasattr(ankimon_tracker_obj, "multiplier"))
+                else 1.0
+            )
 
         if state.opponent.active.hp == 0:
             main_move = "Splash"
@@ -225,13 +285,26 @@ def simulate_battle_with_poke_engine(
         weights = [outcome.percentage for outcome in transpose_instructions]
         chosen_outcome = random.choices(transpose_instructions, weights=weights, k=1)[0]
 
-    
-        if settings_obj.get("battle.review_based_damage"):
+        if settings_obj and settings_obj.get("battle.review_based_damage"):
             instrs = []
             for instr in chosen_outcome.instructions:
                 if instr[0] == constants.DAMAGE and instr[1] == constants.OPPONENT:
-                    modified_instr = (instr[0], instr[1], math.floor(instr[2] * ankimon_tracker_obj.multiplier)) + instr[3:]
-                    instrs.append(modified_instr)
+                    if hasattr(mutator, "review_based_damage_multiplier_applied"):
+                        # Engine-level wrapper already scaled this damage.
+                        instrs.append(instr)
+                    else:
+                        tracker_mult = (
+                            ankimon_tracker_obj.multiplier
+                            if ankimon_tracker_obj
+                            else 1.0
+                        )
+                        raw_dmg = instr[2]
+                        if raw_dmg > 0:
+                            mult_dmg = max(1, math.floor(raw_dmg * tracker_mult))
+                        else:
+                            mult_dmg = math.floor(raw_dmg * tracker_mult)
+                        modified_instr = (instr[0], instr[1], mult_dmg) + instr[3:]
+                        instrs.append(modified_instr)
                 else:
                     instrs.append(instr)
         else:
@@ -255,42 +328,43 @@ def simulate_battle_with_poke_engine(
         enemy_pokemon.current_hp = state.opponent.active.hp
 
         main_pokemon.stat_stages = {
-            'atk': state.user.active.attack_boost,
-            'def': state.user.active.defense_boost,
-            'spa': state.user.active.special_attack_boost,
-            'spd': state.user.active.special_defense_boost,
-            'spe': state.user.active.speed_boost,
-            'accuracy': state.user.active.accuracy_boost,
-            'evasion': state.user.active.evasion_boost
+            "atk": state.user.active.attack_boost,
+            "def": state.user.active.defense_boost,
+            "spa": state.user.active.special_attack_boost,
+            "spd": state.user.active.special_defense_boost,
+            "spe": state.user.active.speed_boost,
+            "accuracy": state.user.active.accuracy_boost,
+            "evasion": state.user.active.evasion_boost,
         }
 
         # Save volatile status from poke-engine state to Pokemon object - NEW
-        if hasattr(state.user.active, 'volatile_status'):
+        if hasattr(state.user.active, "volatile_status"):
             main_pokemon.volatile_status = state.user.active.volatile_status.copy()
-        elif not hasattr(main_pokemon, 'volatile_status'):
+        elif not hasattr(main_pokemon, "volatile_status"):
             main_pokemon.volatile_status = set()
-
 
         # Same for enemy Pokemon
         enemy_pokemon.stat_stages = {
-            'atk': state.opponent.active.attack_boost,
-            'def': state.opponent.active.defense_boost,
-            'spa': state.opponent.active.special_attack_boost,
-            'spd': state.opponent.active.special_defense_boost,
-            'spe': state.opponent.active.speed_boost,
-            'accuracy': state.opponent.active.accuracy_boost,
-            'evasion': state.opponent.active.evasion_boost
+            "atk": state.opponent.active.attack_boost,
+            "def": state.opponent.active.defense_boost,
+            "spa": state.opponent.active.special_attack_boost,
+            "spd": state.opponent.active.special_defense_boost,
+            "spe": state.opponent.active.speed_boost,
+            "accuracy": state.opponent.active.accuracy_boost,
+            "evasion": state.opponent.active.evasion_boost,
         }
 
         # Save volatile status for enemy - NEW
-        if hasattr(state.opponent.active, 'volatile_status'):
+        if hasattr(state.opponent.active, "volatile_status"):
             enemy_pokemon.volatile_status = state.opponent.active.volatile_status.copy()
-        elif not hasattr(enemy_pokemon, 'volatile_status'):
+        elif not hasattr(enemy_pokemon, "volatile_status"):
             enemy_pokemon.volatile_status = set()
 
         new_state = copy.deepcopy(state)
 
-        mutator_full_reset = 0 # preserve battle state - until something else changes this value
+        mutator_full_reset = (
+            0  # preserve battle state - until something else changes this value
+        )
 
         user_hp_after = int(new_state.user.active.hp)
         opponent_hp_after = int(new_state.opponent.active.hp)
@@ -316,16 +390,24 @@ def simulate_battle_with_poke_engine(
             battle_effects.append(list(instr))  # Convert tuples to lists
 
         battle_info = {
-            'battle_header': battle_header,
-            'instructions': battle_effects,
-            'state': new_state
-            }
+            "battle_header": battle_header,
+            "instructions": battle_effects,
+            "state": new_state,
+        }
 
         print(f"{unlucky_life * 100}% chance: {battle_effects}")
-        return battle_info, new_state, dmg_from_enemy_move, dmg_from_user_move, mutator_full_reset, battle_info_changes
+        return (
+            battle_info,
+            new_state,
+            dmg_from_enemy_move,
+            dmg_from_user_move,
+            mutator_full_reset,
+            battle_info_changes,
+        )
 
     except Exception as e:
         show_warning_with_traceback(exception=e, message="Error simulating battle:")
+
 
 def diff_states(state_before, state_after, path="", changes=None):
     """
@@ -339,52 +421,48 @@ def diff_states(state_before, state_after, path="", changes=None):
     if state_before is None and state_after is None:
         return changes
     if state_before is None or state_after is None:
-        changes.append({
-            'key': path or 'root',
-            'before': state_before,
-            'after': state_after
-        })
+        changes.append(
+            {"key": path or "root", "before": state_before, "after": state_after}
+        )
         return changes
 
     # Handle primitive types (int, float, str, bool)
-    if isinstance(state_before, (int, float, str, bool)) or isinstance(state_after, (int, float, str, bool)):
+    if isinstance(state_before, (int, float, str, bool)) or isinstance(
+        state_after, (int, float, str, bool)
+    ):
         if state_before != state_after:
-            changes.append({
-                'key': path or 'root',
-                'before': state_before,
-                'after': state_after
-            })
+            changes.append(
+                {"key": path or "root", "before": state_before, "after": state_after}
+            )
         return changes
 
     # Handle sets
     if isinstance(state_before, set) or isinstance(state_after, set):
         if state_before != state_after:
-            changes.append({
-                'key': path or 'root',
-                'before': state_before,
-                'after': state_after
-            })
+            changes.append(
+                {"key": path or "root", "before": state_before, "after": state_after}
+            )
         return changes
 
     # Handle tuples
     if isinstance(state_before, tuple) or isinstance(state_after, tuple):
         if state_before != state_after:
-            changes.append({
-                'key': path or 'root',
-                'before': state_before,
-                'after': state_after
-            })
+            changes.append(
+                {"key": path or "root", "before": state_before, "after": state_after}
+            )
         return changes
 
     # Handle lists
     if isinstance(state_before, list) and isinstance(state_after, list):
         # Compare list lengths and elements
         if len(state_before) != len(state_after):
-            changes.append({
-                'key': f"{path}.length" if path else 'length',
-                'before': len(state_before),
-                'after': len(state_after)
-            })
+            changes.append(
+                {
+                    "key": f"{path}.length" if path else "length",
+                    "before": len(state_before),
+                    "after": len(state_after),
+                }
+            )
 
         # Compare elements up to the shorter length
         min_len = min(len(state_before), len(state_after))
@@ -396,19 +474,15 @@ def diff_states(state_before, state_after, path="", changes=None):
         if len(state_before) > min_len:
             for i in range(min_len, len(state_before)):
                 new_path = f"{path}[{i}]" if path else f"[{i}]"
-                changes.append({
-                    'key': new_path,
-                    'before': state_before[i],
-                    'after': None
-                })
+                changes.append(
+                    {"key": new_path, "before": state_before[i], "after": None}
+                )
         elif len(state_after) > min_len:
             for i in range(min_len, len(state_after)):
                 new_path = f"{path}[{i}]" if path else f"[{i}]"
-                changes.append({
-                    'key': new_path,
-                    'before': None,
-                    'after': state_after[i]
-                })
+                changes.append(
+                    {"key": new_path, "before": None, "after": state_after[i]}
+                )
         return changes
 
     # Handle dictionaries
@@ -423,11 +497,9 @@ def diff_states(state_before, state_after, path="", changes=None):
 
     # Handle custom objects - check if they're the same type
     if type(state_before) != type(state_after):
-        changes.append({
-            'key': path or 'root',
-            'before': state_before,
-            'after': state_after
-        })
+        changes.append(
+            {"key": path or "root", "before": state_before, "after": state_after}
+        )
         return changes
 
     # Custom class: recurse into attributes (__dict__ and __slots__ on the class)
@@ -459,8 +531,7 @@ def print_state_changes(changes):
         return
 
     for change in changes:
-        key = change['key']
-        before = change['before']
-        after = change['after']
+        key = change["key"]
+        before = change["before"]
+        after = change["after"]
         print(f"{key}: {before} -> {after}")
-

--- a/tests/test_review_based_damage_multiplier.py
+++ b/tests/test_review_based_damage_multiplier.py
@@ -1,0 +1,191 @@
+"""Parity test for F37 — Review-based-damage poke_engine multiplier rewrite.
+
+Behaviour ported from BRRRR_Experimental onto main's seam architecture. The
+feature wraps ``poke_engine.instruction_generator.get_instructions_from_damage``
+so that, when ``settings.battle.review_based_damage`` is on, opponent-directed
+damage is scaled by the reviewer multiplier at the engine level (and flagged so
+the post-hoc pass in ``simulate_battle_with_poke_engine`` does not double-apply).
+
+These are deterministic golden-value checks of the observable contract:
+  * the exact damage-scaling math (floor, with ``max(1, ...)`` for positive
+    damage, plain floor for non-positive damage),
+  * the "applied" dedup flag,
+  * pass-through when the wrapper must not fire (non-opponent defender, no
+    multiplier attribute, ``damage is None``),
+  * reload-safety: the monkeypatch is idempotent and never double-wraps.
+
+The end-to-end seed->golden behaviour of the whole battle path is additionally
+covered by the GAMEPLAY harness gates (probe_real_play / longrun / economy).
+"""
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+_src = Path(__file__).parent.parent / "src"
+
+
+def _ensure_pkg(name):
+    """(Re)establish ``name`` as a real package rooted at src/.
+
+    Sibling test modules pollute ``sys.modules`` (e.g. test_database_manager
+    replaces ``sys.modules["Ankimon"]`` with a path-less ModuleType, which breaks
+    ``from Ankimon.*`` imports for whichever test runs next). Restoring the
+    package stub with a ``__path__`` makes this test robust to collection order.
+    """
+    mod = sys.modules.get(name)
+    if not isinstance(mod, types.ModuleType) or not getattr(mod, "__path__", None):
+        stub = types.ModuleType(name)
+        stub.__path__ = [str(_src / name.replace(".", "/"))]
+        stub.__package__ = name
+        sys.modules[name] = stub
+
+
+for _pkg in ("Ankimon", "Ankimon.functions", "Ankimon.pyobj"):
+    _ensure_pkg(_pkg)
+
+# The module under test imports the services registry and the error dialog at
+# module scope but does not use them in the code paths exercised here; stub them
+# so the import never needs aqt or a booted app.
+sys.modules.setdefault("Ankimon.services", MagicMock())
+sys.modules["Ankimon.pyobj.error_handler"] = MagicMock()
+
+# The real poke_engine IS needed (the wrapper delegates to the genuine engine);
+# drop any non-real stand-ins so the actual modules load under Ankimon.__path__.
+for _name in [n for n in list(sys.modules) if n.startswith("Ankimon.poke_engine")]:
+    _m = sys.modules[_name]
+    if not isinstance(_m, types.ModuleType) or getattr(_m, "__file__", None) is None:
+        del sys.modules[_name]
+
+from Ankimon.poke_engine import constants, instruction_generator
+
+# Load the module under test fresh from its file; importing installs the
+# poke-engine damage-wrapper monkeypatch (idempotently).
+_spec = importlib.util.spec_from_file_location(
+    "Ankimon.functions.ankimon_hooks_to_poke_engine",
+    _src / "Ankimon" / "functions" / "ankimon_hooks_to_poke_engine.py",
+)
+hook = importlib.util.module_from_spec(_spec)
+sys.modules[_spec.name] = hook
+_spec.loader.exec_module(hook)
+
+
+class _FakeMutator:
+    """Minimal stand-in; the wrapper only touches these attributes."""
+
+
+@pytest.fixture
+def spy(monkeypatch):
+    """Redirect the installed wrapper's delegated original to a recording spy.
+
+    The wrapper resolves ``_original_get_instructions_from_damage`` as a module
+    global of ``hook`` at call time, so patching that global intercepts the call
+    without needing a real poke-engine ``State``.
+    """
+    calls = {}
+
+    def _spy(mutator, defender, damage, accuracy, attacking_move, instruction):
+        calls["damage"] = damage
+        calls["defender"] = defender
+        return ["SENTINEL"]
+
+    monkeypatch.setattr(hook, "_original_get_instructions_from_damage", _spy)
+    return calls
+
+
+def _call(defender, damage, mult=None):
+    m = _FakeMutator()
+    if mult is not None:
+        m.review_based_damage_multiplier = mult
+    out = instruction_generator.get_instructions_from_damage(
+        m, defender, damage, True, {}, object()
+    )
+    return m, out
+
+
+def test_wrapper_is_installed():
+    fn = instruction_generator.get_instructions_from_damage
+    assert getattr(fn, "_ankimon_review_wrapped", False) is True
+    # The captured original must be the genuine engine function, never a wrapper.
+    assert (
+        getattr(
+            hook._original_get_instructions_from_damage,
+            "_ankimon_review_wrapped",
+            False,
+        )
+        is False
+    )
+
+
+def test_positive_damage_scaled_and_flagged(spy):
+    m, out = _call(constants.OPPONENT, 10, mult=2.5)
+    assert spy["damage"] == 25  # max(1, floor(10 * 2.5))
+    assert m.review_based_damage_multiplier_applied is True
+    assert out == ["SENTINEL"]
+
+
+def test_positive_damage_floors_to_at_least_one(spy):
+    # floor(3 * 0.05) == 0, but positive damage never drops below 1.
+    _call(constants.OPPONENT, 3, mult=0.05)
+    assert spy["damage"] == 1
+
+
+def test_zero_damage_uses_plain_floor_and_still_flags(spy):
+    m, _ = _call(constants.OPPONENT, 0, mult=2.0)
+    assert spy["damage"] == 0  # floor(0 * 2.0), no max(1, ...) clamp
+    assert m.review_based_damage_multiplier_applied is True
+
+
+def test_negative_damage_uses_plain_floor(spy):
+    # Healing / negative damage keeps its sign (no min-1 clamp).
+    _call(constants.OPPONENT, -4, mult=1.5)
+    assert spy["damage"] == -6  # floor(-4 * 1.5)
+
+
+def test_passthrough_for_non_opponent_defender(spy):
+    m, _ = _call("__self__", 10, mult=9.0)
+    assert spy["damage"] == 10  # unchanged
+    assert not hasattr(m, "review_based_damage_multiplier_applied")
+
+
+def test_passthrough_without_multiplier_attribute(spy):
+    m, _ = _call(constants.OPPONENT, 10, mult=None)
+    assert spy["damage"] == 10  # unchanged
+    assert not hasattr(m, "review_based_damage_multiplier_applied")
+
+
+def test_passthrough_when_damage_is_none(spy):
+    m, _ = _call(constants.OPPONENT, None, mult=2.0)
+    assert spy["damage"] is None
+    assert not hasattr(m, "review_based_damage_multiplier_applied")
+
+
+def test_monkeypatch_is_idempotent_on_reload():
+    fn_before = instruction_generator.get_instructions_from_damage
+    original_before = hook._original_get_instructions_from_damage
+
+    importlib.reload(hook)
+
+    # Reload must not re-wrap: the installed function and the captured pristine
+    # original are unchanged, so damage can never be scaled twice.
+    assert instruction_generator.get_instructions_from_damage is fn_before
+    assert hook._original_get_instructions_from_damage is original_before
+    assert getattr(original_before, "_ankimon_review_wrapped", False) is False
+
+
+def test_normalize_name_fix_matters_for_reset_trigger():
+    """The reset trigger now compares against normalize_name(name).
+
+    poke-engine ``Pokemon.id`` values are normalized (lowercased, punctuation and
+    whitespace stripped). The base code compared them against ``name.lower()``,
+    which disagrees for multi-word / punctuated species and forced a spurious
+    full state reset every turn; F37 uses ``normalize_name`` instead.
+    """
+    from Ankimon.poke_engine.helpers import normalize_name
+
+    for name in ["Mr. Mime", "Farfetch'd", "Type: Null", "Ho-Oh"]:
+        assert normalize_name(name) != name.lower()


### PR DESCRIPTION
## F37 — Review-based-damage poke_engine multiplier rewrite

Stage-B port of one BRRRR_Experimental leaf onto main's seam architecture.

### (a) Inventory row
- **ID:** F37 — Review-based-damage poke_engine multiplier rewrite
- **Source:** `src/Ankimon/functions/ankimon_hooks_to_poke_engine.py`
- **Class:** LEAF · **Harness tier:** GAMEPLAY · **Parity strategy:** DETERMINISTIC/SEEDED
- **Manifest:** the whole feature is the two-dot diff
  `a8abbd66..origin/BRRRR_Experimental -- src/Ankimon/functions/ankimon_hooks_to_poke_engine.py`
  (single upstream commit `92acefcc`). The hunks are self-contained to this one file
  and reference only already-imported symbols (`instruction_generator`, `constants`,
  `normalize_name`, `math`) — no partition leak into another row's paths.

### (b) Source → target re-fit + MERGE_ARCH_MAP rules applied
Ported exp's behaviour **onto main's seam version of the file** (three-way re-author;
main's `HEAD` already routes through the seam, exp branched from the pre-seam ancestor).
Three behaviour changes ported:
1. **Engine-level multiplier** — module-level monkeypatch of
   `poke_engine.instruction_generator.get_instructions_from_damage`. `find_state_instructions`
   calls it by module attribute (`instruction_generator.get_instructions_from_damage(...)`),
   so wrapping the attribute scales opponent-directed damage during instruction generation and
   sets `mutator.review_based_damage_multiplier_applied` so the post-hoc pass does not double-apply.
2. **`normalize_name` bug fix** — the state-reset trigger now compares
   `state.user.active.id != normalize_name(main_pokemon.name)` instead of `main_pokemon.name.lower()`.
   poke-engine ids are normalized (punctuation/space-stripped), so `.lower()` forced a spurious full
   reset every turn for multi-word / punctuated species.
3. **Post-hoc dedup** — the `settings.battle.review_based_damage` instruction loop skips re-scaling
   when the engine wrapper already applied the multiplier, and otherwise falls back to scaling with
   the `max(1, floor(dmg*mult))` (positive) / `floor(dmg*mult)` (non-positive) math.

Rules applied: MERGE_ARCH_MAP **§2.1** (bare-name globals bound by `core.bind_runtime_globals()`),
**§3** row for this file (main via `services`, exp inline `mw` — kept main's seam), **§6 last bullet**
(no seam signature reshaped; purely-additive change only).

### (c) Seam re-expression (which mw.* → which seam entrypoint)
exp introduced a `mw`-fallback anti-pattern inside the simulate loop:
```
from aqt import mw
settings = getattr(mw, "settings_obj", None) or settings_obj
tracker  = getattr(mw, "ankimon_tracker_obj", None) or ankimon_tracker_obj
```
Re-expressed via main's seam per §2.1: **dropped the `from aqt import mw` import entirely** and use
the bare module globals `settings_obj` / `ankimon_tracker_obj`, which `core.bind_runtime_globals()`
binds to `services.settings` / `services.tracker` (module is registered in `core._RUNTIME_GLOBALS`
for `Ankimon.functions.ankimon_hooks_to_poke_engine`). The module remains **aqt-free** (verified: no
`from aqt` / `import aqt` / `singletons` import remains).
- **No new seam method added** — this feature needed none (existing bare-global binding covers it).

### (d) Main guards preserved / improvements kept
- Kept main's `from ..services import services` seam import and the `ankimon_tracker_obj = None` /
  `settings_obj = None` bare-global block + `bind_runtime_globals` docstring — did **not** revert to
  exp's `from ..singletons import ankimon_tracker_obj, settings_obj`.
- **GUARD-TO-REAPPLY (reload safety):** the row flags that the import-time monkeypatch can double-wrap
  on module reload (`_original_` capture non-idempotent). Made it **idempotent**: the wrapper is tagged
  `_ankimon_review_wrapped` and installed only if the current target is not already tagged, so reload
  never captures an already-wrapped function or scales damage twice. Behaviour on first import is
  identical to exp.
- Added None-safety (`if settings_obj and settings_obj.get(...)`, `ankimon_tracker_obj and hasattr(...)`)
  consistent with exp's guarding; strictly safer, no regression vs main.

### (e) Parity oracle + gate commands with REAL output
**Oracle:** `tests/test_review_based_damage_multiplier.py` — deterministic golden-value
characterization of the wrapper's damage-scaling math, the applied/dedup flag, pass-through cases
(non-opponent defender, no multiplier attr, `damage is None`), reload-idempotency, and the
`normalize_name`-vs-`.lower()` divergence. The end-to-end seed→golden battle path is additionally
covered by the GAMEPLAY harness gates below.

Two environments (Qt-free `venv_t1`; full-Qt `venv_qt` offscreen), never mixed.

```
# compileall (incl poke_engine)
$ python -m compileall -q src/Ankimon      -> exit 0

# ruff (ci_ruff_check.toml) on changed files
$ ruff check  --config ci_ruff_check.toml <2 changed .py>   -> All checks passed!
$ ruff format --check --config ci_ruff_check.toml <2 changed .py> -> 2 files already formatted

# Tier-1 harness gate
$ python harness/check.py   -> PASS — all 9 Tier-1 checks green

# full logic suite (minus integrity + scaffolding smoke)
$ python -m pytest tests/ --ignore=tests/test_addon_integrity.py \
        --ignore=tests/test_scaffolding_smoke.py -q   -> 159 passed  (149 baseline + 10 new)

# targeted parity test
$ python -m pytest tests/test_review_based_damage_multiplier.py -q   -> 10 passed

# GAMEPLAY scenarios (Tier-1 env)
$ python harness/scenarios/economy.py      -> economy: OK
$ python harness/scenarios/longrun.py 3000 -> longrun: OK (3000 answers, 3,100 turns/sec)

# GAMEPLAY Tier-2 (venv_qt, offscreen)
$ python -m harness.checks.probe_real_boot -> probe_real_boot: OK
$ python -m harness.checks.probe_real_play -> probe_real_play: OK (answers ~29, caught 2, defeated 1)
```
No NEW failures vs `MERGE_BASELINE.md` (baseline reds — 10 UP018 in `AnkimonWindow copy.py`,
78-file format debt, integrity-smoke modal — untouched and unchanged).

### (f) Context7 APIs verified
None required — pure-logic port over stdlib `math` and the in-repo `poke_engine` submodule; no
external library signature was re-authored.

### (g) Residual concerns
- The diff is large (196/125) because the file was in the baseline 78-file `ruff format` debt set;
  since STEP 5 requires changed files be format-clean, `ruff format` normalized the whole file
  (quotes / line-wrapping only — semantically inert, compileall + full suite green). Net effect
  removes this file from the format-debt set (count does not increase).
- The engine-level wrapper and the post-hoc loop are intentionally belt-and-suspenders: the wrapper
  applies during `get_all_state_instructions`; the post-hoc loop only scales the (rare) opponent-damage
  instructions the wrapper did not flag. The dedup flag prevents any double-application.
- Feature is gated by the existing `battle.review_based_damage` setting (already defined in
  `pyobj/settings.py` + `lang/setting_*.json` on main); no config change needed.

---
Row: F37 · Base: `integration/brrr-into-main`


## Attribution
The feature ported here was originally implemented on the `BRRRR_Experimental` branch by @hakimh2 (also commits as BrAk909). Authorship credit is recorded via a `Co-authored-by` trailer on this branch.
