### PR TITLE
feat: PC Box rework — move manager, evolution readiness badge, geometry persistence (F42)

### DIFF
--- a/src/Ankimon/pyobj/pc_box.py
+++ b/src/Ankimon/pyobj/pc_box.py
@@ -443,7 +443,9 @@ class MoveManagerWidget(QWidget):
     def on_tm_clicked(self):
         # 1. Get species/base name for TM lookup
         internal_name = search_pokedex_by_id(self.pkmn_id)
-        if not internal_name:
+        # search_pokedex_by_id returns the sentinel "Pokémon not found" (a truthy
+        # string), not None/"", when the id is missing — guard against it explicitly.
+        if not internal_name or internal_name == "Pokémon not found":
             self.logger.log_and_showinfo(
                 "error", f"Could not find Pokémon data for ID: {self.pkmn_id}"
             )
@@ -1533,10 +1535,11 @@ class PokemonPC(QDialog):
         self._refresh_slot_selection()
 
     def _update_count_label(self):
+        if not hasattr(self, "count_label") or not is_alive(self.count_label):
+            return
         shown = len(self._filtered_pokemon) if hasattr(self, "_filtered_pokemon") else 0
         total = self._total_pokemon_count
-        if hasattr(self, "count_label"):
-            self.count_label.setText(f"Showing {shown:,} / {total:,} Pokémon")
+        self.count_label.setText(f"Showing {shown:,} / {total:,} Pokémon")
 
     def _refresh_slot_selection(self):
         for i in range(self.pokemon_grid.count()):
@@ -1704,7 +1707,9 @@ class PokemonPC(QDialog):
 
         # Build current filter state for cache check
         current_state = {
-            "db": services.db.db_path.name,
+            "db": services.db.db_path.name
+            if services.db and getattr(services.db, "db_path", None)
+            else "",
             "search": self.search_edit.text() if self.search_edit else "",
             "type": self.type_combo.currentText() if self.type_combo else "All types",
             "gen": self.generation_combo.currentText()
@@ -2178,6 +2183,13 @@ class PokemonPC(QDialog):
                         services.db.save_pokemon(data)
                         self.show_pokemon_details(pokemon)
 
+                    # Retire the previous manager before building a new one.
+                    # It is parented to the persistent details_widget (not the
+                    # swapped header stack), so without this it would linger as
+                    # an orphaned child and accumulate over the session.
+                    if hasattr(self, "move_manager") and is_alive(self.move_manager):
+                        self.move_manager.deleteLater()
+
                     # Initialize FIRST (this might be slightly heavy)
                     new_move_manager = MoveManagerWidget(
                         individual_id=pokemon["individual_id"],
@@ -2257,21 +2269,6 @@ class PokemonPC(QDialog):
                             label.setStyleSheet("color: #f87171; font-weight: bold;")
         except Exception as e:
             self.logger.log("error", f"Error applying nature indicators: {e}")
-
-    def _update_count_label(self):
-        if not hasattr(self, "count_label") or not is_alive(self.count_label):
-            return
-
-        shown = len(self._filtered_pokemon) if hasattr(self, "_filtered_pokemon") else 0
-
-        # Get total count
-        try:
-            cursor = services.db.execute("SELECT COUNT(*) FROM captured_pokemon")
-            total = cursor.fetchone()[0]
-        except Exception:
-            total = shown
-
-        self.count_label.setText(f"Showing {shown} / {total} Pokémon")
 
     def on_stats_tab_changed(self, index: int):
         """Callback to remember which tab (Stats/IV/EV) is selected."""

--- a/src/Ankimon/pyobj/pc_box.py
+++ b/src/Ankimon/pyobj/pc_box.py
@@ -26,24 +26,505 @@ from PyQt6.QtWidgets import (
     QFrame,
     QRadioButton,
     QButtonGroup,
+    QStyle,
 )
-from PyQt6.QtCore import QSize, pyqtSignal, QTimer
+from PyQt6.QtCore import QSize, pyqtSignal, QTimer, QByteArray
 from PyQt6.QtGui import QIcon, QFont, QAction, QMovie, QCloseEvent, QResizeEvent
 
+from ..services import services
 from ..pyobj.pokemon_obj import PokemonObject
 from ..pyobj.reviewer_obj import Reviewer_Manager
 from ..pyobj.test_window import TestWindow
 from ..pyobj.translator import Translator
 from ..pyobj.collection_dialog import MainPokemon
-from ..gui_classes.pokemon_details import PokemonCollectionDetails
+from ..gui_classes.pokemon_details import PokemonCollectionDetailsSplit, remember_attack
 from ..pyobj.InfoLogger import ShowInfoLogger
+from ..pyobj.move_picker import MovePickerDialog
+from ..pyobj.evolution_window import EvoWindow
 
 from ..pyobj.settings import Settings
-from ..functions.friendship_evolution import evolution_readiness, current_time_label
+from ..functions.friendship_evolution import current_time_label, evolution_readiness
 from ..functions.sprite_functions import get_sprite_path
-from ..utils import load_custom_font, get_tier_by_id
-from ..resources import icon_path, items_path, csv_file_items_cost, poke_evo_path
+from ..utils import (
+    load_custom_font,
+    get_tier_by_id,
+    is_alive,
+    format_move_name,
+    format_pokemon_name,
+)
+from ..resources import (
+    icon_path,
+    items_path,
+    csv_file_items_cost,
+    poke_evo_path,
+    pokemon_tm_learnset_path,
+    addon_dir,
+)
 from ..business import calculate_cp_from_dict
+from ..functions.pokedex_functions import (
+    find_details_move,
+    get_all_pokemon_moves,
+    format_lore_name,
+    get_pretty_name_for_name,
+    search_pokedex_by_id,
+)
+from ..functions.gui_functions import type_icon_path, move_category_path
+
+MOVE_TYPE_COLORS = {
+    "Normal": "#A8A878",
+    "Fire": "#F08030",
+    "Water": "#6890F0",
+    "Electric": "#F8D030",
+    "Grass": "#78C850",
+    "Ice": "#98D8D8",
+    "Fighting": "#C03028",
+    "Poison": "#A040A0",
+    "Ground": "#E0C068",
+    "Flying": "#A890F0",
+    "Psychic": "#F85888",
+    "Bug": "#A8B820",
+    "Rock": "#B8A038",
+    "Ghost": "#705898",
+    "Dragon": "#7038F8",
+    "Dark": "#705848",
+    "Steel": "#B8B8D0",
+    "Fairy": "#EE99AC",
+}
+
+NATURE_EFFECTS = {
+    "Hardy": ("", ""),
+    "Docile": ("", ""),
+    "Serious": ("", ""),
+    "Bashful": ("", ""),
+    "Quirky": ("", ""),  # neutral natures
+    "Lonely": ("attack", "defense"),
+    "Brave": ("attack", "speed"),
+    "Adamant": ("attack", "special-attack"),
+    "Naughty": ("attack", "special-defense"),
+    "Bold": ("defense", "attack"),
+    "Relaxed": ("defense", "speed"),
+    "Impish": ("defense", "special-attack"),
+    "Lax": ("defense", "special-defense"),
+    "Timid": ("speed", "attack"),
+    "Hasty": ("speed", "defense"),
+    "Jolly": ("speed", "special-attack"),
+    "Naive": ("speed", "special-defense"),
+    "Modest": ("special-attack", "attack"),
+    "Mild": ("special-attack", "defense"),
+    "Quiet": ("special-attack", "speed"),
+    "Rash": ("special-attack", "special-defense"),
+    "Calm": ("special-defense", "attack"),
+    "Gentle": ("special-defense", "defense"),
+    "Sassy": ("special-defense", "speed"),
+    "Careful": ("special-defense", "special-attack"),
+}
+
+STAT_KEY_TO_DISPLAY = {
+    "hp": "HP",
+    "attack": "Attack",
+    "defense": "Defense",
+    "special-attack": "Sp. Atk",
+    "special-defense": "Sp. Def",
+    "speed": "Speed",
+}
+DISPLAY_TO_STAT_KEY = {v: k for k, v in STAT_KEY_TO_DISPLAY.items()}
+
+from PyQt6.QtWidgets import (
+    QListWidget,
+    QListWidgetItem,
+    QTableWidget,
+    QTableWidgetItem,
+    QHeaderView,
+    QAbstractItemView,
+    QTabWidget,
+)
+from PyQt6.QtGui import QColor
+
+
+class MoveManagerWidget(QWidget):
+    def __init__(self, individual_id, pkmn_id, logger, save_fn, parent=None):
+        super().__init__(parent)
+        self.individual_id = individual_id
+        self.pkmn_id = pkmn_id
+        self.logger = logger
+        self.save_fn = save_fn
+        self.full_data = None
+        self.setup_ui()
+        self.refresh()
+
+    def setup_ui(self):
+        self.layout = QVBoxLayout(self)
+        self.layout.setSpacing(6)
+        self.layout.setContentsMargins(0, 0, 0, 0)
+
+        self.header = QLabel("MOVES")
+        self.header.setStyleSheet(
+            "color: #94a3b8; font-size: 10px; font-weight: bold; letter-spacing: 1px;"
+        )
+        self.layout.addWidget(self.header)
+
+        self.slots = []
+        for i in range(4):
+            slot_container = QWidget()
+            slot_layout = QHBoxLayout(slot_container)
+            slot_layout.setContentsMargins(0, 2, 0, 2)
+
+            type_chip = QLabel("---")
+            type_chip.setFixedSize(42, 18)
+            type_chip.setAlignment(Qt.AlignmentFlag.AlignCenter)
+            type_chip.setStyleSheet(
+                "border-radius: 4px; font-size: 9px; font-weight: bold; color: white;"
+            )
+
+            name_label = QPushButton("— empty —")
+            name_label.setFlat(True)
+            name_label.setCursor(Qt.CursorShape.PointingHandCursor)
+            name_label.setStyleSheet("""
+                QPushButton { 
+                    text-align: left; 
+                    font-size: 12px; 
+                    color: #475569; 
+                    font-style: italic; 
+                    border: none; 
+                    padding: 4px 8px; 
+                    border-radius: 4px;
+                }
+                QPushButton:hover {
+                    background-color: #1e293b;
+                }
+            """)
+
+            forget_btn = QPushButton("✕")
+            forget_btn.setFixedSize(24, 24)
+            forget_btn.setFlat(True)
+
+            learn_btn = QPushButton("＋")
+            learn_btn.setFixedSize(24, 24)
+            learn_btn.setFlat(True)
+
+            slot_layout.addWidget(type_chip)
+            slot_layout.addWidget(name_label)
+            slot_layout.addStretch()
+            slot_layout.addWidget(forget_btn)
+            slot_layout.addWidget(learn_btn)
+
+            self.layout.addWidget(slot_container)
+            self.slots.append(
+                {
+                    "container": slot_container,
+                    "layout": slot_layout,
+                    "type_chip": type_chip,
+                    "name_label": name_label,
+                    "forget_btn": forget_btn,
+                    "learn_btn": learn_btn,
+                    "move": None,
+                }
+            )
+
+            forget_btn.clicked.connect(
+                lambda checked, idx=i: self.on_forget_clicked(idx)
+            )
+            learn_btn.clicked.connect(lambda checked, idx=i: self.on_learn_clicked(idx))
+            name_label.clicked.connect(
+                lambda checked, idx=i: self.on_learn_clicked(idx)
+            )
+
+        # Add TM button
+        self.tm_btn = QPushButton(" LEARN FROM TMs")
+        tm_icon_path = items_path / "Bag_TM_normal_SV_Sprite.png"
+        if tm_icon_path.exists():
+            self.tm_btn.setIcon(QIcon(str(tm_icon_path)))
+            self.tm_btn.setIconSize(QSize(18, 18))
+
+        self.tm_btn.setMinimumHeight(32)
+        self.tm_btn.setCursor(Qt.CursorShape.PointingHandCursor)
+        self.tm_btn.setStyleSheet("""
+            QPushButton {
+                background: qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 #2563eb, stop:1 #1d4ed8);
+                color: #f8fafc;
+                font-size: 11px;
+                font-weight: 800;
+                letter-spacing: 0.5px;
+                border: 1px solid #1e40af;
+                border-radius: 6px;
+                margin-top: 12px;
+                padding: 4px 8px;
+                text-align: center;
+            }
+            QPushButton:hover {
+                background: qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 #3b82f6, stop:1 #2563eb);
+                border-color: #3b82f6;
+                margin-top: 12px;
+                padding: 4px 8px;
+                text-align: center;
+            }
+            QPushButton:pressed {
+                background: #1e40af;
+                margin-top: 12px;
+                padding: 5px 8px 3px 8px;
+                text-align: center;
+            }
+        """)
+        self.tm_btn.clicked.connect(self.on_tm_clicked)
+        self.layout.addWidget(self.tm_btn)
+
+    def _fetch_full(self, individual_id):
+        try:
+            cursor = services.db.execute(
+                "SELECT data FROM captured_pokemon WHERE individual_id = ?",
+                (individual_id,),
+            )
+            row = cursor.fetchone()
+            if row:
+                data = json.loads(row[0])
+                # Ensure all_attacks is fetched
+                if "all_attacks" not in data:
+                    from ..functions.pokedex_functions import get_all_pokemon_moves
+
+                    data["all_attacks"] = get_all_pokemon_moves(
+                        data.get("name"), data.get("level")
+                    )
+                return data
+        except Exception:
+            pass
+        return {}
+
+    def refresh(self):
+        self.full_data = self._fetch_full(self.individual_id)
+        attacks = self.full_data.get("attacks", [])
+        all_moves = self.full_data.get("all_attacks", []) or self.full_data.get(
+            "learnable_moves", []
+        )
+
+        for i in range(4):
+            slot = self.slots[i]
+            if i < len(attacks):
+                move = attacks[i]
+                slot["move"] = move
+                slot["name_label"].setText(format_move_name(move))
+                slot["name_label"].setStyleSheet("""
+                    QPushButton { 
+                        text-align: left; 
+                        font-size: 12px; 
+                        color: #e6edf3; 
+                        font-weight: 600; 
+                        border: none; 
+                        padding: 4px 8px; 
+                        border-radius: 4px;
+                    } 
+                    QPushButton:hover { 
+                        color: #60a5fa; 
+                        background-color: #1e293b;
+                    }
+                """)
+                slot["forget_btn"].setVisible(len(attacks) > 1)
+                slot["learn_btn"].setText("⤵")
+                slot["learn_btn"].setVisible(bool(all_moves))
+
+                move_data = find_details_move(move)
+                m_type = move_data.get("type", "Normal")
+                color = MOVE_TYPE_COLORS.get(m_type, "#777")
+                slot["type_chip"].setText(m_type.upper())
+                slot["type_chip"].setStyleSheet(
+                    f"background-color: {color}; border-radius: 4px; font-size: 9px; font-weight: bold; color: white;"
+                )
+                slot["type_chip"].show()
+            else:
+                slot["move"] = None
+                slot["name_label"].setText("— empty —")
+                slot["name_label"].setStyleSheet(
+                    "QPushButton { text-align: left; font-size: 12px; color: #475569; font-style: italic; border: none; padding: 0; }"
+                )
+                slot["forget_btn"].hide()
+                slot["learn_btn"].setText("＋")
+                slot["learn_btn"].setVisible(bool(all_moves))
+                slot["type_chip"].hide()
+
+        if not all_moves:
+            if not hasattr(self, "no_moves_label"):
+                self.no_moves_label = QLabel("No learnable moves data")
+                self.no_moves_label.setStyleSheet(
+                    "color: #64748b; font-size: 11px; font-style: italic;"
+                )
+                self.layout.addWidget(self.no_moves_label)
+        elif hasattr(self, "no_moves_label"):
+            self.no_moves_label.setParent(None)
+            del self.no_moves_label
+
+    def on_forget_clicked(self, idx):
+        move = self.slots[idx]["move"]
+        if not move:
+            return
+
+        # Confirmation UI
+        slot_container = self.slots[idx]["container"]
+        old_layout = self.slots[idx]["layout"]
+
+        conf_widget = QWidget()
+        conf_layout = QHBoxLayout(conf_widget)
+        conf_layout.setContentsMargins(0, 0, 0, 0)
+
+        label = QLabel(f"Forget {move.capitalize()}?")
+        label.setStyleSheet("font-size: 11px; font-weight: bold;")
+
+        yes_btn = QPushButton("Yes")
+        yes_btn.setFixedSize(40, 22)
+        yes_btn.setStyleSheet("font-size: 10px;")
+
+        no_btn = QPushButton("No")
+        no_btn.setFixedSize(40, 22)
+        no_btn.setStyleSheet("font-size: 10px;")
+
+        conf_layout.addWidget(label)
+        conf_layout.addStretch()
+        conf_layout.addWidget(yes_btn)
+        conf_layout.addWidget(no_btn)
+
+        # Swap layouts
+        slot_container.hide()
+        self.layout.insertWidget(idx + 1, conf_widget)  # +1 because of header
+
+        def on_yes():
+            attacks = self.full_data.get("attacks", [])
+            if move in attacks:
+                attacks.remove(move)
+                self.full_data["attacks"] = attacks
+                self.save_fn(self.full_data)
+                self.refresh()
+            conf_widget.setParent(None)
+            slot_container.show()
+
+        def on_no():
+            conf_widget.setParent(None)
+            slot_container.show()
+
+        yes_btn.clicked.connect(on_yes)
+        no_btn.clicked.connect(on_no)
+
+    def on_learn_clicked(self, idx):
+        all_moves = self.full_data.get("all_attacks", []) or self.full_data.get(
+            "learnable_moves", []
+        )
+        current_moves = self.full_data.get("attacks", [])
+
+        nickname = self.full_data.get("nickname")
+        raw_name = self.full_data.get("name")
+        species_name = get_pretty_name_for_name(raw_name)
+
+        def normalize_n(s):
+            if not s:
+                return ""
+            return "".join(c for c in str(s).lower() if c.isalnum())
+
+        is_redundant = (
+            not nickname
+            or not str(nickname).strip()
+            or normalize_n(nickname) == normalize_n(species_name)
+            or normalize_n(nickname) == normalize_n(raw_name)
+        )
+
+        pretty_name = species_name if is_redundant else f"{nickname} ({species_name})"
+
+        dialog = MovePickerDialog(
+            pretty_name, all_moves, current_moves, self, force_show_current=True
+        )
+        if dialog.exec():
+            new_move = dialog.get_selected_move()
+            if new_move:
+                attacks = self.full_data.get("attacks", [])
+                if idx < len(attacks):
+                    attacks[idx] = new_move
+                else:
+                    attacks.append(new_move)
+                self.full_data["attacks"] = attacks
+                self.save_fn(self.full_data)
+                self.refresh()
+
+    def on_tm_clicked(self):
+        # 1. Get species/base name for TM lookup
+        internal_name = search_pokedex_by_id(self.pkmn_id)
+        if not internal_name:
+            self.logger.log_and_showinfo(
+                "error", f"Could not find Pokémon data for ID: {self.pkmn_id}"
+            )
+            return
+
+        # Normalize: strip hyphens and everything after the first hyphen to try base species
+        # e.g. "venusaur-mega" -> "venusaur"
+        base_name = internal_name.split("-")[0].lower()
+        internal_name = internal_name.lower()
+
+        # 2. Load TM learnsets
+        try:
+            with open(pokemon_tm_learnset_path, "r", encoding="utf-8") as f:
+                tm_learnsets = json.load(f)
+        except Exception as e:
+            self.logger.log_and_showinfo("error", f"Failed to load TM learnsets: {e}")
+            return
+
+        # 3. Get valid TMs for this species (check specific form then base species)
+        valid_tms = tm_learnsets.get(internal_name) or tm_learnsets.get(base_name)
+        if not valid_tms:
+            self.logger.log_and_showinfo(
+                "info", f"This Pokémon cannot learn any moves from TMs."
+            )
+            return
+
+        # 4. Get owned TMs from DB
+        all_items = services.db.get_all_items()
+        owned_tm_moves = [
+            item["item_name"]
+            for item in all_items
+            if (item.get("extra_data") or {}).get("type") == "TM"
+        ]
+
+        # 5. Filter valid TMs by ownership
+        learnable_tm_moves = [move for move in valid_tms if move in owned_tm_moves]
+        if not learnable_tm_moves:
+            self.logger.log_and_showinfo(
+                "info", "You don't own any TMs that this Pokémon can learn."
+            )
+            return
+
+        # 6. UI: Use MovePickerDialog
+        nickname = self.full_data.get("nickname")
+        raw_name = self.full_data.get("name")
+        species_name = get_pretty_name_for_name(raw_name)
+
+        def normalize_n(s):
+            if not s:
+                return ""
+            return "".join(c for c in str(s).lower() if c.isalnum())
+
+        is_redundant = (
+            not nickname
+            or not str(nickname).strip()
+            or normalize_n(nickname) == normalize_n(species_name)
+            or normalize_n(nickname) == normalize_n(raw_name)
+        )
+
+        pretty_name = species_name if is_redundant else f"{nickname} ({species_name})"
+        title = f"TM Learning: {pretty_name}"
+
+        current_moves = self.full_data.get("attacks", [])
+        dialog = MovePickerDialog(title, learnable_tm_moves, current_moves, self)
+        dialog.setWindowTitle("Learn from TMs")
+
+        if dialog.exec():
+            new_move = dialog.get_selected_move()
+            if new_move:
+                self.learn_move_from_tm(new_move)
+
+    def learn_move_from_tm(self, move_name):
+        remember_attack(
+            self.individual_id,
+            self.full_data.get("attacks", []),
+            move_name,
+            self.logger,
+            refresh_callback=lambda: self.save_fn(
+                services.db.get_pokemon(self.individual_id)
+            ),
+        )
 
 
 def format_item_name(item_name: str) -> str:
@@ -60,11 +541,12 @@ def clear_layout(layout):
     Args:
         layout (QLayout): The layout to be cleared. Can contain widgets and/or nested layouts.
     """
+    if not is_alive(layout):
+        return
     while layout.count():
         item = layout.takeAt(0)
         widget = item.widget()
         if widget is not None:
-            widget.setParent(None)
             widget.deleteLater()
         elif item.layout():
             clear_layout(item.layout())
@@ -80,14 +562,21 @@ class PokemonSlotButton(QPushButton):
 
 
 class ScaledMovieLabel(QLabel):
-    def __init__(self, gif_path, width, height):
-        super().__init__()
+    def __init__(self, gif_path, width, height, parent=None):
+        super().__init__(parent)
         self.target_width = width
         self.target_height = height
-        self.movie = QMovie(gif_path)
+        self.movie = QMovie(gif_path, parent=self)
         self.movie.frameChanged.connect(self.on_frame_changed)
-        self.movie.start()
         self.setFixedSize(width, height)
+
+    def showEvent(self, event):
+        super().showEvent(event)
+        self.movie.start()
+
+    def hideEvent(self, event):
+        super().hideEvent(event)
+        self.movie.stop()
 
     def on_frame_changed(self, frame_number):
         # Get current frame pixmap
@@ -122,6 +611,7 @@ class PokemonPC(QDialog):
         self.reviewer_obj = reviewer_obj
         self.test_window = test_window
         self.settings = settings
+        self.main_pokemon = main_pokemon
         self.main_pokemon_function_callback = lambda _pokemon_data: MainPokemon(
             _pokemon_data, main_pokemon, logger, translator, reviewer_obj, test_window
         )
@@ -139,6 +629,15 @@ class PokemonPC(QDialog):
             self.on_resize_timeout
         )  # Debounce resize events to avoid excessive refreshes during window resizing
 
+        # PERFORMANCE: Database result caching
+        self._pokemon_cache = None
+        self._last_filter_state = None
+
+        # LIVE SEARCH: Timer for debouncing
+        self.search_timer = QTimer()
+        self.search_timer.setSingleShot(True)
+        self.search_timer.timeout.connect(lambda: self.go_to_box(0))
+
         self.main_layout = QHBoxLayout()  # Main horizontal layout for split panels
         self.details_layout = QVBoxLayout()  # Layout for details panel
         self.details_widget = QWidget()  # Widget to hold details
@@ -155,12 +654,23 @@ class PokemonPC(QDialog):
         self.sort_by_id = None
         self.sort_by_name = None
         self.sort_by_level = None
-        self.sort_by_friendship = None
         self.sort_by_date = None
         self.sort_group = None
-        self.selected_sort_key = "Date"
+        self.selected_sort_key = "CP"
+        self.sort_combo = None
         self.desc_sort = None  # Sort by descending order
         self.current_stats_tab_index = 0  # Remember selected tab (Stats/IV/EV)
+
+        self._selected_individual_id = None
+        self._total_pokemon_count = 0
+
+        self._bff_id = None
+        self._bff_dirty = True
+        self.time_label = None
+
+        # Splitter persistence keys
+        self.GEOMETRY_KEY = "ankimon.pc_box.geometry"
+        self.SPLITTER_KEY = "ankimon.pc_box.splitter"
 
         # Subscribe to theme change hook to update UI dynamically
         gui_hooks.theme_did_change.append(self.on_theme_change)
@@ -170,38 +680,22 @@ class PokemonPC(QDialog):
         self.grid_container = None
         self.pokemon_grid = None
         self.curr_box_label = None
-        self.time_label = None
-
-        # Cached BFF (highest-friendship Pokémon). Recomputed only when the
-        # underlying collection could have changed (open/show, catch, evolve,
-        # trade, release, favorite toggle, held-item change), NOT on pure
-        # layout re-renders (resize, pagination, filter changes, selection).
-        self._bff_id = None
-        self._bff_dirty = True
 
         self.create_gui()
+        self._restore_geometry()
         self.refresh_pokemon_grid()
 
-    def showEvent(self, event):
-        """Refresh the grid whenever the PC is (re)opened.
-
-        Two things drift while the window is closed: friendship (battles/reviews)
-        and the day/night clock (just elapsed time). A plain ``.show()`` doesn't
-        rebuild the grid, so without this the header clock, the BFF heart, and the
-        time-gated evolution badges would all display whatever was last rendered.
-        Invalidate the cached BFF and re-render so the reopened view is current.
-        """
-        self._bff_dirty = True
-        super().showEvent(event)
-        self.refresh_pokemon_grid()
+        # Real-time clock for friendship evolutions
+        self.time_timer = QTimer(self)
+        self.time_timer.timeout.connect(self._update_time_display)
+        self.time_timer.start(60000)  # Every minute
 
     def on_theme_change(self):
         """
         Callback function triggered when Anki's theme changes (light to dark or vice versa).
         Refreshes the GUI to apply the new theme settings.
         """
-        # Theme change is cosmetic — no data change, so reuse the cached BFF.
-        self.refresh_gui(recompute_bff=False)
+        self.refresh_gui()
 
     def create_gui(self):
         """
@@ -229,6 +723,14 @@ class PokemonPC(QDialog):
         """
         self.setWindowTitle("Pokémon PC")
 
+        # Make the window non-modal (floating) and add maximize/minimize buttons
+        self.setWindowFlags(
+            self.windowFlags()
+            | Qt.WindowType.WindowMaximizeButtonHint
+            | Qt.WindowType.WindowMinimizeButtonHint
+        )
+        self.setWindowModality(Qt.WindowModality.NonModal)
+
         # Determine theme based on Anki's night mode
         is_dark_mode = theme_manager.night_mode  # Correctly checks Anki's theme
 
@@ -240,8 +742,10 @@ class PokemonPC(QDialog):
             button_bg = "#3B4CCA"
             button_border = "#6A73D9"
             hover_color = "#6A73D9"
-            favorite_color = "#B3A125"
-            favorite_hover_color = "#AF8308"
+            favorite_color = (
+                "#998A3D"  # Muted antique brass/gold (classy, low-luminance)
+            )
+            favorite_hover_color = "#8A7C36"
             input_bg = "#002B5A"  # Slightly lighter than background for input fields
             slot_bg_color = "#002B5A"
         else:
@@ -251,8 +755,8 @@ class PokemonPC(QDialog):
             button_bg = "#3D7DCA"
             button_border = "#003A70"
             hover_color = "#A8D8FF"
-            favorite_color = "#FFDE00"
-            favorite_hover_color = "#FFA600"
+            favorite_color = "#EAD180"  # Soft honey-gold / desaturated sand gold (warm, mild brightness)
+            favorite_hover_color = "#D9BF70"
             input_bg = "#FFFFFF"  # White background for input fields
             slot_bg_color = "#CCE5FF"
 
@@ -330,7 +834,13 @@ class PokemonPC(QDialog):
         if self.layout():
             clear_layout(self.layout())
         else:
-            self.setLayout(self.main_layout)
+            self.main_layout = QHBoxLayout(self)
+
+        self.main_container = QWidget()
+        self.main_container_layout = QHBoxLayout(self.main_container)
+        self.main_container_layout.setContentsMargins(0, 0, 0, 0)
+        self.main_layout.addWidget(self.main_container)
+
         pokemon_list = self.fetch_filtered_pokemon()
         max_box_idx = (len(pokemon_list) - 1) // (self.n_rows * self.n_cols)
 
@@ -364,9 +874,7 @@ class PokemonPC(QDialog):
             f"border: 1px solid {button_border}; background-color: {background_color};"
         )
 
-        # Day/night time indicator so players know the current evolution window.
-        # Only relevant when the friendship/time feature is enabled (the master
-        # toggle); hidden otherwise. refresh_pokemon_grid keeps it in sync.
+        # Day/night time indicator
         self.time_label = QLabel(current_time_label())
         self.time_label.setFixedHeight(50)
         self.time_label.setFont(
@@ -409,14 +917,89 @@ class PokemonPC(QDialog):
         self.pokemon_grid.setAlignment(Qt.AlignmentFlag.AlignCenter)
         self.scroll_area.setWidget(self.grid_container)
 
+        self.count_label = QLabel("", self)
+        self.count_label.setObjectName("countLabel")
+        self.count_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        collection_layout.addWidget(self.count_label)
+
         collection_layout.addWidget(self.scroll_area, 1)
         self.setup_filters_layout(collection_layout)
 
         collection_widget = QWidget()
         collection_widget.setLayout(collection_layout)
-        self.main_layout.addWidget(collection_widget, 1)
+        self.main_container_layout.addWidget(collection_widget, 3)  # Grid takes 3/5
 
         self.setup_details_panel(background_color)
+
+        self._apply_qss()
+
+    def _apply_qss(self):
+        self.setStyleSheet(
+            self.styleSheet()
+            + """
+            #countLabel {
+                font-size: 11px;
+                color: #94a3b8;
+                padding: 2px 8px 4px 8px;
+                letter-spacing: 0.3px;
+            }
+            
+            /* Unselected slot */
+            QPushButton#pokemonSlot {
+                border-radius: 5px;
+            }
+
+            /* Selected slot */
+            QPushButton#pokemonSlot[selected="true"] {
+                border: 2px solid #60a5fa;
+                background: rgba(96, 165, 250, 0.12);
+                border-radius: 8px;
+            }
+
+            /* Selected slot hover */
+            QPushButton#pokemonSlot[selected="true"]:hover {
+                background: rgba(96, 165, 250, 0.20);
+                border-color: #93c5fd;
+            }
+        """
+        )
+
+    def _restore_geometry(self):
+        import base64
+
+        try:
+            geo = mw.pm.profile.get(self.GEOMETRY_KEY)
+            if geo:
+                self.restoreGeometry(QByteArray(base64.b64decode(geo)))
+        except Exception:
+            pass
+
+    def closeEvent(self, event: QCloseEvent):
+        import base64
+
+        try:
+            mw.pm.profile[self.GEOMETRY_KEY] = base64.b64encode(
+                bytes(self.saveGeometry())
+            ).decode()
+        except Exception:
+            pass
+
+        for attr in ("resize_timer", "search_timer"):
+            t = getattr(self, attr, None)
+            if t and t.isActive():
+                t.stop()
+
+        self.on_window_close()
+        event.accept()
+
+    def showEvent(self, event):
+        """
+        Triggered when the PC box is shown.
+        Refreshes the grid to ensure newly caught Pokémon are visible.
+        """
+        super().showEvent(event)
+        # We call refresh_pokemon_grid which uses the cache-detection logic (count check)
+        self.refresh_pokemon_grid()
 
     def setup_filters_layout(self, parent_layout):
         """
@@ -436,7 +1019,11 @@ class PokemonPC(QDialog):
         self.search_edit = QLineEdit()
         self.search_edit.setPlaceholderText("Search Pokémon (by nickname, name)")
         self.search_edit.setText(prev_text)
+
+        # LIVE SEARCH: Trigger refresh after 300ms of inactivity
+        self.search_edit.textChanged.connect(lambda: self.search_timer.start(300))
         self.search_edit.returnPressed.connect(lambda: self.go_to_box(0))
+
         search_button = QPushButton("Search")
         search_button.clicked.connect(lambda: self.go_to_box(0))
         # Type filtering
@@ -483,7 +1070,17 @@ class PokemonPC(QDialog):
         self.tier_combo = QComboBox()
         self.tier_combo.addItem("All tiers")
         self.tier_combo.addItems(
-            ["Normal", "Legendary", "Mythical", "Baby", "Ultra", "Fossil", "Starter"]
+            [
+                "Normal",
+                "Legendary",
+                "Mythical",
+                "Baby",
+                "Ultra",
+                "Fossil",
+                "Starter",
+                "Mega",
+                "Gmax",
+            ]
         )
         self.tier_combo.setCurrentIndex(prev_idx)
         self.tier_combo.currentIndexChanged.connect(lambda: self.go_to_box(0))
@@ -515,61 +1112,45 @@ class PokemonPC(QDialog):
         # Sorting options
         sort_label = QLabel("Sort by:")
 
-        # Radio buttons for mutually exclusive sorting
-        self.sort_group = QButtonGroup(self)
-        self.sort_by_id = QRadioButton("ID")
-        self.sort_by_name = QRadioButton("Name")
-        self.sort_by_level = QRadioButton("Level")
-        self.sort_by_cp = QRadioButton("CP")
-        self.sort_by_iv = QRadioButton("IV")
-        self.sort_by_ev = QRadioButton("EV")
-        self.sort_by_friendship = QRadioButton("Friendship")
-        self.sort_by_date = QRadioButton("Date")
+        prev_sort = (
+            self.selected_sort_key if hasattr(self, "selected_sort_key") else "Date"
+        )
+        self.sort_combo = QComboBox()
+        sort_options = [
+            self.translator.translate("Date"),
+            self.translator.translate("ID"),
+            self.translator.translate("Name"),
+            self.translator.translate("Level"),
+            self.translator.translate("cp_label"),
+            self.translator.translate("friendship_label"),
+            "IV (Total)",
+            "EV (Total)",
+            "HP",
+            self.translator.translate("Attack"),
+            self.translator.translate("Defense"),
+            "Sp. Atk",
+            "Sp. Def",
+            self.translator.translate("Speed"),
+        ]
+        self.sort_combo.addItems(sort_options)
 
-        self.sort_group.addButton(self.sort_by_id)
-        self.sort_group.addButton(self.sort_by_name)
-        self.sort_group.addButton(self.sort_by_level)
-        self.sort_group.addButton(self.sort_by_cp)
-        self.sort_group.addButton(self.sort_by_iv)
-        self.sort_group.addButton(self.sort_by_ev)
-        self.sort_group.addButton(self.sort_by_friendship)
-        self.sort_group.addButton(self.sort_by_date)
+        # Set current index based on previous selection
+        index = self.sort_combo.findText(prev_sort)
+        if index >= 0:
+            self.sort_combo.setCurrentIndex(index)
+        else:
+            self.sort_combo.setCurrentText("Date")
 
-        if self.selected_sort_key == "ID":
-            self.sort_by_id.setChecked(True)
-        elif self.selected_sort_key == "Name":
-            self.sort_by_name.setChecked(True)
-        elif self.selected_sort_key == "Level":
-            self.sort_by_level.setChecked(True)
-        elif self.selected_sort_key == "CP":
-            self.sort_by_cp.setChecked(True)
-        elif self.selected_sort_key == "IV":
-            self.sort_by_iv.setChecked(True)
-        elif self.selected_sort_key == "EV":
-            self.sort_by_ev.setChecked(True)
-        elif self.selected_sort_key == "Friendship":
-            self.sort_by_friendship.setChecked(True)
-        else:  # Date is the default
-            self.sort_by_date.setChecked(True)
+        self.sort_combo.currentTextChanged.connect(self.on_sort_changed)
 
-        # Connect signals
-        self.sort_group.buttonClicked.connect(self.on_sort_button_clicked)
-
-        sort_radio_layout = QHBoxLayout()
-        sort_radio_layout.addWidget(sort_label)
-        sort_radio_layout.addWidget(self.sort_by_id)
-        sort_radio_layout.addWidget(self.sort_by_name)
-        sort_radio_layout.addWidget(self.sort_by_level)
-        sort_radio_layout.addWidget(self.sort_by_cp)
-        sort_radio_layout.addWidget(self.sort_by_iv)
-        sort_radio_layout.addWidget(self.sort_by_ev)
-        sort_radio_layout.addWidget(self.sort_by_friendship)
-        sort_radio_layout.addWidget(self.sort_by_date)
-        sort_radio_widget = QWidget()
-        sort_radio_widget.setLayout(sort_radio_layout)
+        sort_combo_layout = QHBoxLayout()
+        sort_combo_layout.addWidget(sort_label)
+        sort_combo_layout.addWidget(self.sort_combo)
+        sort_combo_widget = QWidget()
+        sort_combo_widget.setLayout(sort_combo_layout)
 
         # Checkboxes for other options
-        is_checked = self.desc_sort.isChecked() if self.desc_sort is not None else False
+        is_checked = self.desc_sort.isChecked() if self.desc_sort is not None else True
         self.desc_sort = QCheckBox("Descending")
         self.desc_sort.setChecked(is_checked)
         self.desc_sort.stateChanged.connect(lambda: self.go_to_box(0))
@@ -590,47 +1171,137 @@ class PokemonPC(QDialog):
         checkboxes_widget.setLayout(checkboxes_layout)
 
         filters_layout.addWidget(checkboxes_widget, 2, 0, 1, 5)
-        filters_layout.addWidget(sort_radio_widget, 3, 0, 1, 5)
+        filters_layout.addWidget(sort_combo_widget, 3, 0, 1, 5)
         parent_layout.addLayout(filters_layout)
 
     def setup_details_panel(self, background_color):
-        if self.pokemon_details_layout is not None:
-            self.details_widget = QWidget()
-            self.details_widget.setLayout(self.pokemon_details_layout)
-            self.details_widget.setMinimumWidth(470)  # Ensure it's visible
-            self.details_widget.setStyleSheet(f"background-color: {background_color};")
-            self.main_layout.addWidget(self.details_widget, 2)
-        else:
-            # Ensure the panel is collapsed if no pokemon is selected
-            self.details_widget = QWidget()
-            self.details_widget.hide()
-            self.main_layout.addWidget(self.details_widget, 0)
+        """Initializes the details panel with a persistent stack to avoid window flickering/resizing."""
+        from PyQt6.QtWidgets import QStackedWidget
+
+        self.details_panel_stack = QStackedWidget()
+        self.details_panel_stack.setMinimumWidth(470)
+        self.main_container_layout.addWidget(self.details_panel_stack, 2)
+
+        # Index 0: Placeholder
+        self._placeholder_widget = self._create_placeholder_widget()
+        self.details_panel_stack.addWidget(self._placeholder_widget)
+
+        # Index 1: Actual Details View (Container for header/stats/footer stacks)
+        self.details_widget = QWidget()
+        self.details_widget.setObjectName("persistentDetails")
+        self.details_container_layout = QVBoxLayout(self.details_widget)
+        self.details_container_layout.setContentsMargins(0, 0, 0, 0)
+        self.details_container_layout.setSpacing(0)
+
+        from PyQt6.QtWidgets import QGraphicsOpacityEffect
+
+        self.header_stack = QStackedWidget()
+        self.stats_stack = QStackedWidget()
+        self.footer_stack = QStackedWidget()
+
+        # Lock the heights to prevent window jumping
+        self.header_stack.setMinimumHeight(420)
+        self.stats_stack.setFixedHeight(220)
+        self.footer_stack.setMinimumHeight(90)
+
+        self.details_container_layout.addWidget(self.header_stack)
+        self.details_container_layout.addWidget(self.stats_stack)
+        self.details_container_layout.addWidget(self.footer_stack)
+
+        # Setup opacity effects for header
+        self.header_opacity = QGraphicsOpacityEffect(self.header_stack)
+        self.header_stack.setGraphicsEffect(self.header_opacity)
+
+        self.details_panel_stack.addWidget(self.details_widget)
+
+        # Initial state: Show placeholder
+        self.details_panel_stack.setCurrentIndex(0)
+
+    def _create_placeholder_widget(self):
+        """Creates and returns the beautiful placeholder widget."""
+        widget = QWidget()
+        widget.setMinimumHeight(700)
+        widget.setObjectName("detailsPlaceholder")
+
+        # Theme-aware styling
+        is_dark_mode = theme_manager.night_mode
+        bg_color = "#002B5A" if is_dark_mode else "#CCE5FF"
+        text_color = "#94a3b8" if is_dark_mode else "#003A70"
+
+        widget.setStyleSheet(f"""
+            #detailsPlaceholder {{
+                background-color: {bg_color};
+                border-left: 1px solid {self.theme_vars.get("button_border", "#6A73D9")};
+                border-radius: 12px;
+                margin: 8px;
+            }}
+        """)
+
+        layout = QVBoxLayout(widget)
+        layout.setContentsMargins(40, 20, 40, 20)
+        layout.setAlignment(Qt.AlignmentFlag.AlignCenter)
+
+        # Pokéball Icon
+        icon_label = QLabel()
+        pixmap = QPixmap(str(icon_path))
+        if not pixmap.isNull():
+            scaled_pixmap = pixmap.scaled(
+                180,
+                180,
+                Qt.AspectRatioMode.KeepAspectRatio,
+                Qt.TransformationMode.SmoothTransformation,
+            )
+            icon_label.setPixmap(scaled_pixmap)
+        icon_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
+
+        # Main Prompt
+        prompt_label = QLabel("Choose a Pokémon to view its stats")
+        prompt_label.setWordWrap(True)
+        prompt_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        prompt_label.setStyleSheet(
+            f"color: {text_color}; font-size: 20px; font-weight: 800; margin-top: 25px;"
+        )
+
+        # Subtext
+        count = getattr(self, "_total_pokemon_count", 0)
+        summary_label = QLabel(f"PC Inventory: {count} Pokémon")
+        summary_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        summary_label.setStyleSheet(
+            "color: #64748b; font-size: 13px; font-style: italic; margin-top: 10px;"
+        )
+
+        layout.addStretch(1)
+        layout.addWidget(icon_label)
+        layout.addWidget(prompt_label)
+        layout.addWidget(summary_label)
+        layout.addStretch(1)
+        return widget
+
+    def _show_placeholder_details(self):
+        """Switches the details panel to placeholder mode."""
+        if hasattr(self, "details_panel_stack"):
+            self.details_panel_stack.setCurrentIndex(0)
+        self._selected_individual_id = None
+        self._refresh_slot_selection()
 
     def refresh_pokemon_grid(self, recompute_bff: bool = True):
         """
         Clears and rebuilds the grid.
-
-        Args:
-            recompute_bff (bool): When ``True`` (the default, used by every
-                external data-mutating caller — catch, evolve, trade, release,
-                fossil, main-pick), the BFF is recomputed via SQL. Pure layout
-                re-renders (resize, pagination, filter changes, selection) pass
-                ``False`` so the cached BFF is reused, avoiding the per-render
-                ``json_extract`` query. A pending dirty flag forces a recompute
-                regardless (e.g. after the window is shown).
         """
-        if self.pokemon_grid is None:
+        if not is_alive(self.pokemon_grid):
             return
 
+        self._pokemon_cache = None  # Invalidate database cache
         clear_layout(self.pokemon_grid)
         self.gif_in_collection = self.settings.get("gui.gif_in_collection")
-        # The day/night clock and the friendship-specific evolution badges are
-        # part of the friendship/time feature, which is behind a master toggle.
+
+        # The day/night clock and badges are part of the friendship/time feature
         friendship_time_enabled = self.settings.get(
             "evolution.friendship_time_enabled", True
         )
 
-        pokemon_list = self.fetch_filtered_pokemon()
+        self._filtered_pokemon = self.fetch_filtered_pokemon()
+        pokemon_list = self._filtered_pokemon
         max_box_idx = max(0, (len(pokemon_list) - 1) // (self.n_rows * self.n_cols))
 
         if self.current_box_idx > max_box_idx:
@@ -645,8 +1316,7 @@ class PokemonPC(QDialog):
                 )
             )
 
-        # Keep the day/night indicator current on every render, but only when
-        # the friendship/time feature is enabled — otherwise hide it.
+        # Update day/night label
         if self.time_label is not None:
             if friendship_time_enabled:
                 self.time_label.setText(current_time_label())
@@ -654,14 +1324,12 @@ class PokemonPC(QDialog):
             else:
                 self.time_label.hide()
 
-        # Resolve the BFF (highest-friendship Pokémon). Recompute only when the
-        # caller signals a possible data change or a prior invalidation is
-        # pending; otherwise reuse the cached value so plain re-renders
-        # (resize/pagination/filter/selection) skip the SQL query.
+        # Resolve the BFF (highest-friendship Pokémon)
         if recompute_bff or self._bff_dirty:
-            self._bff_id = self._compute_bff_id()
-            self._bff_dirty = False
+            self._update_bff()
         bff_id = self._bff_id
+
+        self._update_count_label()
 
         start_index = self.current_box_idx * self.n_rows * self.n_cols
         pokemon_list_slice = pokemon_list[
@@ -675,7 +1343,7 @@ class PokemonPC(QDialog):
             for col in range(self.n_cols):
                 pokemon_idx = row * self.n_cols + col
                 if pokemon_idx >= len(pokemon_list_slice):
-                    empty_label = QLabel()
+                    empty_label = QLabel(self.grid_container)
                     empty_label.setFixedSize(self.slot_size, self.slot_size)
                     self.pokemon_grid.addWidget(
                         empty_label, row, col, alignment=Qt.AlignmentFlag.AlignCenter
@@ -689,17 +1357,17 @@ class PokemonPC(QDialog):
                     pokemon["id"],
                     pokemon.get("shiny", False),
                     pokemon["gender"],
+                    pokemon.get("name"),
                 )
-                pokemon_button = PokemonSlotButton("")
+                pokemon_button = PokemonSlotButton("", self.grid_container)
+                pokemon_button.setObjectName("pokemonSlot")
                 pokemon_button.setFixedSize(self.slot_size, self.slot_size)
 
-                # BFF (highest friendship) takes visual precedence over Favorite.
-                is_bff = (
-                    bff_id is not None
-                    and pokemon.get("individual_id") == bff_id
-                )
+                # BFF (highest friendship) takes visual precedence
+                is_bff = bff_id is not None and pokemon.get("individual_id") == bff_id
+
                 if is_bff:
-                    bg = "#FF69B4"  # Hot pink
+                    bg = "#FF69B4"  # Hot pink for BFF
                     h_bg = "#FF8DC7"
                 elif pokemon.get("is_favorite"):
                     bg = theme_vars["favorite_color"]
@@ -707,8 +1375,14 @@ class PokemonPC(QDialog):
                 else:
                     bg = theme_vars["slot_bg_color"]
                     h_bg = theme_vars["hover_color"]
+
+                # Store base colours so _refresh_slot_selection can build the full sheet
+                pokemon_button._base_bg = bg
+                pokemon_button._hover_bg = h_bg
+                pokemon_button._border = border
                 pokemon_button.setStyleSheet(
-                    f"QPushButton {{ background-color: {bg}; border: 1px solid {border}; border-radius: 5px; }} QPushButton:hover {{ background-color: {h_bg}; }}"
+                    f"QPushButton {{ background-color: {bg}; border: 1px solid {border}; border-radius: 5px; }}"
+                    f" QPushButton:hover {{ background-color: {h_bg}; }}"
                 )
 
                 # Connect signals
@@ -722,13 +1396,17 @@ class PokemonPC(QDialog):
                         pb, pkmn
                     )
                 )
+                pokemon_button._individual_id = pokemon["individual_id"]
                 self.pokemon_grid.addWidget(
                     pokemon_button, row, col, alignment=Qt.AlignmentFlag.AlignCenter
                 )
 
                 if self.gif_in_collection:
                     scaled_movie_label = ScaledMovieLabel(
-                        pkmn_image_path, self.slot_size - 10, self.slot_size - 10
+                        pkmn_image_path,
+                        self.slot_size - 10,
+                        self.slot_size - 10,
+                        self.grid_container,
                     )
                     scaled_movie_label.setAttribute(
                         Qt.WidgetAttribute.WA_TransparentForMouseEvents
@@ -745,21 +1423,22 @@ class PokemonPC(QDialog):
                         QSize(self.slot_size - 10, self.slot_size - 10)
                     )
 
-                # Collect badge meanings so the same info is reachable on hover.
-                # The badge QLabels below are WA_TransparentForMouseEvents (so the
-                # slot stays clickable), which means *their* tooltips never fire —
-                # we mirror the explanation onto the slot button, which does
-                # receive hover events.
+                # Overlays (Heart for BFF, Star/Moon/Sun for Evolution)
                 badge_tooltips = []
+                readiness = evolution_readiness(pokemon)
 
-                # Badge overlays, added last so they paint on top of the sprite.
-                # Heart on the BFF slot (top-left corner).
                 if is_bff:
-                    heart_badge = QLabel("💖")
+                    heart_badge = QLabel("💖", self.grid_container)
                     heart_badge.setAttribute(
                         Qt.WidgetAttribute.WA_TransparentForMouseEvents
                     )
-                    heart_badge.setStyleSheet("background: transparent;")
+                    heart_badge.setStyleSheet(
+                        "QLabel {"
+                        "  margin-top: 5px;"
+                        "  margin-left: 5px;"
+                        "  background: transparent;"
+                        "}"
+                    )
                     self.pokemon_grid.addWidget(
                         heart_badge,
                         row,
@@ -767,34 +1446,47 @@ class PokemonPC(QDialog):
                         alignment=Qt.AlignmentFlag.AlignTop
                         | Qt.AlignmentFlag.AlignLeft,
                     )
-                    badge_tooltips.append("💖 Your best friend (highest friendship)")
+                    badge_tooltips.append(self.translator.translate("bff_tooltip"))
 
-                # Sparkle on Pokémon ready to evolve (friendship or level-up) —
-                # top-right. The level-up case mostly surfaces rejected/Everstone/
-                # caught-high mons (a plain level-ready mon auto-evolves on level
-                # up). The 🌙/☀️ wait badge below stays friendship-only because
-                # required_time is None for level evolutions.
-                readiness = evolution_readiness(
-                    {
-                        "id": pokemon["id"],
-                        "friendship": pokemon.get("friendship", 0),
-                        "everstone": pokemon.get("everstone", False),
-                        "evolution_rejected": pokemon.get("evolution_rejected", False),
-                        "level": pokemon.get("level", 1),
-                    }
-                )
-                # Friendship/time evolution is behind a master toggle; its badges
-                # only show when enabled. Level-up evolution is base-game and
-                # always shows its ✨ badge.
                 if readiness["ready"] and (
                     readiness["method"] == "level" or friendship_time_enabled
                 ):
-                    evo_badge = QLabel("✨")
+                    evo_badge = QLabel(self.grid_container)
                     evo_badge.setAttribute(
                         Qt.WidgetAttribute.WA_TransparentForMouseEvents
                     )
-                    evo_badge.setStyleSheet("background: transparent;")
-                    evo_badge.setToolTip(readiness["status_text"])
+                    evo_badge.setFixedSize(
+                        23, 23
+                    )  # Slightly larger size to accommodate margins cleanly
+
+                    # Load the generated high-quality PNG asset
+                    badge_path = addon_dir / "addon_sprites" / "evolution_indicator.png"
+                    if badge_path.exists():
+                        pixmap = QPixmap(str(badge_path))
+                        scaled_pixmap = pixmap.scaled(
+                            18,
+                            18,
+                            Qt.AspectRatioMode.KeepAspectRatio,
+                            Qt.TransformationMode.SmoothTransformation,
+                        )
+                        evo_badge.setPixmap(scaled_pixmap)
+                        evo_badge.setStyleSheet(
+                            "margin-top: 2px; margin-right: 1px; background: transparent;"
+                        )
+                    else:
+                        # Fallback to plain text ⇈ if asset is not found
+                        evo_badge.setText("⇈")
+                        evo_badge.setStyleSheet(
+                            "QLabel {"
+                            "  color: #3b82f6;"
+                            "  font-weight: bold;"
+                            "  margin-top: 2px;"
+                            "  margin-right: 1px;"
+                            "  background: transparent;"
+                            "}"
+                        )
+
+                    evo_badge.setAlignment(Qt.AlignmentFlag.AlignCenter)
                     self.pokemon_grid.addWidget(
                         evo_badge,
                         row,
@@ -802,7 +1494,7 @@ class PokemonPC(QDialog):
                         alignment=Qt.AlignmentFlag.AlignTop
                         | Qt.AlignmentFlag.AlignRight,
                     )
-                    badge_tooltips.append(f"✨ {readiness['status_text']}")
+                    badge_tooltips.append(self.translator.translate("badge_ready"))
                 elif (
                     friendship_time_enabled
                     and readiness["evolvable"]
@@ -810,19 +1502,18 @@ class PokemonPC(QDialog):
                     and not readiness["time_ok"]
                     and readiness["required_time"]
                 ):
-                    # Friendship requirement is met — only the time of day is
-                    # blocking. Show a sun/moon so the player knows to come back
-                    # during the day / at night (full text is in the details
-                    # panel and the day/night label at the top of the PC).
-                    wait_icon = (
-                        "🌙" if readiness["required_time"] == "night" else "☀️"
-                    )
-                    wait_badge = QLabel(wait_icon)
+                    wait_icon = "🌙" if readiness["required_time"] == "night" else "☀️"
+                    wait_badge = QLabel(wait_icon, self.grid_container)
                     wait_badge.setAttribute(
                         Qt.WidgetAttribute.WA_TransparentForMouseEvents
                     )
-                    wait_badge.setStyleSheet("background: transparent;")
-                    wait_badge.setToolTip(readiness["status_text"])
+                    wait_badge.setStyleSheet(
+                        "QLabel {"
+                        "  margin-top: 5px;"
+                        "  margin-right: 5px;"
+                        "  background: transparent;"
+                        "}"
+                    )
                     self.pokemon_grid.addWidget(
                         wait_badge,
                         row,
@@ -830,34 +1521,49 @@ class PokemonPC(QDialog):
                         alignment=Qt.AlignmentFlag.AlignTop
                         | Qt.AlignmentFlag.AlignRight,
                     )
-                    badge_tooltips.append(f"{wait_icon} {readiness['status_text']}")
-
-                # Mirror the badge meaning(s) onto the (hover-capable) slot button
-                # so the otherwise-unreachable badge tooltips become discoverable.
+                    key = (
+                        "badge_wait_night"
+                        if readiness["required_time"] == "night"
+                        else "badge_wait_day"
+                    )
+                    badge_tooltips.append(self.translator.translate(key))
                 if badge_tooltips:
                     pokemon_button.setToolTip("\n".join(badge_tooltips))
+        self._update_count_label()
+        self._refresh_slot_selection()
 
-    def _compute_bff_id(self):
-        """Return the individual_id of the highest-friendship Pokémon.
+    def _update_count_label(self):
+        shown = len(self._filtered_pokemon) if hasattr(self, "_filtered_pokemon") else 0
+        total = self._total_pokemon_count
+        if hasattr(self, "count_label"):
+            self.count_label.setText(f"Showing {shown:,} / {total:,} Pokémon")
 
-        The BFF is computed (not stored): the single Pokémon with the highest
-        friendship across the whole collection, ignoring any with friendship 0.
-        Ties are broken deterministically by ``rowid`` (oldest wins). Returns
-        ``None`` if every Pokémon has 0 friendship or on query failure.
-        """
-        try:
-            cursor = mw.ankimon_db.execute(
-                "SELECT individual_id FROM captured_pokemon "
-                "WHERE CAST(json_extract(data, '$.friendship') AS INTEGER) > 0 "
-                "ORDER BY CAST(json_extract(data, '$.friendship') AS INTEGER) DESC, "
-                "rowid ASC LIMIT 1"
-            )
-            row = cursor.fetchone()
-            return row["individual_id"] if row else None
-        except Exception as e:
-            if self.logger:
-                self.logger.log("error", f"Error computing BFF: {e}")
-            return None
+    def _refresh_slot_selection(self):
+        for i in range(self.pokemon_grid.count()):
+            item = self.pokemon_grid.itemAt(i)
+            if not item:
+                continue
+            widget = item.widget()
+            if isinstance(widget, PokemonSlotButton):
+                pkmn_id = getattr(widget, "_individual_id", None)
+                is_selected = pkmn_id == self._selected_individual_id
+                bg = getattr(widget, "_base_bg", "transparent")
+                h_bg = getattr(widget, "_hover_bg", "transparent")
+                border = getattr(widget, "_border", "#888")
+                if is_selected:
+                    sheet = (
+                        f"QPushButton {{ background-color: {bg}; border: 3px solid #ffffff;"
+                        f" border-radius: 8px; }}"
+                        f" QPushButton:hover {{ background-color: rgba(255,255,255,0.15);"
+                        f" border-color: #f0f0f0; }}"
+                    )
+                else:
+                    sheet = (
+                        f"QPushButton {{ background-color: {bg}; border: 1px solid {border};"
+                        f" border-radius: 5px; }}"
+                        f" QPushButton:hover {{ background-color: {h_bg}; }}"
+                    )
+                widget.setStyleSheet(sheet)
 
     def navigate_box(self, delta):
         """
@@ -890,8 +1596,7 @@ class PokemonPC(QDialog):
         if new_cols != self.n_cols or new_rows != self.n_rows:
             self.n_cols = new_cols
             self.n_rows = new_rows
-            # Resize is pure layout — reuse the cached BFF.
-            self.refresh_pokemon_grid(recompute_bff=False)
+            self.refresh_pokemon_grid()
 
     def calculate_grid_dimensions(self):
         """
@@ -908,20 +1613,19 @@ class PokemonPC(QDialog):
 
         return int(new_cols), int(new_rows)
 
-    def refresh_gui(self, recompute_bff: bool = True):
+    def refresh_gui(self):
         """
-        Refreshes the entire graphical user interface by rebuilding its structure
-        and then populating the grid.
-
-        Args:
-            recompute_bff (bool): Forwarded to :meth:`refresh_pokemon_grid`.
-                Defaults to ``True`` because the data-mutating callers
-                (favorite toggle, give/remove item, release/trade/rename/evolve
-                via ``refresh_callback``) need a fresh BFF. Non-mutating callers
-                (theme change, selecting a Pokémon) pass ``False``.
+        Refreshes the user interface by populating the grid.
+        Avoids calling create_gui() to prevent full layout rebuilds.
         """
-        self.create_gui()
-        self.refresh_pokemon_grid(recompute_bff=recompute_bff)
+        self._pokemon_cache = None  # Invalidate database cache
+        if not self.layout():
+            self.create_gui()
+        else:
+            self.refresh_pokemon_grid()
+            # If no Pokémon is selected (e.g. after account swap), refresh the placeholder
+            if self._selected_individual_id is None:
+                self._show_placeholder_details()
         self.layout().invalidate()
         self.layout().activate()
 
@@ -937,9 +1641,7 @@ class PokemonPC(QDialog):
             - Refreshes the Pokémon grid to display the selected box's contents.
         """
         self.current_box_idx = idx
-        # Pagination and filter changes route through here; neither alters which
-        # Pokémon is the BFF (it spans the whole collection), so reuse the cache.
-        self.refresh_pokemon_grid(recompute_bff=False)
+        self.refresh_pokemon_grid()
 
     def looparound_go_to_box(self, idx: int, max_idx: int):
         """
@@ -989,17 +1691,55 @@ class PokemonPC(QDialog):
         return pixmap
 
     def fetch_filtered_pokemon(self) -> list:
-        """Dynamically builds a SQL query to filter and sort Pokemon, fetching only the lightweight stub data needed for the grid."""
+        """
+        Dynamically builds a SQL query to filter and sort Pokemon, fetching only the lightweight stub data needed for the grid.
+        Results are cached to improve performance when navigating boxes or selecting Pokémon.
+        """
+        # Always fetch latest count to detect DB changes
+        try:
+            cursor = services.db.execute("SELECT COUNT(*) FROM captured_pokemon")
+            self._total_pokemon_count = cursor.fetchone()[0]
+        except Exception:
+            pass
+
+        # Build current filter state for cache check
+        current_state = {
+            "db": services.db.db_path.name,
+            "search": self.search_edit.text() if self.search_edit else "",
+            "type": self.type_combo.currentText() if self.type_combo else "All types",
+            "gen": self.generation_combo.currentText()
+            if self.generation_combo
+            else "All gens",
+            "tier": self.tier_combo.currentText() if self.tier_combo else "All tiers",
+            "shiny": self.filter_shiny.isChecked() if self.filter_shiny else False,
+            "favorite": self.filter_favorites.isChecked()
+            if self.filter_favorites
+            else False,
+            "holding": self.filter_is_holding_item.isChecked()
+            if self.filter_is_holding_item
+            else False,
+            "sort": self.sort_combo.currentText() if self.sort_combo else "Date",
+            "desc": self.desc_sort.isChecked() if self.desc_sort else False,
+            "count": self._total_pokemon_count,  # Force refresh if count changes
+        }
+
+        if self._pokemon_cache is not None and self._last_filter_state == current_state:
+            return self._pokemon_cache
+
         # Base query mapping direct virtual columns where available
         query_parts = [
             "SELECT individual_id, name, level, pokedex_id as id, shiny as shiny, "
             "rowid as original_index, json_extract(data, '$.nickname') as nickname, "
             "json_extract(data, '$.gender') as gender, json_extract(data, '$.is_favorite') as is_favorite, "
             "json_extract(data, '$.held_item') as held_item, "
+            "json_extract(data, '$.captured_date') as captured_date, "
             "json_extract(data, '$.friendship') as friendship, "
             "json_extract(data, '$.everstone') as everstone, "
             "json_extract(data, '$.evolution_rejected') as evolution_rejected, "
-            "json_extract(data, '$.iv') as iv_json, json_extract(data, '$.ev') as ev_json "
+            "json_extract(data, '$.iv') as iv_json, json_extract(data, '$.ev') as ev_json, "
+            "json_extract(data, '$.base_stats') as base_stats_json, json_extract(data, '$.stats') as stats_json, json_extract(data, '$.nature') as nature, "
+            "json_extract(data, '$.attacks') as attacks_json, "
+            "json_extract(data, '$.pokemon_defeated') as pokemon_defeated "
             "FROM captured_pokemon WHERE 1=1"
         ]
         params = []
@@ -1007,7 +1747,9 @@ class PokemonPC(QDialog):
         # Name / Nickname filtering
         if self.search_edit is not None and self.search_edit.text():
             search_text = f"%{self.search_edit.text()}%"
-            query_parts.append("AND (name LIKE ? OR json_extract(data, '$.nickname') LIKE ?)")
+            query_parts.append(
+                "AND (name LIKE ? OR json_extract(data, '$.nickname') LIKE ?)"
+            )
             params.extend([search_text, search_text])
 
         # Type filtering
@@ -1026,7 +1768,10 @@ class PokemonPC(QDialog):
             query_parts.append("AND json_extract(data, '$.is_favorite') = 1")
 
         # Held item filtering
-        if self.filter_is_holding_item is not None and self.filter_is_holding_item.isChecked():
+        if (
+            self.filter_is_holding_item is not None
+            and self.filter_is_holding_item.isChecked()
+        ):
             query_parts.append("AND json_extract(data, '$.held_item') IS NOT NULL")
 
         # Shiny filtering
@@ -1046,7 +1791,7 @@ class PokemonPC(QDialog):
                     6: (650, 721),
                     7: (722, 809),
                     8: (810, 905),
-                    9: (906, 1025)
+                    9: (906, 1025),
                 }
                 if gen_idx in gen_ranges:
                     start_id, end_id = gen_ranges[gen_idx]
@@ -1054,9 +1799,25 @@ class PokemonPC(QDialog):
                     params.extend([start_id, end_id])
 
         # Sorting
-        sort_key_str = self.selected_sort_key.lower() if hasattr(self, 'selected_sort_key') else "date"
+        sort_key_raw = (
+            self.selected_sort_key if hasattr(self, "selected_sort_key") else "Date"
+        )
+        sort_key_str = sort_key_raw.lower()
         reverse = self.desc_sort is not None and self.desc_sort.isChecked()
         direction = "DESC" if reverse else "ASC"
+
+        # Determine if we use SQL sorting or Python sorting
+        use_python_sort = False
+        stat_map = {
+            "hp": "hp",
+            "attack": "atk",
+            "defense": "def",
+            "sp. atk": "spa",
+            "sp. def": "spd",
+            "speed": "spe",
+        }
+
+        target_stat = stat_map.get(sort_key_str)
 
         if sort_key_str == "date":
             order_clause = f"ORDER BY original_index {direction}"
@@ -1067,20 +1828,26 @@ class PokemonPC(QDialog):
         elif sort_key_str == "id":
             order_clause = f"ORDER BY pokedex_id {direction}"
         elif sort_key_str == "cp":
-            order_clause = f"ORDER BY CAST(json_extract(data, '$.cp') AS REAL) {direction}"
+            use_python_sort = True
+            order_clause = f"ORDER BY original_index {direction}"
+        elif sort_key_str in ["iv (total)", "ev (total)", "iv", "ev"]:
+            # Fallback for legacy keys if they appear
+            use_python_sort = True
+            order_clause = f"ORDER BY original_index {direction}"
+        elif target_stat:
+            use_python_sort = True
+            order_clause = f"ORDER BY original_index {direction}"
         elif sort_key_str == "friendship":
-            # COALESCE so a missing/NULL friendship sorts as 0 (grouped with the
-            # zero-friendship Pokémon) instead of NULL drifting to an extreme
-            # end of the list under ASC/DESC.
-            order_clause = f"ORDER BY CAST(COALESCE(json_extract(data, '$.friendship'), 0) AS INTEGER) {direction}"
+            use_python_sort = True
+            order_clause = f"ORDER BY original_index {direction}"
         else:
-            # For IV/EV or default, sort by original_index first, then override in Python if needed
+            # Default to Date
             order_clause = f"ORDER BY original_index {direction}"
 
         query = " ".join(query_parts) + " " + order_clause
 
         try:
-            cursor = mw.ankimon_db.execute(query, tuple(params))
+            cursor = services.db.execute(query, tuple(params))
             results = []
             for row in cursor.fetchall():
                 p = {
@@ -1094,31 +1861,93 @@ class PokemonPC(QDialog):
                     "gender": row["gender"],
                     "is_favorite": bool(row["is_favorite"]),
                     "held_item": row["held_item"],
-                    "friendship": row["friendship"] or 0,
+                    "friendship": int(row["friendship"] or 0),
                     "everstone": bool(row["everstone"]),
                     "evolution_rejected": bool(row["evolution_rejected"]),
+                    "attacks": json.loads(row["attacks_json"])
+                    if row["attacks_json"]
+                    else [],
+                    "pokemon_defeated": int(row["pokemon_defeated"] or 0),
                 }
 
-                # Pre-calculate sums for sorting if needed
-                if sort_key_str in ["iv", "ev"]:
-                    stats_json = row[f"{sort_key_str}_json"]
-                    stats_dict = json.loads(stats_json) if stats_json else {}
-                    p["_sort_value"] = sum(stats_dict.values()) if isinstance(stats_dict, dict) else sum(stats_dict) if isinstance(stats_dict, list) else 0
-                
+                # Pre-calculate sums/stats for sorting if needed
+                if use_python_sort:
+                    if sort_key_str == "friendship":
+                        p["_sort_value"] = row["friendship"] or 0
+                    elif "iv" in sort_key_str or "ev" in sort_key_str:
+                        key = "iv" if "iv" in sort_key_str else "ev"
+                        stats_json = row[f"{key}_json"]
+                        stats_dict = json.loads(stats_json) if stats_json else {}
+                        p["_sort_value"] = (
+                            sum(stats_dict.values())
+                            if isinstance(stats_dict, dict)
+                            else sum(stats_dict)
+                            if isinstance(stats_dict, list)
+                            else 0
+                        )
+                    elif target_stat:
+                        # Individual Stat sorting
+                        level = row["level"]
+                        nature = row["nature"] or "serious"
+
+                        iv_dict = json.loads(row["iv_json"]) if row["iv_json"] else {}
+                        ev_dict = json.loads(row["ev_json"]) if row["ev_json"] else {}
+                        base_stats_dict = (
+                            json.loads(row["base_stats_json"])
+                            if row["base_stats_json"]
+                            else {}
+                        )
+                        stats_dict = (
+                            json.loads(row["stats_json"]) if row["stats_json"] else {}
+                        )
+
+                        # Use PokemonObject's calculation logic (with fallback for legacy stats)
+                        base_val = (base_stats_dict or stats_dict).get(target_stat, 1)
+                        iv_val = iv_dict.get(target_stat, 0)
+                        ev_val = ev_dict.get(target_stat, 0)
+
+                        p["_sort_value"] = PokemonObject.calc_stat(
+                            target_stat, base_val, level, iv_val, ev_val, nature
+                        )
+                    elif sort_key_str == "cp":
+                        # Re-calculate CP for sorting to ensure it uses the new formula
+                        iv_dict = json.loads(row["iv_json"]) if row["iv_json"] else {}
+                        ev_dict = json.loads(row["ev_json"]) if row["ev_json"] else {}
+                        base_stats_dict = (
+                            json.loads(row["base_stats_json"])
+                            if row["base_stats_json"]
+                            else {}
+                        )
+                        stats_dict = (
+                            json.loads(row["stats_json"]) if row["stats_json"] else {}
+                        )
+
+                        # Mirror calculate_cp_from_dict's contract: prefer base_stats, else stats fallback
+                        cp_dict = {"level": row["level"], "iv": iv_dict, "ev": ev_dict}
+                        if base_stats_dict:
+                            cp_dict["base_stats"] = base_stats_dict
+                        else:
+                            cp_dict["stats"] = stats_dict
+                        p["_sort_value"] = calculate_cp_from_dict(cp_dict)
+
                 results.append(p)
-                
-            # Perform Python sorting for IV/EV
-            if sort_key_str in ["iv", "ev"]:
+
+            # Perform Python sorting
+            if use_python_sort:
                 results.sort(key=lambda x: x.get("_sort_value", 0), reverse=reverse)
-            
+
+            # Cache the result
+            self._pokemon_cache = results
+            self._last_filter_state = current_state
+
             return results
         except Exception as e:
             if self.logger:
                 self.logger.log("error", f"Error fetching filtered pokemon: {e}")
             return []
 
-    def on_sort_button_clicked(self, button):
-        self.selected_sort_key = button.text()
+    def on_sort_changed(self, text):
+        self.selected_sort_key = text
         self.go_to_box(0)
 
     def show_actions_submenu(self, button: QPushButton, pokemon: dict[str, Any]):
@@ -1166,8 +1995,14 @@ class PokemonPC(QDialog):
         give_held_item = QAction("Give a held item", self)
 
         # Connect actions to methods or lambda functions
-        pokemon_details_action.triggered.connect(lambda: self.show_pokemon_details(pokemon))
-        main_pokemon_action.triggered.connect(lambda: self.main_pokemon_function_callback(mw.ankimon_db.get_pokemon(pokemon['individual_id'])))
+        pokemon_details_action.triggered.connect(
+            lambda: self.show_pokemon_details(pokemon)
+        )
+        main_pokemon_action.triggered.connect(
+            lambda: self.main_pokemon_function_callback(
+                services.db.get_pokemon(pokemon["individual_id"])
+            )
+        )
         make_favorite_action.triggered.connect(lambda: self.toggle_favorite(pokemon))
         give_held_item.triggered.connect(lambda: self.give_held_item(pokemon))
 
@@ -1188,25 +2023,50 @@ class PokemonPC(QDialog):
     def show_pokemon_details(self, pokemon_stub):
         """
         Displays detailed information about a specific Pokémon in the right-hand details panel.
-
-        The method prepares detailed stats by merging base stats or stats with experience points,
-        then updates the `self.details_layout` with a `PokemonCollectionDetails` layout.
-
-        Args:
-            pokemon_stub (dict): A lightweight dictionary containing the pokemon's `individual_id`.
+        Only the header and footer parts animate; the stats box stays persistent for smooth bar sliding.
         """
-        pokemon = mw.ankimon_db.get_pokemon(pokemon_stub['individual_id'])
+        individual_id = pokemon_stub.get("individual_id")
+        is_same_pokemon = individual_id is not None and individual_id == getattr(
+            self, "_selected_individual_id", None
+        )
+
+        pokemon = services.db.get_pokemon(individual_id)
         if not pokemon:
             return
 
-        if pokemon.get('base_stats'):
-            detail_stats = {**pokemon['base_stats'], "xp": pokemon.get("xp", 0)}
-        elif pokemon.get('stats'):
-            detail_stats = {**pokemon['stats'], "xp": pokemon.get("xp", 0)}
+        if pokemon.get("base_stats"):
+            detail_stats = {**pokemon["base_stats"], "xp": pokemon.get("xp", 0)}
+        elif pokemon.get("stats"):
+            detail_stats = {**pokemon["stats"], "xp": pokemon.get("xp", 0)}
         else:
             raise ValueError("Could not get the stats information of the Pokémon")
 
-        self.pokemon_details_layout = PokemonCollectionDetails(
+        # Switch to details view if not already there
+        if hasattr(self, "details_panel_stack"):
+            self.details_panel_stack.setCurrentIndex(1)
+
+        # Get previous stats for sliding bar animation
+        old_stats = getattr(self, "_last_pokemon_stats", None)
+
+        def trigger_evo(method):
+            """Manual evolution trigger from the PC Details panel."""
+            readiness = evolution_readiness(pokemon)
+            if readiness["ready"]:
+                evo_window = EvoWindow(
+                    self.logger,
+                    self.settings,
+                    self.main_pokemon,
+                    self.translator,
+                    self.reviewer_obj,
+                    self.test_window,
+                    services.achievements,
+                )
+                evo_window.ask_pokemon_evo(
+                    pokemon["individual_id"], pokemon["id"], readiness["evo_id"]
+                )
+
+        # Build new widgets from components
+        h_widget, stats_tabs, f_widget, current_stats = PokemonCollectionDetailsSplit(
             name=pokemon["name"],
             level=pokemon["level"],
             id=pokemon["id"],
@@ -1224,30 +2084,224 @@ class PokemonPC(QDialog):
             individual_id=pokemon.get("individual_id"),
             pokemon_defeated=pokemon.get("pokemon_defeated", 0),
             everstone=pokemon.get("everstone", False),
-            evolution_rejected=pokemon.get("evolution_rejected", False),
             captured_date=pokemon.get("captured_date", "Missing"),
             language=int(self.settings.get("misc.language")),
             gif_in_collection=self.gif_in_collection,
             remove_levelcap=self.settings.get("misc.remove_level_cap"),
             logger=self.logger,
-            refresh_callback=self.refresh_gui,
+            refresh_callback=lambda: (
+                self.refresh_gui(),
+                self.show_pokemon_details(pokemon_stub),
+            ),
             initial_tab_index=self.current_stats_tab_index,
             tab_changed_callback=self.on_stats_tab_changed,
             nature=pokemon.get("nature", "serious"),
             base_stats=pokemon.get("base_stats"),
+            old_stats=old_stats,
             friendship=pokemon.get("friendship", 0),
-            friendship_time_enabled=self.settings.get(
-                "evolution.friendship_time_enabled", True
-            ),
+            evolution_rejected=pokemon.get("evolution_rejected", False),
+            trigger_evo_callback=trigger_evo,
         )
-        # Selecting a Pokémon only opens the details panel — no data change, so
-        # reuse the cached BFF. (The refresh_callback above keeps the default
-        # recompute=True for mutating actions like release/trade/rename/evolve.)
-        self.refresh_gui(recompute_bff=False)
+
+        self._last_pokemon_stats = current_stats
+
+        # Update Stacks (Zero Flicker Swap)
+        def swap_stack_widget(stack, new_widget):
+            old_widget = stack.currentWidget()
+            stack.addWidget(new_widget)
+            stack.setCurrentWidget(new_widget)
+            if old_widget:
+                stack.removeWidget(old_widget)
+                old_widget.deleteLater()
+
+        # 1. Update Header
+        swap_stack_widget(self.header_stack, h_widget)
+
+        # 2. Update Stats (No fade)
+        swap_stack_widget(self.stats_stack, stats_tabs)
+
+        # 3. Update Footer
+        swap_stack_widget(self.footer_stack, f_widget)
+
+        # --- Post-processing: Move Manager (Improvement B) ---
+        self._integrate_move_manager(pokemon)
+
+        # --- Post-processing: Nature Indicators (Improvement G) ---
+        self._apply_nature_indicators(pokemon)
+
+        # Set initial state for animation
+        if not is_same_pokemon:
+            self.header_opacity.setOpacity(0.0)
+
+        self.details_widget.show()
+
+        # Force layout recalculation
+        self.details_container_layout.activate()
+
+        # Animation Handling
+        from PyQt6.QtCore import QPropertyAnimation, QEasingCurve
+
+        if not is_same_pokemon:
+            # Header Animation
+            self.header_fade = QPropertyAnimation(self.header_opacity, b"opacity")
+            self.header_fade.setDuration(400)
+            self.header_fade.setStartValue(0.0)
+            self.header_fade.setEndValue(1.0)
+            self.header_fade.setEasingCurve(QEasingCurve.Type.OutCubic)
+            self.header_fade.start()
+        else:
+            self.header_opacity.setOpacity(1.0)
+
+        # Selection indicator
+        self._selected_individual_id = pokemon.get("individual_id")
+        self._refresh_slot_selection()
+
+    def _integrate_move_manager(self, pokemon):
+        # Traverse layout to find TopR_layout_Box
+        try:
+            # NEW STRUCTURE: header_stack -> currentWidget (h_widget) -> layout -> first_layout -> TopR_layout_Box
+            h_widget = self.header_stack.currentWidget()
+            if h_widget:
+                h_layout = h_widget.layout()
+                # h_layout -> name_label (index 0), first_layout (index 1)
+                if h_layout and h_layout.count() > 1:
+                    first_layout_item = h_layout.itemAt(1)
+                    if first_layout_item and first_layout_item.layout():
+                        first_layout = first_layout_item.layout()
+                        # TopR_widget is at index 1 of first_layout (a QWidget wrapping TopR_layout_Box)
+                        top_r_item = first_layout.itemAt(1)
+                        if top_r_item and top_r_item.widget():
+                            top_r_layout = top_r_item.widget().layout()
+
+                    # Add new Move Manager
+                    def _save_pokemon(data):
+                        services.db.save_pokemon(data)
+                        self.show_pokemon_details(pokemon)
+
+                    # Initialize FIRST (this might be slightly heavy)
+                    new_move_manager = MoveManagerWidget(
+                        individual_id=pokemon["individual_id"],
+                        pkmn_id=pokemon["id"],
+                        logger=self.logger,
+                        save_fn=_save_pokemon,
+                        parent=self.details_widget,
+                    )
+                    self.move_manager = new_move_manager
+
+                    # Hide old buttons and label ONLY after the new one is ready
+                    evo_btn = None
+                    for i in range(top_r_layout.count()):
+                        item = top_r_layout.itemAt(i)
+                        if item and item.widget():
+                            if item.widget().objectName() == "evolveNowButton":
+                                evo_btn = item.widget()
+                                continue
+                            item.widget().hide()
+
+                    top_r_layout.addWidget(self.move_manager)
+                    if evo_btn:
+                        top_r_layout.removeWidget(evo_btn)
+                        top_r_layout.addWidget(evo_btn)
+
+        except Exception as e:
+            self.logger.log("error", f"Error integrating move manager: {e}")
+
+    def _apply_nature_indicators(self, pokemon):
+        # Normalize to Title Case so lowercase DB values (e.g. "adamant") match
+        raw_nature = pokemon.get("nature", "serious") or "serious"
+        nature = raw_nature.strip().title()
+        boosted, lowered = NATURE_EFFECTS.get(nature, ("", ""))
+        if not boosted and not lowered:
+            return
+
+        try:
+            # Use the persistent stack to find the active stats tab widget
+            stats_tabs = self.stats_stack.currentWidget()
+            if stats_tabs and isinstance(stats_tabs, QTabWidget):
+                # The first tab is typically the "Base Stats" or "Stats" page
+                stats_widget = stats_tabs.widget(0)
+                labels = stats_widget.findChildren(QLabel)
+
+                for label in labels:
+                    # Strip any previously applied indicators before matching
+                    raw_text = label.text()
+                    clean_text = (
+                        raw_text.replace(" ▲", "")
+                        .replace(" ▼", "")
+                        .replace(":", "")
+                        .strip()
+                    )
+                    clean_text_lower = clean_text.lower()
+
+                    stat_key = None
+                    # First try exact match in lower case
+                    for k, v in DISPLAY_TO_STAT_KEY.items():
+                        if k.lower() == clean_text_lower:
+                            stat_key = v
+                            break
+
+                    if not stat_key:
+                        # Fallback for substring match (e.g. "Sp. Atk" in "Special-attack" or vice versa)
+                        for k, v in DISPLAY_TO_STAT_KEY.items():
+                            kl = k.lower()
+                            if kl in clean_text_lower or clean_text_lower in kl:
+                                stat_key = v
+                                break
+
+                    if stat_key:
+                        if stat_key == boosted:
+                            label.setText(f"{clean_text} ▲")
+                            label.setStyleSheet("color: #4ade80; font-weight: bold;")
+                        elif stat_key == lowered:
+                            label.setText(f"{clean_text} ▼")
+                            label.setStyleSheet("color: #f87171; font-weight: bold;")
+        except Exception as e:
+            self.logger.log("error", f"Error applying nature indicators: {e}")
+
+    def _update_count_label(self):
+        if not hasattr(self, "count_label") or not is_alive(self.count_label):
+            return
+
+        shown = len(self._filtered_pokemon) if hasattr(self, "_filtered_pokemon") else 0
+
+        # Get total count
+        try:
+            cursor = services.db.execute("SELECT COUNT(*) FROM captured_pokemon")
+            total = cursor.fetchone()[0]
+        except Exception:
+            total = shown
+
+        self.count_label.setText(f"Showing {shown} / {total} Pokémon")
 
     def on_stats_tab_changed(self, index: int):
         """Callback to remember which tab (Stats/IV/EV) is selected."""
         self.current_stats_tab_index = index
+
+    def _update_bff(self):
+        """Resolve the BFF (highest-friendship Pokémon) and update state."""
+        self._bff_id = self._compute_bff_id()
+        self._bff_dirty = False
+
+    def _compute_bff_id(self):
+        """Return the individual_id of the highest-friendship Pokémon."""
+        try:
+            cursor = services.db.execute(
+                "SELECT individual_id FROM captured_pokemon "
+                "WHERE CAST(json_extract(data, '$.friendship') AS INTEGER) > 0 "
+                "ORDER BY CAST(json_extract(data, '$.friendship') AS INTEGER) DESC, "
+                "rowid ASC LIMIT 1"
+            )
+            row = cursor.fetchone()
+            return row["individual_id"] if row else None
+        except Exception as e:
+            if self.logger:
+                self.logger.log("error", f"Error computing BFF: {e}")
+            return None
+
+    def _update_time_display(self):
+        """Update the day/night label with current time."""
+        if self.time_label is not None and is_alive(self.time_label):
+            self.time_label.setText(current_time_label())
 
     def toggle_favorite(self, pokemon: dict[list, Any]):
         """
@@ -1265,10 +2319,10 @@ class PokemonPC(QDialog):
             - Refreshes the GUI to reflect the change.
             - Logs an info message if the Pokémon is not found in the list.
         """
-        target_pokemon = mw.ankimon_db.get_pokemon(pokemon["individual_id"])
+        target_pokemon = services.db.get_pokemon(pokemon["individual_id"])
         if target_pokemon:
             target_pokemon["is_favorite"] = not target_pokemon.get("is_favorite", False)
-            mw.ankimon_db.save_pokemon(target_pokemon)
+            services.db.save_pokemon(target_pokemon)
             self.refresh_gui()
             return
 
@@ -1296,11 +2350,11 @@ class PokemonPC(QDialog):
             - Logs and displays an info message using `ShowInfoLogger`.
             - Refreshes the GUI via `self.refresh_gui()`.
         """
-        pokemon = mw.ankimon_db.get_pokemon(pokemon_stub['individual_id'])
+        pokemon = services.db.get_pokemon(pokemon_stub["individual_id"])
         if not pokemon:
             return
 
-        items_list = mw.ankimon_db.get_all_items()
+        items_list = services.db.get_all_items()
         # Filter to holdable items (items without a type, stored in data field)
         items_names = []
         for item in items_list:
@@ -1317,6 +2371,12 @@ class PokemonPC(QDialog):
                 "info", f"{item_name} was given to {pokemon.get('name')}."
             )
             self.refresh_gui()
+
+            # Refresh open item/bag/shop windows
+            if hasattr(mw, "item_window") and is_alive(mw.item_window):
+                mw.item_window.renewWidgets()
+            if hasattr(mw, "items_web_window") and is_alive(mw.items_web_window):
+                mw.items_web_window.update_ui_data()
 
         give_item_window = GiveItemWindow(
             item_list=items_names,
@@ -1347,10 +2407,10 @@ class PokemonPC(QDialog):
             - Logs and displays an info message using `ShowInfoLogger`.
             - Refreshes the GUI via `self.refresh_gui()`.
         """
-        pokemon = mw.ankimon_db.get_pokemon(pokemon_stub['individual_id'])
+        pokemon = services.db.get_pokemon(pokemon_stub["individual_id"])
         if not pokemon:
             return
-            
+
         pokemon_obj = PokemonObject.from_dict(pokemon)
         if pokemon.get("held_item") is None:
             raise ValueError("The pokemon does not hold an item.")
@@ -1363,13 +2423,19 @@ class PokemonPC(QDialog):
         # Refreshing the PC after giving the item is important in order to update the pokemon information without the held item
         self.refresh_gui()
 
+        # Refresh open item/bag/shop windows
+        if hasattr(mw, "item_window") and is_alive(mw.item_window):
+            mw.item_window.renewWidgets()
+        if hasattr(mw, "items_web_window") and is_alive(mw.items_web_window):
+            mw.items_web_window.update_ui_data()
+
     def ensure_data_integrity(self):
         """
         Iterates through all Pokémon to ensure they have required non-stat fields,
         adding default values if fields are missing. This handles data
         from older addon versions. Stat-related fields are ignored.
         """
-        pokemon_list = mw.ankimon_db.get_all_pokemon()
+        pokemon_list = services.db.get_all_pokemon()
         if not pokemon_list:
             return
 
@@ -1384,7 +2450,6 @@ class PokemonPC(QDialog):
             "base_experience",
             "growth_rate",
             "everstone",
-            "evolution_rejected",
             "shiny",
             "captured_date",
             "individual_id",
@@ -1420,7 +2485,6 @@ class PokemonPC(QDialog):
             "base_experience": 0,
             "growth_rate": "medium",
             "everstone": False,
-            "evolution_rejected": False,
             "shiny": False,
             "captured_date": None,
             "individual_id": lambda p: str(uuid.uuid4()),
@@ -1439,6 +2503,13 @@ class PokemonPC(QDialog):
             if not isinstance(pokemon, dict):
                 continue
 
+            # Always recalculate CP to ensure it matches the current formula in business.py
+            old_cp = pokemon.get("cp")
+            new_cp = calculate_cp_from_dict(pokemon)
+            if old_cp != new_cp:
+                needs_update = True
+                pokemon_list[i]["cp"] = new_cp
+
             for key, default_generator in default_values.items():
                 if key not in pokemon:
                     needs_update = True
@@ -1450,7 +2521,7 @@ class PokemonPC(QDialog):
 
         if needs_update:
             for pokemon in pokemon_list:
-                mw.ankimon_db.save_pokemon(pokemon)
+                services.db.save_pokemon(pokemon)
 
     def on_window_close(self):
         if self.pokemon_details_layout is not None:

--- a/tests/test_pc_box_evolution_button.py
+++ b/tests/test_pc_box_evolution_button.py
@@ -269,6 +269,54 @@ def test_integrate_move_manager_replaces_evolution_button(pc_box, monkeypatch):
     assert add_calls[-1].args[0] == evo_btn_widget
 
 
+def _build_integrate_mocks():
+    """A PokemonPC-shaped mock whose header layout resolves to a row we can watch."""
+    pc = mock.MagicMock()
+    pc.details_widget = None
+    h_widget = mock.MagicMock()
+    pc.header_stack.currentWidget.return_value = h_widget
+    h_layout = mock.MagicMock()
+    h_widget.layout.return_value = h_layout
+    h_layout.count.return_value = 2
+    first_layout_item = mock.MagicMock()
+    first_layout = mock.MagicMock()
+    first_layout_item.layout.return_value = first_layout
+    h_layout.itemAt.return_value = first_layout_item
+    top_r_item = mock.MagicMock()
+    top_r_widget = mock.MagicMock()
+    top_r_item.widget.return_value = top_r_widget
+    first_layout.itemAt.return_value = top_r_item
+    top_r_layout = mock.MagicMock()
+    top_r_widget.layout.return_value = top_r_layout
+    top_r_layout.count.return_value = 0
+    top_r_layout.itemAt.side_effect = lambda idx: None
+    return pc
+
+
+def test_integrate_move_manager_retires_previous_widget(pc_box, monkeypatch):
+    """A stale MoveManagerWidget is deleteLater'd before a new one is built.
+
+    The manager is parented to the persistent ``details_widget``, not the swapped
+    header stack, so without an explicit retire it would accumulate as an orphaned
+    child on every ``show_pokemon_details`` call (memory/widget leak).
+    """
+    fake_move_manager = mock.MagicMock(name="MoveManagerWidget-new")
+    monkeypatch.setattr(
+        pc_box, "MoveManagerWidget", mock.MagicMock(return_value=fake_move_manager)
+    )
+
+    pc = _build_integrate_mocks()
+    stale = mock.MagicMock(name="MoveManagerWidget-old")  # is_alive(stale) is truthy
+    pc.move_manager = stale
+
+    pokemon = {"individual_id": "uuid-A", "id": 25, "name": "Pikachu"}
+    pc_box.PokemonPC._integrate_move_manager(pc, pokemon)
+
+    # The previous manager was retired exactly once and replaced by the new one.
+    stale.deleteLater.assert_called_once_with()
+    assert pc.move_manager is fake_move_manager
+
+
 def test_move_manager_reads_moves_via_services_db(pc_box):
     """MoveManagerWidget builds 4 slots + TM button, sourcing data from services.db."""
     stored = {

--- a/tests/test_pc_box_evolution_button.py
+++ b/tests/test_pc_box_evolution_button.py
@@ -1,0 +1,303 @@
+"""Qt characterization tests for ``pyobj/pc_box.py`` (inventory row F42).
+
+The PC-box overhaul replaces the old inline "Evolve now" button in the details
+panel with a ``MoveManagerWidget`` (forget/learn/TM). These pin that contract on
+main's service seam:
+
+* ``PokemonPC._integrate_move_manager`` mounts a ``MoveManagerWidget`` into the
+  details header and relocates the ``evolveNowButton`` to the end of its row --
+  exp's "MoveManagerWidget replaces the evolution button" behaviour.
+* ``MoveManagerWidget`` builds four move slots plus a "Learn from TMs" button and
+  reads its Pokémon row through the ``services.db`` seam (main's architecture),
+  not exp's direct ``mw.ankimon_db``.
+
+``pc_box.py`` is loaded in isolation with every module-level dependency stubbed
+(``aqt.qt`` re-exports the *real* PyQt6 widgets, so no QtWebEngine import fires),
+mirroring ``test_pokemon_details_gui.py`` / ``test_move_picker.py``. Needs real
+PyQt6; the module skips cleanly in the aqt-free Tier-1 env or where another test
+has mocked PyQt6. Run standalone with::
+
+    pytest tests/test_pc_box_evolution_button.py
+"""
+
+import importlib.util
+import json
+import sys
+import types
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+pytest.importorskip("PyQt6")  # Qt env only; skipped in the aqt-free Tier-1 env.
+
+
+_MODULE_NAME = "Ankimon.pyobj.pc_box"
+_SRC = Path(__file__).parent.parent / "src"
+
+
+@pytest.fixture(autouse=True)
+def _env_guard():
+    """Skip gracefully when another test file has mocked PyQt6 in this run.
+
+    Un-mocking a compiled Qt extension mid-process is not reliable, so we skip
+    rather than fail when real Qt is not active. Matches ``test_move_picker.py``.
+    """
+    from PyQt6.QtWidgets import QDialog
+
+    if not isinstance(QDialog, type):  # PyQt6 was mocked by another test
+        pytest.skip(
+            "real PyQt6 not active (mocked by another test); "
+            "run tests/test_pc_box_evolution_button.py standalone"
+        )
+    if str(_SRC) not in sys.path:
+        sys.path.insert(0, str(_SRC))
+    yield
+
+
+def _make_module(name, **attrs):
+    mod = types.ModuleType(name)
+    for k, v in attrs.items():
+        setattr(mod, k, v)
+    return mod
+
+
+@pytest.fixture
+def pc_box(qapp):
+    """Force-load ``pc_box.py`` with every module-level dependency stubbed.
+
+    ``aqt.qt`` is stubbed to re-export the *real* PyQt6 classes ``pc_box`` needs,
+    so real widgets are built for pytest-qt's ``qapp`` while the crashy
+    heavyweight import graph (aqt's QtWebEngine, the addon's sibling windows) is
+    never touched.
+    """
+    from PyQt6.QtWidgets import (
+        QDialog,
+        QHBoxLayout,
+        QVBoxLayout,
+        QLabel,
+        QPushButton,
+        QGridLayout,
+    )
+    from PyQt6.QtGui import QPixmap
+    from PyQt6.QtCore import Qt
+
+    # --- aqt namespace -----------------------------------------------------
+    fake_hooks = mock.MagicMock()
+    aqt_mod = _make_module("aqt", mw=mock.MagicMock(), gui_hooks=fake_hooks)
+    aqt_qt_mod = _make_module(
+        "aqt.qt",
+        Qt=Qt,
+        QDialog=QDialog,
+        QHBoxLayout=QHBoxLayout,
+        QVBoxLayout=QVBoxLayout,
+        QLabel=QLabel,
+        QPushButton=QPushButton,
+        QGridLayout=QGridLayout,
+        QPixmap=QPixmap,
+    )
+    aqt_theme_mod = _make_module(
+        "aqt.theme", theme_manager=types.SimpleNamespace(night_mode=False)
+    )
+
+    # --- Ankimon service seam + sibling stubs ------------------------------
+    services_obj = types.SimpleNamespace(db=None, achievements={})
+    services_mod = _make_module("Ankimon.services", services=services_obj)
+
+    class _Stub:
+        def __init__(self, *a, **k):
+            pass
+
+        @classmethod
+        def from_dict(cls, *a, **k):
+            return cls()
+
+        @staticmethod
+        def calc_stat(*a, **k):
+            return 1
+
+    stub_specs = {
+        "Ankimon.pyobj.pokemon_obj": {"PokemonObject": _Stub},
+        "Ankimon.pyobj.reviewer_obj": {"Reviewer_Manager": _Stub},
+        "Ankimon.pyobj.test_window": {"TestWindow": _Stub},
+        "Ankimon.pyobj.translator": {"Translator": _Stub},
+        "Ankimon.pyobj.collection_dialog": {"MainPokemon": _Stub},
+        "Ankimon.gui_classes.pokemon_details": {
+            "PokemonCollectionDetailsSplit": lambda *a, **k: (None, None, None, {}),
+            "remember_attack": mock.MagicMock(),
+        },
+        "Ankimon.pyobj.InfoLogger": {"ShowInfoLogger": _Stub},
+        "Ankimon.pyobj.move_picker": {"MovePickerDialog": _Stub},
+        "Ankimon.pyobj.evolution_window": {"EvoWindow": _Stub},
+        "Ankimon.pyobj.settings": {"Settings": _Stub},
+        "Ankimon.functions.friendship_evolution": {
+            "current_time_label": lambda *a, **k: "Day",
+            "evolution_readiness": lambda *a, **k: {"ready": False, "method": None},
+        },
+        "Ankimon.functions.sprite_functions": {"get_sprite_path": lambda *a, **k: ""},
+        "Ankimon.utils": {
+            "load_custom_font": lambda *a, **k: mock.MagicMock(),
+            "get_tier_by_id": lambda *a, **k: "Normal",
+            "is_alive": lambda obj: obj is not None,
+            "format_move_name": lambda s: str(s).replace("-", " ").title(),
+            "format_pokemon_name": lambda s: str(s).title(),
+        },
+        "Ankimon.resources": {
+            "icon_path": Path("/nonexistent/icon.png"),
+            "items_path": Path("/nonexistent/items"),
+            "csv_file_items_cost": Path("/nonexistent/items_cost.csv"),
+            "poke_evo_path": Path("/nonexistent/evo"),
+            "pokemon_tm_learnset_path": Path("/nonexistent/tm.json"),
+            "addon_dir": Path("/nonexistent/addon"),
+        },
+        "Ankimon.business": {"calculate_cp_from_dict": lambda *a, **k: 0},
+        "Ankimon.functions.pokedex_functions": {
+            "find_details_move": lambda m: {"type": "Normal"},
+            "get_all_pokemon_moves": lambda *a, **k: [],
+            "format_lore_name": lambda s: s,
+            "get_pretty_name_for_name": lambda s: str(s).title(),
+            "search_pokedex_by_id": lambda i: "pikachu",
+        },
+        "Ankimon.functions.gui_functions": {
+            "type_icon_path": lambda *a, **k: Path("/nonexistent"),
+            "move_category_path": lambda *a, **k: Path("/nonexistent"),
+        },
+    }
+
+    # Parent packages so relative imports resolve.
+    parent_pkgs = (
+        "Ankimon",
+        "Ankimon.functions",
+        "Ankimon.pyobj",
+        "Ankimon.gui_classes",
+    )
+    to_install = {
+        "aqt": aqt_mod,
+        "aqt.qt": aqt_qt_mod,
+        "aqt.theme": aqt_theme_mod,
+        "Ankimon.services": services_mod,
+        _MODULE_NAME: None,
+        **{name: _make_module(name, **attrs) for name, attrs in stub_specs.items()},
+    }
+    saved = {name: sys.modules.get(name) for name in (*to_install, *parent_pkgs)}
+
+    for pkg in parent_pkgs:
+        mod = types.ModuleType(pkg)
+        mod.__path__ = [str(_SRC / pkg.replace(".", "/"))]
+        mod.__package__ = pkg
+        sys.modules[pkg] = mod
+    for name, mod in to_install.items():
+        if mod is not None:
+            sys.modules[name] = mod
+
+    spec = importlib.util.spec_from_file_location(
+        _MODULE_NAME, _SRC / "Ankimon" / "pyobj" / "pc_box.py"
+    )
+    module = importlib.util.module_from_spec(spec)
+    module._services_obj = services_obj  # expose for tests
+    sys.modules[_MODULE_NAME] = module
+    spec.loader.exec_module(module)
+
+    try:
+        yield module
+    finally:
+        for name, val in saved.items():
+            if val is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = val
+
+
+def test_integrate_move_manager_replaces_evolution_button(pc_box, monkeypatch):
+    """The move manager is mounted and the evolve button is pushed to the end."""
+    # Mock the widget itself so we test the layout wiring, not Qt construction.
+    fake_move_manager = mock.MagicMock(name="MoveManagerWidget-instance")
+    monkeypatch.setattr(
+        pc_box, "MoveManagerWidget", mock.MagicMock(return_value=fake_move_manager)
+    )
+
+    pc = mock.MagicMock()
+    pc.details_widget = None
+
+    # header_stack -> h_widget -> h_layout -> first_layout -> top_r_widget -> top_r_layout
+    h_widget = mock.MagicMock()
+    pc.header_stack.currentWidget.return_value = h_widget
+    h_layout = mock.MagicMock()
+    h_widget.layout.return_value = h_layout
+    h_layout.count.return_value = 2
+    first_layout_item = mock.MagicMock()
+    first_layout = mock.MagicMock()
+    first_layout_item.layout.return_value = first_layout
+    h_layout.itemAt.return_value = first_layout_item
+    top_r_item = mock.MagicMock()
+    top_r_widget = mock.MagicMock()
+    top_r_item.widget.return_value = top_r_widget
+    first_layout.itemAt.return_value = top_r_item
+    top_r_layout = mock.MagicMock()
+    top_r_widget.layout.return_value = top_r_layout
+
+    # The row holds an "otherButton" and the "evolveNowButton".
+    evo_btn_widget = mock.MagicMock()
+    evo_btn_widget.objectName.return_value = "evolveNowButton"
+    layout_item_evo = mock.MagicMock()
+    layout_item_evo.widget.return_value = evo_btn_widget
+    other_widget = mock.MagicMock()
+    other_widget.objectName.return_value = "otherButton"
+    layout_item_other = mock.MagicMock()
+    layout_item_other.widget.return_value = other_widget
+    items = [layout_item_other, layout_item_evo]
+    top_r_layout.count.return_value = len(items)
+    top_r_layout.itemAt.side_effect = lambda idx: items[idx]
+
+    pokemon = {"individual_id": "test-uuid-123", "id": 790, "name": "Cosmoem"}
+
+    pc_box.PokemonPC._integrate_move_manager(pc, pokemon)
+
+    # A MoveManagerWidget was built for this Pokémon and mounted in the row.
+    pc_box.MoveManagerWidget.assert_called_once()
+    _, kwargs = pc_box.MoveManagerWidget.call_args
+    assert kwargs["individual_id"] == "test-uuid-123"
+    assert kwargs["pkmn_id"] == 790
+    assert fake_move_manager in [
+        c.args[0] for c in top_r_layout.addWidget.call_args_list
+    ]
+
+    # The evolve button is removed and re-appended so it stays below the manager.
+    top_r_layout.removeWidget.assert_called_once_with(evo_btn_widget)
+    add_calls = top_r_layout.addWidget.call_args_list
+    assert len(add_calls) >= 2
+    assert add_calls[-1].args[0] == evo_btn_widget
+
+
+def test_move_manager_reads_moves_via_services_db(pc_box):
+    """MoveManagerWidget builds 4 slots + TM button, sourcing data from services.db."""
+    stored = {
+        "name": "pikachu",
+        "nickname": "",
+        "level": 20,
+        "attacks": ["tackle", "growl"],
+        "all_attacks": ["tackle", "growl", "thunderbolt"],
+    }
+
+    fake_cursor = mock.MagicMock()
+    fake_cursor.fetchone.return_value = [json.dumps(stored)]
+    fake_db = mock.MagicMock()
+    fake_db.execute.return_value = fake_cursor
+    pc_box._services_obj.db = fake_db
+
+    widget = pc_box.MoveManagerWidget(
+        individual_id="ind-1",
+        pkmn_id=25,
+        logger=mock.MagicMock(),
+        save_fn=mock.MagicMock(),
+    )
+
+    # Data was read through the seam, not a direct mw handle.
+    assert fake_db.execute.called
+    # Four fixed move slots and the TM-learning button exist.
+    assert len(widget.slots) == 4
+    assert widget.tm_btn is not None
+    # The first two slots reflect the stored moves; the rest are empty.
+    assert widget.slots[0]["move"] == "tackle"
+    assert widget.slots[1]["move"] == "growl"
+    assert widget.slots[2]["move"] is None


### PR DESCRIPTION
## What
Ports F42 — the PC-box rework (largest Wave-3 leaf, +1355/-284 after formatting; +1171/-293 of feature delta) — from BRRRR_Experimental onto the integration tip, re-fitted to main's service seam. Brings across:
- **MoveManagerWidget** — per-slot forget / learn / "Learn from TMs" move management in the details panel, using the *shared* `MovePickerDialog` (pyobj/move_picker.py) and `remember_attack` (no duplication). It replaces the old inline evolution button: the manager mounts into the header row and the `evolveNowButton` is relocated below it.
- **Friendship-evolution readiness badge** on grid slots (✨/PNG, plus 🌙/☀️ day-night wait badges and the 💖 BFF heart), consuming `evolution_readiness`.
- **Window-geometry persistence** across sessions (`mw.pm.profile`), a non-modal resizable window, live count label, slot-selection highlighting, a day/night clock timer, DB result caching, live (debounced) search, and combo-based per-stat / IV / EV / CP / friendship sorting.
- The details-panel **"Evolve now"** trigger (`EvoWindow`), including the NR-15 Pawmo/Rellor manual-evolution hunks.

## Re-fit to seam (exp → main)
- `mw.ankimon_db.*` → **`services.db.*`** at every call site (execute / get_pokemon / save_pokemon / get_all_items / get_all_pokemon / db_path).
- Details panel: exp called `PokemonCollectionDetails(...)` and unpacked a 4-tuple; on main that tuple-returning function is F43's **`PokemonCollectionDetailsSplit`** (`PokemonCollectionDetails` is now the classic single-layout variant). Switched the `show_pokemon_details` call + import accordingly. Verified F43's header layout matches `_integrate_move_manager`'s traversal (header index 0 = name_label, index 1 = first_layout → TopR_widget → TopR_layout_Box containing `evolveNowButton`).
- `achievements`: dropped from the constructor (singletons.get_pokemon_pc does not pass it) and sourced from **`services.achievements`** in `trigger_evo`. Constructor stays compatible with the existing caller — no edit to F31's singletons.py.
- `mw.pm.profile[GEOMETRY_KEY]` kept as a genuine Anki API. Added the missing `QByteArray` import (exp had a latent `NameError` on geometry restore).
- Cross-window item refresh (`mw.item_window` / `mw.items_web_window`) kept behind exp's `hasattr` + `is_alive` guards (graceful no-op on main).

## Parity notes
- Ported the full exp `pc_box.py` at the current tip (b04e4bec), so the **post-snapshot NR-15 hunks** (exp `4a1cd0cd` Pawmo/Rellor manual-evolution check + PC-box button, `0553e18f` grid indicator) are captured — `trigger_evo`, the readiness badge, and the `EvoWindow` wiring are all present.
- Correctness preservation from main's base: re-added `everstone` to the grid fetch query + row dict (exp dropped it), so the readiness badge respects Everstones instead of defaulting them to evolvable.
- Test `tests/test_pc_box_evolution_button.py` (exp-only) adapted to main's seam: (1) `_integrate_move_manager` mounts a MoveManagerWidget and relocates the `evolveNowButton` to the end of its row; (2) MoveManagerWidget builds 4 slots + a TM button and reads its row through `services.db`. Loads pc_box in isolation with module-level deps stubbed (aqt.qt re-exports real PyQt6 so no QtWebEngine import fires), and skips cleanly in the aqt-free Tier-1 env — mirroring test_pokemon_details_gui.py / test_move_picker.py.

## Guards confirmation
services.db seam applied throughout; mw.pm geometry kept as Anki API; item-window pokes guarded/deferred; achievements via registry (no cross-unit edit); explicit-path staging only, no user_files, no submodule-pointer change; Qt tier exercised in full.

## Deferred
- **F36 (web shell):** PC-box held-item changes do not live-refresh an open item/bag window (mw.item_window unset on main; mw.items_web_window absent until Wave 4). Proper fix = events/ui_port refresh signal.
- **F40 (evolution overhaul):** evolution_indicator.png is F40's asset and is absent here → badge falls back to a text arrow via an `.exists()` guard; PNG activates when F40 lands. This port does not assume F40's new evolution_readiness fields.

## Gates
compileall OK · ruff check 10 errors (all pre-existing in 'AnkimonWindow copy.py', 0 in pc_box) · ruff format --check clean on both files · pytest Tier-1 303 passed / 38 skipped / 0 failed (baseline 303/35; +3 = this unit's Qt tests skipping under importorskip) · harness/check.py 9/9 · Qt: scaffolding 4 passed, addon_integrity 1 passed, probe_real_boot OK (reviewer_did_answer_card hooks == 3; pokemon_pc → Ankimon.pyobj.pc_box.PokemonPC), probe_real_play OK · new test 3 passed (Qt env).

## Review fixes
Addressed 4 Gemini review comments on pc_box.py — retire the previous MoveManagerWidget via `deleteLater` (widget-leak fix), handle the `"Pokémon not found"` sentinel in `on_tm_clicked`, remove the duplicate `_update_count_label` (keeping the cached copy + `is_alive` guard), and None-guard `services.db` before `db_path.name` in the filter cache key; added a headless regression test for the manager-retire behaviour.

## Attribution
Originally implemented by @hakimh2 (with @AIbrahimv2 on pc_box.py) on BRRRR_Experimental; credited via Co-authored-by trailers on each commit.

