### PR TITLE
feat: asynchronous thread-safe startup boot (F32)

### DIFF
--- a/src/Ankimon/__init__.py
+++ b/src/Ankimon/__init__.py
@@ -25,27 +25,16 @@ from .resources import ensure_ankimon_infrastructure, user_path, addon_dir
 
 ensure_ankimon_infrastructure(addon_dir, user_path)
 
+# Only the cheap, aqt-free core objects are imported here. The GUI windows
+# (test_window, item_window, …) are F31 lazy factories: importing their names
+# constructs them, so those imports are deferred into the async-boot success
+# callback below and the boot never builds a window before Anki is up.
 from .singletons import (
     settings_obj,
-    settings_window,
     logger,
     translator,
-    reviewer_obj,
     ankimon_tracker_obj,
-    test_window,
-    achievement_bag,
     shop_manager,
-    ankimon_tracker_window,
-    pokedex_window,
-    eff_chart,
-    gen_id_chart,
-    license,
-    credits,
-    evo_window,
-    starter_window,
-    item_window,
-    version_dialog,
-    pokemon_pc,
     trainer_card,
 )
 from .functions.url_functions import (
@@ -64,6 +53,9 @@ from .utils import test_online_connectivity
 from .menu_buttons import create_menu_actions
 from .hooks import setupHooks
 from .pyobj.error_handler import show_warning_with_traceback
+from .pyobj.backup_manager import BackupManager
+from .services import services
+from .events import events
 
 # singletons.py already populated the service registry and mirrored these onto
 # mw (see services.py), so the previous mw.settings_ankimon/logger/settings_obj
@@ -74,12 +66,17 @@ from .pyobj.error_handler import show_warning_with_traceback
 # once menu_buttons stops building its own translator.
 mw.translator = translator
 
+# Importing overview_team registers its deck-browser/overview hooks exactly
+# once, at module scope, gated by the gui.team_deck_view setting.
 from .gui_classes import overview_team
 
-# --- Startup: backup, migration, assets, first enemy ---
-from .startup import run_startup_sequence
-
-database_complete, collected_pokemon_ids, backup_manager = run_startup_sequence()
+# --- Startup readiness flag (F32 async boot) ---
+# Expressed on the services registry (not mw): reviews that arrive before the
+# background boot finishes are dropped by the gated hook below, exactly like
+# exp's mw.ankimon_startup_finished gate. Consumers read
+# getattr(services, "startup_finished", False).
+_STARTUP_FINISHED_ATTR = "startup_finished"
+setattr(services, _STARTUP_FINISHED_ATTR, False)
 
 # --- Web exports for reviewer UI ---
 mw.addonManager.setWebExports(
@@ -122,44 +119,43 @@ schedule_branch_update_check(online_connectivity, ssh)
 # --- Battle loop ---
 from .battle_loop import on_review_card, init_battle_state
 
-init_battle_state(collected_pokemon_ids)
-gui_hooks.reviewer_did_answer_card.append(on_review_card)
 
-# --- Menu ---
-create_menu_actions(
-    database_complete,
-    online_connectivity,
-    item_window,
-    test_window,
-    achievement_bag,
-    open_team_builder,
-    export_to_pkmn_showdown,
-    export_all_pkmn_showdown,
-    flex_pokemon_collection,
-    eff_chart,
-    gen_id_chart,
-    credits,
-    license,
-    open_help_window,
-    report_bug,
-    rate_addon_url,
-    version_dialog,
-    trainer_card,
-    ankimon_tracker_window,
-    logger,
-    settings_window,
-    shop_manager,
-    pokedex_window,
-    settings_obj.get("controls.key_for_opening_closing_ankimon"),
-    join_discord_url,
-    open_leaderboard_url,
-    settings_obj,
-    addon_dir,
-    pokemon_pc,
-    backup_manager,
-)
+def _on_review_card_gated(*args, **kwargs):
+    """Forward reviews to the battle loop only once the async boot finished.
 
-# --- Hook registry, profile hooks, reviewer UI, discord ---
+    Until the background startup completes (first enemy generated, collected
+    IDs loaded) a review cannot be battled; dropping it mirrors exp's
+    startup-finished gate, re-expressed on the services registry.
+    """
+    if not getattr(services, _STARTUP_FINISHED_ATTR, False):
+        return None
+    return on_review_card(*args, **kwargs)
+
+
+# Reload safety (NR-21, same pattern as card_hooks.register_card_hooks): the
+# (hook, handler) record lives on the services registry — which survives a
+# re-execution of this module — so a second boot removes the previous
+# handler before appending, instead of stacking a duplicate.
+_REVIEW_HOOK_RECORD = "_review_card_handlers"
+
+for _hook, _handler in getattr(services, _REVIEW_HOOK_RECORD, ()):
+    _hook.remove(_handler)
+_review_handlers = ((gui_hooks.reviewer_did_answer_card, _on_review_card_gated),)
+for _hook, _handler in _review_handlers:
+    _hook.append(_handler)
+setattr(services, _REVIEW_HOOK_RECORD, _review_handlers)
+
+# --- Shared boot state -------------------------------------------------------
+# Both are created eagerly (cheap) so the profile hooks can be registered at
+# module scope — profileLoaded / profile_did_open can fire before the
+# background boot completes, and a hook registered too late never runs. The
+# collected-ID set is shared by identity: the async success callback fills it
+# in place, so profile hooks, battle state and reviewer UI all observe the
+# same live set.
+backup_manager = BackupManager(logger, settings_obj)
+collected_pokemon_ids = set()
+
+# --- Hook registry + profile hooks ---
 from .hook_registry import (
     CatchPokemonHook,
     DefeatPokemonHook,
@@ -179,15 +175,117 @@ register_profile_hooks(
     collected_pokemon_ids,
 )
 
-from .reviewer_ui import setup_reviewer_ui, set_collected_ids
 
-set_collected_ids(collected_pokemon_ids)
-setup_reviewer_ui(
-    settings_obj.get("controls.catch_key"),
-    settings_obj.get("controls.defeat_key"),
-    settings_obj.get("controls.pokemon_buttons"),
-)
+# --- Asynchronous startup (F32) ----------------------------------------------
+def start_asynchronous_startup():
+    """Run the heavy boot work off the GUI thread via Anki's QueryOp.
 
+    ``run_startup_background_checks`` (aqt-free disk/DB/CPU work) executes on
+    a background thread; ``on_startup_complete`` marshals its results back to
+    the main thread for the Qt half of the boot.
+    """
+    from aqt.operations import QueryOp
+    from .startup import run_startup_background_checks, run_startup_ui_callbacks
+
+    def on_startup_complete(results):
+        # 1. Qt half of the startup sequence (migration dialog, sprite
+        #    downloader, first-enemy stat application, starter window, rate
+        #    prompt).
+        database_complete = run_startup_ui_callbacks(results)
+
+        # 2. Fill the shared collected-ID set in place (identity preserved
+        #    for the module-level consumers registered above).
+        collected_pokemon_ids.update(results["collected_pokemon_ids"])
+        init_battle_state(collected_pokemon_ids)
+
+        # 3. Reviewer UI: collected IDs + shortcut/button wiring. Imported
+        #    here (not at module scope) because reviewer_ui pulls lazy F31
+        #    window names at ITS import time.
+        from .reviewer_ui import setup_reviewer_ui, set_collected_ids
+
+        set_collected_ids(collected_pokemon_ids)
+
+        # 4. Menu. The window names are F31 lazy factories: first access
+        #    constructs them — on the main thread, after the boot work.
+        from .singletons import (
+            settings_window,
+            test_window,
+            achievement_bag,
+            ankimon_tracker_window,
+            pokedex_window,
+            eff_chart,
+            gen_id_chart,
+            license,
+            credits,
+            item_window,
+            version_dialog,
+            pokemon_pc,
+        )
+
+        create_menu_actions(
+            database_complete,
+            online_connectivity,
+            item_window,
+            test_window,
+            achievement_bag,
+            open_team_builder,
+            export_to_pkmn_showdown,
+            export_all_pkmn_showdown,
+            flex_pokemon_collection,
+            eff_chart,
+            gen_id_chart,
+            credits,
+            license,
+            open_help_window,
+            report_bug,
+            rate_addon_url,
+            version_dialog,
+            trainer_card,
+            ankimon_tracker_window,
+            logger,
+            settings_window,
+            shop_manager,
+            pokedex_window,
+            settings_obj.get("controls.key_for_opening_closing_ankimon"),
+            join_discord_url,
+            open_leaderboard_url,
+            settings_obj,
+            addon_dir,
+            pokemon_pc,
+            backup_manager,
+        )
+
+        # 5. Reviewer shortcuts/buttons (base signature; F34 adds its
+        #    team-cycle argument as a defaulted kwarg on its own).
+        setup_reviewer_ui(
+            settings_obj.get("controls.catch_key"),
+            settings_obj.get("controls.defeat_key"),
+            settings_obj.get("controls.pokemon_buttons"),
+        )
+
+        # 6. Boot finished: open the review gate and signal observers.
+        setattr(services, _STARTUP_FINISHED_ATTR, True)
+        events.emit("startup_finished")
+
+        # 7. If the user is already reviewing, redraw the bottom bar so the
+        #    freshly wrapped _bottomHTML (catch/defeat buttons) shows up.
+        if getattr(mw, "state", None) == "review" and getattr(mw, "reviewer", None):
+            try:
+                mw.reviewer.bottom.draw()
+            except Exception:
+                pass
+
+    QueryOp(
+        parent=mw,
+        op=lambda _col: run_startup_background_checks(backup_manager),
+        success=on_startup_complete,
+    ).without_collection().run_in_background()
+
+
+# --- Discord integration ---
 from .discord_integration import setup_discord_hooks
 
 setup_discord_hooks()
+
+# Start the background boot last, once every module-scope hook is registered.
+start_asynchronous_startup()

--- a/src/Ankimon/startup.py
+++ b/src/Ankimon/startup.py
@@ -1,12 +1,26 @@
-import json
-import random
+"""Ankimon boot sequence, split for the asynchronous startup (F32).
+
+The old synchronous ``run_startup_sequence()`` is split in two so the heavy
+boot work no longer blocks Anki's GUI thread:
+
+* :func:`run_startup_background_checks` — the aqt-free half. Backup, DB
+  migration status, collected-ID load, config migration, sprite-folder
+  checks and first-enemy generation are all disk/DB/CPU work and run on a
+  ``QueryOp`` background thread. It must never touch Qt: everything it
+  learns is returned in a plain results dict.
+* :func:`run_startup_ui_callbacks` — the main-thread half. Consumes that
+  results dict and performs every Qt interaction (migration dialog, sprite
+  download dialog, enemy stat application for GUI bindings, starter window,
+  rate prompt).
+
+``__init__.py`` drives the pair through ``aqt.operations.QueryOp`` (a genuine
+Anki API); the harness's synchronous QueryOp fake drives it deterministically
+in tests.
+"""
 
 from aqt import mw
 
-from .resources import (
-    pkmnimgfolder,
-    sound_list_path,
-)
+from .resources import pkmnimgfolder
 from .utils import (
     check_folders_exist,
     get_main_pokemon_data,
@@ -28,23 +42,117 @@ from .singletons import (
     ankimon_tracker_obj,
     main_pokemon,
     enemy_pokemon,
-    starter_window,
     ankimon_db,
 )
 
+# GC anchor for the assets-check dialog shown by run_startup_ui_callbacks:
+# a bare local would be collected (and the dialog closed) as soon as the
+# callback returns.
+_file_check_dialog = None
 
-def run_startup_sequence():
+# The seven per-tier toggles F28 introduced; the legacy single toggle folds
+# into all of them on first boot after an upgrade (see
+# _migrate_auto_catch_settings below).
+_AUTO_CATCH_KEYS = (
+    "battle.auto_catch_legendary",
+    "battle.auto_catch_mythical",
+    "battle.auto_catch_ultra",
+    "battle.auto_catch_starter",
+    "battle.auto_catch_mega",
+    "battle.auto_catch_gmax",
+    "battle.auto_catch_regional",
+)
+
+
+def run_startup_background_checks(backup_manager=None):
+    """Aqt-free half of the boot; runs on the QueryOp background thread.
+
+    Only disk, DB and CPU work happens here — no Qt calls. Everything the
+    main-thread half needs is returned in the results dict. The DB layer is
+    thread-safe (per-thread connections), so its reads/writes are legal off
+    the GUI thread.
+    """
+    # "game"-level log lines write to the log file / event bus only (no Qt),
+    # so they are safe here and keep the boot log order of the old
+    # synchronous sequence.
     logger.log_and_showinfo("game", translator.translate("startup"))
     logger.log_and_showinfo("game", translator.translate("backing_up_files"))
 
+    # 1. Run the legacy file backup; report failures on the main thread.
+    backup_error = None
     try:
         run_backup()
     except Exception as e:
-        show_warning_with_traceback(parent=mw, exception=e, message="Backup error:")
+        backup_error = e
 
-    backup_manager = BackupManager(logger, settings_obj)
+    # Dev-mode auto-backup (disk copy — background work). __init__ passes its
+    # module-level BackupManager so profile hooks and the menu share the same
+    # instance; constructing one here keeps this function standalone-callable.
+    if backup_manager is None:
+        backup_manager = BackupManager(logger, settings_obj)
+    try:
+        if settings_obj.get("misc.developer_mode"):
+            backup_manager.create_backup(manual=False)
+    except Exception as e:
+        logger.log("error", f"Error in background backup creation: {e}")
 
-    if not ankimon_db.is_migrated():
+    # 2. Read-only DB checks.
+    is_migrated = ankimon_db.is_migrated()
+    collected_pokemon_ids = load_collected_pokemon_ids()
+
+    # 3. Config migration (legacy exp key -> F28 per-tier keys).
+    _migrate_auto_catch_settings()
+
+    # 4. Sprite/asset folder checks (disk).
+    database_complete = _check_assets_background()
+
+    # 5. First enemy + starter/rating preconditions (DB/CPU); the Qt side of
+    #    each (stat application, starter window, rate dialog) runs in
+    #    run_startup_ui_callbacks.
+    enemy_info = None
+    needs_starter = False
+    needs_rating = False
+
+    if database_complete:
+        enemy_info = _generate_first_enemy_background()
+
+        if ankimon_db.get_pokemon_count() == 0:
+            needs_starter = True
+
+        badge_list = get_achieved_badges()
+        if len(badge_list) > 1 and ankimon_db.get_user_data("rate_this") is not True:
+            needs_rating = True
+
+    # 6. Item-count consolidation (DB write; thread-safe layer).
+    try:
+        count_items_and_rewrite()
+    except Exception as e:
+        logger.log("error", f"Error in count_items_and_rewrite: {e}")
+
+    return {
+        "backup_error": backup_error,
+        "backup_manager": backup_manager,
+        "is_migrated": is_migrated,
+        "collected_pokemon_ids": collected_pokemon_ids,
+        "database_complete": database_complete,
+        "enemy_info": enemy_info,
+        "needs_starter": needs_starter,
+        "needs_rating": needs_rating,
+    }
+
+
+def run_startup_ui_callbacks(results):
+    """Main-thread half of the boot: every Qt interaction lives here."""
+    global _file_check_dialog
+
+    # Show the backup error (if any) now that we are on the GUI thread.
+    if results.get("backup_error") is not None:
+        show_warning_with_traceback(
+            parent=mw, exception=results["backup_error"], message="Backup error:"
+        )
+
+    # Database migration dialog.
+    if not results["is_migrated"]:
         from .pyobj.migration_dialog import show_migration_dialog_if_needed
         from .resources import (
             mypokemon_path,
@@ -70,31 +178,51 @@ def run_startup_sequence():
             rate_path,
         )
 
-    if settings_obj.get("misc.developer_mode"):
-        backup_manager.create_backup(manual=False)
+    # Missing assets: sprite download agreement + file checker.
+    if not results["database_complete"]:
+        show_agreement_and_download_dialog(force_download=True)
+        _file_check_dialog = CheckFiles()
+        _file_check_dialog.show()
 
-    collected_pokemon_ids = load_collected_pokemon_ids()
+    # Apply the first enemy's stats on the main thread (the enemy object is
+    # bound into GUI code, so its mutation stays off the background thread).
+    if results["database_complete"] and results["enemy_info"] is not None:
+        _apply_first_enemy(results["enemy_info"])
 
-    with open(sound_list_path, "r", encoding="utf-8") as json_file:
-        sound_list = json.load(json_file)
+    # Starter selection for a blank profile.
+    if results["database_complete"] and results["needs_starter"]:
+        from .singletons import get_starter_window
 
+        get_starter_window().display_starter_pokemon()
+
+    # Rate-this-addon prompt.
+    if results["database_complete"] and results["needs_rating"]:
+        rate_this_addon()
+
+    # Reset the encounter counter for the new session.
     ankimon_tracker_obj.pokemon_encounter = 0
 
-    database_complete = _check_assets()
-
-    if database_complete:
-        _init_first_enemy()
-        _check_starter()
-        badge_list = get_achieved_badges()
-        if len(badge_list) > 1:
-            rate_this_addon()
-
-    count_items_and_rewrite()
-
-    return database_complete, collected_pokemon_ids, backup_manager
+    return results["database_complete"]
 
 
-def _check_assets():
+def _migrate_auto_catch_settings():
+    """Fold the legacy ``battle.automatic_catch_special`` toggle into F28's
+    seven per-tier ``battle.auto_catch_*`` keys, then tombstone the old key.
+
+    Only profiles that ran the experimental branch ever stored the legacy
+    key, so this is a no-op everywhere else. The tombstone (``None``, which
+    the DB scalar layer round-trips as the string ``"None"``) marks the
+    migration done, keeping it one-shot across boots.
+    """
+    old_value = settings_obj.config.get("battle.automatic_catch_special")
+    if old_value is None or old_value == "None":
+        return
+    for key in _AUTO_CATCH_KEYS:
+        settings_obj.set(key, bool(old_value))
+    settings_obj.set("battle.automatic_catch_special", None)
+
+
+def _check_assets_background():
     back_sprites = check_folders_exist(pkmnimgfolder, "back_default")
     back_default_gif = check_folders_exist(pkmnimgfolder, "back_default_gif")
     front_sprites = check_folders_exist(pkmnimgfolder, "front_default")
@@ -102,7 +230,7 @@ def _check_assets():
     item_sprites = check_folders_exist(pkmnimgfolder, "items")
     badges_sprites = check_folders_exist(pkmnimgfolder, "badges")
 
-    database_complete = all(
+    return all(
         [
             back_sprites,
             front_sprites,
@@ -113,20 +241,29 @@ def _check_assets():
         ]
     )
 
-    if not database_complete:
-        show_agreement_and_download_dialog(force_download=True)
-        dialog = CheckFiles()
-        dialog.show()
 
-    return database_complete
+def _generate_first_enemy_background():
+    """Generate the first wild encounter's data (CPU/DB work, no Qt).
 
-
-def _init_first_enemy():
+    Goes through ``generate_random_pokemon`` so the level-cap NameError
+    guard (#402) inside encounter generation keeps protecting the first
+    encounter of every session.
+    """
     try:
         get_main_pokemon_data()
     except Exception:
         pass
 
+    main_pokemon_level = main_pokemon.level if hasattr(main_pokemon, "level") else 5
+
+    try:
+        return generate_random_pokemon(main_pokemon_level, ankimon_tracker_obj)
+    except Exception as e:
+        logger.log("error", f"Error generating first enemy: {e}")
+        return None
+
+
+def _apply_first_enemy(enemy_info):
     (
         name,
         id,
@@ -146,7 +283,7 @@ def _init_first_enemy():
         ev_yield,
         shiny,
         nature,
-    ) = generate_random_pokemon(main_pokemon.level, ankimon_tracker_obj)
+    ) = enemy_info
 
     enemy_pokemon.update_stats(
         name=name,
@@ -173,11 +310,3 @@ def _init_first_enemy():
     enemy_pokemon.hp = max_hp
     enemy_pokemon.max_hp = max_hp
     ankimon_tracker_obj.randomize_battle_scene()
-
-
-def _check_starter():
-    from .pyobj.database_manager import get_db
-
-    db = get_db()
-    if db.get_pokemon_count() == 0:
-        starter_window.display_starter_pokemon()

--- a/src/Ankimon/startup.py
+++ b/src/Ankimon/startup.py
@@ -213,12 +213,22 @@ def _migrate_auto_catch_settings():
     key, so this is a no-op everywhere else. The tombstone (``None``, which
     the DB scalar layer round-trips as the string ``"None"``) marks the
     migration done, keeping it one-shot across boots.
+
+    The stored toggle is normally a real ``bool`` (the config DB layer
+    round-trips booleans through ``json``), but a legacy/string value would
+    survive as ``"True"``/``"False"`` via that layer's ``str()`` fallback —
+    and ``bool("False")`` is truthy. Normalize any string form explicitly so
+    a disabled toggle never migrates as enabled.
     """
     old_value = settings_obj.config.get("battle.automatic_catch_special")
     if old_value is None or old_value == "None":
         return
+    if isinstance(old_value, bool):
+        enabled = old_value
+    else:
+        enabled = str(old_value).strip().lower() in ("true", "1")
     for key in _AUTO_CATCH_KEYS:
-        settings_obj.set(key, bool(old_value))
+        settings_obj.set(key, enabled)
     settings_obj.set("battle.automatic_catch_special", None)
 
 

--- a/tests/test_async_startup_boot.py
+++ b/tests/test_async_startup_boot.py
@@ -1,0 +1,905 @@
+"""Characterization tests for the asynchronous startup boot (F32).
+
+Pins the background/UI split of ``startup.py`` and the boot ordering of
+``__init__.py`` without Qt:
+
+* ``run_startup_background_checks`` is the aqt-free half: it returns a plain
+  results dict and performs NO UI work (no dialogs, no window construction).
+* ``run_startup_ui_callbacks`` is the main-thread half: migration dialog,
+  sprite downloader, first-enemy stat application, starter window and rate
+  prompt all happen here, driven purely by the results dict.
+* The legacy ``battle.automatic_catch_special`` toggle folds into F28's seven
+  ``battle.auto_catch_*`` keys exactly once (tombstoned afterwards).
+* ``__init__.py`` registers every module-scope hook (profile hooks, gated
+  review hook, changelog schedule) BEFORE starting the QueryOp boot, keeps
+  the changelog check on REAL connectivity, calls ``create_menu_actions``
+  with the full base argument list (no exp None placeholders), calls
+  ``setup_reviewer_ui`` with base's 3-argument signature, and flips
+  ``services.startup_finished`` when the boot completes.
+* Re-executing ``__init__.py`` (add-on reload / double boot) must not stack a
+  second ``reviewer_did_answer_card`` handler (NR-21): the registration
+  record lives on the surviving services registry.
+
+House pattern: mock aqt + the collaborating Ankimon modules in
+``sys.modules``, then exec the real module file under its dotted name
+(tests/conftest.py provides the package stubs).
+"""
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+_src = Path(__file__).parent.parent / "src"
+
+ENEMY_INFO = (
+    "Pikachu",  # name
+    25,  # id
+    7,  # level
+    "static",  # ability
+    ["electric"],  # type
+    {"hp": 35},  # base_stats
+    ["thunder-shock"],  # enemy_attacks
+    112,  # base_experience
+    "medium",  # growth_rate
+    {"hp": 0},  # ev
+    {"hp": 1},  # iv
+    "male",  # gender
+    None,  # battle_status
+    {},  # battle_stats
+    "Normal",  # tier
+    {"hp": 0},  # ev_yield
+    False,  # shiny
+    "hardy",  # nature
+)
+
+AUTO_CATCH_KEYS = (
+    "battle.auto_catch_legendary",
+    "battle.auto_catch_mythical",
+    "battle.auto_catch_ultra",
+    "battle.auto_catch_starter",
+    "battle.auto_catch_mega",
+    "battle.auto_catch_gmax",
+    "battle.auto_catch_regional",
+)
+
+
+def _stub_module(name, **attrs):
+    mod = types.ModuleType(name)
+    for key, value in attrs.items():
+        setattr(mod, key, value)
+    return mod
+
+
+class FakeLogger:
+    def __init__(self, calls):
+        self.calls = calls
+
+    def log(self, level, message):
+        self.calls.append(("log", level, message))
+
+    def log_and_showinfo(self, level, message):
+        self.calls.append(("log_and_showinfo", level, message))
+
+
+class FakeSettings:
+    def __init__(self, config=None):
+        self.config = dict(config or {})
+        self.set_calls = []
+
+    def get(self, key, default=None):
+        value = self.config.get(key)
+        if value is not None:
+            return value
+        return default
+
+    def set(self, key, value):
+        self.config[key] = value
+        self.set_calls.append((key, value))
+
+
+class FakeDB:
+    def __init__(self, migrated=True, pokemon_count=3, user_data=None):
+        self.migrated = migrated
+        self.pokemon_count = pokemon_count
+        self.user_data = dict(user_data or {})
+
+    def is_migrated(self):
+        return self.migrated
+
+    def get_pokemon_count(self):
+        return self.pokemon_count
+
+    def get_user_data(self, key, default=None):
+        return self.user_data.get(key, default)
+
+
+class FakeEnemy:
+    def __init__(self):
+        self.update_kwargs = None
+        self.current_hp = None
+        self.hp = None
+        self.max_hp = None
+
+    def update_stats(self, **kwargs):
+        self.update_kwargs = kwargs
+
+    def calculate_max_hp(self):
+        return 42
+
+
+class FakeTracker:
+    def __init__(self, calls):
+        self.calls = calls
+        self.pokemon_encounter = 99
+
+    def randomize_battle_scene(self):
+        self.calls.append(("randomize_battle_scene",))
+
+
+class FakeBackupManager:
+    instances = []
+
+    def __init__(self, logger, settings_obj):
+        type(self).instances.append(self)
+        self.create_calls = []
+
+    def create_backup(self, manual=False):
+        self.create_calls.append(manual)
+
+    def on_anki_close(self):
+        pass
+
+
+class FakeCheckFiles:
+    instances = []
+
+    def __init__(self):
+        type(self).instances.append(self)
+        self.shown = False
+
+    def show(self):
+        self.shown = True
+
+
+class FakeStarterWindow:
+    def __init__(self, calls):
+        self.calls = calls
+
+    def display_starter_pokemon(self):
+        self.calls.append(("display_starter_pokemon",))
+
+
+# ---------------------------------------------------------------------------
+# Part A: the startup.py background/UI split
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def startup_env(monkeypatch, tmp_path):
+    """Stub every startup.py collaborator, exec the real module."""
+    FakeBackupManager.instances = []
+    FakeCheckFiles.instances = []
+
+    calls = []
+
+    def rec(name, result=None):
+        def _f(*args, **kwargs):
+            calls.append((name, args, kwargs))
+            return result
+
+        return _f
+
+    logger = FakeLogger(calls)
+    settings = FakeSettings({"misc.developer_mode": False, "misc.language": 9})
+    db = FakeDB()
+    enemy = FakeEnemy()
+    tracker = FakeTracker(calls)
+    main_pokemon = SimpleNamespace(level=32)
+    starter_window = FakeStarterWindow([])
+
+    translator = SimpleNamespace(translate=lambda key: key)
+
+    env = SimpleNamespace(
+        calls=calls,
+        logger=logger,
+        settings=settings,
+        db=db,
+        enemy=enemy,
+        tracker=tracker,
+        main_pokemon=main_pokemon,
+        starter_window=starter_window,
+        folders_exist=True,
+        run_backup_error=None,
+    )
+
+    def run_backup():
+        calls.append(("run_backup", (), {}))
+        if env.run_backup_error is not None:
+            raise env.run_backup_error
+
+    monkeypatch.setitem(sys.modules, "aqt", _stub_module("aqt", mw=SimpleNamespace()))
+    monkeypatch.setitem(
+        sys.modules,
+        "Ankimon.resources",
+        _stub_module(
+            "Ankimon.resources",
+            pkmnimgfolder=str(tmp_path),
+            mypokemon_path="mypokemon",
+            mainpokemon_path="mainpokemon",
+            itembag_path="itembag",
+            badgebag_path="badgebag",
+            team_pokemon_path="team",
+            pokemon_history_path="history",
+            user_path_credentials="credentials",
+            rate_path="rate",
+        ),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "Ankimon.utils",
+        _stub_module(
+            "Ankimon.utils",
+            check_folders_exist=lambda parent, folder: env.folders_exist,
+            get_main_pokemon_data=rec("get_main_pokemon_data"),
+            load_collected_pokemon_ids=rec("load_collected_pokemon_ids", {1, 4, 7}),
+            count_items_and_rewrite=rec("count_items_and_rewrite"),
+        ),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "Ankimon.functions.encounter_functions",
+        _stub_module(
+            "Ankimon.functions.encounter_functions",
+            generate_random_pokemon=rec("generate_random_pokemon", ENEMY_INFO),
+        ),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "Ankimon.functions.badges_functions",
+        _stub_module(
+            "Ankimon.functions.badges_functions",
+            get_achieved_badges=lambda: env.badges,
+        ),
+    )
+    env.badges = []
+    monkeypatch.setitem(
+        sys.modules,
+        "Ankimon.functions.rate_addon_functions",
+        _stub_module(
+            "Ankimon.functions.rate_addon_functions",
+            rate_this_addon=rec("rate_this_addon"),
+        ),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "Ankimon.gui_entities",
+        _stub_module("Ankimon.gui_entities", CheckFiles=FakeCheckFiles),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "Ankimon.pyobj.download_sprites",
+        _stub_module(
+            "Ankimon.pyobj.download_sprites",
+            show_agreement_and_download_dialog=rec(
+                "show_agreement_and_download_dialog"
+            ),
+        ),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "Ankimon.pyobj.backup_files",
+        _stub_module("Ankimon.pyobj.backup_files", run_backup=run_backup),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "Ankimon.pyobj.backup_manager",
+        _stub_module("Ankimon.pyobj.backup_manager", BackupManager=FakeBackupManager),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "Ankimon.pyobj.error_handler",
+        _stub_module(
+            "Ankimon.pyobj.error_handler",
+            show_warning_with_traceback=rec("show_warning_with_traceback"),
+        ),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "Ankimon.pyobj.migration_dialog",
+        _stub_module(
+            "Ankimon.pyobj.migration_dialog",
+            show_migration_dialog_if_needed=rec("show_migration_dialog_if_needed"),
+        ),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "Ankimon.singletons",
+        _stub_module(
+            "Ankimon.singletons",
+            logger=logger,
+            translator=translator,
+            settings_obj=settings,
+            ankimon_tracker_obj=tracker,
+            main_pokemon=main_pokemon,
+            enemy_pokemon=enemy,
+            ankimon_db=db,
+            get_starter_window=lambda: starter_window,
+        ),
+    )
+
+    spec = importlib.util.spec_from_file_location(
+        "Ankimon.startup", _src / "Ankimon" / "startup.py"
+    )
+    mod = importlib.util.module_from_spec(spec)
+    monkeypatch.setitem(sys.modules, "Ankimon.startup", mod)
+    spec.loader.exec_module(mod)
+    env.mod = mod
+    return env
+
+
+def _called(env, name):
+    return [c for c in env.calls if c[0] == name]
+
+
+def test_background_checks_do_no_ui_work_and_return_contract(startup_env):
+    env = startup_env
+    results = env.mod.run_startup_background_checks()
+
+    assert set(results) == {
+        "backup_error",
+        "backup_manager",
+        "is_migrated",
+        "collected_pokemon_ids",
+        "database_complete",
+        "enemy_info",
+        "needs_starter",
+        "needs_rating",
+    }
+    assert results["backup_error"] is None
+    assert results["is_migrated"] is True
+    assert results["collected_pokemon_ids"] == {1, 4, 7}
+    assert results["database_complete"] is True
+    assert results["enemy_info"] == ENEMY_INFO
+    assert results["needs_starter"] is False  # pokemon_count > 0
+    assert results["needs_rating"] is False  # no badges
+
+    # The aqt-free half must not have touched any UI collaborator.
+    assert FakeCheckFiles.instances == []
+    assert _called(env, "show_agreement_and_download_dialog") == []
+    assert _called(env, "show_migration_dialog_if_needed") == []
+    assert _called(env, "rate_this_addon") == []
+    assert env.starter_window.calls == []
+    # ...but the background work did run.
+    assert _called(env, "run_backup")
+    assert _called(env, "generate_random_pokemon")
+    assert _called(env, "count_items_and_rewrite")
+
+
+def test_background_checks_flag_starter_and_rating(startup_env):
+    env = startup_env
+    env.db.pokemon_count = 0
+    env.badges = ["boulder", "cascade"]
+
+    results = env.mod.run_startup_background_checks()
+    assert results["needs_starter"] is True
+    assert results["needs_rating"] is True
+
+    env.mod.run_startup_ui_callbacks(results)
+    assert env.starter_window.calls == [("display_starter_pokemon",)]
+    assert len(_called(env, "rate_this_addon")) == 1
+
+
+def test_rating_not_needed_when_already_rated(startup_env):
+    env = startup_env
+    env.badges = ["boulder", "cascade"]
+    env.db.user_data["rate_this"] = True
+
+    results = env.mod.run_startup_background_checks()
+    assert results["needs_rating"] is False
+
+
+def test_ui_callbacks_apply_first_enemy_and_reset_tracker(startup_env):
+    env = startup_env
+    results = env.mod.run_startup_background_checks()
+    returned = env.mod.run_startup_ui_callbacks(results)
+
+    assert returned is True
+    assert env.enemy.update_kwargs["name"] == "Pikachu"
+    assert env.enemy.update_kwargs["id"] == 25
+    assert env.enemy.update_kwargs["attacks"] == ["thunder-shock"]
+    assert env.enemy.update_kwargs["nature"] == "hardy"
+    assert env.enemy.current_hp == env.enemy.hp == env.enemy.max_hp == 42
+    assert _called(env, "randomize_battle_scene")
+    assert env.tracker.pokemon_encounter == 0
+
+
+def test_ui_callbacks_show_downloader_and_keep_checker_alive(startup_env):
+    env = startup_env
+    env.folders_exist = False
+
+    results = env.mod.run_startup_background_checks()
+    assert results["database_complete"] is False
+    assert results["enemy_info"] is None
+
+    returned = env.mod.run_startup_ui_callbacks(results)
+    assert returned is False
+
+    dialog_calls = _called(env, "show_agreement_and_download_dialog")
+    assert len(dialog_calls) == 1
+    assert dialog_calls[0][2] == {"force_download": True}
+    assert len(FakeCheckFiles.instances) == 1
+    assert FakeCheckFiles.instances[0].shown is True
+    # The dialog is anchored on the module so it cannot be garbage-collected.
+    assert env.mod._file_check_dialog is FakeCheckFiles.instances[0]
+    # No enemy was applied on the incomplete path.
+    assert env.enemy.update_kwargs is None
+
+
+def test_backup_error_is_reported_on_the_ui_side(startup_env):
+    env = startup_env
+    boom = RuntimeError("backup boom")
+    env.run_backup_error = boom
+
+    results = env.mod.run_startup_background_checks()
+    assert results["backup_error"] is boom
+    # Not reported from the background thread...
+    assert _called(env, "show_warning_with_traceback") == []
+
+    env.mod.run_startup_ui_callbacks(results)
+    warn_calls = _called(env, "show_warning_with_traceback")
+    assert len(warn_calls) == 1
+    assert warn_calls[0][2]["exception"] is boom
+
+
+def test_migration_dialog_shown_only_when_not_migrated(startup_env):
+    env = startup_env
+    env.db.migrated = False
+
+    results = env.mod.run_startup_background_checks()
+    assert results["is_migrated"] is False
+    env.mod.run_startup_ui_callbacks(results)
+    assert len(_called(env, "show_migration_dialog_if_needed")) == 1
+
+
+def test_dev_mode_auto_backup_uses_passed_manager(startup_env):
+    env = startup_env
+    env.settings.config["misc.developer_mode"] = True
+
+    manager = FakeBackupManager(env.logger, env.settings)
+    results = env.mod.run_startup_background_checks(manager)
+
+    assert results["backup_manager"] is manager
+    assert manager.create_calls == [False]
+    # No second manager was constructed inside the background half.
+    assert FakeBackupManager.instances == [manager]
+
+
+def test_auto_catch_migration_folds_legacy_key_once(startup_env):
+    env = startup_env
+    env.settings.config["battle.automatic_catch_special"] = False
+    # F28's load_config seeds the new keys with defaults before startup runs.
+    for key in AUTO_CATCH_KEYS:
+        env.settings.config[key] = True
+
+    env.mod.run_startup_background_checks()
+
+    for key in AUTO_CATCH_KEYS:
+        assert env.settings.config[key] is False, key
+    # Tombstoned: the legacy key is neutralized...
+    assert env.settings.config["battle.automatic_catch_special"] is None
+
+    # ...so a second boot (where the DB round-trips None as "None") is a no-op.
+    env.settings.config["battle.automatic_catch_special"] = "None"
+    env.settings.set_calls.clear()
+    env.mod.run_startup_background_checks()
+    assert env.settings.set_calls == []
+
+
+def test_auto_catch_migration_noop_without_legacy_key(startup_env):
+    env = startup_env
+    for key in AUTO_CATCH_KEYS:
+        env.settings.config[key] = True
+
+    env.mod.run_startup_background_checks()
+    assert env.settings.set_calls == []
+    for key in AUTO_CATCH_KEYS:
+        assert env.settings.config[key] is True
+
+
+# ---------------------------------------------------------------------------
+# Part B: __init__.py boot ordering + reload-safe review hook (NR-21)
+# ---------------------------------------------------------------------------
+
+
+class SyncQueryOp:
+    """The harness QueryOp contract: op off-thread, success on the GUI thread
+    — here synchronous, so a test observes the full boot deterministically."""
+
+    instances = []
+
+    def __init__(self, *, parent=None, op=None, success=None):
+        type(self).instances.append(self)
+        self._op = op
+        self._success = success
+        self.without_collection_called = False
+
+    def without_collection(self):
+        self.without_collection_called = True
+        return self
+
+    def run_in_background(self):
+        result = self._op(None) if self._op else None
+        if self._success:
+            self._success(result)
+        return result
+
+
+def _fresh_services(monkeypatch):
+    spec = importlib.util.spec_from_file_location(
+        "Ankimon.services", _src / "Ankimon" / "services.py"
+    )
+    mod = importlib.util.module_from_spec(spec)
+    monkeypatch.setitem(sys.modules, "Ankimon.services", mod)
+    spec.loader.exec_module(mod)
+    return mod.services
+
+
+@pytest.fixture
+def boot_env(monkeypatch):
+    """Stub every __init__.py collaborator; exec_init() runs the real boot."""
+    SyncQueryOp.instances = []
+    calls = []
+
+    def rec(name, result=None):
+        def _f(*args, **kwargs):
+            calls.append((name, args, kwargs))
+            return result
+
+        return _f
+
+    FakeBackupManager.instances = []
+
+    services = _fresh_services(monkeypatch)
+
+    settings = FakeSettings(
+        {
+            "misc.YouShallNotPass_Ankimon_News": False,
+            "misc.ssh": True,
+            "controls.key_for_opening_closing_ankimon": "Ctrl+Shift+P",
+            "controls.catch_key": "6",
+            "controls.defeat_key": "5",
+            "controls.pokemon_buttons": True,
+        }
+    )
+    logger = FakeLogger(calls)
+    tracker = FakeTracker(calls)
+
+    hooks = SimpleNamespace(reviewer_did_answer_card=[])
+    mw = SimpleNamespace(
+        addonManager=SimpleNamespace(
+            setWebExports=rec("setWebExports"),
+            addonFromModule=lambda name: "ankimon",
+        )
+    )
+    aqt_stub = _stub_module(
+        "aqt",
+        mw=mw,
+        gui_hooks=hooks,
+        reviewer=SimpleNamespace(Reviewer=type("Reviewer", (), {})),
+    )
+    monkeypatch.setitem(sys.modules, "aqt", aqt_stub)
+
+    webview_hook = []
+    monkeypatch.setitem(
+        sys.modules,
+        "aqt.gui_hooks",
+        _stub_module("aqt.gui_hooks", webview_will_set_content=webview_hook),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "aqt.webview",
+        _stub_module("aqt.webview", WebContent=type("WebContent", (), {})),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "aqt.operations",
+        _stub_module("aqt.operations", QueryOp=SyncQueryOp),
+    )
+
+    background_results = {
+        "backup_error": None,
+        "backup_manager": None,
+        "is_migrated": True,
+        "collected_pokemon_ids": {10, 20},
+        "database_complete": True,
+        "enemy_info": ENEMY_INFO,
+        "needs_starter": False,
+        "needs_rating": False,
+    }
+
+    def run_startup_background_checks(backup_manager=None):
+        calls.append(("run_startup_background_checks", (backup_manager,), {}))
+        results = dict(background_results)
+        results["backup_manager"] = backup_manager
+        return results
+
+    def run_startup_ui_callbacks(results):
+        calls.append(("run_startup_ui_callbacks", (results,), {}))
+        return results["database_complete"]
+
+    singletons = _stub_module(
+        "Ankimon.singletons",
+        settings_obj=settings,
+        logger=logger,
+        translator=SimpleNamespace(translate=lambda key: key),
+        ankimon_tracker_obj=tracker,
+        shop_manager=SimpleNamespace(),
+        trainer_card=SimpleNamespace(),
+        settings_window=object(),
+        test_window=object(),
+        achievement_bag=object(),
+        ankimon_tracker_window=object(),
+        pokedex_window=object(),
+        eff_chart=object(),
+        gen_id_chart=object(),
+        license=object(),
+        credits=object(),
+        item_window=object(),
+        version_dialog=object(),
+        pokemon_pc=object(),
+    )
+
+    stubs = {
+        "Ankimon.resources": _stub_module(
+            "Ankimon.resources",
+            ensure_ankimon_infrastructure=rec("ensure_ankimon_infrastructure"),
+            user_path="user_path",
+            addon_dir="addon_dir",
+        ),
+        "Ankimon.singletons": singletons,
+        "Ankimon.functions.url_functions": _stub_module(
+            "Ankimon.functions.url_functions",
+            open_team_builder=rec("open_team_builder"),
+            rate_addon_url=rec("rate_addon_url"),
+            report_bug=rec("report_bug"),
+            join_discord_url=rec("join_discord_url"),
+            open_leaderboard_url=rec("open_leaderboard_url"),
+        ),
+        "Ankimon.functions.pokemon_showdown_functions": _stub_module(
+            "Ankimon.functions.pokemon_showdown_functions",
+            export_to_pkmn_showdown=rec("export_to_pkmn_showdown"),
+            export_all_pkmn_showdown=rec("export_all_pkmn_showdown"),
+            flex_pokemon_collection=rec("flex_pokemon_collection"),
+        ),
+        "Ankimon.utils": _stub_module(
+            "Ankimon.utils",
+            test_online_connectivity=rec("test_online_connectivity", True),
+        ),
+        "Ankimon.menu_buttons": _stub_module(
+            "Ankimon.menu_buttons",
+            create_menu_actions=rec("create_menu_actions"),
+        ),
+        "Ankimon.hooks": _stub_module("Ankimon.hooks", setupHooks=rec("setupHooks")),
+        "Ankimon.pyobj.error_handler": _stub_module(
+            "Ankimon.pyobj.error_handler",
+            show_warning_with_traceback=rec("show_warning_with_traceback"),
+        ),
+        "Ankimon.pyobj.backup_manager": _stub_module(
+            "Ankimon.pyobj.backup_manager", BackupManager=FakeBackupManager
+        ),
+        "Ankimon.events": _stub_module(
+            "Ankimon.events", events=SimpleNamespace(emit=rec("events.emit"))
+        ),
+        "Ankimon.gui_classes.overview_team": _stub_module(
+            "Ankimon.gui_classes.overview_team"
+        ),
+        "Ankimon.card_hooks": _stub_module(
+            "Ankimon.card_hooks",
+            register_card_hooks=rec("register_card_hooks"),
+        ),
+        "Ankimon.changelog": _stub_module(
+            "Ankimon.changelog",
+            check_and_show_changelog=rec("check_and_show_changelog"),
+            open_help_window=rec("open_help_window"),
+            schedule_branch_update_check=rec("schedule_branch_update_check"),
+        ),
+        "Ankimon.hook_registry": _stub_module(
+            "Ankimon.hook_registry",
+            CatchPokemonHook=rec("CatchPokemonHook"),
+            DefeatPokemonHook=rec("DefeatPokemonHook"),
+            add_catch_pokemon_hook=rec("add_catch_pokemon_hook"),
+            add_defeat_pokemon_hook=rec("add_defeat_pokemon_hook"),
+        ),
+        "Ankimon.profile_hooks": _stub_module(
+            "Ankimon.profile_hooks",
+            register_profile_hooks=rec("register_profile_hooks"),
+        ),
+        "Ankimon.reviewer_ui": _stub_module(
+            "Ankimon.reviewer_ui",
+            setup_reviewer_ui=rec("setup_reviewer_ui"),
+            set_collected_ids=rec("set_collected_ids"),
+        ),
+        "Ankimon.discord_integration": _stub_module(
+            "Ankimon.discord_integration",
+            setup_discord_hooks=rec("setup_discord_hooks"),
+        ),
+        "Ankimon.startup": _stub_module(
+            "Ankimon.startup",
+            run_startup_background_checks=run_startup_background_checks,
+            run_startup_ui_callbacks=run_startup_ui_callbacks,
+        ),
+    }
+    for name, mod in stubs.items():
+        monkeypatch.setitem(sys.modules, name, mod)
+
+    # `from .battle_loop import on_review_card` needs a real-looking module.
+    def on_review_card(*args, **kwargs):
+        calls.append(("on_review_card", args, kwargs))
+
+    monkeypatch.setitem(
+        sys.modules,
+        "Ankimon.battle_loop",
+        _stub_module(
+            "Ankimon.battle_loop",
+            on_review_card=on_review_card,
+            init_battle_state=rec("init_battle_state"),
+        ),
+    )
+
+    # `from .gui_classes import overview_team` resolves via the parent module.
+    gui_classes_pkg = _stub_module("Ankimon.gui_classes")
+    gui_classes_pkg.overview_team = stubs["Ankimon.gui_classes.overview_team"]
+    monkeypatch.setitem(sys.modules, "Ankimon.gui_classes", gui_classes_pkg)
+
+    def exec_init():
+        sys.modules.pop("Ankimon", None)
+        spec = importlib.util.spec_from_file_location(
+            "Ankimon",
+            _src / "Ankimon" / "__init__.py",
+            submodule_search_locations=[str(_src / "Ankimon")],
+        )
+        mod = importlib.util.module_from_spec(spec)
+        sys.modules["Ankimon"] = mod
+        spec.loader.exec_module(mod)
+        return mod
+
+    return SimpleNamespace(
+        calls=calls,
+        services=services,
+        settings=settings,
+        hooks=hooks,
+        singletons=singletons,
+        exec_init=exec_init,
+    )
+
+
+def _names(env):
+    return [c[0] for c in env.calls]
+
+
+def _first(env, name):
+    for c in env.calls:
+        if c[0] == name:
+            return c
+    raise AssertionError(f"{name} was never called")
+
+
+def test_boot_ordering_background_then_ui_then_menu(boot_env):
+    boot_env.exec_init()
+    names = _names(boot_env)
+
+    # Module-scope registrations happen BEFORE the async boot starts, so a
+    # profileLoaded/profile_did_open fired mid-boot can never be missed.
+    assert names.index("register_profile_hooks") < names.index(
+        "run_startup_background_checks"
+    )
+    assert names.index("register_card_hooks") < names.index(
+        "run_startup_background_checks"
+    )
+    # Background half -> UI half -> menu, in order.
+    assert (
+        names.index("run_startup_background_checks")
+        < names.index("run_startup_ui_callbacks")
+        < names.index("create_menu_actions")
+    )
+    # The QueryOp ran collection-free.
+    assert len(SyncQueryOp.instances) == 1
+    assert SyncQueryOp.instances[0].without_collection_called is True
+
+
+def test_changelog_keeps_real_connectivity(boot_env):
+    """exp stubbed online_connectivity=False and dropped the changelog call;
+    the port must keep both on the REAL connectivity result."""
+    boot_env.exec_init()
+
+    changelog = _first(boot_env, "check_and_show_changelog")
+    # (online_connectivity, ssh, no_more_news) — connectivity is the real
+    # test_online_connectivity() result (stubbed True), NOT a False stub.
+    assert changelog[1] == (True, True, False)
+
+    branch_check = _first(boot_env, "schedule_branch_update_check")
+    assert branch_check[1] == (True, True)
+
+
+def test_menu_gets_base_call_shape_no_none_placeholders(boot_env):
+    mod = boot_env.exec_init()
+
+    menu = _first(boot_env, "create_menu_actions")
+    args = menu[1]
+    assert len(args) == 30
+    # exp passed 11 None placeholders; the port passes base's real objects.
+    assert not any(arg is None for arg in args)
+    assert args[0] is True  # database_complete
+    assert args[1] is True  # online_connectivity (real result)
+    assert args[2] is boot_env.singletons.item_window
+    assert args[3] is boot_env.singletons.test_window
+    assert args[-1] is mod.backup_manager
+
+
+def test_reviewer_ui_called_with_base_three_arg_signature(boot_env):
+    boot_env.exec_init()
+
+    setup = _first(boot_env, "setup_reviewer_ui")
+    assert setup[1] == ("6", "5", True)
+    assert setup[2] == {}
+
+
+def test_collected_ids_shared_by_identity_across_consumers(boot_env):
+    mod = boot_env.exec_init()
+
+    profile = _first(boot_env, "register_profile_hooks")
+    battle = _first(boot_env, "init_battle_state")
+    reviewer = _first(boot_env, "set_collected_ids")
+
+    # One live set object everywhere...
+    assert profile[1][6] is mod.collected_pokemon_ids
+    assert battle[1][0] is mod.collected_pokemon_ids
+    assert reviewer[1][0] is mod.collected_pokemon_ids
+    # ...filled in place by the async boot's results.
+    assert mod.collected_pokemon_ids == {10, 20}
+
+    # The background half received the module's own BackupManager.
+    background = _first(boot_env, "run_startup_background_checks")
+    assert background[1][0] is mod.backup_manager
+
+
+def test_startup_finished_flag_gates_the_review_hook(boot_env):
+    boot_env.exec_init()
+
+    # The synchronous QueryOp completed the boot during exec.
+    assert getattr(boot_env.services, "startup_finished") is True
+
+    handlers = boot_env.hooks.reviewer_did_answer_card
+    assert len(handlers) == 1
+    handler = handlers[0]
+
+    # Gate closed: the review is dropped before the boot finishes.
+    setattr(boot_env.services, "startup_finished", False)
+    handler("reviewer", "card", 3)
+    assert [c for c in boot_env.calls if c[0] == "on_review_card"] == []
+
+    # Gate open: the review reaches the battle loop.
+    setattr(boot_env.services, "startup_finished", True)
+    handler("reviewer", "card", 3)
+    forwarded = [c for c in boot_env.calls if c[0] == "on_review_card"]
+    assert len(forwarded) == 1
+    assert forwarded[0][1] == ("reviewer", "card", 3)
+
+
+def test_double_boot_does_not_stack_review_handlers(boot_env):
+    """NR-21: a re-execution of __init__ (add-on reload) must swap the
+    reviewer_did_answer_card handler, not append a second one."""
+    boot_env.exec_init()
+    assert len(boot_env.hooks.reviewer_did_answer_card) == 1
+    first_handler = boot_env.hooks.reviewer_did_answer_card[0]
+
+    mod2 = boot_env.exec_init()
+
+    handlers = boot_env.hooks.reviewer_did_answer_card
+    assert len(handlers) == 1, "reload must not stack review handlers"
+    assert handlers[0] is not first_handler
+    assert handlers[0] is mod2._on_review_card_gated

--- a/tests/test_async_startup_boot.py
+++ b/tests/test_async_startup_boot.py
@@ -510,6 +510,32 @@ def test_auto_catch_migration_noop_without_legacy_key(startup_env):
         assert env.settings.config[key] is True
 
 
+def test_auto_catch_migration_coerces_string_toggle(startup_env):
+    # A legacy value that survives the config DB layer's str() fallback comes
+    # back as the string "True"/"False" — bool("False") is truthy, so the
+    # migration must normalize the string form, not fold it verbatim.
+    env = startup_env
+    for legacy, expected in (
+        ("False", False),
+        ("True", True),
+        ("1", True),
+        ("0", False),
+    ):
+        env.settings.config.clear()
+        env.settings.config["battle.automatic_catch_special"] = legacy
+        for key in AUTO_CATCH_KEYS:
+            env.settings.config[key] = not expected
+
+        env.mod.run_startup_background_checks()
+
+        for key in AUTO_CATCH_KEYS:
+            assert env.settings.config[key] is expected, (legacy, key)
+        # Every migrated key is a real bool, never the raw string.
+        for key in AUTO_CATCH_KEYS:
+            assert isinstance(env.settings.config[key], bool), (legacy, key)
+        assert env.settings.config["battle.automatic_catch_special"] is None
+
+
 # ---------------------------------------------------------------------------
 # Part B: __init__.py boot ordering + reload-safe review hook (NR-21)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What
Ports F32 (exp `14f42873` "zero-lag asynchronous & thread-safe startup") onto the integration tip, re-fitted to main's service seam. The old synchronous `run_startup_sequence()` is split into two halves driven by Anki's `aqt.operations.QueryOp(parent=mw, ...).without_collection().run_in_background()`:

- `run_startup_background_checks()` — the aqt-free half (backup, dev auto-backup, DB migration-status read, collected-ID load, legacy config migration, sprite-folder checks, first-enemy generation, item-count consolidation). Runs on the QueryOp background thread; touches only disk/DB/CPU and returns a plain results dict.
- `run_startup_ui_callbacks(results)` — the main-thread half (backup-error dialog, migration dialog, sprite-download dialog, first-enemy stat application, starter window, rate prompt, tracker reset).

`__init__.py` registers every module-scope hook first, then launches the pair via QueryOp; the success callback marshals results back to the main thread, fills the shared collected-ID set, wires battle state / reviewer UI / menu, flips the readiness flag and opens the review gate.

## Re-fit to seam (exp -> main mapping)
- `mw.ankimon_startup_finished` -> `setattr(services, "startup_finished", ...)` on the services registry + an `events.emit("startup_finished")`. exp's `mw.online_connectivity` and `mw._ankimon_review_proxy` mw-writes are NOT ported (base keeps `online_connectivity` as a local; base has no such mw mirror, so none is added).
- exp gated reviews inside `battle_loop` via `mw.ankimon_startup_finished`; on main the gate is a `_on_review_card_gated` wrapper in `__init__.py` that returns `None` until `services.startup_finished` is True, then forwards to `on_review_card` (base's battle loop is untouched).
- reviewer_did_answer_card registration uses F31's registry-anchored `(hook, handler)` remove-before-append record (NR-21), so a reload swaps the handler instead of stacking a duplicate.
- `create_menu_actions` keeps base's full 30-arg real-object call shape (F31 lazy window factories are imported inside the success callback and first constructed there, on the main thread) — exp's 11 `None` placeholders are not ported.
- `setup_reviewer_ui` keeps base's 3-arg signature (F34 owns the team-cycle 4th arg).
- The legacy `battle.automatic_catch_special` -> seven `battle.auto_catch_*` migration runs in the background half, one-shot via a tombstone. Unlike exp (which only sets keys `not in config`), the port sets the seven keys unconditionally: F28 already seeds all seven keys, so exp's "only if missing" guard would silently no-op the migration on main — the unconditional fold is the correct re-fit.
- Logger boot lines stay `log_and_showinfo("game", ...)`, verified aqt-free (game level only records + emits an event; the blocking QMessageBox path is info/warning/error only), so they are safe on the background thread. They sit at the top of the background half, preserving the old synchronous sequence's boot-log order. DB work off-thread is legal: `AnkimonDB` uses `threading.local()` per-thread connections with `check_same_thread=False`.

## Parity notes
- 18 Qt-free characterization tests (`tests/test_async_startup_boot.py`) exec the REAL `startup.py` / `__init__.py` under sys.modules stubs, driving the QueryOp with a synchronous fake: background/UI contract, no-UI-in-background, first-enemy application, GC-anchored CheckFiles dialog, backup-error surfacing, one-shot config migration, boot ordering (module-scope hooks before the QueryOp launch; background -> UI -> menu; QueryOp `without_collection`), real changelog connectivity, 30-arg menu shape with no None placeholders, 3-arg reviewer_ui, collected-ID set shared by identity across profile hooks / battle state / reviewer UI, the startup-finished review gate, and NR-21 double-exec idempotency.
- Post-snapshot exp hunks (NR-15): the port is taken against the final exp tip `b04e4bec`, so all of the file's exp history is captured. No net-new file outside this manifest.

## Guards confirmation (independently re-verified)
- Changelog: `check_and_show_changelog(...)` AND F26 `schedule_branch_update_check(...)` both fire with the REAL `test_online_connectivity()` result (True,True,False confirmed by unit test and by probe_real_boot). exp's `online_connectivity=False` stub + dropped changelog call (exp imported only `open_help_window`) is NOT ported.
- Encounter level-cap NameError guard #402: first enemy still routed through `generate_random_pokemon()` (probe_real_boot generates Rattata cleanly).
- Monthly-challenge None-safety: `register_profile_hooks` path preserved unchanged at module scope with real connectivity.
- F28 config migration: no double-migration; one-shot tombstone, handles the DB `"None"`-string tombstone round-trip AND normalizes any legacy string toggle form (`"True"`/`"False"`/`"1"`/`"0"`) so `bool("False")` can never migrate a disabled toggle as enabled; genuine booleans already round-trip correctly through the json-based config layer.
- overview_team hook registration happens exactly once (module-scope import, gated by `gui.team_deck_view`).
- NR-21: real single boot = 3 reviewer_did_answer_card hooks; real reload (importlib.reload) stays at exactly 3.

## Deferred
- F34 (Wave-3 parallel): team-cycle 4th arg to `setup_reviewer_ui` (added by F34, not here).
- F36 (Wave 4): web-shell/dev-menu None-placeholder menu wiring (base's real 30-arg call kept instead).

## Gates (re-run fresh by the verifier vs the f03f1fd9 baseline)
- compileall OK.
- ruff check (ci_ruff_check.toml): 10 errors, all pre-existing in `src/Ankimon/gui_classes/AnkimonWindow copy.py` — zero new.
- ruff format --check: clean on all 3 touched/created files.
- pytest Tier-1 (ignoring addon_integrity + scaffolding_smoke): 321 passed / 35 skipped / 0 failed (303 baseline + 18 new).
- harness/check.py: 9/9 PASS.
- Qt: scaffolding smoke 4 passed, addon integrity 1 passed, probe_real_boot OK (reviewer_did_answer_card hooks == 3, Rattata first enemy), probe_real_play OK (23 answers, 2 caught, 1 defeated), real double-boot hook count stays 3.

## Attribution
Originally implemented by @hakimh2 (and @jupiterslegacy) on BRRRR_Experimental; credited via Co-authored-by trailers on both commits (`Hakimh2 <74561421+hakimh2@users.noreply.github.com>`, `Jupytrr <291307696+jupiterslegacy@users.noreply.github.com>`). The broken `Your Name <you@example.com>` identity in the file history maps to Hakimh2; h0tp-ftw self-credit excluded.

