### PR TITLE
feat: region-aware + move-based evolutions, form data (pokedex) (F17)

### DIFF
--- a/src/Ankimon/data_files/pokedex.json
+++ b/src/Ankimon/data_files/pokedex.json
@@ -1374,37 +1374,6 @@
     "canGigantamax": "G-Max Volt Crash",
     "tier": "ZU"
   },
-  "pikachucosplay": {
-    "species_id": 25,
-    "actual_id": 10085,
-    "name": "Pikachu-Cosplay",
-    "baseSpecies": "Pikachu",
-    "forme": "Cosplay",
-    "types": [
-      "Electric"
-    ],
-    "gender": "F",
-    "baseStats": {
-      "hp": 35,
-      "atk": 55,
-      "def": 40,
-      "spa": 50,
-      "spd": 50,
-      "spe": 90
-    },
-    "abilities": {
-      "0": "Lightning Rod"
-    },
-    "heightm": 0.4,
-    "weightkg": 6,
-    "color": "Yellow",
-    "eggGroups": [
-      "Undiscovered"
-    ],
-    "gen": 6,
-    "tier": "Illegal",
-    "isNonstandard": "Past"
-  },
   "pikachurockstar": {
     "species_id": 25,
     "actual_id": 10080,
@@ -1561,6 +1530,37 @@
       "Undiscovered"
     ],
     "changesFrom": "Pikachu-Cosplay",
+    "gen": 6,
+    "tier": "Illegal",
+    "isNonstandard": "Past"
+  },
+  "pikachucosplay": {
+    "species_id": 25,
+    "actual_id": 10085,
+    "name": "Pikachu-Cosplay",
+    "baseSpecies": "Pikachu",
+    "forme": "Cosplay",
+    "types": [
+      "Electric"
+    ],
+    "gender": "F",
+    "baseStats": {
+      "hp": 35,
+      "atk": 55,
+      "def": 40,
+      "spa": 50,
+      "spd": 50,
+      "spe": 90
+    },
+    "abilities": {
+      "0": "Lightning Rod"
+    },
+    "heightm": 0.4,
+    "weightkg": 6,
+    "color": "Yellow",
+    "eggGroups": [
+      "Undiscovered"
+    ],
     "gen": 6,
     "tier": "Illegal",
     "isNonstandard": "Past"
@@ -1812,6 +1812,37 @@
     "tier": "Illegal",
     "isNonstandard": "LGPE"
   },
+  "pikachuworld": {
+    "species_id": 25,
+    "actual_id": 10160,
+    "name": "Pikachu-World",
+    "baseSpecies": "Pikachu",
+    "forme": "World",
+    "types": [
+      "Electric"
+    ],
+    "gender": "M",
+    "baseStats": {
+      "hp": 35,
+      "atk": 55,
+      "def": 40,
+      "spa": 50,
+      "spd": 50,
+      "spe": 90
+    },
+    "abilities": {
+      "0": "Static",
+      "H": "Lightning Rod"
+    },
+    "heightm": 0.4,
+    "weightkg": 6,
+    "color": "Yellow",
+    "eggGroups": [
+      "Undiscovered"
+    ],
+    "gen": 8,
+    "tier": "ZU"
+  },
   "pikachugmax": {
     "species_id": 25,
     "actual_id": 10199,
@@ -1843,37 +1874,6 @@
     "changesFrom": "Pikachu",
     "tier": "Illegal",
     "isNonstandard": "Past"
-  },
-  "pikachuworld": {
-    "species_id": 25,
-    "actual_id": 10160,
-    "name": "Pikachu-World",
-    "baseSpecies": "Pikachu",
-    "forme": "World",
-    "types": [
-      "Electric"
-    ],
-    "gender": "M",
-    "baseStats": {
-      "hp": 35,
-      "atk": 55,
-      "def": 40,
-      "spa": 50,
-      "spd": 50,
-      "spe": 90
-    },
-    "abilities": {
-      "0": "Static",
-      "H": "Lightning Rod"
-    },
-    "heightm": 0.4,
-    "weightkg": 6,
-    "color": "Yellow",
-    "eggGroups": [
-      "Undiscovered"
-    ],
-    "gen": 8,
-    "tier": "ZU"
   },
   "raichu": {
     "species_id": 26,
@@ -1946,6 +1946,70 @@
       "Fairy"
     ],
     "tier": "ZU"
+  },
+  "raichumegax": {
+    "species_id": 26,
+    "actual_id": 10304,
+    "name": "Raichu-Mega-X",
+    "baseSpecies": "Raichu",
+    "forme": "Mega-X",
+    "types": [
+      "Electric"
+    ],
+    "baseStats": {
+      "hp": 60,
+      "atk": 135,
+      "def": 95,
+      "spa": 90,
+      "spd": 95,
+      "spe": 110
+    },
+    "abilities": {
+      "0": "Surge Surfer"
+    },
+    "heightm": 1.2,
+    "weightkg": 38,
+    "color": "Yellow",
+    "eggGroups": [
+      "Field",
+      "Fairy"
+    ],
+    "requiredItem": "Raichunite X",
+    "gen": 9,
+    "tier": "Illegal",
+    "isNonstandard": "Past"
+  },
+  "raichumegay": {
+    "species_id": 26,
+    "actual_id": 10305,
+    "name": "Raichu-Mega-Y",
+    "baseSpecies": "Raichu",
+    "forme": "Mega-Y",
+    "types": [
+      "Electric"
+    ],
+    "baseStats": {
+      "hp": 60,
+      "atk": 100,
+      "def": 55,
+      "spa": 160,
+      "spd": 80,
+      "spe": 130
+    },
+    "abilities": {
+      "0": "Surge Surfer"
+    },
+    "heightm": 1,
+    "weightkg": 26,
+    "color": "Yellow",
+    "eggGroups": [
+      "Field",
+      "Fairy"
+    ],
+    "requiredItem": "Raichunite Y",
+    "gen": 9,
+    "tier": "Illegal",
+    "isNonstandard": "Past"
   },
   "sandshrew": {
     "species_id": 27,
@@ -4782,7 +4846,7 @@
   "farfetchd": {
     "species_id": 83,
     "actual_id": 83,
-    "name": "Farfetch\u2019d",
+    "name": "Farfetch’d",
     "types": [
       "Normal",
       "Flying"
@@ -4808,11 +4872,11 @@
       "Field"
     ],
     "otherFormes": [
-      "Farfetch\u2019d-Galar"
+      "Farfetch’d-Galar"
     ],
     "formeOrder": [
-      "Farfetch\u2019d",
-      "Farfetch\u2019d-Galar"
+      "Farfetch’d",
+      "Farfetch’d-Galar"
     ],
     "tier": "Illegal",
     "isNonstandard": "Past"
@@ -4820,8 +4884,8 @@
   "farfetchdgalar": {
     "species_id": 83,
     "actual_id": 10166,
-    "name": "Farfetch\u2019d-Galar",
-    "baseSpecies": "Farfetch\u2019d",
+    "name": "Farfetch’d-Galar",
+    "baseSpecies": "Farfetch’d",
     "forme": "Galar",
     "types": [
       "Fighting"
@@ -4842,7 +4906,7 @@
     "weightkg": 42,
     "color": "Brown",
     "evos": [
-      "Sirfetch\u2019d"
+      "Sirfetch’d"
     ],
     "eggGroups": [
       "Flying",
@@ -16279,6 +16343,38 @@
     "canHatch": true,
     "tier": "ZU"
   },
+  "chimechomega": {
+    "species_id": 358,
+    "actual_id": 10306,
+    "name": "Chimecho-Mega",
+    "baseSpecies": "Chimecho",
+    "forme": "Mega",
+    "types": [
+      "Psychic",
+      "Steel"
+    ],
+    "baseStats": {
+      "hp": 75,
+      "atk": 50,
+      "def": 110,
+      "spa": 135,
+      "spd": 120,
+      "spe": 65
+    },
+    "abilities": {
+      "0": "Levitate"
+    },
+    "heightm": 1.2,
+    "weightkg": 8,
+    "color": "Blue",
+    "eggGroups": [
+      "Amorphous"
+    ],
+    "requiredItem": "Chimechite",
+    "gen": 9,
+    "tier": "Illegal",
+    "isNonstandard": "Past"
+  },
   "absol": {
     "species_id": 359,
     "actual_id": 359,
@@ -16342,6 +16438,38 @@
       "Field"
     ],
     "requiredItem": "Absolite",
+    "tier": "Illegal",
+    "isNonstandard": "Past"
+  },
+  "absolmegaz": {
+    "species_id": 359,
+    "actual_id": 10307,
+    "name": "Absol-Mega-Z",
+    "baseSpecies": "Absol",
+    "forme": "Mega-Z",
+    "types": [
+      "Dark",
+      "Ghost"
+    ],
+    "baseStats": {
+      "hp": 65,
+      "atk": 154,
+      "def": 60,
+      "spa": 75,
+      "spd": 60,
+      "spe": 151
+    },
+    "abilities": {
+      "0": "Magic Bounce"
+    },
+    "heightm": 1.2,
+    "weightkg": 49,
+    "color": "Black",
+    "eggGroups": [
+      "Field"
+    ],
+    "requiredItem": "Absolite Z",
+    "gen": 9,
     "tier": "Illegal",
     "isNonstandard": "Past"
   },
@@ -18026,6 +18154,39 @@
       "Flying"
     ],
     "tier": "NU"
+  },
+  "staraptormega": {
+    "species_id": 398,
+    "actual_id": 10308,
+    "name": "Staraptor-Mega",
+    "baseSpecies": "Staraptor",
+    "forme": "Mega",
+    "types": [
+      "Fighting",
+      "Flying"
+    ],
+    "baseStats": {
+      "hp": 85,
+      "atk": 140,
+      "def": 100,
+      "spa": 60,
+      "spd": 90,
+      "spe": 110
+    },
+    "abilities": {
+      "0": "Intimidate",
+      "H": "Reckless"
+    },
+    "heightm": 1.9,
+    "weightkg": 50,
+    "color": "Gray",
+    "eggGroups": [
+      "Flying"
+    ],
+    "requiredItem": "Staraptite",
+    "gen": 9,
+    "tier": "Illegal",
+    "isNonstandard": "Past"
   },
   "bidoof": {
     "species_id": 399,
@@ -19754,6 +19915,38 @@
     "tier": "Illegal",
     "isNonstandard": "Past"
   },
+  "garchompmegaz": {
+    "species_id": 445,
+    "actual_id": 10309,
+    "name": "Garchomp-Mega-Z",
+    "baseSpecies": "Garchomp",
+    "forme": "Mega-Z",
+    "types": [
+      "Dragon"
+    ],
+    "baseStats": {
+      "hp": 108,
+      "atk": 130,
+      "def": 85,
+      "spa": 141,
+      "spd": 85,
+      "spe": 151
+    },
+    "abilities": {
+      "0": "Sand Force"
+    },
+    "heightm": 1.9,
+    "weightkg": 99,
+    "color": "Blue",
+    "eggGroups": [
+      "Monster",
+      "Dragon"
+    ],
+    "requiredItem": "Garchompite Z",
+    "gen": 9,
+    "tier": "Illegal",
+    "isNonstandard": "Past"
+  },
   "munchlax": {
     "species_id": 446,
     "actual_id": 446,
@@ -19903,6 +20096,43 @@
       "Human-Like"
     ],
     "requiredItem": "Lucarionite",
+    "tier": "Illegal",
+    "isNonstandard": "Past"
+  },
+  "lucariomegaz": {
+    "species_id": 448,
+    "actual_id": 10310,
+    "name": "Lucario-Mega-Z",
+    "baseSpecies": "Lucario",
+    "forme": "Mega-Z",
+    "types": [
+      "Fighting",
+      "Steel"
+    ],
+    "genderRatio": {
+      "M": 0.875,
+      "F": 0.125
+    },
+    "baseStats": {
+      "hp": 70,
+      "atk": 100,
+      "def": 70,
+      "spa": 164,
+      "spd": 70,
+      "spe": 151
+    },
+    "abilities": {
+      "0": "Adaptability"
+    },
+    "heightm": 1.3,
+    "weightkg": 49.4,
+    "color": "Gray",
+    "eggGroups": [
+      "Field",
+      "Human-Like"
+    ],
+    "requiredItem": "Lucarionite Z",
+    "gen": 9,
     "tier": "Illegal",
     "isNonstandard": "Past"
   },
@@ -21459,6 +21689,42 @@
     ],
     "tier": "OU"
   },
+  "heatranmega": {
+    "species_id": 485,
+    "actual_id": 10311,
+    "name": "Heatran-Mega",
+    "baseSpecies": "Heatran",
+    "forme": "Mega",
+    "types": [
+      "Fire",
+      "Steel"
+    ],
+    "baseStats": {
+      "hp": 91,
+      "atk": 120,
+      "def": 106,
+      "spa": 175,
+      "spd": 141,
+      "spe": 67
+    },
+    "abilities": {
+      "0": "Flash Fire",
+      "H": "Flame Body"
+    },
+    "heightm": 2.8,
+    "weightkg": 570,
+    "color": "Brown",
+    "tags": [
+      "Sub-Legendary"
+    ],
+    "eggGroups": [
+      "Undiscovered"
+    ],
+    "requiredItem": "Heatranite",
+    "gen": 9,
+    "tier": "Illegal",
+    "isNonstandard": "Past"
+  },
   "regigigas": {
     "species_id": 486,
     "actual_id": 486,
@@ -21682,6 +21948,41 @@
       "Undiscovered"
     ],
     "tier": "OU"
+  },
+  "darkraimega": {
+    "species_id": 491,
+    "actual_id": 10312,
+    "name": "Darkrai-Mega",
+    "baseSpecies": "Darkrai",
+    "forme": "Mega",
+    "types": [
+      "Dark"
+    ],
+    "gender": "N",
+    "baseStats": {
+      "hp": 70,
+      "atk": 120,
+      "def": 130,
+      "spa": 165,
+      "spd": 130,
+      "spe": 85
+    },
+    "abilities": {
+      "0": "Bad Dreams"
+    },
+    "heightm": 3,
+    "weightkg": 240,
+    "color": "Black",
+    "tags": [
+      "Mythical"
+    ],
+    "eggGroups": [
+      "Undiscovered"
+    ],
+    "requiredItem": "Darkranite",
+    "gen": 9,
+    "tier": "Illegal",
+    "isNonstandard": "Past"
   },
   "shaymin": {
     "species_id": 492,
@@ -27419,6 +27720,39 @@
     ],
     "tier": "PU"
   },
+  "golurkmega": {
+    "species_id": 623,
+    "actual_id": 10313,
+    "name": "Golurk-Mega",
+    "baseSpecies": "Golurk",
+    "forme": "Mega",
+    "types": [
+      "Ground",
+      "Ghost"
+    ],
+    "gender": "N",
+    "baseStats": {
+      "hp": 89,
+      "atk": 159,
+      "def": 105,
+      "spa": 70,
+      "spd": 105,
+      "spe": 55
+    },
+    "abilities": {
+      "0": "Unseen Fist"
+    },
+    "heightm": 4,
+    "weightkg": 330,
+    "color": "Green",
+    "eggGroups": [
+      "Mineral"
+    ],
+    "requiredItem": "Golurkite",
+    "gen": 9,
+    "tier": "Illegal",
+    "isNonstandard": "Past"
+  },
   "pawniard": {
     "species_id": 624,
     "actual_id": 624,
@@ -29675,7 +30009,7 @@
   "flabebe": {
     "species_id": 669,
     "actual_id": 669,
-    "name": "Flab\u00e9b\u00e9",
+    "name": "Flabébé",
     "baseForme": "Red",
     "types": [
       "Fairy"
@@ -29703,17 +30037,17 @@
       "Fairy"
     ],
     "cosmeticFormes": [
-      "Flab\u00e9b\u00e9-Blue",
-      "Flab\u00e9b\u00e9-Orange",
-      "Flab\u00e9b\u00e9-White",
-      "Flab\u00e9b\u00e9-Yellow"
+      "Flabébé-Blue",
+      "Flabébé-Orange",
+      "Flabébé-White",
+      "Flabébé-Yellow"
     ],
     "formeOrder": [
-      "Flab\u00e9b\u00e9",
-      "Flab\u00e9b\u00e9-Yellow",
-      "Flab\u00e9b\u00e9-Orange",
-      "Flab\u00e9b\u00e9-Blue",
-      "Flab\u00e9b\u00e9-White"
+      "Flabébé",
+      "Flabébé-Yellow",
+      "Flabébé-Orange",
+      "Flabébé-Blue",
+      "Flabébé-White"
     ],
     "tier": "LC"
   },
@@ -29741,7 +30075,7 @@
     "heightm": 0.2,
     "weightkg": 0.9,
     "color": "White",
-    "prevo": "Flab\u00e9b\u00e9",
+    "prevo": "Flabébé",
     "evoLevel": 19,
     "evos": [
       "Florges"
@@ -32059,40 +32393,6 @@
     "tier": "Illegal",
     "isNonstandard": "Past"
   },
-  "zygarde10": {
-    "species_id": 718,
-    "actual_id": 10181,
-    "name": "Zygarde-10%",
-    "baseSpecies": "Zygarde",
-    "forme": "10%",
-    "types": [
-      "Dragon",
-      "Ground"
-    ],
-    "gender": "N",
-    "baseStats": {
-      "hp": 54,
-      "atk": 100,
-      "def": 71,
-      "spa": 61,
-      "spd": 85,
-      "spe": 115
-    },
-    "abilities": {
-      "0": "Aura Break",
-      "S": "Power Construct"
-    },
-    "heightm": 1.2,
-    "weightkg": 33.5,
-    "color": "Black",
-    "eggGroups": [
-      "Undiscovered"
-    ],
-    "changesFrom": "Zygarde",
-    "gen": 7,
-    "tier": "Illegal",
-    "isNonstandard": "Past"
-  },
   "zygardecomplete": {
     "species_id": 718,
     "actual_id": 10120,
@@ -32126,6 +32426,40 @@
       "Zygarde",
       "Zygarde-10%"
     ],
+    "gen": 7,
+    "tier": "Illegal",
+    "isNonstandard": "Past"
+  },
+  "zygarde10": {
+    "species_id": 718,
+    "actual_id": 10181,
+    "name": "Zygarde-10%",
+    "baseSpecies": "Zygarde",
+    "forme": "10%",
+    "types": [
+      "Dragon",
+      "Ground"
+    ],
+    "gender": "N",
+    "baseStats": {
+      "hp": 54,
+      "atk": 100,
+      "def": 71,
+      "spa": 61,
+      "spd": 85,
+      "spe": 115
+    },
+    "abilities": {
+      "0": "Aura Break",
+      "S": "Power Construct"
+    },
+    "heightm": 1.2,
+    "weightkg": 33.5,
+    "color": "Black",
+    "eggGroups": [
+      "Undiscovered"
+    ],
+    "changesFrom": "Zygarde",
     "gen": 7,
     "tier": "Illegal",
     "isNonstandard": "Past"
@@ -33084,6 +33418,38 @@
       "Water 3"
     ],
     "tier": "ZU"
+  },
+  "crabominablemega": {
+    "species_id": 740,
+    "actual_id": 10315,
+    "name": "Crabominable-Mega",
+    "baseSpecies": "Crabominable",
+    "forme": "Mega",
+    "types": [
+      "Fighting",
+      "Ice"
+    ],
+    "baseStats": {
+      "hp": 97,
+      "atk": 157,
+      "def": 122,
+      "spa": 62,
+      "spd": 107,
+      "spe": 33
+    },
+    "abilities": {
+      "0": "Iron Fist"
+    },
+    "heightm": 2.6,
+    "weightkg": 252.8,
+    "color": "White",
+    "eggGroups": [
+      "Water 3"
+    ],
+    "requiredItem": "Crabominite",
+    "gen": 9,
+    "tier": "Illegal",
+    "isNonstandard": "Past"
   },
   "oricorio": {
     "species_id": 741,
@@ -34382,6 +34748,39 @@
     "tier": "Illegal",
     "isNonstandard": "Past"
   },
+  "golisopodmega": {
+    "species_id": 768,
+    "actual_id": 10316,
+    "name": "Golisopod-Mega",
+    "baseSpecies": "Golisopod",
+    "forme": "Mega",
+    "types": [
+      "Bug",
+      "Steel"
+    ],
+    "baseStats": {
+      "hp": 75,
+      "atk": 150,
+      "def": 175,
+      "spa": 70,
+      "spd": 120,
+      "spe": 40
+    },
+    "abilities": {
+      "0": "Emergency Exit"
+    },
+    "heightm": 2.3,
+    "weightkg": 148,
+    "color": "Gray",
+    "eggGroups": [
+      "Bug",
+      "Water 3"
+    ],
+    "requiredItem": "Golisopite",
+    "gen": 9,
+    "tier": "Illegal",
+    "isNonstandard": "Past"
+  },
   "sandygast": {
     "species_id": 769,
     "actual_id": 769,
@@ -35122,6 +35521,37 @@
     "tier": "Illegal",
     "isNonstandard": "Past"
   },
+  "miniormeteor": {
+    "species_id": 774,
+    "actual_id": 774,
+    "name": "Minior-Meteor",
+    "baseSpecies": "Minior",
+    "forme": "Meteor",
+    "types": [
+      "Rock",
+      "Flying"
+    ],
+    "gender": "N",
+    "baseStats": {
+      "hp": 60,
+      "atk": 60,
+      "def": 100,
+      "spa": 60,
+      "spd": 100,
+      "spe": 60
+    },
+    "abilities": {
+      "0": "Shields Down"
+    },
+    "heightm": 0.3,
+    "weightkg": 40,
+    "color": "Brown",
+    "eggGroups": [
+      "Mineral"
+    ],
+    "requiredAbility": "Shields Down",
+    "battleOnly": "Minior"
+  },
   "minior": {
     "species_id": 774,
     "actual_id": 10136,
@@ -35178,36 +35608,65 @@
     ],
     "tier": "ZU"
   },
-  "miniormeteor": {
+  "miniororange": {
     "species_id": 774,
-    "actual_id": 774,
-    "name": "Minior-Meteor",
+    "actual_id": 10137,
+    "isCosmeticForme": true,
+    "name": "Minior-Orange",
     "baseSpecies": "Minior",
-    "forme": "Meteor",
-    "types": [
-      "Rock",
-      "Flying"
-    ],
-    "gender": "N",
-    "baseStats": {
-      "hp": 60,
-      "atk": 60,
-      "def": 100,
-      "spa": 60,
-      "spd": 100,
-      "spe": 60
-    },
-    "abilities": {
-      "0": "Shields Down"
-    },
-    "heightm": 0.3,
-    "weightkg": 40,
-    "color": "Brown",
-    "eggGroups": [
-      "Mineral"
-    ],
-    "requiredAbility": "Shields Down",
-    "battleOnly": "Minior"
+    "forme": "Orange",
+    "color": "Red",
+    "tier": "ZU"
+  },
+  "minioryellow": {
+    "species_id": 774,
+    "actual_id": 10138,
+    "isCosmeticForme": true,
+    "name": "Minior-Yellow",
+    "baseSpecies": "Minior",
+    "forme": "Yellow",
+    "color": "Yellow",
+    "tier": "ZU"
+  },
+  "miniorgreen": {
+    "species_id": 774,
+    "actual_id": 10139,
+    "isCosmeticForme": true,
+    "name": "Minior-Green",
+    "baseSpecies": "Minior",
+    "forme": "Green",
+    "color": "Green",
+    "tier": "ZU"
+  },
+  "miniorblue": {
+    "species_id": 774,
+    "actual_id": 10140,
+    "isCosmeticForme": true,
+    "name": "Minior-Blue",
+    "baseSpecies": "Minior",
+    "forme": "Blue",
+    "color": "Blue",
+    "tier": "ZU"
+  },
+  "miniorindigo": {
+    "species_id": 774,
+    "actual_id": 10141,
+    "isCosmeticForme": true,
+    "name": "Minior-Indigo",
+    "baseSpecies": "Minior",
+    "forme": "Indigo",
+    "color": "Blue",
+    "tier": "ZU"
+  },
+  "miniorviolet": {
+    "species_id": 774,
+    "actual_id": 10142,
+    "isCosmeticForme": true,
+    "name": "Minior-Violet",
+    "baseSpecies": "Minior",
+    "forme": "Violet",
+    "color": "Purple",
+    "tier": "ZU"
   },
   "komala": {
     "species_id": 775,
@@ -35957,6 +36416,7 @@
     ],
     "prevo": "Cosmoem",
     "evoLevel": 53,
+    "evoCondition": "Day",
     "eggGroups": [
       "Undiscovered"
     ],
@@ -35990,6 +36450,7 @@
     ],
     "prevo": "Cosmoem",
     "evoLevel": 53,
+    "evoCondition": "Night",
     "eggGroups": [
       "Undiscovered"
     ],
@@ -36424,6 +36885,73 @@
       "Undiscovered"
     ]
   },
+  "magearnamega": {
+    "species_id": 801,
+    "actual_id": 10317,
+    "name": "Magearna-Mega",
+    "baseSpecies": "Magearna",
+    "forme": "Mega",
+    "types": [
+      "Steel",
+      "Fairy"
+    ],
+    "gender": "N",
+    "baseStats": {
+      "hp": 80,
+      "atk": 125,
+      "def": 115,
+      "spa": 170,
+      "spd": 115,
+      "spe": 95
+    },
+    "abilities": {
+      "0": "Soul-Heart"
+    },
+    "heightm": 1.3,
+    "weightkg": 248.1,
+    "color": "Gray",
+    "eggGroups": [
+      "Undiscovered"
+    ],
+    "requiredItem": "Magearnite",
+    "gen": 9,
+    "tier": "Illegal",
+    "isNonstandard": "Past"
+  },
+  "magearnaoriginalmega": {
+    "species_id": 801,
+    "actual_id": 10318,
+    "name": "Magearna-Original-Mega",
+    "baseSpecies": "Magearna",
+    "forme": "Original-Mega",
+    "types": [
+      "Steel",
+      "Fairy"
+    ],
+    "gender": "N",
+    "baseStats": {
+      "hp": 80,
+      "atk": 125,
+      "def": 115,
+      "spa": 170,
+      "spd": 115,
+      "spe": 95
+    },
+    "abilities": {
+      "0": "Soul-Heart"
+    },
+    "heightm": 1.3,
+    "weightkg": 248.1,
+    "color": "Red",
+    "eggGroups": [
+      "Undiscovered"
+    ],
+    "requiredItem": "Magearnite",
+    "battleOnly": "Magearna-Original",
+    "gen": 9,
+    "tier": "Illegal",
+    "isNonstandard": "Past"
+  },
   "marshadow": {
     "species_id": 802,
     "actual_id": 802,
@@ -36617,6 +37145,41 @@
     "eggGroups": [
       "Undiscovered"
     ],
+    "tier": "Illegal",
+    "isNonstandard": "Past"
+  },
+  "zeraoramega": {
+    "species_id": 807,
+    "actual_id": 10319,
+    "name": "Zeraora-Mega",
+    "baseSpecies": "Zeraora",
+    "forme": "Mega",
+    "types": [
+      "Electric"
+    ],
+    "gender": "N",
+    "baseStats": {
+      "hp": 88,
+      "atk": 157,
+      "def": 75,
+      "spa": 147,
+      "spd": 80,
+      "spe": 153
+    },
+    "abilities": {
+      "0": "Volt Absorb"
+    },
+    "heightm": 1.5,
+    "weightkg": 44.5,
+    "color": "Yellow",
+    "tags": [
+      "Mythical"
+    ],
+    "eggGroups": [
+      "Undiscovered"
+    ],
+    "requiredItem": "Zeraorite",
+    "gen": 9,
     "tier": "Illegal",
     "isNonstandard": "Past"
   },
@@ -39223,7 +39786,7 @@
   "sirfetchd": {
     "species_id": 865,
     "actual_id": 865,
-    "name": "Sirfetch\u2019d",
+    "name": "Sirfetch’d",
     "types": [
       "Fighting"
     ],
@@ -39242,7 +39805,7 @@
     "heightm": 0.8,
     "weightkg": 117,
     "color": "White",
-    "prevo": "Farfetch\u2019d-Galar",
+    "prevo": "Farfetch’d-Galar",
     "evoType": "other",
     "evoCondition": "Land 3 critical hits in 1 battle",
     "eggGroups": [
@@ -41925,6 +42488,39 @@
     ],
     "tier": "LC"
   },
+  "mausholdfour": {
+    "species_id": 925,
+    "actual_id": 925,
+    "name": "Maushold-Four",
+    "baseSpecies": "Maushold",
+    "forme": "Four",
+    "types": [
+      "Normal"
+    ],
+    "gender": "N",
+    "baseStats": {
+      "hp": 74,
+      "atk": 75,
+      "def": 70,
+      "spa": 65,
+      "spd": 75,
+      "spe": 111
+    },
+    "abilities": {
+      "0": "Friend Guard",
+      "1": "Cheek Pouch",
+      "H": "Technician"
+    },
+    "heightm": 0.3,
+    "weightkg": 2.8,
+    "color": "White",
+    "prevo": "Tandemaus",
+    "evoLevel": 25,
+    "eggGroups": [
+      "Field",
+      "Fairy"
+    ]
+  },
   "maushold": {
     "species_id": 925,
     "actual_id": 10257,
@@ -41964,39 +42560,6 @@
       "Fairy"
     ],
     "tier": "RU"
-  },
-  "mausholdfour": {
-    "species_id": 925,
-    "actual_id": 925,
-    "name": "Maushold-Four",
-    "baseSpecies": "Maushold",
-    "forme": "Four",
-    "types": [
-      "Normal"
-    ],
-    "gender": "N",
-    "baseStats": {
-      "hp": 74,
-      "atk": 75,
-      "def": 70,
-      "spa": 65,
-      "spd": 75,
-      "spe": 111
-    },
-    "abilities": {
-      "0": "Friend Guard",
-      "1": "Cheek Pouch",
-      "H": "Technician"
-    },
-    "heightm": 0.3,
-    "weightkg": 2.8,
-    "color": "White",
-    "prevo": "Tandemaus",
-    "evoLevel": 25,
-    "eggGroups": [
-      "Field",
-      "Fairy"
-    ]
   },
   "fidough": {
     "species_id": 926,
@@ -42934,6 +43497,37 @@
     ],
     "tier": "ZU"
   },
+  "scovillainmega": {
+    "species_id": 952,
+    "actual_id": 10320,
+    "name": "Scovillain-Mega",
+    "baseSpecies": "Scovillain",
+    "forme": "Mega",
+    "types": [
+      "Grass",
+      "Fire"
+    ],
+    "baseStats": {
+      "hp": 65,
+      "atk": 138,
+      "def": 85,
+      "spa": 138,
+      "spd": 85,
+      "spe": 75
+    },
+    "abilities": {
+      "0": "Spicy Spray"
+    },
+    "heightm": 1.2,
+    "weightkg": 22,
+    "color": "Green",
+    "eggGroups": [
+      "Grass"
+    ],
+    "requiredItem": "Scovillainite",
+    "tier": "Illegal",
+    "isNonstandard": "Past"
+  },
   "rellor": {
     "species_id": 953,
     "actual_id": 953,
@@ -43521,6 +44115,37 @@
     ],
     "tier": "OU"
   },
+  "glimmoramega": {
+    "species_id": 970,
+    "actual_id": 10321,
+    "name": "Glimmora-Mega",
+    "baseSpecies": "Glimmora",
+    "forme": "Mega",
+    "types": [
+      "Rock",
+      "Poison"
+    ],
+    "baseStats": {
+      "hp": 83,
+      "atk": 90,
+      "def": 105,
+      "spa": 150,
+      "spd": 96,
+      "spe": 101
+    },
+    "abilities": {
+      "0": "Adaptability"
+    },
+    "heightm": 2.8,
+    "weightkg": 77,
+    "color": "Blue",
+    "eggGroups": [
+      "Mineral"
+    ],
+    "requiredItem": "Glimmoranite",
+    "tier": "Illegal",
+    "isNonstandard": "Past"
+  },
   "greavard": {
     "species_id": 971,
     "actual_id": 971,
@@ -43765,6 +44390,165 @@
       "Water 2"
     ],
     "tier": "PU"
+  },
+  "tatsugiridroopy": {
+    "species_id": 978,
+    "actual_id": 10258,
+    "name": "Tatsugiri-Droopy",
+    "baseSpecies": "Tatsugiri",
+    "forme": "Droopy",
+    "types": [
+      "Dragon",
+      "Water"
+    ],
+    "baseStats": {
+      "hp": 68,
+      "atk": 50,
+      "def": 60,
+      "spa": 120,
+      "spd": 95,
+      "spe": 82
+    },
+    "abilities": {
+      "0": "Commander",
+      "H": "Storm Drain"
+    },
+    "heightm": 0.3,
+    "weightkg": 8,
+    "color": "Pink",
+    "eggGroups": [
+      "Water 2"
+    ],
+    "tier": "PU"
+  },
+  "tatsugiristretchy": {
+    "species_id": 978,
+    "actual_id": 10259,
+    "name": "Tatsugiri-Stretchy",
+    "baseSpecies": "Tatsugiri",
+    "forme": "Stretchy",
+    "types": [
+      "Dragon",
+      "Water"
+    ],
+    "baseStats": {
+      "hp": 68,
+      "atk": 50,
+      "def": 60,
+      "spa": 120,
+      "spd": 95,
+      "spe": 82
+    },
+    "abilities": {
+      "0": "Commander",
+      "H": "Storm Drain"
+    },
+    "heightm": 0.3,
+    "weightkg": 8,
+    "color": "Yellow",
+    "eggGroups": [
+      "Water 2"
+    ],
+    "tier": "PU"
+  },
+  "tatsugiricurlymega": {
+    "species_id": 978,
+    "actual_id": 10322,
+    "name": "Tatsugiri-Curly-Mega",
+    "baseSpecies": "Tatsugiri",
+    "forme": "Curly-Mega",
+    "types": [
+      "Dragon",
+      "Water"
+    ],
+    "baseStats": {
+      "hp": 68,
+      "atk": 65,
+      "def": 90,
+      "spa": 135,
+      "spd": 125,
+      "spe": 92
+    },
+    "abilities": {
+      "0": "Commander",
+      "H": "Storm Drain"
+    },
+    "heightm": 0.3,
+    "weightkg": 24,
+    "color": "Red",
+    "eggGroups": [
+      "Water 2"
+    ],
+    "requiredItem": "Tatsugirinite",
+    "battleOnly": "Tatsugiri",
+    "tier": "Illegal",
+    "isNonstandard": "Past"
+  },
+  "tatsugiridroopymega": {
+    "species_id": 978,
+    "actual_id": 10323,
+    "name": "Tatsugiri-Droopy-Mega",
+    "baseSpecies": "Tatsugiri",
+    "forme": "Droopy-Mega",
+    "types": [
+      "Dragon",
+      "Water"
+    ],
+    "baseStats": {
+      "hp": 68,
+      "atk": 65,
+      "def": 90,
+      "spa": 135,
+      "spd": 125,
+      "spe": 92
+    },
+    "abilities": {
+      "0": "Commander",
+      "H": "Storm Drain"
+    },
+    "heightm": 0.3,
+    "weightkg": 24,
+    "color": "Pink",
+    "eggGroups": [
+      "Water 2"
+    ],
+    "requiredItem": "Tatsugirinite",
+    "battleOnly": "Tatsugiri-Droopy",
+    "tier": "Illegal",
+    "isNonstandard": "Past"
+  },
+  "tatsugiristretchymega": {
+    "species_id": 978,
+    "actual_id": 10324,
+    "name": "Tatsugiri-Stretchy-Mega",
+    "baseSpecies": "Tatsugiri",
+    "forme": "Stretchy-Mega",
+    "types": [
+      "Dragon",
+      "Water"
+    ],
+    "baseStats": {
+      "hp": 68,
+      "atk": 65,
+      "def": 90,
+      "spa": 135,
+      "spd": 125,
+      "spe": 92
+    },
+    "abilities": {
+      "0": "Commander",
+      "H": "Storm Drain"
+    },
+    "heightm": 0.3,
+    "weightkg": 24,
+    "color": "Yellow",
+    "eggGroups": [
+      "Water 2"
+    ],
+    "requiredItem": "Tatsugirinite",
+    "battleOnly": "Tatsugiri-Stretchy",
+    "tier": "Illegal",
+    "isNonstandard": "Past"
   },
   "annihilape": {
     "species_id": 979,
@@ -44433,6 +45217,39 @@
       "Mineral"
     ],
     "tier": "Uber"
+  },
+  "baxcaliburmega": {
+    "species_id": 998,
+    "actual_id": 10325,
+    "name": "Baxcalibur-Mega",
+    "baseSpecies": "Baxcalibur",
+    "forme": "Mega",
+    "types": [
+      "Dragon",
+      "Ice"
+    ],
+    "baseStats": {
+      "hp": 115,
+      "atk": 175,
+      "def": 117,
+      "spa": 105,
+      "spd": 101,
+      "spe": 87
+    },
+    "abilities": {
+      "0": "Thermal Exchange",
+      "H": "Ice Body"
+    },
+    "heightm": 2.1,
+    "weightkg": 315,
+    "color": "Blue",
+    "eggGroups": [
+      "Dragon",
+      "Mineral"
+    ],
+    "requiredItem": "Baxcalibrite",
+    "tier": "Illegal",
+    "isNonstandard": "Past"
   },
   "gimmighoul": {
     "species_id": 999,
@@ -45176,6 +45993,36 @@
     "requiredTeraType": "Grass",
     "tier": "UU"
   },
+  "ogerpontealtera": {
+    "species_id": 1017,
+    "actual_id": 1017,
+    "name": "Ogerpon-Teal-Tera",
+    "baseSpecies": "Ogerpon",
+    "forme": "Teal-Tera",
+    "types": [
+      "Grass"
+    ],
+    "gender": "F",
+    "baseStats": {
+      "hp": 80,
+      "atk": 120,
+      "def": 84,
+      "spa": 60,
+      "spd": 96,
+      "spe": 110
+    },
+    "abilities": {
+      "0": "Embody Aspect (Teal)"
+    },
+    "heightm": 1.2,
+    "weightkg": 39.8,
+    "color": "Green",
+    "eggGroups": [
+      "Undiscovered"
+    ],
+    "battleOnly": "Ogerpon",
+    "requiredTeraType": "Grass"
+  },
   "ogerponwellspring": {
     "species_id": 1017,
     "actual_id": 10273,
@@ -45208,6 +46055,38 @@
     "changesFrom": "Ogerpon",
     "requiredTeraType": "Water",
     "tier": "OU"
+  },
+  "ogerponwellspringtera": {
+    "species_id": 1017,
+    "actual_id": 10273,
+    "name": "Ogerpon-Wellspring-Tera",
+    "baseSpecies": "Ogerpon",
+    "forme": "Wellspring-Tera",
+    "types": [
+      "Grass",
+      "Water"
+    ],
+    "gender": "F",
+    "baseStats": {
+      "hp": 80,
+      "atk": 120,
+      "def": 84,
+      "spa": 60,
+      "spd": 96,
+      "spe": 110
+    },
+    "abilities": {
+      "0": "Embody Aspect (Wellspring)"
+    },
+    "heightm": 1.2,
+    "weightkg": 39.8,
+    "color": "Blue",
+    "eggGroups": [
+      "Undiscovered"
+    ],
+    "requiredItem": "Wellspring Mask",
+    "battleOnly": "Ogerpon-Wellspring",
+    "requiredTeraType": "Water"
   },
   "ogerponhearthflame": {
     "species_id": 1017,
@@ -45242,6 +46121,38 @@
     "requiredTeraType": "Fire",
     "tier": "Uber"
   },
+  "ogerponhearthflametera": {
+    "species_id": 1017,
+    "actual_id": 10274,
+    "name": "Ogerpon-Hearthflame-Tera",
+    "baseSpecies": "Ogerpon",
+    "forme": "Hearthflame-Tera",
+    "types": [
+      "Grass",
+      "Fire"
+    ],
+    "gender": "F",
+    "baseStats": {
+      "hp": 80,
+      "atk": 120,
+      "def": 84,
+      "spa": 60,
+      "spd": 96,
+      "spe": 110
+    },
+    "abilities": {
+      "0": "Embody Aspect (Hearthflame)"
+    },
+    "heightm": 1.2,
+    "weightkg": 39.8,
+    "color": "Red",
+    "eggGroups": [
+      "Undiscovered"
+    ],
+    "requiredItem": "Hearthflame Mask",
+    "battleOnly": "Ogerpon-Hearthflame",
+    "requiredTeraType": "Fire"
+  },
   "ogerponcornerstone": {
     "species_id": 1017,
     "actual_id": 10275,
@@ -45274,100 +46185,6 @@
     "changesFrom": "Ogerpon",
     "requiredTeraType": "Rock",
     "tier": "UUBL"
-  },
-  "ogerpontealtera": {
-    "species_id": 1017,
-    "actual_id": 1017,
-    "name": "Ogerpon-Teal-Tera",
-    "baseSpecies": "Ogerpon",
-    "forme": "Teal-Tera",
-    "types": [
-      "Grass"
-    ],
-    "gender": "F",
-    "baseStats": {
-      "hp": 80,
-      "atk": 120,
-      "def": 84,
-      "spa": 60,
-      "spd": 96,
-      "spe": 110
-    },
-    "abilities": {
-      "0": "Embody Aspect (Teal)"
-    },
-    "heightm": 1.2,
-    "weightkg": 39.8,
-    "color": "Green",
-    "eggGroups": [
-      "Undiscovered"
-    ],
-    "battleOnly": "Ogerpon",
-    "requiredTeraType": "Grass"
-  },
-  "ogerponwellspringtera": {
-    "species_id": 1017,
-    "actual_id": 10273,
-    "name": "Ogerpon-Wellspring-Tera",
-    "baseSpecies": "Ogerpon",
-    "forme": "Wellspring-Tera",
-    "types": [
-      "Grass",
-      "Water"
-    ],
-    "gender": "F",
-    "baseStats": {
-      "hp": 80,
-      "atk": 120,
-      "def": 84,
-      "spa": 60,
-      "spd": 96,
-      "spe": 110
-    },
-    "abilities": {
-      "0": "Embody Aspect (Wellspring)"
-    },
-    "heightm": 1.2,
-    "weightkg": 39.8,
-    "color": "Blue",
-    "eggGroups": [
-      "Undiscovered"
-    ],
-    "requiredItem": "Wellspring Mask",
-    "battleOnly": "Ogerpon-Wellspring",
-    "requiredTeraType": "Water"
-  },
-  "ogerponhearthflametera": {
-    "species_id": 1017,
-    "actual_id": 10274,
-    "name": "Ogerpon-Hearthflame-Tera",
-    "baseSpecies": "Ogerpon",
-    "forme": "Hearthflame-Tera",
-    "types": [
-      "Grass",
-      "Fire"
-    ],
-    "gender": "F",
-    "baseStats": {
-      "hp": 80,
-      "atk": 120,
-      "def": 84,
-      "spa": 60,
-      "spd": 96,
-      "spe": 110
-    },
-    "abilities": {
-      "0": "Embody Aspect (Hearthflame)"
-    },
-    "heightm": 1.2,
-    "weightkg": 39.8,
-    "color": "Red",
-    "eggGroups": [
-      "Undiscovered"
-    ],
-    "requiredItem": "Hearthflame Mask",
-    "battleOnly": "Ogerpon-Hearthflame",
-    "requiredTeraType": "Fire"
   },
   "ogerponcornerstonetera": {
     "species_id": 1017,

--- a/src/Ankimon/functions/pokedex_functions.py
+++ b/src/Ankimon/functions/pokedex_functions.py
@@ -122,20 +122,24 @@ def _load_pokedex_id_index():
             pokedex_data = _load_pokedex_cache()
             _pokedex_id_index = {}
 
-            # Pass 1: map every specific form by its actual_id.
+            # Pass 1: map every specific form by its actual_id. Missing/invalid
+            # ids resolve to None (default=None) so they are skipped rather than
+            # collapsing onto key 0.
             for entry_name, attributes in pokedex_data.items():
-                actual_id = safe_int(attributes.get("actual_id"))
+                actual_id = safe_int(attributes.get("actual_id"), default=None)
                 if actual_id is not None:
                     _pokedex_id_index[actual_id] = entry_name
 
             # Pass 2: map base species_ids. A base form (actual_id == species_id
             # or no actual_id, and no "baseSpecies") must ALWAYS own its species_id
             # mapping so that form variants (megas/regionals carrying a baseSpecies
-            # and a 10xxx actual_id) never shadow the base species entry.
+            # and a 10xxx actual_id) never shadow the base species entry. Parsing
+            # with default=None keeps the ``actual_id is None`` base-form test
+            # meaningful for rows that omit actual_id.
             for entry_name, attributes in pokedex_data.items():
-                species_id = safe_int(attributes.get("species_id"))
+                species_id = safe_int(attributes.get("species_id"), default=None)
                 if species_id is not None:
-                    actual_id = safe_int(attributes.get("actual_id"))
+                    actual_id = safe_int(attributes.get("actual_id"), default=None)
                     has_base_species = attributes.get("baseSpecies") is not None
                     is_base_form = (
                         actual_id is None or actual_id == species_id
@@ -743,22 +747,30 @@ def _get_active_region():
         if settings_obj is None:
             return None
         region = settings_obj.get("misc.active_region")
+        # The scalar settings layer may hand back a non-string (int/None/list);
+        # only strings carry a region name, everything else normalizes to None.
+        if isinstance(region, str):
+            region = region.strip()
+            if region in ("", "No Region"):
+                return None
+            return region
     except Exception:
-        return None
-    if region:
-        region = region.strip()
-    if region in (None, "", "No Region"):
-        return None
-    return region
+        pass
+    return None
 
 
 def return_identifier_for_item_id(item_id):
     """Return the string identifier of an item given its numeric id (items.csv)."""
+    # Guard None/invalid before coercion so a bad item_id can never accidentally
+    # match a row whose own id is missing/invalid (both would coerce to 0).
+    target_id = safe_int(item_id, default=None)
+    if target_id is None:
+        return None
     try:
         with open(csv_file_items_cost, mode="r", encoding="utf-8") as file:
             reader = csv.DictReader(file)
             for row in reader:
-                if safe_int(row.get("id")) == safe_int(item_id):
+                if safe_int(row.get("id"), default=None) == target_id:
                     return row.get("identifier")
     except Exception:
         pass
@@ -811,12 +823,25 @@ def check_evolution_by_item(pokemon_id, item_id, file_path=poke_evo_path):
                         ) or pokedex_data.get(target_evo_name.lower())
 
                         if target_data and target_data.get("evoType") == "useItem":
+                            # Normalize both sides by stripping spaces, hyphens and
+                            # apostrophes so pokedex.json display names (e.g.
+                            # "King's Rock") match items.csv identifiers (e.g.
+                            # "kings-rock"), which drop the apostrophe.
                             required_item = (
                                 (target_data.get("evoItem") or "")
                                 .lower()
-                                .replace(" ", "-")
+                                .replace(" ", "")
+                                .replace("-", "")
+                                .replace("'", "")
                             )
-                            if required_item == item_name:
+                            normalized_item_name = (
+                                (item_name or "")
+                                .lower()
+                                .replace(" ", "")
+                                .replace("-", "")
+                                .replace("'", "")
+                            )
+                            if required_item == normalized_item_name:
                                 target_region = target_data.get("evoRegion")
 
                                 if target_region:
@@ -1051,7 +1076,8 @@ def check_evolution_for_pokemon(
                             if pkmn_data and "attacks" in pkmn_data:
                                 p_attacks = pkmn_data["attacks"]
                                 if required_move and any(
-                                    a.lower().replace(" ", "").replace("-", "")
+                                    isinstance(a, str)
+                                    and a.lower().replace(" ", "").replace("-", "")
                                     == required_move.lower()
                                     .replace(" ", "")
                                     .replace("-", "")

--- a/src/Ankimon/functions/pokedex_functions.py
+++ b/src/Ankimon/functions/pokedex_functions.py
@@ -12,6 +12,7 @@ from ..resources import (
     pokemon_csv,
 )
 from ..services import services
+
 try:
     # Only used as a parent for the error dialog; None when headless.
     from aqt import mw
@@ -29,7 +30,7 @@ GROWTH_RATES = {
     3: "fast",
     4: "medium-slow",
     5: "slow-then-very-fast",
-    6: "fast-then-very-slow"
+    6: "fast-then-very-slow",
 }
 
 STATS = {
@@ -44,6 +45,7 @@ STATS = {
 # === PERFORMANCE FIX: Cache pokedex data ===
 _pokedex_cache = None
 _poke_species_cache = None
+
 
 def safe_int(value, default=0):
     """Safely convert a value to an integer, returning a default if conversion fails."""
@@ -60,6 +62,7 @@ def safe_int(value, default=0):
     except (ValueError, TypeError):
         return default
 
+
 def _load_pokedex_cache():
     """Load pokedex JSON once and cache it in memory"""
     global _pokedex_cache
@@ -67,13 +70,49 @@ def _load_pokedex_cache():
         try:
             with open(str(pokedex_path), "r", encoding="utf-8") as json_file:
                 _pokedex_cache = json.load(json_file)
+
+                # Dynamic enrichment for location-based Hisuian forms. The bundled
+                # pokedex.json does not carry evoRegion/evoItem/evoMove for these
+                # forms, so the region-aware evolution branches below inject them
+                # once, when the cache is first built.
+                hisuian_forms = [
+                    "decidueyehisui",
+                    "typhlosionhisui",
+                    "samurotthisui",
+                    "sliggoohisui",
+                    "braviaryhisui",
+                    "avalugghisui",
+                    "lilliganthisui",
+                ]
+                for form in hisuian_forms:
+                    if form in _pokedex_cache:
+                        _pokedex_cache[form]["evoRegion"] = "Hisui"
+
+                # Kleavor
+                if "kleavor" in _pokedex_cache:
+                    _pokedex_cache["kleavor"]["evoRegion"] = "Hisui"
+                    _pokedex_cache["kleavor"]["evoItem"] = "Black Augurite"
+
+                # Ursaluna
+                if "ursaluna" in _pokedex_cache:
+                    _pokedex_cache["ursaluna"]["evoRegion"] = "Hisui"
+                    _pokedex_cache["ursaluna"]["evoType"] = "useItem"
+                    _pokedex_cache["ursaluna"]["evoItem"] = "Peat Block"
+
+                # Wyrdeer
+                if "wyrdeer" in _pokedex_cache:
+                    _pokedex_cache["wyrdeer"]["evoRegion"] = "Hisui"
+                    _pokedex_cache["wyrdeer"]["evoType"] = "levelMove"
+                    _pokedex_cache["wyrdeer"]["evoMove"] = "Psyshield Bash"
         except Exception as e:
             print(f"Error loading pokedex cache: {e}")
             _pokedex_cache = {}
     return _pokedex_cache
 
+
 # === ID INDEX CACHE: Fast O(1) lookups by species_id ===
 _pokedex_id_index = None
+
 
 def _load_pokedex_id_index():
     """Build a reverse index: species_id -> pokemon_name for O(1) lookups"""
@@ -82,22 +121,31 @@ def _load_pokedex_id_index():
         try:
             pokedex_data = _load_pokedex_cache()
             _pokedex_id_index = {}
+
+            # Pass 1: map every specific form by its actual_id.
             for entry_name, attributes in pokedex_data.items():
-                species_id = safe_int(attributes.get("species_id"))
                 actual_id = safe_int(attributes.get("actual_id"))
-                
-                # Use internal names (keys) for logic consistency
                 if actual_id is not None:
                     _pokedex_id_index[actual_id] = entry_name
-                
+
+            # Pass 2: map base species_ids. A base form (actual_id == species_id
+            # or no actual_id, and no "baseSpecies") must ALWAYS own its species_id
+            # mapping so that form variants (megas/regionals carrying a baseSpecies
+            # and a 10xxx actual_id) never shadow the base species entry.
+            for entry_name, attributes in pokedex_data.items():
+                species_id = safe_int(attributes.get("species_id"))
                 if species_id is not None:
-                    if species_id not in _pokedex_id_index:
+                    actual_id = safe_int(attributes.get("actual_id"))
+                    has_base_species = attributes.get("baseSpecies") is not None
+                    is_base_form = (
+                        actual_id is None or actual_id == species_id
+                    ) and not has_base_species
+                    if is_base_form or species_id not in _pokedex_id_index:
                         _pokedex_id_index[species_id] = entry_name
         except Exception as e:
             print(f"Error building pokedex ID index: {e}")
             _pokedex_id_index = {}
     return _pokedex_id_index
-
 
 
 def _load_poke_species_cache():
@@ -116,11 +164,13 @@ def _load_poke_species_cache():
             _poke_species_cache = {}
     return _poke_species_cache
 
+
 # === ADDITIONAL CACHES ===
 _pokemon_csv_cache = None
 _stats_csv_cache = None
 _poke_evo_cache = None
 _moves_cache = None
+
 
 def _load_pokemon_csv_cache():
     """Cache pokemon.csv to avoid repeated file I/O"""
@@ -137,6 +187,7 @@ def _load_pokemon_csv_cache():
             print(f"Error loading pokemon CSV cache: {e}")
             _pokemon_csv_cache = {}
     return _pokemon_csv_cache
+
 
 def _load_stats_csv_cache():
     """Cache stats.csv to avoid repeated file I/O. Keyed by pokemon_id."""
@@ -158,6 +209,7 @@ def _load_stats_csv_cache():
             _stats_csv_cache = {}
     return _stats_csv_cache
 
+
 def _load_poke_evo_cache():
     """Cache pokemon evolution data to avoid repeated file I/O"""
     global _poke_evo_cache
@@ -172,6 +224,7 @@ def _load_poke_evo_cache():
             _poke_evo_cache = []
     return _poke_evo_cache
 
+
 def _load_moves_cache():
     """Cache moves.json to avoid repeated file I/O"""
     global _moves_cache
@@ -184,9 +237,11 @@ def _load_moves_cache():
             _moves_cache = {}
     return _moves_cache
 
+
 # === POKEMON NAME & DESCRIPTION CACHES ===
 _pokemon_names_cache = {}  # {(pokemon_id, language): name}
 _pokemon_descriptions_cache = {}  # {(species_id, language): description}
+
 
 def _load_pokemon_names_csv():
     """Load all pokemon names into cache on first access"""
@@ -204,6 +259,7 @@ def _load_pokemon_names_csv():
             print(f"Error loading pokemon names cache: {e}")
     return _pokemon_names_cache
 
+
 def _load_pokemon_descriptions_csv():
     """Load all pokemon descriptions into cache on first access"""
     global _pokemon_descriptions_cache
@@ -215,7 +271,7 @@ def _load_pokemon_descriptions_csv():
                     species_id = safe_int(row.get("species_id"))
                     lang_id = safe_int(row.get("language_id"))
                     flavor_text = row.get("flavor_text", "").replace("\x0c", " ")
-                    
+
                     # Store all descriptions for this (species_id, lang_id) pair
                     key = (species_id, lang_id)
                     if key not in _pokemon_descriptions_cache:
@@ -225,9 +281,19 @@ def _load_pokemon_descriptions_csv():
             print(f"Error loading pokemon descriptions cache: {e}")
     return _pokemon_descriptions_cache
 
+
 def clear_pokedex_caches():
     """Call this when pokedex data is updated or session ends"""
-    global _pokedex_cache, _poke_species_cache, _pokemon_csv_cache, _stats_csv_cache, _poke_evo_cache, _moves_cache, _pokedex_id_index, _pokemon_names_cache, _pokemon_descriptions_cache
+    global \
+        _pokedex_cache, \
+        _poke_species_cache, \
+        _pokemon_csv_cache, \
+        _stats_csv_cache, \
+        _poke_evo_cache, \
+        _moves_cache, \
+        _pokedex_id_index, \
+        _pokemon_names_cache, \
+        _pokemon_descriptions_cache
     _pokedex_cache = None
     _poke_species_cache = None
     _pokemon_csv_cache = None
@@ -237,6 +303,7 @@ def clear_pokedex_caches():
     _pokedex_id_index = None
     _pokemon_names_cache = {}
     _pokemon_descriptions_cache = {}
+
 
 def _normalize_language_id(language):
     """Map unsupported language IDs to a fallback that exists in data files."""
@@ -322,9 +389,10 @@ def special_pokemon_names_for_min_level(name):
 
 def search_pokedex(pokemon_name, variable):
     try:
-        if isinstance(pokemon_name, str):
-            pokemon_name = pokemon_name.lower()
-            
+        if not isinstance(pokemon_name, str):
+            return []
+
+        pokemon_name = pokemon_name.lower()
         pokemon_name = special_pokemon_names_for_min_level(pokemon_name)
         pokedex_data = _load_pokedex_cache()  # Use cache instead of file I/O
 
@@ -338,10 +406,16 @@ def search_pokedex(pokemon_name, variable):
                 var = pokemon_info.get(variable)
                 if var is not None:
                     return var
-            
-            # 2. Try normalized version (no spaces, hyphens, or apostrophes)
+
+            # 2. Try normalized version (no spaces, hyphens, apostrophes, dots or colons)
             # This handles cases like "Venusaur-Mega" matching "venusaurmega"
-            normalized_name = current_name.replace(" ", "").replace("-", "").replace("'", "")
+            normalized_name = (
+                current_name.replace(" ", "")
+                .replace("-", "")
+                .replace("'", "")
+                .replace(".", "")
+                .replace(":", "")
+            )
             if normalized_name in pokedex_data:
                 pokemon_info = pokedex_data[normalized_name]
                 var = pokemon_info.get(variable)
@@ -377,15 +451,20 @@ def search_pokedex(pokemon_name, variable):
         )
         return []
 
+
 def search_pokedex_by_id(species_id):
     id_index = _load_pokedex_id_index()  # Use index for O(1) lookup instead of O(n)
     return id_index.get(safe_int(species_id), "Pokémon not found")
+
 
 def format_lore_name(name: str) -> str:
     """Transform internal hyphenated names into lore-accurate ones (e.g. Venusaur-Mega -> Mega Venusaur)."""
     if not name or not isinstance(name, str):
         return name
-        
+
+    if name.lower() == "eternatus-eternamax":
+        return "Eternamax"
+
     # Order matters: check more specific ones first
     if "-Mega-X" in name:
         return "Mega " + name.replace("-Mega-X", " X")
@@ -393,7 +472,7 @@ def format_lore_name(name: str) -> str:
         return "Mega " + name.replace("-Mega-Y", " Y")
     if "-Mega-Z" in name:
         return "Mega " + name.replace("-Mega-Z", " Z")
-    
+
     replacements = {
         "-Mega": "Mega ",
         "-Gmax": "Gigantamax ",
@@ -404,14 +483,36 @@ def format_lore_name(name: str) -> str:
         "-Primal": "Primal ",
         "-Origin": "Origin ",
         "-Therian": "Therian ",
+        "-Attack": "Attack ",
+        "-Defense": "Defense ",
+        "-Speed": "Speed ",
+        "-Sky": "Sky ",
+        "-Pirouette": "Pirouette ",
+        "-Resolute": "Resolute ",
+        "-Black": "Black ",
+        "-White": "White ",
+        "-Crowned": "Crowned ",
+        "-Ice": "Ice Rider ",
+        "-Shadow": "Shadow Rider ",
+        "-Terastal": "Terastal ",
+        "-Stellar": "Stellar ",
+        "-Dusk-Mane": "Dusk Mane ",
+        "-Dawn-Wings": "Dawn Wings ",
+        "-Ultra": "Ultra ",
+        "-Unbound": "Unbound ",
+        "-Original": "Original Color ",
+        "-Rapid-Strike": "Rapid Strike ",
+        "-10%": "10% ",
+        "-Complete": "Complete ",
     }
-    
+
     for suffix, prefix in replacements.items():
         if suffix in name:
             base = name.replace(suffix, "")
             return prefix + base
-            
+
     return name
+
 
 def get_pretty_name_for_id(species_id):
     """Get the official pretty name (e.g. Mega Venusaur) for an ID."""
@@ -419,11 +520,14 @@ def get_pretty_name_for_id(species_id):
         pokedex_data = _load_pokedex_cache()
         internal_name = search_pokedex_by_id(species_id)
         if internal_name in pokedex_data:
-            raw_name = pokedex_data[internal_name].get("name", internal_name.capitalize())
+            raw_name = pokedex_data[internal_name].get(
+                "name", internal_name.capitalize()
+            )
             return format_lore_name(raw_name)
     except:
         pass
     return "Pokémon not found"
+
 
 def get_pretty_name_for_name(pokemon_name):
     """Get the official pretty name (e.g. Mega Venusaur) from an internal name."""
@@ -431,21 +535,24 @@ def get_pretty_name_for_name(pokemon_name):
         pokedex_data = _load_pokedex_cache()
         # Use aggressive normalization (isalnum) to match cache keys
         internal_name = "".join(c for c in str(pokemon_name).lower() if c.isalnum())
-        
+
         if internal_name in pokedex_data:
             raw_name = pokedex_data[internal_name].get("name", pokemon_name.title())
             return format_lore_name(raw_name)
-            
+
         # Fallback: try removing common suffixes if direct match fails
         for suffix in ["-mega", "-gmax", "-alola", "-galar", "-hisui", "-paldea"]:
             if suffix in pokemon_name.lower():
                 base_name = pokemon_name.lower().replace(suffix, "").replace("-", "")
                 if base_name in pokedex_data:
-                    raw_base = pokedex_data[base_name].get("name", base_name.capitalize())
+                    raw_base = pokedex_data[base_name].get(
+                        "name", base_name.capitalize()
+                    )
                     return format_lore_name(pokemon_name.title())
     except:
         pass
     return format_lore_name(str(pokemon_name).replace("-", " ").title())
+
 
 def get_mainpokemon_evo(pokemon_name):
     pokedex_data = _load_pokedex_cache()  # Use cache instead of file I/O
@@ -455,18 +562,41 @@ def get_mainpokemon_evo(pokemon_name):
     evolutions = pokemon_info.get("evos", [])
     return evolutions
 
+
 def get_growth_rate(species_id: int) -> str:
-    # Coerce string callers to int so they match the integer CSV ids; a
-    # non-numeric argument keeps the original "not found" behaviour.
+    """Return the growth-rate name for a species/form id.
+
+    Alternate-form ids (>= 10000, e.g. mega/regional actual_ids) are resolved to
+    their base species via the pokedex before the CSV lookup. Unknown ids fall
+    back to ``"medium"`` instead of raising. Rationale (NR-21 fuzz finding): every
+    caller assigns the result straight into ``pokemon["growth_rate"]`` (no
+    ``or "medium"`` guard), so a raised ``ValueError`` on 10xxx form ids — reached
+    ~5% of fuzz iterations now that F22/F38 make form encounters real — was an
+    uncaught crash, and returning ``None`` would merely defer the failure into the
+    experience/level maths downstream.
+    """
     try:
         species_id = int(species_id)
     except (TypeError, ValueError):
-        raise ValueError(species_id)
+        return "medium"
+
     cache = _load_poke_species_cache()
     row = cache.get(species_id)
+
+    # Alternate-form actual_id -> resolve to the base species_id via the pokedex.
+    if row is None and species_id >= 10000:
+        internal_name = search_pokedex_by_id(species_id)
+        pokedex_data = _load_pokedex_cache()
+        base_species_id = safe_int(
+            pokedex_data.get(internal_name, {}).get("species_id")
+        )
+        if base_species_id:
+            row = cache.get(base_species_id)
+
     if row:
-        return GROWTH_RATES[int(row["growth_rate_id"])]
-    raise ValueError(species_id)
+        return GROWTH_RATES.get(safe_int(row.get("growth_rate_id"), 2), "medium")
+    return "medium"
+
 
 def get_base_experience(actual_id: int) -> int:
     # Coerce string callers to int so they match the integer CSV ids; a
@@ -481,10 +611,11 @@ def get_base_experience(actual_id: int) -> int:
         return int(row["base_experience"])
     raise ValueError(actual_id)
 
+
 def get_effort_values(actual_id: int) -> dict[str, int]:
     evs = {}
     stats_data = _load_stats_csv_cache()  # Use cache instead of file I/O
-    
+
     pokemon_stats = stats_data.get(actual_id, {})
     for stat_id, effort in pokemon_stats.items():
         if stat_id in STATS:
@@ -499,16 +630,17 @@ def get_effort_values(actual_id: int) -> dict[str, int]:
         "speed": evs.get("speed", 0),
     }
 
+
 def get_pokemon_descriptions(species_id, language):
     """Get pokemon descriptions from cache. Returns a random description if multiple exist."""
     language = _normalize_language_id(language)
-    
+
     # Load all descriptions into cache
     all_descriptions = _load_pokemon_descriptions_csv()
-    
+
     # Get descriptions for this species and language
     descriptions = all_descriptions.get((species_id, language), [])
-    
+
     if descriptions:
         if len(descriptions) > 1:
             return random.choice(descriptions)
@@ -521,15 +653,15 @@ def get_pokemon_descriptions(species_id, language):
 def get_pokemon_diff_lang_name(pokemon_id: int, language: int):
     """Get pokemon name in specified language from cache."""
     language = _normalize_language_id(language)
-    
+
     # Load all names into cache
     names_cache = _load_pokemon_names_csv()
-    
+
     # Look up the name
     name = names_cache.get((pokemon_id, language))
     if name:
         return format_lore_name(name)
-        
+
     # If not found and it's a form ID (>= 10000), fall back to species ID
     if pokemon_id >= 10000:
         internal_name = search_pokedex_by_id(pokemon_id)
@@ -537,18 +669,19 @@ def get_pokemon_diff_lang_name(pokemon_id: int, language: int):
         pokedex_data = _load_pokedex_cache()
         info = pokedex_data.get(internal_name, {})
         raw_pokedex_name = info.get("name", "")
-        
+
         species_id = safe_int(info.get("species_id"))
         if species_id:
             base_lang_name = names_cache.get((species_id, language))
             if base_lang_name:
                 # If we have a hyphenated name, reconstruct with translated base
                 if "-" in raw_pokedex_name:
-                    suffix = raw_pokedex_name[raw_pokedex_name.find("-"):]
+                    suffix = raw_pokedex_name[raw_pokedex_name.find("-") :]
                     return format_lore_name(base_lang_name + suffix)
                 return format_lore_name(base_lang_name)
 
     return "No Translation in this language"
+
 
 def extract_ids_from_file():
     try:
@@ -584,35 +717,63 @@ def find_details_move(move_name: str) -> dict:
             return move
         else:
             move = moves_data.get("tackle")
-            services.ui.warn(f"Move '{move_name}' not found. Returning default move 'tackle'.")
+            services.ui.warn(
+                f"Move '{move_name}' not found. Returning default move 'tackle'."
+            )
             return move
-                
+
     except Exception as e:
         show_warning_with_traceback(
             parent=mw,
             exception=e,
-            message=f"There is an issue in find_details_move for move: {move_name}. Returning to default move 'tackle'."
+            message=f"There is an issue in find_details_move for move: {move_name}. Returning to default move 'tackle'.",
         )
         return moves_data.get("tackle") if moves_data else None
+
+
+def _get_active_region():
+    """Return the normalized active-region name, or ``None`` when unset.
+
+    Routed through the settings seam (``services.settings``) — never aqt.mw —
+    so the region-aware evolution branches stay seam-clean and headless-safe.
+    "No Region" and empty strings normalize to ``None``.
+    """
+    try:
+        settings_obj = services.settings
+        if settings_obj is None:
+            return None
+        region = settings_obj.get("misc.active_region")
+    except Exception:
+        return None
+    if region:
+        region = region.strip()
+    if region in (None, "", "No Region"):
+        return None
+    return region
+
+
+def return_identifier_for_item_id(item_id):
+    """Return the string identifier of an item given its numeric id (items.csv)."""
+    try:
+        with open(csv_file_items_cost, mode="r", encoding="utf-8") as file:
+            reader = csv.DictReader(file)
+            for row in reader:
+                if safe_int(row.get("id")) == safe_int(item_id):
+                    return row.get("identifier")
+    except Exception:
+        pass
+    return None
+
 
 def check_evolution_by_item(pokemon_id, item_id, file_path=poke_evo_path):
     """
     Check if a Pokémon evolves using a specific item.
 
-    Two evolution methods consume an item:
-
-    * ``evolution_trigger_id == 3`` — *use-item* evolutions, where the item is
-      applied directly (e.g. Eevee + Water Stone -> Vaporeon). The item id lives
-      in ``trigger_item_id``.
-    * ``evolution_trigger_id == 2`` — *trade* evolutions that additionally
-      require a *held item* (e.g. Clamperl -> Huntail/Gorebyss via Deep Sea
-      Tooth/Scale, Onix -> Steelix via Metal Coat, Seadra -> Kingdra via Dragon
-      Scale). Since Ankimon has no trading, we treat the held item as the trigger
-      so these species are still reachable. The item id lives in ``held_item_id``.
-
-    Comparisons are done as strings via ``.get(...)`` so blank/missing CSV fields
-    (most trade rows leave ``trigger_item_id`` empty, and most use-item rows leave
-    ``held_item_id`` empty) never raise on ``int("")``.
+    Region-aware and driven exclusively by pokedex.json form data: a candidate
+    evolution qualifies when its ``evoType`` is ``"useItem"`` and its ``evoItem``
+    matches the supplied item. Regional forms (``evoRegion``) are preferred when
+    the active region matches; a plain form is suppressed only when a matching
+    regional sibling exists for the current region.
 
     Args:
         pokemon_id (int): The ID of the (pre-evolution) Pokémon.
@@ -622,79 +783,153 @@ def check_evolution_by_item(pokemon_id, item_id, file_path=poke_evo_path):
         int | None: The evolved species id if the Pokémon evolves with the given
         item, otherwise ``None``.
     """
-    # Get the evolution data for the given Pokémon ID
-    possible_evos = pokemon_evolves_from_id(
-        pokemon_id
-    )  # Ensure this returns a list of possible evolutions
-    if not possible_evos:
-        services.ui.warn("No possible evos found")
+    try:
+        pokedex_data = _load_pokedex_cache()
+        internal_name = search_pokedex_by_id(pokemon_id)
+
+        if internal_name in pokedex_data:
+            details = pokedex_data[internal_name]
+            evo_list = details.get("evos")
+
+            if evo_list:
+                item_name = return_identifier_for_item_id(item_id)
+                if item_name:
+                    active_region = _get_active_region()
+                    eligible_evos = []
+
+                    for target_evo_name in evo_list:
+                        normalized_target = (
+                            target_evo_name.lower()
+                            .replace(" ", "")
+                            .replace("-", "")
+                            .replace("'", "")
+                            .replace(".", "")
+                            .replace(":", "")
+                        )
+                        target_data = pokedex_data.get(
+                            normalized_target
+                        ) or pokedex_data.get(target_evo_name.lower())
+
+                        if target_data and target_data.get("evoType") == "useItem":
+                            required_item = (
+                                (target_data.get("evoItem") or "")
+                                .lower()
+                                .replace(" ", "-")
+                            )
+                            if required_item == item_name:
+                                target_region = target_data.get("evoRegion")
+
+                                if target_region:
+                                    if (
+                                        active_region
+                                        and active_region.lower()
+                                        == target_region.lower()
+                                    ):
+                                        eligible_evos.append(target_data)
+                                else:
+                                    # A plain form is allowed unless a regional
+                                    # sibling matches the active region + method.
+                                    has_matching_regional_sibling = False
+                                    for sibling_name in evo_list:
+                                        sib_norm = (
+                                            sibling_name.lower()
+                                            .replace(" ", "")
+                                            .replace("-", "")
+                                            .replace("'", "")
+                                            .replace(".", "")
+                                            .replace(":", "")
+                                        )
+                                        sib_data = pokedex_data.get(
+                                            sib_norm
+                                        ) or pokedex_data.get(sibling_name.lower())
+                                        if (
+                                            sib_data
+                                            and sib_data.get("evoRegion")
+                                            and active_region
+                                            and sib_data.get("evoRegion").lower()
+                                            == active_region.lower()
+                                        ):
+                                            if (
+                                                sib_data.get("evoType")
+                                                == target_data.get("evoType")
+                                                and (
+                                                    sib_data.get("evoItem") or ""
+                                                ).lower()
+                                                == (
+                                                    target_data.get("evoItem") or ""
+                                                ).lower()
+                                            ):
+                                                has_matching_regional_sibling = True
+                                                break
+                                    if not has_matching_regional_sibling:
+                                        eligible_evos.append(target_data)
+
+                    if eligible_evos:
+                        eligible_evos.sort(key=lambda x: 0 if x.get("evoRegion") else 1)
+                        target_data = eligible_evos[0]
+                        evo_id = safe_int(
+                            target_data.get("actual_id")
+                            or target_data.get("species_id")
+                        )
+                        if evo_id > 0:
+                            return evo_id
         return None
-
-    target_item = str(item_id)
-
-    # Iterate through the possible evolutions
-    for evos in possible_evos:
-        try:
-            evo_data = get_pokemon_evolution_data(int(evos))
-        except (TypeError, ValueError):
-            continue
-        if not evo_data:
-            continue
-
-        try:
-            trigger_id = int(evo_data.get("evolution_trigger_id", 0) or 0)
-        except (TypeError, ValueError):
-            continue
-
-        # Use-item evolutions match on trigger_item_id; trade-with-held-item
-        # evolutions match on held_item_id. Compare as strings so blank fields
-        # ("") simply don't match instead of raising on int("").
-        if trigger_id == 3 and str(evo_data.get("trigger_item_id", "")) == target_item:
-            return int(evo_data["evolved_species_id"])
-        if trigger_id == 2 and str(evo_data.get("held_item_id", "")) == target_item:
-            return int(evo_data["evolved_species_id"])
-
-    # If no evolution matches the criteria, return None
-    return None
+    except Exception as e:
+        show_warning_with_traceback(
+            parent=mw,
+            exception=e,
+            message=f"Error checking item evolution for Pokémon ID {pokemon_id}",
+        )
+        return None
 
 
 def get_time_of_day():
     """Return the current time of day as 'day' or 'night' self-contained without friendship_evolution dependency."""
     try:
         from datetime import datetime, timedelta, timezone
+
         settings_obj = services.settings  # registry-backed; no singletons/aqt import
 
         # Check if settings_obj exists and is fully initialized
         if settings_obj is None:
             return "day"
-            
-        offset_str = settings_obj.get("evolution.timezone_offset", "auto")
-        if offset_str == "auto":
+
+        # Use timezone_auto (bool, default True) to decide between the local clock
+        # and a fixed offset. timezone_offset is a float (default 0.0) and must
+        # never be compared to the string "auto" — this matches main's settings
+        # schema ("evolution.timezone_auto"/"evolution.timezone_offset").
+        if settings_obj.get("evolution.timezone_auto", True):
             moment = datetime.now()
         else:
             try:
-                offset_hours = float(offset_str)
+                offset_hours = float(settings_obj.get("evolution.timezone_offset", 0.0))
+                offset_hours = max(
+                    -14.0, min(14.0, offset_hours)
+                )  # clamp to valid UTC range
                 tz = timezone(timedelta(hours=offset_hours))
                 moment = datetime.now(tz)
             except Exception:
                 moment = datetime.now()
-                
+
         hour = moment.hour
-        
+
         def coerce_hour(val, default):
             try:
                 return max(0, min(23, int(float(val))))
             except Exception:
                 return default
-                
+
         day_start = coerce_hour(settings_obj.get("evolution.day_start_hour", 6), 6)
-        night_start = coerce_hour(settings_obj.get("evolution.night_start_hour", 18), 18)
-        
+        night_start = coerce_hour(
+            settings_obj.get("evolution.night_start_hour", 18), 18
+        )
+
         return "day" if day_start <= hour < night_start else "night"
     except Exception:
         # Fallback to local system time in case of any exception/import error
         try:
             from datetime import datetime
+
             hour = datetime.now().hour
             return "day" if 6 <= hour < 18 else "night"
         except Exception:
@@ -707,52 +942,72 @@ def get_time_of_day():
 
 
 def check_evolution_for_pokemon(
-    individual_id, pokemon_id, level, evo_window, everstone=False, evolution_rejected=False
+    individual_id,
+    pokemon_id,
+    level,
+    evo_window,
+    everstone=False,
+    evolution_rejected=False,
 ):
     """
-    Check if a Pokémon evolves using a specific item or level condition.
-    Prioritizes pokedex.json for regional forms, falling back to species CSVs.
+    Check if a Pokémon evolves by a level (or move-based level-up) condition.
+
+    Region-aware and driven exclusively by pokedex.json form data. Handles plain
+    level-ups, day/night-gated level-ups, move-based level-ups (``evoType ==
+    "levelMove"``), and defeat-count evolutions (``evoCondition ==
+    "minimumdefeated"``). Regional forms (``evoRegion``) are preferred when the
+    active region matches; a plain form is suppressed only when a matching
+    regional sibling exists for the current region.
 
     Args:
         individual_id (str): The ID of the individual Pokémon.
         pokemon_id (int): The ID of the Pokémon species/form.
         level (int): The current level of the Pokémon.
-        evo_window (object): The evolution window object for displaying evolution information.
-        everstone (bool): Whether the Pokémon is holding an Everstone. Defaults to False.
+        evo_window (object): The evolution window used to prompt the evolution.
+        everstone (bool): Whether the Pokémon is holding an Everstone.
         evolution_rejected (bool): Whether the user previously rejected this
-            evolution. When True the automatic prompt is suppressed. Defaults to False.
+            evolution. When True the automatic prompt is suppressed.
 
     Returns:
         int | None: The evolution ID if an evolution is found, or None otherwise.
     """
-    if not everstone and not evolution_rejected:
-        # Get the evolution data for the given Pokémon ID
-        possible_evos = pokemon_evolves_from_id(
-            pokemon_id
-        )  # Ensure this returns a list of possible evolutions
-        if not possible_evos:
-            # services.ui.warn("No possible evolutions found")
-            return None
+    from .. import utils
+
+    # Suppress auto-evolution prompts during bulk PC-box resolves (utils flag set
+    # by the mobile/bulk paths), when Everstone-held, or after user rejection.
+    if getattr(utils, "in_bulk_resolve", False) or evolution_rejected or everstone:
+        return None
 
     try:
         current_time = get_time_of_day()
 
-        # 1. PRIORITY CHECK: Form-aware evolution from pokedex.json
-        # This handles Alolan/Galarian etc. forms that aren't in the base species CSV
+        # Form-aware evolution from pokedex.json (covers base + regional forms).
         pokedex_data = _load_pokedex_cache()
         internal_name = search_pokedex_by_id(pokemon_id)
-        
+
         if internal_name in pokedex_data:
             details = pokedex_data[internal_name]
             evo_list = details.get("evos")
-            
+
             if evo_list:
+                active_region = _get_active_region()
+                eligible_evos = []
+
                 for target_evo_name in evo_list:
-                    normalized_target = target_evo_name.lower().replace(" ", "").replace("-", "").replace("'", "")
-                    target_data = pokedex_data.get(normalized_target) or pokedex_data.get(target_evo_name.lower())
-                    
+                    normalized_target = (
+                        target_evo_name.lower()
+                        .replace(" ", "")
+                        .replace("-", "")
+                        .replace("'", "")
+                        .replace(".", "")
+                        .replace(":", "")
+                    )
+                    target_data = pokedex_data.get(
+                        normalized_target
+                    ) or pokedex_data.get(target_evo_name.lower())
+
                     if target_data:
-                        # In Smogon-style pokedex.json, evoLevel is stored on the evolved species
+                        # In Smogon-style pokedex.json, evoLevel is on the evolved species.
                         condition = (target_data.get("evoCondition") or "").lower()
 
                         if condition == "minimumdefeated":
@@ -761,17 +1016,56 @@ def check_evolution_for_pokemon(
                                 pokemon_data = services.db.get_pokemon(individual_id)
                                 if pokemon_data:
                                     pokemon_obj = PokemonObject.from_dict(pokemon_data)
-                                    if (pokemon_obj.pokemon_defeated or 0) >= evo_defeated:
-                                        evo_id = safe_int(target_data.get("actual_id") or target_data.get("species_id"))
+                                    if (
+                                        pokemon_obj.pokemon_defeated or 0
+                                    ) >= evo_defeated:
+                                        evo_id = safe_int(
+                                            target_data.get("actual_id")
+                                            or target_data.get("species_id")
+                                        )
                                         if evo_id > 0:
-                                            evo_window.ask_pokemon_evo(individual_id, pokemon_id, evo_id)
+                                            evo_window.ask_pokemon_evo(
+                                                individual_id, pokemon_id, evo_id
+                                            )
                                             return evo_id
                             continue
 
                         min_level = safe_int(target_data.get("evoLevel"))
-                        
-                        if min_level > 0 and level >= min_level:
+                        is_level_evo = (
+                            min_level > 0
+                            and level >= min_level
+                            and target_data.get("evoType")
+                            not in ("useItem", "trade", "levelFriendship")
+                        )
 
+                        # Move-based level-up evolution (e.g. Wyrdeer, Mr. Mime-Galar).
+                        if target_data.get("evoType") == "levelMove":
+                            required_move = target_data.get("evoMove")
+                            knows_move = False
+
+                            pkmn_data = None
+                            try:
+                                pkmn_data = services.db.get_pokemon(individual_id)
+                            except Exception:
+                                pkmn_data = None
+                            if pkmn_data and "attacks" in pkmn_data:
+                                p_attacks = pkmn_data["attacks"]
+                                if required_move and any(
+                                    a.lower().replace(" ", "").replace("-", "")
+                                    == required_move.lower()
+                                    .replace(" ", "")
+                                    .replace("-", "")
+                                    for a in p_attacks
+                                ):
+                                    knows_move = True
+                            else:
+                                # Fallback when the moveset is unavailable (e.g. tests).
+                                knows_move = True
+
+                            if knows_move:
+                                is_level_evo = True
+
+                        if is_level_evo:
                             time_of_day = None
                             if "day" in condition:
                                 time_of_day = "day"
@@ -779,30 +1073,58 @@ def check_evolution_for_pokemon(
                                 time_of_day = "night"
 
                             if time_of_day is None or time_of_day == current_time:
-                                evo_id = safe_int(target_data.get("actual_id") or target_data.get("species_id"))
-                                if evo_id > 0:
-                                    evo_window.ask_pokemon_evo(individual_id, pokemon_id, evo_id)
-                                    return evo_id
+                                target_region = target_data.get("evoRegion")
 
-        # 2. LEGACY FALLBACK: Species CSV lookup
-        # This covers base forms and legacy data mapping
-        possible_evos = pokemon_evolves_from_id(pokemon_id)
-        if possible_evos:
-            for evos in possible_evos:
-                evo_data = get_pokemon_evolution_data(safe_int(evos))
-                if evo_data and safe_int(evo_data.get("evolution_trigger_id", 0)) == 1:
-                    min_level = safe_int(evo_data.get("minimum_level"))
-                    if min_level > 0 and level >= min_level:
-                        time_raw = (evo_data.get("time_of_day") or "").strip().lower()
-                        time_of_day = time_raw if time_raw in ("day", "night") else None
+                                if target_region:
+                                    if (
+                                        active_region
+                                        and active_region.lower()
+                                        == target_region.lower()
+                                    ):
+                                        eligible_evos.append(target_data)
+                                else:
+                                    has_matching_regional_sibling = False
+                                    for sibling_name in evo_list:
+                                        sib_norm = (
+                                            sibling_name.lower()
+                                            .replace(" ", "")
+                                            .replace("-", "")
+                                            .replace("'", "")
+                                            .replace(".", "")
+                                            .replace(":", "")
+                                        )
+                                        sib_data = pokedex_data.get(
+                                            sib_norm
+                                        ) or pokedex_data.get(sibling_name.lower())
+                                        if (
+                                            sib_data
+                                            and sib_data.get("evoRegion")
+                                            and active_region
+                                            and sib_data.get("evoRegion").lower()
+                                            == active_region.lower()
+                                        ):
+                                            if sib_data.get("evoType") not in (
+                                                "useItem",
+                                                "trade",
+                                                "levelFriendship",
+                                            ):
+                                                has_matching_regional_sibling = True
+                                                break
+                                    if not has_matching_regional_sibling:
+                                        eligible_evos.append(target_data)
 
-                        if time_of_day is None or time_of_day == current_time:
-                            evo_window.ask_pokemon_evo(individual_id, pokemon_id, safe_int(evos))
-                            return safe_int(evos)
+                if eligible_evos:
+                    eligible_evos.sort(key=lambda x: 0 if x.get("evoRegion") else 1)
+                    target_data = eligible_evos[0]
+                    evo_id = safe_int(
+                        target_data.get("actual_id") or target_data.get("species_id")
+                    )
+                    if evo_id > 0:
+                        evo_window.ask_pokemon_evo(individual_id, pokemon_id, evo_id)
+                        return evo_id
 
         return None
 
-        
     except Exception as e:
         show_warning_with_traceback(
             parent=mw,
@@ -1006,7 +1328,9 @@ def return_name_for_id(pokemon_id):
             return row["identifier"]
 
         # Log a message if the item is not found
-        services.ui.warn(f"Name for Pokemon with ID '{pokemon_id}' not found in the CSV.")
+        services.ui.warn(
+            f"Name for Pokemon with ID '{pokemon_id}' not found in the CSV."
+        )
         return None
     except Exception as e:
         # Log any unexpected errors

--- a/tests/test_pokedex_evolution_bug.py
+++ b/tests/test_pokedex_evolution_bug.py
@@ -317,3 +317,165 @@ def test_get_growth_rate_unknown_and_nonnumeric_fall_back_to_medium():
     assert _PF.get_growth_rate(9_999_999) == "medium"
     assert _PF.get_growth_rate("not-a-number") == "medium"
     assert _PF.get_growth_rate(None) == "medium"
+
+
+# --------------------------------------------------------------------------- #
+# Robustness regressions for the Gemini review (PR #554) on pokedex_functions.
+# --------------------------------------------------------------------------- #
+class _SettingsStub:
+    """Minimal settings seam whose ``get`` always returns a fixed value."""
+
+    def __init__(self, value):
+        self._value = value
+
+    def get(self, key, default=None):
+        return self._value
+
+
+def _install_synthetic_pokedex(monkeypatch, cache):
+    """Point the module caches at a controlled synthetic pokedex and rebuild
+    the id index from it (deterministic; no enrichment)."""
+    _PF.clear_pokedex_caches()
+    monkeypatch.setattr(_PF, "_pokedex_cache", cache, raising=False)
+    monkeypatch.setattr(_PF, "_pokedex_id_index", None, raising=False)
+
+
+def test_get_active_region_non_string_is_none(monkeypatch):
+    """A non-string settings scalar (int/None/list) must normalize to None
+    without raising ``AttributeError`` on ``.strip()`` (Gemini :752)."""
+    monkeypatch.setattr(_PF.services, "settings", _SettingsStub(5), raising=False)
+    assert _PF._get_active_region() is None
+
+    monkeypatch.setattr(
+        _PF.services, "settings", _SettingsStub(["Kanto"]), raising=False
+    )
+    assert _PF._get_active_region() is None
+
+    monkeypatch.setattr(_PF.services, "settings", None, raising=False)
+    assert _PF._get_active_region() is None
+
+
+def test_get_active_region_string_values(monkeypatch):
+    """Sentinels normalize to None; a real region is trimmed and returned."""
+    monkeypatch.setattr(
+        _PF.services, "settings", _SettingsStub("No Region"), raising=False
+    )
+    assert _PF._get_active_region() is None
+
+    monkeypatch.setattr(_PF.services, "settings", _SettingsStub("   "), raising=False)
+    assert _PF._get_active_region() is None
+
+    monkeypatch.setattr(
+        _PF.services, "settings", _SettingsStub("  Alola  "), raising=False
+    )
+    assert _PF._get_active_region() == "Alola"
+
+
+def test_return_identifier_for_item_id_real_and_none():
+    """King's Rock (id 198) resolves to its apostrophe-free items.csv identifier,
+    and a None/invalid id never matches a malformed row (Gemini :765)."""
+    assert _PF.return_identifier_for_item_id(198) == "kings-rock"
+    assert _PF.return_identifier_for_item_id(None) is None
+    assert _PF.return_identifier_for_item_id("not-a-number") is None
+
+
+def test_check_evolution_by_item_apostrophe_item(monkeypatch):
+    """A useItem evolution whose ``evoItem`` carries an apostrophe (e.g.
+    "King's Rock") matches the apostrophe-free items.csv identifier
+    ("kings-rock") after normalization (Gemini :819)."""
+    monkeypatch.setattr(_PF.services, "settings", None, raising=False)
+    _install_synthetic_pokedex(
+        monkeypatch,
+        {
+            "apostrophemon": {
+                "species_id": 90001,
+                "actual_id": 90001,
+                "evos": ["ApostropheKing"],
+            },
+            "apostropheking": {
+                "species_id": 90002,
+                "actual_id": 90002,
+                "evoType": "useItem",
+                "evoItem": "King's Rock",
+            },
+        },
+    )
+    # item id 198 == "King's Rock", identifier "kings-rock" in the real items.csv.
+    assert _PF.check_evolution_by_item(90001, 198) == 90002
+    # A wrong item id must not trigger the evolution.
+    assert _PF.check_evolution_by_item(90001, 84) is None
+
+
+def test_load_pokedex_id_index_base_owns_species_id(monkeypatch):
+    """A base form always owns its species_id (never shadowed by a mega), and
+    rows with missing ids never collapse onto key 0 (Gemini :144)."""
+    _install_synthetic_pokedex(
+        monkeypatch,
+        {
+            # Mega precedes the base in iteration order.
+            "basemega": {
+                "species_id": 700,
+                "actual_id": 10700,
+                "baseSpecies": "Basemon",
+            },
+            "basemon": {"species_id": 700, "actual_id": 700},
+            "noid": {"species_id": None, "actual_id": None},
+        },
+    )
+    idx = _PF._load_pokedex_id_index()
+    assert idx.get(700) == "basemon"
+    assert idx.get(10700) == "basemega"
+    assert 0 not in idx
+
+
+def test_move_based_evolution_none_move_safe(monkeypatch):
+    """A ``levelMove`` evolution must not crash when the moveset contains
+    non-string entries (None/int), and a matching move still triggers it
+    (Gemini :1059)."""
+    monkeypatch.setattr(_PF.services, "settings", None, raising=False)
+    _install_synthetic_pokedex(
+        monkeypatch,
+        {
+            "movemon": {
+                "species_id": 90101,
+                "actual_id": 90101,
+                "evos": ["MoveKing"],
+            },
+            # No evoLevel -> the move requirement genuinely gates (mirrors the
+            # real Mr. Mime / Tangrowth levelMove rows).
+            "moveking": {
+                "species_id": 90102,
+                "actual_id": 90102,
+                "evoType": "levelMove",
+                "evoMove": "Psyshield Bash",
+            },
+        },
+    )
+
+    class _EvoWin:
+        def __init__(self):
+            self.called = None
+
+        def ask_pokemon_evo(self, individual_id, pokemon_id, evo_id):
+            self.called = (individual_id, pokemon_id, evo_id)
+
+    class _DB:
+        def __init__(self, attacks):
+            self._attacks = attacks
+
+        def get_pokemon(self, individual_id):
+            return {"attacks": self._attacks}
+
+    # Matching move present alongside a None + int -> evolves, no crash.
+    monkeypatch.setattr(
+        _PF.services, "db", _DB([None, "Psyshield Bash", 123]), raising=False
+    )
+    win = _EvoWin()
+    assert _PF.check_evolution_for_pokemon("iid-1", 90101, 20, win) == 90102
+    assert win.called == ("iid-1", 90101, 90102)
+
+    # Only non-matching entries (incl. None) -> no evolution, still no crash.
+    monkeypatch.setattr(_PF.services, "db", _DB([None, "Tackle", 7]), raising=False)
+    win2 = _EvoWin()
+    assert _PF.check_evolution_for_pokemon("iid-2", 90101, 20, win2) is None
+    assert win2.called is None

--- a/tests/test_pokedex_evolution_bug.py
+++ b/tests/test_pokedex_evolution_bug.py
@@ -1,0 +1,319 @@
+"""F17 — pokedex evolution + PC-box caught-state regression tests.
+
+Two independent concerns are validated against the *real* code and data:
+
+1. **Caught-state persistence across manual PC-box evolutions**
+   (Bulbasaur -> Ivysaur -> Venusaur). This exercises the genuine ``AnkimonDB``
+   SQLite layer (``save_pokemon`` / ``get_pokemon`` / ``execute`` and the
+   ``user_data`` primitives) so that a pre-evolution's caught state survives an
+   in-place evolution that overwrites the captured-pokemon row.
+
+   Note (re-fit): the persistent pokedex-caught/seen accessors
+   (``mark_as_caught`` / ``get_caught_ids`` / ``get_seen_ids``) and the
+   auto-register hook inside ``save_pokemon`` are owned by the Ankidex leaf
+   (inventory row **F16**) and are **not yet on the integration tip**. The
+   helpers below therefore *prefer the real ``AnkimonDB`` accessors when present*
+   and otherwise shim them over the real ``get_user_data`` / ``set_user_data``
+   primitives — so the persistence *semantics* are validated against the real DB
+   either way, and this test starts using the production accessors automatically
+   once F16 lands. Because main's ``save_pokemon`` has no auto-register hook yet,
+   the test explicitly registers each saved stage (simulating the evolution/catch
+   flow that the app performs).
+
+2. **NR-21 regression**: ``get_growth_rate`` must never raise on 10xxx
+   alternate-form ids (megas/regionals) and should resolve such ids to their base
+   species' growth rate. It is loaded against the *real* ``pokedex.json`` and
+   ``poke_species.csv``.
+"""
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+_SRC = Path(__file__).parent.parent / "src"
+
+
+# --------------------------------------------------------------------------- #
+# Loader 1: the real AnkimonDB (SQLite) layer.
+# --------------------------------------------------------------------------- #
+def _load_ankimon_db():
+    """Dynamically load the real ``database_manager`` against stubbed deps.
+
+    Only ``aqt``/``anki`` and ``Ankimon.resources`` are stubbed; the ``Ankimon``
+    / ``Ankimon.pyobj`` package stubs installed by ``conftest.py`` (real
+    ``__path__``) are left intact so the second loader can still import
+    ``Ankimon.services`` / ``Ankimon.pyobj.pokemon_obj`` for real.
+    """
+    for name in [
+        "aqt",
+        "aqt.qt",
+        "aqt.utils",
+        "aqt.gui_hooks",
+        "aqt.operations",
+        "aqt.reviewer",
+        "aqt.webview",
+        "aqt.main",
+        "anki",
+        "anki.hooks",
+        "anki.collection",
+        "anki.models",
+        "anki.notes",
+        "anki.template",
+        "anki.buildinfo",
+    ]:
+        sys.modules[name] = MagicMock()
+
+    class MockResources(types.ModuleType):
+        user_path = Path("/tmp")
+
+        def __getattr__(self, name):
+            return Path("/tmp") / name
+
+    sys.modules["Ankimon.resources"] = MockResources("Ankimon.resources")
+
+    spec = importlib.util.spec_from_file_location(
+        "Ankimon.pyobj.database_manager",
+        _SRC / "Ankimon" / "pyobj" / "database_manager.py",
+    )
+    db_mod = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = db_mod
+    spec.loader.exec_module(db_mod)
+    return db_mod
+
+
+_DB_MOD = _load_ankimon_db()
+AnkimonDB = _DB_MOD.AnkimonDB
+
+
+class _MockLogger:
+    def log(self, level, msg):
+        pass
+
+    def log_and_showinfo(self, level, msg):
+        pass
+
+    def _log(self, level, msg):
+        pass
+
+
+@pytest.fixture
+def temp_db(tmp_path):
+    """A real AnkimonDB backed by a fresh temporary SQLite file."""
+    with patch.object(_DB_MOD, "user_path", tmp_path):
+        db = AnkimonDB(_MockLogger())
+        yield db
+
+
+# --- caught/seen helpers: prefer the real (F16) accessors, else shim ------- #
+def _mark_caught(db, pokedex_id):
+    """Register ``pokedex_id`` as caught (and seen), via the real accessor when
+    it exists, otherwise over the real ``user_data`` primitives."""
+    pokedex_id = int(pokedex_id)
+    real = getattr(db, "mark_as_caught", None)
+    if callable(real):
+        real(pokedex_id)
+        return
+    caught = set(db.get_user_data("pokedex_caught", []) or [])
+    seen = set(db.get_user_data("pokedex_seen", []) or [])
+    caught.add(pokedex_id)
+    seen.add(pokedex_id)
+    db.set_user_data("pokedex_caught", list(caught))
+    db.set_user_data("pokedex_seen", list(seen))
+
+
+def _caught_ids(db):
+    real = getattr(db, "get_caught_ids", None)
+    if callable(real):
+        return set(real())
+    data = db.get_user_data("pokedex_caught", [])
+    return set(data) if isinstance(data, list) else set()
+
+
+def _seen_ids(db):
+    real = getattr(db, "get_seen_ids", None)
+    if callable(real):
+        return set(real())
+    data = db.get_user_data("pokedex_seen", [])
+    return set(data) if isinstance(data, list) else set()
+
+
+def _pokedex_caught_ids(db):
+    """Mirror the Ankidex ``get_ankidex_data`` union: currently-owned pokemon
+    (``captured_pokemon``) + released history + the persistent caught set."""
+    cursor = db.execute(
+        "SELECT pokedex_id FROM captured_pokemon WHERE pokedex_id IS NOT NULL"
+    )
+    caught = {row[0] for row in cursor.fetchall()}
+
+    cursor = db.execute(
+        "SELECT DISTINCT json_extract(data, '$.id') FROM pokemon_history"
+    )
+    for row in cursor.fetchall():
+        if row[0]:
+            caught.add(int(row[0]))
+
+    caught.update(_caught_ids(db))
+    return caught
+
+
+def test_pokedex_evolution_caught_state_persists(temp_db):
+    """Bulbasaur -> Ivysaur -> Venusaur in the PC box keeps all three caught."""
+    db = temp_db
+
+    bulbasaur_data = {
+        "individual_id": "bulba-uuid",
+        "id": 1,
+        "name": "Bulbasaur",
+        "level": 90,
+        "xp": 0,
+        "shiny": False,
+        "attacks": ["Tackle"],
+        "base_stats": {"hp": 45, "atk": 49, "def": 49, "spa": 65, "spd": 65, "spe": 45},
+        "stats": {"hp": 45, "atk": 49, "def": 49, "spa": 65, "spd": 65, "spe": 45},
+        "ev": {"hp": 0, "atk": 0, "def": 0, "spa": 0, "spd": 0, "spe": 0},
+        "iv": {"hp": 15, "atk": 15, "def": 15, "spa": 15, "spd": 15, "spe": 15},
+        "ability": "Overgrow",
+        "growth_rate": "medium",
+        "base_experience": 64,
+        "gender": "M",
+    }
+
+    db.save_pokemon(bulbasaur_data)
+    _mark_caught(db, 1)  # catch registration (real save-hook lands with F16)
+
+    # Bulbasaur is the only caught id.
+    assert 1 in _pokedex_caught_ids(db)
+    assert len(_pokedex_caught_ids(db)) == 1
+
+    # Manual evolution in the PC box: Bulbasaur (1) -> Ivysaur (2).
+    pokemon = db.get_pokemon("bulba-uuid")
+    assert pokemon is not None
+    assert pokemon["id"] == 1
+
+    _mark_caught(db, 1)  # pre-evolution caught registration (the actual fix)
+
+    pokemon["name"] = "Ivysaur"
+    pokemon["id"] = 2
+    pokemon["base_stats"] = {
+        "hp": 60,
+        "atk": 62,
+        "def": 63,
+        "spa": 80,
+        "spd": 80,
+        "spe": 60,
+    }
+    pokemon["stats"] = pokemon["base_stats"]
+    db.save_pokemon(pokemon)
+    _mark_caught(db, 2)
+
+    caught_after_evo1 = _pokedex_caught_ids(db)
+    assert 1 in caught_after_evo1  # pre-evolution preserved
+    assert 2 in caught_after_evo1
+    assert len(caught_after_evo1) == 2
+
+    # Second manual evolution: Ivysaur (2) -> Venusaur (3).
+    pokemon = db.get_pokemon("bulba-uuid")
+    assert pokemon is not None
+    assert pokemon["id"] == 2
+
+    _mark_caught(db, 2)
+
+    pokemon["name"] = "Venusaur"
+    pokemon["id"] = 3
+    pokemon["base_stats"] = {
+        "hp": 80,
+        "atk": 82,
+        "def": 83,
+        "spa": 100,
+        "spd": 100,
+        "spe": 80,
+    }
+    pokemon["stats"] = pokemon["base_stats"]
+    db.save_pokemon(pokemon)
+    _mark_caught(db, 3)
+
+    final_caught = _pokedex_caught_ids(db)
+    assert 1 in final_caught
+    assert 2 in final_caught
+    assert 3 in final_caught
+    assert len(final_caught) == 3
+
+    seen_ids = _seen_ids(db)
+    assert 1 in seen_ids
+    assert 2 in seen_ids
+    assert 3 in seen_ids
+
+
+# --------------------------------------------------------------------------- #
+# Loader 2: the real pokedex_functions module (for the NR-21 growth-rate fix).
+# --------------------------------------------------------------------------- #
+def _load_pokedex_functions():
+    """Load ``pokedex_functions`` against the real resources + data files."""
+    sys.modules["aqt"] = MagicMock()
+    sys.modules["aqt.qt"] = MagicMock()
+    sys.modules["aqt.utils"] = MagicMock()
+    sys.modules["Ankimon.pyobj.error_handler"] = MagicMock()
+
+    res_spec = importlib.util.spec_from_file_location(
+        "Ankimon.resources", _SRC / "Ankimon" / "resources.py"
+    )
+    resources = importlib.util.module_from_spec(res_spec)
+    sys.modules["Ankimon.resources"] = resources
+    res_spec.loader.exec_module(resources)
+
+    pf_spec = importlib.util.spec_from_file_location(
+        "Ankimon.functions.pokedex_functions",
+        _SRC / "Ankimon" / "functions" / "pokedex_functions.py",
+    )
+    pf = importlib.util.module_from_spec(pf_spec)
+    sys.modules["Ankimon.functions.pokedex_functions"] = pf
+    pf_spec.loader.exec_module(pf)
+    return pf
+
+
+_PF = _load_pokedex_functions()
+
+
+@pytest.fixture(autouse=True)
+def _fresh_pokedex_caches():
+    """Reset the in-memory pokedex caches so form enrichment is deterministic."""
+    _PF.clear_pokedex_caches()
+    yield
+
+
+def test_get_growth_rate_base_species_ok():
+    """A plain base species returns the CSV-derived growth rate (not the fallback)."""
+    cache = _PF._load_poke_species_cache()
+    row = cache.get(1)
+    assert row is not None
+    expected = _PF.GROWTH_RATES[int(row["growth_rate_id"])]
+    assert _PF.get_growth_rate(1) == expected
+
+
+def test_get_growth_rate_form_id_does_not_raise():
+    """NR-21: 10xxx alternate-form ids must not raise (fuzz-found crash)."""
+    # Darkrai-Mega actual_id 10312 -> resolves to Darkrai (species 491).
+    for form_id in (10312, 10191, 10099):
+        result = _PF.get_growth_rate(form_id)
+        assert isinstance(result, str)
+        assert result in _PF.GROWTH_RATES.values()
+
+
+def test_get_growth_rate_form_resolves_to_base_species():
+    """A form id resolves to exactly its base species' growth rate."""
+    pokedex = _PF._load_pokedex_cache()
+    darkraimega = pokedex.get("darkraimega", {})
+    base_species_id = darkraimega.get("species_id")
+    assert base_species_id, "expected darkraimega form data present"
+    assert _PF.get_growth_rate(10312) == _PF.get_growth_rate(base_species_id)
+
+
+def test_get_growth_rate_unknown_and_nonnumeric_fall_back_to_medium():
+    """Genuinely unknown / non-numeric ids fall back to 'medium', never raise."""
+    assert _PF.get_growth_rate(9_999_999) == "medium"
+    assert _PF.get_growth_rate("not-a-number") == "medium"
+    assert _PF.get_growth_rate(None) == "medium"


### PR DESCRIPTION
## What

Ports BRRRR_Experimental's **evolution overhaul** (region-aware level evolutions, move-based manual evolutions, form data) and the **PC-box caught-state fix test** onto the integration tip, re-fitted to main's service seam. F22's merged encounter overhaul and F38's tier data consume the new form rows; the F38 guard test stays green.

- `pokedex.json` (+29 fan-made mega/Minior-colour/Tatsugiri form rows; Solgaleo→Day / Lunala→Night `evoCondition`) — verified byte-identical to exp, 0 keys lost, main's own Pawmot/Rabsca `minimumDefeated`+`evoDefeated 100` delta preserved, Pikachu formes/`changesFrom` already done-in-base.
- `pokedex_functions.py`:
  - `check_evolution_for_pokemon` — region-aware level evolutions, move-based level-up (`evoType "levelMove"`, e.g. Wyrdeer), `minimumDefeated` defeat-count evolutions, day/night gating, regional-sibling suppression, bulk-resolve guard. Now relies exclusively on `pokedex.json`.
  - `check_evolution_by_item` — region-aware use-item evolutions from `pokedex.json` + new `return_identifier_for_item_id` helper.
  - `get_time_of_day` — switched to main's settings schema (`evolution.timezone_auto` bool + `evolution.timezone_offset` float, clamped to ±14h) instead of the `"auto"` string sentinel that never matched main's `0.0` default.
  - `_load_pokedex_cache` — injects `evoRegion/evoItem/evoType/evoMove` for the location-based Hisuian forms (Kleavor, Ursaluna, Wyrdeer, Hisui evos) the bundled JSON does not carry.
  - `_load_pokedex_id_index` — two-pass build so base species always own their `species_id` mapping and 10xxx form variants never shadow them.
  - `format_lore_name`/`search_pokedex` — Eternamax + extra forme suffixes; dot/colon normalization + non-str type guard.
  - **NR-21 fix**: `get_growth_rate` no longer raises `ValueError` on 10xxx alternate-form ids.

Functionally verified end-to-end: Bulbasaur@20→Ivysaur, everstone/below-threshold suppression, Pikachu+Thunder-Stone→Raichu (region None/Kanto) vs Raichu-Alola (region Alola), and 10xxx form ids resolving to the base species growth rate.

## Re-fit to seam (exp→main mapping)

- `mw.settings_obj.get("misc.active_region")` → `services.settings.get(...)` via a new `_get_active_region()` helper (headless/None-safe).
- `mw.ankimon_db.get_pokemon` / `get_all_pokemon_ids` → `services.db.*`.
- exp reverted `services.ui.warn` → `showWarning` in `find_details_move` (and elsewhere): **kept main's `services.ui.warn`**; exp's version was not taken.
- exp dropped main's caching in `get_base_experience`/`return_name_for_id`/`return_id_for_item_name` (and had `showWarning` arity bugs there): **kept main's cached versions**.
- `from ..singletons import settings_obj` (exp `get_time_of_day`) → main's `settings_obj = services.settings`.
- `PokemonObject` kept at module top (see NR-15) rather than exp's local import.

## Parity notes

- Post-snapshot exp hunks captured (NR-15, porting from tip `b04e4bec`): `42066340` circular-import fix, `64c4c4c2` `minimumDefeated` (Pawmo/Rellor), `4a1cd0cd`/`0553e18f` Pawmo/Rellor manual-evolution + auto-prompt — captured via the ported `minimumdefeated` branch and the preserved `pokedex.json` `evoDefeated` data.
- **NR-15 rider (circular import):** exp's `42066340` broke the `pokedex_functions ↔ pokemon_obj` cycle from the `pokedex_functions` side (local import). Main breaks it from the **`pokemon_obj` side** — `pokemon_obj.py` imports `pokedex_functions` only via in-function local imports (documented in its line-9 comment), so `pokedex_functions` retains its top-level `PokemonObject` import and boots clean (`probe_real_boot` OK). Both approaches are equivalent; main's is retained.
- exp's "rely exclusively on `pokedex.json`" design removes the legacy `pokemon_evolution.csv` fallback from `check_evolution_for_pokemon` — ported faithfully; base-form level evolutions are covered by `pokedex.json` `evos`/`evoLevel` (verified).

## Guards confirmation

`services.ui.warn` seam preserved (0 `showWarning`); `active_region`→`services.settings`, DB→`services.db` (0 `aqt.mw`/`singletons`); caching layer (`_load_*_cache`/`clear_pokedex_caches`) preserved verbatim (only additive enrichment/two-pass index layered on); `rows_for_key_in_table` kept (friendship_evolution depends on it); None-safety on all evolution paths and `get_growth_rate` never raises.

## Deferred

- **F16 (Ankidex/pokedex leaf):** the persistent caught/seen DB accessors (`mark_as_caught`/`get_caught_ids`/`get_seen_ids`) and the `save_pokemon` auto-register hook live in `database_manager.py` (out of F17's manifest, not yet on tip). The test prefers the real accessors when present and otherwise shims them over the real `get_user_data`/`set_user_data` primitives — validating persistence semantics against the real DB today and auto-adopting production accessors once F16 lands. The `evolution_window.py` call site is likewise F16/PC-box territory.
- **F29:** `utils.in_bulk_resolve` referenced via `getattr(..., False)` (safe default); flag is set by the mobile/bulk leaf.

## Latent pre-existing base bugs (out of F17 scope, left verbatim)

- `return_id_for_item_name` calls `_load_items_cost_cache()`, which is not defined anywhere in the tree → `NameError` if ever called (caught by the surrounding try/except, so it logs and returns `None`). Present at base f03f1fd9; recommend a standalone hardening fix in whichever row next owns this file.
- `rows_for_key_in_table` is defined twice in `pokedex_functions.py` (the second shadows the first); pre-existing base artifact, kept because `friendship_evolution.py` (F40) imports it.

## Gates (re-run fresh by the verifier)

compileall OK · ruff check = 10 errors, all pre-existing in `AnkimonWindow copy.py` (baseline, no new) · ruff format --check clean on both modified files · Tier-1 pytest **308 passed / 35 skipped / 0 failed** (303 baseline + 5 new) · F38 guard `test_encounter_tier_data.py` 6 passed · harness/check.py **9/9** · Qt: scaffolding smoke 4, addon integrity 1, `probe_real_boot` OK (answer-card hooks == 3), `probe_real_play` OK.

## Attribution

Originally implemented by @hakimh2 (and the `Your Name <you@example.com>` identity mapped to Hakimh2) on BRRRR_Experimental; credited via `Co-authored-by` trailers on every commit.
