### PR TITLE
feat: Mega/Gmax sprite form-id resolution (F45)

### DIFF
--- a/src/Ankimon/functions/sprite_functions.py
+++ b/src/Ankimon/functions/sprite_functions.py
@@ -107,11 +107,12 @@ def get_sprite_path(
 
     lookup_id = id
 
-    # For Mega/Gmax forms, try to get the form-specific ID from pokedex
+    # For Mega/Gmax forms, try to get the form-specific ID from pokedex.
+    # Match whole name tokens (split on '-'/space) so base names that merely
+    # contain "mega" (Meganium, Yanmega) do not trigger a form lookup.
     base_species_id = None
-    if pokemon_name and any(
-        form in pokemon_name.lower() for form in ["mega", "gmax", "gigantamax"]
-    ):
+    name_tokens = pokemon_name.lower().replace("-", " ").split() if pokemon_name else ()
+    if any(form in name_tokens for form in ("mega", "gmax", "gigantamax")):
         forme_id = _get_pokemon_id_from_pokedex(pokemon_name)
         if forme_id:
             lookup_id = forme_id
@@ -120,10 +121,16 @@ def get_sprite_path(
             )
         # Also get the base species_id for fallback
         try:
+            from .pokedex_functions import safe_int
+
             pokedex = _load_pokedex()
             pokemon_key = pokemon_name.lower().replace(" ", "").replace("-", "")
-            if pokemon_key in pokedex:
-                base_species_id = pokedex[pokemon_key].get("species_id")
+            entry = pokedex.get(pokemon_key)
+            if isinstance(entry, dict):
+                # Coerce like the rest of the codebase (pokedex_functions
+                # wraps every species_id read in safe_int); its 0 default
+                # (= not found) is normalized back to None.
+                base_species_id = safe_int(entry.get("species_id")) or None
         except Exception:
             pass
 
@@ -193,4 +200,7 @@ def get_relative_sprite_path(
             return "../" + norm[idx:]
     except Exception:
         pass
-    return "../user_files/sprites/front_default/0.png"
+    # Web-relative twin of SUBSTITUTE_PATH: unlike exp's "0.png" (no sprite id
+    # 0 exists), substitute.png ships with the sprite pack, so the client gets
+    # a real image instead of a broken link.
+    return "../user_files/sprites/front_default/substitute.png"

--- a/src/Ankimon/functions/sprite_functions.py
+++ b/src/Ankimon/functions/sprite_functions.py
@@ -6,6 +6,38 @@ from ..resources import pkmnimgfolder
 SUBSTITUTE_PATH = f"{pkmnimgfolder}/front_default/substitute.png"
 
 
+def _load_pokedex():
+    """Return the in-memory pokedex cache.
+
+    The import is deliberately lazy (function-local, not module top level) to
+    preserve main's import-cycle discipline: ``pokedex_functions`` imports
+    ``pyobj.pokemon_obj``, which imports this module — a top-level
+    ``from .pokedex_functions import ...`` here would close that loop and break
+    whichever module in it loads first.
+    """
+    from .pokedex_functions import _load_pokedex_cache
+
+    return _load_pokedex_cache()
+
+
+def _get_pokemon_id_from_pokedex(pokemon_name):
+    """Get the sprite ID for a Pokémon form from pokedex (handles Mega/Gmax forms)."""
+    try:
+        from .pokedex_functions import safe_int
+
+        pokedex = _load_pokedex()
+
+        pokemon_key = pokemon_name.lower().replace(" ", "").replace("-", "")
+        if pokemon_key in pokedex:
+            pdata = pokedex[pokemon_key]
+            # Ensure we return an integer ID
+            return safe_int(pdata.get("actual_id")) or safe_int(pdata.get("num"))
+    except Exception as e:
+        services.logger.log("debug", f"Error looking up pokemon ID in pokedex: {e}")
+
+    return None
+
+
 def _path_format(back: bool, id: int, gif: bool, shiny: bool, female: bool):
     side = "back" if back else "front"
     base_path = f"{side}_default_gif" if gif else f"{side}_default"
@@ -30,7 +62,7 @@ def _try_gendered(back: bool, id: int, gif: bool, shiny: bool, female: bool):
         return path
 
     if female:
-        # requested gendered gif but not found, try non-gendered
+        # requested gendered but not found, try non-gendered
         path = _path_format(back, id, gif, shiny, False)
         if os.path.exists(path):
             services.logger.log("debug", f"Sprite found (gender fallback): {path}")
@@ -43,40 +75,122 @@ def _try_back(back: bool, id: int, gif: bool, shiny: bool, female: bool):
         return path
 
     if back:
-        # requested back
-
-        # special fallback
-        if not gif:
-            path = f"sprites/missing_back/{id}.png"
-            if os.path.exists(path):
-                services.logger.log("debug", f"Sprite found (back fallback): {path}")
-                return path
-
-        path = _try_gendered(False, id, gif, shiny, False)
+        # requested back, fallback to front
+        path = _try_gendered(False, id, gif, shiny, female)
         if path:
             return path
 
 
-def get_sprite_path(side: str, sprite_type: str, id: int, shiny: bool, gender: str):
-    """Return the path to the sprite of the Pokémon with robust fallbacks."""
+def get_sprite_path(
+    side: str,
+    sprite_type: str,
+    id: int,
+    shiny: bool,
+    gender: str,
+    pokemon_name: str = None,
+):
+    """Return the path to the sprite of the Pokémon with robust fallbacks.
+
+    Args:
+        side: "front" or "back"
+        sprite_type: "gif" or "png"
+        id: Pokémon ID (base form)
+        shiny: Whether the Pokémon is shiny
+        gender: "M" or "F"
+        pokemon_name: Optional Pokémon name (used for Mega/Gmax forms to look up
+            the correct form-specific sprite ID)
+    """
 
     gif = sprite_type == "gif"
     female = gender == "F"
     back = side == "back"
 
-    path = _try_back(back, id, gif, shiny, female)
+    lookup_id = id
+
+    # For Mega/Gmax forms, try to get the form-specific ID from pokedex
+    base_species_id = None
+    if pokemon_name and any(
+        form in pokemon_name.lower() for form in ["mega", "gmax", "gigantamax"]
+    ):
+        forme_id = _get_pokemon_id_from_pokedex(pokemon_name)
+        if forme_id:
+            lookup_id = forme_id
+            services.logger.log(
+                "debug", f"Using Mega/Gmax form ID {lookup_id} for {pokemon_name}"
+            )
+        # Also get the base species_id for fallback
+        try:
+            pokedex = _load_pokedex()
+            pokemon_key = pokemon_name.lower().replace(" ", "").replace("-", "")
+            if pokemon_key in pokedex:
+                base_species_id = pokedex[pokemon_key].get("species_id")
+        except Exception:
+            pass
+
+    # Try requested format first
+    path = _try_back(back, lookup_id, gif, shiny, female)
     if path:
         return path
 
+    # If GIF requested but not found, try PNG
     if gif:
-        # requested gif but not found, try png
-        path = _try_back(back, id, False, shiny, female)
+        path = _try_back(back, lookup_id, False, shiny, female)
         if path:
             return path
+
+    # If we used a forme ID and still found nothing, fallback to base form ID
+    if lookup_id != id:
+        path = _try_back(back, id, gif, shiny, female)
+        if path:
+            return path
+
+        if gif:
+            path = _try_back(back, id, False, shiny, female)
+            if path:
+                return path
+
+    # Final fallback: try species_id (base form) for Mega/Gmax
+    if base_species_id and base_species_id != id and base_species_id != lookup_id:
+        path = _try_back(back, base_species_id, gif, shiny, female)
+        if path:
+            return path
+        if gif:
+            path = _try_back(back, base_species_id, False, shiny, female)
+            if path:
+                return path
 
     # Fallback to the generic substitute image
     services.logger.log(
         "warning",
-        f"Unable to find sprite for ID {id} (Side: {side} Sprite: {sprite_type} Shiny: {shiny}, Gender: {gender}). Returning substitute.",
+        f"Unable to find sprite for {pokemon_name} ID {id} (Side: {side} Sprite: {sprite_type} Shiny: {shiny}, Gender: {gender}). Returning substitute.",
     )
     return SUBSTITUTE_PATH
+
+
+def get_relative_sprite_path(
+    pokemon_id: int,
+    shiny: bool,
+    gender: str = "N",
+    pokemon_name: str = None,
+    sprite_type: str = "png",
+) -> str:
+    """Return a sprite path relative to the web root (../user_files/sprites/...)."""
+    try:
+        abs_path = str(
+            get_sprite_path(
+                "front",
+                sprite_type,
+                pokemon_id,
+                bool(shiny),
+                gender,
+                pokemon_name,
+            )
+        )
+        norm = abs_path.replace("\\", "/")
+        marker = "user_files/sprites/"
+        idx = norm.find(marker)
+        if idx != -1:
+            return "../" + norm[idx:]
+    except Exception:
+        pass
+    return "../user_files/sprites/front_default/0.png"

--- a/tests/test_sprite_functions.py
+++ b/tests/test_sprite_functions.py
@@ -191,6 +191,51 @@ def test_non_mega_name_does_not_trigger_form_lookup(fake_logger, monkeypatch):
     assert result == base_path
 
 
+def test_mega_substring_names_do_not_trigger_form_lookup(fake_logger, monkeypatch):
+    # Base names merely containing "mega" (Meganium, Yanmega) are not Mega
+    # forms; the token-based check must skip the pokedex entirely.
+    def _boom(_name):
+        raise AssertionError("pokedex lookup must not run for names containing 'mega'")
+
+    monkeypatch.setattr(sf, "_get_pokemon_id_from_pokedex", _boom)
+
+    for name, dex_id in [("Meganium", 154), ("Yanmega", 469)]:
+        base_path = sf._path_format(
+            back=False, id=dex_id, gif=False, shiny=False, female=False
+        )
+        monkeypatch.setattr("os.path.exists", lambda p, _bp=base_path: p == _bp)
+
+        result = sf.get_sprite_path(
+            "front", "png", dex_id, shiny=False, gender="M", pokemon_name=name
+        )
+
+        assert result == base_path
+
+
+def test_gmax_and_gigantamax_spellings_trigger_form_lookup(
+    fake_logger, fake_pokedex, monkeypatch
+):
+    # Hyphenated "-Gmax" and the full "Gigantamax" spelling must still be
+    # recognized by the token-based (non-substring) form check.
+    looked_up = []
+
+    def _recorder(name):
+        looked_up.append(name)
+        return None
+
+    monkeypatch.setattr(sf, "_get_pokemon_id_from_pokedex", _recorder)
+    monkeypatch.setattr("os.path.exists", lambda p: True)
+
+    sf.get_sprite_path(
+        "front", "png", 3, shiny=False, gender="M", pokemon_name="Venusaur-Gmax"
+    )
+    sf.get_sprite_path(
+        "front", "png", 6, shiny=False, gender="M", pokemon_name="Charizard-Gigantamax"
+    )
+
+    assert looked_up == ["Venusaur-Gmax", "Charizard-Gigantamax"]
+
+
 def test_get_relative_sprite_path_web_relative(fake_logger, monkeypatch):
     # get_sprite_path returns an absolute path under user_files/sprites/ -> the
     # relative helper rebases it to the web-root-relative "../user_files/sprites/...".
@@ -203,9 +248,10 @@ def test_get_relative_sprite_path_web_relative(fake_logger, monkeypatch):
 
 
 def test_get_relative_sprite_path_default_on_error(fake_logger, monkeypatch):
-    # If get_sprite_path returns a path without the marker (or raises), the helper
-    # returns the documented default.
+    # If get_sprite_path returns a path without the marker (or raises), the
+    # helper returns the web-relative substitute image (deliberate improvement
+    # over exp's "0.png", which never exists — sprite ids start at 1).
     monkeypatch.setattr(sf, "get_sprite_path", lambda *a, **k: "/no/marker/here.png")
     assert sf.get_relative_sprite_path(25, shiny=False) == (
-        "../user_files/sprites/front_default/0.png"
+        "../user_files/sprites/front_default/substitute.png"
     )

--- a/tests/test_sprite_functions.py
+++ b/tests/test_sprite_functions.py
@@ -5,6 +5,9 @@ registry. Like test_badges_functions, the entire setup is a plain import plus
 below would fail outright if the module still pulled in Anki.
 """
 
+import sys
+import types
+
 import pytest
 
 from Ankimon.services import services
@@ -51,9 +54,158 @@ def test_missing_sprite_returns_substitute_and_logs_warning(fake_logger, monkeyp
 
 def test_gender_fallback_to_nongendered(fake_logger, monkeypatch):
     # Female sprite absent, non-gendered present -> should fall back to it.
-    nongendered = sf._path_format(back=False, id=25, gif=False, shiny=False, female=False)
+    nongendered = sf._path_format(
+        back=False, id=25, gif=False, shiny=False, female=False
+    )
     monkeypatch.setattr("os.path.exists", lambda p: p == nongendered)
 
     result = sf.get_sprite_path("front", "png", 25, shiny=False, gender="F")
 
     assert result == nongendered
+
+
+# ---------------------------------------------------------------------------
+# F45 — Mega/Gmax form sprite-id resolution (characterization / parity tests)
+#
+# Golden pokedex fixture mirrors the shipped pokedex.json shape: a Mega/Gmax
+# form key (name lowercased, spaces & hyphens stripped) carries a form-specific
+# ``actual_id`` sprite id plus the base ``species_id``.
+# ---------------------------------------------------------------------------
+
+FAKE_POKEDEX = {
+    # Charizard-Mega-X: forme sprite id 10034, base species (Charizard) id 6
+    "charizardmegax": {"actual_id": 10034, "num": None, "species_id": 6},
+    # Venusaur-Gmax: forme sprite id 10195, base species (Venusaur) id 3
+    "venusaurgmax": {"actual_id": 10195, "num": None, "species_id": 3},
+    # A form whose actual_id is absent -> should fall back to ``num``
+    "onlynumform": {"actual_id": None, "num": 424242, "species_id": 7},
+}
+
+
+def _safe_int(value, default=0):
+    """Faithful copy of pokedex_functions.safe_int (kept local so the test does
+    not have to import the real module, which sibling tests routinely evict from
+    sys.modules)."""
+    if value is None:
+        return default
+    try:
+        if isinstance(value, str):
+            value = value.strip()
+            if not value:
+                return default
+        return int(float(value))
+    except (ValueError, TypeError):
+        return default
+
+
+@pytest.fixture
+def fake_pokedex(monkeypatch):
+    """Inject a deterministic pokedex cache in place of the real pokedex.json.
+
+    sprite_functions reaches the pokedex through lazy
+    ``from .pokedex_functions import ...`` statements, resolved via
+    ``sys.modules["Ankimon.functions.pokedex_functions"]`` at call time. We swap
+    that entry for a lightweight stub so the fixture is immune to sibling tests
+    that evict/replace ``Ankimon.*`` modules (test_database_manager,
+    test_settings_init_order, ...). monkeypatch.setitem restores it afterwards.
+    """
+    stub = types.ModuleType("Ankimon.functions.pokedex_functions")
+    stub._load_pokedex_cache = lambda: FAKE_POKEDEX
+    stub.safe_int = _safe_int
+    monkeypatch.setitem(sys.modules, "Ankimon.functions.pokedex_functions", stub)
+    return FAKE_POKEDEX
+
+
+def test_get_pokemon_id_from_pokedex_returns_actual_id(fake_logger, fake_pokedex):
+    # Key normalization (lower, strip spaces & hyphens) + actual_id selection.
+    assert sf._get_pokemon_id_from_pokedex("Charizard-Mega-X") == 10034
+    assert sf._get_pokemon_id_from_pokedex("Venusaur-Gmax") == 10195
+
+
+def test_get_pokemon_id_from_pokedex_falls_back_to_num(fake_logger, fake_pokedex):
+    # actual_id absent -> num is used.
+    assert sf._get_pokemon_id_from_pokedex("Only-Num-Form") == 424242
+
+
+def test_get_pokemon_id_from_pokedex_unknown_returns_none(fake_logger, fake_pokedex):
+    assert sf._get_pokemon_id_from_pokedex("Totally Unknown Mon") is None
+
+
+def test_mega_form_uses_forme_sprite_id(fake_logger, fake_pokedex, monkeypatch):
+    # Only the forme id (10034) has a sprite file present; base id 6 does not.
+    forme_path = sf._path_format(
+        back=False, id=10034, gif=False, shiny=False, female=False
+    )
+    monkeypatch.setattr("os.path.exists", lambda p: p == forme_path)
+
+    # id passed in is the base species id (6); pokemon_name drives the Mega lookup.
+    result = sf.get_sprite_path(
+        "front", "png", 6, shiny=False, gender="M", pokemon_name="Charizard-Mega-X"
+    )
+
+    assert result == forme_path
+    assert any("Mega/Gmax form ID 10034" in msg for _, msg in fake_logger.logs)
+
+
+def test_mega_form_falls_back_to_base_id(fake_logger, fake_pokedex, monkeypatch):
+    # Forme sprite (10034) missing -> should fall back to the passed-in base id (6).
+    base_path = sf._path_format(back=False, id=6, gif=False, shiny=False, female=False)
+    monkeypatch.setattr("os.path.exists", lambda p: p == base_path)
+
+    result = sf.get_sprite_path(
+        "front", "png", 6, shiny=False, gender="M", pokemon_name="Charizard-Mega-X"
+    )
+
+    assert result == base_path
+
+
+def test_mega_form_final_fallback_to_species_id(fake_logger, fake_pokedex, monkeypatch):
+    # Neither forme (10034) nor a distinct base id (99) present, but the pokedex
+    # species_id (6) sprite exists -> species_id is the final fallback.
+    species_path = sf._path_format(
+        back=False, id=6, gif=False, shiny=False, female=False
+    )
+    monkeypatch.setattr("os.path.exists", lambda p: p == species_path)
+
+    # Pass a base id (99) that differs from both forme (10034) and species (6).
+    result = sf.get_sprite_path(
+        "front", "png", 99, shiny=False, gender="M", pokemon_name="Charizard-Mega-X"
+    )
+
+    assert result == species_path
+
+
+def test_non_mega_name_does_not_trigger_form_lookup(fake_logger, monkeypatch):
+    # A non-Mega/Gmax name must never consult the pokedex; the base id is used.
+    def _boom(_name):
+        raise AssertionError("pokedex lookup must not run for non-Mega/Gmax names")
+
+    monkeypatch.setattr(sf, "_get_pokemon_id_from_pokedex", _boom)
+    base_path = sf._path_format(back=False, id=25, gif=False, shiny=False, female=False)
+    monkeypatch.setattr("os.path.exists", lambda p: p == base_path)
+
+    result = sf.get_sprite_path(
+        "front", "png", 25, shiny=False, gender="M", pokemon_name="Pikachu"
+    )
+
+    assert result == base_path
+
+
+def test_get_relative_sprite_path_web_relative(fake_logger, monkeypatch):
+    # get_sprite_path returns an absolute path under user_files/sprites/ -> the
+    # relative helper rebases it to the web-root-relative "../user_files/sprites/...".
+    abs_path = "/home/user/.../user_files/sprites/front_default/25.png"
+    monkeypatch.setattr(sf, "get_sprite_path", lambda *a, **k: abs_path)
+
+    result = sf.get_relative_sprite_path(25, shiny=False, gender="M")
+
+    assert result == "../user_files/sprites/front_default/25.png"
+
+
+def test_get_relative_sprite_path_default_on_error(fake_logger, monkeypatch):
+    # If get_sprite_path returns a path without the marker (or raises), the helper
+    # returns the documented default.
+    monkeypatch.setattr(sf, "get_sprite_path", lambda *a, **k: "/no/marker/here.png")
+    assert sf.get_relative_sprite_path(25, shiny=False) == (
+        "../user_files/sprites/front_default/0.png"
+    )


### PR DESCRIPTION
## F45 — Sprite Mega/Gmax form resolution (+ web-relative sprite path helper)

Ports BRRRR_Experimental's `pokemon_name`-aware Mega/Gmax/Gigantamax sprite-id
resolution onto main's seam architecture. Behavior = exp's; architecture =
main's (`services.logger`, import-cycle discipline preserved).

### (a) Inventory row (F45, LEAF, GAMEPLAY tier)
- **Source location(s):** `src/Ankimon/functions/sprite_functions.py`, `src/Ankimon/pyobj/download_sprites.py`
- **Target:** `sprite_functions.py` on main's seam; add `pokemon_name`-aware Mega/Gmax id lookup on top of main's `services.logger` version.
- **Parity strategy:** DETERMINISTIC/SEEDED (pokedex-key → golden sprite id / path).
- **GUARDS-TO-REAPPLY:** service seam (`services.logger`).

### (b) Source → target re-fit + MERGE_ARCH_MAP rules applied
The two-dot manifest (`a8abbd66..origin/BRRRR_Experimental -- <source paths>`) spans **two** exp commits — Stage A's snapshot advanced, so post-snapshot hunks are present (per the Stage-B note):

1. **`180bcf29`** (PC Box / Battle overhaul) — the F45 core: `pokemon_name` param on `get_sprite_path`, `_get_pokemon_id_from_pokedex` (Mega/Gmax `actual_id`/`num` lookup), base-form + `species_id` fallback chain, and the back-sprite lookup improvement ("prevent MissingNo"). **Ported.**
2. **`92acefcc`** (Mobile & Web Reviews integration) — adds `get_relative_sprite_path()`. This is a **post-snapshot hunk that belongs to the Mobile & Web Reviews feature**, but it lands in `sprite_functions.py`, which the partition assigns **exclusively to F45** (verified: `grep sprite_functions MERGE_FEATURE_INVENTORY.md` → only row F45). Its only consumers (`ankimon_items_web/shop_obj.py`, `functions/mobile_sync.py`) import it **lazily** and live in other rows that may not touch `sprite_functions.py`. Leaving it out would orphan it (anti-loss violation); it is a self-contained, additive sprite-path helper squarely in F45's "sprite delivery" domain. **Ported here and flagged for the Mobile & Web Reviews owner.**

MERGE_ARCH_MAP rules applied: §2.1 (`from aqt import mw` state → do not import mw; notifications/logging stay on the seam), §3 shared-module row for `functions/sprite_functions.py` (`mw.* → services.*`; keep `services.logger`), §6 (no immutable/seam file touched → no authorization needed; purely-additive functions only).

`download_sprites.py`: the only F45 hunk is a **trailing-comma no-op** on the two mirror URLs (row calls it "noise"). Base already ships the identical URL set; carrying the change is behaviorally void **and** fights main's ruff-format magic-trailing-comma convention (ruff re-adds the comma). Intentionally **not** carried — no behavior lost. `download_sprites.py` is left byte-for-byte identical to base.

### (c) Seam re-expression done
- exp REVERTED `services.logger` → `mw.logger.log(...)` throughout. **Reverted back to `services.logger.log(...)`** at all 5 call sites (2 in `_try_gendered`, 1 debug in `get_sprite_path` for the Mega/Gmax id, 1 warning fallback, 1 debug in `_get_pokemon_id_from_pokedex`). No `from aqt import mw` remains (`grep -nE 'aqt|mw\.' sprite_functions.py` → none).
- **No seam signature edited.** `get_sprite_path` gains a trailing **optional** `pokemon_name: str = None`, backward-compatible with all 20+ existing callers (none pass it today).
- **Purely-additive module-private helper** `_load_pokedex()` introduced (not a `services`/`events`/`ui_port`/`hooks` seam method — it is a file-local lazy accessor). It funnels both pokedex reads through one lazy `from .pokedex_functions import _load_pokedex_cache`, which (1) preserves the import-cycle guard below and (2) gives a stable test seam. No new public seam entrypoint was added.

### (d) Main guards preserved
- **`services.logger` seam** kept everywhere (the row's GUARDS-TO-REAPPLY).
- **Import-cycle guard.** main documents (pokemon_obj.py) the cycle `pokedex_functions → pyobj.pokemon_obj → functions.sprite_functions`. exp added a **top-level** `from .pokedex_functions import _load_pokedex_cache, safe_int` in `sprite_functions.py`, which would **close that loop and break import** (`sprite_functions` is currently the leaf that keeps it open). Re-fit uses **function-local (lazy) imports** instead — same behavior, cycle stays open. Verified: `import Ankimon.functions.sprite_functions` and the full call path load cleanly aqt-free.
- Base's own three sprite tests (unchanged behavior contracts) still pass verbatim.

### (e) Parity oracle + gate output
**Oracle:** `tests/test_sprite_functions.py` — extended the shipped characterization suite (exp ships no sprite test) with 9 deterministic cases pinning: pokedex-key normalization (lower, strip spaces/hyphens) → `actual_id`, `num` fallback, unknown→None; `get_sprite_path` Mega/Gmax **forme-id → base-id → species_id** fallback chain; non-Mega names never consult the pokedex; and `get_relative_sprite_path` web-root rebasing + default. Golden ids mirror shipped `pokedex.json` (`charizardmegax`: actual_id 10034 / species_id 6; `venusaurgmax`: 10195 / 3). The fixture swaps `sys.modules["Ankimon.functions.pokedex_functions"]` for a stub so it is immune to sibling tests that evict/replace `Ankimon.*` modules.

Gate commands (REAL output):

```
# compileall (venv_t1)            -> exit 0
# ruff check   (ci_ruff_check.toml, changed files)  -> All checks passed!
# ruff format --check (changed files)               -> 2 files already formatted
# harness/check.py (Tier-1)       -> PASS — all 9 Tier-1 checks green.
# pytest tests/ (Qt-free, ignoring addon_integrity + scaffolding_smoke)
                                   -> 158 passed in 1.09s   (149 baseline + 9 new)
# harness/scenarios/economy.py    -> economy: OK
# harness/scenarios/longrun.py 3000 -> longrun: OK  (3000 answers, 0 errors)
# probe_real_boot (venv_qt, offscreen) -> probe_real_boot: OK
# probe_real_play (venv_qt, offscreen) -> probe_real_play: OK  (answers ~29, caught 2, defeated 1)
```

New-only sprite test slice:
```
tests/test_sprite_functions.py .... 12 passed
  test_get_pokemon_id_from_pokedex_returns_actual_id / _falls_back_to_num / _unknown_returns_none
  test_mega_form_uses_forme_sprite_id / _falls_back_to_base_id / _final_fallback_to_species_id
  test_non_mega_name_does_not_trigger_form_lookup
  test_get_relative_sprite_path_web_relative / _default_on_error
```

### (f) Context7 APIs verified
None required — pure-logic re-fit (os.path + in-memory dict lookup); no external library signatures re-authored.

### (g) Residual concerns
- `get_relative_sprite_path` is delivered here but **owned in spirit by the Mobile & Web Reviews row** (its consumers `shop_obj.py`/`mobile_sync.py` land elsewhere). It is dead-but-additive on main until those rows land (both import it lazily). Flagged so the Mobile owner does not re-add it (they cannot touch `sprite_functions.py` under the partition).
- exp's vestigial `import json` and `from ..resources import ... pokedex_path` (both unused in the exp file) were **omitted** to avoid dead imports.
- The removed legacy `sprites/missing_back/{id}.png` CWD-relative fallback (part of exp's back-sprite overhaul) is not covered by any test/probe and effectively never fires in a real deployment; its removal is exp's intended behavior.

### (h) Post-review amendments (Gemini round 1, commit b8910248)
- **Mega/Gmax detection is now token-based**, not substring-based: the name is lowercased, hyphens become spaces, and the gate requires `mega`/`gmax`/`gigantamax` as a whole token. Base names merely containing "mega" (Meganium, Yanmega) no longer trigger a pokedex form lookup or the misleading form-ID debug log. `Charizard-Mega-X`, `Venusaur-Gmax`, `Charizard-Gigantamax` still match (pinned by 2 new tests). Deliberate (benign-behavior) deviation from exp's substring check.
- **`species_id` coerced via `pokedex_functions.safe_int`** (lazy import, cycle-safe) with an `isinstance(entry, dict)` guard; `safe_int`'s 0 default is normalized back to `None`. Defensive idiom only — shipped pokedex.json carries int `species_id` throughout.
- **`get_relative_sprite_path` terminal fallback is now `../user_files/sprites/front_default/substitute.png`** (web-relative twin of `SUBSTITUTE_PATH`) instead of exp's `0.png`, which references a file that never exists (sprite ids start at 1; substitute.png ships with the sprite pack). Deliberate improvement over exp; paired test assertion updated.
- Gate deltas: sprite suite is now 14 tests (11 F45 additions); full Qt-free suite 160 passed (was 158). All other gate lines unchanged (compileall OK, ruff baseline-only, harness 9/9).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>


## Attribution
The feature ported here was originally implemented on the `BRRRR_Experimental` branch by @hakimh2 (also commits as BrAk909). Authorship credit is recorded via a `Co-authored-by` trailer on this branch.
