### PR TITLE
feat: Pokemon details GUI — nature chart, animated stat bars, remember-attack (F43)

### DIFF
--- a/src/Ankimon/addon_files/nature_chart.html
+++ b/src/Ankimon/addon_files/nature_chart.html
@@ -1,0 +1,38 @@
+
+<table class="wikitable" style="margin: 0 auto; border-collapse: collapse; width: 600px; font-family: sans-serif;">
+  <caption style="font-weight: bold; font-size: 1.5em; text-align: center; color: white; margin: 20px 0;">Pokémon Nature Chart</caption>
+  <thead style="background-color: #009879; color: #ffffff; text-align: left;">
+    <tr>
+      <th scope="col" style="padding: 10px; border: 1px solid #ddd; text-align: center;">Nature</th>
+      <th scope="col" style="padding: 10px; border: 1px solid #ddd; text-align: center;">Boosted Stat (+10%)</th>
+      <th scope="col" style="padding: 10px; border: 1px solid #ddd; text-align: center;">Hindered Stat (-10%)</th>
+    </tr>
+  </thead>
+  <tbody style="background-color: #2c2c2c; color: white;">
+    <tr><td align="center" style="padding: 8px; border: 1px solid #444;"><b>Adamant</b></td><td align="center" style="color: #4ade80;">Attack</td><td align="center" style="color: #f87171;">Sp. Atk</td></tr>
+    <tr><td align="center" style="padding: 8px; border: 1px solid #444;"><b>Bashful</b></td><td align="center" colspan="2">--- (Neutral) ---</td></tr>
+    <tr><td align="center" style="padding: 8px; border: 1px solid #444;"><b>Bold</b></td><td align="center" style="color: #4ade80;">Defense</td><td align="center" style="color: #f87171;">Attack</td></tr>
+    <tr><td align="center" style="padding: 8px; border: 1px solid #444;"><b>Brave</b></td><td align="center" style="color: #4ade80;">Attack</td><td align="center" style="color: #f87171;">Speed</td></tr>
+    <tr><td align="center" style="padding: 8px; border: 1px solid #444;"><b>Calm</b></td><td align="center" style="color: #4ade80;">Sp. Def</td><td align="center" style="color: #f87171;">Attack</td></tr>
+    <tr><td align="center" style="padding: 8px; border: 1px solid #444;"><b>Careful</b></td><td align="center" style="color: #4ade80;">Sp. Def</td><td align="center" style="color: #f87171;">Sp. Atk</td></tr>
+    <tr><td align="center" style="padding: 8px; border: 1px solid #444;"><b>Docile</b></td><td align="center" colspan="2">--- (Neutral) ---</td></tr>
+    <tr><td align="center" style="padding: 8px; border: 1px solid #444;"><b>Gentle</b></td><td align="center" style="color: #4ade80;">Sp. Def</td><td align="center" style="color: #f87171;">Defense</td></tr>
+    <tr><td align="center" style="padding: 8px; border: 1px solid #444;"><b>Hardy</b></td><td align="center" colspan="2">--- (Neutral) ---</td></tr>
+    <tr><td align="center" style="padding: 8px; border: 1px solid #444;"><b>Hasty</b></td><td align="center" style="color: #4ade80;">Speed</td><td align="center" style="color: #f87171;">Defense</td></tr>
+    <tr><td align="center" style="padding: 8px; border: 1px solid #444;"><b>Impish</b></td><td align="center" style="color: #4ade80;">Defense</td><td align="center" style="color: #f87171;">Sp. Atk</td></tr>
+    <tr><td align="center" style="padding: 8px; border: 1px solid #444;"><b>Jolly</b></td><td align="center" style="color: #4ade80;">Speed</td><td align="center" style="color: #f87171;">Sp. Atk</td></tr>
+    <tr><td align="center" style="padding: 8px; border: 1px solid #444;"><b>Lax</b></td><td align="center" style="color: #4ade80;">Defense</td><td align="center" style="color: #f87171;">Sp. Def</td></tr>
+    <tr><td align="center" style="padding: 8px; border: 1px solid #444;"><b>Lonely</b></td><td align="center" style="color: #4ade80;">Attack</td><td align="center" style="color: #f87171;">Defense</td></tr>
+    <tr><td align="center" style="padding: 8px; border: 1px solid #444;"><b>Mild</b></td><td align="center" style="color: #4ade80;">Sp. Atk</td><td align="center" style="color: #f87171;">Defense</td></tr>
+    <tr><td align="center" style="padding: 8px; border: 1px solid #444;"><b>Modest</b></td><td align="center" style="color: #4ade80;">Sp. Atk</td><td align="center" style="color: #f87171;">Attack</td></tr>
+    <tr><td align="center" style="padding: 8px; border: 1px solid #444;"><b>Naive</b></td><td align="center" style="color: #4ade80;">Speed</td><td align="center" style="color: #f87171;">Sp. Def</td></tr>
+    <tr><td align="center" style="padding: 8px; border: 1px solid #444;"><b>Naughty</b></td><td align="center" style="color: #4ade80;">Attack</td><td align="center" style="color: #f87171;">Sp. Def</td></tr>
+    <tr><td align="center" style="padding: 8px; border: 1px solid #444;"><b>Quiet</b></td><td align="center" style="color: #4ade80;">Sp. Atk</td><td align="center" style="color: #f87171;">Speed</td></tr>
+    <tr><td align="center" style="padding: 8px; border: 1px solid #444;"><b>Quirky</b></td><td align="center" colspan="2">--- (Neutral) ---</td></tr>
+    <tr><td align="center" style="padding: 8px; border: 1px solid #444;"><b>Rash</b></td><td align="center" style="color: #4ade80;">Sp. Atk</td><td align="center" style="color: #f87171;">Sp. Def</td></tr>
+    <tr><td align="center" style="padding: 8px; border: 1px solid #444;"><b>Relaxed</b></td><td align="center" style="color: #4ade80;">Defense</td><td align="center" style="color: #f87171;">Speed</td></tr>
+    <tr><td align="center" style="padding: 8px; border: 1px solid #444;"><b>Sassy</b></td><td align="center" style="color: #4ade80;">Sp. Def</td><td align="center" style="color: #f87171;">Speed</td></tr>
+    <tr><td align="center" style="padding: 8px; border: 1px solid #444;"><b>Serious</b></td><td align="center" colspan="2">--- (Neutral) ---</td></tr>
+    <tr><td align="center" style="padding: 8px; border: 1px solid #444;"><b>Timid</b></td><td align="center" style="color: #4ade80;">Speed</td><td align="center" style="color: #f87171;">Attack</td></tr>
+  </tbody>
+</table>

--- a/src/Ankimon/gui_classes/pokemon_details.py
+++ b/src/Ankimon/gui_classes/pokemon_details.py
@@ -1333,7 +1333,7 @@ def remember_attack_details_window(
 
 
 def forget_attack_details_window(
-    individual_id: int,
+    individual_id: str,
     attack_set: list[str],
     logger: "ShowInfoLogger",
     refresh_callback=None,
@@ -1342,7 +1342,7 @@ def forget_attack_details_window(
     Creates a window that will allow the user to erase moves from a Pokemon.
 
     Args:
-        individual_id (int): The Pokemon's identifier.
+        individual_id (str): The Pokemon's unique identifier (uuid).
         attack_set (list[str]): The Pokemon's move set.
         logger: Logger object that can log info and display windows containing messages.
         refresh_callback: Optional callable invoked after a move is forgotten.
@@ -1451,7 +1451,7 @@ def remember_attack(
 
 
 def forget_attack(
-    individual_id: int,
+    individual_id: str,
     attacks: list[str],
     attack_to_forget: str,
     logger: ShowInfoLogger,

--- a/src/Ankimon/gui_classes/pokemon_details.py
+++ b/src/Ankimon/gui_classes/pokemon_details.py
@@ -291,8 +291,15 @@ def PokemonCollectionDetailsSplit(
         _stats_dict = {}
         for key in ("hp", "atk", "def", "spa", "spd", "spe"):
             if key in detail_stats:
+                # Persisted records may predate full IV/EV dicts — default
+                # missing entries to 0 rather than raising KeyError.
                 _stats_dict[key] = PokemonObject.calc_stat(
-                    key, detail_stats[key], level, iv[key], ev[key], nature
+                    key,
+                    detail_stats[key],
+                    level,
+                    (iv or {}).get(key, 0),
+                    (ev or {}).get(key, 0),
+                    nature,
                 )
         _stats_dict["xp"] = detail_stats.get("xp", 0)
         _stats_dict["friendship"] = friendship
@@ -554,7 +561,8 @@ def PokemonCollectionDetailsSplit(
         if readiness["ready"] and trigger_evo_callback and show_evolution_ui:
             translator = services.translator or Translator(language)
             evolve_text = translator.translate(
-                "evolve_now_button", evo_name=readiness["evo_name"]
+                "evolve_now_button",
+                evo_name=readiness["evo_name"] or "the next form",
             )
             evolve_now_button = QPushButton(evolve_text.upper())
             evolve_now_button.setCursor(Qt.CursorShape.PointingHandCursor)
@@ -830,14 +838,17 @@ def PokemonDetailsStats(
     # 1. Query the max level in the player's collection to dynamically scale
     #    the visual baseline.
     max_level = 100
-    try:
-        cursor = services.db.execute("SELECT MAX(level) FROM captured_pokemon")
-        row = cursor.fetchone()
-        if row and row[0] is not None:
-            max_level = int(row[0])
-    except Exception:
-        # Headless/registry-less callers keep the default baseline.
-        pass
+    # services.db is None for headless/registry-less callers (same idiom as
+    # pyobj/settings.py); they keep the default baseline.
+    if services.db is not None:
+        try:
+            cursor = services.db.execute("SELECT MAX(level) FROM captured_pokemon")
+            row = cursor.fetchone()
+            if row and row[0] is not None:
+                max_level = int(row[0])
+        except Exception:
+            # A broken/locked DB keeps the default baseline too.
+            pass
 
     # 2. Get the maximum stat of the currently selected Pokémon (handles manual
     #    DB/JSON stat edits).
@@ -894,10 +905,12 @@ def PokemonDetailsStats(
         if old_stats and stat in old_stats:
             old_val = old_stats[stat]
             if stat == "xp":
-                experience = int(find_experience_for_level(growth_rate, level, True))
-                old_val_mapped = int(
-                    (int(old_val) / int(experience)) * max_width_stat_item
+                # find_experience_for_level returns 0 for unknown growth rates
+                # / missing CSV rows — clamp to 1 to avoid ZeroDivisionError.
+                experience = max(
+                    1, int(find_experience_for_level(growth_rate, level, True))
                 )
+                old_val_mapped = int((int(old_val) / experience) * max_width_stat_item)
             elif stat == "friendship":
                 try:
                     old_friendship = int(old_val)
@@ -920,8 +933,11 @@ def PokemonDetailsStats(
             old_val_mapped = 0
 
         if stat == "xp":
-            experience = int(find_experience_for_level(growth_rate, level, True))
-            new_val_mapped = int((int(value) / int(experience)) * max_width_stat_item)
+            # Same zero-experience clamp as the old_stats mapping above.
+            experience = max(
+                1, int(find_experience_for_level(growth_rate, level, True))
+            )
+            new_val_mapped = int((int(value) / experience) * max_width_stat_item)
         elif stat == "friendship":
             # Bar reads 100% exactly at the evolution threshold (bar_max).
             new_val_mapped = min(

--- a/src/Ankimon/gui_classes/pokemon_details.py
+++ b/src/Ankimon/gui_classes/pokemon_details.py
@@ -1,13 +1,18 @@
 import math
-from math import exp
 import json
-from typing import Any
+from typing import Any, Callable
 import re
 
-from aqt import mw, qconnect
-from aqt.utils import showWarning
+from aqt import qconnect
 from PyQt6.QtGui import QPixmap, QPainter, QIcon, QColor, QPolygonF, QPen, QBrush
-from PyQt6.QtCore import Qt, QPointF, QRectF
+from PyQt6.QtCore import (
+    Qt,
+    QPointF,
+    QRectF,
+    QPropertyAnimation,
+    QEasingCurve,
+    pyqtProperty,
+)
 from PyQt6.QtWidgets import QScrollArea
 from PyQt6.QtWidgets import (
     QDialog,
@@ -23,22 +28,26 @@ from PyQt6.QtWidgets import (
     QSizePolicy,
 )
 
+from ..services import services
 from ..business import (
     calculate_pokemon_go_cp,
     pokemon_go_raw_stats,
-    calculate_cpm,
     cp_breakdown_tooltip,
+    split_string_by_length,
 )
 from ..pyobj.attack_dialog import AttackDialog
 from ..pyobj.pokemon_trade import PokemonTrade
 from ..pyobj.error_handler import show_warning_with_traceback
 from ..pyobj.pokemon_obj import PokemonObject
 from ..pyobj.InfoLogger import ShowInfoLogger
+from ..pyobj.translator import Translator
 from ..functions.pokedex_functions import (
     get_pokemon_diff_lang_name,
     get_pokemon_descriptions,
     get_all_pokemon_moves,
+    get_pretty_name_for_name,
     find_details_move,
+    search_pokedex,
     search_pokedex_by_id,
 )
 from ..functions.pokemon_functions import find_experience_for_level
@@ -46,16 +55,11 @@ from ..functions.friendship_evolution import evolution_readiness
 from ..functions.gui_functions import type_icon_path, move_category_path
 from ..functions.sprite_functions import get_sprite_path
 from ..gui_entities import MovieSplashLabel
-from ..business import split_string_by_length
 from ..utils import format_move_name, load_custom_font
 from ..resources import (
     icon_path,
     addon_dir,
-    mainpokemon_path,
-    mypokemon_path,
-    pokemon_history_path,
     pokemon_tm_learnset_path,
-    itembag_path,
 )
 from ..texts import (
     attack_details_window_template,
@@ -63,6 +67,10 @@ from ..texts import (
     remember_attack_details_window_template,
     remember_attack_details_window_template_end,
 )
+
+# Scaled sprite pixmaps are cached per (path, shiny, gender) so re-opening the
+# details panel doesn't re-load and re-scale the same image from disk.
+_SCALED_PIXMAP_CACHE: dict = {}
 
 
 def _lookup_move_data(attack: str):
@@ -77,7 +85,7 @@ def _lookup_move_data(attack: str):
     return find_details_move("tackle")
 
 
-def PokemonCollectionDetails(
+def PokemonCollectionDetailsSplit(
     name: str,
     level: int,
     id: int,
@@ -105,47 +113,91 @@ def PokemonCollectionDetails(
     tab_changed_callback=None,
     nature: str = "serious",
     base_stats: dict = None,
+    old_stats: dict = None,
     friendship: int = 0,
     evolution_rejected: bool = False,
     friendship_time_enabled: bool = True,
+    trigger_evo_callback: Callable = None,
 ):
-    # Create a layout for the details panel
+    """Build the details panel as split components.
+
+    Returns ``(header_widget, stats_tabs, footer_widget, stats_dict)`` so
+    callers can place the scrollable header, the fixed Stats/IV/EV tabs and the
+    action footer independently (and diff ``stats_dict`` against the previous
+    Pokémon for the stat-bar slide animation via ``old_stats``).
+
+    Callers that only need the classic single-layout panel should use
+    :func:`PokemonCollectionDetails` instead.
+    """
     try:
-        readiness = evolution_readiness(
-            {
-                "id": id,
-                "friendship": friendship,
-                "everstone": everstone,
-                "evolution_rejected": evolution_rejected,
-                "level": level,
-            }
-        )
-        lang_name = get_pokemon_diff_lang_name(int(id), language).capitalize()
-        lang_desc = get_pokemon_descriptions(int(id), language)
+        # Manual-evolution readiness (friendship/level and, on richer data sets,
+        # defeat/move methods). The stub carries every key evolution_readiness
+        # may consume; unknown keys are ignored.
+        pkmn_data_stub = {
+            "id": id,
+            "level": level,
+            "friendship": friendship,
+            "evolution_rejected": evolution_rejected,
+            "individual_id": individual_id,
+            "everstone": everstone,
+            "attacks": attacks,
+            "pokemon_defeated": pokemon_defeated,
+        }
+        readiness = evolution_readiness(pkmn_data_stub)
+
+        # For Mega/Gmax and Regional forms, the species CSV often has no entry
+        # or is hyphenated — use the pretty pokedex name instead.
+        if any(
+            f in name.lower()
+            for f in ["mega", "gmax", "alola", "galar", "hisui", "paldea"]
+        ):
+            lang_name = get_pretty_name_for_name(name)
+            # Use species_id for the description since the descriptions CSV
+            # only has base species.
+            desc_id = (
+                search_pokedex(
+                    name.lower().replace(" ", "").replace("-", ""), "species_id"
+                )
+                or id
+            )
+            lang_desc = get_pokemon_descriptions(int(desc_id), language)
+        else:
+            lang_name = get_pokemon_diff_lang_name(int(id), language)
+            lang_desc = get_pokemon_descriptions(int(id), language)
         description = lang_desc
-        layout = QVBoxLayout()
         typelayout = QHBoxLayout()
-        attackslayout = QVBoxLayout()
         # Display the Pokémon image
         pkmnimage_label = QLabel()
-        pkmnpixmap = QPixmap()
         pkmnimage_path = get_sprite_path(
-            "front", "gif" if gif_in_collection else "png", id, shiny, gender
+            "front", "gif" if gif_in_collection else "png", id, shiny, gender, name
         )
 
         if gif_in_collection:
             pkmnimage_label = MovieSplashLabel(pkmnimage_path)
         else:
-            if not pkmnpixmap.load(str(pkmnimage_path)):
-                logger.log_and_showinfo(
-                    "warning", f"Failed to load Pokémon image: {pkmnimage_path}"
-                )
-            max_width = 150
-            original_width = pkmnpixmap.width()
-            original_height = pkmnpixmap.height()
-            new_width = max_width
-            new_height = (original_height * max_width) // original_width
-            pkmnpixmap = pkmnpixmap.scaled(new_width, new_height)
+            cache_key = (str(pkmnimage_path), shiny, gender)
+            if cache_key in _SCALED_PIXMAP_CACHE:
+                pkmnpixmap = _SCALED_PIXMAP_CACHE[cache_key]
+            else:
+                pkmnpixmap = QPixmap()
+                if not pkmnpixmap.load(str(pkmnimage_path)):
+                    logger.log_and_showinfo(
+                        "warning", f"Failed to load Pokémon image: {pkmnimage_path}"
+                    )
+                max_width = 150
+                original_width = pkmnpixmap.width()
+                if original_width > 0:
+                    original_height = pkmnpixmap.height()
+                    new_width = max_width
+                    new_height = (original_height * max_width) // original_width
+                    pkmnpixmap = pkmnpixmap.scaled(
+                        new_width,
+                        new_height,
+                        Qt.AspectRatioMode.KeepAspectRatio,
+                        Qt.TransformationMode.SmoothTransformation,
+                    )
+                    _SCALED_PIXMAP_CACHE[cache_key] = pkmnpixmap
+
             pkmnimage_label.setPixmap(pkmnpixmap)
 
         # Load and set type icons
@@ -185,12 +237,40 @@ def PokemonCollectionDetails(
         namefont = load_custom_font(30, language)
         namefont.setUnderline(True)
 
-        if nickname is None:
-            capitalized_name = f"{lang_name.capitalize()} {' ⭐ ' if shiny else ''}"
+        # Resolve species_id for the [No. XXX] display. We use the internal
+        # 'name' to look up the species_id because forms share dex numbers.
+        lookup_name = name.lower().replace(" ", "").replace("-", "")
+        species_id = search_pokedex(lookup_name, "species_id")
+        if not species_id:
+            species_id = id
+
+        dex_prefix = f"[No. {str(species_id).zfill(3)}] "
+
+        # Avoid redundant "Name (Name)" display: nickname is dropped when it is
+        # empty, matches the formatted species name, or matches the raw
+        # internal name.
+        def normalize_name(s):
+            if not s:
+                return ""
+            return "".join(c for c in str(s).lower() if c.isalnum())
+
+        base_display_name = lang_name  # Already formatted by format_lore_name
+        shiny_star = " ⭐ " if shiny else ""
+
+        is_redundant = (
+            not nickname
+            or not str(nickname).strip()
+            or normalize_name(nickname) == normalize_name(base_display_name)
+            or normalize_name(nickname) == normalize_name(name)
+        )
+
+        if is_redundant:
+            capitalized_name = f"{dex_prefix}{base_display_name}{shiny_star}"
         else:
             capitalized_name = (
-                f"{nickname} {' ⭐ ' if shiny else ''} ({lang_name.capitalize()})"
+                f"{dex_prefix}{nickname}{shiny_star} ({base_display_name})"
             )
+
         if (
             language == 11
             or language == 12
@@ -206,29 +286,21 @@ def PokemonCollectionDetails(
         description_txt = f"Description: \n {description_formated}"
         lvl = f" Level: {level}"
         ability_txt = f" Ability: {ability.capitalize()}"
-        type_txt = f" Type:"
-        stats_list = []
-        for key, val in detail_stats.items():
-            if key not in ("hp", "atk", "def", "spa", "spd", "spe"):
-                continue
-            stat = PokemonObject.calc_stat(key, val, level, iv[key], ev[key], nature)
-            stats_list.append(stat)
-        stats_list.append(detail_stats.get("xp", 0))
-        stats_txt = f"Stats:\n Hp: {stats_list[0]}\n Attack: {stats_list[1]}\n Defense: {stats_list[2]}\n Special-attack: {stats_list[3]}\n Special-defense: {stats_list[4]}\n Speed: {stats_list[5]}\n XP: {stats_list[6]}"
+        nature_display = (nature or "serious").strip().title()
+        nature_txt = f" Nature: {nature_display}"
+        _stats_dict = {}
+        for key in ("hp", "atk", "def", "spa", "spd", "spe"):
+            if key in detail_stats:
+                _stats_dict[key] = PokemonObject.calc_stat(
+                    key, detail_stats[key], level, iv[key], ev[key], nature
+                )
+        _stats_dict["xp"] = detail_stats.get("xp", 0)
+        _stats_dict["friendship"] = friendship
+
         attacks_txt = "MOVES:"
         for attack in attacks:
             attacks_txt += f"\n{attack.capitalize()}"
 
-        _stats_dict = {
-            "hp": stats_list[0],
-            "atk": stats_list[1],
-            "def": stats_list[2],
-            "spa": stats_list[3],
-            "spd": stats_list[4],
-            "spe": stats_list[5],
-            "xp": stats_list[6],
-            "friendship": friendship,
-        }
         CompleteTable_layout = PokemonDetailsStats(
             _stats_dict,
             growth_rate,
@@ -236,6 +308,7 @@ def PokemonCollectionDetails(
             remove_levelcap,
             language,
             friendship_bar_max=readiness["bar_max"],
+            old_stats=old_stats,
         )
 
         if gender == "M":
@@ -255,81 +328,32 @@ def PokemonCollectionDetails(
             {"base_stats": _cp_stats, "iv": iv, "ev": ev, "level": level}
         )
 
-        name_label = QLabel(f"{capitalized_name} - {gender_symbol}")
+        display_full_name = (
+            f"{capitalized_name} - {gender_symbol}"
+            if gender_symbol
+            else capitalized_name
+        )
+        name_label = QLabel(display_full_name)
         name_label.setFont(namefont)
         description_label = QLabel(description_txt)
         level_label = QLabel(lvl)
         cp_label = QLabel(cp_txt)
         cp_label.setToolTip(cp_tooltip)
         ability_label = QLabel(ability_txt)
+        nature_label = QLabel(nature_txt)
         attacks_label = QLabel(attacks_txt)
         pokemon_defeated_label = QLabel(f"Pokémon Defeated: {pokemon_defeated}")
         if captured_date is not None:
             captured_date_label = QLabel(f"Captured: {captured_date.split()[0]}")
         else:
-            captured_date_label = QLabel(f"Captured: N/A")
-        # Friendship-evolution UI: an actionable "Evolve now" button when the
-        # Pokémon is ready, otherwise the requirement line (e.g. "40 friendship
-        # to evolve into Espeon · needs Day"). Only shown when relevant.
-        evolution_req_widget = None
-        # A secondary note shown alongside the Evolve button when the user
-        # previously rejected this evolution (soft state) — the manual button
-        # stays available so they can still evolve on demand.
-        evolution_note_widget = None
-        # The friendship/time evolution feature is gated behind a master toggle,
-        # so its UI must only appear when the toggle is on. Plain LEVEL-method
-        # evolution UI is base-game behaviour and always shows.
-        show_evolution_ui = readiness["method"] == "level" or (
-            readiness["method"] == "friendship" and friendship_time_enabled
-        )
-        if show_evolution_ui and readiness["ready"]:
-            evo_name = readiness["evo_name"] or "the next form"
-            evolve_now_button = QPushButton(f"✨ Evolve into {evo_name} now")
-            evolve_now_button.setFont(custom_font)
-            evolve_now_button.setFixedWidth(230)
-            evolve_now_button.setStyleSheet(
-                "QPushButton { background-color: #FF69B4; color: white;"
-                " border-radius: 6px; padding: 5px; font-weight: bold; }"
-                " QPushButton:hover { background-color: #FF8DC7; }"
-            )
-
-            def evolve_now():
-                # Lazy import: evo_window is a singleton built after this module
-                # is first imported, so importing it at module top would cycle.
-                from ..singletons import evo_window
-
-                # ask_pokemon_evo is modeless and returns immediately, so a
-                # refresh here would run BEFORE the user confirms — a no-op. The
-                # real refresh happens inside evolve_pokemon after confirmation.
-                evo_window.ask_pokemon_evo(individual_id, id, readiness["evo_id"])
-
-            qconnect(evolve_now_button.clicked, evolve_now)
-            evolution_req_widget = evolve_now_button
-
-            if readiness.get("rejected"):
-                evolution_note_label = QLabel(
-                    "Evolution rejected — tap Evolve now to override"
-                )
-                evolution_note_label.setFont(custom_font)
-                evolution_note_label.setWordWrap(True)
-                evolution_note_label.setFixedWidth(230)
-                evolution_note_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
-                evolution_note_label.setStyleSheet("color: #FF69B4;")
-                evolution_note_widget = evolution_note_label
-        elif show_evolution_ui and readiness["status_text"]:
-            evolution_req_label = QLabel(readiness["status_text"])
-            evolution_req_label.setFont(custom_font)
-            evolution_req_label.setWordWrap(True)
-            evolution_req_label.setFixedWidth(230)
-            evolution_req_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
-            evolution_req_label.setStyleSheet("color: #FF69B4;")
-            evolution_req_widget = evolution_req_label
+            captured_date_label = QLabel("Captured: N/A")
 
         level_label.setFont(custom_font)
         cp_label.setFont(custom_font)
         type_label = QLabel("Type:")
         type_label.setFont(custom_font)
         ability_label.setFont(custom_font)
+        nature_label.setFont(custom_font)
         attacks_label.setFont(custom_font)
         description_label.setFont(
             load_custom_font(15 if language != 1 else 20, language)
@@ -340,6 +364,7 @@ def PokemonCollectionDetails(
         if gif_in_collection is False:
             pkmnimage_label.setFixedHeight(100)
         pkmnimage_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
+
         name_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
         level_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
         cp_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
@@ -347,19 +372,84 @@ def PokemonCollectionDetails(
             Qt.AlignmentFlag.AlignLeft | Qt.AlignmentFlag.AlignCenter
         )
         ability_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        nature_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
         attacks_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
         description_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
         pokemon_defeated_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
         captured_date_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
 
-        level_label.setFixedWidth(230)
-        ability_label.setFixedWidth(230)
         attacks_label.setFixedWidth(230)
-        attacks_label.setFixedHeight(70)
+        attacks_label.setFixedHeight(80)
+
+        # Friendship-evolution UI (classic single-panel path): an actionable
+        # "Evolve now" button when the Pokémon is ready, otherwise the
+        # requirement line (e.g. "40 friendship to evolve into Espeon · needs
+        # Day"). Only shown when relevant, and only when the caller did not
+        # supply its own trigger_evo_callback (which renders the button in the
+        # right-hand column instead).
+        evolution_req_widget = None
+        # A secondary note shown alongside the Evolve button when the user
+        # previously rejected this evolution (soft state) — the manual button
+        # stays available so they can still evolve on demand.
+        evolution_note_widget = None
+        # The friendship/time evolution feature is gated behind a master toggle,
+        # so its UI must only appear when the toggle is on. Every other
+        # evolution method (level, and any future methods) is base-game
+        # behaviour and always shows.
+        show_evolution_ui = readiness["method"] is not None and (
+            readiness["method"] != "friendship" or friendship_time_enabled
+        )
+        if trigger_evo_callback is None:
+            if show_evolution_ui and readiness["ready"]:
+                evo_name = readiness["evo_name"] or "the next form"
+                evolve_now_button = QPushButton(f"✨ Evolve into {evo_name} now")
+                evolve_now_button.setFont(custom_font)
+                evolve_now_button.setFixedWidth(230)
+                evolve_now_button.setStyleSheet(
+                    "QPushButton { background-color: #FF69B4; color: white;"
+                    " border-radius: 6px; padding: 5px; font-weight: bold; }"
+                    " QPushButton:hover { background-color: #FF8DC7; }"
+                )
+
+                def evolve_now():
+                    # Lazy import: evo_window is a singleton built after this
+                    # module is first imported, so importing it at module top
+                    # would cycle.
+                    from ..singletons import evo_window
+
+                    # ask_pokemon_evo is modeless and returns immediately, so a
+                    # refresh here would run BEFORE the user confirms — a no-op.
+                    # The real refresh happens inside evolve_pokemon after
+                    # confirmation.
+                    evo_window.ask_pokemon_evo(individual_id, id, readiness["evo_id"])
+
+                qconnect(evolve_now_button.clicked, evolve_now)
+                evolution_req_widget = evolve_now_button
+
+                if readiness.get("rejected"):
+                    evolution_note_label = QLabel(
+                        "Evolution rejected — tap Evolve now to override"
+                    )
+                    evolution_note_label.setFont(custom_font)
+                    evolution_note_label.setWordWrap(True)
+                    evolution_note_label.setFixedWidth(230)
+                    evolution_note_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
+                    evolution_note_label.setStyleSheet("color: #FF69B4;")
+                    evolution_note_widget = evolution_note_label
+            elif show_evolution_ui and readiness["status_text"]:
+                evolution_req_label = QLabel(readiness["status_text"])
+                evolution_req_label.setFont(custom_font)
+                evolution_req_label.setWordWrap(True)
+                evolution_req_label.setFixedWidth(230)
+                evolution_req_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
+                evolution_req_label.setStyleSheet("color: #FF69B4;")
+                evolution_req_widget = evolution_req_label
 
         first_layout = QHBoxLayout()
         TopL_layout_Box = QVBoxLayout()
         TopR_layout_Box = QVBoxLayout()
+        TopR_layout_Box.setAlignment(Qt.AlignmentFlag.AlignCenter)
+
         typelayout_widget = QWidget()
         TopL_layout_Box.addWidget(level_label)
         TopL_layout_Box.addWidget(cp_label)
@@ -376,8 +466,11 @@ def PokemonCollectionDetails(
 
         typelayout_widget.setLayout(typelayout)
         typelayout_widget.setFixedWidth(230)
-        TopL_layout_Box.addWidget(typelayout_widget)
+        TopL_layout_Box.addWidget(
+            typelayout_widget, alignment=Qt.AlignmentFlag.AlignCenter
+        )
         TopL_layout_Box.addWidget(ability_label)
+        TopL_layout_Box.addWidget(nature_label)
         TopL_layout_Box.addWidget(captured_date_label)
         TopL_layout_Box.addWidget(pokemon_defeated_label)
         if evolution_req_widget is not None:
@@ -392,33 +485,129 @@ def PokemonCollectionDetails(
         qconnect(
             remember_attacks_details_button.clicked,
             lambda: remember_attack_details_window(
-                individual_id, attacks, all_attacks, logger
+                individual_id, attacks, all_attacks, logger, refresh_callback
             ),
         )
         forget_attacks_details_button = QPushButton("Forget Attacks")
         qconnect(
             forget_attacks_details_button.clicked,
-            lambda: forget_attack_details_window(individual_id, attacks, logger),
+            lambda: forget_attack_details_window(
+                individual_id, attacks, logger, refresh_callback
+            ),
         )
 
         tm_attacks_details_button = QPushButton("Learn attacks from TMs")
         qconnect(
             tm_attacks_details_button.clicked,
-            lambda: tm_attack_details_window(id, individual_id, attacks, logger),
+            lambda: tm_attack_details_window(
+                id, individual_id, attacks, logger, refresh_callback
+            ),
         )
 
+        # Pin padding across ALL button states so Anki's hover theme never
+        # shifts the geometry.
+        _BTN_STYLE = (
+            "QPushButton {"
+            "  min-width: 230px; max-width: 230px;"
+            "  padding: 4px 8px;"
+            "  text-align: center;"
+            "}"
+            "QPushButton:hover {"
+            "  padding: 4px 8px;"  # identical padding — no layout reflow on hover
+            "}"
+            "QPushButton:pressed {"
+            "  padding: 4px 8px;"
+            "}"
+        )
+        for btn in [
+            attacks_details_button,
+            remember_attacks_details_button,
+            forget_attacks_details_button,
+            tm_attacks_details_button,
+        ]:
+            btn.setFixedWidth(230)
+            btn.setSizePolicy(QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed)
+            btn.setStyleSheet(_BTN_STYLE)
+
         TopR_layout_Box.addWidget(attacks_label)
+        TopR_layout_Box.setAlignment(attacks_label, Qt.AlignmentFlag.AlignHCenter)
         TopR_layout_Box.addWidget(attacks_details_button)
+        TopR_layout_Box.setAlignment(
+            attacks_details_button, Qt.AlignmentFlag.AlignHCenter
+        )
         TopR_layout_Box.addWidget(remember_attacks_details_button)
+        TopR_layout_Box.setAlignment(
+            remember_attacks_details_button, Qt.AlignmentFlag.AlignHCenter
+        )
         TopR_layout_Box.addWidget(forget_attacks_details_button)
+        TopR_layout_Box.setAlignment(
+            forget_attacks_details_button, Qt.AlignmentFlag.AlignHCenter
+        )
         TopR_layout_Box.addWidget(tm_attacks_details_button)
+        TopR_layout_Box.setAlignment(
+            tm_attacks_details_button, Qt.AlignmentFlag.AlignHCenter
+        )
 
-        first_layout.addLayout(TopL_layout_Box)
-        first_layout.addLayout(TopR_layout_Box)
+        # Caller-driven evolution trigger (split-panel path): render the evolve
+        # button in the right-hand column and delegate the actual evolution to
+        # the callback. The same friendship master-toggle gating applies.
+        if readiness["ready"] and trigger_evo_callback and show_evolution_ui:
+            translator = services.translator or Translator(language)
+            evolve_text = translator.translate(
+                "evolve_now_button", evo_name=readiness["evo_name"]
+            )
+            evolve_now_button = QPushButton(evolve_text.upper())
+            evolve_now_button.setCursor(Qt.CursorShape.PointingHandCursor)
+            evolve_now_button.setObjectName("evolveNowButton")
 
-        layout.addWidget(name_label)
-        layout.addLayout(first_layout)
-        layout.addWidget(description_label)
+            # Match TM button typography/color exactly, but increase height to 40px
+            evolve_now_button.setFixedHeight(40)
+            evolve_now_button.setStyleSheet("""
+                QPushButton {
+                    background: qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 #2563eb, stop:1 #1d4ed8);
+                    color: #f8fafc;
+                    font-size: 11px;
+                    font-weight: 800;
+                    letter-spacing: 0.5px;
+                    border: 1px solid #1e40af;
+                    border-radius: 6px;
+                    margin-top: 12px;
+                    padding: 4px 8px;
+                    text-align: center;
+                }
+                QPushButton:hover {
+                    background: qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 #3b82f6, stop:1 #2563eb);
+                    border-color: #3b82f6;
+                    margin-top: 12px;
+                    padding: 4px 8px;
+                    text-align: center;
+                }
+                QPushButton:pressed {
+                    background: #1e40af;
+                    margin-top: 12px;
+                    padding: 5px 8px 3px 8px;
+                    text-align: center;
+                }
+            """)
+            qconnect(
+                evolve_now_button.clicked,
+                lambda: trigger_evo_callback(readiness["method"]),
+            )
+            TopR_layout_Box.addWidget(evolve_now_button)
+
+        TopR_widget = QWidget()
+        TopR_widget.setLayout(TopR_layout_Box)
+        TopR_widget.setFixedWidth(240)
+
+        first_layout.addLayout(TopL_layout_Box, 1)
+        first_layout.addWidget(TopR_widget)
+
+        # Create container widgets for split parts
+        header_widget = QWidget()
+        header_layout = QVBoxLayout(header_widget)
+        header_layout.addWidget(name_label)
+        header_layout.addLayout(first_layout)
+        header_layout.addWidget(description_label)
 
         # Create tabbed widget for Stats / IV / EV
         stats_tabs = QTabWidget()
@@ -446,8 +635,6 @@ def PokemonCollectionDetails(
         stats_tabs.setCurrentIndex(initial_tab_index)
         if tab_changed_callback:
             stats_tabs.currentChanged.connect(tab_changed_callback)
-
-        layout.addWidget(stats_tabs)
 
         free_pokemon_button = QPushButton("Release Pokémon")
         qconnect(
@@ -496,20 +683,115 @@ def PokemonCollectionDetails(
         rename_button.adjustSize()
         rename_layout.addWidget(rename_button, 0)
 
-        layout.addLayout(actions_layout)
-        layout.addLayout(rename_layout)
+        # Create container footer widget
+        footer_widget = QWidget()
+        footer_layout = QVBoxLayout(footer_widget)
+        footer_layout.addLayout(actions_layout)
+        footer_layout.addLayout(rename_layout)
 
-        return layout
+        # Return the split components and the newly calculated stats dict
+        return header_widget, stats_tabs, footer_widget, _stats_dict
 
     except Exception as e:
         show_warning_with_traceback(
             exception=e, message="Error occured in Pokemon Details Button:"
         )
-        return QVBoxLayout()
+        # Return empty structures on error
+        return QWidget(), QWidget(), QWidget(), {}
+
+
+def PokemonCollectionDetails(
+    name: str,
+    level: int,
+    id: int,
+    shiny: bool,
+    ability: str,
+    type: list[str],
+    detail_stats: dict[Any, Any],
+    attacks: list[str],
+    base_experience: int,
+    growth_rate,
+    ev: dict[str, int],
+    iv: dict[str, int],
+    gender: str,
+    nickname: str,
+    individual_id: str,
+    pokemon_defeated: int,
+    everstone: bool,
+    captured_date: str,
+    language: int,
+    gif_in_collection,
+    remove_levelcap: bool,
+    logger: ShowInfoLogger,
+    refresh_callback,
+    initial_tab_index: int = 0,
+    tab_changed_callback=None,
+    nature: str = "serious",
+    base_stats: dict = None,
+    old_stats: dict = None,
+    friendship: int = 0,
+    evolution_rejected: bool = False,
+    friendship_time_enabled: bool = True,
+    trigger_evo_callback: Callable = None,
+):
+    """Classic single-layout details panel (backward-compatible entrypoint).
+
+    Assembles the split components from :func:`PokemonCollectionDetailsSplit`
+    into one ``QVBoxLayout``, which is what the current PC-box details panel
+    consumes (``setLayout``/``clear_layout``). Callers that place the header,
+    stats tabs and footer independently should use the Split variant directly.
+    """
+    header_widget, stats_tabs, footer_widget, _stats_dict = (
+        PokemonCollectionDetailsSplit(
+            name=name,
+            level=level,
+            id=id,
+            shiny=shiny,
+            ability=ability,
+            type=type,
+            detail_stats=detail_stats,
+            attacks=attacks,
+            base_experience=base_experience,
+            growth_rate=growth_rate,
+            ev=ev,
+            iv=iv,
+            gender=gender,
+            nickname=nickname,
+            individual_id=individual_id,
+            pokemon_defeated=pokemon_defeated,
+            everstone=everstone,
+            captured_date=captured_date,
+            language=language,
+            gif_in_collection=gif_in_collection,
+            remove_levelcap=remove_levelcap,
+            logger=logger,
+            refresh_callback=refresh_callback,
+            initial_tab_index=initial_tab_index,
+            tab_changed_callback=tab_changed_callback,
+            nature=nature,
+            base_stats=base_stats,
+            old_stats=old_stats,
+            friendship=friendship,
+            evolution_rejected=evolution_rejected,
+            friendship_time_enabled=friendship_time_enabled,
+            trigger_evo_callback=trigger_evo_callback,
+        )
+    )
+    layout = QVBoxLayout()
+    layout.addWidget(header_widget)
+    layout.addWidget(stats_tabs)
+    layout.addWidget(footer_widget)
+    return layout
 
 
 def PokemonDetailsStats(
-    detail_stats, growth_rate, level, remove_levelcap, language, friendship_bar_max=400
+    detail_stats,
+    growth_rate,
+    level,
+    remove_levelcap,
+    language,
+    friendship_bar_max=400,
+    old_stats=None,
 ):
     CompleteTable_layout = QVBoxLayout()
     CompleteTable_layout.addSpacing(15)
@@ -545,6 +827,30 @@ def PokemonDetailsStats(
         "friendship": "Friendship",
     }
 
+    # 1. Query the max level in the player's collection to dynamically scale
+    #    the visual baseline.
+    max_level = 100
+    try:
+        cursor = services.db.execute("SELECT MAX(level) FROM captured_pokemon")
+        row = cursor.fetchone()
+        if row and row[0] is not None:
+            max_level = int(row[0])
+    except Exception:
+        # Headless/registry-less callers keep the default baseline.
+        pass
+
+    # 2. Get the maximum stat of the currently selected Pokémon (handles manual
+    #    DB/JSON stat edits).
+    core_stats = ["hp", "atk", "def", "spa", "spd", "spe"]
+    current_max_stat = (
+        max(detail_stats.get(s, 0) for s in core_stats)
+        if any(s in detail_stats for s in core_stats)
+        else 0
+    )
+
+    # 3. Determine unified global maximum for this database context
+    global_max_stat = max(750, max_level * 7.5, current_max_stat)
+
     for row, (stat, value) in enumerate(detail_stats.items()):
         # Skip unknown stats that are not in stat_colors
         if stat not in stat_colors:
@@ -558,12 +864,13 @@ def PokemonDetailsStats(
             Qt.AlignmentFlag.AlignLeft | Qt.AlignmentFlag.AlignVCenter
         )
 
-        # Friendship is uncapped (it keeps climbing past the bar's threshold as a
-        # "flex" stat), so a full bar alone is ambiguous. Mark the value with a ✓
-        # once it has met/exceeded the threshold the bar fills at, so the player
-        # can tell "full bar" means "requirement met" rather than just a high
-        # number that happens to be clipped. Coerce defensively: a legacy/None
-        # friendship must not blank out the whole details panel.
+        # Friendship is uncapped (it keeps climbing past the bar's threshold as
+        # a "flex" stat), so a full bar alone is ambiguous. Mark the value with
+        # a ✓ once it has met/exceeded the threshold the bar fills at, so the
+        # player can tell "full bar" means "requirement met" rather than just a
+        # high number that happens to be clipped. Coerce defensively: a
+        # legacy/None friendship must not blank out the whole details panel.
+        friendship_value = 0
         if stat == "friendship":
             try:
                 friendship_value = int(value)
@@ -582,24 +889,58 @@ def PokemonDetailsStats(
         value_item2.setAlignment(
             Qt.AlignmentFlag.AlignRight | Qt.AlignmentFlag.AlignVCenter
         )
-        # Create a bar item
-        bar_item2 = QLabel()
+
+        # Map the previous value (if any) so the bar can slide from it.
+        if old_stats and stat in old_stats:
+            old_val = old_stats[stat]
+            if stat == "xp":
+                experience = int(find_experience_for_level(growth_rate, level, True))
+                old_val_mapped = int(
+                    (int(old_val) / int(experience)) * max_width_stat_item
+                )
+            elif stat == "friendship":
+                try:
+                    old_friendship = int(old_val)
+                except (TypeError, ValueError):
+                    old_friendship = 0
+                # Bar reads 100% exactly at the evolution threshold (bar_max).
+                old_val_mapped = min(
+                    max_width_stat_item,
+                    int(
+                        (old_friendship / max(1, friendship_bar_max))
+                        * max_width_stat_item
+                    ),
+                )
+            else:
+                old_val_mapped = int(
+                    (math.sqrt(max(0, old_val)) / math.sqrt(global_max_stat))
+                    * max_width_stat_item
+                )
+        else:
+            old_val_mapped = 0
+
         if stat == "xp":
             experience = int(find_experience_for_level(growth_rate, level, True))
-            value = int((int(value) / int(experience)) * max_width_stat_item)
+            new_val_mapped = int((int(value) / int(experience)) * max_width_stat_item)
         elif stat == "friendship":
             # Bar reads 100% exactly at the evolution threshold (bar_max).
-            value = min(
+            new_val_mapped = min(
                 max_width_stat_item,
-                int((friendship_value / max(1, friendship_bar_max)) * max_width_stat_item),
+                int(
+                    (friendship_value / max(1, friendship_bar_max))
+                    * max_width_stat_item
+                ),
             )
         else:
-            value = int(max_width_stat_item * (1 - exp(-value / max_width_stat_item)))
-        pixmap2 = createStatBar(stat_colors.get(stat), value)
-        # Convert the QPixmap to an QIcon
-        icon = QIcon(pixmap2)
-        # Set the QIcon as the background for the QLabel
-        bar_item2.setPixmap(pixmap2)
+            new_val_mapped = int(
+                (math.sqrt(max(0, value)) / math.sqrt(global_max_stat))
+                * max_width_stat_item
+            )
+
+        bar_item2 = AnimatedStatBar(
+            stat_colors.get(stat), old_val_mapped, new_val_mapped
+        )
+
         layout_row = QHBoxLayout()
         layout_row.setContentsMargins(0, 0, 0, 0)  # Tight layout
         layout_row.addStretch()  # Add stretch padding at start (Centers the content)
@@ -609,34 +950,60 @@ def PokemonDetailsStats(
         layout_row.addWidget(bar_item2)
         layout_row.addStretch()  # Ensure alignment logic is identical
         stat_item2.setAlignment(Qt.AlignmentFlag.AlignCenter)
-        bar_item2.setAlignment(Qt.AlignmentFlag.AlignCenter)
         CompleteTable_layout.addLayout(layout_row)
 
     return CompleteTable_layout
 
 
+class AnimatedStatBar(QWidget):
+    def __init__(self, color: QColor, old_value: float, new_value: float, parent=None):
+        super().__init__(parent)
+        self.setFixedSize(200, 10)
+        self._color = color if color else QColor(128, 128, 128)
+        self._current_value = float(old_value)
+        self.new_value = float(new_value)
+
+        # Ensure values don't exceed max width
+        if self._current_value > 200:
+            self._current_value = 200
+        if self.new_value > 200:
+            self.new_value = 200
+
+        self.animation = QPropertyAnimation(self, b"current_value")
+        self.animation.setDuration(800)  # 800ms for a smooth slide
+        self.animation.setEasingCurve(QEasingCurve.Type.OutCubic)
+        self.animation.setStartValue(self._current_value)
+        self.animation.setEndValue(self.new_value)
+        self.animation.start()
+
+    @pyqtProperty(float)
+    def current_value(self):
+        return self._current_value
+
+    @current_value.setter
+    def current_value(self, val):
+        self._current_value = val
+        self.update()
+
+    def paintEvent(self, event):
+        painter = QPainter(self)
+        painter.setRenderHint(QPainter.RenderHint.Antialiasing)
+
+        # Background bar
+        painter.setPen(Qt.PenStyle.NoPen)
+        painter.setBrush(QColor(0, 0, 0, 200))  # Semi-transparent black
+        painter.drawRoundedRect(0, 0, 200, 10, 3, 3)
+
+        # Foreground colored bar
+        painter.setBrush(self._color)
+        painter.drawRoundedRect(0, 0, int(self._current_value), 10, 3, 3)
+
+
 def createStatBar(color, value):
-    pixmap = QPixmap(200, 10)
-    pixmap.fill(QColor(0, 0, 0, 0))  # RGBA where A (alpha) is 0 for full transparency
-
-    # Default to gray if color is None
-    if color is None:
-        color = QColor(128, 128, 128)  # Gray
-
-    painter = QPainter(pixmap)
-    painter.setRenderHint(QPainter.RenderHint.Antialiasing)
-
-    # Draw bar in the background
-    painter.setPen(Qt.PenStyle.NoPen)
-    painter.setBrush(QColor(0, 0, 0, 200))  # Semi-transparent black
-    painter.drawRoundedRect(0, 0, 200, 10, 3, 3)
-
-    # Draw the colored bar based on the value
-    painter.setBrush(color)  # Now color is guaranteed to be a valid QColor
-    painter.drawRoundedRect(0, 0, value, 10, 3, 3)
-
-    painter.end()  # Important: end the painter to avoid memory leaks
-    return pixmap
+    # Fallback for non-animated uses: a static bar is an animation whose start
+    # and end values coincide.
+    bar = AnimatedStatBar(color, value, value)
+    return bar
 
 
 def create_iv_ev_tab_layout(
@@ -789,8 +1156,6 @@ class RadarChart(QWidget):
         label_font.setBold(True)
         painter.setFont(label_font)
 
-        font_metrics = painter.fontMetrics()
-
         for i, key in enumerate(self.stat_keys):
             angle_deg = -90 + (i * 60)
             angle_rad = math.radians(angle_deg)
@@ -903,7 +1268,9 @@ def attack_details_window(attacks):
     window.exec()
 
 
-def remember_attack_details_window(individual_id, attack_set, all_attacks, logger):
+def remember_attack_details_window(
+    individual_id, attack_set, all_attacks, logger, refresh_callback=None
+):
     window = QDialog()
     window.setWindowIcon(QIcon(str(icon_path)))
     outer_layout = QVBoxLayout(window)
@@ -935,7 +1302,7 @@ def remember_attack_details_window(individual_id, attack_set, all_attacks, logge
         qconnect(
             remember_attack_button.clicked,
             lambda checked, a=attack: remember_attack(
-                individual_id, attack_set, a, logger
+                individual_id, attack_set, a, logger, refresh_callback
             ),
         )
         attack_layout.addWidget(remember_attack_button)
@@ -950,15 +1317,19 @@ def remember_attack_details_window(individual_id, attack_set, all_attacks, logge
 
 
 def forget_attack_details_window(
-    individual_id: int, attack_set: list[str], logger: "InfoLogger.ShowInfoLogger"
+    individual_id: int,
+    attack_set: list[str],
+    logger: "ShowInfoLogger",
+    refresh_callback=None,
 ) -> None:
     """
     Creates a window that will allow the user to erase moves from a Pokemon.
 
     Args:
-        id (int): The Pokemon's identifier.
+        individual_id (int): The Pokemon's identifier.
         attack_set (list[str]): The Pokemon's move set.
         logger: Logger object that can log info and display windows containing messages.
+        refresh_callback: Optional callable invoked after a move is forgotten.
 
     Returns:
         None
@@ -995,7 +1366,7 @@ def forget_attack_details_window(
         qconnect(
             forget_attack_button.clicked,
             lambda checked, a=attack: forget_attack(
-                individual_id, attack_set, a, logger
+                individual_id, attack_set, a, logger, refresh_callback
             ),
         )
         attack_layout.addWidget(forget_attack_button)
@@ -1010,11 +1381,15 @@ def forget_attack_details_window(
 
 
 def remember_attack(
-    individual_id: str, attacks: list[str], new_attack: str, logger: ShowInfoLogger
+    individual_id: str,
+    attacks: list[str],
+    new_attack: str,
+    logger: ShowInfoLogger,
+    refresh_callback=None,
 ):
     """Learn a new attack using database."""
-    db = mw.ankimon_db
-    
+    db = services.db
+
     if new_attack in attacks:
         logger.log_and_showinfo("warning", "Your pokemon already knows this move!")
         return
@@ -1038,12 +1413,14 @@ def remember_attack(
                 try:
                     index_to_replace = attacks.index(selected_attack)
                     attacks[index_to_replace] = new_attack
-                    logger.log_and_showinfo("info", f"Replaced '{selected_attack}' with '{new_attack}'")
+                    logger.log_and_showinfo(
+                        "info", f"Replaced '{selected_attack}' with '{new_attack}'"
+                    )
                 except ValueError:
                     logger.log_and_showinfo("info", f"{new_attack} will be discarded.")
             else:
                 logger.log_and_showinfo("info", f"{new_attack} will be discarded.")
-    
+
     pokemon_data["attacks"] = attacks
     db.save_pokemon(pokemon_data)
 
@@ -1053,15 +1430,19 @@ def remember_attack(
         main_pokemon["attacks"] = attacks
         db.save_main_pokemon(main_pokemon)
 
+    if refresh_callback:
+        refresh_callback()
+
 
 def forget_attack(
     individual_id: int,
     attacks: list[str],
     attack_to_forget: str,
     logger: ShowInfoLogger,
+    refresh_callback=None,
 ) -> None:
     """Forget a move using database."""
-    db = mw.ankimon_db
+    db = services.db
 
     pokemon_data = db.get_pokemon(individual_id)
     if not pokemon_data:
@@ -1080,7 +1461,7 @@ def forget_attack(
     else:
         msg = f"Your {pokemon_data['name'].capitalize()} does not know {attack_to_forget}."
         logger.log_and_showinfo("info", f"{msg}")
-    
+
     pokemon_data["attacks"] = attacks
     db.save_pokemon(pokemon_data)
 
@@ -1090,110 +1471,82 @@ def forget_attack(
         main_pokemon["attacks"] = attacks
         db.save_main_pokemon(main_pokemon)
 
+    if refresh_callback:
+        refresh_callback()
+
 
 def tm_attack_details_window(
     id: int,
     individual_id: str,
     current_pokemon_moveset: list[str],
     logger: ShowInfoLogger,
+    refresh_callback=None,
 ) -> None:
     """
     Creates a window that will allow the user to learn TM moves.
-
-    Args:
-        id (int): The Pokemon's identifier.
-        individual_id (str): The Pokemon's unique identifier.
-        current_pokemon_moveset (list[str]): The moves that the Pokemon currently knows.
-        logger: Logger object that can log info and display windows containing messages.
-
-    Returns:
-        None
     """
-    window = QDialog()
-    window.setWindowIcon(QIcon(str(icon_path)))
-    layout = QHBoxLayout()
-    window.setWindowTitle("Learn TM Move")  # Optional: Set a window title
-    # Outer layout contains everything
-    outer_layout = QVBoxLayout(window)
+    from ..pyobj.move_picker import MovePickerDialog
 
-    # Create a scroll area that will contain our main layout
-    scroll_area = QScrollArea()
-    scroll_area.setWidgetResizable(True)
+    # 1. Get species/base name for TM lookup
+    internal_name = search_pokedex_by_id(id)
+    if not internal_name:
+        logger.log_and_showinfo("error", f"Could not find Pokémon data for ID: {id}")
+        return
 
-    # Main widget that contains the content
-    content_widget = QWidget()
-    layout = QHBoxLayout(content_widget)  # The main layout is now set on this widget
+    base_name = internal_name.split("-")[0].lower()
+    internal_name = internal_name.lower()
 
-    # HTML content
-    html_content = remember_attack_details_window_template
-    from pathlib import Path
+    # 2. Load TM learnsets
+    try:
+        with open(pokemon_tm_learnset_path, "r", encoding="utf-8") as f:
+            tm_learnsets = json.load(f)
+    except Exception as e:
+        logger.log_and_showinfo("error", f"Failed to load TM learnsets: {e}")
+        return
 
-    with open(pokemon_tm_learnset_path, "r") as f:
-        pokemon_tm_learnset = json.load(f)
+    # 3. Get valid TMs for this species (check specific form then base species)
+    valid_tms = tm_learnsets.get(internal_name) or tm_learnsets.get(base_name)
+    if not valid_tms:
+        logger.log_and_showinfo("info", "This Pokémon cannot learn any moves from TMs.")
+        return
 
-    pokemon_name = search_pokedex_by_id(id)
-    tm_learnset = pokemon_tm_learnset.get(
-        pokemon_name, []
-    )  # TMs that can be learnt by the Pokemon
-    
-    # Get owned TMs from database
-    db = mw.ankimon_db
+    # 4. Get owned TMs from DB
+    db = services.db
     all_items = db.get_all_items()
-    owned_tms = [item["item_name"] for item in all_items if (item.get("extra_data") or {}).get("type") == "TM"]
-    attack_set = [tm for tm in tm_learnset if tm in owned_tms]
+    owned_tm_moves = [
+        item["item_name"]
+        for item in all_items
+        if (item.get("extra_data") or {}).get("type") == "TM"
+    ]
 
-    # Loop through the list of attacks and add them to the HTML content
-    for attack in attack_set:
-        move = find_details_move(attack) or _lookup_move_data(attack)
-        display_name = format_move_name(attack)
-
-        html_content += f"""
-        <tr>
-          <td class="move-name">{display_name}</td>
-          <td><img src="{type_icon_path(move["type"])}" alt="{move["type"]}"/></td>
-          <td><img src="{move_category_path(move["category"].lower())}" alt="{move["category"]}"/></td>
-          <td class="basePower">{move["basePower"]}</td>
-          <td class="no-accuracy">{move["accuracy"]}</td>
-          <td>{move["pp"]}</td>
-          <td>{move["shortDesc"]}</td>
-        </tr>
-        """
-
-    html_content += remember_attack_details_window_template_end
-
-    # Create a QLabel to display the HTML content
-    label = QLabel(html_content)
-    label.setAlignment(
-        Qt.AlignmentFlag.AlignLeft
-    )  # Align the label's content to the top
-    label.setScaledContents(True)  # Enable scaling of the pixmap
-    attack_layout = QVBoxLayout()
-    for attack in attack_set:
-        move = find_details_move(attack)
-        learn_attack_button = QPushButton(f"Learn {attack}")  # add Details to Moves
-        learn_attack_button.clicked.connect(
-            lambda checked, a=attack: (
-                remember_attack(  # We can use "remember_attack()" because the process is the same
-                    individual_id, current_pokemon_moveset, a, logger
-                )
-            )
+    # 5. Filter valid TMs by ownership
+    learnable_tm_moves = [move for move in valid_tms if move in owned_tm_moves]
+    if not learnable_tm_moves:
+        logger.log_and_showinfo(
+            "info", "You don't own any TMs that this Pokémon can learn."
         )
-        attack_layout.addWidget(learn_attack_button)
-    attack_layout_widget = QWidget()
-    attack_layout_widget.setLayout(attack_layout)
-    # Add the label and button layout widget to the main layout
-    layout.addWidget(label)
-    layout.addWidget(attack_layout_widget)
+        return
 
-    # Set the main widget with content as the scroll area's widget
-    scroll_area.setWidget(content_widget)
+    # 6. UI: Use MovePickerDialog
+    pkmn_data = db.get_pokemon(individual_id)
+    nickname = pkmn_data.get("nickname") if pkmn_data else None
+    raw_name = pkmn_data.get("name") if pkmn_data else internal_name
+    species_name = get_pretty_name_for_name(raw_name)
 
-    # Add the scroll area to the outer layout
-    outer_layout.addWidget(scroll_area)
+    title = f"TM Learning: {nickname if nickname else species_name}"
+    dialog = MovePickerDialog(title, learnable_tm_moves, current_pokemon_moveset)
+    dialog.setWindowTitle("Learn from TMs")
 
-    window.setLayout(outer_layout)
-    window.resize(1000, 400)  # Optional: Set a default size for the window
-    window.exec()
+    if dialog.exec():
+        new_move = dialog.get_selected_move()
+        if new_move:
+            remember_attack(
+                individual_id,
+                current_pokemon_moveset,
+                new_move,
+                logger,
+                refresh_callback,
+            )
 
 
 def rename_pkmn(
@@ -1204,8 +1557,8 @@ def rename_pkmn(
     refresh_callback,
 ):
     """Rename a pokemon using database."""
-    db = mw.ankimon_db
-    
+    db = services.db
+
     try:
         pokemon = db.get_pokemon(individual_id)
         if pokemon is not None:
@@ -1217,18 +1570,16 @@ def rename_pkmn(
             )
             refresh_callback()
         else:
-            showWarning("Pokémon not found.")
+            services.ui.warn("Pokémon not found.")
     except Exception as e:
-        show_warning_with_traceback(
-            parent=mw, exception=e, message=f"An error occurred: {e}"
-        )
+        show_warning_with_traceback(exception=e, message=f"An error occurred: {e}")
 
 
 def PokemonFree(
     individual_id: str, name: str, logger: ShowInfoLogger, refresh_callback
 ):
     """Release a pokemon using database."""
-    
+
     # Confirmation dialog
     reply = QMessageBox.question(
         None,
@@ -1242,14 +1593,16 @@ def PokemonFree(
         logger.log_and_showinfo("info", "Release cancelled.")
         return
 
+    db = services.db
+
     # Check if the Pokémon is the main pokemon
-    main_pokemon = mw.ankimon_db.get_main_pokemon()
+    main_pokemon = db.get_main_pokemon()
     if main_pokemon and main_pokemon.get("individual_id") == individual_id:
         logger.log_and_showinfo("info", "You can't free your Main Pokémon!")
         return
 
     # Get the pokemon from database
-    pokemon_to_release = mw.ankimon_db.get_pokemon(individual_id)
+    pokemon_to_release = db.get_pokemon(individual_id)
     if not pokemon_to_release:
         logger.log_and_showinfo("info", "No Pokémon found with the specified ID.")
         refresh_callback()
@@ -1257,31 +1610,34 @@ def PokemonFree(
 
     # Save important stats to history before release
     from datetime import datetime
+
     history_data = {
         "id": pokemon_to_release.get("id"),
         "name": pokemon_to_release.get("name"),
         "shiny": pokemon_to_release.get("shiny", False),
         "pokemon_defeated": pokemon_to_release.get("pokemon_defeated", 0),
         "individual_id": pokemon_to_release.get("individual_id"),
-        "released_date": datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+        "released_date": datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
     }
-    
+
     # Add to history via database
-    if mw.ankimon_db.add_to_history(history_data):
+    if db.add_to_history(history_data):
         pass  # Success
     else:
         logger.log_and_showinfo("error", f"Failed to add {name} to history.")
-    
+
     # If this Pokémon is the current XP-Share target, clear the setting before
     # it disappears from the DB. Otherwise the dangling individual_id would make
     # xp_share_gain_exp look up a now-missing Pokémon and crash on the next
     # review. str() guards against any id type mismatch in the compare.
-    settings_obj = getattr(mw, "settings_obj", None)
-    if settings_obj is not None and str(settings_obj.get("trainer.xp_share")) == str(individual_id):
+    settings_obj = services.settings
+    if settings_obj is not None and str(settings_obj.get("trainer.xp_share")) == str(
+        individual_id
+    ):
         settings_obj.set("trainer.xp_share", None)
 
     # Delete from database
-    mw.ankimon_db.delete_pokemon(individual_id)
+    db.delete_pokemon(individual_id)
     logger.log_and_showinfo("info", f"{name.capitalize()} has been let free.")
 
     refresh_callback()

--- a/src/Ankimon/gui_entities.py
+++ b/src/Ankimon/gui_entities.py
@@ -1,15 +1,39 @@
 import markdown
 import json
 from PyQt6.QtGui import QMovie, QIcon
-from PyQt6.QtWidgets import QLabel, QVBoxLayout, QTextEdit, QCheckBox, QPushButton, QMessageBox, QWidget, QScrollArea, QGridLayout, QTextBrowser
+from PyQt6.QtWidgets import (
+    QLabel,
+    QVBoxLayout,
+    QTextEdit,
+    QCheckBox,
+    QPushButton,
+    QMessageBox,
+    QWidget,
+    QScrollArea,
+    QGridLayout,
+    QTextBrowser,
+)
 from aqt import mw
 from aqt.qt import QDialog, qconnect
 from aqt.utils import showWarning, showInfo, tooltip
 from PyQt6.QtCore import Qt
 
-from .resources import icon_path, addon_dir, eff_chart_html_path, table_gen_id_html_path, mypokemon_path
+from .resources import (
+    icon_path,
+    addon_dir,
+    eff_chart_html_path,
+    table_gen_id_html_path,
+    nature_chart_html_path,
+    mypokemon_path,
+)
 from .texts import terms_text, pokedex_html_template
-from .utils import read_local_file, read_github_file, compare_files, write_local_file, read_html_file
+from .utils import (
+    read_local_file,
+    read_github_file,
+    compare_files,
+    write_local_file,
+    read_html_file,
+)
 from .pyobj.error_handler import show_warning_with_traceback
 
 
@@ -27,8 +51,10 @@ class MovieSplashLabel(QLabel):
     def hideEvent(self, event):
         self.movie.stop()
 
+
 class UpdateNotificationWindow(QDialog):
     """Custom Dialog class with enhanced features."""
+
     def __init__(self, content, is_markdown=False):
         super().__init__()
         self.setWindowTitle("Ankimon Notifications")
@@ -37,12 +63,17 @@ class UpdateNotificationWindow(QDialog):
         layout = QVBoxLayout()
         self.text_browser = QTextBrowser()
         self.text_browser.setOpenExternalLinks(True)  # Enable clickable links
-        self.text_browser.setVerticalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAlwaysOn)
-        self.text_browser.setHorizontalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
+        self.text_browser.setVerticalScrollBarPolicy(
+            Qt.ScrollBarPolicy.ScrollBarAlwaysOn
+        )
+        self.text_browser.setHorizontalScrollBarPolicy(
+            Qt.ScrollBarPolicy.ScrollBarAlwaysOff
+        )
 
         # If content is markdown, convert to HTML
         if is_markdown:
             import markdown
+
             html_content = markdown.markdown(content)
         else:
             html_content = content
@@ -55,6 +86,7 @@ class UpdateNotificationWindow(QDialog):
     def open(self):
         self.exec()
 
+
 class AgreementDialog(QDialog):
     def __init__(self):
         super().__init__()
@@ -62,13 +94,15 @@ class AgreementDialog(QDialog):
         # Setup the dialog layout
         layout = QVBoxLayout()
         # Add a label with the warning message
-        title = QLabel("""Please agree to the terms before downloading the information:""")
+        title = QLabel(
+            """Please agree to the terms before downloading the information:"""
+        )
         subtitle = QLabel("""Terms and Conditions Clause""")
         terms = QLabel(terms_text)
         layout.addWidget(title)
         layout.addWidget(subtitle)
         layout.addWidget(terms)
-         # Ensure the terms QLabel is readable and scrolls if necessary
+        # Ensure the terms QLabel is readable and scrolls if necessary
         terms.setWordWrap(True)
         terms.setAlignment(Qt.AlignmentFlag.AlignLeft)
         title.setAlignment(Qt.AlignmentFlag.AlignCenter)
@@ -88,10 +122,14 @@ class AgreementDialog(QDialog):
         if self.checkbox.isChecked():
             self.accept()  # Close the dialog and return success
         else:
-            QMessageBox.warning(self, "Agreement Required", "You must agree to the terms to proceed.")
+            QMessageBox.warning(
+                self, "Agreement Required", "You must agree to the terms to proceed."
+            )
+
 
 class Version_Dialog(QDialog):
     """Custom Dialog class"""
+
     def __init__(self):
         super().__init__()
         self.setWindowTitle("Ankimon Notifications")
@@ -99,30 +137,40 @@ class Version_Dialog(QDialog):
         layout = QVBoxLayout()
         self.text_browser = QTextBrowser()
         self.text_browser.setOpenExternalLinks(True)  # Enable clickable links
-        self.text_browser.setVerticalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAlwaysOn)
-        self.text_browser.setHorizontalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
-        self.local_file_path = addon_dir / "updateinfos.md"
-        self.local_content = read_local_file(self.local_file_path)
-        self.html_content = markdown.markdown(self.local_content)
-        self.text_browser.setHtml(self.html_content)
+        self.text_browser.setVerticalScrollBarPolicy(
+            Qt.ScrollBarPolicy.ScrollBarAlwaysOn
+        )
+        self.text_browser.setHorizontalScrollBarPolicy(
+            Qt.ScrollBarPolicy.ScrollBarAlwaysOff
+        )
         layout.addWidget(self.text_browser)
         self.setWindowIcon(QIcon(str(icon_path)))
         self.setLayout(layout)
+        self.loaded = False
 
     def open(self):
+        if not self.loaded:
+            self.local_file_path = addon_dir / "updateinfos.md"
+            self.local_content = read_local_file(self.local_file_path) or ""
+            self.html_content = markdown.markdown(self.local_content)
+            self.text_browser.setHtml(self.html_content)
+            self.loaded = True
         self.exec()
+
 
 class License(QWidget):
     def __init__(self):
         super().__init__()
-        self.initUI()
+        self.initialized = False
 
     def initUI(self):
         self.setWindowTitle("AnkiMon License")
 
         # Create a label and set HTML content
         label = QLabel()
-        html_content = self.read_html_file(f"{addon_dir}/license.html")  # Replace with the path to your HTML file
+        html_content = self.read_html_file(
+            f"{addon_dir}/license.html"
+        )  # Replace with the path to your HTML file
         # Create a QScrollArea to enable scrolling
         scroll_area = QScrollArea()
         scroll_area.setWidgetResizable(True)
@@ -136,7 +184,7 @@ class License(QWidget):
         label.setText(html_content)  # 'html_table' contains the HTML table string
         label.setWordWrap(True)
 
-        #layout = QVBoxLayout()
+        # layout = QVBoxLayout()
         scroll_layout.addWidget(label)
         # Set the widget for the scroll area
         scroll_area.setWidget(container)
@@ -151,24 +199,32 @@ class License(QWidget):
         window_layout = QVBoxLayout()
         window_layout.addWidget(scroll_area)
         self.setLayout(window_layout)
+        self.initialized = True
+
     def read_html_file(self, file_path):
         """Reads an HTML file and returns its content as a string."""
-        with open(file_path, 'r', encoding='utf-8') as file:
+        with open(file_path, "r", encoding="utf-8") as file:
             return file.read()
+
     def show_window(self):
+        if not self.initialized:
+            self.initUI()
         self.show()
+
 
 class Credits(QWidget):
     def __init__(self):
         super().__init__()
-        self.initUI()
+        self.initialized = False
 
     def initUI(self):
         self.setWindowTitle("AnkiMon License")
 
         # Create a label and set HTML content
         label = QLabel()
-        html_content = self.read_html_file(f"{addon_dir}/credits.html")  # Replace with the path to your HTML file
+        html_content = self.read_html_file(
+            f"{addon_dir}/credits.html"
+        )  # Replace with the path to your HTML file
         # Create a QScrollArea to enable scrolling
         scroll_area = QScrollArea()
         scroll_area.setWidgetResizable(True)
@@ -182,7 +238,7 @@ class Credits(QWidget):
         label.setText(html_content)  # 'html_table' contains the HTML table string
         label.setWordWrap(True)
 
-        #layout = QVBoxLayout()
+        # layout = QVBoxLayout()
         scroll_layout.addWidget(label)
         # Set the widget for the scroll area
         scroll_area.setWidget(container)
@@ -197,12 +253,18 @@ class Credits(QWidget):
         window_layout = QVBoxLayout()
         window_layout.addWidget(scroll_area)
         self.setLayout(window_layout)
+        self.initialized = True
+
     def read_html_file(self, file_path):
         """Reads an HTML file and returns its content as a string."""
-        with open(file_path, 'r', encoding='utf-8') as file:
+        with open(file_path, "r", encoding="utf-8") as file:
             return file.read()
+
     def show_window(self):
+        if not self.initialized:
+            self.initUI()
         self.show()
+
 
 class HelpWindow(QDialog):
     def __init__(self, online_connectivity):
@@ -218,7 +280,9 @@ class HelpWindow(QDialog):
                 local_content = read_local_file(help_local_file_path)
                 # Read content from GitHub
                 github_content = read_github_file(help_github_url)
-                if local_content is not None and compare_files(local_content, github_content):
+                if local_content is not None and compare_files(
+                    local_content, github_content
+                ):
                     html_content = github_content
                 else:
                     # Download new content from GitHub
@@ -234,7 +298,11 @@ class HelpWindow(QDialog):
                 local_content = read_local_file(help_local_file_path)
                 html_content = local_content
         except Exception as e:
-            show_warning_with_traceback(parent=mw, exception=e, message="Failed to retrieve Ankimon HelpGuide from GitHub.")
+            show_warning_with_traceback(
+                parent=mw,
+                exception=e,
+                message="Failed to retrieve Ankimon HelpGuide from GitHub.",
+            )
             local_content = read_local_file(help_local_file_path)
             html_content = local_content
         self.setWindowTitle("Ankimon HelpGuide")
@@ -244,54 +312,143 @@ class HelpWindow(QDialog):
         self.text_edit = QTextEdit()
         self.text_edit.setReadOnly(True)
         self.text_edit.setVerticalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAlwaysOn)
-        self.text_edit.setHorizontalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
+        self.text_edit.setHorizontalScrollBarPolicy(
+            Qt.ScrollBarPolicy.ScrollBarAlwaysOff
+        )
         self.text_edit.setHtml(html_content)
         layout.addWidget(self.text_edit)
         self.setWindowIcon(QIcon(str(icon_path)))
         self.setLayout(layout)
 
+
 class TableWidget(QWidget):
     def __init__(self):
         super().__init__()
-        self.initUI()
+        self.initialized = False
 
     def initUI(self):
         self.setWindowTitle("Pokémon Type Effectiveness Table")
+        self.setGeometry(100, 100, 800, 600)
 
         # Create a label and set HTML content
         label = QLabel()
-        html_content = read_html_file(f"{eff_chart_html_path}")  # Replace with the path to your HTML file
-        label.setText(html_content)  # 'html_table' contains the HTML table string
+        html_content = read_html_file(f"{eff_chart_html_path}")
+        label.setText(html_content)
         label.setWordWrap(True)
+        label.setAlignment(Qt.AlignmentFlag.AlignTop | Qt.AlignmentFlag.AlignHCenter)
+        label.setStyleSheet("background-color: rgb(44,44,44); padding: 10px;")
 
-        # Layout
+        # Create a scroll area
+        scroll_area = QScrollArea()
+        scroll_area.setWidgetResizable(True)
+        scroll_area.setStyleSheet("background-color: rgb(44,44,44); border: none;")
+
+        # Container widget for the label
+        container = QWidget()
+        container_layout = QVBoxLayout()
+        container_layout.addWidget(label)
+        container.setLayout(container_layout)
+
+        scroll_area.setWidget(container)
+
+        # Main layout
         layout = QVBoxLayout()
-        layout.addWidget(label)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.addWidget(scroll_area)
         self.setLayout(layout)
+        self.initialized = True
 
     def show_eff_chart(self):
+        if not self.initialized:
+            self.initUI()
         self.show()
+
 
 class IDTableWidget(QWidget):
     def __init__(self):
         super().__init__()
-        self.initUI()
+        self.initialized = False
 
     def initUI(self):
         self.setWindowTitle("Pokémon - Generations and ID")
+        self.setGeometry(100, 100, 800, 600)
+
         # Create a label and set HTML content
         label = QLabel()
-        html_content = read_html_file(f"{table_gen_id_html_path}")  # Replace with the path to your HTML file
-        label.setText(html_content)  # 'html_table' contains the HTML table string
+        html_content = read_html_file(f"{table_gen_id_html_path}")
+        label.setText(html_content)
         label.setWordWrap(True)
-        label.setStyleSheet("background-color: rgb(44,44,44);")
-        # Layout
+        label.setAlignment(Qt.AlignmentFlag.AlignTop | Qt.AlignmentFlag.AlignHCenter)
+        label.setStyleSheet("background-color: rgb(44,44,44); padding: 10px;")
+
+        # Create a scroll area
+        scroll_area = QScrollArea()
+        scroll_area.setWidgetResizable(True)
+        scroll_area.setStyleSheet("background-color: rgb(44,44,44); border: none;")
+
+        # Container widget for the label
+        container = QWidget()
+        container_layout = QVBoxLayout()
+        container_layout.addWidget(label)
+        container.setLayout(container_layout)
+
+        scroll_area.setWidget(container)
+
+        # Main layout
         layout = QVBoxLayout()
-        layout.addWidget(label)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.addWidget(scroll_area)
         self.setLayout(layout)
+        self.initialized = True
 
     def show_gen_chart(self):
+        if not self.initialized:
+            self.initUI()
         self.show()
+
+
+class NatureTableWidget(QWidget):
+    def __init__(self):
+        super().__init__()
+        self.initialized = False
+
+    def initUI(self):
+        self.setWindowTitle("Pokémon Nature Chart")
+        self.setGeometry(100, 100, 650, 500)
+
+        # Create a label and set HTML content
+        label = QLabel()
+        html_content = read_html_file(f"{nature_chart_html_path}")
+        label.setText(html_content)
+        label.setWordWrap(True)
+        label.setAlignment(Qt.AlignmentFlag.AlignTop | Qt.AlignmentFlag.AlignHCenter)
+        label.setStyleSheet("background-color: rgb(44,44,44); padding: 10px;")
+
+        # Create a scroll area
+        scroll_area = QScrollArea()
+        scroll_area.setWidgetResizable(True)
+        scroll_area.setStyleSheet("background-color: rgb(44,44,44); border: none;")
+
+        # Container widget for the label
+        container = QWidget()
+        container_layout = QVBoxLayout()
+        container_layout.addWidget(label)
+        container.setLayout(container_layout)
+
+        scroll_area.setWidget(container)
+
+        # Main layout
+        layout = QVBoxLayout()
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.addWidget(scroll_area)
+        self.setLayout(layout)
+        self.initialized = True
+
+    def show_nature_chart(self):
+        if not self.initialized:
+            self.initUI()
+        self.show()
+
 
 class Pokedex_Widget(QWidget):
     def __init__(self):
@@ -312,12 +469,17 @@ class Pokedex_Widget(QWidget):
         # (self.available_pokedex_ids is fetched in read_poke_coll)
 
         # Now we generate the HTML rows for each Pokémon in the range 1-898, graying out those not in the JSON file
-        table_rows = [self.generate_table_row(i, i not in self.available_pokedex_ids) for i in range(1, 899)]
+        table_rows = [
+            self.generate_table_row(i, i not in self.available_pokedex_ids)
+            for i in range(1, 899)
+        ]
 
         # Combine the HTML template with the generated rows
-        html_content = pokedex_html_template.replace('<!-- Table Rows Will Go Here -->', ''.join(table_rows))
+        html_content = pokedex_html_template.replace(
+            "<!-- Table Rows Will Go Here -->", "".join(table_rows)
+        )
 
-        #html_content = self.read_html_file(f"{pokedex_html_path}")  # Replace with the path to your HTML file
+        # html_content = self.read_html_file(f"{pokedex_html_path}")  # Replace with the path to your HTML file
         label.setText(html_content)  # 'html_table' contains the HTML table string
         label.setWordWrap(True)
 
@@ -328,7 +490,7 @@ class Pokedex_Widget(QWidget):
 
     # Helper function to generate table rows
     def generate_table_row(self, pokedex_number, is_gray):
-        name = f"Pokemon #{pokedex_number}" # Placeholder, actual name should be fetched from a database or API
+        name = f"Pokemon #{pokedex_number}"  # Placeholder, actual name should be fetched from a database or API
         image_class = "pokemon-gray" if is_gray else ""
         return f'''
         <tr>
@@ -341,6 +503,7 @@ class Pokedex_Widget(QWidget):
     def show_pokedex(self):
         self.read_poke_coll()
         self.show()
+
 
 class CheckFiles(QDialog):
     def __init__(self):

--- a/tests/test_gui_entities_nature_chart.py
+++ b/tests/test_gui_entities_nature_chart.py
@@ -1,0 +1,242 @@
+"""Qt characterization tests for the F43 additions to ``gui_entities.py``.
+
+Pins the exp-ported behaviour layered onto main's version of the module:
+
+* ``NatureTableWidget`` — the new nature-chart window backed by the real
+  ``addon_files/nature_chart.html`` asset via ``resources.nature_chart_html_path``.
+* Lazy initialisation (``initialized``/``loaded`` flags, initUI-on-show) for
+  ``TableWidget``/``IDTableWidget``/``License``/``Credits``/``Version_Dialog``
+  so eager singleton construction at startup stays cheap.
+* ``Pokedex_Widget`` stays present: exp deleted it, but main's ``singletons.py``
+  still constructs it, and F43 is not authorized to remove it.
+
+These need real PyQt6 (a QApplication), so they run in the Qt / Tier-2 env; the
+whole module skips cleanly where PyQt6 is absent OR has been mocked in
+``sys.modules`` by another (Tier-1) test file -- mirroring
+``test_move_picker.py``. Run standalone with::
+
+    pytest tests/test_gui_entities_nature_chart.py
+"""
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("PyQt6")  # Qt env only; skipped in the aqt-free Tier-1 env.
+
+
+_MODULE_NAME = "Ankimon.gui_entities"
+_SRC = Path(__file__).parent.parent / "src"
+
+
+@pytest.fixture(autouse=True)
+def _env_guard():
+    """Skip gracefully when another test file has mocked PyQt6 in this run."""
+    from PyQt6.QtWidgets import QDialog
+
+    if not isinstance(QDialog, type):  # PyQt6 was mocked by another test
+        pytest.skip(
+            "real PyQt6 not active (mocked by another test); "
+            "run tests/test_gui_entities_nature_chart.py standalone"
+        )
+
+    if str(_SRC) not in sys.path:
+        sys.path.insert(0, str(_SRC))
+    yield
+
+
+@pytest.fixture
+def gui_entities(qapp):
+    """Load ``gui_entities`` in isolation with aqt/utils/texts stubbed.
+
+    ``Ankimon.resources`` is the REAL module so the widgets read the real
+    shipped HTML assets (nature_chart.html, eff chart, license, credits).
+    """
+    saved = {
+        name: sys.modules.get(name)
+        for name in (
+            "Ankimon",
+            "Ankimon.pyobj",
+            "Ankimon.pyobj.error_handler",
+            "Ankimon.resources",
+            "Ankimon.texts",
+            "Ankimon.utils",
+            "aqt",
+            "aqt.qt",
+            "aqt.utils",
+            "markdown",
+            _MODULE_NAME,
+        )
+    }
+
+    from PyQt6.QtWidgets import QDialog
+
+    for pkg in ("Ankimon", "Ankimon.pyobj"):
+        mod = types.ModuleType(pkg)
+        mod.__path__ = [str(_SRC / pkg.replace(".", "/"))]
+        mod.__package__ = pkg
+        sys.modules[pkg] = mod
+
+    # aqt stub: gui_entities only needs mw (as an error-dialog parent),
+    # QDialog/qconnect and the three notification helpers.
+    aqt_mod = types.ModuleType("aqt")
+    aqt_mod.mw = None
+    aqt_qt = types.ModuleType("aqt.qt")
+    aqt_qt.QDialog = QDialog
+    aqt_qt.qconnect = lambda signal, func: signal.connect(func)
+    aqt_utils = types.ModuleType("aqt.utils")
+    aqt_utils.showWarning = lambda *a, **k: None
+    aqt_utils.showInfo = lambda *a, **k: None
+    aqt_utils.tooltip = lambda *a, **k: None
+    aqt_mod.qt = aqt_qt
+    aqt_mod.utils = aqt_utils
+    sys.modules["aqt"] = aqt_mod
+    sys.modules["aqt.qt"] = aqt_qt
+    sys.modules["aqt.utils"] = aqt_utils
+
+    md = types.ModuleType("markdown")
+    md.markdown = lambda text: f"<p>{text}</p>"
+    sys.modules["markdown"] = md
+
+    # Real resources module (aqt-free) so asset paths are the shipped ones.
+    spec = importlib.util.spec_from_file_location(
+        "Ankimon.resources", _SRC / "Ankimon" / "resources.py"
+    )
+    resources = importlib.util.module_from_spec(spec)
+    sys.modules["Ankimon.resources"] = resources
+    spec.loader.exec_module(resources)
+
+    texts = types.ModuleType("Ankimon.texts")
+    texts.terms_text = "terms"
+    texts.pokedex_html_template = "<!-- Table Rows Will Go Here -->"
+    sys.modules["Ankimon.texts"] = texts
+
+    ut = types.ModuleType("Ankimon.utils")
+
+    def read_html_file(file_path):
+        with open(file_path, "r", encoding="utf-8") as f:
+            return f.read()
+
+    def read_local_file(file_path):
+        try:
+            with open(file_path, "r", encoding="utf-8") as f:
+                return f.read()
+        except FileNotFoundError:
+            return None
+
+    ut.read_html_file = read_html_file
+    ut.read_local_file = read_local_file
+    ut.read_github_file = lambda url: None
+    ut.compare_files = lambda a, b: a == b
+    ut.write_local_file = lambda path, content: None
+    sys.modules["Ankimon.utils"] = ut
+
+    eh = types.ModuleType("Ankimon.pyobj.error_handler")
+
+    def _raise(parent=None, exception=None, message=""):
+        raise AssertionError(f"show_warning_with_traceback called: {message}") from (
+            exception
+        )
+
+    eh.show_warning_with_traceback = _raise
+    sys.modules["Ankimon.pyobj.error_handler"] = eh
+
+    spec = importlib.util.spec_from_file_location(
+        _MODULE_NAME, _SRC / "Ankimon" / "gui_entities.py"
+    )
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[_MODULE_NAME] = module
+    spec.loader.exec_module(module)
+
+    try:
+        yield module
+    finally:
+        for name, val in saved.items():
+            if val is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = val
+
+
+def _label_texts(widget):
+    from PyQt6.QtWidgets import QLabel
+
+    return [lbl.text() for lbl in widget.findChildren(QLabel)]
+
+
+def test_nature_table_widget_is_lazy_and_renders_the_real_asset(gui_entities):
+    w = gui_entities.NatureTableWidget()
+    assert w.initialized is False
+    assert w.layout() is None  # nothing built at construction time
+
+    w.show_nature_chart()
+    try:
+        assert w.initialized is True
+        assert w.windowTitle() == "Pokémon Nature Chart"
+        texts = " ".join(_label_texts(w))
+        # Real addon_files/nature_chart.html content reached the label.
+        assert "Adamant" in texts
+        assert "Boosted Stat (+10%)" in texts
+    finally:
+        w.close()
+
+    # Second show must not rebuild the UI (single scroll area child).
+    from PyQt6.QtWidgets import QScrollArea
+
+    w.show_nature_chart()
+    try:
+        assert len(w.findChildren(QScrollArea)) == 1
+    finally:
+        w.close()
+
+
+def test_eff_and_gen_chart_widgets_init_lazily(gui_entities):
+    eff = gui_entities.TableWidget()
+    gen = gui_entities.IDTableWidget()
+    assert eff.initialized is False
+    assert gen.initialized is False
+
+    eff.show_eff_chart()
+    gen.show_gen_chart()
+    try:
+        assert eff.initialized is True
+        assert eff.windowTitle() == "Pokémon Type Effectiveness Table"
+        assert gen.initialized is True
+        assert gen.windowTitle() == "Pokémon - Generations and ID"
+    finally:
+        eff.close()
+        gen.close()
+
+
+def test_license_and_credits_init_lazily(gui_entities):
+    lic = gui_entities.License()
+    cred = gui_entities.Credits()
+    assert lic.initialized is False
+    assert cred.initialized is False
+
+    lic.show_window()
+    cred.show_window()
+    try:
+        assert lic.initialized is True
+        assert cred.initialized is True
+    finally:
+        lic.close()
+        cred.close()
+
+
+def test_version_dialog_defers_reading_updateinfos(gui_entities):
+    dlg = gui_entities.Version_Dialog()
+    # Construction must not read/convert updateinfos.md (the file is only
+    # written at runtime by changelog.py; eager markdown(None) used to crash).
+    assert dlg.loaded is False
+    assert dlg.text_browser.toPlainText() == ""
+    assert not hasattr(dlg, "local_content")
+
+
+def test_pokedex_widget_still_exists_for_singletons(gui_entities):
+    # exp deleted Pokedex_Widget, but main's singletons.py still constructs it;
+    # F43 keeps it (removal belongs to the Ankidex row).
+    assert hasattr(gui_entities, "Pokedex_Widget")

--- a/tests/test_nature_chart_asset.py
+++ b/tests/test_nature_chart_asset.py
@@ -1,0 +1,76 @@
+"""Tier-1 asset checks for the nature chart (inventory row F43).
+
+``addon_files/nature_chart.html`` is an exp-only static asset consumed by
+``gui_entities.NatureTableWidget.show_nature_chart`` through the
+``resources.nature_chart_html_path`` constant (landed by F38). These tests are
+Qt-free so they run in the aqt-free Tier-1 environment: they pin that the
+shipped asset exists, that the resources constant points at it, and that the
+chart covers all 25 natures.
+"""
+
+from pathlib import Path
+
+# All 25 official natures; the 5 neutral ones are rendered as "--- (Neutral) ---".
+ALL_NATURES = [
+    "Adamant",
+    "Bashful",
+    "Bold",
+    "Brave",
+    "Calm",
+    "Careful",
+    "Docile",
+    "Gentle",
+    "Hardy",
+    "Hasty",
+    "Impish",
+    "Jolly",
+    "Lax",
+    "Lonely",
+    "Mild",
+    "Modest",
+    "Naive",
+    "Naughty",
+    "Quiet",
+    "Quirky",
+    "Rash",
+    "Relaxed",
+    "Sassy",
+    "Serious",
+    "Timid",
+]
+NEUTRAL_NATURES = {"Bashful", "Docile", "Hardy", "Quirky", "Serious"}
+
+
+def _asset_path() -> Path:
+    return (
+        Path(__file__).parent.parent
+        / "src"
+        / "Ankimon"
+        / "addon_files"
+        / "nature_chart.html"
+    )
+
+
+def test_nature_chart_asset_exists():
+    assert _asset_path().is_file()
+
+
+def test_resources_constant_points_at_the_asset():
+    from Ankimon import resources
+
+    assert Path(resources.nature_chart_html_path) == _asset_path()
+    assert Path(resources.nature_chart_html_path).is_file()
+
+
+def test_nature_chart_lists_all_25_natures():
+    html = _asset_path().read_text(encoding="utf-8")
+    for nature in ALL_NATURES:
+        assert f"<b>{nature}</b>" in html, f"missing nature row: {nature}"
+    # The 5 neutral natures span both stat columns instead of naming stats.
+    assert html.count("--- (Neutral) ---") == len(NEUTRAL_NATURES)
+
+
+def test_nature_chart_names_the_boosted_and_hindered_stat_columns():
+    html = _asset_path().read_text(encoding="utf-8")
+    assert "Boosted Stat (+10%)" in html
+    assert "Hindered Stat (-10%)" in html

--- a/tests/test_pokemon_details_gui.py
+++ b/tests/test_pokemon_details_gui.py
@@ -443,6 +443,20 @@ def test_split_returns_components_and_freshly_computed_stats(details):
     }
 
 
+def test_stats_dict_tolerates_missing_iv_ev_keys(details):
+    # Persisted records may predate full IV/EV dicts: missing keys default to 0
+    # instead of raising KeyError (which the error-handler stub would surface
+    # as an AssertionError).
+    _, _, _, stats = details.PokemonCollectionDetailsSplit(
+        **_details_kwargs(
+            iv={"hp": 31, "atk": 20},  # def/spa/spd/spe missing
+            ev={},  # fully absent
+        )
+    )
+    # calc_stat stub returns base+level, so every core stat is still computed.
+    assert stats["hp"] == 47 and stats["spe"] == 102
+
+
 def test_header_shows_dex_prefix_and_suppresses_redundant_nickname(details):
     header, _, _, _ = details.PokemonCollectionDetailsSplit(**_details_kwargs())
     texts = _labels(header)
@@ -533,6 +547,18 @@ def test_callback_path_renders_button_and_invokes_callback(details):
     assert calls == ["level"]
 
 
+def test_callback_path_falls_back_when_evo_name_missing(details):
+    # A missing evo_name must not reach the translator as None — it falls back
+    # to "the next form", matching the base (singleton) path.
+    _make_ready(details, method="level")
+    details._test_readiness["evo_name"] = None
+    header, _, _, _ = details.PokemonCollectionDetailsSplit(
+        **_details_kwargs(trigger_evo_callback=lambda method: None)
+    )
+    button = next(b for b in _buttons(header) if b.objectName() == "evolveNowButton")
+    assert "THE NEXT FORM" in button.text()
+
+
 # ---------------------------------------------------------------------------
 # Stat bars
 # ---------------------------------------------------------------------------
@@ -601,6 +627,23 @@ def test_stats_layout_uses_db_max_level_when_available(details):
         old_stats={"hp": 50},
     )
     # One row per known stat (hp, xp), each with two labels (name + value).
+    assert len(_stat_row_labels(layout)) == 4
+
+
+def test_stats_layout_survives_zero_experience_for_level(details):
+    # find_experience_for_level returns 0 for unknown growth rates / missing
+    # CSV rows; the XP bar mapping (both the old_stats slide source and the
+    # new value) must clamp instead of dividing by zero.
+    details.find_experience_for_level = lambda growth_rate, level, capped: 0
+    layout = details.PokemonDetailsStats(
+        {"hp": 100, "xp": 120},
+        "unknown-growth-rate",
+        1,
+        False,
+        9,
+        old_stats={"xp": 60, "hp": 50},
+    )
+    # Both rows (hp, xp) built without a ZeroDivisionError.
     assert len(_stat_row_labels(layout)) == 4
 
 

--- a/tests/test_pokemon_details_gui.py
+++ b/tests/test_pokemon_details_gui.py
@@ -1,0 +1,713 @@
+"""Qt characterization tests for ``gui_classes/pokemon_details.py`` (row F43).
+
+Pins the OBSERVABLE contract of the ported details panel:
+
+* ``PokemonCollectionDetails`` keeps main's single-``QVBoxLayout`` return shape
+  (what the current PC-box details panel consumes), while
+  ``PokemonCollectionDetailsSplit`` exposes exp's
+  ``(header, stats_tabs, footer, stats_dict)`` components for the PC-box
+  overhaul (row F42).
+* The ``[No. XXX]`` dex prefix and redundant-nickname suppression.
+* The two evolve-button paths (main's singleton-driven button vs exp's
+  ``trigger_evo_callback`` button) and the friendship master-toggle guard.
+* ``AnimatedStatBar`` clamping and the stat-bar layout's friendship ✓ marker
+  plus its DB-less fallback (``services.db`` may be absent headless).
+* Move learn/forget and release routed through ``services.db`` — including
+  main's XP-share clear guard on release, which exp had dropped.
+
+These need real PyQt6 (a QApplication), so they run in the Qt / Tier-2 env; the
+whole module skips cleanly where PyQt6 is absent OR has been mocked in
+``sys.modules`` by another (Tier-1) test file -- mirroring
+``test_move_picker.py``. Run standalone with::
+
+    pytest tests/test_pokemon_details_gui.py
+"""
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("PyQt6")  # Qt env only; skipped in the aqt-free Tier-1 env.
+
+
+_MODULE_NAME = "Ankimon.gui_classes.pokemon_details"
+_SRC = Path(__file__).parent.parent / "src"
+
+_NOT_READY = {
+    "evolvable": False,
+    "ready": False,
+    "method": None,
+    "evo_id": None,
+    "evo_name": None,
+    "min_happiness": None,
+    "current_friendship": 0,
+    "friendship_remaining": 0,
+    "required_time": None,
+    "time_ok": True,
+    "status_text": "",
+    "bar_max": 400,
+    "rejected": False,
+}
+
+
+class _RecorderLogger:
+    def __init__(self):
+        self.records = []
+
+    def log_and_showinfo(self, level, msg):
+        self.records.append((level, msg))
+
+    def log(self, level, msg):
+        self.records.append((level, msg))
+
+
+class _FakeSettings:
+    def __init__(self, values=None):
+        self.values = dict(values or {})
+        self.sets = []
+
+    def get(self, key, default=None):
+        return self.values.get(key, default)
+
+    def set(self, key, value):
+        self.sets.append((key, value))
+        self.values[key] = value
+
+
+class _FakeDB:
+    """Duck-typed stand-in for the AnkimonDB surface this module touches."""
+
+    def __init__(self, pokemon=None, main_pokemon=None, max_level=50):
+        self.pokemon = dict(pokemon or {})
+        self.main_pokemon = main_pokemon
+        self.max_level = max_level
+        self.saved = []
+        self.saved_main = []
+        self.deleted = []
+        self.history = []
+
+    def execute(self, query, parameters=()):
+        max_level = self.max_level
+
+        class _Cursor:
+            def fetchone(self):
+                return (max_level,)
+
+        return _Cursor()
+
+    def get_pokemon(self, individual_id):
+        record = self.pokemon.get(individual_id)
+        return dict(record) if record else None
+
+    def save_pokemon(self, data):
+        self.saved.append(data)
+        self.pokemon[data["individual_id"]] = data
+
+    def get_main_pokemon(self):
+        return dict(self.main_pokemon) if self.main_pokemon else None
+
+    def save_main_pokemon(self, data):
+        self.saved_main.append(data)
+        self.main_pokemon = data
+
+    def delete_pokemon(self, individual_id):
+        self.deleted.append(individual_id)
+        self.pokemon.pop(individual_id, None)
+        return True
+
+    def add_to_history(self, data):
+        self.history.append(data)
+        return True
+
+    def get_all_items(self):
+        return []
+
+
+class _NoIconPath:
+    def exists(self):
+        return False
+
+
+@pytest.fixture(autouse=True)
+def _env_guard():
+    """Skip gracefully when another test file has mocked PyQt6 in this run."""
+    from PyQt6.QtWidgets import QDialog
+
+    if not isinstance(QDialog, type):  # PyQt6 was mocked by another test
+        pytest.skip(
+            "real PyQt6 not active (mocked by another test); "
+            "run tests/test_pokemon_details_gui.py standalone"
+        )
+
+    if str(_SRC) not in sys.path:
+        sys.path.insert(0, str(_SRC))
+    yield
+
+
+@pytest.fixture
+def details(qapp, tmp_path):
+    """Load ``pokemon_details`` in isolation with every module-level dep stubbed."""
+    stub_names = (
+        "Ankimon",
+        "Ankimon.gui_classes",
+        "Ankimon.functions",
+        "Ankimon.pyobj",
+        "Ankimon.services",
+        "Ankimon.business",
+        "Ankimon.pyobj.attack_dialog",
+        "Ankimon.pyobj.pokemon_trade",
+        "Ankimon.pyobj.error_handler",
+        "Ankimon.pyobj.pokemon_obj",
+        "Ankimon.pyobj.InfoLogger",
+        "Ankimon.pyobj.translator",
+        "Ankimon.functions.pokedex_functions",
+        "Ankimon.functions.pokemon_functions",
+        "Ankimon.functions.friendship_evolution",
+        "Ankimon.functions.gui_functions",
+        "Ankimon.functions.sprite_functions",
+        "Ankimon.gui_entities",
+        "Ankimon.utils",
+        "Ankimon.resources",
+        "Ankimon.texts",
+        "aqt",
+        _MODULE_NAME,
+    )
+    saved = {name: sys.modules.get(name) for name in stub_names}
+
+    from PyQt6.QtGui import QFont
+    from PyQt6.QtWidgets import QLabel
+
+    for pkg in ("Ankimon", "Ankimon.gui_classes", "Ankimon.functions", "Ankimon.pyobj"):
+        mod = types.ModuleType(pkg)
+        mod.__path__ = [str(_SRC / pkg.replace(".", "/"))]
+        mod.__package__ = pkg
+        sys.modules[pkg] = mod
+
+    aqt_mod = types.ModuleType("aqt")
+    aqt_mod.qconnect = lambda signal, func: signal.connect(func)
+    sys.modules["aqt"] = aqt_mod
+
+    sv = types.ModuleType("Ankimon.services")
+    sv.services = types.SimpleNamespace(
+        db=None, settings=None, translator=None, ui=None
+    )
+    sys.modules["Ankimon.services"] = sv
+
+    bz = types.ModuleType("Ankimon.business")
+    bz.calculate_pokemon_go_cp = lambda a, d, s, level: 1234
+    bz.pokemon_go_raw_stats = lambda stats, iv, ev: (10, 11, 12)
+    bz.cp_breakdown_tooltip = lambda payload: "cp tooltip"
+
+    def _split(text, n):
+        for i in range(0, len(text), n):
+            yield text[i : i + n]
+
+    bz.split_string_by_length = _split
+    sys.modules["Ankimon.business"] = bz
+
+    ad = types.ModuleType("Ankimon.pyobj.attack_dialog")
+
+    class AttackDialog:
+        def __init__(self, attacks, new_attack):
+            self.selected_attack = attacks[0]
+
+        def exec(self):
+            return 0  # rejected by default
+
+    ad.AttackDialog = AttackDialog
+    sys.modules["Ankimon.pyobj.attack_dialog"] = ad
+
+    pt = types.ModuleType("Ankimon.pyobj.pokemon_trade")
+
+    class PokemonTrade:
+        def __init__(self, *args, **kwargs):
+            pass
+
+    pt.PokemonTrade = PokemonTrade
+    sys.modules["Ankimon.pyobj.pokemon_trade"] = pt
+
+    eh = types.ModuleType("Ankimon.pyobj.error_handler")
+
+    def _raise(parent=None, exception=None, message=""):
+        raise AssertionError(
+            f"show_warning_with_traceback called: {message}"
+        ) from exception
+
+    eh.show_warning_with_traceback = _raise
+    sys.modules["Ankimon.pyobj.error_handler"] = eh
+
+    po = types.ModuleType("Ankimon.pyobj.pokemon_obj")
+
+    class PokemonObject:
+        @staticmethod
+        def calc_stat(key, base, level, iv, ev, nature):
+            return base + level  # deterministic, checkable
+
+    po.PokemonObject = PokemonObject
+    sys.modules["Ankimon.pyobj.pokemon_obj"] = po
+
+    il = types.ModuleType("Ankimon.pyobj.InfoLogger")
+    il.ShowInfoLogger = _RecorderLogger
+    sys.modules["Ankimon.pyobj.InfoLogger"] = il
+
+    tr = types.ModuleType("Ankimon.pyobj.translator")
+
+    class Translator:
+        def __init__(self, language):
+            self.language = language
+
+        def translate(self, key, **kwargs):
+            if key == "evolve_now_button":
+                return f"Evolve into {kwargs.get('evo_name')}!"
+            return key
+
+    tr.Translator = Translator
+    sys.modules["Ankimon.pyobj.translator"] = tr
+
+    pf = types.ModuleType("Ankimon.functions.pokedex_functions")
+    pf.get_pokemon_diff_lang_name = lambda pid, lang: "Pikachu"
+    pf.get_pokemon_descriptions = lambda pid, lang: "A mouse Pokemon."
+    pf.get_all_pokemon_moves = lambda name, level: ["tackle", "thunderbolt"]
+    pf.get_pretty_name_for_name = lambda name: str(name).replace("-", " ").title()
+    pf.find_details_move = lambda name: {
+        "type": "Normal",
+        "category": "Physical",
+        "basePower": 40,
+        "accuracy": 100,
+        "pp": 35,
+        "shortDesc": "desc",
+    }
+    pf.search_pokedex = lambda name, variable: 25 if variable == "species_id" else None
+    pf.search_pokedex_by_id = lambda pid: "pikachu"
+    sys.modules["Ankimon.functions.pokedex_functions"] = pf
+
+    pkf = types.ModuleType("Ankimon.functions.pokemon_functions")
+    pkf.find_experience_for_level = lambda growth_rate, level, capped: 1000
+    sys.modules["Ankimon.functions.pokemon_functions"] = pkf
+
+    fe = types.ModuleType("Ankimon.functions.friendship_evolution")
+    fe.READINESS = dict(_NOT_READY)
+    fe.evolution_readiness = lambda pokemon, now=None: dict(fe.READINESS)
+    sys.modules["Ankimon.functions.friendship_evolution"] = fe
+
+    gf = types.ModuleType("Ankimon.functions.gui_functions")
+    gf.type_icon_path = lambda t: _NoIconPath()
+    gf.move_category_path = lambda c: _NoIconPath()
+    sys.modules["Ankimon.functions.gui_functions"] = gf
+
+    sf = types.ModuleType("Ankimon.functions.sprite_functions")
+    sf.get_sprite_path = lambda side, fmt, pid, shiny, gender, name=None: (
+        tmp_path / "missing.png"
+    )
+    sys.modules["Ankimon.functions.sprite_functions"] = sf
+
+    ge = types.ModuleType("Ankimon.gui_entities")
+    ge.MovieSplashLabel = QLabel
+    sys.modules["Ankimon.gui_entities"] = ge
+
+    ut = types.ModuleType("Ankimon.utils")
+    ut.format_move_name = lambda s: str(s).replace("-", " ").title()
+    ut.load_custom_font = lambda size, language: QFont()
+    sys.modules["Ankimon.utils"] = ut
+
+    rs = types.ModuleType("Ankimon.resources")
+    rs.icon_path = tmp_path / "icon.png"
+    rs.addon_dir = tmp_path
+    rs.pokemon_tm_learnset_path = tmp_path / "tm_learnset.json"
+    sys.modules["Ankimon.resources"] = rs
+
+    tx = types.ModuleType("Ankimon.texts")
+    tx.attack_details_window_template = "<table>"
+    tx.attack_details_window_template_end = "</table>"
+    tx.remember_attack_details_window_template = "<table>"
+    tx.remember_attack_details_window_template_end = "</table>"
+    sys.modules["Ankimon.texts"] = tx
+
+    spec = importlib.util.spec_from_file_location(
+        _MODULE_NAME, _SRC / "Ankimon" / "gui_classes" / "pokemon_details.py"
+    )
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[_MODULE_NAME] = module
+    spec.loader.exec_module(module)
+
+    # Handy handles for the tests
+    module._test_services = sv.services
+    module._test_readiness = fe.READINESS
+
+    try:
+        yield module
+    finally:
+        for name, val in saved.items():
+            if val is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = val
+
+
+def _details_kwargs(**overrides):
+    """The exact keyword set main's pc_box.show_pokemon_details passes today."""
+    kwargs = dict(
+        name="pikachu",
+        level=12,
+        id=25,
+        shiny=False,
+        ability="static",
+        type=["Electric"],
+        detail_stats={
+            "hp": 35,
+            "atk": 55,
+            "def": 40,
+            "spa": 50,
+            "spd": 50,
+            "spe": 90,
+            "xp": 120,
+        },
+        attacks=["tackle", "thunder-shock"],
+        base_experience=112,
+        growth_rate="medium",
+        ev={"hp": 0, "atk": 0, "def": 0, "spa": 0, "spd": 0, "spe": 0},
+        iv={"hp": 31, "atk": 20, "def": 10, "spa": 15, "spd": 25, "spe": 31},
+        gender="M",
+        nickname=None,
+        individual_id="uuid-1",
+        pokemon_defeated=3,
+        everstone=False,
+        evolution_rejected=False,
+        captured_date="2024-01-01 10:00:00",
+        language=9,
+        gif_in_collection=False,
+        remove_levelcap=False,
+        logger=_RecorderLogger(),
+        refresh_callback=lambda: None,
+        initial_tab_index=0,
+        tab_changed_callback=None,
+        nature="jolly",
+        base_stats={"hp": 35, "atk": 55, "def": 40, "spa": 50, "spd": 50, "spe": 90},
+        friendship=70,
+        friendship_time_enabled=True,
+    )
+    kwargs.update(overrides)
+    return kwargs
+
+
+def _labels(widget):
+    from PyQt6.QtWidgets import QLabel
+
+    return [lbl.text() for lbl in widget.findChildren(QLabel)]
+
+
+def _buttons(widget):
+    from PyQt6.QtWidgets import QPushButton
+
+    return widget.findChildren(QPushButton)
+
+
+# ---------------------------------------------------------------------------
+# Panel construction contracts
+# ---------------------------------------------------------------------------
+
+
+def test_wrapper_keeps_single_layout_contract_for_base_pc_box(details):
+    from PyQt6.QtWidgets import QTabWidget, QVBoxLayout
+
+    layout = details.PokemonCollectionDetails(**_details_kwargs())
+    assert isinstance(layout, QVBoxLayout)
+    assert layout.count() == 3  # header / stats tabs / footer
+    tabs = layout.itemAt(1).widget()
+    assert isinstance(tabs, QTabWidget)
+    assert [tabs.tabText(i) for i in range(tabs.count())] == ["Stats", "IV", "EV"]
+
+
+def test_split_returns_components_and_freshly_computed_stats(details):
+    from PyQt6.QtWidgets import QTabWidget, QWidget
+
+    header, tabs, footer, stats = details.PokemonCollectionDetailsSplit(
+        **_details_kwargs()
+    )
+    assert isinstance(header, QWidget)
+    assert isinstance(tabs, QTabWidget)
+    assert isinstance(footer, QWidget)
+    # calc_stat stub returns base+level; xp/friendship pass through.
+    assert stats == {
+        "hp": 47,
+        "atk": 67,
+        "def": 52,
+        "spa": 62,
+        "spd": 62,
+        "spe": 102,
+        "xp": 120,
+        "friendship": 70,
+    }
+
+
+def test_header_shows_dex_prefix_and_suppresses_redundant_nickname(details):
+    header, _, _, _ = details.PokemonCollectionDetailsSplit(**_details_kwargs())
+    texts = _labels(header)
+    assert any(t.startswith("[No. 025] Pikachu") for t in texts)
+
+    # A nickname equal to the species name is redundant -> no "(Pikachu)".
+    header, _, _, _ = details.PokemonCollectionDetailsSplit(
+        **_details_kwargs(nickname="Pikachu")
+    )
+    name_text = next(t for t in _labels(header) if t.startswith("[No. 025]"))
+    assert "(" not in name_text
+
+    # A real nickname shows "Nick (Species)".
+    header, _, _, _ = details.PokemonCollectionDetailsSplit(
+        **_details_kwargs(nickname="Sparky")
+    )
+    name_text = next(t for t in _labels(header) if t.startswith("[No. 025]"))
+    assert "Sparky" in name_text and "(Pikachu)" in name_text
+
+
+def test_nature_row_is_displayed(details):
+    header, _, _, _ = details.PokemonCollectionDetailsSplit(**_details_kwargs())
+    assert any("Nature: Jolly" in t for t in _labels(header))
+
+
+# ---------------------------------------------------------------------------
+# Evolution UI (both paths + master-toggle guard)
+# ---------------------------------------------------------------------------
+
+
+def _make_ready(details, method="friendship"):
+    details._test_readiness.update(
+        {
+            "evolvable": True,
+            "ready": True,
+            "method": method,
+            "evo_id": 26,
+            "evo_name": "Raichu",
+            "status_text": "",
+        }
+    )
+
+
+def test_base_path_shows_singleton_evolve_button_when_ready(details):
+    _make_ready(details, method="friendship")
+    header, _, _, _ = details.PokemonCollectionDetailsSplit(**_details_kwargs())
+    assert any("Evolve into Raichu now" in b.text() for b in _buttons(header))
+
+
+def test_friendship_master_toggle_hides_evolution_ui(details):
+    _make_ready(details, method="friendship")
+    header, _, _, _ = details.PokemonCollectionDetailsSplit(
+        **_details_kwargs(friendship_time_enabled=False)
+    )
+    assert not any("Evolve into" in b.text() for b in _buttons(header))
+
+    # A level evolution is base-game behaviour: it ignores the toggle.
+    _make_ready(details, method="level")
+    header, _, _, _ = details.PokemonCollectionDetailsSplit(
+        **_details_kwargs(friendship_time_enabled=False)
+    )
+    assert any("Evolve into Raichu now" in b.text() for b in _buttons(header))
+
+
+def test_status_text_requirement_line_is_shown_when_not_ready(details):
+    details._test_readiness.update(
+        {
+            "ready": False,
+            "method": "friendship",
+            "status_text": "40 friendship to evolve into Raichu",
+        }
+    )
+    header, _, _, _ = details.PokemonCollectionDetailsSplit(**_details_kwargs())
+    assert any("40 friendship to evolve into Raichu" in t for t in _labels(header))
+
+
+def test_callback_path_renders_button_and_invokes_callback(details):
+    _make_ready(details, method="level")
+    calls = []
+    header, _, _, _ = details.PokemonCollectionDetailsSplit(
+        **_details_kwargs(trigger_evo_callback=calls.append)
+    )
+    button = next(b for b in _buttons(header) if b.objectName() == "evolveNowButton")
+    assert "RAICHU" in button.text()  # translator text upper-cased
+    # The base-path pink button must NOT also be present.
+    assert not any("Evolve into Raichu now" in b.text() for b in _buttons(header))
+    button.click()
+    assert calls == ["level"]
+
+
+# ---------------------------------------------------------------------------
+# Stat bars
+# ---------------------------------------------------------------------------
+
+
+def test_animated_stat_bar_clamps_to_bar_width(details):
+    bar = details.AnimatedStatBar(None, 500.0, 300.0)
+    assert bar.current_value == 200.0
+    assert bar.new_value == 200.0
+
+    bar = details.AnimatedStatBar(None, 0.0, 150.0)
+    assert bar.new_value == 150.0
+
+
+def _stat_row_labels(layout):
+    """Collect all QLabel texts from a PokemonDetailsStats layout."""
+    from PyQt6.QtWidgets import QLabel
+
+    texts = []
+    for i in range(layout.count()):
+        item = layout.itemAt(i)
+        inner = item.layout()
+        if inner is None:
+            continue
+        for j in range(inner.count()):
+            w = inner.itemAt(j).widget()
+            if isinstance(w, QLabel):
+                texts.append(w.text())
+    return texts
+
+
+def test_stats_layout_marks_met_friendship_and_survives_missing_db(details):
+    # services.db is None here: the MAX(level) query must fall back silently.
+    assert details._test_services.db is None
+    layout = details.PokemonDetailsStats(
+        {"hp": 100, "friendship": 450, "xp": 120},
+        "medium",
+        10,
+        False,
+        9,
+        friendship_bar_max=220,
+    )
+    texts = _stat_row_labels(layout)
+    assert "450 ✓" in texts  # met-threshold marker (base guard kept)
+
+    layout = details.PokemonDetailsStats(
+        {"hp": 100, "friendship": 10, "xp": 120},
+        "medium",
+        10,
+        False,
+        9,
+        friendship_bar_max=220,
+    )
+    texts = _stat_row_labels(layout)
+    assert "10" in texts and not any("✓" in t for t in texts)
+
+
+def test_stats_layout_uses_db_max_level_when_available(details):
+    details._test_services.db = _FakeDB(max_level=80)
+    layout = details.PokemonDetailsStats(
+        {"hp": 100, "xp": 120},
+        "medium",
+        10,
+        False,
+        9,
+        old_stats={"hp": 50},
+    )
+    # One row per known stat (hp, xp), each with two labels (name + value).
+    assert len(_stat_row_labels(layout)) == 4
+
+
+# ---------------------------------------------------------------------------
+# services.db routing for move + release actions
+# ---------------------------------------------------------------------------
+
+
+def test_remember_attack_saves_via_services_db_and_refreshes(details):
+    db = _FakeDB(
+        pokemon={
+            "uuid-1": {
+                "individual_id": "uuid-1",
+                "name": "pikachu",
+                "attacks": ["tackle"],
+            }
+        },
+        main_pokemon={"individual_id": "uuid-1", "attacks": ["tackle"]},
+    )
+    details._test_services.db = db
+    refreshed = []
+    logger = _RecorderLogger()
+
+    details.remember_attack(
+        "uuid-1", ["tackle"], "thunderbolt", logger, lambda: refreshed.append(True)
+    )
+
+    assert db.saved and db.saved[-1]["attacks"] == ["tackle", "thunderbolt"]
+    # The main pokemon mirror is kept in sync too.
+    assert db.saved_main and db.saved_main[-1]["attacks"] == ["tackle", "thunderbolt"]
+    assert refreshed == [True]
+
+
+def test_forget_attack_refuses_to_remove_last_move(details):
+    db = _FakeDB(
+        pokemon={
+            "uuid-1": {
+                "individual_id": "uuid-1",
+                "name": "pikachu",
+                "attacks": ["tackle"],
+            }
+        }
+    )
+    details._test_services.db = db
+    logger = _RecorderLogger()
+
+    details.forget_attack("uuid-1", ["tackle"], "tackle", logger)
+
+    assert db.saved[-1]["attacks"] == ["tackle"]
+    assert any("can't forget" in msg for _, msg in logger.records)
+
+
+def _accept_release(details):
+    from PyQt6.QtWidgets import QMessageBox
+
+    class _YesBox:
+        StandardButton = QMessageBox.StandardButton
+
+        @staticmethod
+        def question(*args, **kwargs):
+            return QMessageBox.StandardButton.Yes
+
+    details.QMessageBox = _YesBox
+
+
+def test_pokemon_free_clears_xp_share_before_delete(details):
+    _accept_release(details)
+    db = _FakeDB(
+        pokemon={
+            "uuid-1": {
+                "individual_id": "uuid-1",
+                "id": 25,
+                "name": "pikachu",
+            }
+        },
+        main_pokemon=None,
+    )
+    settings = _FakeSettings({"trainer.xp_share": "uuid-1"})
+    details._test_services.db = db
+    details._test_services.settings = settings
+
+    details.PokemonFree("uuid-1", "pikachu", _RecorderLogger(), lambda: None)
+
+    # Base guard (dropped by exp, reinstated here): the stale XP-share target is
+    # cleared BEFORE the Pokémon vanishes from the DB.
+    assert ("trainer.xp_share", None) in settings.sets
+    assert db.deleted == ["uuid-1"]
+    assert db.history and db.history[0]["individual_id"] == "uuid-1"
+
+
+def test_pokemon_free_keeps_unrelated_xp_share(details):
+    _accept_release(details)
+    db = _FakeDB(
+        pokemon={
+            "uuid-1": {
+                "individual_id": "uuid-1",
+                "id": 25,
+                "name": "pikachu",
+            }
+        },
+        main_pokemon=None,
+    )
+    settings = _FakeSettings({"trainer.xp_share": "other-uuid"})
+    details._test_services.db = db
+    details._test_services.settings = settings
+
+    details.PokemonFree("uuid-1", "pikachu", _RecorderLogger(), lambda: None)
+
+    assert settings.sets == []
+    assert db.deleted == ["uuid-1"]


### PR DESCRIPTION
## F43 — Pokémon details GUI (nature chart, animated stat bars, remember-attack) + native-window lazy-init

### What
Ports the exp-branch overhaul of the Pokémon details panel and the native info windows onto the integration tip (fd9010f4):
- **`gui_classes/pokemon_details.py`** (+643/−287 after ruff-format): `AnimatedStatBar` (800ms OutCubic slide, clamped at bar width) replaces static pixmap bars; global sqrt stat-bar scaling driven by the collection's max level (`max(750, max_level*7.5, current stat)`); `[No. XXX]` dex prefix with redundant-nickname suppression; Mega/Gmax/regional pretty-name + species-id description fallback; Nature row; scaled-pixmap cache; pinned button styles; TM learning rebuilt on the shared **MovePickerDialog (F41)**; `refresh_callback` plumbed through remember/forget/TM flows; split header/tabs/footer construction with a freshly-computed stats dict for animation diffing.
- **`gui_entities.py`** (edit-vs-edit; main's version is the base): new `NatureTableWidget` (`show_nature_chart`) consuming `resources.nature_chart_html_path` (F38); lazy-init (`initialized`/`loaded` flags, initUI-on-show) for `TableWidget`/`IDTableWidget`/`License`/`Credits`/`Version_Dialog`; `Version_Dialog` now reads `updateinfos.md` on `open()` with an `or ""` guard (the file only exists after changelog.py writes it — eager `markdown.markdown(None)` was a latent crash); scroll-area redesign for the eff/gen chart windows.
- **`addon_files/nature_chart.html`**: new asset, ported **byte-identical** to exp (blob `aa33ff45`).

### Re-fit to seam (exp → main mapping)
| exp | main |
|---|---|
| `mw.ankimon_db.execute/get_pokemon/save_pokemon/save_main_pokemon/get_main_pokemon/get_all_items/delete_pokemon/add_to_history` | `services.db.*` |
| `mw.settings_obj` (n/a in exp — guard was dropped) | `services.settings` (XP-share clear guard reinstated) |
| `showWarning(...)` in `rename_pkmn` | `services.ui.warn(...)` |
| `MovePickerDialog(..., mw)` | `MovePickerDialog(...)` (parent `None`; a details-window handle does not exist in this module-function design) |
| `Translator(language)` built unconditionally | `services.translator or Translator(language)`, built lazily only for the evolve-button text |
| `from aqt import mw, qconnect` | `from aqt import qconnect` only (no `mw` state access remains) |
| `PokemonCollectionDetails` returning `(header, tabs, footer, stats)` | `PokemonCollectionDetailsSplit` (exp contract, for F42) + `PokemonCollectionDetails` wrapper keeping main's single-`QVBoxLayout` contract so the current `pc_box.show_pokemon_details` keeps working unchanged |

### Parity notes
- **Post-snapshot exp hunks captured** (ported from tip b04e4bec): `pokemon_defeated` added to the evolution-readiness stub (64c4c4c2 / 4a1cd0cd, minimumDefeated evolutions); the `read_github_file` tuple-return was **reverted upstream** (5ff1a54b, #489) so tip == base single-return — no gui_entities/help_window change needed, base callers unaffected.
- At the exp tip only `tm_attack_details_window` is built on MovePickerDialog; remember/forget windows remain list-button dialogs upstream (the row note describing remember-attack on MovePickerDialog reflects an intermediate exp state) — ported per git ground truth.
- Evolution UI is a superset: main's singleton-driven pink Evolve button / requirement line / rejected note render when no `trigger_evo_callback` is given (today's pc_box); exp's translator-driven blue button renders when F42 passes the callback. The friendship master-toggle gates both paths; level/other methods stay always-on.
- Friendship stat bar keeps main's threshold semantics (`bar_max`, ✓ marker + tooltip, None-coercion) rather than exp's flat MAX_FRIENDSHIP scale; exp's `old_stats` animation mapping uses the same scale.
- `nature=` is NOT passed to `PokemonTrade` (base signature lacks it; lands with Trade V2, F48).
- `nature_chart_button` remains English-only (F01 guard); the key already exists in `lang/en_text.json`.
- Exp deleted `Pokedex_Widget`; kept here (main's `singletons.py` constructs it; deletion belongs to the Ankidex row).

### GUARDS-TO-REAPPLY confirmation
- ✅ service seam (`services.db` everywhere; no `aqt.mw` state access)
- ✅ MovePicker parent never `mw`
- ✅ gui_entities reconciled with main's version winning; only nature-chart + lazy-init additions layered
- ✅ `read_github_file` backward-compatible (no change needed; documented above)
- ✅ XP-share clear guard on release reinstated (exp had dropped it) + regression test

### Deferred
- **F42**: switch pc_box's call site to `PokemonCollectionDetailsSplit` (same kwargs incl. `old_stats`/`trigger_evo_callback`; mechanical rename).
- **F36**: `nature_chart_action` help-menu entry + `singletons.get_nature_chart` lazy getter (menu wiring lives in F36's files; the widget ships here unreachable from the menu until then).
- **F48**: re-add `nature=` to the details-panel `PokemonTrade` call when Trade V2 lands.
- **F16/owner triage**: remove `Pokedex_Widget` once Ankidex covers it.

### Gates (re-run independently by the verifier)
- compileall: OK · ruff check: 10 errors, all baseline (`AnkimonWindow copy.py`), no new · ruff format: all 5 touched files clean
- Tier-1 pytest: **268 passed / 31 skipped / 0 failed** (baseline 264/15; +4 new Tier-1 asset tests pass; +16 skips are the two new Qt-only modules skipping by design in the aqt-free env — 15 per-test skips from `test_pokemon_details_gui.py` + 1 module-level skip from `test_gui_entities_nature_chart.py`, mirroring `test_move_picker.py`)
- harness/check.py: **9/9** · Qt tier: scaffolding smoke **4 passed**, addon integrity **1 passed**, probe_real_boot **OK**, probe_real_play **OK**
- New F43 tests (venv_qt, offscreen): **24/24 passed**

### Post-review hardening (Gemini round 1, commits 7ac2f29 + 299011c)
- XP stat-bar mapping clamps the experience divisor with `max(1, ...)` at both sites (`find_experience_for_level` returns 0 for unknown growth rates / missing CSV rows — latent ZeroDivisionError present in exp too).
- Core-stat loop tolerates partial/absent IV-EV dicts via `(iv or {}).get(key, 0)`.
- Callback-path evolve button falls back to "the next form" when `evo_name` is missing (mirrors the base path).
- MAX(level) baseline query checks `services.db is not None` (`pyobj/settings.py` idiom), `try/except` retained for real DB errors.
- Forget-attack helpers' `individual_id` annotations corrected `int` -> `str` (uuid; no runtime change).
- Gate deltas vs the numbers above: Tier-1 pytest is now **268 passed / 34 skipped** (the 3 added Qt-only edge-case tests skip by design in the aqt-free env); F43 Qt tests are now **27/27** (`test_pokemon_details_gui.py` grew 15 -> 18: zero-experience clamp, missing IV/EV keys, missing evo_name fallback). All other gate numbers unchanged.

### Attribution
Originally implemented by @hakimh2 on BRRRR_Experimental; credited via `Co-authored-by: Hakimh2 <74561421+hakimh2@users.noreply.github.com>` trailers on every commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

