### PR TITLE
feat: Pokemon-GO CPM economy tuning (F30)

### DIFF
--- a/src/Ankimon/business.py
+++ b/src/Ankimon/business.py
@@ -85,10 +85,10 @@ def calculate_cpm(level: int) -> float:
 
     Models the Pokemon GO idea of a level-scaling multiplier that grows
     quickly at low levels and tapers off as the Pokemon approaches its
-    level ceiling. Asymptotes just below ``0.84`` — the approximate max
+    level ceiling. Asymptotes just below ``1.2`` — the approximate max
     CPM in Pokemon GO — but is smooth and defined for any Anki level.
     """
-    return 0.84 * (1 - math.exp(-max(level, 1) / 20))
+    return 3.5 * (1 - math.exp(-max(level, 1) / 85))
 
 
 def pokemon_go_raw_stats(base_stats: dict, iv: dict, ev: dict):

--- a/src/Ankimon/business.py
+++ b/src/Ankimon/business.py
@@ -85,8 +85,10 @@ def calculate_cpm(level: int) -> float:
 
     Models the Pokemon GO idea of a level-scaling multiplier that grows
     quickly at low levels and tapers off as the Pokemon approaches its
-    level ceiling. Asymptotes just below ``1.2`` — the approximate max
-    CPM in Pokemon GO — but is smooth and defined for any Anki level.
+    level ceiling. The curve asymptotes toward ``3.5`` as level grows —
+    reaching about ``2.42`` at the level-100 cap — and is smooth and
+    defined for any Anki level. The scale is deliberately larger than
+    Pokemon GO's real CPM cap (~``0.84``) to tune Ankimon's CP economy.
     """
     return 3.5 * (1 - math.exp(-max(level, 1) / 85))
 

--- a/tests/test_cp_formula.py
+++ b/tests/test_cp_formula.py
@@ -46,7 +46,7 @@ class TestCalculateCPM:
 
     def test_level_100_near_cap(self):
         cpm = calculate_cpm(100)
-        assert 0.8 < cpm <= 0.84
+        assert 2.4 < cpm <= 2.45
 
     def test_monotonically_increasing(self):
         values = [calculate_cpm(lv) for lv in range(1, 101)]


### PR DESCRIPTION
## Inventory row
Implements **F30 — Pokemon-GO CPM economy tuning** (LEAF; DEFERRED-TO-STAGE-B; Harness tier GAMEPLAY).

## What / re-fit
Pure numeric rescale of `business.calculate_cpm()` (new-org target = same path; `business.py` is NOT co-edited by main, so a clean 3-way — base == exp pre-image):
- `0.84 * (1 - e^(-level/20))` → `3.5 * (1 - e^(-level/85))`
- docstring asymptote note `0.84` → `1.2` (verbatim from exp)

Seam-neutral: no `aqt.mw.*` access, pure math — no seam re-expression needed.

## Cross-row atomicity (orchestrator authorization)
exp shipped this as ONE atomic change (commit `180bcf29`): the `business.py` formula **and** the paired assertion in `tests/test_cp_formula.py::test_level_100_near_cap` (`0.8 < cpm <= 0.84` → `2.4 < cpm <= 2.45`). Stage A's clean partition put `business.py` in **F30** and `test_cp_formula.py` in **F22** (encounter overhaul), which made F30 un-shippable in isolation (the base test still pinned the old 0.84 cap → 1 new pytest failure). Per the row's own note ("test_cp_formula asserts a formula change in business.py — coordinate") and F22's dependency on `business.calculate_cpm`, the orchestrator **authorized F30 to carry the single `test_level_100_near_cap` assertion line**. It is byte-identical to what F22 will also carry, so it auto-merges with F22's later PR (no conflict, no semantic double-port). Verified: `calculate_cpm(100) = 2.4207…` ∈ (2.4, 2.45].

## Guards preserved
None applicable (business.py has no main-side guards; not co-edited by main).

## Parity oracle
DETERMINISTIC/SEEDED — exp's own `tests/test_cp_formula.py::TestCalculateCPM` (seed→golden math): `test_level_100_near_cap` (2.4 < cpm ≤ 2.45), `test_level_1_is_small`, `test_monotonically_increasing`, `test_level_0_treated_as_1` — 39 passed.

## Verification (real gate output)
- `compileall -q src/Ankimon` (incl poke_engine): **PASS** (exit 0)
- `ruff check --config ci_ruff_check.toml business.py test_cp_formula.py`: **All checks passed!** (0 new errors)
- `ruff format`: my added lines are format-clean; both files carry **pre-existing** whole-tree baseline format debt (they "would reformat" on the untouched base too) — the 78-file baseline count is **unchanged** (consistent with the other Wave-1 PRs; not mass-reformatted).
- `harness/check.py` (Tier-1): **9/9 green**
- `pytest tests/` (minus integrity+scaffolding): **149 passed** (= baseline, no new failures; `test_cp_formula` now matches the new formula)
- `harness/scenarios/economy.py`: **OK** · `longrun.py 3000`: **OK**
- `probe_real_boot` / `probe_real_play` (Tier-2 offscreen): **OK / OK**

## Context7
N/A (stdlib `math` only).

## Residual concern — RESOLVED (review follow-up)
The originally-flagged doc-vs-code mismatch ("Asymptotes just below `1.2`" vs the formula's true `3.5` asymptote) is now fixed in this PR (commit bad13fa0, addressing Gemini review comment 3507093519). `calculate_cpm`'s docstring now states the true asymptote (`3.5`), the level-100 value (~`2.42`, matching the `2.4 < cpm ≤ 2.45` test bound; exact value 2.4207), and notes the scale is a deliberate Ankimon-economy rescale above Pokemon GO's real ~`0.84` CPM cap (the bot's verbatim suggestion, which called 3.5 "the approximate max CPM in Pokemon GO", was adapted rather than pasted because that claim is factually wrong about GO). The docstring-parity line earlier in "What / re-fit" ("docstring asymptote note `0.84` → `1.2` (verbatim from exp)") remains accurate as a description of the original port commit only.


## Attribution
The feature ported here was originally implemented on the `BRRRR_Experimental` branch by @hakimh2 (also commits as BrAk909). Authorship credit is recorded via a `Co-authored-by` trailer on this branch.
