### PR TITLE
test: reconcile conftest stubs + submodule integrity test onto main (F39)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,9 +11,101 @@ from pathlib import Path
 _src = Path(__file__).parent.parent / "src"
 
 # Stub parent packages so relative imports resolve without loading __init__.py
-for _pkg in ("Ankimon", "Ankimon.functions"):
+for _pkg in (
+    "Ankimon",
+    "Ankimon.functions",
+    "Ankimon.pyobj",
+    "Ankimon.ankimon_items_web",
+):
     if _pkg not in sys.modules:
         _mod = types.ModuleType(_pkg)
         _mod.__path__ = [str(_src / _pkg.replace(".", "/"))]
         _mod.__package__ = _pkg
         sys.modules[_pkg] = _mod
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def restore_package_stubs():
+    from unittest.mock import MagicMock
+
+    def do_restore():
+        # After each test, restore the stubs if they were replaced by MagicMock/None/etc.
+        for _pkg in (
+            "Ankimon",
+            "Ankimon.functions",
+            "Ankimon.pyobj",
+            "Ankimon.ankimon_items_web",
+        ):
+            current = sys.modules.get(_pkg)
+            if (
+                current is None
+                or not hasattr(current, "__path__")
+                or not isinstance(current, types.ModuleType)
+                or isinstance(current, MagicMock)
+            ):
+                _mod = types.ModuleType(_pkg)
+                _mod.__path__ = [str(_src / _pkg.replace(".", "/"))]
+                _mod.__package__ = _pkg
+                sys.modules[_pkg] = _mod
+
+        # Link sub-packages to parent packages so attribute access works
+        if "Ankimon" in sys.modules:
+            for attr in ("functions", "pyobj", "ankimon_items_web"):
+                subpkg = f"Ankimon.{attr}"
+                if subpkg in sys.modules:
+                    setattr(sys.modules["Ankimon"], attr, sys.modules[subpkg])
+
+        # Also restore Ankimon.resources to the real resources module if it was mocked with tmp paths
+        current_res = sys.modules.get("Ankimon.resources")
+        if (
+            current_res is None
+            or not isinstance(current_res, types.ModuleType)
+            or isinstance(current_res, MagicMock)
+            or not hasattr(current_res, "pokedex_path")
+            or "tmp" in str(getattr(current_res, "pokedex_path", ""))
+            or getattr(current_res, "pokedex_path", "") == "dummy"
+        ):
+            import importlib.util
+
+            res_spec = importlib.util.spec_from_file_location(
+                "Ankimon.resources", _src / "Ankimon" / "resources.py"
+            )
+            resources = importlib.util.module_from_spec(res_spec)
+            sys.modules["Ankimon.resources"] = resources
+            try:
+                res_spec.loader.exec_module(resources)
+            except Exception:
+                pass
+
+        # Also restore Ankimon.utils if it is a MagicMock
+        current_utils = sys.modules.get("Ankimon.utils")
+        if current_utils is None or isinstance(current_utils, MagicMock):
+            import importlib.util
+
+            utils_spec = importlib.util.spec_from_file_location(
+                "Ankimon.utils", _src / "Ankimon" / "utils.py"
+            )
+            utils_mod = importlib.util.module_from_spec(utils_spec)
+            sys.modules["Ankimon.utils"] = utils_mod
+            try:
+                utils_spec.loader.exec_module(utils_mod)
+            except Exception:
+                pass
+
+        # NOTE (main re-fit): exp additionally re-executed the real
+        # ``Ankimon.singletons`` module here.  On main, singletons.py is the
+        # production Qt/DB composition root: at module level it runs
+        # ``build_core()`` and constructs SettingsWindow / TestWindow /
+        # Reviewer_Manager / EvoWindow / PokemonPC / ... .  Re-exec'ing it in a
+        # headless test session hangs (it blocks constructing Qt windows), which
+        # is exactly why tests/test_addon_integrity.py keeps it pre-stubbed.
+        # Restoring it to the *real* module would require reload-safe singletons
+        # (Stage-B F31/F32), which is not on this branch yet, so we intentionally
+        # do NOT re-exec it here.  A test that mocks singletons simply keeps its
+        # mock; nothing headless imports the real composition root.
+
+    do_restore()
+    yield
+    do_restore()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -77,7 +77,14 @@ def restore_package_stubs():
             try:
                 res_spec.loader.exec_module(resources)
             except Exception:
-                pass
+                # Never leave a partially-initialized module in sys.modules —
+                # it would poison every subsequent import.  Put back whatever
+                # was there before (or drop the entry) and surface the error.
+                if current_res is not None:
+                    sys.modules["Ankimon.resources"] = current_res
+                else:
+                    sys.modules.pop("Ankimon.resources", None)
+                raise
 
         # Also restore Ankimon.utils if it is a MagicMock
         current_utils = sys.modules.get("Ankimon.utils")
@@ -92,7 +99,14 @@ def restore_package_stubs():
             try:
                 utils_spec.loader.exec_module(utils_mod)
             except Exception:
-                pass
+                # Never leave a partially-initialized module in sys.modules —
+                # it would poison every subsequent import.  Put back whatever
+                # was there before (or drop the entry) and surface the error.
+                if current_utils is not None:
+                    sys.modules["Ankimon.utils"] = current_utils
+                else:
+                    sys.modules.pop("Ankimon.utils", None)
+                raise
 
         # NOTE (main re-fit): exp additionally re-executed the real
         # ``Ankimon.singletons`` module here.  On main, singletons.py is the

--- a/tests/test_addon_integrity.py
+++ b/tests/test_addon_integrity.py
@@ -1,73 +1,242 @@
+"""
+Integrity test for the Ankimon add-on.
+
+Strategy
+--------
+We import each submodule individually and assert none raises ImportError /
+AttributeError at module level.
+
+We deliberately do NOT import Ankimon.__init__ because it is Anki's entry
+point and runs irreducible side effects at import time (database init,
+startup sequence, Qt widget construction, etc.).  Those side effects interact
+badly with the MagicMock stubs used here, previously causing 10+ GB of RAM
+usage as MagicMock iterators generated unbounded object trees.
+
+We also deliberately do NOT use pkgutil.walk_packages() for the same reason:
+iterating a MagicMock __path__ generates objects indefinitely.
+
+The explicit MODULES_TO_CHECK list is reconciled against main's actual module
+set: it includes main's service-seam / scaffolding modules (core, services,
+events, ui_port, gui_presenter, boot_async, webshell.*) and omits Stage-B leaf
+modules that have not landed on this branch yet (e.g. pyobj.move_picker,
+pyobj.encounter_simulator_dialog, ankidex.ankidex_obj, reloader).
+"""
+
 import os
 import sys
 import importlib
-import pkgutil
 import traceback
 import pytest
 from unittest.mock import MagicMock
 
-# Import aqt modules BEFORE QApplication is instantiated by pytest-qt.
-try:
-    import aqt
-    import aqt.qt
-except ImportError:
-    pass
+# ---------------------------------------------------------------------------
+# 1. Stub out external runtime deps not available outside the Anki runtime
+# ---------------------------------------------------------------------------
 
-import sys
-from unittest.mock import MagicMock
 try:
     import anki
     import anki.buildinfo
 except ImportError:
-    class MockAnkiPackage(MagicMock):
+
+    class _MockAnkiPkg(MagicMock):
         __path__ = []
 
-    _anki_mock = MockAnkiPackage()
-    sys.modules['anki'] = _anki_mock
-    sys.modules['anki.hooks'] = MagicMock()
-    sys.modules['anki.utils'] = MagicMock()
-    _buildinfo_mock = MagicMock()
-    _buildinfo_mock.version = "0.0.0-test"
-    sys.modules['anki.buildinfo'] = _buildinfo_mock
+    _anki_mock = _MockAnkiPkg()
+    sys.modules["anki"] = _anki_mock
+    sys.modules["anki.hooks"] = MagicMock()
+    sys.modules["anki.utils"] = MagicMock()
+    _buildinfo = MagicMock()
+    _buildinfo.version = "0.0.0-test"
+    sys.modules["anki.buildinfo"] = _buildinfo
 
 try:
     import aqt.operations
 except ImportError:
-    # Need an empty path for the top-level package mock so submodules work
-    class MockAqtPackage(MagicMock):
+
+    class _MockAqtPkg(MagicMock):
         __path__ = []
 
-    sys.modules['aqt'] = MockAqtPackage()
-    sys.modules['aqt.operations'] = MagicMock()
-    sys.modules['aqt.qt'] = MagicMock()
-    sys.modules['aqt.utils'] = MagicMock()
-    sys.modules['aqt.reviewer'] = MagicMock()
-    sys.modules['aqt.gui_hooks'] = MagicMock()
-    sys.modules['aqt.webview'] = MagicMock()
-    sys.modules['aqt.theme'] = MagicMock()
-    sys.modules['aqt.sound'] = MagicMock()
-    sys.modules['aqt.main'] = MagicMock()
+    sys.modules["aqt"] = _MockAqtPkg()
+    sys.modules["aqt.operations"] = MagicMock()
+    sys.modules["aqt.qt"] = MagicMock()
+    sys.modules["aqt.utils"] = MagicMock()
+    sys.modules["aqt.reviewer"] = MagicMock()
+    sys.modules["aqt.gui_hooks"] = MagicMock()
+    sys.modules["aqt.webview"] = MagicMock()
+    sys.modules["aqt.theme"] = MagicMock()
+    sys.modules["aqt.sound"] = MagicMock()
+    sys.modules["aqt.main"] = MagicMock()
 
-# Add the 'src' directory to the Python path to allow for absolute imports of Ankimon
-ANKIMON_SRC_PARENT_DIR = os.path.abspath(
-    os.path.join(os.path.dirname(__file__), "..", "src")
-)
-if ANKIMON_SRC_PARENT_DIR not in sys.path:
-    sys.path.insert(0, ANKIMON_SRC_PARENT_DIR)
+# ---------------------------------------------------------------------------
+# 2. Put src/ on sys.path so "import Ankimon.xxx" resolves correctly
+# ---------------------------------------------------------------------------
+
+_SRC = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "src"))
+if _SRC not in sys.path:
+    sys.path.insert(0, _SRC)
+
+# ---------------------------------------------------------------------------
+# 3. Modules to pre-stub before any import runs
+#
+#    These perform blocking I/O or event-loop operations at import time and
+#    must never actually execute in a headless test environment.
+# ---------------------------------------------------------------------------
+
+PRE_STUB_MODULES = {
+    # ---- must stay stubbed (heavy side-effects or C extensions at import) ---
+    "Ankimon.singletons",  # full Qt + DB init at module level
+    "Ankimon.pyobj.download_sprites",  # spawns download threads
+    "Ankimon.pyobj.backup_files",  # touches the filesystem
+    "Ankimon.pyobj.migration_dialog",  # shows blocking Qt dialogs
+    "Ankimon.functions.rate_addon_functions",  # reads rate_this.json on import
+    "Ankimon.functions.ankimon_hooks_to_poke_engine",  # C extension bridge
+    "Ankimon.pyobj.tip_of_the_day",  # from aqt.qt import * at class level
+}
+
+# ---------------------------------------------------------------------------
+# 4. Explicit module list — every importable .py in the package.
+#
+#    NEVER switch back to pkgutil.walk_packages(): see module docstring.
+#    When you add a new .py file to the package, add it here too.
+# ---------------------------------------------------------------------------
+
+# Modules we explicitly skip (stubbed above or require full runtime).
+# Listed separately so it is easy to see what we are omitting and why.
+SKIP_MODULES = PRE_STUB_MODULES | {
+    "Ankimon",  # __init__.py — entry point; runs irreducible side effects
+    "Ankimon.poke_engine.tests",
+    "Ankimon.poke_engine.setup",
+}
+
+MODULES_TO_CHECK = [
+    # top-level helpers & hooks
+    "Ankimon.battle_loop",
+    "Ankimon.business",
+    "Ankimon.card_hooks",
+    "Ankimon.changelog",
+    "Ankimon.const",
+    "Ankimon.discord_integration",
+    "Ankimon.gui_entities",
+    "Ankimon.hook_registry",
+    "Ankimon.hooks",
+    "Ankimon.menu_buttons",
+    "Ankimon.move_names",
+    "Ankimon.profile_hooks",
+    "Ankimon.resources",
+    "Ankimon.reviewer_ui",
+    "Ankimon.startup",
+    "Ankimon.texts",
+    "Ankimon.utils",
+    # service seam + scaffolding (main-only foundation modules)
+    "Ankimon.boot_async",
+    "Ankimon.core",
+    "Ankimon.events",
+    "Ankimon.gui_presenter",
+    "Ankimon.services",
+    "Ankimon.ui_port",
+    # webshell frame (main-only; zero screens yet)
+    "Ankimon.webshell",
+    "Ankimon.webshell.host",
+    "Ankimon.webshell.live_update",
+    # functions/
+    "Ankimon.functions",
+    "Ankimon.functions.badges_functions",
+    "Ankimon.functions.battle_functions",
+    "Ankimon.functions.battle_text_functions",
+    "Ankimon.functions.create_css_for_reviewer",
+    "Ankimon.functions.create_gui_functions",
+    "Ankimon.functions.discord_function",
+    "Ankimon.functions.drawing_utils",
+    "Ankimon.functions.encounter_data",
+    "Ankimon.functions.encounter_functions",
+    "Ankimon.functions.friendship_evolution",
+    "Ankimon.functions.gui_functions",
+    "Ankimon.functions.learnset_retrieval",
+    "Ankimon.functions.migration",
+    "Ankimon.functions.pokedex_functions",
+    "Ankimon.functions.pokemon_functions",
+    "Ankimon.functions.pokemon_showdown_functions",
+    "Ankimon.functions.reviewer_iframe",
+    "Ankimon.functions.sprite_functions",
+    "Ankimon.functions.starters",
+    "Ankimon.functions.trainer_functions",
+    "Ankimon.functions.update_main_pokemon",
+    "Ankimon.functions.url_functions",
+    # pyobj/
+    "Ankimon.pyobj",
+    "Ankimon.pyobj.InfoLogger",
+    "Ankimon.pyobj.achievement_window",
+    "Ankimon.pyobj.achievements_dialog",
+    "Ankimon.pyobj.ankimon_leaderboard",
+    "Ankimon.pyobj.ankimon_shop",
+    "Ankimon.pyobj.ankimon_sync",
+    "Ankimon.pyobj.ankimon_tracker",
+    "Ankimon.pyobj.ankimon_tracker_window",
+    "Ankimon.pyobj.attack_dialog",
+    "Ankimon.pyobj.backup_manager",
+    "Ankimon.pyobj.collection_dialog",
+    "Ankimon.pyobj.database_manager",
+    "Ankimon.pyobj.error_handler",
+    "Ankimon.pyobj.evolution_window",
+    "Ankimon.pyobj.help_window",
+    "Ankimon.pyobj.item_window",
+    "Ankimon.pyobj.pc_box",
+    "Ankimon.pyobj.pokemon_obj",
+    "Ankimon.pyobj.pokemon_trade",
+    "Ankimon.pyobj.reviewer_obj",
+    "Ankimon.pyobj.settings",
+    "Ankimon.pyobj.settings_window",
+    "Ankimon.pyobj.starter_window",
+    "Ankimon.pyobj.test_window",
+    "Ankimon.pyobj.trainer_card",
+    "Ankimon.pyobj.trainer_card_window",
+    "Ankimon.pyobj.translator",
+    "Ankimon.pyobj.update_dialog",
+    "Ankimon.pyobj.update_manager",
+    # gui_classes/
+    "Ankimon.gui_classes",
+    "Ankimon.gui_classes.backup_manager_dialog",
+    "Ankimon.gui_classes.check_files",
+    "Ankimon.gui_classes.choose_trainer_sprite_graphical",
+    "Ankimon.gui_classes.overview_team",
+    "Ankimon.gui_classes.pokemon_details",
+    "Ankimon.gui_classes.pokemon_team_window",
+    # classes/
+    "Ankimon.classes.choose_move_dialog",
+    # pokedex/ (legacy; superseded by the future ankidex leaf)
+    "Ankimon.pokedex.pokedex_obj",
+]
+
+# ---------------------------------------------------------------------------
+# 5. Known-benign error patterns
+#    These are tracked issues, not regressions. Real import bugs must NOT
+#    match any of these patterns.
+# ---------------------------------------------------------------------------
+
+KNOWN_BENIGN_PATTERNS = [
+    # overview_team.init_hooks — tracked as a separate fix
+    "module 'Ankimon.gui_classes.overview_team' has no attribute 'init_hooks'",
+    # trainer_card_window reference cleanup in progress
+    "No module named 'Ankimon.pyobj.trainer_card_window'",
+]
+
+# ---------------------------------------------------------------------------
+# 6. The test
+# ---------------------------------------------------------------------------
 
 
-def test_ankimon_initialization(qapp):
+def test_ankimon_submodule_integrity(qapp):
     """
-    Dynamically loads the Ankimon add-on to catch real AttributeError or ImportError
-    that happen at module level, such as failing to register GUI hooks properly.
-    `qapp` is a pytest-qt fixture that provides a QApplication instance, allowing
-    real PyQt6 widgets to be instantiated without crashing.
+    Imports every Ankimon submodule and asserts none raises an ImportError or
+    AttributeError.  Uses the pytest-qt `qapp` fixture so that Qt widget
+    construction in module bodies does not crash.
+
+    Does NOT import Ankimon.__init__ (see module docstring).
     """
     import aqt
     from PyQt6.QtWidgets import QMainWindow
 
-    # Instead of a MagicMock which Qt rejects for parent classes, use a real QWidget
-    # as the mock main window.
+    # Use a real QMainWindow subclass — Qt rejects MagicMock as a parent
     class MockMainWindow(QMainWindow):
         def __init__(self):
             super().__init__()
@@ -83,81 +252,58 @@ def test_ankimon_initialization(qapp):
             pass
 
     aqt.mw = MockMainWindow()
-
-    # Mocking QThreadPool and query execution because we don't want background threads to actually run in the test
     aqt.mw.taskman = MagicMock()
     aqt.mw.logger = MagicMock()
     aqt.mw.ankimon_db = MagicMock()
+    # Ensure getattr(mw, "x", None) returns None for lazy-init guards
+    # (MagicMock attributes are truthy, so we explicitly set common ones)
+    aqt.mw.main_pokemon = None
+    aqt.mw.enemy_pokemon = None
+    aqt.mw.trainer_card = None
+    aqt.mw.ankimon_tracker_obj = None
+    aqt.mw.shop_manager = None
+    aqt.mw.reviewer_obj = None
+    aqt.mw.achievements_dict = None
+    aqt.mw.translator = None
 
-    # Track errors
+    # main re-fit: unlike exp (which routes settings through the service seam),
+    # main's menu_buttons.py and gui_classes/overview_team.py read
+    # ``mw.settings_obj`` at *import* time (Translator + menu construction, and a
+    # deck-view hook gate).  A bare ``None`` breaks those module-level reads, so
+    # give settings_obj a light import-safe fake.  The None attrs above are kept
+    # None so the in-function lazy-init guards elsewhere still behave.
+    class _ImportSafeSettings:
+        _defaults = {"misc.language": 0, "gui.team_deck_view": False}
+
+        def get(self, key, default=None):
+            return self._defaults.get(key, default)
+
+    aqt.mw.settings_obj = _ImportSafeSettings()
+
+    # Install pre-stubs so that imports of heavy modules are intercepted
+    for mod_name in PRE_STUB_MODULES:
+        if mod_name not in sys.modules:
+            sys.modules[mod_name] = MagicMock()
+
     errors = []
 
-    try:
-        import builtins
-        original_import = builtins.__import__
+    for mod_name in MODULES_TO_CHECK:
+        if mod_name in SKIP_MODULES or any(
+            mod_name.startswith(skip + ".") for skip in SKIP_MODULES
+        ):
+            continue
 
-        def custom_import(name, globals=None, locals=None, fromlist=(), level=0):
-            try:
-                return original_import(name, globals, locals, fromlist, level)
-            except ImportError as e:
-                if 'Ankimon' in str(e):
-                    raise
-                if 'qt' in name.lower() or 'aqt' in name.lower() or 'anki' in name.lower() or name == 'markdown':
-                    return MagicMock()
-                raise
-
-        builtins.__import__ = custom_import
-        # Import the main __init__ to simulate Anki loading the add-on
-        import Ankimon
-        builtins.__import__ = original_import
-    except Exception as e:
-        error_msg = f"Failed to load Ankimon/__init__.py:\n{traceback.format_exc()}"
-        errors.append(error_msg)
-
-    # Walk packages and catch remaining errors
-    package = sys.modules.get("Ankimon")
-    if package and hasattr(package, "__path__"):
-        prefix = package.__name__ + "."
-
-        ignore_modules = [
-            "pypresence",
-            "Ankimon.poke_engine.data.scripts",
-            "Ankimon.poke_engine.data.mods",
-            "Ankimon.poke_engine.tests",
-            "Ankimon.poke_engine.setup",
-            "Ankimon.pyobj.tip_of_the_day",
-            "Ankimon.singletons",
-            "Ankimon.poke_engine.ankimon_hooks_to_poke_engine",
-        ]
-
-        for importer, modname, ispkg in pkgutil.walk_packages(package.__path__, prefix):
-            if any(ignored in modname for ignored in ignore_modules):
-                continue
-
-            try:
-                importlib.import_module(modname)
-            except Exception as e:
-                error_msg = f"Failed to dynamically import module {modname}:\n{traceback.format_exc()}"
-                errors.append(error_msg)
-
-    # Filter out known issues that are not real bugs:
-    # - singletons.py requires a full Anki runtime with real Qt widgets
-    # - overview_team init_hooks is a known pending fix
-    # - trainer_card_window was removed/renamed
-    known_patterns = [
-        "module 'Ankimon.gui_classes.overview_team' has no attribute 'init_hooks'",
-        "No module named 'Ankimon.pyobj.trainer_card_window'",
-        "Ankimon.singletons",
-        "singletons.py",
-        "StopIteration",
-    ]
-    errors = [
-        e for e in errors
-        if not any(pattern in e for pattern in known_patterns)
-    ]
+        try:
+            importlib.import_module(mod_name)
+        except Exception:
+            tb = traceback.format_exc()
+            if not any(pat in tb for pat in KNOWN_BENIGN_PATTERNS):
+                errors.append(f"[{mod_name}]\n{tb}")
 
     if errors:
-        error_text = "\n".join(errors)
         pytest.fail(
-            f"Integrity check failed with {len(errors)} error(s):\n{error_text}"
+            f"Integrity check failed with {len(errors)} error(s):\n\n"
+            + "\n"
+            + ("-" * 60)
+            + "\n".join(errors)
         )

--- a/tests/test_addon_integrity.py
+++ b/tests/test_addon_integrity.py
@@ -286,13 +286,22 @@ def test_ankimon_submodule_integrity(qapp):
             sys.modules[mod_name] = MagicMock()
 
     errors = []
+    checked = 0
 
     for mod_name in MODULES_TO_CHECK:
+        # Exact-match skips, plus prefix skips for anything living *under* a
+        # skipped package.  The bare "Ankimon" entry must be exact-match only:
+        # every module in MODULES_TO_CHECK starts with "Ankimon.", so
+        # prefix-matching it would silently skip the entire list and make the
+        # test vacuous.
         if mod_name in SKIP_MODULES or any(
-            mod_name.startswith(skip + ".") for skip in SKIP_MODULES
+            mod_name.startswith(skip + ".")
+            for skip in SKIP_MODULES
+            if skip != "Ankimon"
         ):
             continue
 
+        checked += 1
         try:
             importlib.import_module(mod_name)
         except Exception:
@@ -301,9 +310,17 @@ def test_ankimon_submodule_integrity(qapp):
                 errors.append(f"[{mod_name}]\n{tb}")
 
     if errors:
+        divider = "\n" + "-" * 60 + "\n"
         pytest.fail(
-            f"Integrity check failed with {len(errors)} error(s):\n\n"
-            + "\n"
-            + ("-" * 60)
-            + "\n".join(errors)
+            f"Integrity check failed with {len(errors)} error(s):"
+            + divider
+            + divider.join(errors)
         )
+
+    # Vacuity guard: the skip filter must never regress into excluding the
+    # whole list (prefix-matching the bare "Ankimon" entry once did exactly
+    # that, silently turning this test into a no-op).
+    assert checked >= len(MODULES_TO_CHECK) - len(SKIP_MODULES), (
+        f"skip filter excluded too much: only {checked} of "
+        f"{len(MODULES_TO_CHECK)} modules were import-checked"
+    )


### PR DESCRIPTION
## F39 — Test-harness stub plumbing (conftest + integrity test)

Ports BRRRR_Experimental's test-infra improvements onto main's architecture:
an autouse `restore_package_stubs` fixture in `tests/conftest.py`, and a rewrite
of `tests/test_addon_integrity.py` that imports each submodule individually
instead of importing `Ankimon.__init__` + `pkgutil.walk_packages()` (the old
approach caused 10+ GB MagicMock blowups and blocked on a modal dialog).

Class: **SCAFFOLDING** · Harness tier: **UI-ONLY** · Parity: **OBSERVABLE (import+construct smoke)**

### (a) Inventory row
- **Source:** `tests/conftest.py`, `tests/test_addon_integrity.py`
- **Target:** `tests/` on main — reconcile exp's fixture + import-by-submodule test WITH main's existing conftest/harness rather than overwriting.
- **Dependencies:** Reload-safe singletons (restores `Ankimon.singletons`) — **DEFERRED** (F31/F32, not on this branch).
- **GUARDS-TO-REAPPLY:** preserve main's `harness/` + test infra (exp deletes top-level `harness/`; that deletion must NOT ride in).

### (b) Source → target re-fit
Both files **exist in base** and are byte-identical to the Stage-A snapshot
(`HEAD` blobs `243829cc` / `436db158` == `a8abbd66`), so this is a three-way
re-author of exp's hunks onto main's base, **not** a wholesale checkout.

`git diff a8abbd66..origin/BRRRR_Experimental` for these two paths is the whole
feature. The rewritten integrity test's `MODULES_TO_CHECK` list is data that must
mirror the **target** repo, so it was reconciled to main's actual module set:

- **Dropped (Stage-B leaves not yet landed on this branch):** `Ankimon.reloader`,
  `Ankimon.pyobj.encounter_simulator_dialog`, `Ankimon.pyobj.move_picker`,
  `Ankimon.ankidex.ankidex_obj` (verified absent via `git cat-file`).
- **Added (main-only foundation modules exp's list predates):** the service seam
  `Ankimon.{core,services,events,ui_port,gui_presenter}`, `Ankimon.boot_async`,
  the web-shell frame `Ankimon.webshell{,.host,.live_update}`, and legacy
  `Ankimon.pokedex.pokedex_obj`. This gives the integrity check real coverage of
  main's new architecture.
- `PRE_STUB_MODULES` / `SKIP_MODULES` unchanged (all still exist on main).
- The `ankimon_items_web` package stub in `conftest.py` is kept verbatim from exp;
  it is **inert** on main (the leaf web-shell package is absent) and forward-compatible.

### (c) Seam re-expression
These are **test files that deliberately mock the Anki runtime** (`aqt.mw` is a
`QMainWindow` stand-in) to exercise module-level imports; the §2.1 seam dictionary
governs production code, not scaffolding that mocks `mw`. **No production code is
touched. No seam method added or reshaped.**

One main-specific re-fit inside the test's mock: exp set `aqt.mw.settings_obj = None`
(it routes settings through the seam), but main's `menu_buttons.py:45`
(`Translator(language=int(mw.settings_obj.get("misc.language")))`) and
`gui_classes/overview_team.py:390` (`mw.settings_obj.get("gui.team_deck_view") is True`)
read `mw.settings_obj` at **import** time. A bare `None` breaks those module-level
reads, so `settings_obj` is given a tiny import-safe fake returning
`{"misc.language": 0, "gui.team_deck_view": False}` and `default` otherwise. All the
other `mw.*` attrs stay `None` (their lazy-init guards are all inside functions, so
they don't run at import — verified by grep + a cumulative import probe).

### (d) Main guards preserved
- `harness/` and the whole seam are **untouched** (`git diff --name-only HEAD` = exactly the two `tests/` files); exp's `harness/` deletion did NOT ride in.
- **Reconciliation for the deferred dependency:** exp's fixture also re-executed the
  real `Ankimon.singletons` when it was mocked. On main, `singletons.py` is the
  production Qt/DB composition root — its module body runs `build_core()` and
  constructs `SettingsWindow`/`TestWindow`/`Reviewer_Manager`/`EvoWindow`/`PokemonPC`/…
  Re-exec'ing it headlessly **hangs** (reproduced: `singletons.py` exec in venv_qt →
  timeout/`propagateSizeHints` block), which is exactly why the integrity test keeps
  it pre-stubbed. Restoring it to the real module needs **reload-safe singletons
  (F31/F32), which is not on this branch** — so that one branch is intentionally not
  re-executed here (documented inline). The safe `resources` + `utils` restore
  branches are kept (both exec cleanly: 0.00s / 0.98s in venv_qt). This is the only
  behavioral deviation from exp, and it is the "do not regress main" guard.

### (e) Parity oracle + gate output
**Oracle:** the ported exp test itself — `tests/test_addon_integrity.py::test_ankimon_submodule_integrity`
(re-fit to main's module set) — pins the observable contract "every main submodule
imports without ImportError/AttributeError at module level". Runs in the full-Qt env
(needs the pytest-qt `qapp` fixture).

Gates (GREEN = no NEW failures vs MERGE_BASELINE):

```
# venv_t1 — compileall src/Ankimon (incl poke_engine)
$ python -m compileall -q src/Ankimon      → exit 0

# venv_t1 — ruff (ci_ruff_check.toml; PLE+UP018) on changed files
$ ruff format --config ci_ruff_check.toml tests/conftest.py tests/test_addon_integrity.py
1 file reformatted, 1 file left unchanged
$ ruff format --check --config ci_ruff_check.toml tests/conftest.py tests/test_addon_integrity.py
2 files already formatted
$ ruff check --config ci_ruff_check.toml tests/conftest.py tests/test_addon_integrity.py
All checks passed!

# venv_t1 — Tier-1 harness
$ python harness/check.py
PASS — all 9 Tier-1 checks green.

# venv_t1 — base logic suite (baseline ≥149)
$ python -m pytest tests/ --ignore=tests/test_addon_integrity.py --ignore=tests/test_scaffolding_smoke.py -q
149 passed in 1.25s

# venv_qt (offscreen) — parity oracle
$ QT_QPA_PLATFORM=offscreen ... python -m pytest tests/test_addon_integrity.py -q
1 passed in 0.90s
```

UI-ONLY tier: the GAMEPLAY probes (economy/longrun/probe_real_boot/probe_real_play)
are not in this row's gate set and were not run.

### (f) Context7 APIs verified
None required — no library API re-authored (pure test scaffolding; the QtWebEngine /
QApplication ordering used only in throwaway diagnostic probes, not in the shipped test,
which relies on pytest-qt's `qapp`).

### (g) Residual concerns
- **Singletons restore is deferred**, not dropped in spirit: when reload-safe
  singletons (F31/F32) lands, the `restore_package_stubs` singletons branch can be
  re-enabled. The inline NOTE in `conftest.py` records this.
- `MODULES_TO_CHECK` must be kept in sync as Stage-B leaves land: each leaf PR that
  adds `pyobj/move_picker.py`, `ankidex/`, `ankimon_items_web/*`, etc. should add its
  module(s) to this list (the file comment says so).
- Two modules (`menu_buttons`, `gui_classes/overview_team`) read `mw.settings_obj` at
  import; covered by the import-safe fake rather than being skipped, so they remain
  under integrity coverage.

---

### Post-review amendment (commits `fa465dcb`, `3888002f`)

1. **Review fix** — `restore_package_stubs` no longer leaves a partially-initialized
   `Ankimon.resources` / `Ankimon.utils` module in `sys.modules` when re-exec fails:
   each site restores the prior entry (or drops it) and **re-raises** instead of
   silently swallowing (Gemini comments 3507065751 / 3507065758, hardened with re-raise).
2. **Correction to section (e)** — the originally reported oracle run
   ("1 passed in 0.90s") was a **vacuous pass**: the skip filter prefix-matched the
   bare `"Ankimon"` entry of `SKIP_MODULES` against every module name, so the test
   imported nothing. This inherited exp bug is now fixed: the bare package entry is
   exact-match-only, a vacuity guard asserts the checked count can never silently
   collapse, and the failure-message divider now actually separates collected errors.
   Re-verified in venv_qt: **88 modules genuinely import-checked, 0 errors**, neither
   `KNOWN_BENIGN_PATTERNS` entry fires (both are dormant safety nets on main).

All other gate results in this body were re-run post-change and remain green
(149 passed Tier-1, harness 9/9, smoke 4 passed, probe_real_boot / probe_real_play OK).


## Attribution
The feature ported here was originally implemented on the `BRRRR_Experimental` branch by @hakimh2 (also commits as BrAk909). Authorship credit is recorded via a `Co-authored-by` trailer on this branch.
