### PR TITLE
feat: reload-safe singletons + lazy window construction (F31)

### DIFF
--- a/src/Ankimon/card_hooks.py
+++ b/src/Ankimon/card_hooks.py
@@ -1,7 +1,7 @@
-import aqt
 from aqt import gui_hooks, mw, utils
 from aqt.utils import tooltip
 
+from .services import services
 from .singletons import ankimon_tracker_obj, reviewer_obj
 
 
@@ -37,19 +37,31 @@ def answerCard_after(rev, card, ease):
     ankimon_tracker_obj.reset_card_timer()
 
 
-# Reload safety (F31): a second boot in the same session must not register the
-# reviewer hooks twice, or every review would be double-counted.
-_hooks_registered = False
+# Reload safety (F31): a second boot in the same session must not leave the
+# reviewer hooks registered twice, or every review would be double-counted.
+# The registration record lives on the services registry — which, unlike a
+# module-level flag, survives a re-execution of this module — and it stores
+# the exact handler objects that were appended: after a re-exec the functions
+# above are NEW objects, so only the stored originals can still be found and
+# removed from gui_hooks. Re-registering therefore swaps the handlers for the
+# current module's instead of stacking a second set.
+_HANDLER_RECORD = "_card_hook_handlers"
 
 
 def register_card_hooks():
-    global _hooks_registered
-    if _hooks_registered:
-        return
-    _hooks_registered = True
+    # Drop the previous registration first. No-op on a first boot (no record);
+    # on a re-boot the stored pairs are removed so the appends below cannot
+    # double-register. gui_hooks' remove() tolerates already-absent callbacks.
+    for hook, handler in getattr(services, _HANDLER_RECORD, ()):
+        hook.remove(handler)
 
-    gui_hooks.reviewer_did_show_question.append(on_show_question)
-    gui_hooks.reviewer_did_show_answer.append(on_show_answer)
-    gui_hooks.reviewer_did_show_question.append(on_reviewer_did_show_question)
-    aqt.gui_hooks.reviewer_will_answer_card.append(answerCard_before)
-    aqt.gui_hooks.reviewer_did_answer_card.append(answerCard_after)
+    handlers = (
+        (gui_hooks.reviewer_did_show_question, on_show_question),
+        (gui_hooks.reviewer_did_show_answer, on_show_answer),
+        (gui_hooks.reviewer_did_show_question, on_reviewer_did_show_question),
+        (gui_hooks.reviewer_will_answer_card, answerCard_before),
+        (gui_hooks.reviewer_did_answer_card, answerCard_after),
+    )
+    for hook, handler in handlers:
+        hook.append(handler)
+    setattr(services, _HANDLER_RECORD, handlers)

--- a/src/Ankimon/card_hooks.py
+++ b/src/Ankimon/card_hooks.py
@@ -37,7 +37,17 @@ def answerCard_after(rev, card, ease):
     ankimon_tracker_obj.reset_card_timer()
 
 
+# Reload safety (F31): a second boot in the same session must not register the
+# reviewer hooks twice, or every review would be double-counted.
+_hooks_registered = False
+
+
 def register_card_hooks():
+    global _hooks_registered
+    if _hooks_registered:
+        return
+    _hooks_registered = True
+
     gui_hooks.reviewer_did_show_question.append(on_show_question)
     gui_hooks.reviewer_did_show_answer.append(on_show_answer)
     gui_hooks.reviewer_did_show_question.append(on_reviewer_did_show_question)

--- a/src/Ankimon/functions/rate_addon_functions.py
+++ b/src/Ankimon/functions/rate_addon_functions.py
@@ -5,18 +5,23 @@ from PyQt6.QtWidgets import (
     QLabel,
     QPushButton,
     QVBoxLayout,
-    )
-    
-from ..texts import rate_addon_text_label, thankyou_message_text, dont_show_this_button_text
+)
+
+from ..texts import (
+    rate_addon_text_label,
+    thankyou_message_text,
+    dont_show_this_button_text,
+)
 from ..utils import give_item
-from ..singletons import logger, test_window
+from ..singletons import logger
 
 from aqt import mw
+
 
 def rate_this_addon():
     # Only check database
     db_rate_this = mw.ankimon_db.get_user_data("rate_this")
-    
+
     if db_rate_this is True:
         return
 
@@ -54,21 +59,23 @@ def rate_this_addon():
         rate_window.close()
         # Save to DB
         mw.ankimon_db.set_user_data("rate_this", True)
-        logger.log_and_showinfo("info",dont_show_this_button_text)
+        logger.log_and_showinfo("info", dont_show_this_button_text)
 
     def rate_this_button():
         rate_window.close()
         rate_url = "https://ankiweb.net/shared/review/1908235722"
         QDesktopServices.openUrl(QUrl(rate_url))
         thankyou_message()
-        
+
         # Save to DB
         mw.ankimon_db.set_user_data("rate_this", True)
-        
-        test_window.rate_display_item("potion")
+
+        from ..singletons import get_test_window
+
+        get_test_window().rate_display_item("potion")
         # add item to item list
         give_item("potion")
-            
+
     rate_button.clicked.connect(rate_this_button)
     layout.addWidget(rate_button)
 

--- a/src/Ankimon/singletons.py
+++ b/src/Ankimon/singletons.py
@@ -1,5 +1,5 @@
 """
-singletons.py — the production composition root (Anki / Qt).
+singletons.py — the production composition root (Anki / Qt), reload-safe.
 
 Originally this module both *built* every Ankimon object and *held* it as a
 module global. It has since been split:
@@ -10,46 +10,77 @@ module global. It has since been split:
   everything — core objects, GUI windows, and the Qt UI presenter — in the
   service registry (:mod:`Ankimon.services`).
 
-It also keeps the historical module-level names (``settings_obj``, ``logger``,
-``test_window``, …) and the ``mw.<service>`` shims so the not-yet-migrated
-importers and ``__init__.py`` keep working unchanged.
+Reload safety (F31): construction is idempotent and lazy.
+
+* The **core** is get-or-create through the services registry: when a previous
+  composition root already populated ``services`` (an add-on reload, a double
+  boot, or the harness), the live registry objects are reused instead of being
+  rebuilt — so a second boot cannot duplicate the DB connection, the tracker,
+  or the ``Reviewer_Manager`` (whose constructor registers ``gui_hooks``).
+* The **windows** are no longer constructed at import time. Each window is
+  built on first access — via its ``get_*_window()`` factory or via plain
+  ``from .singletons import <name>`` (which lands in the module-level
+  ``__getattr__`` below) — and cached, with :func:`Ankimon.utils.is_alive`
+  liveness checks so a window whose underlying C++ object was deleted is
+  transparently re-created instead of handed out dead.
+
+The historical module-level names (``settings_obj``, ``logger``,
+``test_window``, …) and the ``mw.<service>`` shims are kept, so the
+not-yet-migrated importers and ``__init__.py`` keep working unchanged: the
+window names now resolve through ``__getattr__`` to the same live instances.
 
 The agent harness is the *other* root: it calls the same ``build_core()`` but
 wires recording fakes + the headless presenter instead of the Qt windows below.
 
-Author: Axil (original); split into core/gui 2026-06.
+Author: Axil (original); split into core/gui 2026-06; reload-safe 2026-07.
 """
+
+from types import SimpleNamespace
 
 from aqt import mw
 
-# GUI window/widget classes (all import Qt).
-from .pyobj.settings_window import SettingsWindow
-from .pyobj.test_window import TestWindow
-from .pyobj.achievement_window import AchievementWindow
-from .pyobj.ankimon_tracker_window import AnkimonTrackerWindow
 from .pyobj.ankimon_shop import PokemonShopManager
-from .pokedex.pokedex_obj import Pokedex
 from .pyobj.reviewer_obj import Reviewer_Manager
-from .pyobj.evolution_window import EvoWindow
-from .pyobj.starter_window import StarterWindow
-from .pyobj.item_window import ItemWindow
-from .pyobj.pc_box import PokemonPC
-from .gui_entities import (
-    License,
-    Credits,
-    TableWidget,
-    IDTableWidget,
-    Pokedex_Widget,
-    Version_Dialog,
-)
 from .resources import addon_dir
 from .services import services
 from .core import build_core, bind_runtime_globals
 from .gui_presenter import QtPresenter
+from .utils import is_alive
 
-# --- Core (aqt-free) composition. Populates services.{db,logger,settings,
-#     translator,tracker,main_pokemon,enemy_pokemon,trainer_card,achievements}. ---
-_core = build_core()
+# --- Core (aqt-free) composition: get-or-create (reload-safe). ---------------
+# First boot: build_core() constructs everything and populates services.
+# Reload / double boot (the services module survived): reuse the live registry
+# objects instead of constructing duplicates.
+
+
+def _core_is_populated() -> bool:
+    """True when a previous composition root already built the core."""
+    return (
+        services.db is not None
+        and services.logger is not None
+        and services.settings is not None
+    )
+
+
+def _core_from_registry() -> SimpleNamespace:
+    """Mirror the live registry objects into the shape build_core() returns."""
+    return SimpleNamespace(
+        logger=services.logger,
+        ankimon_db=services.db,
+        settings_obj=services.settings,
+        translator=services.translator,
+        main_pokemon=services.main_pokemon,
+        # Only known at first construction (update_main_pokemon() reports it);
+        # nothing imports it, so a reused root does not recompute it.
+        mainpokemon_empty=None,
+        enemy_pokemon=services.enemy_pokemon,
+        trainer_card=services.trainer_card,
+        ankimon_tracker_obj=services.tracker,
+        achievements=services.achievements,
+    )
+
+
+_core = _core_from_registry() if _core_is_populated() else build_core()
 logger = _core.logger
 ankimon_db = _core.ankimon_db
 settings_obj = _core.settings_obj
@@ -71,29 +102,10 @@ mw.logger = logger
 mw.translator = translator
 mw.settings_obj = settings_obj
 
-# --- GUI windows (Qt), built on top of the core objects above. ---
-settings_window = SettingsWindow(
-    config=settings_obj.config,  # Use settings_obj.config instead of settings_obj.settings.config
-    set_config_callback=settings_obj.set,
-    save_config_callback=settings_obj.save_config,
-    load_config_callback=settings_obj.load_config,
-)
-mw.settings_ankimon = settings_window
+# --- Window-less managers (eager, get-or-create where the registry knows them). ---
 
-# Create an instance of the MainWindow
-test_window = TestWindow(
-    main_pokemon=main_pokemon,
-    enemy_pokemon=enemy_pokemon,
-    settings_obj=settings_obj,
-    ankimon_tracker_obj=ankimon_tracker_obj,
-    translator=translator,
-    parent=mw,
-    logger=logger,
-)
-
-achievement_bag = AchievementWindow()
-
-# Initialize the Pokémon Shop Manager
+# The Pokémon Shop Manager. Not registry-backed (yet): cheap, side-effect-free
+# construction, so rebuilding it on a reload is harmless.
 shop_manager = PokemonShopManager(
     logger=logger,
     settings_obj=settings_obj,
@@ -101,62 +113,272 @@ shop_manager = PokemonShopManager(
     get_callback=settings_obj.get,
 )
 
-ankimon_tracker_window = AnkimonTrackerWindow(tracker=ankimon_tracker_obj)
-pokedex_window = Pokedex(addon_dir, ankimon_tracker=ankimon_tracker_obj)
-reviewer_obj = Reviewer_Manager(
-    settings_obj=settings_obj,
-    main_pokemon=main_pokemon,
-    enemy_pokemon=enemy_pokemon,
-    ankimon_tracker=ankimon_tracker_obj,
-)
+# Reviewer manager. Get-or-create: its constructor appends to gui_hooks, so a
+# reload that re-ran it unconditionally would double-register those hooks.
+reviewer_obj = services.reviewer
+if reviewer_obj is None:
+    reviewer_obj = Reviewer_Manager(
+        settings_obj=settings_obj,
+        main_pokemon=main_pokemon,
+        enemy_pokemon=enemy_pokemon,
+        ankimon_tracker=ankimon_tracker_obj,
+    )
+    services.populate(reviewer=reviewer_obj)
 
-eff_chart = TableWidget()
-pokedex = Pokedex_Widget()
-gen_id_chart = IDTableWidget()
-license = License()
-credits = Credits()
-version_dialog = Version_Dialog()
+# --- GUI windows: lazy, idempotent factories (F31). ---------------------------
+#
+# No window is constructed at import time. The seam-registered windows
+# (test_window / evo_window / pokemon_pc) are cached in the services registry
+# itself; every other window lives in _WINDOW_CACHE. After registering a seam
+# window its factory re-runs core.bind_runtime_globals() so the core logic
+# modules' bare globals (battle_loop.test_window, …) pick up the live instance.
 
-evo_window = EvoWindow(
-    logger,
-    settings_obj,
-    main_pokemon,
-    translator,
-    reviewer_obj,
-    test_window,
-    achievements,
-)
-starter_window = StarterWindow(logger, settings_obj)
-item_window = ItemWindow(  # Create an instance of the MainWindow
-    logger=logger,
-    settings_obj=settings_obj,
-    main_pokemon=main_pokemon,
-    enemy_pokemon=enemy_pokemon,
-    achievements=achievements,
-    starter_window=starter_window,
-    evo_window=evo_window,
-)
+_WINDOW_CACHE = {}
 
-pokemon_pc = PokemonPC(
-    logger=logger,
-    translator=translator,
-    reviewer_obj=reviewer_obj,
-    test_window=test_window,
-    settings=settings_obj,
-    main_pokemon=main_pokemon,
-)
 
-# --- Register the GUI windows + the Qt UI presenter in the registry, so the
-#     core logic (battle_loop / encounter_functions) reaches them via services. ---
-services.populate(
-    ui=QtPresenter(),
-    test_window=test_window,
-    evo_window=evo_window,
-    pokemon_pc=pokemon_pc,
-    reviewer=reviewer_obj,
-)
+def _cached(name, factory):
+    """Get-or-create a non-registry window: reuse while alive, else rebuild."""
+    win = _WINDOW_CACHE.get(name)
+    if is_alive(win):
+        return win
+    win = factory()
+    _WINDOW_CACHE[name] = win
+    return win
+
+
+def get_settings_window():
+    def _build():
+        from .pyobj.settings_window import SettingsWindow
+
+        win = SettingsWindow(
+            config=settings_obj.config,  # Use settings_obj.config instead of settings_obj.settings.config
+            set_config_callback=settings_obj.set,
+            save_config_callback=settings_obj.save_config,
+            load_config_callback=settings_obj.load_config,
+        )
+        # Back-compat shim (pre-F31 this was written at import time).
+        mw.settings_ankimon = win
+        return win
+
+    return _cached("settings_window", _build)
+
+
+def get_test_window():
+    win = services.test_window
+    if is_alive(win):
+        return win
+    from .pyobj.test_window import TestWindow
+
+    win = TestWindow(
+        main_pokemon=main_pokemon,
+        enemy_pokemon=enemy_pokemon,
+        settings_obj=settings_obj,
+        ankimon_tracker_obj=ankimon_tracker_obj,
+        translator=translator,
+        parent=mw,
+        logger=logger,
+    )
+    services.populate(test_window=win)
+    bind_runtime_globals()
+    return win
+
+
+def get_achievement_bag():
+    def _build():
+        from .pyobj.achievement_window import AchievementWindow
+
+        return AchievementWindow()
+
+    return _cached("achievement_bag", _build)
+
+
+def get_ankimon_tracker_window():
+    def _build():
+        from .pyobj.ankimon_tracker_window import AnkimonTrackerWindow
+
+        return AnkimonTrackerWindow(tracker=ankimon_tracker_obj)
+
+    return _cached("ankimon_tracker_window", _build)
+
+
+def get_pokedex_window():
+    def _build():
+        from .pokedex.pokedex_obj import Pokedex
+
+        return Pokedex(addon_dir, ankimon_tracker=ankimon_tracker_obj)
+
+    return _cached("pokedex_window", _build)
+
+
+def get_eff_chart():
+    def _build():
+        from .gui_entities import TableWidget
+
+        return TableWidget()
+
+    return _cached("eff_chart", _build)
+
+
+def get_pokedex_widget():
+    def _build():
+        from .gui_entities import Pokedex_Widget
+
+        return Pokedex_Widget()
+
+    return _cached("pokedex", _build)
+
+
+def get_gen_id_chart():
+    def _build():
+        from .gui_entities import IDTableWidget
+
+        return IDTableWidget()
+
+    return _cached("gen_id_chart", _build)
+
+
+def get_license():
+    def _build():
+        from .gui_entities import License
+
+        return License()
+
+    return _cached("license", _build)
+
+
+def get_credits():
+    def _build():
+        from .gui_entities import Credits
+
+        return Credits()
+
+    return _cached("credits", _build)
+
+
+def get_version_dialog():
+    def _build():
+        from .gui_entities import Version_Dialog
+
+        return Version_Dialog()
+
+    return _cached("version_dialog", _build)
+
+
+def get_evo_window():
+    win = services.evo_window
+    if is_alive(win):
+        return win
+    from .pyobj.evolution_window import EvoWindow
+
+    win = EvoWindow(
+        logger,
+        settings_obj,
+        main_pokemon,
+        translator,
+        reviewer_obj,
+        get_test_window(),
+        achievements,
+    )
+    services.populate(evo_window=win)
+    bind_runtime_globals()
+    return win
+
+
+def get_starter_window():
+    def _build():
+        from .pyobj.starter_window import StarterWindow
+
+        return StarterWindow(logger, settings_obj)
+
+    return _cached("starter_window", _build)
+
+
+def get_item_window():
+    def _build():
+        from .pyobj.item_window import ItemWindow
+
+        return ItemWindow(  # Create an instance of the MainWindow
+            logger=logger,
+            settings_obj=settings_obj,
+            main_pokemon=main_pokemon,
+            enemy_pokemon=enemy_pokemon,
+            achievements=achievements,
+            starter_window=get_starter_window(),
+            evo_window=get_evo_window(),
+        )
+
+    return _cached("item_window", _build)
+
+
+def get_pokemon_pc():
+    win = services.pokemon_pc
+    if is_alive(win):
+        return win
+    from .pyobj.pc_box import PokemonPC
+
+    win = PokemonPC(
+        logger=logger,
+        translator=translator,
+        reviewer_obj=reviewer_obj,
+        test_window=get_test_window(),
+        settings=settings_obj,
+        main_pokemon=main_pokemon,
+    )
+    services.populate(pokemon_pc=win)
+    bind_runtime_globals()
+    return win
+
+
+# DEFERRED seam points (do NOT add here in F31):
+# * get_items_window() -> ankimon_items_web / web-shell Items screen and
+#   get_ankidex_window() -> ankidex/ SPA land with F36 (their modules do not
+#   exist on this base yet); mount via webshell host per MERGE_ARCH_MAP §4.
+# * get_nature_chart() -> gui_entities.NatureTableWidget lands with F36 (the
+#   widget does not exist on this base yet).
+# * notify_stats_changed() (QWebChannel live-update push) belongs to the
+#   webshell host / F10+F49, not to this module (NR-04).
+# * swap_ankimon_account() (dev DB switch) belongs to F36/F27 wiring and must
+#   call services.db.switch_database when it lands.
+
+# Per-name lazy proxies: `from .singletons import test_window` (and plain
+# module attribute access) constructs ONLY the requested window, on first
+# access. None of these names is a real module global, so this __getattr__ is
+# their only resolution path.
+_LAZY_WINDOWS = {
+    "settings_window": get_settings_window,
+    "test_window": get_test_window,
+    "achievement_bag": get_achievement_bag,
+    "ankimon_tracker_window": get_ankimon_tracker_window,
+    "pokedex_window": get_pokedex_window,
+    "eff_chart": get_eff_chart,
+    "pokedex": get_pokedex_widget,
+    "gen_id_chart": get_gen_id_chart,
+    "license": get_license,
+    "credits": get_credits,
+    "version_dialog": get_version_dialog,
+    "evo_window": get_evo_window,
+    "starter_window": get_starter_window,
+    "item_window": get_item_window,
+    "pokemon_pc": get_pokemon_pc,
+}
+
+
+def __getattr__(name):
+    factory = _LAZY_WINDOWS.get(name)
+    if factory is not None:
+        return factory()
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+# --- Qt UI presenter + runtime-global binding. --------------------------------
+# Idempotent: only swap in a QtPresenter when the registry does not already
+# hold one, so a reload keeps the existing presenter instance.
+if not isinstance(services.ui, QtPresenter):
+    services.populate(ui=QtPresenter())
 
 # Bind the core logic modules' bare globals (main_pokemon, settings_obj,
-# test_window, …) to the now-fully-populated registry. Must run after the
-# services.populate above so the GUI window bindings are non-None.
+# test_window, …) to the now-populated registry. The window bindings
+# (test_window / evo_window / pokemon_pc) may still be None here — each lazy
+# factory re-runs bind_runtime_globals() after registering its window, so the
+# bindings are live before any gameplay code can run.
 bind_runtime_globals()

--- a/tests/test_reload_safe_singletons.py
+++ b/tests/test_reload_safe_singletons.py
@@ -13,8 +13,10 @@ without Qt:
   returns the same instance, and a window whose underlying C++ object died
   (``is_alive`` False) is transparently re-created.
 * Every name the base consumers import from ``singletons`` still resolves.
-* ``register_card_hooks()`` is idempotent: a second call must not append the
-  reviewer hooks again.
+* ``register_card_hooks()`` is idempotent: its registration record lives on
+  the services registry, so neither a second call nor a re-execution of the
+  module (an add-on reload: new function objects, surviving registry) can
+  stack a second set of reviewer hooks.
 
 House pattern: mock aqt + the window-class modules in ``sys.modules``, then
 exec the real module file under its dotted name (tests/conftest.py provides the
@@ -116,6 +118,17 @@ def _stub_module(name, **attrs):
     return mod
 
 
+def _fresh_services(monkeypatch):
+    """Exec a fresh, REAL services registry (isolated from other tests)."""
+    services_spec = importlib.util.spec_from_file_location(
+        "Ankimon.services", _src / "Ankimon" / "services.py"
+    )
+    services_mod = importlib.util.module_from_spec(services_spec)
+    monkeypatch.setitem(sys.modules, "Ankimon.services", services_mod)
+    services_spec.loader.exec_module(services_mod)
+    return services_mod.services
+
+
 @pytest.fixture
 def env(monkeypatch):
     """Fresh aqt stub + fresh services registry + stubbed window modules."""
@@ -148,13 +161,7 @@ def env(monkeypatch):
     )
 
     # Fresh, REAL services registry per test (isolated from other tests).
-    services_spec = importlib.util.spec_from_file_location(
-        "Ankimon.services", _src / "Ankimon" / "services.py"
-    )
-    services_mod = importlib.util.module_from_spec(services_spec)
-    monkeypatch.setitem(sys.modules, "Ankimon.services", services_mod)
-    services_spec.loader.exec_module(services_mod)
-    services = services_mod.services
+    services = _fresh_services(monkeypatch)
 
     # core stub: mimics the real build_core (populates services, returns the
     # namespace) and records every call so the tests can count boots/binds.
@@ -350,13 +357,29 @@ def test_unknown_attribute_raises(env):
         mod.definitely_not_a_window
 
 
-def test_register_card_hooks_is_idempotent(monkeypatch):
-    hooks = SimpleNamespace(
+def _fresh_hooks():
+    """gui_hooks stub: plain lists, so an unmatched remove() would fail loudly."""
+    return SimpleNamespace(
         reviewer_did_show_question=[],
         reviewer_did_show_answer=[],
         reviewer_will_answer_card=[],
         reviewer_did_answer_card=[],
     )
+
+
+def _hook_counts(hooks):
+    return (
+        len(hooks.reviewer_did_show_question),
+        len(hooks.reviewer_did_show_answer),
+        len(hooks.reviewer_will_answer_card),
+        len(hooks.reviewer_did_answer_card),
+    )
+
+
+def _exec_card_hooks(monkeypatch, hooks):
+    """Exec the real card_hooks.py against a gui_hooks stub. Each call returns
+    a FRESH module object (fresh handler functions) — exactly what an add-on
+    reload produces — while ``Ankimon.services`` is left to the caller."""
     aqt_stub = _stub_module(
         "aqt", gui_hooks=hooks, mw=SimpleNamespace(), utils=SimpleNamespace()
     )
@@ -374,21 +397,47 @@ def test_register_card_hooks_is_idempotent(monkeypatch):
     card_hooks = importlib.util.module_from_spec(spec)
     monkeypatch.setitem(sys.modules, "Ankimon.card_hooks", card_hooks)
     spec.loader.exec_module(card_hooks)
+    return card_hooks
+
+
+def test_register_card_hooks_is_idempotent(monkeypatch):
+    # Fresh registry = fresh registration record (order-independent tests).
+    _fresh_services(monkeypatch)
+    hooks = _fresh_hooks()
+    card_hooks = _exec_card_hooks(monkeypatch, hooks)
 
     card_hooks.register_card_hooks()
-    counts_after_first = (
-        len(hooks.reviewer_did_show_question),
-        len(hooks.reviewer_did_show_answer),
-        len(hooks.reviewer_will_answer_card),
-        len(hooks.reviewer_did_answer_card),
-    )
+    counts_after_first = _hook_counts(hooks)
     # on_show_question + on_reviewer_did_show_question share the question hook.
     assert counts_after_first == (2, 1, 1, 1)
 
     card_hooks.register_card_hooks()
-    assert (
-        len(hooks.reviewer_did_show_question),
-        len(hooks.reviewer_did_show_answer),
-        len(hooks.reviewer_will_answer_card),
-        len(hooks.reviewer_did_answer_card),
-    ) == counts_after_first, "second registration must be a no-op"
+    assert _hook_counts(hooks) == counts_after_first, (
+        "second registration must not stack handlers"
+    )
+
+
+def test_register_card_hooks_survives_module_reexec(monkeypatch):
+    """The F31 failure this guards: re-executing card_hooks (an add-on reload)
+    creates NEW handler function objects, so a module-level flag would reset
+    and remove()-by-identity would miss the old handlers. The registry-stored
+    record must swap the handlers instead of stacking a second set."""
+    _fresh_services(monkeypatch)
+    hooks = _fresh_hooks()
+
+    mod1 = _exec_card_hooks(monkeypatch, hooks)
+    mod1.register_card_hooks()
+    assert _hook_counts(hooks) == (2, 1, 1, 1)
+
+    # Reload: fresh module + functions, same gui_hooks, surviving registry.
+    mod2 = _exec_card_hooks(monkeypatch, hooks)
+    assert mod2.answerCard_after is not mod1.answerCard_after
+    mod2.register_card_hooks()
+
+    assert _hook_counts(hooks) == (2, 1, 1, 1), "reload must not stack handlers"
+    # The live handlers are the reloaded module's, not the stale first set.
+    assert hooks.reviewer_did_answer_card == [mod2.answerCard_after]
+    assert hooks.reviewer_did_show_question == [
+        mod2.on_show_question,
+        mod2.on_reviewer_did_show_question,
+    ]

--- a/tests/test_reload_safe_singletons.py
+++ b/tests/test_reload_safe_singletons.py
@@ -1,0 +1,394 @@
+"""Characterization tests for the reload-safe composition root (F31).
+
+Pins the reload-safety contract of ``singletons.py`` + ``card_hooks.py``
+without Qt:
+
+* Importing ``singletons`` builds the core exactly once; a second exec of the
+  module (an add-on reload / double boot with the services registry surviving)
+  REUSES the live registry objects instead of rebuilding them — in particular
+  ``Reviewer_Manager`` (whose constructor registers gui_hooks) is not
+  duplicated.
+* No window is constructed at import time. Window names resolve lazily through
+  the module-level ``__getattr__``: first access constructs, second access
+  returns the same instance, and a window whose underlying C++ object died
+  (``is_alive`` False) is transparently re-created.
+* Every name the base consumers import from ``singletons`` still resolves.
+* ``register_card_hooks()`` is idempotent: a second call must not append the
+  reviewer hooks again.
+
+House pattern: mock aqt + the window-class modules in ``sys.modules``, then
+exec the real module file under its dotted name (tests/conftest.py provides the
+``Ankimon`` package stubs and the real ``Ankimon.utils``/``Ankimon.resources``).
+"""
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+_src = Path(__file__).parent.parent / "src"
+
+# Every name the base consumers import from singletons (enumerated with
+# `git grep "from .singletons import\|from ..singletons import"`):
+# __init__.py, card_hooks.py, discord_integration.py, hook_registry.py,
+# profile_hooks.py, reviewer_ui.py, startup.py, functions/
+# pokemon_showdown_functions.py, functions/rate_addon_functions.py, and the
+# deferred pokemon_pc / evo_window imports in pyobj/ + gui_classes/.
+CONSUMED_NAMES = {
+    "settings_obj",
+    "settings_window",
+    "logger",
+    "translator",
+    "reviewer_obj",
+    "ankimon_tracker_obj",
+    "test_window",
+    "achievement_bag",
+    "shop_manager",
+    "ankimon_tracker_window",
+    "pokedex_window",
+    "eff_chart",
+    "gen_id_chart",
+    "license",
+    "credits",
+    "evo_window",
+    "starter_window",
+    "item_window",
+    "version_dialog",
+    "pokemon_pc",
+    "trainer_card",
+    "main_pokemon",
+    "enemy_pokemon",
+    "achievements",
+    "ankimon_db",
+    "get_test_window",
+}
+
+
+class FakeWindow:
+    """Stands in for any Qt window class: records constructions, is 'alive'."""
+
+    instances = []
+
+    def __init__(self, *args, **kwargs):
+        type(self).instances.append(self)
+        self._dead = False
+
+    def objectName(self):
+        if self._dead:
+            raise RuntimeError("wrapped C/C++ object has been deleted")
+        return ""
+
+    def kill(self):
+        """Simulate Qt deleting the underlying C++ object."""
+        self._dead = True
+
+
+class FakeTestWindow(FakeWindow):
+    instances = []
+
+
+class FakeStarterWindow(FakeWindow):
+    instances = []
+
+
+class FakeReviewerManager:
+    instances = []
+
+    def __init__(self, *args, **kwargs):
+        type(self).instances.append(self)
+
+
+class FakeShopManager:
+    instances = []
+
+    def __init__(self, *args, **kwargs):
+        type(self).instances.append(self)
+
+
+def _stub_module(name, **attrs):
+    mod = types.ModuleType(name)
+    for key, value in attrs.items():
+        setattr(mod, key, value)
+    return mod
+
+
+@pytest.fixture
+def env(monkeypatch):
+    """Fresh aqt stub + fresh services registry + stubbed window modules."""
+    FakeWindow.instances = []
+    FakeTestWindow.instances = []
+    FakeStarterWindow.instances = []
+    FakeReviewerManager.instances = []
+    FakeShopManager.instances = []
+
+    # aqt stub: mw is a plain attribute bag (singletons only writes shims on it).
+    mw = SimpleNamespace()
+    monkeypatch.setitem(sys.modules, "aqt", _stub_module("aqt", mw=mw))
+
+    # utils stub whose is_alive is a verbatim copy of the real one
+    # (src/Ankimon/utils.py:1005-1018). We stub rather than exec the real
+    # utils module because other test files leave partial ModuleType stubs of
+    # Ankimon.utils behind that conftest keeps, which makes importing/exec'ing
+    # the real module here order-dependent.
+    def is_alive(obj):
+        if obj is None:
+            return False
+        try:
+            obj.objectName()
+            return True
+        except (RuntimeError, AttributeError):
+            return False
+
+    monkeypatch.setitem(
+        sys.modules, "Ankimon.utils", _stub_module("Ankimon.utils", is_alive=is_alive)
+    )
+
+    # Fresh, REAL services registry per test (isolated from other tests).
+    services_spec = importlib.util.spec_from_file_location(
+        "Ankimon.services", _src / "Ankimon" / "services.py"
+    )
+    services_mod = importlib.util.module_from_spec(services_spec)
+    monkeypatch.setitem(sys.modules, "Ankimon.services", services_mod)
+    services_spec.loader.exec_module(services_mod)
+    services = services_mod.services
+
+    # core stub: mimics the real build_core (populates services, returns the
+    # namespace) and records every call so the tests can count boots/binds.
+    calls = []
+
+    def build_core():
+        calls.append("build_core")
+        core_objs = {
+            "logger": MagicMock(name="logger"),
+            "db": MagicMock(name="db"),
+            "settings": MagicMock(name="settings"),
+            "translator": MagicMock(name="translator"),
+            "tracker": MagicMock(name="tracker"),
+            "main_pokemon": MagicMock(name="main_pokemon"),
+            "enemy_pokemon": MagicMock(name="enemy_pokemon"),
+            "trainer_card": MagicMock(name="trainer_card"),
+            "achievements": {"1": False},
+        }
+        services.populate(**core_objs)
+        return SimpleNamespace(
+            logger=core_objs["logger"],
+            ankimon_db=core_objs["db"],
+            settings_obj=core_objs["settings"],
+            translator=core_objs["translator"],
+            main_pokemon=core_objs["main_pokemon"],
+            mainpokemon_empty=False,
+            enemy_pokemon=core_objs["enemy_pokemon"],
+            trainer_card=core_objs["trainer_card"],
+            ankimon_tracker_obj=core_objs["tracker"],
+            achievements=core_objs["achievements"],
+        )
+
+    def bind_runtime_globals():
+        calls.append("bind")
+
+    monkeypatch.setitem(
+        sys.modules,
+        "Ankimon.core",
+        _stub_module(
+            "Ankimon.core",
+            build_core=build_core,
+            bind_runtime_globals=bind_runtime_globals,
+        ),
+    )
+
+    class QtPresenter:
+        pass
+
+    monkeypatch.setitem(
+        sys.modules,
+        "Ankimon.gui_presenter",
+        _stub_module("Ankimon.gui_presenter", QtPresenter=QtPresenter),
+    )
+
+    # Window/manager classes singletons touches eagerly or in the factories
+    # under test.
+    monkeypatch.setitem(
+        sys.modules,
+        "Ankimon.pyobj.ankimon_shop",
+        _stub_module("Ankimon.pyobj.ankimon_shop", PokemonShopManager=FakeShopManager),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "Ankimon.pyobj.reviewer_obj",
+        _stub_module(
+            "Ankimon.pyobj.reviewer_obj", Reviewer_Manager=FakeReviewerManager
+        ),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "Ankimon.pyobj.test_window",
+        _stub_module("Ankimon.pyobj.test_window", TestWindow=FakeTestWindow),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "Ankimon.pyobj.starter_window",
+        _stub_module("Ankimon.pyobj.starter_window", StarterWindow=FakeStarterWindow),
+    )
+
+    sys.modules.pop("Ankimon.singletons", None)
+
+    yield SimpleNamespace(services=services, calls=calls, mw=mw)
+
+    sys.modules.pop("Ankimon.singletons", None)
+
+
+def _exec_singletons():
+    spec = importlib.util.spec_from_file_location(
+        "Ankimon.singletons", _src / "Ankimon" / "singletons.py"
+    )
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["Ankimon.singletons"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_first_boot_builds_core_once_and_no_windows(env):
+    mod = _exec_singletons()
+
+    assert env.calls.count("build_core") == 1
+    # Exactly one bind at the bottom of the module (no factory ran yet).
+    assert env.calls.count("bind") == 1
+    # No window constructed at import time.
+    assert FakeTestWindow.instances == []
+    assert FakeStarterWindow.instances == []
+    # Core names are exposed as real module globals.
+    assert mod.logger is env.services.logger
+    assert mod.settings_obj is env.services.settings
+    assert mod.ankimon_db is env.services.db
+    # mw back-compat shims mirror the registry.
+    assert env.mw.ankimon_db is env.services.db
+    assert env.mw.settings_obj is env.services.settings
+
+
+def test_second_boot_reuses_core_and_reviewer(env):
+    mod1 = _exec_singletons()
+    reviewer1 = mod1.reviewer_obj
+    ui1 = env.services.ui
+    assert env.services.reviewer is reviewer1
+    assert len(FakeReviewerManager.instances) == 1
+
+    # Simulate an add-on reload: the module is re-executed from scratch while
+    # the services registry survives.
+    sys.modules.pop("Ankimon.singletons")
+    mod2 = _exec_singletons()
+
+    assert env.calls.count("build_core") == 1, "second boot must not rebuild the core"
+    assert mod2.logger is mod1.logger
+    assert mod2.settings_obj is mod1.settings_obj
+    # Reviewer_Manager registers gui_hooks in its constructor: it must be
+    # get-or-create, or the double boot double-registers those hooks.
+    assert len(FakeReviewerManager.instances) == 1
+    assert mod2.reviewer_obj is reviewer1
+    # The Qt presenter is also reused, not re-instantiated.
+    assert env.services.ui is ui1
+
+
+def test_window_is_lazy_idempotent_and_registered(env):
+    mod = _exec_singletons()
+    binds_before = env.calls.count("bind")
+
+    win1 = mod.test_window  # attribute access -> module __getattr__ -> factory
+    win2 = mod.get_test_window()
+
+    assert win1 is win2
+    assert len(FakeTestWindow.instances) == 1
+    # The seam window is registered in the services registry...
+    assert env.services.test_window is win1
+    # ...and the runtime globals were re-bound so battle_loop/encounter code
+    # picks up the live instance.
+    assert env.calls.count("bind") == binds_before + 1
+
+
+def test_dead_window_is_recreated(env):
+    mod = _exec_singletons()
+
+    win1 = mod.get_test_window()
+    win1.kill()  # underlying C++ object deleted -> is_alive() False
+
+    win2 = mod.get_test_window()
+    assert win2 is not win1
+    assert len(FakeTestWindow.instances) == 2
+    assert env.services.test_window is win2
+
+
+def test_from_import_resolves_lazy_names(env):
+    _exec_singletons()
+
+    # `from .singletons import starter_window` is how startup.py consumes it.
+    from Ankimon.singletons import starter_window
+
+    assert isinstance(starter_window, FakeStarterWindow)
+    assert len(FakeStarterWindow.instances) == 1
+
+    # A second from-import returns the same live instance.
+    from Ankimon.singletons import starter_window as starter_window2
+
+    assert starter_window2 is starter_window
+    assert len(FakeStarterWindow.instances) == 1
+
+
+def test_every_consumer_name_still_resolves(env):
+    mod = _exec_singletons()
+
+    exposed = set(vars(mod)) | set(mod._LAZY_WINDOWS)
+    missing = CONSUMED_NAMES - exposed
+    assert not missing, f"singletons no longer exposes consumer names: {missing}"
+
+
+def test_unknown_attribute_raises(env):
+    mod = _exec_singletons()
+    with pytest.raises(AttributeError):
+        mod.definitely_not_a_window
+
+
+def test_register_card_hooks_is_idempotent(monkeypatch):
+    hooks = SimpleNamespace(
+        reviewer_did_show_question=[],
+        reviewer_did_show_answer=[],
+        reviewer_will_answer_card=[],
+        reviewer_did_answer_card=[],
+    )
+    aqt_stub = _stub_module(
+        "aqt", gui_hooks=hooks, mw=SimpleNamespace(), utils=SimpleNamespace()
+    )
+    monkeypatch.setitem(sys.modules, "aqt", aqt_stub)
+    monkeypatch.setitem(
+        sys.modules,
+        "aqt.utils",
+        _stub_module("aqt.utils", tooltip=lambda *a, **k: None),
+    )
+    monkeypatch.setitem(sys.modules, "Ankimon.singletons", MagicMock())
+
+    spec = importlib.util.spec_from_file_location(
+        "Ankimon.card_hooks", _src / "Ankimon" / "card_hooks.py"
+    )
+    card_hooks = importlib.util.module_from_spec(spec)
+    monkeypatch.setitem(sys.modules, "Ankimon.card_hooks", card_hooks)
+    spec.loader.exec_module(card_hooks)
+
+    card_hooks.register_card_hooks()
+    counts_after_first = (
+        len(hooks.reviewer_did_show_question),
+        len(hooks.reviewer_did_show_answer),
+        len(hooks.reviewer_will_answer_card),
+        len(hooks.reviewer_did_answer_card),
+    )
+    # on_show_question + on_reviewer_did_show_question share the question hook.
+    assert counts_after_first == (2, 1, 1, 1)
+
+    card_hooks.register_card_hooks()
+    assert (
+        len(hooks.reviewer_did_show_question),
+        len(hooks.reviewer_did_show_answer),
+        len(hooks.reviewer_will_answer_card),
+        len(hooks.reviewer_did_answer_card),
+    ) == counts_after_first, "second registration must be a no-op"


### PR DESCRIPTION
## What

Ports F31 (reload-safe singletons + lazy window construction) from `origin/BRRRR_Experimental` onto the integration tip (fd9010f4) — the composition-root unit of Wave 2.

- `src/Ankimon/singletons.py`: the production composition root is now idempotent and lazy. The aqt-free core is **get-or-create through the services registry** (a second exec — add-on reload / double boot — reuses the live registry objects instead of re-running `core.build_core()`, so the DB connection, tracker and `Reviewer_Manager`, whose constructor registers `gui_hooks`, are never duplicated). **No window is constructed at import time**: every window moved into a lazy, idempotent `get_*_window()` factory with `utils.is_alive()` liveness checks (F33 base scaffolding) — dead (C++-deleted) windows are transparently re-created instead of handed out stale.
- Consumer compatibility (the crux): every consumer enumerated via `git grep "singletons import"` (`__init__.py`, `card_hooks.py`, `discord_integration.py`, `hook_registry.py`, `profile_hooks.py`, `reviewer_ui.py`, `startup.py`, `functions/pokemon_showdown_functions.py`, `functions/rate_addon_functions.py`, and the deferred `pokemon_pc`/`evo_window` imports in `pyobj/` + `gui_classes/`) keeps working **unchanged**, via per-name module-level `__getattr__` proxies: `from .singletons import test_window` constructs only the requested window on first access (PEP 562 fires for from-imports). Boot behavior is unchanged — `__init__.py`'s from-import materializes the same windows at the same point in boot; no consumer file was rewritten (those belong to F32/F34/F36).
- `src/Ankimon/card_hooks.py`: the hook-registration record lives on the services registry (hardened per Gemini review): `register_card_hooks()` stores the exact (hook, handler) pairs it appended and removes the stored originals before re-appending, so neither a second call nor a re-execution of the module (add-on reload: fresh function objects, surviving registry) can stack a second set of reviewer hooks or strand stale handlers — a module-level flag would reset on re-exec, and a bare registry flag would leave the stale first set registered (and would strand zero handlers once the deferred NR-06 reloader teardown lands).
- `src/Ankimon/functions/rate_addon_functions.py`: eager `from ..singletons import test_window` snapshot swapped for the lazy `get_test_window()` accessor deferred to the click handler (file also ruff-formatted; it carried format debt).

## Re-fit to seam (exp → main mapping)

exp anchors every object on `mw.*` via `getattr(mw, name, None) or Construct()` — the direct-mw architecture main deliberately left. This port keeps the **intent** (idempotent construction, lazy factories, liveness checks) but re-expresses it on main's seam:

| exp mechanism | this port |
|---|---|
| `getattr(mw, "logger"/"ankimon_db"/"settings_obj"/…, None) or Construct()` | get-or-create through `services` (`_core_from_registry()` when `services.db/logger/settings` are populated, else `core.build_core()`) |
| `mw.test_window` / `mw.evo_window` / `mw.pokemon_pc` caches | cached in the `services` registry itself (`services.test_window/evo_window/pokemon_pc`); factories call `services.populate(...)` + re-run `core.bind_runtime_globals()` so `battle_loop`/`encounter_functions` bare globals pick up the live instance |
| `mw.<other window>` caches (settings/starter/item/tracker/achievement/charts/dialogs) | module-level `_WINDOW_CACHE` with `is_alive()` get-or-create (registry signature untouched — no seam edit) |
| `mw.reviewer_obj` get-or-create | `services.reviewer` get-or-create (prevents duplicate gui_hooks registration from its ctor) |
| exp's FakeEvoWindow / `'mock' in mw.__class__.__name__` harness hack | unnecessary: the harness populates `services` with fakes, and the factories' registry-first lookup reuses them naturally |

`services.py`, `core.py`, `gui_presenter.py`, `hooks.py` are untouched — no seam signature was added or reshaped.

## Parity notes

- exp behaviors intentionally NOT ported here (owned by other rows): `notify_stats_changed()` (F10/F49, NR-04), `get_items_window`/`get_ankidex_window`/`get_nature_chart` (F36 — target modules/widgets don't exist on base; a clearly-marked seam-point comment sits where they slot in), `swap_ankimon_account` (F36/F27), `pokemon_pc(achievements=...)` ctor arg (exp's F42 PC-box overhaul — base signature kept).
- `pokedex_window` (base-only, exp deleted it for ankidex) gained a lazy factory so `__init__.py`/`menu_buttons.py` keep working; the unused `pokedex` (`Pokedex_Widget`) name also resolves lazily.
- Post-snapshot exp hunks: `git log aad0d6b4..origin/BRRRR_Experimental -- <manifest paths>` is **empty** — no NR-15 rider hunks exist for this unit's files.
- New Qt-free characterization tests (`tests/test_reload_safe_singletons.py`, 9 tests): core built exactly once and reused on re-exec; reviewer/presenter not duplicated; zero windows at import; lazy `__getattr__`/factory identity on second access; dead-window re-creation; every consumer import name still resolves; unknown attr raises; `register_card_hooks()` idempotent; `register_card_hooks()` survives a module re-exec (handlers swapped, not stacked). Tier-2 probes are the real proof (both green, below).

## GUARDS-TO-REAPPLY confirmation

- **Settings DB-before-construction ordering** — preserved: construction still runs only inside `core.build_core()` (db registered before `Settings()`); the reuse path constructs nothing. Pinned by existing `tests/test_settings_init_order.py`.
- **core/services/gui_presenter seam remains the access path** — no new `mw.*` state anchoring; only the pre-existing back-compat shims (`mw.ankimon_db/logger/translator/settings_obj`, `mw.settings_ankimon`) are kept with unchanged meaning; `QtPresenter` is swapped into `services.ui` only when not already present.
- **Reload-safe idempotency** — double boot cannot duplicate hooks or windows (get-or-create core, registry-anchored card-hook registration record, `is_alive`-guarded factories). Pinned by the new tests.

## Deferred

- `src/Ankimon/reloader.py` — **excluded from this port** per owner decision (NR-06); stays escalated and lands with the Dev-Mode/web-shell leaves.
- `get_items_window` (ankimon_items_web) + `get_ankidex_window` (ankidex/) + `get_nature_chart` (NatureTableWidget) → **F36** (seam point marked in `singletons.py`).
- `notify_stats_changed()` → **F10/F49** (webshell host live bridge, NR-04).
- `swap_ankimon_account()` → **F36/F27** (must call `services.db.switch_database`).

## Gates (re-run independently by the verifier)

- `compileall`: OK
- `ruff check` (ci_ruff_check.toml): 10 errors, all pre-existing in `AnkimonWindow copy.py` — identical to baseline, **0 new**
- `ruff format --check` on all 4 created/modified files: clean
- pytest Tier-1: **273 passed / 15 skipped / 0 failed** (baseline 264; +9 new tests)
- `harness/check.py`: **9/9**
- Qt tier: scaffolding smoke **4 passed**; addon integrity **1 passed**; `probe_real_boot` **OK** (real TestWindow/EvoWindow/PokemonPC/Reviewer_Manager + QtPresenter registered through the lazy path); `probe_real_play` **OK** (3 resolutions, 0 error events)
- Verifier extra: targeted real-Qt probe (module exec of `singletons.py` under the Tier-2 fake Anki host, without running `__init__.py`) confirms **zero windows constructed at import**, first access builds the real `TestWindow`, registers it in `services`, rebinds `battle_loop.test_window`, and second access returns the identical instance.

## Attribution

Originally implemented by @hakimh2 (with contributions by @AIbrahimv2 on `singletons.py`) on BRRRR_Experimental; credited via Co-authored-by trailers on every commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

