### PR TITLE
feat: reviewer HUD rewrite — ownership cache + team-cycle hotkeys (F34)

### DIFF
--- a/src/Ankimon/pyobj/reviewer_obj.py
+++ b/src/Ankimon/pyobj/reviewer_obj.py
@@ -227,7 +227,6 @@ class Reviewer_Manager:
         self._last_state = current_state
 
         image_format = "gif" if self.settings.get("gui.reviewer_image_gif") else "png"
-        mime_type = f"image/{image_format}"
 
         addon_package = self._resolve_addon_package()
 

--- a/src/Ankimon/pyobj/reviewer_obj.py
+++ b/src/Ankimon/pyobj/reviewer_obj.py
@@ -1,14 +1,14 @@
 from aqt import gui_hooks, mw, utils
 from aqt.utils import showInfo
 from ..functions.pokemon_functions import find_experience_for_level
-from ..business import get_image_as_base64
 from ..functions.create_css_for_reviewer import create_css_for_reviewer
 import json
 import os
 from ..functions.create_gui_functions import create_status_html
-from ..functions.pokedex_functions import get_pokemon_diff_lang_name
+from ..services import services
 
 from .pokemon_obj import PokemonObject
+
 
 class Reviewer_Manager:
     def __init__(self, settings_obj, main_pokemon, enemy_pokemon, ankimon_tracker):
@@ -19,32 +19,58 @@ class Reviewer_Manager:
         self.life_bar_injected = False
         self.seconds = 0
         self.myseconds = 0
-        self.hud_hidden = False 
-        self.hud_data = None    
+        # === PERFORMANCE STATE ===
+        self._ownership_cache = {}  # {pokemon_id: bool} — cache HUD ownership DB reads
+        self._last_state = None  # skip redundant HUD repaints when nothing changed
+        self._listener_registered = (
+            False  # JS keydown listener registered once per view
+        )
 
         # Register the functions for the hooks
         gui_hooks.reviewer_will_end.append(self.reviewer_reset_life_bar_inject)
+        # Idempotent: drop any prior registration before appending so a re-run of
+        # __init__ (e.g. add-on reload) does not double-fire update_life_bar.
+        try:
+            gui_hooks.reviewer_did_answer_card.remove(self.update_life_bar)
+        except (ValueError, AttributeError):
+            pass
         gui_hooks.reviewer_did_answer_card.append(self.update_life_bar)
 
     def reviewer_reset_life_bar_inject(self):
+        """Clear per-session HUD state when the battle/review session ends."""
         self.life_bar_injected = False
+        self._ownership_cache.clear()
+        self._last_state = None
 
-    def get_boost_values_string(self, pokemon: PokemonObject, display_neutral_boost: bool=False) -> str:
+    def get_boost_values_string(
+        self, pokemon: PokemonObject, display_neutral_boost: bool = False
+    ) -> str:
         """Generates a formatted string representing the stat boost multipliers of a Pokémon."""
         pokemon_dict = pokemon.to_engine_format()
         boosts = {
-            "atk": pokemon_dict.get('attack_boost', 0),
-            "def": pokemon_dict.get('defense_boost', 0),
-            "SpA": pokemon_dict.get('special_attack_boost', 0),
-            "SpD": pokemon_dict.get('special_defense_boost', 0),
-            "SPE": pokemon_dict.get('speed_boost', 0),
-            "ACC": pokemon_dict.get('accuracy_boost', 0),
-            "EVD": pokemon_dict.get('evasion_boost', 0),
+            "atk": pokemon_dict.get("attack_boost", 0),
+            "def": pokemon_dict.get("defense_boost", 0),
+            "SpA": pokemon_dict.get("special_attack_boost", 0),
+            "SpD": pokemon_dict.get("special_defense_boost", 0),
+            "SPE": pokemon_dict.get("speed_boost", 0),
+            "ACC": pokemon_dict.get("accuracy_boost", 0),
+            "EVD": pokemon_dict.get("evasion_boost", 0),
         }
 
         boost_to_mult = {
-            0: "x1", 1: "x1.5", 2: "x2", 3: "x2.5", 4: "x3", 5: "x3.5", 6: "x4",
-            -1: "x0.67", -2: "x0.5", -3: "x0.4", -4: "x0.33", -5: "x0.29", -6: "x0.25",
+            0: "x1",
+            1: "x1.5",
+            2: "x2",
+            3: "x2.5",
+            4: "x3",
+            5: "x3.5",
+            6: "x4",
+            -1: "x0.67",
+            -2: "x0.5",
+            -3: "x0.4",
+            -4: "x0.33",
+            -5: "x0.29",
+            -6: "x0.25",
         }
 
         boost_display = " "
@@ -81,52 +107,185 @@ class Reviewer_Manager:
         except Exception:
             pass
 
+    def _resolve_addon_package(self):
+        """Return the add-on package name for building /_addons/ media URLs."""
+        try:
+            addon_package = mw.addonManager.addonFromModule(__name__)
+        except Exception:
+            addon_package = None
+        if not addon_package:
+            # Fallback add-on folder names (AnkiWeb id / source checkout).
+            try:
+                folder = mw.addonManager.addonsFolder()
+                for name in ["1908235722", "Ankimon"]:
+                    if os.path.exists(os.path.join(folder, name)):
+                        addon_package = name
+                        break
+            except Exception:
+                pass
+        return addon_package or "1908235722"
+
     def update_life_bar(self, reviewer, card, ease):
+        # GUARD: only repaint on direct calls (refresh_hud / battle_loop pass
+        # card=0, ease=0). The reviewer_did_answer_card hook fires with a real
+        # Card object and a non-zero ease; those are handled by battle_loop's
+        # refresh_hud() call, so short-circuit here to avoid a redundant repaint.
+        if isinstance(ease, int) and ease != 0:
+            return  # Hook from reviewer_did_answer_card
+        if card is not None and not isinstance(card, int):
+            return  # Hook received a Card object
+
         if int(self.settings.get("gui.show_mainpkmn_in_reviewer")) == 3:
             reviewer.web.eval("if(window.__ankimonHud) window.__ankimonHud.clear();")
             return
 
-        # Check if the enemy pokemon is in the user's collection
-        is_pokemon_owned = False
-        try:
-            db = mw.ankimon_db
-            cursor = db.execute(
-                "SELECT 1 FROM captured_pokemon WHERE pokedex_id = ? LIMIT 1",
-                (self.enemy_pokemon.id,),
-            )
-            is_pokemon_owned = cursor.fetchone() is not None
-        except Exception:
-            pass
+        # 1. Ownership cache (avoid a DB query on every repaint of the same enemy).
+        is_pokemon_owned = self._ownership_cache.get(self.enemy_pokemon.id)
+        if is_pokemon_owned is None:
+            is_pokemon_owned = False
+            try:
+                db = services.db
+                cursor = db.execute(
+                    "SELECT 1 FROM captured_pokemon WHERE pokedex_id = ? LIMIT 1",
+                    (self.enemy_pokemon.id,),
+                )
+                is_pokemon_owned = cursor.fetchone() is not None
+                self._ownership_cache[self.enemy_pokemon.id] = is_pokemon_owned
+            except Exception:
+                pass
 
-        image_format = "gif" if self.settings.get('gui.reviewer_image_gif') else "png"
+        # Register keydown listener (8) to toggle HUD visibility. Called every
+        # time because Anki reloads the webview on card switches; the JS itself
+        # guards against duplicate listeners (window.ankimonKeyListener).
+        reviewer.web.eval("""
+            (function() {
+                if (window.ankimonKeyListener) return;
+                window.ankimonKeyListener = true;
+                let originalParent = null;
+                let hudHost = null;
+
+                document.addEventListener('keydown', function(event) {
+                    if (event.key === '8') {
+                        if (!hudHost) {
+                            hudHost = document.getElementById('ankimon-hud-host');
+                            if (hudHost) {
+                                originalParent = hudHost.parentNode;
+                            } else {
+                                console.error('Ankimon: ankimon-hud-host not found.');
+                                return;
+                            }
+                        }
+
+                        // First time: render if not yet rendered
+                        if (!window.__ankimonHudRendered && window.__ankimonHudData && window.__ankimonHud) {
+                            window.__ankimonHud.update(window.__ankimonHudData.html, window.__ankimonHudData.css);
+                            window.__ankimonHudRendered = true;
+                            originalParent = hudHost.parentNode;
+                            // Toggle visibility on first render
+                            window.__ankimonHudHidden = !window.__ankimonHudHidden;
+                            // If should be hidden, remove it from DOM
+                            if (window.__ankimonHudHidden && originalParent) {
+                                originalParent.removeChild(hudHost);
+                            }
+                        } else if (window.__ankimonHudRendered) {
+                            // Already rendered, toggle visibility
+                            window.__ankimonHudHidden = !window.__ankimonHudHidden;
+
+                            // If showing (unhiding), update with latest data
+                            if (!window.__ankimonHudHidden && window.__ankimonHudData && window.__ankimonHud) {
+                                window.__ankimonHud.update(window.__ankimonHudData.html, window.__ankimonHudData.css);
+                            }
+
+                            // Toggle DOM visibility
+                            if (hudHost.parentNode) {
+                                hudHost.parentNode.removeChild(hudHost);
+                            } else if (originalParent) {
+                                originalParent.appendChild(hudHost);
+                            }
+                        }
+                    }
+                });
+            })();
+        """)
+
+        # 2. State-based update check (avoid redundant eval() calls for HTML/CSS).
+        current_state = (
+            self.enemy_pokemon.id,
+            self.enemy_pokemon.hp,
+            self.enemy_pokemon.max_hp,
+            self.enemy_pokemon.battle_status,
+            self.main_pokemon.id,
+            self.main_pokemon.hp,
+            self.main_pokemon.max_hp,
+            self.main_pokemon.xp,
+            self.settings.get("gui.show_mainpkmn_in_reviewer"),
+            self.settings.get("gui.reviewer_image_gif"),
+            self.settings.get("misc.language"),
+        )
+        if self._last_state == current_state and card is not None:
+            return  # No changes, skip update
+        self._last_state = current_state
+
+        image_format = "gif" if self.settings.get("gui.reviewer_image_gif") else "png"
         mime_type = f"image/{image_format}"
 
-        pokemon_image_file = self.enemy_pokemon.get_sprite_path("front", image_format)
+        addon_package = self._resolve_addon_package()
 
-        main_pkmn_imagefile_path = None
-        side = "back" # Default side
-        if int(self.settings.get('gui.show_mainpkmn_in_reviewer')) > 0:
+        # 3. Serve sprites via the Anki media server (/_addons/...) instead of
+        # inlining base64 — a large repaint-cost saving on every HUD refresh.
+        def get_sprite_url(pkmn, side):
+            try:
+                abs_path = pkmn.get_sprite_path(side, image_format)
+                from ..resources import addon_dir
+
+                rel_path = os.path.relpath(abs_path, addon_dir).replace("\\", "/")
+                return f"/_addons/{addon_package}/{rel_path}"
+            except Exception:
+                return ""
+
+        enemy_sprite_url = get_sprite_url(self.enemy_pokemon, "front")
+
+        main_pkmn_sprite_url = None
+        side = "back"  # Default side
+        if int(self.settings.get("gui.show_mainpkmn_in_reviewer")) > 0:
             if image_format == "gif":
-                if self.settings.compute_special_variable('view_main_front') == -1:
+                if self.settings.compute_special_variable("view_main_front") == -1:
                     side = "front"
                 else:
                     side = "back"
-            else: # png
+            else:  # png
                 side = "back"
-            main_pkmn_imagefile_path = self.main_pokemon.get_sprite_path(side, image_format)
+            main_pkmn_sprite_url = get_sprite_url(self.main_pokemon, side)
 
-        if int(self.settings.get('gui.show_mainpkmn_in_reviewer')) > 0:
-            pokemon_hp_percent = int((self.enemy_pokemon.hp / self.enemy_pokemon.max_hp) * 50) if self.enemy_pokemon.max_hp > 0 else 0
-            mainpkmn_hp_percent = int((self.main_pokemon.hp / self.main_pokemon.max_hp) * 50) if self.main_pokemon.max_hp > 0 else 0
-            image_base64_mainpkmn = get_image_as_base64(main_pkmn_imagefile_path)
+        if int(self.settings.get("gui.show_mainpkmn_in_reviewer")) > 0:
+            pokemon_hp_percent = (
+                int((self.enemy_pokemon.hp / self.enemy_pokemon.max_hp) * 50)
+                if self.enemy_pokemon.max_hp > 0
+                else 0
+            )
+            mainpkmn_hp_percent = (
+                int((self.main_pokemon.hp / self.main_pokemon.max_hp) * 50)
+                if self.main_pokemon.max_hp > 0
+                else 0
+            )
         else:
-            pokemon_hp_percent = int((self.enemy_pokemon.hp / self.enemy_pokemon.max_hp) * 100) if self.enemy_pokemon.max_hp > 0 else 0
-            mainpkmn_hp_percent = 0 # Not used in this mode
+            pokemon_hp_percent = (
+                int((self.enemy_pokemon.hp / self.enemy_pokemon.max_hp) * 100)
+                if self.enemy_pokemon.max_hp > 0
+                else 0
+            )
+            mainpkmn_hp_percent = 0  # Not used in this mode
 
-        enemy_hp_true_percent = (self.enemy_pokemon.hp / self.enemy_pokemon.max_hp) * 100 if self.enemy_pokemon.max_hp > 0 else 0
-        main_hp_true_percent = (self.main_pokemon.hp / self.main_pokemon.max_hp) * 100 if self.main_pokemon.max_hp > 0 else 0
-
-        image_base64 = get_image_as_base64(pokemon_image_file)
+        enemy_hp_true_percent = (
+            (self.enemy_pokemon.hp / self.enemy_pokemon.max_hp) * 100
+            if self.enemy_pokemon.max_hp > 0
+            else 0
+        )
+        main_hp_true_percent = (
+            (self.main_pokemon.hp / self.main_pokemon.max_hp) * 100
+            if self.main_pokemon.max_hp > 0
+            else 0
+        )
 
         # Build hud_html
         hud_html = '<div id="ankimon-hud">'
@@ -136,38 +295,39 @@ class Reviewer_Manager:
             hud_html += '<div id="xp-bar" class="Ankimon"></div>'
             hud_html += '<div id="xp_text" class="Ankimon">XP</div>'
 
-        enemy_lang_name = (get_pokemon_diff_lang_name(int(self.enemy_pokemon.id), int(self.settings.get('misc.language'))).capitalize())
+        # display_name handles translations, regional forms, megas and gmax.
+        enemy_lang_name = self.enemy_pokemon.display_name
         if self.enemy_pokemon.shiny is True:
             enemy_lang_name += " ⭐ "
-        name_display_text = f"{enemy_lang_name} LvL: {self.enemy_pokemon.level}"
-        name_display_text += self.get_boost_values_string(self.enemy_pokemon, display_neutral_boost=False)
+        # Format: [#ID] Name (Gen X) LvL: Y
+        pokedex_id = getattr(self.enemy_pokemon, "pokedex_id", self.enemy_pokemon.id)
+        generation = getattr(self.enemy_pokemon, "generation", 1)
+        name_display_text = f"[#{pokedex_id}] {enemy_lang_name} (Gen {generation}) LvL: {self.enemy_pokemon.level}"
+        name_display_text += self.get_boost_values_string(
+            self.enemy_pokemon, display_neutral_boost=False
+        )
         hud_html += f'<div id="name-display" class="Ankimon">{name_display_text}</div>'
 
-        try:
-            addon_package = mw.addonManager.addonFromModule(__name__)
-        except Exception:
-            addon_package = None
-
-        if not addon_package:
-            # Try fallback addon folder names
-            for name in ["1908235722", "Ankimon"]:
-                if os.path.exists(os.path.join(mw.addonManager.addonsFolder(), name)):
-                    addon_package = name
-                    break
-
         if self.enemy_pokemon.hp > 0:
-            hud_html += create_status_html(f"{self.enemy_pokemon.battle_status}", self.settings, is_pokemon_owned, addon_package)
+            hud_html += create_status_html(
+                f"{self.enemy_pokemon.battle_status}",
+                self.settings,
+                is_pokemon_owned,
+                addon_package,
+            )
         else:
-            hud_html += create_status_html("fainted", self.settings, is_pokemon_owned, addon_package)
+            hud_html += create_status_html(
+                "fainted", self.settings, is_pokemon_owned, addon_package
+            )
 
         hud_html += f'<div id="hp-display" class="Ankimon">HP: {int(self.enemy_pokemon.hp)}/{int(self.enemy_pokemon.max_hp)}</div>'
 
+        enemy_poke_animation_style = (
+            f"animation: ankimon-shake-normal {self.seconds}s ease;"
+        )
+        hud_html += f'<div id="PokeImage" class="Ankimon"><img src="{enemy_sprite_url}" alt="PokeImage" style="{enemy_poke_animation_style}"></div>'
 
-        enemy_poke_animation_style = f"animation: ankimon-shake-normal {self.seconds}s ease;"
-        hud_html += f'<div id="PokeImage" class="Ankimon"><img src="data:{mime_type};base64,{image_base64}" alt="PokeImage" style="{enemy_poke_animation_style}"></div>'
-
-        if int(self.settings.get('gui.show_mainpkmn_in_reviewer')) > 0:
-
+        if int(self.settings.get("gui.show_mainpkmn_in_reviewer")) > 0:
             my_poke_html_attributes = ""
             # SPECIAL CASE: For front-facing GIFs, the animation conflicts with the transform.
             # We will sacrifice the animation in this case to force the flip using a static class.
@@ -175,43 +335,60 @@ class Reviewer_Manager:
                 my_poke_html_attributes = 'class="force-flip"'
             else:
                 # For all other cases, the flipped animation works correctly.
-                animation_style = f"animation: ankimon-shake-flipped {self.myseconds}s ease;"
+                animation_style = (
+                    f"animation: ankimon-shake-flipped {self.myseconds}s ease;"
+                )
                 my_poke_html_attributes = f'style="{animation_style}"'
 
-            hud_html += (f'<div id="MyPokeImage" class="Ankimon">'
-                         f'<img src="data:{mime_type};base64,{image_base64_mainpkmn}" alt="MyPokeImage" {my_poke_html_attributes}>'
-                         f'</div>')
+            hud_html += (
+                f'<div id="MyPokeImage" class="Ankimon">'
+                f'<img src="{main_pkmn_sprite_url}" alt="MyPokeImage" {my_poke_html_attributes}>'
+                f"</div>"
+            )
 
-            main_lang_name = (get_pokemon_diff_lang_name(int(self.main_pokemon.id), int(self.settings.get('misc.language'))).capitalize())
-            if str(main_lang_name) == 'No translation in this language':
-                main_lang_name = 'RESTART ANKI NOW' 
+            main_lang_name = self.main_pokemon.display_name
             if self.main_pokemon.shiny:
                 main_lang_name += " ⭐ "
-            main_name_display_text = f"{main_lang_name} LvL: {self.main_pokemon.level}"
-            main_name_display_text += self.get_boost_values_string(self.main_pokemon, display_neutral_boost=False)
+            # Format: [#ID] Name (Gen X) LvL: Y
+            main_pokedex_id = getattr(
+                self.main_pokemon, "pokedex_id", self.main_pokemon.id
+            )
+            main_generation = getattr(self.main_pokemon, "generation", 1)
+            main_name_display_text = f"[#{main_pokedex_id}] {main_lang_name} (Gen {main_generation}) LvL: {self.main_pokemon.level}"
+            main_name_display_text += self.get_boost_values_string(
+                self.main_pokemon, display_neutral_boost=False
+            )
             hud_html += f'<div id="myname-display" class="Ankimon">{main_name_display_text}</div>'
             hud_html += f'<div id="myhp-display" class="Ankimon">HP: {int(self.main_pokemon.hp)}/{int(self.main_pokemon.max_hp)}</div>'
             if self.settings.get("gui.hp_bar_config") is True:
                 hud_html += '<div id="mylife-bar" class="Ankimon"></div>'
 
-        hud_html += '</div>'
+        hud_html += "</div>"
 
         # Build hud_css
         hud_css = create_css_for_reviewer(
-            int(self.settings.get('gui.show_mainpkmn_in_reviewer')),
+            int(self.settings.get("gui.show_mainpkmn_in_reviewer")),
             pokemon_hp_percent,
             self.settings.get("gui.review_hp_bar_thickness") * 4,
-            int(self.settings.compute_special_variable('xp_bar_spacer')),
-            -1 if int(self.settings.get('gui.show_mainpkmn_in_reviewer')) == 1 else self.settings.compute_special_variable('view_main_front'),
+            int(self.settings.compute_special_variable("xp_bar_spacer")),
+            -1
+            if int(self.settings.get("gui.show_mainpkmn_in_reviewer")) == 1
+            else self.settings.compute_special_variable("view_main_front"),
             mainpkmn_hp_percent,
-            int(self.settings.compute_special_variable('hp_only_spacer')),
-            int(self.settings.compute_special_variable('wild_hp_spacer')),
+            int(self.settings.compute_special_variable("hp_only_spacer")),
+            int(self.settings.compute_special_variable("wild_hp_spacer")),
             self.settings.get("gui.xp_bar_config"),
             self.main_pokemon,
-            int(find_experience_for_level(self.main_pokemon.growth_rate, self.main_pokemon.level, self.settings.get("misc.remove_level_cap"))),
-            self.settings.compute_special_variable('xp_bar_location'),
+            int(
+                find_experience_for_level(
+                    self.main_pokemon.growth_rate,
+                    self.main_pokemon.level,
+                    self.settings.get("misc.remove_level_cap"),
+                )
+            ),
+            self.settings.compute_special_variable("xp_bar_location"),
             enemy_hp_true_percent,
-            main_hp_true_percent
+            main_hp_true_percent,
         )
         hud_css += """
         #ankimon-hud #name-display, #ankimon-hud #myname-display, #ankimon-hud #hp-display, #ankimon-hud #myhp-display, #ankimon-hud #xp_text {
@@ -258,13 +435,13 @@ class Reviewer_Manager:
             if(window.__ankimonHud){{
                 // Always update the stored data, regardless of visibility
                 window.__ankimonHudData = {{html: h, css: c}};
-                
+
                 // Only initialize on first call - preserve user's toggle state on subsequent updates
                 if(window.__ankimonHudHidden === undefined){{
                     window.__ankimonHudHidden = hiddenOnStartup;
                     window.__ankimonHudRendered = false;
                 }}
-                
+
                 // If HUD should be visible on startup, render it now
                 if(!hiddenOnStartup && !window.__ankimonHudRendered){{
                     window.__ankimonHud.update(h,c);
@@ -279,55 +456,3 @@ class Reviewer_Manager:
         }})({json.dumps(hud_html)}, {json.dumps(hud_css)}, {str(hud_hidden_on_startup).lower()});
         """
         reviewer.web.eval(js_code)
-
-        # Add keydown listener to toggle HUD visibility
-        reviewer.web.eval("""
-            (function() {
-                if (window.ankimonKeyListener) return;
-                window.ankimonKeyListener = true;
-                let originalParent = null;
-                let hudHost = null;
-
-                document.addEventListener('keydown', function(event) {
-                    if (event.key === '8') {
-                        if (!hudHost) {
-                            hudHost = document.getElementById('ankimon-hud-host');
-                            if (hudHost) {
-                                originalParent = hudHost.parentNode;
-                            } else {
-                                console.error('Ankimon: ankimon-hud-host not found.');
-                                return;
-                            }
-                        }
-
-                        // First time: render if not yet rendered
-                        if (!window.__ankimonHudRendered && window.__ankimonHudData && window.__ankimonHud) {
-                            window.__ankimonHud.update(window.__ankimonHudData.html, window.__ankimonHudData.css);
-                            window.__ankimonHudRendered = true;
-                            originalParent = hudHost.parentNode;
-                            // Toggle visibility on first render
-                            window.__ankimonHudHidden = !window.__ankimonHudHidden;
-                            // If should be hidden, remove it from DOM
-                            if (window.__ankimonHudHidden && originalParent) {
-                                originalParent.removeChild(hudHost);
-                            }
-                        } else if (window.__ankimonHudRendered) {
-                            // Already rendered, toggle visibility
-                            window.__ankimonHudHidden = !window.__ankimonHudHidden;
-                            
-                            // If showing (unhiding), update with latest data
-                            if (!window.__ankimonHudHidden && window.__ankimonHudData && window.__ankimonHud) {
-                                window.__ankimonHud.update(window.__ankimonHudData.html, window.__ankimonHudData.css);
-                            }
-                            
-                            // Toggle DOM visibility
-                            if (hudHost.parentNode) {
-                                hudHost.parentNode.removeChild(hudHost);
-                            } else if (originalParent) {
-                                originalParent.appendChild(hudHost);
-                            }
-                        }
-                    }
-                });
-            })();
-        """)

--- a/src/Ankimon/reviewer_ui.py
+++ b/src/Ankimon/reviewer_ui.py
@@ -2,6 +2,7 @@ from anki.hooks import wrap
 from aqt.reviewer import Reviewer
 from aqt.utils import downArrow, tooltip, tr
 
+from .services import services
 from .singletons import (
     enemy_pokemon,
     main_pokemon,
@@ -20,7 +21,126 @@ from .functions.encounter_functions import (
 )
 from .texts import _bottomHTML_template, button_style
 
+try:
+    from .utils import is_dev_mode
+except ImportError:  # dev helper not landed yet (thread-reload-and-misc-utils unit)
+
+    def is_dev_mode():
+        return False
+
+
 _collected_pokemon_ids = set()
+
+# === TEAM CYCLING STATE ===
+_team_cycle_index = 0
+_team_cycle_pokemon_ids = []  # cache of the first N team member ids
+
+
+def _team_cycle_count():
+    """Rotation size from settings (default 3), via the service seam."""
+    try:
+        return int(services.settings.get("controls.team_cycle_count", 3))
+    except Exception:
+        return 3
+
+
+def get_team_pokemon_list():
+    """Load the first N team member individual_ids from the DB (seam: services.db)."""
+    global _team_cycle_pokemon_ids
+    try:
+        db = services.db
+        team_data = db.get_team()  # list of dicts with 'individual_id'
+        cycle_count = _team_cycle_count()
+        _team_cycle_pokemon_ids = [
+            entry.get("individual_id")
+            for entry in team_data[:cycle_count]
+            if entry.get("individual_id")
+        ]
+        return _team_cycle_pokemon_ids
+    except Exception as e:
+        print(f"Error loading team pokemon from database: {e}")
+        return []
+
+
+def get_pokemon_from_collection(individual_id):
+    """Load a full pokemon record from the DB by individual_id (seam: services.db)."""
+    try:
+        db = services.db
+        return db.get_pokemon(individual_id)
+    except Exception as e:
+        print(f"Error loading pokemon {individual_id} from database: {e}")
+        return None
+
+
+def cycle_team_pokemon():
+    """Cycle the active (main) pokemon to the next team slot and repaint the HUD."""
+    global _team_cycle_index, _team_cycle_pokemon_ids
+
+    try:
+        from .functions.update_main_pokemon import save_main_pokemon
+
+        cycle_count = _team_cycle_count()
+        if cycle_count <= 1:
+            tooltip("Team cycling is disabled (set rotation limit > 1 in Team Select)")
+            return
+
+        team_ids = get_team_pokemon_list()
+        if not team_ids or len(team_ids) < 2:
+            tooltip("Not enough team members to cycle (need at least 2)")
+            return
+
+        # Bounds check for safety
+        if _team_cycle_index >= len(team_ids):
+            _team_cycle_index = 0
+
+        _team_cycle_index = (_team_cycle_index + 1) % len(team_ids)
+        next_id = team_ids[_team_cycle_index]
+
+        pokemon_data = get_pokemon_from_collection(next_id)
+        if not pokemon_data or not pokemon_data.get("id"):
+            tooltip("Invalid pokemon data")
+            return
+
+        try:
+            from .functions.pokedex_functions import (
+                search_pokedex_by_id,
+                search_pokedex,
+            )
+
+            pokemon_name = pokemon_data.get("name")
+            if not pokemon_name:
+                pokemon_name = search_pokedex_by_id(pokemon_data.get("id", 1))
+                pokemon_data["name"] = pokemon_name
+
+            pokemon_data["base_stats"] = search_pokedex(pokemon_name, "baseStats")
+
+            main_pokemon.update_stats(**pokemon_data)
+            main_pokemon.max_hp = main_pokemon.calculate_max_hp()
+            main_pokemon.hp = main_pokemon.max_hp
+            main_pokemon.reset_bonuses()
+
+            save_main_pokemon(main_pokemon)
+        except Exception as e:
+            print(f"Error updating pokemon: {e}")
+            tooltip(f"Error switching pokemon: {e}")
+            return
+
+        # Repaint immediately through the HUD's single repaint entry point.
+        try:
+            reviewer_obj.refresh_hud()
+        except Exception as e:
+            print(f"Error updating HUD: {e}")
+
+        pkmn_name = pokemon_data.get("nickname") or pokemon_data.get("name", "Unknown")
+        pkmn_level = pokemon_data.get("level", "?")
+        tooltip(f"Switched to {pkmn_name}! LVL: {pkmn_level}")
+
+    except Exception as e:
+        print(f"Unexpected error: {e}")
+        import traceback
+
+        traceback.print_exc()
+        tooltip(f"Error: {str(e)}")
 
 
 def set_collected_ids(ids):
@@ -65,32 +185,104 @@ def defeat_shortcut_function():
         tooltip("Wild pokemon has to be fainted to defeat it!")
 
 
+def team_cycle_shortcut_function():
+    """Callback for the team-cycle hotkey."""
+    cycle_team_pokemon()
+
+
+def test_encounter_shortcut_function():
+    """Dev-only hotkey (0): trigger a new pokemon encounter immediately."""
+    if is_dev_mode():
+        new_pokemon(
+            enemy_pokemon,
+            test_window,
+            ankimon_tracker_obj,
+            reviewer_obj,
+            update_hud=True,
+        )
+        tooltip("New encounter triggered (Test Hotkey 0)")
+
+
+# Module-level key storage so the wrapped Reviewer methods read the current keys
+# at call time; re-running setup_reviewer_ui() only refreshes these.
+_current_keys = {"catch": "6", "defeat": "5", "team_cycle": "9"}
+_original_shortcutkeys_wrapped = False
+_ui_hooks_installed = False
+
+
+def _resolve_team_cycle_key(team_cycle_shortcut):
+    """4th-arg default: read controls.team_cycle_key via services.settings.
+
+    Lets base's unmodified 3-arg setup_reviewer_ui() call keep working (the key
+    comes from settings) while the settings-aware 4-arg call passes it explicitly.
+    """
+    if team_cycle_shortcut is not None:
+        return str(team_cycle_shortcut).lower()
+    try:
+        return str(services.settings.get("controls.team_cycle_key", "9")).lower()
+    except Exception:
+        return "9"
+
+
 def setup_reviewer_ui(
-    catch_shortcut: str, defeat_shortcut: str, reviewer_buttons: bool
+    catch_shortcut: str,
+    defeat_shortcut: str,
+    reviewer_buttons: bool,
+    team_cycle_shortcut: str = None,
 ):
-    catch_key = str(catch_shortcut).lower()
-    defeat_key = str(defeat_shortcut).lower()
+    """Install reviewer hotkeys / bottom-bar buttons.
 
-    def _shortcutKeys_wrap(self, _old):
-        original = _old(self)
-        original.append((catch_key, lambda: catch_shortcut_function()))
-        original.append((defeat_key, lambda: defeat_shortcut_function()))
-        return original
+    Idempotent: the Reviewer method wrapping happens once and stores the pristine
+    methods as ``Reviewer._ankimon_orig_*`` (the reload-teardown contract shared
+    with the reloader). Repeat calls (e.g. saving settings) only refresh
+    ``_current_keys`` — the wrappers read those at call time, so there is no
+    re-wrapping and no double-wrap of ``Reviewer._shortcutKeys``.
+    """
+    global _current_keys, _original_shortcutkeys_wrapped, _ui_hooks_installed
 
-    Reviewer._shortcutKeys = wrap(Reviewer._shortcutKeys, _shortcutKeys_wrap, "around")
+    _current_keys["catch"] = str(catch_shortcut).lower()
+    _current_keys["defeat"] = str(defeat_shortcut).lower()
+    _current_keys["team_cycle"] = _resolve_team_cycle_key(team_cycle_shortcut)
 
-    if reviewer_buttons is True:
-        Review_linkHandler_Original = Reviewer._linkHandler
+    if not _original_shortcutkeys_wrapped:
+        if not hasattr(Reviewer, "_ankimon_orig_shortcutKeys"):
+            Reviewer._ankimon_orig_shortcutKeys = Reviewer._shortcutKeys
 
-        def linkHandler_wrap(reviewer, url):
+        def _shortcutKeys_wrap(self, _old):
+            original = _old(self)
+            # These lambdas read _current_keys at CALL time, not definition time.
+            original.append((_current_keys["catch"], lambda: catch_shortcut_function()))
+            original.append(
+                (_current_keys["defeat"], lambda: defeat_shortcut_function())
+            )
+            original.append(
+                (_current_keys["team_cycle"], lambda: team_cycle_shortcut_function())
+            )
+            if is_dev_mode():
+                original.append(("0", lambda: test_encounter_shortcut_function()))
+            return original
+
+        Reviewer._shortcutKeys = wrap(
+            Reviewer._shortcutKeys, _shortcutKeys_wrap, "around"
+        )
+        _original_shortcutkeys_wrapped = True
+
+    if reviewer_buttons is True and not _ui_hooks_installed:
+
+        def _linkHandler_wrap(self, url, _old):
             if url == "catch":
                 catch_shortcut_function()
+                return True
             elif url == "defeat":
                 defeat_shortcut_function()
+                return True
+            elif url == "team_cycle":
+                team_cycle_shortcut_function()
+                return True
             else:
-                Review_linkHandler_Original(reviewer, url)
+                return _old(self, url)
 
-        def _bottomHTML(self) -> str:
+        def _bottomHTML_wrap(self, _old):
             return _bottomHTML_template % dict(
                 edit=tr.studying_edit(),
                 editkey=tr.actions_shortcut_key(val="E"),
@@ -98,9 +290,19 @@ def setup_reviewer_ui(
                 morekey=tr.actions_shortcut_key(val="M"),
                 downArrow=downArrow(),
                 time=self.card.time_taken() // 1000,
-                CatchKey=tr.actions_shortcut_key(val=f"{catch_key}"),
-                DefeatKey=tr.actions_shortcut_key(val=f"{defeat_key}"),
+                CatchKey=tr.actions_shortcut_key(val=f"{_current_keys['catch']}"),
+                DefeatKey=tr.actions_shortcut_key(val=f"{_current_keys['defeat']}"),
+                TeamCycleKey=tr.actions_shortcut_key(
+                    val=f"{_current_keys['team_cycle']}"
+                ),
             )
 
-        Reviewer._bottomHTML = _bottomHTML
-        Reviewer._linkHandler = linkHandler_wrap
+        # Store the pristine methods once (reload-teardown contract).
+        if not hasattr(Reviewer, "_ankimon_orig_linkHandler"):
+            Reviewer._ankimon_orig_linkHandler = Reviewer._linkHandler
+        if not hasattr(Reviewer, "_ankimon_orig_bottomHTML"):
+            Reviewer._ankimon_orig_bottomHTML = Reviewer._bottomHTML
+
+        Reviewer._linkHandler = wrap(Reviewer._linkHandler, _linkHandler_wrap, "around")
+        Reviewer._bottomHTML = wrap(Reviewer._bottomHTML, _bottomHTML_wrap, "around")
+        _ui_hooks_installed = True

--- a/src/Ankimon/reviewer_ui.py
+++ b/src/Ankimon/reviewer_ui.py
@@ -89,9 +89,16 @@ def cycle_team_pokemon():
             tooltip("Not enough team members to cycle (need at least 2)")
             return
 
-        # Bounds check for safety
-        if _team_cycle_index >= len(team_ids):
-            _team_cycle_index = 0
+        # Sync the cycle index to the active pokemon's slot so a swap made
+        # outside this hotkey (Team Select / PC) still advances to the member
+        # *after* the current one. Fall back to the running index (with a bounds
+        # check) when the active pokemon is not among the cycled team slots.
+        active_id = getattr(main_pokemon, "individual_id", None)
+        try:
+            _team_cycle_index = team_ids.index(active_id)
+        except ValueError:
+            if _team_cycle_index >= len(team_ids):
+                _team_cycle_index = 0
 
         _team_cycle_index = (_team_cycle_index + 1) % len(team_ids)
         next_id = team_ids[_team_cycle_index]
@@ -112,7 +119,15 @@ def cycle_team_pokemon():
                 pokemon_name = search_pokedex_by_id(pokemon_data.get("id", 1))
                 pokemon_data["name"] = pokemon_name
 
-            pokemon_data["base_stats"] = search_pokedex(pokemon_name, "baseStats")
+            # search_pokedex returns [] (not None) when the name is unknown.
+            # base_stats must be a dict with an "hp" key, or update_stats ->
+            # calculate_max_hp would raise on base_stats["hp"] AFTER partially
+            # mutating main_pokemon. Guard before touching main_pokemon.
+            base_stats = search_pokedex(pokemon_name, "baseStats")
+            if not isinstance(base_stats, dict) or "hp" not in base_stats:
+                tooltip(f"Error: base stats not found for {pokemon_name}")
+                return
+            pokemon_data["base_stats"] = base_stats
 
             main_pokemon.update_stats(**pokemon_data)
             main_pokemon.max_hp = main_pokemon.calculate_max_hp()
@@ -245,7 +260,15 @@ def setup_reviewer_ui(
     _current_keys["team_cycle"] = _resolve_team_cycle_key(team_cycle_shortcut)
 
     if not _original_shortcutkeys_wrapped:
-        if not hasattr(Reviewer, "_ankimon_orig_shortcutKeys"):
+        # Reload-teardown contract: capture the pristine method once, and always
+        # wrap the pristine version — never an already-wrapped copy. A module
+        # re-exec (add-on reload) resets _original_shortcutkeys_wrapped while the
+        # Reviewer class persists with the previous boot's wrapper installed, so
+        # restore the pristine first; otherwise wrap() below would stack a second
+        # layer and every Ankimon shortcut would fire twice.
+        if hasattr(Reviewer, "_ankimon_orig_shortcutKeys"):
+            Reviewer._shortcutKeys = Reviewer._ankimon_orig_shortcutKeys
+        else:
             Reviewer._ankimon_orig_shortcutKeys = Reviewer._shortcutKeys
 
         def _shortcutKeys_wrap(self, _old):
@@ -297,10 +320,17 @@ def setup_reviewer_ui(
                 ),
             )
 
-        # Store the pristine methods once (reload-teardown contract).
-        if not hasattr(Reviewer, "_ankimon_orig_linkHandler"):
+        # Reload-teardown contract (same as _shortcutKeys above): capture the
+        # pristine methods once and always wrap the pristine version. On a module
+        # re-exec the Reviewer class keeps the previous wrappers, so restore the
+        # originals before re-wrapping to avoid stacking a second layer.
+        if hasattr(Reviewer, "_ankimon_orig_linkHandler"):
+            Reviewer._linkHandler = Reviewer._ankimon_orig_linkHandler
+        else:
             Reviewer._ankimon_orig_linkHandler = Reviewer._linkHandler
-        if not hasattr(Reviewer, "_ankimon_orig_bottomHTML"):
+        if hasattr(Reviewer, "_ankimon_orig_bottomHTML"):
+            Reviewer._bottomHTML = Reviewer._ankimon_orig_bottomHTML
+        else:
             Reviewer._ankimon_orig_bottomHTML = Reviewer._bottomHTML
 
         Reviewer._linkHandler = wrap(Reviewer._linkHandler, _linkHandler_wrap, "around")

--- a/tests/test_reviewer_ownership_cache.py
+++ b/tests/test_reviewer_ownership_cache.py
@@ -1,0 +1,534 @@
+"""Parity oracle for F34 — reviewer HUD ownership cache + team-cycle hotkeys.
+
+Ported from BRRRR_Experimental's ``tests/test_reviewer_ownership_cache.py`` and
+re-fitted to main's service seam:
+
+* HUD ownership DB reads go through ``services.db`` (exp read ``mw.ankimon_db``).
+* Team-cycle DB/settings reads go through ``services.db`` / ``services.settings``.
+* The HUD repaint entry point is ``reviewer_obj.refresh_hud()`` (main/F22), so the
+  ``new_pokemon(..., update_hud=True)`` contract is asserted against ``refresh_hud``
+  rather than exp's direct ``update_life_bar(reviewer, 0, 0)`` call.
+
+The exp oracle also exercised cache-invalidation hooks that live in
+``pyobj/database_manager.py`` (``_clear_reviewer_ownership_cache`` /
+``_all_pokemon_ids_cache`` / ``mark_as_caught``). Those hooks are not present on
+main and ``database_manager.py`` is outside F34's manifest (shared DB hotspot),
+so they are deferred to whichever unit owns that file — see the PR's Deferred
+section. The primary invalidation path (a fresh encounter clears the cache) is
+provided by ``new_pokemon`` on main and is covered here.
+"""
+
+import sys
+import types
+import importlib.util
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+_src = Path(__file__).parent.parent / "src"
+_orig_modules = {}
+
+
+# --------------------------------------------------------------------------- #
+# Test doubles
+# --------------------------------------------------------------------------- #
+class FakeCursor:
+    def __init__(self, found):
+        self._found = found
+
+    def fetchone(self):
+        return (1,) if self._found else None
+
+
+class FakeDB:
+    """Minimal stand-in for AnkimonDB exposing what the HUD/team-cycle touch."""
+
+    def __init__(self, owned_ids=(), team=None, pokemon=None):
+        self.owned = set(owned_ids)
+        self._team = team or []
+        self._pokemon = pokemon or {}
+        self.query_count = 0
+        self.get_team_calls = 0
+        self.get_pokemon_args = []
+
+    def execute(self, sql, params=()):
+        self.query_count += 1
+        pid = params[0] if params else None
+        return FakeCursor(pid in self.owned)
+
+    def get_team(self):
+        self.get_team_calls += 1
+        return self._team
+
+    def get_pokemon(self, individual_id):
+        self.get_pokemon_args.append(individual_id)
+        return self._pokemon
+
+
+class FakeSettings:
+    def __init__(self, overrides=None):
+        self.values = {
+            "gui.show_mainpkmn_in_reviewer": 0,
+            "gui.reviewer_image_gif": False,
+            "gui.hp_bar_config": False,
+            "gui.xp_bar_config": False,
+            "misc.language": 9,
+            "gui.review_hp_bar_thickness": 1,
+            "gui.hud_hidden_on_startup": False,
+            "misc.remove_level_cap": False,
+            "controls.team_cycle_key": "9",
+            "controls.team_cycle_count": 3,
+        }
+        if overrides:
+            self.values.update(overrides)
+
+    def get(self, key, default=None):
+        return self.values.get(key, default)
+
+    def compute_special_variable(self, name):
+        return 0
+
+
+class FakePokemon:
+    def __init__(self, pid=25):
+        self.id = pid
+        self.hp = 10
+        self.max_hp = 20
+        self.battle_status = ""
+        self.shiny = False
+        self.level = 5
+        self.xp = 0
+        self.display_name = "Pikachu"
+        self.pokedex_id = pid
+        self.generation = 1
+        self.growth_rate = "medium"
+
+    def get_sprite_path(self, side, image_format):
+        return "/tmp/sprite." + image_format
+
+    def to_engine_format(self):
+        return {}
+
+
+# --------------------------------------------------------------------------- #
+# Module (un)loading — snapshot/restore so this file cannot leak mocks
+# --------------------------------------------------------------------------- #
+def setup_module():
+    global _orig_modules
+    _orig_modules = sys.modules.copy()
+
+
+def teardown_module():
+    for k in [k for k in sys.modules if k not in _orig_modules]:
+        del sys.modules[k]
+    sys.modules.update(_orig_modules)
+
+
+def _install_common_mocks(fake_services):
+    for name in [
+        "aqt",
+        "aqt.qt",
+        "aqt.utils",
+        "aqt.reviewer",
+        "aqt.gui_hooks",
+        "anki",
+        "anki.hooks",
+    ]:
+        sys.modules[name] = MagicMock()
+
+    services_mod = types.ModuleType("Ankimon.services")
+    services_mod.services = fake_services
+    sys.modules["Ankimon.services"] = services_mod
+
+    events_mod = types.ModuleType("Ankimon.events")
+    events_mod.events = MagicMock()
+    sys.modules["Ankimon.events"] = events_mod
+
+
+def _load_module(mod_name, rel_path):
+    spec = importlib.util.spec_from_file_location(mod_name, _src / rel_path)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[mod_name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _load_reviewer_obj(fake_services):
+    _install_common_mocks(fake_services)
+    for sub in [
+        "Ankimon.pyobj.pokemon_obj",
+        "Ankimon.functions.pokemon_functions",
+        "Ankimon.functions.create_css_for_reviewer",
+        "Ankimon.functions.create_gui_functions",
+        "Ankimon.resources",
+    ]:
+        sys.modules[sub] = MagicMock()
+
+    mod = _load_module("Ankimon.pyobj.reviewer_obj", "Ankimon/pyobj/reviewer_obj.py")
+    # Render helpers are imported from now-mocked modules; make them return
+    # concrete strings/ints so update_life_bar runs end to end.
+    mod.create_status_html = lambda *a, **k: ""
+    mod.create_css_for_reviewer = lambda *a, **k: ""
+    mod.find_experience_for_level = lambda *a, **k: 100
+    return mod
+
+
+def _new_manager(fake_services, enemy_id=25):
+    mod = _load_reviewer_obj(fake_services)
+    mgr = mod.Reviewer_Manager(
+        FakeSettings(), FakePokemon(1), FakePokemon(enemy_id), MagicMock()
+    )
+    return mod, mgr
+
+
+# --------------------------------------------------------------------------- #
+# reviewer_obj: ownership cache semantics
+# --------------------------------------------------------------------------- #
+def test_ownership_cache_starts_empty():
+    fake_services = types.SimpleNamespace(db=FakeDB(), settings=None, reviewer=None)
+    _, mgr = _new_manager(fake_services)
+    assert mgr._ownership_cache == {}
+    assert mgr._last_state is None
+
+
+def test_reset_clears_ownership_cache_and_last_state():
+    fake_services = types.SimpleNamespace(db=FakeDB(), settings=None, reviewer=None)
+    _, mgr = _new_manager(fake_services)
+    mgr._ownership_cache[25] = True
+    mgr._last_state = ("stale",)
+    mgr.reviewer_reset_life_bar_inject()
+    assert mgr._ownership_cache == {}
+    assert mgr._last_state is None
+
+
+def test_update_life_bar_populates_and_reuses_ownership_cache():
+    db = FakeDB(owned_ids={25})
+    fake_services = types.SimpleNamespace(db=db, settings=None, reviewer=None)
+    _, mgr = _new_manager(fake_services, enemy_id=25)
+    reviewer = MagicMock()
+
+    mgr.update_life_bar(reviewer, 0, 0)
+    assert mgr._ownership_cache == {25: True}
+    assert db.query_count == 1
+
+    # Second repaint of the same enemy uses the cache — no new DB query.
+    mgr.update_life_bar(reviewer, 0, 0)
+    assert db.query_count == 1
+
+
+def test_reset_forces_a_fresh_ownership_query():
+    db = FakeDB(owned_ids={25})
+    fake_services = types.SimpleNamespace(db=db, settings=None, reviewer=None)
+    _, mgr = _new_manager(fake_services, enemy_id=25)
+    reviewer = MagicMock()
+
+    mgr.update_life_bar(reviewer, 0, 0)
+    assert db.query_count == 1
+    mgr.reviewer_reset_life_bar_inject()
+    mgr.update_life_bar(reviewer, 0, 0)
+    assert db.query_count == 2
+
+
+def test_ownership_read_goes_through_services_db_not_mw():
+    # A fresh manager whose services.db is a distinct object; the query must land
+    # on services.db (the seam), proving the read was re-fit off mw.ankimon_db.
+    db = FakeDB(owned_ids=set())
+    fake_services = types.SimpleNamespace(db=db, settings=None, reviewer=None)
+    _, mgr = _new_manager(fake_services, enemy_id=99)
+    mgr.update_life_bar(MagicMock(), 0, 0)
+    assert db.query_count == 1
+    assert mgr._ownership_cache == {99: False}
+
+
+def test_ease_guard_blocks_answer_hook_calls():
+    db = FakeDB(owned_ids={25})
+    fake_services = types.SimpleNamespace(db=db, settings=None, reviewer=None)
+    _, mgr = _new_manager(fake_services, enemy_id=25)
+    reviewer = MagicMock()
+
+    # reviewer_did_answer_card fires with a real Card + non-zero ease; guarded off.
+    mgr.update_life_bar(reviewer, card=object(), ease=3)
+    reviewer.web.eval.assert_not_called()
+    assert db.query_count == 0
+
+
+def test_card_object_guard_blocks_hook_calls():
+    db = FakeDB(owned_ids={25})
+    fake_services = types.SimpleNamespace(db=db, settings=None, reviewer=None)
+    _, mgr = _new_manager(fake_services, enemy_id=25)
+    reviewer = MagicMock()
+
+    # ease==0 but a Card object (not int) sneaks in -> still guarded off.
+    mgr.update_life_bar(reviewer, card=object(), ease=0)
+    reviewer.web.eval.assert_not_called()
+    assert db.query_count == 0
+
+
+# --------------------------------------------------------------------------- #
+# reviewer_ui: team-cycle + hotkeys + idempotent wrapping
+# --------------------------------------------------------------------------- #
+class _DummyReviewerFactory:
+    """Fresh Reviewer class per test so ``_ankimon_orig_*`` never leaks across."""
+
+    @staticmethod
+    def make():
+        class DummyReviewer:
+            def _shortcutKeys(self):
+                return [("x", lambda: None)]
+
+            def _linkHandler(self, url):
+                return False
+
+            def _bottomHTML(self):
+                return "base"
+
+        return DummyReviewer
+
+
+def _make_fake_wrap(counter):
+    def fake_wrap(old, new, pos="after"):
+        counter.append((old, new, pos))
+
+        def wrapped(self, *a, **k):
+            return new(self, *a, _old=old, **k)
+
+        return wrapped
+
+    return fake_wrap
+
+
+def _load_reviewer_ui(fake_services, dummy_reviewer=None, wrap_counter=None):
+    _install_common_mocks(fake_services)
+
+    # anki.hooks.wrap + aqt.reviewer.Reviewer must be real-ish for the wrapping.
+    if wrap_counter is not None:
+        sys.modules["anki.hooks"].wrap = _make_fake_wrap(wrap_counter)
+    if dummy_reviewer is not None:
+        sys.modules["aqt.reviewer"].Reviewer = dummy_reviewer
+
+    singletons = types.ModuleType("Ankimon.singletons")
+    for attr in (
+        "enemy_pokemon",
+        "main_pokemon",
+        "ankimon_tracker_obj",
+        "test_window",
+        "evo_window",
+        "logger",
+        "achievements",
+        "trainer_card",
+        "reviewer_obj",
+    ):
+        setattr(singletons, attr, MagicMock())
+    sys.modules["Ankimon.singletons"] = singletons
+
+    for sub in [
+        "Ankimon.functions.encounter_functions",
+        "Ankimon.functions.update_main_pokemon",
+        "Ankimon.functions.pokedex_functions",
+        "Ankimon.texts",
+        "Ankimon.utils",
+    ]:
+        sys.modules[sub] = MagicMock()
+
+    return _load_module("Ankimon.reviewer_ui", "Ankimon/reviewer_ui.py")
+
+
+def test_resolve_team_cycle_key_explicit_and_lowercased():
+    fake_services = types.SimpleNamespace(db=None, settings=FakeSettings())
+    ui = _load_reviewer_ui(fake_services)
+    assert ui._resolve_team_cycle_key("7") == "7"
+    assert ui._resolve_team_cycle_key("K") == "k"
+
+
+def test_resolve_team_cycle_key_defaults_from_services_settings():
+    fake_services = types.SimpleNamespace(
+        db=None, settings=FakeSettings({"controls.team_cycle_key": "3"})
+    )
+    ui = _load_reviewer_ui(fake_services)
+    # 4th arg omitted (None) -> read controls.team_cycle_key via the seam.
+    assert ui._resolve_team_cycle_key(None) == "3"
+
+
+def test_setup_reviewer_ui_three_and_four_args_idempotent():
+    fake_services = types.SimpleNamespace(db=None, settings=FakeSettings())
+    dummy = _DummyReviewerFactory.make()
+    orig_sk = dummy._shortcutKeys
+    orig_lh = dummy._linkHandler
+    orig_bh = dummy._bottomHTML
+    counter = []
+    ui = _load_reviewer_ui(fake_services, dummy_reviewer=dummy, wrap_counter=counter)
+
+    # 4-arg call (settings_window style).
+    ui.setup_reviewer_ui("6", "5", True, "9")
+    assert len(counter) == 3  # shortcutKeys + linkHandler + bottomHTML, once each
+    assert dummy._ankimon_orig_shortcutKeys is orig_sk
+    assert dummy._ankimon_orig_linkHandler is orig_lh
+    assert dummy._ankimon_orig_bottomHTML is orig_bh
+    assert ui._current_keys["team_cycle"] == "9"
+
+    # 3-arg call (base __init__ style) must still work and NOT re-wrap.
+    ui.setup_reviewer_ui("7", "5", True)
+    assert len(counter) == 3  # no double-wrap
+    assert ui._current_keys["catch"] == "7"
+    # 4th arg defaulted from services.settings.
+    assert ui._current_keys["team_cycle"] == "9"
+
+
+def test_cycle_team_pokemon_reads_services_db_and_refreshes_hud():
+    db = FakeDB(
+        team=[{"individual_id": "a"}, {"individual_id": "b"}],
+        pokemon={"id": 25, "name": "Pikachu", "level": 5},
+    )
+    fake_services = types.SimpleNamespace(
+        db=db, settings=FakeSettings({"controls.team_cycle_count": 3})
+    )
+    ui = _load_reviewer_ui(fake_services)
+    ui.main_pokemon = MagicMock()
+    ui.reviewer_obj = MagicMock()
+
+    ui.cycle_team_pokemon()
+
+    assert db.get_team_calls == 1
+    # index cycles 0 -> 1, so the second team member is loaded.
+    assert db.get_pokemon_args == ["b"]
+    ui.reviewer_obj.refresh_hud.assert_called_once()
+
+
+def test_cycle_team_pokemon_disabled_when_count_le_one():
+    db = FakeDB(team=[{"individual_id": "a"}, {"individual_id": "b"}])
+    fake_services = types.SimpleNamespace(
+        db=db, settings=FakeSettings({"controls.team_cycle_count": 1})
+    )
+    ui = _load_reviewer_ui(fake_services)
+    ui.reviewer_obj = MagicMock()
+
+    ui.cycle_team_pokemon()
+
+    assert db.get_team_calls == 0
+    ui.reviewer_obj.refresh_hud.assert_not_called()
+
+
+def test_hotkey_0_triggers_new_encounter_with_update_hud():
+    fake_services = types.SimpleNamespace(db=None, settings=FakeSettings())
+    ui = _load_reviewer_ui(fake_services)
+    ui.is_dev_mode = lambda: True
+    ui.new_pokemon = MagicMock()
+
+    ui.test_encounter_shortcut_function()
+
+    ui.new_pokemon.assert_called_once()
+    _, kwargs = ui.new_pokemon.call_args
+    assert kwargs.get("update_hud") is True
+
+
+def test_hotkey_0_noop_when_not_dev_mode():
+    fake_services = types.SimpleNamespace(db=None, settings=FakeSettings())
+    ui = _load_reviewer_ui(fake_services)
+    ui.is_dev_mode = lambda: False
+    ui.new_pokemon = MagicMock()
+
+    ui.test_encounter_shortcut_function()
+
+    ui.new_pokemon.assert_not_called()
+
+
+# --------------------------------------------------------------------------- #
+# new_pokemon integration — the F22 contract F34's cache relies on
+# --------------------------------------------------------------------------- #
+def _load_encounter_functions():
+    for name in ["aqt", "aqt.qt", "aqt.utils"]:
+        sys.modules[name] = MagicMock()
+    for module in [
+        "Ankimon.pyobj.ankimon_tracker",
+        "Ankimon.pyobj.pokemon_obj",
+        "Ankimon.pyobj.reviewer_obj",
+        "Ankimon.pyobj.test_window",
+        "Ankimon.pyobj.trainer_card",
+        "Ankimon.pyobj.InfoLogger",
+        "Ankimon.pyobj.evolution_window",
+        "Ankimon.pyobj.attack_dialog",
+        "Ankimon.pyobj.translator",
+        "Ankimon.pyobj.error_handler",
+        "Ankimon.functions.pokemon_functions",
+        "Ankimon.functions.pokedex_functions",
+        "Ankimon.functions.trainer_functions",
+        "Ankimon.functions.badges_functions",
+        "Ankimon.functions.drawing_utils",
+        "Ankimon.functions.friendship_evolution",
+        "Ankimon.functions.encounter_data",
+        "Ankimon.utils",
+        "Ankimon.business",
+        "Ankimon.const",
+        "Ankimon.singletons",
+        "Ankimon.resources",
+        "Ankimon.services",
+        "Ankimon.events",
+    ]:
+        sys.modules[module] = MagicMock()
+
+    # new_pokemon only needs a canned generate_random_pokemon (patched below) plus
+    # the reviewer/services/events seams — no real pokedex/encounter data — so the
+    # heavy data modules stay mocked. This keeps the load order-independent.
+    ef = _load_module(
+        "Ankimon.functions.encounter_functions",
+        "Ankimon/functions/encounter_functions.py",
+    )
+    ef.main_pokemon = MagicMock()
+    ef.settings_obj = MagicMock()
+    ef.ankimon_tracker_obj = MagicMock()
+    ef.trainer_card = MagicMock()
+    ef.services = MagicMock()
+    ef.events = MagicMock()
+    # Canned generator so new_pokemon does no RNG work.
+    ef.generate_random_pokemon = lambda *a, **k: (
+        "Pikachu",
+        25,
+        5,
+        "static",
+        ["electric"],
+        {},
+        [],
+        112,
+        "medium",
+        {},
+        {},
+        "N",
+        "",
+        {},
+        "Normal",
+        {},
+        False,
+        "hardy",
+    )
+    return ef
+
+
+class _ReviewerStub:
+    def __init__(self):
+        self._ownership_cache = {}
+        self._last_state = ("stale",)
+        self.refresh_hud = MagicMock()
+
+
+def test_new_pokemon_update_hud_clears_cache_and_refreshes():
+    ef = _load_encounter_functions()
+    reviewer = _ReviewerStub()
+    reviewer._ownership_cache[25] = False
+
+    ef.new_pokemon(MagicMock(), None, MagicMock(), reviewer, update_hud=True)
+
+    assert reviewer._ownership_cache == {}
+    assert reviewer._last_state is None
+    reviewer.refresh_hud.assert_called_once()
+
+
+def test_new_pokemon_without_update_hud_still_clears_cache_but_no_repaint():
+    ef = _load_encounter_functions()
+    reviewer = _ReviewerStub()
+    reviewer._ownership_cache[25] = True
+
+    ef.new_pokemon(MagicMock(), None, MagicMock(), reviewer, update_hud=False)
+
+    assert reviewer._ownership_cache == {}
+    reviewer.refresh_hud.assert_not_called()

--- a/tests/test_reviewer_ownership_cache.py
+++ b/tests/test_reviewer_ownership_cache.py
@@ -375,6 +375,34 @@ def test_setup_reviewer_ui_three_and_four_args_idempotent():
     assert ui._current_keys["team_cycle"] == "9"
 
 
+def test_setup_reviewer_ui_reload_does_not_double_wrap():
+    # An add-on reload re-execs reviewer_ui (module guard flags reset to False)
+    # while the Reviewer *class* persists in memory with the first boot's wrappers
+    # still installed. The pristine method must be restored before re-wrapping, or
+    # every Ankimon shortcut would be appended twice (fires twice per keypress).
+    fake_services = types.SimpleNamespace(db=None, settings=FakeSettings())
+    dummy = _DummyReviewerFactory.make()
+    orig_sk = dummy._shortcutKeys
+    counter = []
+
+    ui = _load_reviewer_ui(fake_services, dummy_reviewer=dummy, wrap_counter=counter)
+    ui.is_dev_mode = lambda: False
+    ui.setup_reviewer_ui("6", "5", True, "9")
+
+    # Second boot: same persistent Reviewer class, fresh module namespace.
+    ui2 = _load_reviewer_ui(fake_services, dummy_reviewer=dummy, wrap_counter=counter)
+    ui2.is_dev_mode = lambda: False
+    ui2.setup_reviewer_ui("6", "5", True, "9")
+
+    # Pristine method preserved across reloads (reload-teardown contract).
+    assert dummy._ankimon_orig_shortcutKeys is orig_sk
+    # The live _shortcutKeys wraps the pristine ONCE: each Ankimon shortcut is
+    # appended exactly once. A stacked (double) wrap would list every key twice.
+    keys = dummy._shortcutKeys(dummy())
+    ankimon_keys = sorted(k for k, _ in keys if k in ("6", "5", "9"))
+    assert ankimon_keys == ["5", "6", "9"]
+
+
 def test_cycle_team_pokemon_reads_services_db_and_refreshes_hud():
     db = FakeDB(
         team=[{"individual_id": "a"}, {"individual_id": "b"}],
@@ -384,15 +412,82 @@ def test_cycle_team_pokemon_reads_services_db_and_refreshes_hud():
         db=db, settings=FakeSettings({"controls.team_cycle_count": 3})
     )
     ui = _load_reviewer_ui(fake_services)
+    # base_stats guard needs a valid dict back from the (mocked) pokedex lookup.
+    sys.modules["Ankimon.functions.pokedex_functions"].search_pokedex.return_value = {
+        "hp": 45,
+        "atk": 49,
+        "def": 49,
+        "spa": 65,
+        "spd": 65,
+        "spe": 90,
+    }
     ui.main_pokemon = MagicMock()
+    ui.main_pokemon.individual_id = "a"  # active pokemon is team slot 0
     ui.reviewer_obj = MagicMock()
 
     ui.cycle_team_pokemon()
 
     assert db.get_team_calls == 1
-    # index cycles 0 -> 1, so the second team member is loaded.
+    # active pokemon is slot 0, so cycling advances to slot 1 ('b').
     assert db.get_pokemon_args == ["b"]
     ui.reviewer_obj.refresh_hud.assert_called_once()
+
+
+def test_cycle_team_pokemon_syncs_index_to_active_pokemon():
+    # Regression for the team-cycle index desync: if the active pokemon is
+    # swapped in outside this hotkey (Team Select / PC), cycling must advance to
+    # the member AFTER the active one, not blindly increment a stale index.
+    db = FakeDB(
+        team=[
+            {"individual_id": "a"},
+            {"individual_id": "b"},
+            {"individual_id": "c"},
+        ],
+        pokemon={"id": 25, "name": "Pikachu", "level": 5},
+    )
+    fake_services = types.SimpleNamespace(
+        db=db, settings=FakeSettings({"controls.team_cycle_count": 3})
+    )
+    ui = _load_reviewer_ui(fake_services)
+    sys.modules["Ankimon.functions.pokedex_functions"].search_pokedex.return_value = {
+        "hp": 45,
+        "atk": 49,
+        "def": 49,
+        "spa": 65,
+        "spd": 65,
+        "spe": 90,
+    }
+    ui.reviewer_obj = MagicMock()
+    ui.main_pokemon = MagicMock()
+    ui.main_pokemon.individual_id = "b"  # active pokemon is slot 1
+    ui._team_cycle_index = 0  # stale running index (would wrongly go to 'b')
+
+    ui.cycle_team_pokemon()
+
+    # Synced to slot 1 ('b'), then advanced -> slot 2 ('c').
+    assert db.get_pokemon_args == ["c"]
+
+
+def test_cycle_team_pokemon_missing_base_stats_aborts_without_mutation():
+    # search_pokedex returns [] (not None) for an unknown name; the guard must
+    # abort before update_stats so main_pokemon is never partially mutated.
+    db = FakeDB(
+        team=[{"individual_id": "a"}, {"individual_id": "b"}],
+        pokemon={"id": 25, "name": "Pikachu", "level": 5},
+    )
+    fake_services = types.SimpleNamespace(
+        db=db, settings=FakeSettings({"controls.team_cycle_count": 3})
+    )
+    ui = _load_reviewer_ui(fake_services)
+    sys.modules["Ankimon.functions.pokedex_functions"].search_pokedex.return_value = []
+    ui.main_pokemon = MagicMock()
+    ui.main_pokemon.individual_id = "a"
+    ui.reviewer_obj = MagicMock()
+
+    ui.cycle_team_pokemon()
+
+    ui.main_pokemon.update_stats.assert_not_called()
+    ui.reviewer_obj.refresh_hud.assert_not_called()
 
 
 def test_cycle_team_pokemon_disabled_when_count_le_one():


### PR DESCRIPTION
## What
Ports BRRRR_Experimental unit **F34** — the reviewer HUD performance rewrite — onto the integration tip, re-fitted to main's service seam and layered on top of the already-merged F22 glue.

- **reviewer_obj.py**: in-memory `_ownership_cache` (keyed by enemy id) + `_last_state` dedup so the HUD only repaints when battle state actually changes; sprites served via the Anki media server (`/_addons/...`) instead of inlined base64; `[#id] Name (Gen X) LvL: Y` display via `PokemonObject.display_name`. `update_life_bar` short-circuits `reviewer_did_answer_card` hook calls (ease!=0 / Card object) so `battle_loop.refresh_hud()` remains the single repaint entry point.
- **reviewer_ui.py**: team-cycle hotkey (rotate the active pokemon through the first N team slots), a dev-only test-encounter hotkey, and idempotent Reviewer method wrapping.
- **tests/test_reviewer_ownership_cache.py**: parity oracle (net-new), re-fit to the seam.

## Re-fit to seam (exp → main mapping)
- `mw.ankimon_db` (HUD ownership read; team list/pokemon lookup) → **`services.db`**.
- `mw.settings_obj` (`controls.team_cycle_count` / `controls.team_cycle_key`) → **`services.settings`**.
- HUD repaint: exp's `reviewer_obj.update_life_bar(mw.reviewer, 0, 0)` → main's **`reviewer_obj.refresh_hud()`** (kept from F22; grabs `mw.reviewer.web` internally).
- `mw.addonManager.addonFromModule` / `mw.reviewer.web` kept as **genuine Anki APIs**.
- `setup_reviewer_ui` gains a 4th `team_cycle_shortcut` param that **defaults off `services.settings['controls.team_cycle_key']`**, so base's unmodified 3-arg call in `__init__.py` (F32-owned, untouched) and base's arity-detecting 4-arg call in `settings_window.py` (F28) both work.

## Parity notes
- **NR-15 delta recomputed** for the 3 manifest files: `git log aad0d6b4..origin/BRRRR_Experimental` shows **0 post-snapshot commits** touching them — no late upstream hunks to capture.
- The exp `update_life_bar` guard (`ease!=0` short-circuit) is faithfully ported and is compatible with base: `refresh_hud()` (called unconditionally by `battle_loop.on_review_card` at line 305 and by `new_pokemon(update_hud=True)`) passes `ease=0`, while the redundant answer-hook repaint is suppressed — this is the perf win, with no behavior loss.
- Idempotent wrapping also **fixes a latent base bug**: base's `setup_reviewer_ui` re-wrapped `Reviewer._shortcutKeys` on every settings save (double-wrap); the module-flag + `_ankimon_orig_*` guards make it wrap once.
- `hud_hidden`/`hud_data` attrs (dead in base, no readers) dropped, matching exp.

## Guards confirmation
- Reload-teardown contract: `Reviewer._shortcutKeys/_linkHandler/_bottomHTML` wrapped once, `_ankimon_orig_*` captured once (probe_real_boot hooks == 3).
- F22 `update_hud` pathway kept working (probe_real_play: catch 2 / defeat 1, 0 errors).
- `_ownership_cache` cleared on `reviewer_reset_life_bar_inject` and on `new_pokemon` (F22).
- XP-share None-check guard: **N/A** — the HUD does not display `xp_share`.

## Deferred
- **database_manager.py** cache-invalidation hooks (exp `_clear_reviewer_ownership_cache` / `_all_pokemon_ids_cache` / `mark_as_caught` + save/delete/replace/save_main/add_to_history/switch_database invalidations) are exp-only, absent on main, and outside F34's manifest (shared DB hotspot; arch-map §6 lists F14/F25/F29 owners, not F34). The primary invalidation (fresh encounter clears the cache, F22) is present and tested; only rare out-of-band staleness is affected. → owner of `pyobj/database_manager.py`.
- **is_dev_mode** (F34 dependency `thread-reload-and-misc-utils`) not yet on main; ported behind a guarded fallback so the dev hotkey is inert until it lands.

## Gates
- compileall: OK · ruff check: 10 errors (all pre-existing in `AnkimonWindow copy.py`, 0 new) · ruff format --check (3 files): clean · pytest Tier-1: **319 passed / 35 skipped / 0 failed** (303 base + 16 new) · harness/check.py: **9/9** · Qt: scaffolding smoke 4 passed, addon_integrity 1 passed, **probe_real_boot OK** (reviewer=Reviewer_Manager, hooks==3), **probe_real_play OK**.

## Attribution
Originally implemented by @hakimh2 (Hakimh2) on BRRRR_Experimental; credited via `Co-authored-by:` trailers on both commits.



---

## Post-review update (Gemini PR #555)

- `reviewer_ui.py` method wrapping is now genuinely reload-safe. The prior `_ankimon_orig_*` capture was idempotent, but the `wrap()` reassignment was NOT: on a module re-exec (add-on reload) the module guard flags reset while the `Reviewer` class persisted with the previous wrappers installed, so `Reviewer._shortcutKeys/_linkHandler/_bottomHTML` gained a second wrapper (every Ankimon shortcut fired twice). Fixed by restoring the pristine method from `Reviewer._ankimon_orig_*` before re-wrapping (F31/F32 restore-then-wrap pattern). The "wrapped once" guarantee in the Guards section now holds across reloads, not just within one module lifetime.
- Team-cycle now syncs `_team_cycle_index` to the active pokemon's slot (`main_pokemon.individual_id`) before advancing, so an out-of-band swap via Team Select / PC no longer desyncs the cycle (with a `ValueError` fallback to the running index).
- `cycle_team_pokemon` now guards missing base stats (`search_pokedex` returns `[]`) before calling `update_stats`, so `main_pokemon` is never left partially mutated on a bad lookup.
- Declined the reviewer_obj None-guard suggestion (:136): `enemy_pokemon`/`main_pokemon` are non-None singletons; the None path is unreachable.
- Dropped a dead `mime_type` local in `reviewer_obj.py`.

Gates: pytest Tier-1 now **322 passed / 35 skipped** (303 base + 19 net-new tests; was 319/16-new). All other gates unchanged and green.
