### PR TITLE
feat: i18n leaf strings for evolution/friendship/badge + nature chart (F01)

### DIFF
--- a/src/Ankimon/lang/ch_text.json
+++ b/src/Ankimon/lang/ch_text.json
@@ -459,5 +459,12 @@
   "cp_label": "CP",
   "bp_label": "BP",
   "combat_power": "战斗力",
-  "battle_power": "对战能力"
+  "battle_power": "对战能力",
+  "friendship_label": "亲密度",
+  "friendship_tooltip": "测量你和宝可梦之间的羁绊。",
+  "bff_tooltip": "💖 最好的朋友 (最高亲密度)",
+  "evolve_now_button": "⇈ 进化为 {evo_name}！ ⇈",
+  "badge_ready": "⇈ 准备进化！",
+  "badge_wait_day": "☀️ 准备在白天进化",
+  "badge_wait_night": "🌙 准备在夜晚进化"
 }

--- a/src/Ankimon/lang/cz_text.json
+++ b/src/Ankimon/lang/cz_text.json
@@ -459,5 +459,12 @@
   "cp_label": "CP",
   "bp_label": "BP",
   "combat_power": "Bojová síla",
-  "battle_power": "Bojová síla"
+  "battle_power": "Bojová síla",
+  "friendship_label": "Přátelství",
+  "friendship_tooltip": "Měří pouto mezi vámi a vaším pokémonem.",
+  "bff_tooltip": "💖 Nejlepší přítel (Nejvyšší přátelství)",
+  "evolve_now_button": "⇈ Vyvinout na {evo_name}! ⇈",
+  "badge_ready": "⇈ Připraven k vývoji!",
+  "badge_wait_day": "☀️ Připraven k vývoji během dne",
+  "badge_wait_night": "🌙 Připraven k vývoji v noci"
 }

--- a/src/Ankimon/lang/de_text.json
+++ b/src/Ankimon/lang/de_text.json
@@ -459,5 +459,12 @@
   "cp_label": "WP",
   "bp_label": "KP",
   "combat_power": "Wettkampfpunkte",
-  "battle_power": "Kampfstärke"
+  "battle_power": "Kampfstärke",
+  "friendship_label": "Freundschaft",
+  "friendship_tooltip": "Misst die Bindung zwischen dir und deinem Pokémon.",
+  "bff_tooltip": "💖 Bester Freund (Höchste Freundschaft)",
+  "evolve_now_button": "⇈ Jetzt zu {evo_name} entwickeln! ⇈",
+  "badge_ready": "⇈ Bereit zur Entwicklung!",
+  "badge_wait_day": "☀️ Bereit zur Entwicklung am Tag",
+  "badge_wait_night": "🌙 Bereit zur Entwicklung in der Nacht"
 }

--- a/src/Ankimon/lang/en_text.json
+++ b/src/Ankimon/lang/en_text.json
@@ -40,6 +40,7 @@
   "open_pokedex_button": "Open Pokedex",
   "eff_chart_button": "Check Effectiveness Chart",
   "gen_chart_button": "Check Generation Chart",
+  "nature_chart_button": "Check Nature Chart",
   "join_discord_button": "Join Discord Channel",
   "ankimon_credits_button": "Ankimon Credits",
   "ankimon_about_and_license_button": "Ankimon About and License",
@@ -459,5 +460,12 @@
   "cp_label": "CP",
   "bp_label": "BP",
   "combat_power": "Combat Power",
-  "battle_power": "Battle Power"
+  "battle_power": "Battle Power",
+  "friendship_label": "Friendship",
+  "friendship_tooltip": "Measures the bond between you and your Pokémon.",
+  "bff_tooltip": "💖 Best Friend (Highest Friendship)",
+  "evolve_now_button": "⇈ Evolve into {evo_name}! ⇈",
+  "badge_ready": "⇈ Ready to evolve!",
+  "badge_wait_day": "☀️ Ready to evolve during the day",
+  "badge_wait_night": "🌙 Ready to evolve at night"
 }

--- a/src/Ankimon/lang/es_latam_text.json
+++ b/src/Ankimon/lang/es_latam_text.json
@@ -458,5 +458,12 @@
   "cp_label": "PC",
   "bp_label": "PC",
   "combat_power": "Poder de combate",
-  "battle_power": "Poder de combate"
+  "battle_power": "Poder de combate",
+  "friendship_label": "Amistad",
+  "friendship_tooltip": "Mide el vínculo entre tú y tu Pokémon.",
+  "bff_tooltip": "💖 Mejor Amigo (Amistad Máxima)",
+  "evolve_now_button": "⇈ ¡Evolucionar a {evo_name} ahora! ⇈",
+  "badge_ready": "⇈ ¡Listo para evolucionar!",
+  "badge_wait_day": "☀️ Listo para evolucionar durante el día",
+  "badge_wait_night": "🌙 Listo para evolucionar durante la noche"
 }

--- a/src/Ankimon/lang/fr_text.json
+++ b/src/Ankimon/lang/fr_text.json
@@ -459,5 +459,12 @@
   "cp_label": "PC",
   "bp_label": "PB",
   "combat_power": "Puissance de combat",
-  "battle_power": "Puissance de combat"
+  "battle_power": "Puissance de combat",
+  "friendship_label": "Amitié",
+  "friendship_tooltip": "Mesure le lien entre vous et votre Pokémon.",
+  "bff_tooltip": "💖 Meilleur Ami (Amitié maximale)",
+  "evolve_now_button": "⇈ Évoluer en {evo_name} ! ⇈",
+  "badge_ready": "⇈ Prêt à évoluer !",
+  "badge_wait_day": "☀️ Prêt à évoluer pendant la journée",
+  "badge_wait_night": "🌙 Prêt à évoluer pendant la nuit"
 }

--- a/src/Ankimon/lang/it_text.json
+++ b/src/Ankimon/lang/it_text.json
@@ -459,5 +459,12 @@
   "cp_label": "PL",
   "bp_label": "PL",
   "combat_power": "Potenza di combattimento",
-  "battle_power": "Potenza di lotta"
+  "battle_power": "Potenza di lotta",
+  "friendship_label": "Amicizia",
+  "friendship_tooltip": "Misura il legame tra te e il tuo Pokémon.",
+  "bff_tooltip": "💖 Migliore Amico (Amicizia Massima)",
+  "evolve_now_button": "⇈ Evolvi in {evo_name} ora! ⇈",
+  "badge_ready": "⇈ Pronto per l'evoluzione!",
+  "badge_wait_day": "☀️ Pronto per l'evoluzione durante il giorno",
+  "badge_wait_night": "🌙 Pronto per l'evoluzione di notte"
 }

--- a/src/Ankimon/lang/jp_text.json
+++ b/src/Ankimon/lang/jp_text.json
@@ -459,5 +459,12 @@
   "cp_label": "CP",
   "bp_label": "BP",
   "combat_power": "戦闘力",
-  "battle_power": "バトルパワー"
+  "battle_power": "バトルパワー",
+  "friendship_label": "なかよし度",
+  "friendship_tooltip": "あなたとポケモンの絆の強さです。",
+  "bff_tooltip": "💖 最高の相棒 (なかよし度最大)",
+  "evolve_now_button": "⇈ {evo_name}に進化させる！ ⇈",
+  "badge_ready": "⇈ 進化の準備ができました！",
+  "badge_wait_day": "☀️ 昼の間に進化できます",
+  "badge_wait_night": "🌙 夜の間に進化できます"
 }

--- a/src/Ankimon/lang/kr_text.json
+++ b/src/Ankimon/lang/kr_text.json
@@ -459,5 +459,12 @@
   "cp_label": "CP",
   "bp_label": "BP",
   "combat_power": "전투력",
-  "battle_power": "배틀 파워"
+  "battle_power": "배틀 파워",
+  "friendship_label": "친밀도",
+  "friendship_tooltip": "당신과 포켓몬 사이의 유대감을 측정합니다.",
+  "bff_tooltip": "💖 베스트 프렌드 (최고 친밀도)",
+  "evolve_now_button": "⇈ 지금 {evo_name}(으)로 진화! ⇈",
+  "badge_ready": "⇈ 진화할 준비가 되었습니다!",
+  "badge_wait_day": "☀️ 낮 동안 진화할 수 있습니다",
+  "badge_wait_night": "🌙 밤 동안 진화할 수 있습니다"
 }

--- a/src/Ankimon/lang/po_text.json
+++ b/src/Ankimon/lang/po_text.json
@@ -459,5 +459,12 @@
   "cp_label": "PC",
   "bp_label": "PB",
   "combat_power": "Poder de combate",
-  "battle_power": "Poder de batalha"
+  "battle_power": "Poder de batalha",
+  "friendship_label": "Amizade",
+  "friendship_tooltip": "Mede o vínculo entre você e seu Pokémon.",
+  "bff_tooltip": "💖 Melhor Amigo (Amizade Máxima)",
+  "evolve_now_button": "⇈ Evoluir para {evo_name} agora! ⇈",
+  "badge_ready": "⇈ Pronto para evoluir!",
+  "badge_wait_day": "☀️ Pronto para evoluir durante o dia",
+  "badge_wait_night": "🌙 Pronto para evoluir à noite"
 }

--- a/src/Ankimon/lang/sp_text.json
+++ b/src/Ankimon/lang/sp_text.json
@@ -458,5 +458,12 @@
   "cp_label": "PC",
   "bp_label": "PC",
   "combat_power": "Poder de combate",
-  "battle_power": "Poder de combate"
+  "battle_power": "Poder de combate",
+  "friendship_label": "Amistad",
+  "friendship_tooltip": "Mide el vínculo entre tú y tu Pokémon.",
+  "bff_tooltip": "💖 Mejor Amigo (Amistad Máxima)",
+  "evolve_now_button": "⇈ ¡Evolucionar a {evo_name} ahora! ⇈",
+  "badge_ready": "⇈ ¡Listo para evolucionar!",
+  "badge_wait_day": "☀️ Listo para evolucionar durante el día",
+  "badge_wait_night": "🌙 Listo para evolucionar durante la noche"
 }

--- a/tests/test_i18n_leaf_strings.py
+++ b/tests/test_i18n_leaf_strings.py
@@ -1,0 +1,123 @@
+"""Characterization / parity test for F01 (i18n leaf-feature string additions).
+
+Pins the observable contract of the leaf-feature translation strings ported from
+BRRRR_Experimental onto main's ``src/Ankimon/lang/*_text.json`` files:
+
+* every language file still parses as valid JSON (import/construct smoke);
+* the seven evolution / friendship / badge leaf keys are present in all eleven
+  ``*_text.json`` files with a non-empty value;
+* the English reference values match byte-for-byte (the strings other languages
+  fall back to via ``Translator.translate``);
+* ``evolve_now_button`` honours the ``{evo_name}`` placeholder contract in every
+  language (this is exactly what ``Translator.translate(key, evo_name=...)``
+  does: ``template.format(**kwargs)``);
+* ``en_text.json`` gained the ``nature_chart_button`` menu label.
+
+The setting_name.json / setting_description.json auto-catch / active-region /
+team-cycle keys from the same upstream change are intentionally NOT part of this
+unit -- they are gate-coupled to F28's ``settings_window.py`` hierarchical_groups
+wiring (see the PR body) and travel with that leaf. This test therefore also
+pins that main's ``setting_*.json`` guard keys are preserved untouched.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+LANG_DIR = Path(__file__).parent.parent / "src" / "Ankimon" / "lang"
+
+TEXT_LANGS = [
+    "ch",
+    "cz",
+    "de",
+    "en",
+    "es_latam",
+    "fr",
+    "it",
+    "jp",
+    "kr",
+    "po",
+    "sp",
+]
+
+FRIENDSHIP_KEYS = [
+    "friendship_label",
+    "friendship_tooltip",
+    "bff_tooltip",
+    "evolve_now_button",
+    "badge_ready",
+    "badge_wait_day",
+    "badge_wait_night",
+]
+
+# English reference values (byte-exact) that every other language falls back to.
+EN_EXPECTED = {
+    "nature_chart_button": "Check Nature Chart",
+    "friendship_label": "Friendship",
+    "friendship_tooltip": "Measures the bond between you and your Pokémon.",
+    "bff_tooltip": "💖 Best Friend (Highest Friendship)",
+    "evolve_now_button": "⇈ Evolve into {evo_name}! ⇈",
+    "badge_ready": "⇈ Ready to evolve!",
+    "badge_wait_day": "☀️ Ready to evolve during the day",
+    "badge_wait_night": "🌙 Ready to evolve at night",
+}
+
+
+def _load(name):
+    path = LANG_DIR / f"{name}.json"
+    assert path.exists(), f"missing lang file: {path}"
+    with open(path, encoding="utf-8") as fh:
+        return json.load(fh)  # import/construct smoke: must be valid JSON
+
+
+@pytest.mark.parametrize("lang", TEXT_LANGS)
+def test_friendship_keys_present_in_every_language(lang):
+    data = _load(f"{lang}_text")
+    for key in FRIENDSHIP_KEYS:
+        assert key in data, f"{lang}_text.json missing leaf key '{key}'"
+        assert isinstance(data[key], str) and data[key].strip(), (
+            f"{lang}_text.json has empty value for '{key}'"
+        )
+
+
+@pytest.mark.parametrize("lang", TEXT_LANGS)
+def test_evolve_now_button_placeholder_contract(lang):
+    # Mirrors Translator.translate(key, evo_name=...) -> template.format(...)
+    template = _load(f"{lang}_text")["evolve_now_button"]
+    assert "{evo_name}" in template, f"{lang}: evolve_now_button lost placeholder"
+    rendered = template.format(evo_name="Ivysaur")
+    assert "Ivysaur" in rendered
+    assert "{evo_name}" not in rendered
+
+
+def test_english_reference_values_exact():
+    data = _load("en_text")
+    for key, expected in EN_EXPECTED.items():
+        assert data.get(key) == expected, (
+            f"en_text.json['{key}'] = {data.get(key)!r}, expected {expected!r}"
+        )
+
+
+def test_nature_chart_button_only_in_english_per_upstream():
+    # Upstream added nature_chart_button to en_text.json only; the other
+    # languages fall back to English via Translator. Pin that contract.
+    assert "nature_chart_button" in _load("en_text")
+
+
+def test_setting_guard_keys_preserved():
+    # F01 does not touch setting_name/description; assert main's economy + time
+    # evolution guard keys remain intact (GUARDS-TO-REAPPLY) and the two files
+    # stay key-consistent (base test_settings_consistency invariant, Check 1).
+    names = _load("setting_name")
+    descs = _load("setting_description")
+    assert set(names) == set(descs), "setting_name/description key sets diverged"
+    for guard in (
+        "trainer.cash_reward_amount",
+        "trainer.cash_reward_interval",
+        "evolution.friendship_time_enabled",
+    ):
+        assert guard in names and guard in descs, f"guard key '{guard}' dropped"
+    # main's cash-reward economy text (daily 400 cap) must not be replaced by
+    # exp's per-card 100 economy text.
+    assert "400" in descs["trainer.cash_reward_amount"]

--- a/tests/test_i18n_leaf_strings.py
+++ b/tests/test_i18n_leaf_strings.py
@@ -11,7 +11,12 @@ BRRRR_Experimental onto main's ``src/Ankimon/lang/*_text.json`` files:
 * ``evolve_now_button`` honours the ``{evo_name}`` placeholder contract in every
   language (this is exactly what ``Translator.translate(key, evo_name=...)``
   does: ``template.format(**kwargs)``);
-* ``en_text.json`` gained the ``nature_chart_button`` menu label.
+* ``en_text.json`` gained the ``nature_chart_button`` menu label -- and no other
+  language file did (they fall back to English via ``Translator``);
+* main's pre-existing guard keys (``pokemon_about_to_evolve_friendship`` and the
+  ``cp_label``/``bp_label``/``combat_power``/``battle_power`` block, both
+  DONE-IN-BASE per GUARDS-TO-REAPPLY) survive in all eleven languages and keep
+  their English reference values.
 
 The setting_name.json / setting_description.json auto-catch / active-region /
 team-cycle keys from the same upstream change are intentionally NOT part of this
@@ -51,6 +56,16 @@ FRIENDSHIP_KEYS = [
     "badge_wait_night",
 ]
 
+# Main guard keys (GUARDS-TO-REAPPLY, DONE-IN-BASE): upstream re-added these,
+# but main already had them; the port must neither drop nor overwrite them.
+TEXT_GUARD_KEYS = [
+    "pokemon_about_to_evolve_friendship",
+    "cp_label",
+    "bp_label",
+    "combat_power",
+    "battle_power",
+]
+
 # English reference values (byte-exact) that every other language falls back to.
 EN_EXPECTED = {
     "nature_chart_button": "Check Nature Chart",
@@ -61,6 +76,14 @@ EN_EXPECTED = {
     "badge_ready": "⇈ Ready to evolve!",
     "badge_wait_day": "☀️ Ready to evolve during the day",
     "badge_wait_night": "🌙 Ready to evolve at night",
+    # Guard values (main's pre-existing English text, must not be overwritten).
+    "pokemon_about_to_evolve_friendship": (
+        "{main_pokemon_name} is ready to evolve into {evo_pokemon_name}!"
+    ),
+    "cp_label": "CP",
+    "bp_label": "BP",
+    "combat_power": "Combat Power",
+    "battle_power": "Battle Power",
 }
 
 
@@ -103,6 +126,25 @@ def test_nature_chart_button_only_in_english_per_upstream():
     # Upstream added nature_chart_button to en_text.json only; the other
     # languages fall back to English via Translator. Pin that contract.
     assert "nature_chart_button" in _load("en_text")
+    for lang in TEXT_LANGS:
+        if lang == "en":
+            continue
+        assert "nature_chart_button" not in _load(f"{lang}_text"), (
+            f"nature_chart_button leaked into {lang}_text.json; upstream keeps "
+            "it English-only (other languages fall back via Translator)"
+        )
+
+
+@pytest.mark.parametrize("lang", TEXT_LANGS)
+def test_main_guard_keys_preserved_in_every_language(lang):
+    # GUARDS-TO-REAPPLY regression: pokemon_about_to_evolve_friendship and the
+    # cp/bp label block were DONE-IN-BASE; the port must not have dropped them.
+    data = _load(f"{lang}_text")
+    for key in TEXT_GUARD_KEYS:
+        assert key in data, f"{lang}_text.json lost guard key '{key}'"
+        assert isinstance(data[key], str) and data[key].strip(), (
+            f"{lang}_text.json has empty value for guard key '{key}'"
+        )
 
 
 def test_setting_guard_keys_preserved():


### PR DESCRIPTION
## F01 — i18n leaf-feature string additions (all lang JSON)

Ports the self-contained leaf-feature **translation strings** from
`origin/BRRRR_Experimental` onto main's `src/Ankimon/lang/*_text.json`, re-fit
surgically so main's divergent values and formatting are preserved.

### (a) Inventory row
- **ID:** F01 — *i18n leaf-feature string additions (all lang JSON)*
- **Class:** MIXED · **Stage-A disposition:** DEFERRED-TO-STAGE-B · **Harness tier:** UI-ONLY
- **Parity strategy:** OBSERVABLE — characterization test / import+construct smoke
- **Source paths (row):** the 11 `*_text.json` files + `setting_name.json` + `setting_description.json`
- **Seam-entrypoints-required:** none — pure data files, no `aqt.mw.*` access. Strings are
  consumed via `pyobj/translator.py` (`Translator.translate` → `json.load` + `template.format`).

### (b) Source → target re-fit + MERGE_ARCH_MAP rules applied
Two-dot manifest `git diff a8abbd66..origin/BRRRR_Experimental -- <13 lang files>` was the
feature. It splits into two classes of keys:

1. **Self-contained translation strings (PORTED here):** the 7 evolution/friendship/badge keys
   `friendship_label, friendship_tooltip, bff_tooltip, evolve_now_button, badge_ready,
   badge_wait_day, badge_wait_night` in all 11 `*_text.json` files, plus `nature_chart_button`
   in `en_text.json` only (upstream added it to English only; other languages fall back to
   English via `Translator`). No settings-schema coupling → landable now, green.

2. **Settings-schema-coupled keys (DEFERRED — see residual concerns):** the
   `battle.auto_catch_{legendary,mythical,ultra,starter,mega,gmax,regional,wishlist}`,
   `misc.active_region`, `controls.team_cycle_key` keys in `setting_name.json` /
   `setting_description.json`. **Not** included here.

Re-fit details (MERGE_ARCH_MAP §7 — `lang/*` "insert keys surgically onto main's files,
NR ledger notes the whitespace-reindent trap on `setting_name.json`"):
- Keys inserted **surgically** at the tail of each `*_text.json` (after `battle_power`),
  preserving main's 2-space indent and trailing newline. `nature_chart_button` inserted in the
  menu-button block after `gen_chart_button` (matching upstream placement).
- Upstream's **wholesale 4-space→2-space reindent of `setting_name.json` was dropped** (the trap
  called out in the row). Because the coupled setting keys are deferred, `setting_name.json` and
  `setting_description.json` are **untouched** (byte-identical to base) — the reindent never lands.
- Post-snapshot check: the two-dot manifest for these 13 paths contained only the leaf-key hunks
  described above; no post-snapshot hunks citing other features were present in the lang files.

### (c) Seam re-expression
None required. F01 is pure JSON data with **zero** `aqt.mw.*` access, so no §2.1 seam
translation applies and **no new seam method was added**. The consuming seam
(`Translator` in `pyobj/translator.py`) is unchanged.

### (d) Main guards preserved (GUARDS-TO-REAPPLY)
- `pokemon_about_to_evolve_friendship` — DONE-IN-BASE in all 11 `*_text.json`; **not re-added**
  (upstream duplicated it; would have collided). Verified present in base and left intact.
- `cp_label / bp_label / combat_power / battle_power` — DONE-IN-BASE; **not overwritten**
  (upstream re-added them with per-language values; main already has them).
- `trainer.cash_reward_amount / trainer.cash_reward_interval` descriptions (main's daily-400¥
  economy text) — **untouched** (setting_description.json not modified). Upstream's per-card-100¥
  economy text is NOT introduced.
- `evolution.friendship_time_enabled` and `evolution.timezone_auto/offset` — **untouched**.
- A regression assertion for these guards ships in the parity test.

### (e) Parity oracle + gate commands (REAL output)
**Oracle:** `tests/test_i18n_leaf_strings.py` (new, 36 cases) — characterization test pinning the
observable contract: every `*_text.json` parses as valid JSON; the 7 leaf keys are present &
non-empty in all 11 languages; English reference values match byte-for-byte; the
`evolve_now_button` `{evo_name}` placeholder round-trips via `str.format` (exactly what
`Translator.translate(key, evo_name=...)` does) in every language; `nature_chart_button` present
in English and absent from all 10 non-English files; the five main guard keys
(`pokemon_about_to_evolve_friendship`, `cp_label`, `bp_label`, `combat_power`, `battle_power`)
present and non-empty in all 11 languages with English values pinned byte-exact; and the deferred
setting-file guard keys remain intact. Qt-free (mirrors base
`test_settings_consistency.py`'s pathlib JSON-load convention, since `Ankimon/__init__.py`
imports `aqt`).

Gates (environment A — Qt-free `venv_t1`; F01 is UI-ONLY so no GAMEPLAY environment B):
```
$ python -m compileall -q src/Ankimon            # exit 0
$ ruff check  --config ci_ruff_check.toml tests/test_i18n_leaf_strings.py
All checks passed!
$ ruff format --check --config ci_ruff_check.toml tests/test_i18n_leaf_strings.py
1 file already formatted
$ python harness/check.py
PASS — all 9 Tier-1 checks green.
$ python -m pytest tests/ --ignore=tests/test_addon_integrity.py --ignore=tests/test_scaffolding_smoke.py -q
185 passed in 1.11s
$ python -m pytest tests/test_i18n_leaf_strings.py -q
36 passed in 0.02s
```
Baseline was 149 passed; 185 = 149 + 36 new cases → **no new failures**. Only the new test file
was touched by ruff (the 78-file/10-error format/lint debt baseline is not increased for any
untouched file).

### (f) Context7 APIs verified
None — no library API re-authoring (pure data + stdlib `json`/`str.format`).

### (g) Residual concerns
- **DEFERRED: `setting_name.json` / `setting_description.json` keys** (`battle.auto_catch_*`,
  `misc.active_region`, `controls.team_cycle_key`). Landing them standalone **breaks the base
  gate** `tests/test_settings_consistency.py` (Check 2: every `setting_name` friendly-name must
  exist in `settings_window.py`'s `hierarchical_groups`). That wiring is owned by **F28**
  (*settings plumbing + Stage-B config keys*), whose source set is
  `settings.py` / `config.json` / `settings_window.py` — but **not** `setting_*.json`. So these
  labels have a gate-enforced dependency on F28 yet live in F01-owned files: a Stage-A partition
  seam. **Recommendation:** add these `setting_*.json` labels in the same owner-gated wave as F28
  (ARCH_MAP §7), e.g. authorize F28 to co-edit `setting_*.json`, or run an F01 follow-up gated on
  F28 having landed its `hierarchical_groups` rows. Proven locally: adding the labels without F28
  fails `test_settings_consistency` with `AssertionError: Friendly name 'Always Catch: Legendary'
  ... is missing from hierarchial_groups`.
- The ported `*_text.json` strings are consumed by not-yet-landed leaves (evolution overhaul
  F17/F40, reviewer HUD F34, nature-chart menu). They are harmless additive keys until then
  (no test requires every string to be referenced); pre-seeding them here keeps the per-leaf
  PRs from each having to touch all 11 language files.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)



## Attribution
The feature ported here was originally implemented on the `BRRRR_Experimental` branch by @hakimh2 (also commits as BrAk909). Authorship credit is recorded via a `Co-authored-by` trailer on this branch.
