### PR TITLE
feat: in-app branch self-updater — 3-tab dialog, snooze, safe apply (F26)

### DIFF
--- a/src/Ankimon/__init__.py
+++ b/src/Ankimon/__init__.py
@@ -22,6 +22,7 @@ from aqt.gui_hooks import webview_will_set_content
 from aqt.webview import WebContent
 
 from .resources import ensure_ankimon_infrastructure, user_path, addon_dir
+
 ensure_ankimon_infrastructure(addon_dir, user_path)
 
 from .singletons import (
@@ -77,6 +78,7 @@ from .gui_classes import overview_team
 
 # --- Startup: backup, migration, assets, first enemy ---
 from .startup import run_startup_sequence
+
 database_complete, collected_pokemon_ids, backup_manager = run_startup_sequence()
 
 # --- Web exports for reviewer UI ---
@@ -84,18 +86,19 @@ mw.addonManager.setWebExports(
     __name__, r"(web|user_files)/.*\.(css|js|jpg|gif|html|ttf|png|mp3)"
 )
 
+
 def on_webview_will_set_content(web_content: WebContent, context) -> None:
     if not isinstance(context, aqt.reviewer.Reviewer):
         return
     ankimon_package = mw.addonManager.addonFromModule(__name__)
-    web_content.js.append(
-        f"/_addons/{ankimon_package}/web/ankimon_hud_portal.js"
-    )
+    web_content.js.append(f"/_addons/{ankimon_package}/web/ankimon_hud_portal.js")
+
 
 webview_will_set_content.append(on_webview_will_set_content)
 
 # --- Card timer and answer hooks ---
 from .card_hooks import register_card_hooks
+
 register_card_hooks()
 
 setupHooks(None, ankimon_tracker_obj)
@@ -105,11 +108,20 @@ online_connectivity = test_online_connectivity()
 no_more_news = settings_obj.get("misc.YouShallNotPass_Ankimon_News")
 ssh = settings_obj.get("misc.ssh")
 
-from .changelog import check_and_show_changelog, open_help_window
+from .changelog import (
+    check_and_show_changelog,
+    open_help_window,
+    schedule_branch_update_check,
+)
+
 check_and_show_changelog(online_connectivity, ssh, no_more_news)
+# Branch self-updater (F26): poll for new BRRRR_Experimental commits once the
+# profile is open (gui_hooks seam), never as a module-level side effect.
+schedule_branch_update_check(online_connectivity, ssh)
 
 # --- Battle loop ---
 from .battle_loop import on_review_card, init_battle_state
+
 init_battle_state(collected_pokemon_ids)
 gui_hooks.reviewer_did_answer_card.append(on_review_card)
 
@@ -156,6 +168,7 @@ from .hook_registry import (
 )
 
 from .profile_hooks import register_profile_hooks
+
 register_profile_hooks(
     online_connectivity,
     backup_manager,
@@ -167,6 +180,7 @@ register_profile_hooks(
 )
 
 from .reviewer_ui import setup_reviewer_ui, set_collected_ids
+
 set_collected_ids(collected_pokemon_ids)
 setup_reviewer_ui(
     settings_obj.get("controls.catch_key"),
@@ -175,4 +189,5 @@ setup_reviewer_ui(
 )
 
 from .discord_integration import setup_discord_hooks
+
 setup_discord_hooks()

--- a/src/Ankimon/changelog.py
+++ b/src/Ankimon/changelog.py
@@ -1,17 +1,23 @@
 from typing import Union
 
-from aqt import mw
+from aqt import gui_hooks, mw
 from aqt.operations import QueryOp
 from aqt.utils import showWarning
-import markdown
 
 from .resources import addon_ver, addon_dir
 from .utils import read_github_file, read_local_file, compare_files, write_local_file
-from .gui_entities import UpdateNotificationWindow
 from .pyobj.error_handler import show_warning_with_traceback
-from .pyobj.help_window import HelpWindow
+from .services import services
 
 update_infos_md = addon_dir / "updateinfos.md"
+
+
+def _log_info(message: str) -> None:
+    """Log through the services registry when a logger is wired (production);
+    stay silent headless / in tests where ``services.logger`` is None."""
+    logger = services.logger
+    if logger is not None:
+        logger.log("info", message)
 
 
 def download_changelog():
@@ -42,6 +48,12 @@ def check_and_show_changelog(online_connectivity: bool, ssh: bool, no_more_news:
         local_content = read_local_file(update_infos_md)
         if not compare_files(local_content, result):
             write_local_file(update_infos_md, result)
+            # Lazy imports: markdown ships with aqt and the notification window
+            # is Qt — neither is available (nor needed) in the headless tier.
+            import markdown
+
+            from .gui_entities import UpdateNotificationWindow
+
             dialog = UpdateNotificationWindow(markdown.markdown(result))
             if not no_more_news:
                 dialog.exec()
@@ -55,9 +67,103 @@ def check_and_show_changelog(online_connectivity: bool, ssh: bool, no_more_news:
 
 def open_help_window(online_connectivity):
     try:
+        from .pyobj.help_window import HelpWindow
+
         help_dialog = HelpWindow(online_connectivity)
         help_dialog.exec()
     except Exception as e:
         show_warning_with_traceback(
             parent=mw, exception=e, message="Error in opening Help Guide:"
         )
+
+
+def check_branch_update(online_connectivity: bool, ssh: bool):
+    """Poll GitHub for new commits on the branch this install came from.
+
+    Only acts when ``update_state.json`` records a branch install of
+    BRRRR_Experimental (written by ``apply_update``); honors the weekly
+    ``skip_until`` snooze. On a new remote SHA it shows the update prompt
+    (``show_branch_update_prompt``) with the pending commit feed.
+    """
+    _log_info(
+        f"check_branch_update triggered: online_connectivity={online_connectivity}, ssh={ssh}"
+    )
+    if not ssh:
+        _log_info("check_branch_update exited early: ssh is False")
+        return
+
+    from .pyobj.update_manager import read_update_state
+
+    state = read_update_state()
+    _log_info(f"check_branch_update: read_update_state={state}")
+    if not state:
+        _log_info("check_branch_update exited early: state is None")
+        return
+
+    import time
+
+    skip_until = state.get("skip_until")
+    _log_info(
+        f"check_branch_update: skip_until={skip_until}, current_time={time.time()}"
+    )
+    if skip_until and time.time() < skip_until:
+        _log_info("check_branch_update exited early: skip_until active")
+        return
+
+    source_type = state.get("source_type")
+    source_name = state.get("source_name")
+    local_sha = state.get("commit_sha")
+    _log_info(
+        f"check_branch_update: source_type={source_type}, source_name={source_name}, local_sha={local_sha}"
+    )
+
+    if source_type != "branch" or source_name != "BRRRR_Experimental":
+        _log_info("check_branch_update exited early: source_type/name mismatch")
+        return
+
+    def bg(_col):
+        try:
+            from .pyobj.update_manager import fetch_branch_sha, fetch_branch_commits
+
+            remote_sha = fetch_branch_sha("BRRRR_Experimental")
+            commits = []
+            if remote_sha and local_sha != remote_sha:
+                commits = fetch_branch_commits("BRRRR_Experimental", local_sha)
+            return remote_sha, commits
+        except Exception as e:
+            return e
+
+    def done(result):
+        if isinstance(result, Exception) or not result:
+            return
+
+        remote_sha, commits = result
+        if not remote_sha:
+            return
+
+        if local_sha != remote_sha:
+            from .pyobj.update_dialog import show_branch_update_prompt
+
+            show_branch_update_prompt("BRRRR_Experimental", remote_sha, commits)
+
+    QueryOp(
+        parent=mw,
+        op=bg,
+        success=done,
+    ).without_collection().run_in_background()
+
+
+def schedule_branch_update_check(online_connectivity: bool, ssh: bool) -> None:
+    """Schedule the branch-update poll for after the profile opens.
+
+    Boot scheduling goes through the gui_hooks seam (profile-open path)
+    rather than running as a module-level side effect at addon import time.
+    The connectivity gate mirrors the upstream call site, which only polled
+    when a connection was available.
+    """
+
+    def _on_profile_open() -> None:
+        if online_connectivity:
+            check_branch_update(online_connectivity, ssh)
+
+    gui_hooks.profile_did_open.append(_on_profile_open)

--- a/src/Ankimon/changelog.py
+++ b/src/Ankimon/changelog.py
@@ -106,7 +106,9 @@ def check_branch_update(online_connectivity: bool, ssh: bool):
     _log_info(
         f"check_branch_update: skip_until={skip_until}, current_time={time.time()}"
     )
-    if skip_until and time.time() < skip_until:
+    # update_state.json is user-editable: a null/non-numeric skip_until must not
+    # crash the comparison (keep in sync with UpdateDialog._populate_brrr_ui).
+    if isinstance(skip_until, (int, float)) and time.time() < skip_until:
         _log_info("check_branch_update exited early: skip_until active")
         return
 

--- a/src/Ankimon/pyobj/update_dialog.py
+++ b/src/Ankimon/pyobj/update_dialog.py
@@ -16,6 +16,8 @@ from aqt.qt import (
     QFrame,
     QSizePolicy,
     QSpacerItem,
+    QTextBrowser,
+    QCheckBox,
 )
 from aqt.theme import theme_manager
 
@@ -28,8 +30,11 @@ from .update_manager import (
     _download_zip_to_temp,
     _download_branch_zip,
     _download_pr_zip,
+    read_update_state,
+    fetch_branch_sha,
+    fetch_commit_date,
 )
-from ..resources import addon_ver
+from ..resources import addon_ver, IS_EXPERIMENTAL_BUILD
 
 
 class UpdateDialog(QDialog):
@@ -43,6 +48,7 @@ class UpdateDialog(QDialog):
         self._tags = []
         self._branches = []
         self._prs = []
+        self.dev_data_loaded = False
 
         self._apply_theme()
 
@@ -57,8 +63,10 @@ class UpdateDialog(QDialog):
         body.setContentsMargins(20, 16, 20, 16)
 
         self.tabs = QTabWidget()
+        self.tabs.addTab(self._build_brrr_tab(), "  BRRRR_Experimental Branch  ")
         self.tabs.addTab(self._build_releases_tab(), "  Releases  ")
         self.tabs.addTab(self._build_dev_tab(), "  Developer  ")
+        self.tabs.currentChanged.connect(self._on_tab_changed)
         body.addWidget(self.tabs)
 
         self.progress_bar = QProgressBar()
@@ -207,14 +215,242 @@ class UpdateDialog(QDialog):
         frame_layout.setSpacing(4)
 
         title = QLabel("Update Ankimon")
-        title.setStyleSheet(f"font-size: 18px; font-weight: bold; color: {c['text']}; background: transparent; border: none;")
+        title.setStyleSheet(
+            f"font-size: 18px; font-weight: bold; color: {c['text']}; background: transparent; border: none;"
+        )
         frame_layout.addWidget(title)
 
-        ver = QLabel(f"Installed: {addon_ver}")
-        ver.setStyleSheet(f"font-size: 12px; color: {c['muted']}; background: transparent; border: none;")
+        state = read_update_state()
+        ver_text = f"Installed: {addon_ver}"
+        if state:
+            source_type = state.get("source_type")
+            source_name = state.get("source_name")
+            commit_sha = state.get("commit_sha", "")
+            sha_short = f" ({commit_sha[:7]})" if commit_sha else ""
+            if source_type == "branch":
+                ver_text = f"Installed: {addon_ver} (Branch: {source_name}{sha_short})"
+            elif source_type == "pr":
+                ver_text = f"Installed: {addon_ver} (PR #{source_name}{sha_short})"
+            elif source_type == "tag":
+                ver_text = f"Installed: {addon_ver} (Tag: {source_name})"
+            elif source_type == "release":
+                ver_text = f"Installed: {addon_ver} (Release: {source_name})"
+        else:
+            if IS_EXPERIMENTAL_BUILD:
+                ver_text = f"Installed: {addon_ver} (Experimental Build)"
+
+        ver = QLabel(ver_text)
+        ver.setStyleSheet(
+            f"font-size: 12px; color: {c['muted']}; background: transparent; border: none;"
+        )
         frame_layout.addWidget(ver)
 
         return frame
+
+    def _build_brrr_tab(self):
+        c = self._colors
+        widget = QWidget()
+        layout = QVBoxLayout(widget)
+        layout.setSpacing(12)
+        layout.setContentsMargins(10, 14, 10, 10)
+
+        # Info & Details Group
+        details_group = QGroupBox("Active Branch: BRRRR_Experimental")
+        details_layout = QVBoxLayout(details_group)
+        details_layout.setSpacing(6)
+
+        self.brrr_installed_commit_label = QLabel("Installed Commit: Loading...")
+        self.brrr_installed_commit_label.setStyleSheet(
+            "font-size: 12px; font-weight: normal;"
+        )
+        details_layout.addWidget(self.brrr_installed_commit_label)
+
+        self.brrr_commit_date_label = QLabel("Commit Date: Loading...")
+        self.brrr_commit_date_label.setStyleSheet(
+            "font-size: 12px; font-weight: normal;"
+        )
+        details_layout.addWidget(self.brrr_commit_date_label)
+
+        self.brrr_last_update_label = QLabel("Last Update Installed: Loading...")
+        self.brrr_last_update_label.setStyleSheet(
+            "font-size: 12px; font-weight: normal;"
+        )
+        details_layout.addWidget(self.brrr_last_update_label)
+
+        self.brrr_status_label = QLabel("Status: Checking branch...")
+        self.brrr_status_label.setStyleSheet(
+            f"font-size: 13px; font-weight: bold; color: {c['muted']};"
+        )
+        details_layout.addWidget(self.brrr_status_label)
+
+        layout.addWidget(details_group)
+
+        # Commits Feed
+        commits_group = QGroupBox("Recent Branch Updates")
+        commits_layout = QVBoxLayout(commits_group)
+        commits_layout.setSpacing(6)
+
+        self.brrr_commits_box = QTextBrowser()
+        self.brrr_commits_box.setReadOnly(True)
+        self.brrr_commits_box.setOpenExternalLinks(True)
+        self.brrr_commits_box.setMinimumHeight(110)
+        self.brrr_commits_box.setStyleSheet(f"""
+            QTextBrowser {{
+                background-color: {c["bg"]};
+                border: 1px solid {c["group_border"]};
+                border-radius: 6px;
+                padding: 6px;
+                font-size: 11px;
+                color: {c["text"]};
+            }}
+        """)
+        self.brrr_commits_box.setHtml(
+            "<font color='gray'>Checking for changes...</font>"
+        )
+        commits_layout.addWidget(self.brrr_commits_box)
+
+        layout.addWidget(commits_group)
+
+        # Snooze and Controls Bar
+        ctrl_layout = QHBoxLayout()
+        self.brrr_snooze_checkbox = QCheckBox("Snooze notifications for 1 week")
+        self.brrr_snooze_checkbox.setStyleSheet(f"color: {c['text']}; font-size: 12px;")
+        self.brrr_snooze_checkbox.stateChanged.connect(self._on_brrr_snooze_changed)
+        ctrl_layout.addWidget(self.brrr_snooze_checkbox)
+        ctrl_layout.addStretch()
+
+        self.brrr_update_btn = QPushButton("Update Experimental Branch")
+        self.brrr_update_btn.setMinimumHeight(38)
+        self.brrr_update_btn.setStyleSheet(f"""
+            QPushButton {{
+                background-color: {c["btn_primary"]};
+                color: white;
+                font-weight: bold;
+                font-size: 12px;
+                border: none;
+                border-radius: 6px;
+                min-width: 180px;
+            }}
+            QPushButton:hover {{ background-color: {c["btn_primary_hover"]}; }}
+            QPushButton:disabled {{ background-color: {c["btn_bg"]}; color: {c["muted"]}; }}
+        """)
+        self.brrr_update_btn.setEnabled(False)
+        self.brrr_update_btn.clicked.connect(self._on_brrr_update_clicked)
+        ctrl_layout.addWidget(self.brrr_update_btn)
+
+        layout.addLayout(ctrl_layout)
+        return widget
+
+    def _populate_brrr_ui(self, state, remote_sha, local_commit_date, commits):
+        c = self._colors
+        import time
+        import html
+
+        # 1. Local Commit SHA
+        local_sha = state.get("commit_sha", "unknown")
+        local_sha_short = local_sha[:7] if len(local_sha) >= 7 else local_sha
+        self.brrr_installed_commit_label.setText(
+            f"Installed Commit:  <b>{local_sha_short}</b>"
+        )
+
+        # 2. Commit Date
+        if local_commit_date:
+            date_clean = local_commit_date.replace("T", " ").replace("Z", "")
+            self.brrr_commit_date_label.setText(
+                f"Commit Date:  <b>{date_clean} UTC</b>"
+            )
+        else:
+            self.brrr_commit_date_label.setText(
+                "Commit Date:  <b>Unknown (first update will fetch this)</b>"
+            )
+
+        # 3. Last Updated On
+        installed_at = state.get("installed_at")
+        if not installed_at:
+            try:
+                from .update_manager import get_update_state_path
+
+                state_path = get_update_state_path()
+                if state_path.exists():
+                    installed_at = state_path.stat().st_mtime
+            except Exception:
+                pass
+
+        if installed_at:
+            date_formatted = time.strftime(
+                "%Y-%m-%d %H:%M:%S", time.localtime(installed_at)
+            )
+            self.brrr_last_update_label.setText(
+                f"Last Update Installed:  <b>{date_formatted}</b>"
+            )
+        else:
+            self.brrr_last_update_label.setText(
+                "Last Update Installed:  <b>Never (Perform update to record)</b>"
+            )
+
+        # 4. Snooze Checkbox
+        skip_until = state.get("skip_until", 0)
+        self.brrr_snooze_checkbox.blockSignals(True)
+        self.brrr_snooze_checkbox.setChecked(skip_until > time.time())
+        self.brrr_snooze_checkbox.blockSignals(False)
+
+        # 5. Status & Update Button
+        if not remote_sha:
+            self.brrr_status_label.setText("Status:  Could not check connection.")
+            self.brrr_status_label.setStyleSheet(
+                f"font-size: 13px; font-weight: bold; color: {c['error']};"
+            )
+            self.brrr_update_btn.setEnabled(False)
+        elif local_sha != remote_sha:
+            self.brrr_status_label.setText(
+                f"Status:  New Update Available! (Latest: {remote_sha[:7]})"
+            )
+            self.brrr_status_label.setStyleSheet(
+                f"font-size: 13px; font-weight: bold; color: {c['warning']};"
+            )
+            self.brrr_update_btn.setEnabled(True)
+            self.brrr_update_btn.setText("Update Branch Now")
+        else:
+            self.brrr_status_label.setText("Status:  Up to date!")
+            self.brrr_status_label.setStyleSheet(
+                f"font-size: 13px; font-weight: bold; color: {c['success']};"
+            )
+            self.brrr_update_btn.setEnabled(False)
+            self.brrr_update_btn.setText("Already Up to Date")
+
+        # 6. Commits Feed
+        if commits:
+            accent_color = c["accent"]
+            html_content = "<b>What's New on Branch:</b><br><ul style='margin-top: 4px; margin-bottom: 4px; padding-left: 20px;'>"
+            for commit in commits:
+                sha = commit.get("sha", "")
+                msg = commit.get("message", "")
+                msg_escaped = html.escape(msg)
+                html_content += f"<li style='margin-bottom: 4px;'><code><font color='{accent_color}'>{sha}</font></code> - {msg_escaped}</li>"
+            html_content += "</ul>"
+            self.brrr_commits_box.setHtml(html_content)
+        else:
+            self.brrr_commits_box.setHtml(
+                "<font color='gray'>No new commit messages fetched.</font>"
+            )
+
+    def _on_brrr_snooze_changed(self, _state):
+        import time
+        from .update_manager import set_update_skip_until
+
+        if self.brrr_snooze_checkbox.isChecked():
+            one_week_later = time.time() + 604800
+            set_update_skip_until(one_week_later)
+        else:
+            set_update_skip_until(0)
+
+    def _on_brrr_update_clicked(self):
+        self._run_update(
+            lambda progress_cb: _download_branch_zip("BRRRR_Experimental", progress_cb),
+            "latest BRRRR_Experimental",
+            source_type="branch",
+            source_name="BRRRR_Experimental",
+        )
 
     def _build_releases_tab(self):
         c = self._colors
@@ -230,11 +466,15 @@ class UpdateDialog(QDialog):
 
         desc = QLabel("One click to get the latest experimental release.")
         desc.setWordWrap(True)
-        desc.setStyleSheet(f"color: {c['muted']}; font-size: 11px; font-weight: normal;")
+        desc.setStyleSheet(
+            f"color: {c['muted']}; font-size: 11px; font-weight: normal;"
+        )
         latest_layout.addWidget(desc)
 
         self.latest_tag_label = QLabel("Checking...")
-        self.latest_tag_label.setStyleSheet(f"font-weight: bold; font-size: 13px; color: {c['muted']};")
+        self.latest_tag_label.setStyleSheet(
+            f"font-weight: bold; font-size: 13px; color: {c['muted']};"
+        )
         latest_layout.addWidget(self.latest_tag_label)
 
         self.update_latest_btn = QPushButton("Update to Latest Release")
@@ -262,7 +502,9 @@ class UpdateDialog(QDialog):
         specific_layout.setSpacing(8)
 
         pick_label = QLabel("Choose a version:")
-        pick_label.setStyleSheet(f"color: {c['muted']}; font-size: 11px; font-weight: normal;")
+        pick_label.setStyleSheet(
+            f"color: {c['muted']}; font-size: 11px; font-weight: normal;"
+        )
         specific_layout.addWidget(pick_label)
 
         self.release_combo = QComboBox()
@@ -297,7 +539,9 @@ class UpdateDialog(QDialog):
             "your checkout — update with 'git pull' instead. (Your Pokémon "
             "data and sprites are always preserved.)"
         )
-        warning.setStyleSheet(f"color: {c['warning']}; font-size: 11px; font-weight: bold;")
+        warning.setStyleSheet(
+            f"color: {c['warning']}; font-size: 11px; font-weight: bold;"
+        )
         warning.setWordWrap(True)
         layout.addWidget(warning)
 
@@ -310,6 +554,7 @@ class UpdateDialog(QDialog):
         group_layout.addWidget(source_label)
 
         self.source_combo = QComboBox()
+        self.source_combo.addItem("Latest BRRRR_Experimental Branch", "branch_brrr")
         self.source_combo.addItem("Latest Main Branch", "main")
         self.source_combo.addItem("Pull Request", "pr")
         self.source_combo.addItem("Branch", "branch")
@@ -353,7 +598,7 @@ class UpdateDialog(QDialog):
 
     def _on_source_changed(self, index):
         source = self.source_combo.currentData()
-        show = source != "main"
+        show = source not in ("branch_brrr", "main")
         self.target_label.setVisible(show)
         self.target_combo.setVisible(show)
         if show:
@@ -371,8 +616,12 @@ class UpdateDialog(QDialog):
         elif source == "branch":
             self.target_label.setText("Branch:")
             if self._branches:
-                for b in self._branches:
+                default_idx = 0
+                for idx, b in enumerate(self._branches):
                     self.target_combo.addItem(b["name"], b)
+                    if b["name"] == "BRRRR_Experimental":
+                        default_idx = idx
+                self.target_combo.setCurrentIndex(default_idx)
             else:
                 self.target_combo.addItem("No branches found")
         elif source == "tag":
@@ -384,14 +633,85 @@ class UpdateDialog(QDialog):
                 self.target_combo.addItem("No tags found")
 
     def _load_data(self):
+        self.status_label.setText("Checking for updates...")
+
         def bg(_col):
-            return (fetch_releases(), fetch_tags(), fetch_branches(), fetch_open_prs())
+            from .update_manager import (
+                fetch_branch_sha,
+                fetch_commit_date,
+                fetch_branch_commits,
+            )
+
+            # 1. Fetch releases
+            releases = []
+            try:
+                releases = fetch_releases()
+            except Exception:
+                pass
+
+            # 2. Get local state
+            state = read_update_state() or {}
+            local_sha = state.get("commit_sha")
+
+            # 3. Fetch remote BRRR branch details
+            remote_sha = None
+            try:
+                remote_sha = fetch_branch_sha("BRRRR_Experimental")
+            except Exception:
+                pass
+
+            local_commit_date = None
+            if local_sha:
+                try:
+                    local_commit_date = fetch_commit_date(local_sha)
+                except Exception:
+                    pass
+
+            # 4. Fetch last 5 commits on BRRR branch
+            commits = []
+            try:
+                commits = fetch_branch_commits("BRRRR_Experimental", local_sha)
+            except Exception:
+                pass
+
+            return releases, state, remote_sha, local_commit_date, commits
 
         def on_done(result):
-            self._releases, self._tags, self._branches, self._prs = result
+            self._releases, state, remote_sha, local_commit_date, commits = result
+            self._populate_brrr_ui(state, remote_sha, local_commit_date, commits)
             self._populate_ui()
+            self.status_label.setText("")
 
-        QueryOp(parent=self, op=bg, success=on_done).without_collection().run_in_background()
+        QueryOp(
+            parent=self, op=bg, success=on_done
+        ).without_collection().run_in_background()
+
+    def _on_tab_changed(self, index):
+        if index == 2 and not self.dev_data_loaded:
+            self._load_dev_data()
+
+    def _load_dev_data(self):
+        self._set_busy(True)
+        self.status_label.setText("Loading developer options...")
+
+        def bg(_col):
+            return (fetch_tags(), fetch_branches(), fetch_open_prs())
+
+        def on_done(result):
+            self._set_busy(False)
+            self._tags, self._branches, self._prs = result
+            self.dev_data_loaded = True
+
+            # Repopulate targets in the Developer tab UI if needed
+            source = self.source_combo.currentData()
+            if source and source not in ("branch_brrr", "main"):
+                self._populate_target(source)
+
+            self.status_label.setText("")
+
+        QueryOp(
+            parent=self, op=bg, success=on_done
+        ).without_collection().run_in_background()
 
     def _populate_ui(self):
         c = self._colors
@@ -399,15 +719,21 @@ class UpdateDialog(QDialog):
             latest = self._releases[0]["name"]
             if latest == addon_ver:
                 self.latest_tag_label.setText(f"You're up to date  ({latest})")
-                self.latest_tag_label.setStyleSheet(f"font-weight: bold; font-size: 13px; color: {c['success']};")
+                self.latest_tag_label.setStyleSheet(
+                    f"font-weight: bold; font-size: 13px; color: {c['success']};"
+                )
                 self.update_latest_btn.setText("Already Up to Date")
             else:
                 self.latest_tag_label.setText(f"New version available: {latest}")
-                self.latest_tag_label.setStyleSheet(f"font-weight: bold; font-size: 13px; color: {c['warning']};")
+                self.latest_tag_label.setStyleSheet(
+                    f"font-weight: bold; font-size: 13px; color: {c['warning']};"
+                )
                 self.update_latest_btn.setEnabled(True)
         else:
             self.latest_tag_label.setText("Could not check for updates.")
-            self.latest_tag_label.setStyleSheet(f"font-weight: bold; font-size: 13px; color: {c['error']};")
+            self.latest_tag_label.setStyleSheet(
+                f"font-weight: bold; font-size: 13px; color: {c['error']};"
+            )
 
         self.release_combo.clear()
         if self._releases:
@@ -418,7 +744,7 @@ class UpdateDialog(QDialog):
             self.release_combo.addItem("No releases found")
 
         source = self.source_combo.currentData()
-        if source and source != "main":
+        if source and source not in ("branch_brrr", "main"):
             self._populate_target(source)
 
     # --- Actions ---
@@ -437,12 +763,21 @@ class UpdateDialog(QDialog):
             percent = int((current / total) * 100)
             mw.taskman.run_on_main(lambda: self.progress_bar.setValue(percent))
 
-    def _run_update(self, download_fn, label: str, extra_warning: str = None):
+    def _run_update(
+        self,
+        download_fn,
+        label: str,
+        source_type: str = None,
+        source_name: str = None,
+        commit_sha: str = None,
+        extra_warning: str = None,
+    ):
         prompt = f"Update Ankimon to {label}?\n\nYour Pokemon data, settings, and sprites will be preserved."
         if extra_warning:
             prompt = f"{extra_warning}\n\n{prompt}"
         confirm = QMessageBox.question(
-            self, "Confirm Update",
+            self,
+            "Confirm Update",
             prompt,
             QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
         )
@@ -453,15 +788,22 @@ class UpdateDialog(QDialog):
         self.status_label.setText(f"Downloading {label}...")
 
         def bg(_col):
+            nonlocal commit_sha
+            if source_type == "branch" and not commit_sha:
+                commit_sha = fetch_branch_sha(source_name)
+
             zip_path = download_fn(progress_cb=self._on_progress)
             if not zip_path:
                 return False, "Download failed. Check your internet connection.", []
             messages = []
+
             def status_update(m):
                 messages.append(m)
                 mw.taskman.run_on_main(lambda: self.status_label.setText(m))
 
-            success, msg = apply_update(zip_path, status_cb=status_update)
+            success, msg = apply_update(
+                zip_path, source_type, source_name, commit_sha, status_cb=status_update
+            )
             return success, msg, messages
 
         def on_done(result):
@@ -470,33 +812,70 @@ class UpdateDialog(QDialog):
             self.status_label.setText(messages[-1] if messages else msg)
             self.progress_bar.setValue(100 if success else 0)
             if success:
-                QMessageBox.information(self, "Update Complete", f"{msg}\n\nPlease restart Anki for changes to take effect.")
+                QMessageBox.information(
+                    self,
+                    "Update Complete",
+                    f"{msg}\n\nPlease restart Anki for changes to take effect.",
+                )
             else:
                 QMessageBox.warning(self, "Update Failed", msg)
 
-        QueryOp(parent=self, op=bg, success=on_done).without_collection().run_in_background()
+        QueryOp(
+            parent=self, op=bg, success=on_done
+        ).without_collection().run_in_background()
 
     def _on_latest_release_update(self):
         if not self._releases:
             return
         r = self._releases[0]
-        self._run_update(lambda progress_cb: _download_zip_to_temp(r["zipball_url"], progress_cb), f"latest release ({r['name']})")
+        self._run_update(
+            lambda progress_cb: _download_zip_to_temp(r["zipball_url"], progress_cb),
+            f"latest release ({r['name']})",
+            source_type="release",
+            source_name=r["name"],
+            commit_sha=r["name"],
+        )
 
     def _on_release_update(self):
         data = self.release_combo.currentData()
         if data:
-            self._run_update(lambda progress_cb: _download_zip_to_temp(data["zipball_url"], progress_cb), f"release {data['name']}")
+            self._run_update(
+                lambda progress_cb: _download_zip_to_temp(
+                    data["zipball_url"], progress_cb
+                ),
+                f"release {data['name']}",
+                source_type="release",
+                source_name=data["name"],
+                commit_sha=data["name"],
+            )
 
     def _on_dev_install(self):
         source = self.source_combo.currentData()
-        if source == "main":
-            self._run_update(lambda progress_cb: _download_branch_zip("main", progress_cb), "latest main")
+        if source == "branch_brrr":
+            self._run_update(
+                lambda progress_cb: _download_branch_zip(
+                    "BRRRR_Experimental", progress_cb
+                ),
+                "latest BRRRR_Experimental",
+                source_type="branch",
+                source_name="BRRRR_Experimental",
+            )
+        elif source == "main":
+            self._run_update(
+                lambda progress_cb: _download_branch_zip("main", progress_cb),
+                "latest main",
+                source_type="branch",
+                source_name="main",
+            )
         elif source == "pr":
             data = self.target_combo.currentData()
             if data:
                 self._run_update(
                     lambda progress_cb: _download_pr_zip(data["head_sha"], progress_cb),
                     f"PR #{data['number']} ({data['title']})",
+                    source_type="pr",
+                    source_name=str(data["number"]),
+                    commit_sha=data["head_sha"],
                     extra_warning=(
                         "⚠ WARNING: Anyone can open a pull request. This code is "
                         "unreviewed and unreleased — installing it runs unverified "
@@ -507,8 +886,313 @@ class UpdateDialog(QDialog):
         elif source == "branch":
             data = self.target_combo.currentData()
             if data:
-                self._run_update(lambda progress_cb: _download_branch_zip(data["name"], progress_cb), f"branch {data['name']}")
+                self._run_update(
+                    lambda progress_cb: _download_branch_zip(data["name"], progress_cb),
+                    f"branch {data['name']}",
+                    source_type="branch",
+                    source_name=data["name"],
+                )
         elif source == "tag":
             data = self.target_combo.currentData()
             if data:
-                self._run_update(lambda progress_cb: _download_zip_to_temp(data["zipball_url"], progress_cb), f"tag {data['name']}")
+                self._run_update(
+                    lambda progress_cb: _download_zip_to_temp(
+                        data["zipball_url"], progress_cb
+                    ),
+                    f"tag {data['name']}",
+                    source_type="tag",
+                    source_name=data["name"],
+                    commit_sha=data["name"],
+                )
+
+
+class BranchUpdatePromptDialog(QDialog):
+    def __init__(
+        self, branch_name: str, remote_sha: str, commits: list[dict] = None, parent=None
+    ):
+        super().__init__(parent or mw)
+        self.setWindowTitle("Ankimon Update Available")
+        self.setMinimumWidth(460)
+        if commits:
+            self.resize(520, 420)
+        else:
+            self.resize(480, 240)
+
+        is_dark = theme_manager.night_mode
+        bg = "#2b2b2b" if is_dark else "#ffffff"
+        text = "#e0e0e0" if is_dark else "#212121"
+        muted = "#888888" if is_dark else "#757575"
+        border = "#444444" if is_dark else "#e0e0e0"
+        btn_bg = "#3d3d3d" if is_dark else "#eeeeee"
+        btn_hover = "#505050" if is_dark else "#e0e0e0"
+        btn_primary = "#1976d2"
+
+        self.setStyleSheet(f"""
+            QDialog {{
+                background-color: {bg};
+                color: {text};
+            }}
+            QLabel {{
+                color: {text};
+                font-size: 13px;
+            }}
+            QPushButton {{
+                padding: 8px 16px;
+                border: 1px solid {border};
+                border-radius: 6px;
+                background-color: {btn_bg};
+                color: {text};
+                font-size: 13px;
+                min-width: 100px;
+            }}
+            QPushButton:hover {{
+                background-color: {btn_hover};
+            }}
+        """)
+
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(20, 20, 20, 20)
+        layout.setSpacing(16)
+
+        title = QLabel(f"<h3>Update Available for {branch_name}</h3>")
+        layout.addWidget(title)
+
+        desc = QLabel(
+            f"A new update is available for your local <b>{branch_name}</b> branch.<br>"
+            f"Latest Commit: <code>{remote_sha[:7]}</code>"
+        )
+        desc.setWordWrap(True)
+        layout.addWidget(desc)
+
+        if commits:
+            commits_box = QTextBrowser()
+            commits_box.setReadOnly(True)
+            commits_box.setOpenExternalLinks(True)
+
+            box_bg = "#333333" if is_dark else "#fafafa"
+            box_border = "#444444" if is_dark else "#e0e0e0"
+            accent_color = "#4fc3f7" if is_dark else "#1976d2"
+
+            commits_box.setStyleSheet(f"""
+                QTextBrowser {{
+                    background-color: {box_bg};
+                    border: 1px solid {box_border};
+                    border-radius: 6px;
+                    padding: 8px;
+                    font-size: 12px;
+                    color: {text};
+                }}
+            """)
+
+            import html
+
+            html_content = "<b>What's New:</b><br><ul style='margin-top: 4px; margin-bottom: 4px; padding-left: 20px;'>"
+            for c in commits:
+                sha = c.get("sha", "")
+                msg = c.get("message", "")
+                msg_escaped = html.escape(msg)
+                html_content += f"<li style='margin-bottom: 4px;'><code><font color='{accent_color}'>{sha}</font></code> - {msg_escaped}</li>"
+            html_content += "</ul>"
+
+            commits_box.setHtml(html_content)
+            layout.addWidget(commits_box)
+
+        prompt_label = QLabel(
+            "Would you like to install the latest changes now?<br>"
+            "Your Pokemon database, team, and settings will be preserved."
+        )
+        prompt_label.setWordWrap(True)
+        layout.addWidget(prompt_label)
+
+        self.skip_checkbox = QCheckBox("Don't notify me for 1 week")
+        self.skip_checkbox.setStyleSheet(
+            f"color: {text}; font-size: 12px; margin-top: 4px;"
+        )
+        layout.addWidget(self.skip_checkbox)
+
+        btn_layout = QHBoxLayout()
+        btn_layout.addStretch()
+
+        self.btn_later = QPushButton("Later")
+        self.btn_later.clicked.connect(self.reject)
+        btn_layout.addWidget(self.btn_later)
+
+        self.btn_update = QPushButton("Update Now")
+        self.btn_update.setStyleSheet(f"""
+            QPushButton {{
+                background-color: {btn_primary};
+                color: white;
+                font-weight: bold;
+                border: none;
+            }}
+            QPushButton:hover {{
+                background-color: #1565c0;
+            }}
+        """)
+        self.btn_update.clicked.connect(self.accept)
+        btn_layout.addWidget(self.btn_update)
+
+        layout.addLayout(btn_layout)
+
+    def reject(self):
+        if self.skip_checkbox.isChecked():
+            import time
+            from .update_manager import set_update_skip_until
+
+            one_week_later = time.time() + 604800
+            set_update_skip_until(one_week_later)
+
+        QMessageBox.information(
+            self,
+            "Update Later",
+            "No problem! You can always check for updates and install them later by going to Ankimon => Help => Check for Updates.",
+        )
+        super().reject()
+
+
+class BranchUpdateProgressDialog(QDialog):
+    def __init__(self, branch_name: str, remote_sha: str, parent=None):
+        super().__init__(parent or mw)
+        self.setWindowTitle("Updating Ankimon")
+        self.setMinimumWidth(440)
+        self.resize(480, 200)
+
+        self.branch_name = branch_name
+        self.remote_sha = remote_sha
+
+        is_dark = theme_manager.night_mode
+        bg = "#2b2b2b" if is_dark else "#ffffff"
+        text = "#e0e0e0" if is_dark else "#212121"
+        muted = "#888888" if is_dark else "#757575"
+        border = "#444444" if is_dark else "#e0e0e0"
+        btn_bg = "#3d3d3d" if is_dark else "#eeeeee"
+        btn_hover = "#505050" if is_dark else "#e0e0e0"
+        accent = "#4fc3f7" if is_dark else "#1976d2"
+
+        self.setStyleSheet(f"""
+            QDialog {{
+                background-color: {bg};
+                color: {text};
+            }}
+            QLabel {{
+                color: {text};
+                font-size: 13px;
+            }}
+            QProgressBar {{
+                border: none;
+                background-color: {border};
+                border-radius: 4px;
+                text-align: center;
+                height: 16px;
+                color: {text};
+            }}
+            QProgressBar::chunk {{
+                background-color: {accent};
+                border-radius: 4px;
+            }}
+            QPushButton {{
+                padding: 8px 16px;
+                border: 1px solid {border};
+                border-radius: 6px;
+                background-color: {btn_bg};
+                color: {text};
+                font-size: 13px;
+                min-width: 100px;
+            }}
+            QPushButton:hover {{
+                background-color: {btn_hover};
+            }}
+            QPushButton:disabled {{
+                color: {muted};
+                background-color: {btn_bg};
+            }}
+        """)
+
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(20, 20, 20, 20)
+        layout.setSpacing(16)
+
+        self.status_label = QLabel(f"Preparing to update {branch_name}...")
+        self.status_label.setWordWrap(True)
+        layout.addWidget(self.status_label)
+
+        self.progress_bar = QProgressBar()
+        self.progress_bar.setRange(0, 100)
+        self.progress_bar.setValue(0)
+        layout.addWidget(self.progress_bar)
+
+        btn_layout = QHBoxLayout()
+        btn_layout.addStretch()
+
+        self.btn_close = QPushButton("Close")
+        self.btn_close.setEnabled(False)
+        self.btn_close.clicked.connect(self.accept)
+        btn_layout.addWidget(self.btn_close)
+
+        layout.addLayout(btn_layout)
+        self.update_started = False
+
+    def showEvent(self, event):
+        super().showEvent(event)
+        if not self.update_started:
+            self.update_started = True
+            self.start_update()
+
+    def start_update(self):
+        from .update_manager import _download_branch_zip, apply_update
+
+        def bg(_col):
+            zip_path = _download_branch_zip(
+                self.branch_name, progress_cb=self.on_progress
+            )
+            if not zip_path:
+                return False, "Download failed. Check your internet connection."
+
+            def status_update(msg):
+                mw.taskman.run_on_main(lambda: self.status_label.setText(msg))
+
+            success, msg = apply_update(
+                zip_path,
+                source_type="branch",
+                source_name=self.branch_name,
+                commit_sha=self.remote_sha,
+                status_cb=status_update,
+            )
+            return success, msg
+
+        def on_done(result):
+            success, msg = result
+            self.btn_close.setEnabled(True)
+            if success:
+                self.btn_close.setText("Restart Anki")
+                self.status_label.setText(
+                    "Update applied successfully! Please restart Anki."
+                )
+                self.progress_bar.setValue(100)
+                QMessageBox.information(
+                    self,
+                    "Update Complete",
+                    f"{msg}\n\nPlease restart Anki for changes to take effect.",
+                )
+            else:
+                self.status_label.setText(f"Update failed: {msg}")
+                self.progress_bar.setValue(0)
+                QMessageBox.warning(self, "Update Failed", msg)
+
+        QueryOp(
+            parent=self, op=bg, success=on_done
+        ).without_collection().run_in_background()
+
+    def on_progress(self, current: int, total: int):
+        if total > 0:
+            percent = int((current / total) * 100)
+            mw.taskman.run_on_main(lambda: self.progress_bar.setValue(percent))
+
+
+def show_branch_update_prompt(
+    branch_name: str, remote_sha: str, commits: list[dict] = None
+):
+    dialog = BranchUpdatePromptDialog(branch_name, remote_sha, commits, mw)
+    if dialog.exec() == QDialog.DialogCode.Accepted:
+        progress_dialog = BranchUpdateProgressDialog(branch_name, remote_sha, mw)
+        progress_dialog.exec()

--- a/src/Ankimon/pyobj/update_dialog.py
+++ b/src/Ankimon/pyobj/update_dialog.py
@@ -32,7 +32,6 @@ from .update_manager import (
     _download_pr_zip,
     read_update_state,
     fetch_branch_sha,
-    fetch_commit_date,
 )
 from ..resources import addon_ver, IS_EXPERIMENTAL_BUILD
 
@@ -346,8 +345,9 @@ class UpdateDialog(QDialog):
         import time
         import html
 
-        # 1. Local Commit SHA
-        local_sha = state.get("commit_sha", "unknown")
+        # 1. Local Commit SHA ("or" also covers a null/empty value persisted in
+        # the user-editable update_state.json, where .get() defaults would not)
+        local_sha = state.get("commit_sha") or "unknown"
         local_sha_short = local_sha[:7] if len(local_sha) >= 7 else local_sha
         self.brrr_installed_commit_label.setText(
             f"Installed Commit:  <b>{local_sha_short}</b>"
@@ -366,6 +366,8 @@ class UpdateDialog(QDialog):
 
         # 3. Last Updated On
         installed_at = state.get("installed_at")
+        if not isinstance(installed_at, (int, float)):
+            installed_at = None
         if not installed_at:
             try:
                 from .update_manager import get_update_state_path
@@ -388,10 +390,12 @@ class UpdateDialog(QDialog):
                 "Last Update Installed:  <b>Never (Perform update to record)</b>"
             )
 
-        # 4. Snooze Checkbox
-        skip_until = state.get("skip_until", 0)
+        # 4. Snooze Checkbox (tolerate a null/non-numeric skip_until in the
+        # user-editable state file; keep in sync with changelog.check_branch_update)
+        skip_until = state.get("skip_until")
+        is_snoozed = isinstance(skip_until, (int, float)) and skip_until > time.time()
         self.brrr_snooze_checkbox.blockSignals(True)
-        self.brrr_snooze_checkbox.setChecked(skip_until > time.time())
+        self.brrr_snooze_checkbox.setChecked(is_snoozed)
         self.brrr_snooze_checkbox.blockSignals(False)
 
         # 5. Status & Update Button
@@ -921,7 +925,6 @@ class BranchUpdatePromptDialog(QDialog):
         is_dark = theme_manager.night_mode
         bg = "#2b2b2b" if is_dark else "#ffffff"
         text = "#e0e0e0" if is_dark else "#212121"
-        muted = "#888888" if is_dark else "#757575"
         border = "#444444" if is_dark else "#e0e0e0"
         btn_bg = "#3d3d3d" if is_dark else "#eeeeee"
         btn_hover = "#505050" if is_dark else "#e0e0e0"

--- a/src/Ankimon/pyobj/update_manager.py
+++ b/src/Ankimon/pyobj/update_manager.py
@@ -69,6 +69,7 @@ def git_pull_ff_only(status_cb=None) -> tuple[bool, str]:
     the tree is dirty or the branch has diverged — so it never creates merge
     conflicts. Returns ``(success, message)``.
     """
+
     def log(msg):
         if status_cb:
             status_cb(msg)
@@ -88,11 +89,15 @@ def git_pull_ff_only(status_cb=None) -> tuple[bool, str]:
     def _git(*args, timeout=180):
         return subprocess.run(
             ["git", "-C", str(root), *args],
-            capture_output=True, text=True, timeout=timeout,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
         )
 
     try:
-        branch = (_git("rev-parse", "--abbrev-ref", "HEAD", timeout=30).stdout or "").strip() or "HEAD"
+        branch = (
+            _git("rev-parse", "--abbrev-ref", "HEAD", timeout=30).stdout or ""
+        ).strip() or "HEAD"
         log(f"Fast-forwarding '{branch}' (git pull --ff-only)...")
         pull = _git("pull", "--ff-only")
         if pull.returncode != 0:
@@ -144,7 +149,9 @@ def _is_supported_version(name: str) -> bool:
     return v is not None and v >= MIN_UPDATER_VERSION
 
 
-def _make_request(url: str, accept: str = "application/vnd.github.v3+json") -> urllib.request.Request:
+def _make_request(
+    url: str, accept: str = "application/vnd.github.v3+json"
+) -> urllib.request.Request:
     req = urllib.request.Request(url)
     req.add_header("Accept", accept)
     req.add_header("User-Agent", USER_AGENT)
@@ -185,16 +192,29 @@ def _should_preserve(rel_path: str, gitignore_patterns: list[str]) -> bool:
     if rel_path == "user_files" or rel_path.startswith("user_files/"):
         return True
 
+    # Unconditionally preserve local metadata, guides and changelogs
+    always_preserve_roots = ["HelpInfos.html", "updateinfos.md", "meta.json"]
+    if rel_path in always_preserve_roots:
+        return True
+
     for pattern in gitignore_patterns:
         pattern = pattern.rstrip("/")
         if rel_path == pattern or rel_path.startswith(pattern + "/"):
             return True
         elif "*" in pattern:
             import fnmatch
-            if fnmatch.fnmatch(rel_path, pattern) or fnmatch.fnmatch(os.path.basename(rel_path), pattern):
+
+            if fnmatch.fnmatch(rel_path, pattern) or fnmatch.fnmatch(
+                os.path.basename(rel_path), pattern
+            ):
                 return True
 
-    always_preserve = ["user_files/sprites/", "user_files/ankimon.db"]
+    always_preserve = [
+        "user_files/sprites/",
+        "user_files/ankimon.db",
+        "user_files/ankimonDEV.db",
+        "user_files/update_state.json",
+    ]
     for p in always_preserve:
         p = p.rstrip("/")
         if rel_path == p or rel_path.startswith(p + "/"):
@@ -218,7 +238,11 @@ def fetch_releases() -> list[dict]:
     if not data:
         return []
     return [
-        {"name": r["tag_name"], "body": r.get("body", ""), "zipball_url": r["zipball_url"]}
+        {
+            "name": r["tag_name"],
+            "body": r.get("body", ""),
+            "zipball_url": r["zipball_url"],
+        }
         for r in data
         if _is_supported_version(r["tag_name"])
     ]
@@ -235,7 +259,122 @@ def fetch_open_prs() -> list[dict]:
     data = _api_get("pulls?state=open&per_page=50")
     if not data:
         return []
-    return [{"number": pr["number"], "title": pr["title"], "head_ref": pr["head"]["ref"], "head_sha": pr["head"]["sha"]} for pr in data]
+    return [
+        {
+            "number": pr["number"],
+            "title": pr["title"],
+            "head_ref": pr["head"]["ref"],
+            "head_sha": pr["head"]["sha"],
+        }
+        for pr in data
+    ]
+
+
+def fetch_branch_sha(branch: str) -> Optional[str]:
+    data = _api_get(f"branches/{branch}")
+    if data and "commit" in data:
+        return data["commit"].get("sha")
+    return None
+
+
+def fetch_commit_date(sha: str) -> Optional[str]:
+    if not sha or len(sha) < 7 or not all(c in "0123456789abcdefABCDEF" for c in sha):
+        return None
+    data = _api_get(f"commits/{sha}")
+    if data and isinstance(data, dict) and "commit" in data:
+        committer = data["commit"].get("committer") or {}
+        author = data["commit"].get("author") or {}
+        return committer.get("date") or author.get("date")
+    return None
+
+
+def fetch_branch_commits(branch: str, local_sha: Optional[str] = None) -> list[dict]:
+    try:
+        if (
+            local_sha
+            and not local_sha.startswith("old_mocked")
+            and len(local_sha) >= 7
+            and all(c in "0123456789abcdefABCDEF" for c in local_sha)
+        ):
+            # Try to use the compare API
+            url = f"compare/{local_sha}...{branch}"
+            data = _api_get(url)
+            if data and "commits" in data:
+                commits = data["commits"]
+                return [
+                    {
+                        "sha": c["sha"][:7],
+                        "message": c["commit"]["message"].splitlines()[0],
+                    }
+                    for c in reversed(commits)
+                ]
+
+        # Fallback: get the last 5 commits of the branch
+        data = _api_get(f"commits?sha={branch}&per_page=5")
+        if data and isinstance(data, list):
+            return [
+                {"sha": c["sha"][:7], "message": c["commit"]["message"].splitlines()[0]}
+                for c in data
+            ]
+    except Exception:
+        pass
+    return []
+
+
+def get_update_state_path() -> Path:
+    return addon_dir / "user_files" / "update_state.json"
+
+
+def save_update_state(
+    source_type: str,
+    source_name: str,
+    commit_sha: str,
+    skip_until: Optional[float] = None,
+):
+    try:
+        import time
+
+        path = get_update_state_path()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        state = {
+            "source_type": source_type,
+            "source_name": source_name,
+            "commit_sha": commit_sha,
+            "installed_at": time.time(),
+        }
+        if skip_until is not None:
+            state["skip_until"] = skip_until
+        elif path.exists():
+            try:
+                old_state = json.loads(path.read_text(encoding="utf-8"))
+                if "skip_until" in old_state:
+                    state["skip_until"] = old_state["skip_until"]
+            except Exception:
+                pass
+        path.write_text(json.dumps(state, indent=2), encoding="utf-8")
+    except Exception as e:
+        print(f"Ankimon Updater: Failed to save update state: {e}")
+
+
+def set_update_skip_until(skip_until: float):
+    try:
+        state = read_update_state() or {}
+        state["skip_until"] = skip_until
+        path = get_update_state_path()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(state, indent=2), encoding="utf-8")
+    except Exception as e:
+        print(f"Ankimon Updater: Failed to set skip_until: {e}")
+
+
+def read_update_state() -> Optional[dict]:
+    try:
+        path = get_update_state_path()
+        if path.exists():
+            return json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        pass
+    return None
 
 
 def _download_zip_to_temp(url: str, progress_cb=None) -> Optional[str]:
@@ -243,12 +382,12 @@ def _download_zip_to_temp(url: str, progress_cb=None) -> Optional[str]:
     try:
         with urllib.request.urlopen(req, timeout=DOWNLOAD_TIMEOUT) as resp:
             total = int(resp.headers.get("Content-Length", 0))
-            
+
             # Create a named temporary file that persists after closing the object
             # but is cleaned up by our manual logic later.
             tmp = tempfile.NamedTemporaryFile(delete=False, suffix=".zip")
             tmp_path = tmp.name
-            
+
             try:
                 downloaded = 0
                 chunk_size = 128 * 1024  # 128KB chunks
@@ -285,15 +424,25 @@ def _get_gitignore_patterns() -> list[str]:
     patterns = _fetch_gitignore_patterns()
     if not patterns:
         patterns = [
-            "user_files/mypokemon.json", "user_files/mainpokemon.json",
-            "user_files/badges.json", "user_files/items.json",
-            "user_files/data.json", "user_files/team.json",
-            "user_files/config.obf", "user_files/pokemon_history.json",
-            "user_files/rate_this.json", "user_files/backups",
-            "user_files/todays_shop.json", "user_files/meta.json",
-            "user_files/download_complete.flag", "user_files/ankimon.db",
-            "user_files/json/*", "user_files/sprites/",
-            "meta.json", "*.pyc", "*.log",
+            "user_files/mypokemon.json",
+            "user_files/mainpokemon.json",
+            "user_files/badges.json",
+            "user_files/items.json",
+            "user_files/data.json",
+            "user_files/team.json",
+            "user_files/config.obf",
+            "user_files/pokemon_history.json",
+            "user_files/rate_this.json",
+            "user_files/backups",
+            "user_files/todays_shop.json",
+            "user_files/meta.json",
+            "user_files/download_complete.flag",
+            "user_files/ankimon.db",
+            "user_files/json/*",
+            "user_files/sprites/",
+            "meta.json",
+            "*.pyc",
+            "*.log",
         ]
     return patterns
 
@@ -327,7 +476,7 @@ def _extract_ref_from_prefix(src_prefix: str) -> str:
     root_dir = parts[0]
     # Remove repo name prefix if present
     if root_dir.startswith("ankimon-"):
-        ref = root_dir[len("ankimon-"):]
+        ref = root_dir[len("ankimon-") :]
         return ref if ref else "main"
     elif "ankimon-" in root_dir:
         # e.g. h0tp-ftw-ankimon-a1b2c3d -> a1b2c3d
@@ -356,7 +505,7 @@ def _download_and_extract_submodule(sha: str, dest_dir: Path, status_cb=None):
 
     url = f"https://github.com/ArdentRoe/poke-engine/archive/{sha}.zip"
     log("Downloading poke_engine submodule package...")
-    
+
     zip_path = _download_zip_to_temp(url)
     if not zip_path:
         raise Exception("Failed to download poke_engine submodule zip archive.")
@@ -370,19 +519,19 @@ def _download_and_extract_submodule(sha: str, dest_dir: Path, status_cb=None):
                 raise Exception("poke_engine submodule archive is empty.")
             # The root directory in zip is e.g. "poke-engine-{sha}"
             root_prefix = names[0].split("/")[0] + "/"
-            
+
             for name in names:
                 if not name.startswith(root_prefix) or name == root_prefix:
                     continue
-                rel_path = name[len(root_prefix):]
+                rel_path = name[len(root_prefix) :]
                 if not rel_path or rel_path.endswith("/"):
                     continue
-                
+
                 dest_file = temp_extract_dir / rel_path
                 dest_file.parent.mkdir(parents=True, exist_ok=True)
                 with zf.open(name) as source, dest_file.open("wb") as target:
                     shutil.copyfileobj(source, target)
-        
+
         # Atomic swap: Delete old dest_dir if it exists, rename temp_extract_dir to dest_dir
         if dest_dir.exists():
             shutil.rmtree(dest_dir)
@@ -402,7 +551,13 @@ def _download_and_extract_submodule(sha: str, dest_dir: Path, status_cb=None):
                 pass
 
 
-def apply_update(zip_path: str, status_cb=None) -> tuple[bool, str]:
+def apply_update(
+    zip_path: str,
+    source_type: Optional[str] = None,
+    source_name: Optional[str] = None,
+    commit_sha: Optional[str] = None,
+    status_cb=None,
+) -> tuple[bool, str]:
     def log(msg):
         if status_cb:
             status_cb(msg)
@@ -445,7 +600,7 @@ def apply_update(zip_path: str, status_cb=None) -> tuple[bool, str]:
             for name in names:
                 if not name.startswith(src_prefix) or name == src_prefix:
                     continue
-                rel_path = name[len(src_prefix):]
+                rel_path = name[len(src_prefix) :]
                 if not rel_path or rel_path.endswith("/"):
                     continue
                 if _should_preserve(rel_path, gitignore_patterns):
@@ -496,16 +651,30 @@ def apply_update(zip_path: str, status_cb=None) -> tuple[bool, str]:
                     continue
                 dest = addon_dir / rel_path
                 dest.parent.mkdir(parents=True, exist_ok=True)
-                with zf.open(zip_name) as source, dest.open("wb") as target:
-                    shutil.copyfileobj(source, target)
-                installed += 1
+                try:
+                    with zf.open(zip_name) as source, dest.open("wb") as target:
+                        shutil.copyfileobj(source, target)
+                    installed += 1
+                except PermissionError as pe:
+                    if dest.exists():
+                        log(
+                            f"Warning: Skipping locked file {rel_path} (already exists)"
+                        )
+                    else:
+                        raise pe
 
             # --- Download and install matching poke_engine submodule version ---
             ref = _extract_ref_from_prefix(src_prefix)
             log(f"Resolving poke_engine submodule for ref '{ref}'...")
             sub_sha = _fetch_submodule_sha(ref) or DEFAULT_SUBMODULE_SHA
-            
-            _download_and_extract_submodule(sub_sha, addon_dir / "poke_engine", status_cb)
+
+            _download_and_extract_submodule(
+                sub_sha, addon_dir / "poke_engine", status_cb
+            )
+
+            # --- Save update state if provided ---
+            if source_type and source_name:
+                save_update_state(source_type, source_name, commit_sha or "")
 
             cleanup()
             log(f"Update complete. Installed {installed} files.")

--- a/src/Ankimon/pyobj/update_manager.py
+++ b/src/Ankimon/pyobj/update_manager.py
@@ -272,7 +272,7 @@ def fetch_open_prs() -> list[dict]:
 
 def fetch_branch_sha(branch: str) -> Optional[str]:
     data = _api_get(f"branches/{branch}")
-    if data and "commit" in data:
+    if isinstance(data, dict) and isinstance(data.get("commit"), dict):
         return data["commit"].get("sha")
     return None
 
@@ -281,41 +281,35 @@ def fetch_commit_date(sha: str) -> Optional[str]:
     if not sha or len(sha) < 7 or not all(c in "0123456789abcdefABCDEF" for c in sha):
         return None
     data = _api_get(f"commits/{sha}")
-    if data and isinstance(data, dict) and "commit" in data:
-        committer = data["commit"].get("committer") or {}
-        author = data["commit"].get("author") or {}
+    commit = data.get("commit") if isinstance(data, dict) else None
+    if isinstance(commit, dict):
+        committer = commit.get("committer") or {}
+        author = commit.get("author") or {}
         return committer.get("date") or author.get("date")
     return None
 
 
 def fetch_branch_commits(branch: str, local_sha: Optional[str] = None) -> list[dict]:
+    def entry(c: dict) -> dict:
+        # Commit messages can be empty — splitlines() on "" yields [].
+        lines = (c["commit"]["message"] or "").splitlines()
+        return {"sha": c["sha"][:7], "message": lines[0] if lines else ""}
+
     try:
         if (
-            local_sha
-            and not local_sha.startswith("old_mocked")
+            isinstance(local_sha, str)
             and len(local_sha) >= 7
             and all(c in "0123456789abcdefABCDEF" for c in local_sha)
         ):
             # Try to use the compare API
-            url = f"compare/{local_sha}...{branch}"
-            data = _api_get(url)
-            if data and "commits" in data:
-                commits = data["commits"]
-                return [
-                    {
-                        "sha": c["sha"][:7],
-                        "message": c["commit"]["message"].splitlines()[0],
-                    }
-                    for c in reversed(commits)
-                ]
+            data = _api_get(f"compare/{local_sha}...{branch}")
+            if isinstance(data, dict) and isinstance(data.get("commits"), list):
+                return [entry(c) for c in reversed(data["commits"])]
 
         # Fallback: get the last 5 commits of the branch
         data = _api_get(f"commits?sha={branch}&per_page=5")
-        if data and isinstance(data, list):
-            return [
-                {"sha": c["sha"][:7], "message": c["commit"]["message"].splitlines()[0]}
-                for c in data
-            ]
+        if isinstance(data, list):
+            return [entry(c) for c in data]
     except Exception:
         pass
     return []
@@ -371,7 +365,11 @@ def read_update_state() -> Optional[dict]:
     try:
         path = get_update_state_path()
         if path.exists():
-            return json.loads(path.read_text(encoding="utf-8"))
+            # update_state.json lives in user_files/ and is user-editable, so
+            # anything a text editor can produce must come back as None here.
+            data = json.loads(path.read_text(encoding="utf-8"))
+            if isinstance(data, dict):
+                return data
     except Exception:
         pass
     return None

--- a/tests/test_branch_updates.py
+++ b/tests/test_branch_updates.py
@@ -226,6 +226,104 @@ def test_check_branch_update_skipped(mock_read_state, mock_query_op):
     mock_query_op.assert_not_called()
 
 
+def test_read_update_state_rejects_non_dict_json(tmp_path):
+    """update_state.json is user-editable: valid JSON that isn't an object
+    (list/string/number/null) must read back as None, not leak through to
+    callers that immediately call .get() on the result."""
+    state_file = tmp_path / "update_state.json"
+
+    with patch.object(update_manager, "get_update_state_path", return_value=state_file):
+        for content in ('["not", "a", "dict"]', '"just a string"', "42", "null"):
+            state_file.write_text(content, encoding="utf-8")
+            assert update_manager.read_update_state() is None
+
+        # Corrupt (non-JSON) content degrades to None too.
+        state_file.write_text("{not json", encoding="utf-8")
+        assert update_manager.read_update_state() is None
+
+
+@patch("Ankimon.changelog.QueryOp")
+@patch("Ankimon.pyobj.update_manager.read_update_state")
+def test_check_branch_update_tolerates_bad_skip_until(mock_read_state, mock_query_op):
+    """A null or non-numeric skip_until in the user-editable state file must not
+    raise a TypeError against time.time(); the poll simply proceeds."""
+    for bad_skip in (None, "not-a-number"):
+        mock_query_op.reset_mock()
+        mock_read_state.return_value = {
+            "source_type": "branch",
+            "source_name": "BRRRR_Experimental",
+            "commit_sha": "abc1234",
+            "skip_until": bad_skip,
+        }
+        changelog.check_branch_update(True, True)
+        mock_query_op.assert_called_once()
+
+
+@patch("Ankimon.changelog.QueryOp")
+@patch("Ankimon.pyobj.update_manager.read_update_state")
+@patch("Ankimon.pyobj.update_manager.fetch_branch_sha")
+@patch("Ankimon.pyobj.update_manager.fetch_branch_commits")
+def test_check_branch_update_null_commit_sha(
+    mock_fetch_commits, mock_fetch_sha, mock_read_state, mock_query_op
+):
+    """A null commit_sha in the state file still polls; the background op passes
+    None through to fetch_branch_commits (which then uses the fallback API)."""
+    mock_read_state.return_value = {
+        "source_type": "branch",
+        "source_name": "BRRRR_Experimental",
+        "commit_sha": None,
+    }
+    mock_fetch_sha.return_value = "remote_sha_456"
+    mock_fetch_commits.return_value = []
+
+    changelog.check_branch_update(True, True)
+
+    mock_query_op.assert_called_once()
+    bg_func = mock_query_op.call_args[1].get("op") or mock_query_op.call_args[0][1]
+    res_sha, res_commits = bg_func(None)
+
+    assert res_sha == "remote_sha_456"
+    assert res_commits == []
+    mock_fetch_commits.assert_called_once_with("BRRRR_Experimental", None)
+
+
+@patch("Ankimon.pyobj.update_manager._api_get")
+def test_fetch_branch_commits_non_string_local_sha_uses_fallback(mock_api_get):
+    """A non-string local_sha (hostile state file) must not raise; the helper
+    skips the compare API and uses the plain commits endpoint."""
+    mock_api_get.return_value = [
+        {"sha": "111111122222", "commit": {"message": "A commit"}},
+    ]
+    commits = update_manager.fetch_branch_commits("BRRRR_Experimental", 1234567890)
+    assert commits == [{"sha": "1111111", "message": "A commit"}]
+    mock_api_get.assert_called_once_with("commits?sha=BRRRR_Experimental&per_page=5")
+
+
+@patch("Ankimon.pyobj.update_manager._api_get")
+def test_fetch_branch_commits_empty_message(mock_api_get):
+    """An empty commit message must not IndexError the whole feed; the other
+    commits are still returned."""
+    mock_api_get.return_value = [
+        {"sha": "111111122222", "commit": {"message": ""}},
+        {"sha": "333333344444", "commit": {"message": "Real message\nDetails"}},
+    ]
+    commits = update_manager.fetch_branch_commits("BRRRR_Experimental")
+    assert commits == [
+        {"sha": "1111111", "message": ""},
+        {"sha": "3333333", "message": "Real message"},
+    ]
+
+
+@patch("Ankimon.pyobj.update_manager._api_get")
+def test_fetch_helpers_tolerate_malformed_api_shapes(mock_api_get):
+    """fetch_branch_sha / fetch_commit_date return None (not raise) when the
+    API helper yields None or an unexpected JSON shape."""
+    for bad in (None, [], "err", {"commit": None}, {"commit": "not-a-dict"}):
+        mock_api_get.return_value = bad
+        assert update_manager.fetch_branch_sha("BRRRR_Experimental") is None
+        assert update_manager.fetch_commit_date("a1b2c3d4e5f6") is None
+
+
 @patch("Ankimon.changelog.check_branch_update")
 def test_schedule_branch_update_check_uses_profile_open_hook(mock_check):
     """The boot wiring registers on gui_hooks.profile_did_open and only polls

--- a/tests/test_branch_updates.py
+++ b/tests/test_branch_updates.py
@@ -1,0 +1,253 @@
+"""Branch self-updater tests (F26): update_state.json persistence, the GitHub
+branch/commit fetch helpers, and the changelog.check_branch_update poll flow.
+
+Ported from BRRRR_Experimental. Tier-1 note: this file must stay collectable
+in the Qt-free venv — aqt/anki are stubbed below, and the product code keeps
+its heavy imports (markdown, Qt dialogs) lazy so importing ``changelog`` and
+``update_manager`` here needs neither Qt nor markdown.
+"""
+
+import sys
+import time
+from unittest.mock import MagicMock, patch
+
+# Mock aqt/anki namespaces if not already mocked by conftest
+for name in [
+    "aqt",
+    "aqt.qt",
+    "aqt.utils",
+    "aqt.gui_hooks",
+    "aqt.operations",
+    "aqt.reviewer",
+    "aqt.webview",
+    "aqt.main",
+    "anki",
+    "anki.hooks",
+    "anki.collection",
+    "anki.models",
+    "anki.notes",
+    "anki.template",
+    "anki.buildinfo",
+]:
+    if name not in sys.modules:
+        sys.modules[name] = MagicMock()
+
+# Ensure QueryOp mock is set up for operations
+if "aqt.operations" in sys.modules:
+    sys.modules["aqt.operations"].QueryOp = MagicMock()
+
+# Import the actual modules under test
+from Ankimon.pyobj import update_manager
+from Ankimon import changelog
+
+
+def test_update_state_read_write(tmp_path):
+    """Test saving and reading the update state to update_state.json."""
+    state_file = tmp_path / "update_state.json"
+
+    with patch.object(update_manager, "get_update_state_path", return_value=state_file):
+        # When file doesn't exist, read_update_state should return None
+        assert update_manager.read_update_state() is None
+
+        # Save state
+        update_manager.save_update_state(
+            "branch", "BRRRR_Experimental", "c0ffee12345", skip_until=999999.9
+        )
+
+        # Verify it exists and matches
+        assert state_file.exists()
+        state = update_manager.read_update_state()
+        assert state is not None
+        assert state["source_type"] == "branch"
+        assert state["source_name"] == "BRRRR_Experimental"
+        assert state["commit_sha"] == "c0ffee12345"
+        assert state["skip_until"] == 999999.9
+
+        # Test set_update_skip_until
+        update_manager.set_update_skip_until(888888.8)
+        state = update_manager.read_update_state()
+        assert state["skip_until"] == 888888.8
+
+
+@patch("Ankimon.pyobj.update_manager._api_get")
+def test_fetch_branch_sha(mock_api_get):
+    """Test fetching branch commit SHA from GitHub API."""
+    mock_api_get.return_value = {
+        "name": "BRRRR_Experimental",
+        "commit": {"sha": "a1b2c3d4e5f6"},
+    }
+    sha = update_manager.fetch_branch_sha("BRRRR_Experimental")
+    assert sha == "a1b2c3d4e5f6"
+    mock_api_get.assert_called_with("branches/BRRRR_Experimental")
+
+
+@patch("Ankimon.pyobj.update_manager._api_get")
+def test_fetch_commit_date(mock_api_get):
+    """Test fetching commit date from GitHub API."""
+    mock_api_get.return_value = {
+        "sha": "a1b2c3d4e5f6",
+        "commit": {"committer": {"date": "2026-05-24T12:00:00Z"}},
+    }
+    date = update_manager.fetch_commit_date("a1b2c3d4e5f6")
+    assert date == "2026-05-24T12:00:00Z"
+    mock_api_get.assert_called_with("commits/a1b2c3d4e5f6")
+
+    # Test invalid SHA
+    assert update_manager.fetch_commit_date("") is None
+    assert update_manager.fetch_commit_date("not-a-sha") is None
+
+
+@patch("Ankimon.changelog.QueryOp")
+@patch("Ankimon.pyobj.update_manager.read_update_state")
+def test_check_branch_update_no_state(mock_read_state, mock_query_op):
+    """Test check_branch_update does nothing if no update state exists."""
+    mock_read_state.return_value = None
+    changelog.check_branch_update(True, True)
+    mock_query_op.assert_not_called()
+
+
+@patch("Ankimon.changelog.QueryOp")
+@patch("Ankimon.pyobj.update_manager.read_update_state")
+def test_check_branch_update_not_experimental_branch(mock_read_state, mock_query_op):
+    """Test check_branch_update does nothing if not on BRRRR_Experimental."""
+    mock_read_state.return_value = {
+        "source_type": "branch",
+        "source_name": "main",
+        "commit_sha": "abc1234",
+    }
+    changelog.check_branch_update(True, True)
+    mock_query_op.assert_not_called()
+
+
+@patch("Ankimon.changelog.QueryOp")
+@patch("Ankimon.pyobj.update_manager.read_update_state")
+def test_check_branch_update_on_experimental_branch(mock_read_state, mock_query_op):
+    """Test check_branch_update starts QueryOp if on BRRRR_Experimental."""
+    mock_read_state.return_value = {
+        "source_type": "branch",
+        "source_name": "BRRRR_Experimental",
+        "commit_sha": "abc1234",
+    }
+    changelog.check_branch_update(True, True)
+    mock_query_op.assert_called_once()
+
+
+@patch("Ankimon.pyobj.update_manager._api_get")
+def test_fetch_branch_commits_compare(mock_api_get):
+    """Test fetching branch commits using the compare API."""
+    mock_api_get.return_value = {
+        "commits": [
+            {
+                "sha": "abcdef123456",
+                "commit": {"message": "First commit message\nSome detail"},
+            },
+            {
+                "sha": "789012345678",
+                "commit": {"message": "Second commit message"},
+            },
+        ]
+    }
+    commits = update_manager.fetch_branch_commits("BRRRR_Experimental", "abc1234")
+    assert len(commits) == 2
+    # Commits are in reversed order (newest first)
+    assert commits[0]["sha"] == "7890123"
+    assert commits[0]["message"] == "Second commit message"
+    assert commits[1]["sha"] == "abcdef1"
+    assert commits[1]["message"] == "First commit message"
+    mock_api_get.assert_called_with("compare/abc1234...BRRRR_Experimental")
+
+
+@patch("Ankimon.pyobj.update_manager._api_get")
+def test_fetch_branch_commits_fallback(mock_api_get):
+    """Test fetching branch commits using the fallback commits list API."""
+    mock_api_get.return_value = [
+        {
+            "sha": "111111122222",
+            "commit": {"message": "Fallback commit message 1"},
+        },
+        {
+            "sha": "333333344444",
+            "commit": {"message": "Fallback commit message 2\nWith some details"},
+        },
+    ]
+    # No local_sha passed, should fallback to commits endpoint
+    commits = update_manager.fetch_branch_commits("BRRRR_Experimental")
+    assert len(commits) == 2
+    assert commits[0]["sha"] == "1111111"
+    assert commits[0]["message"] == "Fallback commit message 1"
+    assert commits[1]["sha"] == "3333333"
+    assert commits[1]["message"] == "Fallback commit message 2"
+    mock_api_get.assert_called_with("commits?sha=BRRRR_Experimental&per_page=5")
+
+
+@patch("Ankimon.changelog.QueryOp")
+@patch("Ankimon.pyobj.update_manager.read_update_state")
+@patch("Ankimon.pyobj.update_manager.fetch_branch_sha")
+@patch("Ankimon.pyobj.update_manager.fetch_branch_commits")
+def test_check_branch_update_bg_op(
+    mock_fetch_commits, mock_fetch_sha, mock_read_state, mock_query_op
+):
+    """Test that the background operation in check_branch_update fetches SHA and commits."""
+    mock_read_state.return_value = {
+        "source_type": "branch",
+        "source_name": "BRRRR_Experimental",
+        "commit_sha": "local_sha_123",
+    }
+    mock_fetch_sha.return_value = "remote_sha_456"
+    mock_fetch_commits.return_value = [{"sha": "7890123", "message": "Commit message"}]
+
+    changelog.check_branch_update(True, True)
+
+    # Get the background operation function passed to QueryOp
+    mock_query_op.assert_called_once()
+    kwargs = mock_query_op.call_args[1]
+    bg_func = kwargs.get("op") or mock_query_op.call_args[0][1]
+
+    # Run the background function
+    res_sha, res_commits = bg_func(None)
+
+    assert res_sha == "remote_sha_456"
+    assert res_commits == [{"sha": "7890123", "message": "Commit message"}]
+    mock_fetch_sha.assert_called_once_with("BRRRR_Experimental")
+    mock_fetch_commits.assert_called_once_with("BRRRR_Experimental", "local_sha_123")
+
+
+@patch("Ankimon.changelog.QueryOp")
+@patch("Ankimon.pyobj.update_manager.read_update_state")
+def test_check_branch_update_skipped(mock_read_state, mock_query_op):
+    """Test check_branch_update does nothing if skip_until is in the future."""
+    mock_read_state.return_value = {
+        "source_type": "branch",
+        "source_name": "BRRRR_Experimental",
+        "commit_sha": "abc1234",
+        "skip_until": time.time() + 3600,  # 1 hour in the future
+    }
+    changelog.check_branch_update(True, True)
+    mock_query_op.assert_not_called()
+
+
+@patch("Ankimon.changelog.check_branch_update")
+def test_schedule_branch_update_check_uses_profile_open_hook(mock_check):
+    """The boot wiring registers on gui_hooks.profile_did_open and only polls
+    when a connection was available at boot (main re-fit of exp's
+    profile-open call site)."""
+    registered = []
+    with patch.object(
+        changelog.gui_hooks.profile_did_open, "append", side_effect=registered.append
+    ):
+        changelog.schedule_branch_update_check(True, True)
+    assert len(registered) == 1
+
+    # Hook fires after the profile opens -> the poll runs.
+    registered[0]()
+    mock_check.assert_called_once_with(True, True)
+
+    # Offline boot: the hook is registered but never polls.
+    mock_check.reset_mock()
+    registered.clear()
+    with patch.object(
+        changelog.gui_hooks.profile_did_open, "append", side_effect=registered.append
+    ):
+        changelog.schedule_branch_update_check(False, True)
+    registered[0]()
+    mock_check.assert_not_called()


### PR DESCRIPTION
## What

Ports **F26 — Branch self-updater (in-app BRRRR_Experimental updater)** from `origin/BRRRR_Experimental` (@ b04e4bec) onto the integration tip (fd9010f4).

- **`pyobj/update_manager.py`** — install-source tracking (`update_state.json` in `user_files/`: `get_update_state_path` / `save_update_state` / `set_update_skip_until` / `read_update_state`), GitHub branch helpers (`fetch_branch_sha`, `fetch_commit_date`, `fetch_branch_commits` — compare API with last-5-commits fallback), `apply_update(zip_path, source_type, source_name, commit_sha, status_cb)` recording the source on success and skipping locked-but-present files on `PermissionError`, `_should_preserve` additions.
- **`pyobj/update_dialog.py`** — the 3-tab dialog: new **BRRRR_Experimental Branch** tab (installed commit/date, last-update-installed, remote status, recent-commit feed, 1-week snooze), header shows recorded install source (falls back to `IS_EXPERIMENTAL_BUILD`), Developer tab gains a `Latest BRRRR_Experimental Branch` source + lazy dev-data loading, all install paths pass source tracking; new `BranchUpdatePromptDialog` / `BranchUpdateProgressDialog` / `show_branch_update_prompt`. Night-mode styling kept for all new widgets.
- **`changelog.py`** — `check_branch_update(online_connectivity, ssh)`: polls only when `update_state.json` records a BRRRR_Experimental branch install, honors the `skip_until` snooze, compares local vs remote SHA in a `QueryOp` and opens the update prompt with the pending commit feed.
- **`tests/test_branch_updates.py`** — 17 tests: ported parity tests (11) incl. a new test for the profile-open scheduling re-fit, plus 6 post-review hardening regressions (see below).

## Re-fit to seam (exp→main mapping)

| exp | main |
|---|---|
| `from .singletons import logger` in `check_branch_update` | `services.logger` via a None-guarded `_log_info` helper (registry seam, silent headless) |
| boot call site in `profile_hooks._on_profile_did_open` connectivity callback | `changelog.schedule_branch_update_check(...)` registers on `gui_hooks.profile_did_open` (events/hooks seam); wired from `__init__.py` next to the existing changelog check — **no bare module-level mw side effect** |
| `QueryOp(parent=mw)`, `mw.taskman.run_on_main`, dialog `parent or mw` | kept — genuine Anki APIs per the seam dictionary (§2.1) |
| module-scope `import markdown` + Qt window imports in `changelog.py` | lazy-imported inside the using functions → `changelog` imports Qt-free/markdown-free in Tier-1 |

`IS_EXPERIMENTAL_BUILD` (the row's declared dependency) already exists in base `resources.py:115` — no addition needed.

## Parity notes (incl. post-snapshot exp hunks captured)

- Exp tip commit `a6204235` (post-snapshot, NR-15 ledger) independently re-implemented main's git-clone ff-only safety, PR-install warning and pre-v2.0 hiding: verified those exp hunks are **byte-identical backports of main's implementation**, so one coherent implementation (main's) ships; exp's UX additions on top (source tracking, BRRRR tab, prompt dialogs) all ported from `988d71dc` + `a6204235`.
- `tests/test_update_manager.py` (net-new at exp tip, NR-15 uncovered item folded into this row): **byte-identical to the copy already on base** — triaged as superseded no-op, untouched, closing that NR-15 item.
- Exp's dialog was verified (reverse diff) to be a strict superset of base's — no base-only hunk dropped. Independent verification at port time: the ported `update_dialog.py` was byte-identical to ruff-formatted exp, and `update_manager.py` differed from ruff-formatted exp only in comments (main's Holy Ground / git-clone guard comments kept) and `Optional[str]` annotations. Since commit `19ca587c` both files (plus `changelog.py`) additionally diverge from exp by the review-driven hardening guards below — a deliberate, documented delta.
- Intentional micro-delta: the poll gates on boot-time connectivity (same source as base's existing changelog gate); exp re-checked connectivity per profile open inside `profile_hooks` — F20 can restore that when it ports `profile_hooks.py`.

## GUARDS-TO-REAPPLY confirmation

- `is_git_clone` / `_git_repo_root` / `git_pull_ff_only` — **intact, unchanged**; `apply_update` still refuses on clones.
- `MIN_UPDATER_VERSION (2,0)` filtering via `_parse_version` / `_is_supported_version` — **intact, unchanged**.
- `_should_preserve` 'Holy Ground' unconditional `user_files/` rule — **kept verbatim**, plus exp's `always_preserve` additions (`ankimonDEV.db`, `update_state.json`) and always-preserved roots (`HelpInfos.html`, `updateinfos.md`, `meta.json`).
- Developer-tab git-clone warning + PR-install unreviewed-code warning — **kept**.

## Post-review hardening (commit 19ca587c)

All six Gemini review comments addressed: null/empty `commit_sha` display fallback (`or "unknown"`), symmetric `isinstance((int, float))` `skip_until` guards in both the dialog and the changelog poll, `read_update_state` now rejects valid-but-non-object JSON (list/string/number/null → `None`), and dict/list shape guards in `fetch_branch_sha` / `fetch_commit_date` / `fetch_branch_commits` — a non-string `local_sha` now degrades to the fallback commits endpoint and an empty commit message no longer drops the whole feed. (`_api_get` already returns `None` on network errors/non-200, so only the genuinely reachable checks were added, in the file's existing idiom.)

Polish in the same commit: dead `old_mocked` condition removed (subsumed by the hex check), non-numeric `installed_at` treated as absent (mtime fallback preserved), unused module-level `fetch_commit_date` import and unused `muted` local removed. Git-clone guards and `MIN_UPDATER_VERSION` filtering remain intact and unchanged.

## Deferred

- **F20** (`profile_hooks.py`): must not double-wire the poll when porting exp's profile hooks; may relocate the F26 wiring into its connectivity callback.
- **F32** (`__init__.py`): carries a minimal additive F26 wiring hunk (flagged out-of-manifest edit) — the async-boot rewrite must preserve the `schedule_branch_update_check` call.
- **NR-15**: `tests/test_update_manager.py` triage closed as no-op (byte-identical on base).

## Gates (independently re-run by verifier at 19ca587c)

- `compileall src/Ankimon`: OK
- `ruff check` (ci_ruff_check.toml): 10 errors — all baseline (`AnkimonWindow copy.py`), **0 new**
- `ruff format --check`: all touched files clean
- pytest Tier-1: **281 passed / 15 skipped / 0 failed** (baseline 264/15/0; +11 parity tests, +6 hardening regressions)
- `harness/check.py`: **9/9 PASS**
- Qt tier: scaffolding smoke **4 passed**, `test_addon_integrity` **1 passed**, `probe_real_boot` **OK**, `probe_real_play` **OK**

## Attribution

Originally implemented by @hakimh2 (commits `988d71dc`, `a6204235`) on BRRRR_Experimental; credited via `Co-authored-by: Hakimh2 <74561421+hakimh2@users.noreply.github.com>` trailers on every commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

