### PR TITLE
feat: encounter simulator — QWebEngine dialog + deterministic rate calc (F23)

### DIFF
--- a/src/Ankimon/encounter_simulator/simulator.html
+++ b/src/Ankimon/encounter_simulator/simulator.html
@@ -1,0 +1,792 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Ankimon Encounter Rate Simulator</title>
+    <!-- We try to load Outfit font, fallback to standard sleek sans-serif -->
+    <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+    <style>
+        :root {
+            --bg-gradient: radial-gradient(135deg, #0d0f19 0%, #151829 100%);
+            --panel-bg: rgba(255, 255, 255, 0.025);
+            --panel-border: rgba(255, 255, 255, 0.05);
+            --panel-border-hover: rgba(255, 255, 255, 0.1);
+            --text-primary: #f1f3f9;
+            --text-secondary: #8f9cae;
+            --accent-cyan: #00e5ff;
+            --accent-glow: rgba(0, 229, 255, 0.35);
+            
+            /* Tier Colors */
+            --color-normal: #8a93a5;
+            --color-baby: #ff7597;
+            --color-ultra: #00e5ff;
+            --color-gmax: #bd00ff;
+            --color-starter: #00ff88;
+            --color-mega: #ff0055;
+            --color-legendary: #ffaa00;
+            --color-mythical: #7b2cff;
+        }
+
+        * {
+            box-sizing: border-box;
+            margin: 0;
+            padding: 0;
+            user-select: none;
+        }
+
+        body {
+            background: #0b0c16; /* Solid deep premium dark background to fix compositor flickering */
+            color: var(--text-primary);
+            font-family: 'Outfit', system-ui, -apple-system, sans-serif;
+            min-height: 100vh;
+            display: flex;
+            flex-direction: column;
+            overflow-x: hidden;
+            padding: 24px;
+        }
+
+        /* Scrollbar styling */
+        ::-webkit-scrollbar {
+            width: 8px;
+            height: 8px;
+        }
+        ::-webkit-scrollbar-track {
+            background: rgba(0,0,0,0.1);
+        }
+        ::-webkit-scrollbar-thumb {
+            background: rgba(255,255,255,0.05);
+            border-radius: 4px;
+        }
+        ::-webkit-scrollbar-thumb:hover {
+            background: rgba(255,255,255,0.15);
+        }
+
+        header {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            margin-bottom: 24px;
+            padding-bottom: 16px;
+            border-bottom: 1px solid var(--panel-border);
+        }
+
+        .header-title h1 {
+            font-size: 24px;
+            font-weight: 600;
+            letter-spacing: -0.5px;
+            background: linear-gradient(90deg, #ffffff 0%, var(--accent-cyan) 100%);
+            -webkit-background-clip: text;
+            -webkit-text-fill-color: transparent;
+            display: flex;
+            align-items: center;
+            gap: 8px;
+        }
+
+        .header-title p {
+            font-size: 13px;
+            color: var(--text-secondary);
+            margin-top: 4px;
+        }
+
+        .dev-badge {
+            background: rgba(0, 229, 255, 0.1);
+            border: 1px solid rgba(0, 229, 255, 0.2);
+            color: var(--accent-cyan);
+            font-size: 11px;
+            font-weight: 600;
+            padding: 4px 10px;
+            border-radius: 20px;
+            letter-spacing: 0.5px;
+            text-transform: uppercase;
+            box-shadow: 0 0 10px rgba(0, 229, 255, 0.05);
+        }
+
+        .dashboard {
+            display: grid;
+            grid-template-columns: 360px 1fr;
+            gap: 24px;
+            flex-grow: 1;
+        }
+
+        /* Premium Solid Panel base (removes backdrop-filter to prevent hover flickering) */
+        .panel {
+            background: #111422;
+            border: 1px solid var(--panel-border);
+            border-radius: 16px;
+            padding: 24px;
+            display: flex;
+            flex-direction: column;
+            gap: 20px;
+        }
+
+        .panel:hover {
+            border-color: var(--panel-border-hover);
+        }
+
+        /* Left controls panel */
+        .controls-panel {
+            max-height: calc(100vh - 100px);
+            overflow-y: auto;
+        }
+
+        .panel-title {
+            font-size: 16px;
+            font-weight: 600;
+            color: var(--text-primary);
+            letter-spacing: -0.2px;
+            display: flex;
+            align-items: center;
+            gap: 8px;
+            border-bottom: 1px solid rgba(255,255,255,0.03);
+            padding-bottom: 12px;
+        }
+
+        .panel-subtitle {
+            font-size: 12px;
+            color: var(--text-secondary);
+            font-weight: 400;
+        }
+
+        /* Slider Controls */
+        .slider-group {
+            display: flex;
+            flex-direction: column;
+            gap: 8px;
+        }
+
+        .slider-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            font-size: 13px;
+        }
+
+        .slider-label {
+            color: var(--text-secondary);
+            font-weight: 500;
+        }
+
+        .slider-value-container {
+            display: flex;
+            align-items: center;
+            gap: 4px;
+        }
+
+        .slider-value {
+            font-weight: 600;
+            color: var(--accent-cyan);
+            background: rgba(0, 229, 255, 0.08);
+            padding: 2px 6px;
+            border-radius: 6px;
+            font-size: 12px;
+            min-width: 36px;
+            text-align: center;
+        }
+
+        .slider-input-wrapper {
+            position: relative;
+            display: flex;
+            align-items: center;
+        }
+
+        .slider-input {
+            -webkit-appearance: none;
+            width: 100%;
+            height: 6px;
+            border-radius: 3px;
+            background: rgba(255,255,255,0.06);
+            outline: none;
+        }
+
+        .slider-input::-webkit-slider-thumb {
+            -webkit-appearance: none;
+            width: 16px;
+            height: 16px;
+            border-radius: 50%;
+            background: var(--accent-cyan);
+            cursor: pointer;
+            box-shadow: 0 0 10px var(--accent-glow);
+        }
+
+        .slider-input::-webkit-slider-thumb:hover {
+            background: #ffffff;
+        }
+
+        /* Right Dashboard Columns */
+        .stats-area {
+            display: flex;
+            flex-direction: column;
+            gap: 24px;
+        }
+
+        .upper-stats {
+            display: grid;
+            grid-template-columns: 240px 1fr;
+            gap: 24px;
+        }
+
+        /* EP Gauge Circular Styling */
+        .ep-gauge-container {
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            justify-content: center;
+            gap: 16px;
+            min-height: 240px;
+        }
+
+        .gauge-svg-container {
+            position: relative;
+            width: 160px;
+            height: 160px;
+        }
+
+        .gauge-circle-bg {
+            fill: none;
+            stroke: rgba(255, 255, 255, 0.025);
+            stroke-width: 10px;
+        }
+
+        .gauge-circle-fill {
+            fill: none;
+            stroke: url(#cyanGrad);
+            stroke-width: 10px;
+            stroke-linecap: round;
+            transform: rotate(-90deg);
+            transform-origin: 50% 50%;
+            stroke-dasharray: 440;
+            stroke-dashoffset: 440;
+            transition: stroke-dashoffset 0.4s ease-out;
+        }
+
+        .gauge-center-text {
+            position: absolute;
+            top: 50%;
+            left: 50%;
+            transform: translate(-50%, -50%);
+            text-align: center;
+        }
+
+        .gauge-value {
+            font-size: 32px;
+            font-weight: 700;
+            color: var(--text-primary);
+            line-height: 1;
+        }
+
+        .gauge-unit {
+            font-size: 11px;
+            color: var(--text-secondary);
+            text-transform: uppercase;
+            letter-spacing: 1px;
+            margin-top: 4px;
+        }
+
+        /* Exponential Graph Canvas */
+        .graph-container {
+            flex-grow: 1;
+            position: relative;
+            display: flex;
+            flex-direction: column;
+            gap: 8px;
+        }
+
+        .canvas-wrapper {
+            position: relative;
+            width: 100%;
+            height: 100%;
+            min-height: 200px;
+            background: rgba(0, 0, 0, 0.15);
+            border-radius: 8px;
+            border: 1px solid rgba(255, 255, 255, 0.02);
+            overflow: hidden;
+        }
+
+        canvas {
+            display: block;
+            width: 100%;
+            height: 100%;
+        }
+
+        /* Matrix Table View */
+        .matrix-panel {
+            flex-grow: 1;
+        }
+
+        table {
+            width: 100%;
+            border-collapse: collapse;
+            text-align: left;
+        }
+
+        th {
+            font-size: 12px;
+            color: var(--text-secondary);
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.5px;
+            padding: 12px 16px;
+            border-bottom: 1px solid rgba(255,255,255,0.05);
+        }
+
+        td {
+            padding: 14px 16px;
+            font-size: 14px;
+            border-bottom: 1px solid rgba(255,255,255,0.02);
+            vertical-align: middle;
+        }
+
+        tr:hover td {
+            background-color: rgba(255,255,255,0.01);
+        }
+
+        .tier-cell {
+            display: flex;
+            align-items: center;
+            gap: 8px;
+            font-weight: 600;
+        }
+
+        .tier-indicator {
+            width: 8px;
+            height: 8px;
+            border-radius: 50%;
+        }
+
+        .lock-indicator {
+            color: #ff3b30;
+            font-size: 12px;
+            margin-left: 6px;
+            display: inline-flex;
+            align-items: center;
+            opacity: 0.8;
+        }
+
+        /* Specific neon glow elements */
+        .color-normal { color: var(--color-normal); }
+        .color-baby { color: var(--color-baby); }
+        .color-ultra { color: var(--color-ultra); }
+        .color-gmax { color: var(--color-gmax); }
+        .color-starter { color: var(--color-starter); }
+        .color-mega { color: var(--color-mega); }
+        .color-legendary { color: var(--color-legendary); }
+        .color-mythical { color: var(--color-mythical); }
+
+        .bg-normal { background: var(--color-normal); box-shadow: 0 0 6px var(--color-normal); }
+        .bg-baby { background: var(--color-baby); box-shadow: 0 0 6px var(--color-baby); }
+        .bg-ultra { background: var(--color-ultra); box-shadow: 0 0 6px var(--color-ultra); }
+        .bg-gmax { background: var(--color-gmax); box-shadow: 0 0 6px var(--color-gmax); }
+        .bg-starter { background: var(--color-starter); box-shadow: 0 0 6px var(--color-starter); }
+        .bg-mega { background: var(--color-mega); box-shadow: 0 0 6px var(--color-mega); }
+        .bg-legendary { background: var(--color-legendary); box-shadow: 0 0 6px var(--color-legendary); }
+        .bg-mythical { background: var(--color-mythical); box-shadow: 0 0 6px var(--color-mythical); }
+
+        .percentage-value {
+            font-family: monospace;
+            font-weight: 600;
+            font-size: 14px;
+        }
+
+        .live-value {
+            color: var(--text-primary);
+        }
+
+        .overhaul-value {
+            color: var(--accent-cyan);
+            font-weight: 700;
+        }
+
+        .legacy-value {
+            color: var(--text-secondary);
+        }
+
+        .legend-container {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 12px;
+            font-size: 11px;
+            color: var(--text-secondary);
+            padding: 8px 12px;
+            background: rgba(0,0,0,0.1);
+            border-radius: 6px;
+        }
+
+        .legend-item {
+            display: flex;
+            align-items: center;
+            gap: 4px;
+        }
+
+        .legend-color {
+            width: 8px;
+            height: 8px;
+            border-radius: 2px;
+        }
+
+        .action-btn {
+            background: rgba(0, 229, 255, 0.08);
+            border: 1px solid rgba(0, 229, 255, 0.2);
+            color: var(--accent-cyan);
+            font-family: 'Outfit', sans-serif;
+            font-size: 13px;
+            font-weight: 600;
+            padding: 8px 16px;
+            border-radius: 8px;
+            cursor: pointer;
+            width: 100%;
+            text-align: center;
+            box-shadow: 0 0 10px rgba(0, 229, 255, 0.02);
+        }
+
+        .action-btn:hover {
+            background: rgba(0, 229, 255, 0.15);
+            border-color: rgba(0, 229, 255, 0.35);
+            color: #ffffff;
+        }
+
+        .action-btn:active {
+            transform: translateY(1px);
+        }
+
+        /* Custom Dropdown Styling */
+        .custom-dropdown-container {
+            position: relative;
+            width: 100%;
+        }
+
+        .custom-dropdown-trigger {
+            background: #151829;
+            border: 1px solid var(--panel-border);
+            color: var(--text-primary);
+            font-family: 'Outfit', sans-serif;
+            padding: 10px 14px;
+            border-radius: 8px;
+            cursor: pointer;
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            font-size: 14px;
+            transition: border-color 0.2s, background 0.2s;
+        }
+
+        .custom-dropdown-trigger:hover {
+            border-color: var(--panel-border-hover);
+            background: #1a1d32;
+        }
+
+        .custom-dropdown-options {
+            display: none;
+            position: absolute;
+            top: calc(100% + 6px);
+            left: 0;
+            width: 100%;
+            background: #151829;
+            border: 1px solid var(--panel-border);
+            border-radius: 8px;
+            box-shadow: 0 10px 25px rgba(0, 0, 0, 0.4);
+            z-index: 1000;
+            overflow: hidden;
+        }
+
+        .custom-dropdown-options.active {
+            display: block;
+        }
+
+        .dropdown-option {
+            padding: 11px 14px;
+            cursor: pointer;
+            font-size: 14px;
+            color: var(--text-primary);
+            transition: background 0.15s, color 0.15s;
+        }
+
+        .dropdown-option:hover {
+            background: rgba(0, 229, 255, 0.08);
+            color: var(--accent-cyan);
+        }
+
+        .dropdown-option.selected {
+            background: rgba(0, 229, 255, 0.15);
+            color: var(--accent-cyan);
+            font-weight: 600;
+        }
+    </style>
+</head>
+<body>
+    <header>
+        <div class="header-title">
+            <h1><span>⚡</span> Encounter Rate Simulator</h1>
+            <p>Ankimon Developer Tool for Modeling Wild Pokémon Spawn Weights</p>
+        </div>
+        <div class="badge-container" style="display: flex; gap: 8px;">
+            <div class="dev-badge" id="system-badge" style="border-color: rgba(255, 255, 255, 0.1); background: rgba(255, 255, 255, 0.03); color: var(--text-secondary);">Active System: ...</div>
+            <div class="dev-badge" style="background: rgba(168, 85, 247, 0.1); border-color: rgba(168, 85, 247, 0.2); color: #a855f7;">Developer Mode</div>
+        </div>
+    </header>
+
+    <div class="dashboard">
+        <!-- Control Panel -->
+        <div class="panel controls-panel">
+            <div class="panel-title" style="flex-direction: column; align-items: stretch; gap: 12px; border: none; padding-bottom: 0;">
+                <div style="display: flex; align-items: center; gap: 8px;">
+                    <span>🔧</span>
+                    <div>
+                        Simulation Variables
+                        <div class="panel-subtitle">Adjust sliding factors to recalculate weight distribution</div>
+                    </div>
+                </div>
+                <button id="btn-reset" class="action-btn">Reset to Live Save</button>
+            </div>
+
+            <!-- Trainer Level Slider -->
+            <div class="slider-group">
+                <div class="slider-header">
+                    <span class="slider-label">Trainer Level (T<sub>norm</sub>)</span>
+                    <div class="slider-value-container">
+                        <span class="slider-value" id="val-trainer-level">1</span>
+                    </div>
+                </div>
+                <div class="slider-input-wrapper">
+                    <input type="range" class="slider-input" id="slide-trainer-level" min="1" max="100" value="1">
+                </div>
+            </div>
+
+            <!-- Dex Completion Slider -->
+            <div class="slider-group">
+                <div class="slider-header">
+                    <span class="slider-label">Dex Completion (D<sub>norm</sub>)</span>
+                    <div class="slider-value-container">
+                        <span class="slider-value" id="val-dex-completion">0%</span>
+                    </div>
+                </div>
+                <div class="slider-input-wrapper">
+                    <input type="range" class="slider-input" id="slide-dex-completion" min="0" max="100" value="0">
+                </div>
+            </div>
+
+            <!-- Reviews Done Slider -->
+            <div class="slider-group">
+                <div class="slider-header">
+                    <span class="slider-label">Session Reviews Done</span>
+                    <div class="slider-value-container">
+                        <span class="slider-value" id="val-reviews-done">0</span>
+                    </div>
+                </div>
+                <div class="slider-input-wrapper">
+                    <input type="range" class="slider-input" id="slide-reviews-done" min="0" max="300" value="0">
+                </div>
+            </div>
+
+            <!-- Daily Review Goal Slider -->
+            <div class="slider-group">
+                <div class="slider-header">
+                    <span class="slider-label">Daily Review Goal</span>
+                    <div class="slider-value-container">
+                        <span class="slider-value" id="val-daily-goal">100</span>
+                    </div>
+                </div>
+                <div class="slider-input-wrapper">
+                    <input type="range" class="slider-input" id="slide-daily-goal" min="10" max="200" value="100">
+                </div>
+            </div>
+
+            <!-- Top 6 CP Slider -->
+            <div class="slider-group">
+                <div class="slider-header">
+                    <span class="slider-label">Avg. CP of Top 6 (C<sub>norm</sub>)</span>
+                    <div class="slider-value-container">
+                        <span class="slider-value" id="val-avg-cp">10</span>
+                    </div>
+                </div>
+                <div class="slider-input-wrapper">
+                    <input type="range" class="slider-input" id="slide-avg-cp" min="10" max="4000" step="50" value="10">
+                </div>
+            </div>
+
+            <!-- Main Pokemon Level Slider -->
+            <div class="slider-group">
+                <div class="slider-header">
+                    <span class="slider-label">Main Pokémon Level (Gating)</span>
+                    <div class="slider-value-container">
+                        <span class="slider-value" id="val-main-level">1</span>
+                    </div>
+                </div>
+                <div class="slider-input-wrapper">
+                    <input type="range" class="slider-input" id="slide-main-level" min="1" max="100" value="1">
+                </div>
+            </div>
+        </div>
+
+        <!-- Right Stats Area -->
+        <div class="stats-area">
+            <!-- Upper Area (EP Circular Gauge & Exponential Graph) -->
+            <div class="upper-stats">
+                <!-- Circular EP Gauge -->
+                <div class="panel ep-gauge-container">
+                    <div class="panel-title" style="width: 100%; border: none; padding: 0;">Encounter Potential</div>
+                    <div class="gauge-svg-container">
+                        <svg width="160" height="160" viewBox="0 0 160 160">
+                            <defs>
+                                <linearGradient id="cyanGrad" x1="0%" y1="0%" x2="100%" y2="100%">
+                                    <stop offset="0%" stop-color="#ffffff" />
+                                    <stop offset="100%" stop-color="#00e5ff" />
+                                </linearGradient>
+                            </defs>
+                            <circle class="gauge-circle-bg" cx="80" cy="80" r="70" />
+                            <circle class="gauge-circle-fill" id="gauge-fill" cx="80" cy="80" r="70" />
+                        </svg>
+                        <div class="gauge-center-text">
+                            <div class="gauge-value" id="ep-value">0.0</div>
+                            <div class="gauge-unit">EP</div>
+                        </div>
+                    </div>
+                    <div class="panel-subtitle" style="text-align: center;">Mastery Index (0.0 - 100.0)</div>
+                </div>
+
+                <!-- Interactive Exponential Curve Graph -->
+                <div class="panel graph-container">
+                    <div class="panel-title" style="border: none; padding-bottom: 0;">
+                        <div>
+                            Exponential Rarity Curves
+                            <div class="panel-subtitle">Base Weight Gating as a Function of EP</div>
+                        </div>
+                    </div>
+                    <div class="canvas-wrapper">
+                        <canvas id="curves-graph"></canvas>
+                    </div>
+                    <div class="legend-container">
+                        <div class="legend-item"><span class="legend-color bg-normal"></span><span>Normal</span></div>
+                        <div class="legend-item"><span class="legend-color bg-baby"></span><span>Baby</span></div>
+                        <div class="legend-item"><span class="legend-color bg-ultra"></span><span>Ultra</span></div>
+                        <div class="legend-item"><span class="legend-color bg-gmax"></span><span>Gmax</span></div>
+                        <div class="legend-item"><span class="legend-color bg-starter"></span><span>Starter</span></div>
+                        <div class="legend-item"><span class="legend-color bg-mega"></span><span>Mega</span></div>
+                        <div class="legend-item"><span class="legend-color bg-legendary"></span><span>Legendary</span></div>
+                        <div class="legend-item"><span class="legend-color bg-mythical"></span><span>Mythical</span></div>
+                    </div>
+                </div>
+            </div>
+
+            <!-- Lower Area (Matrix Table View) -->
+            <div class="panel matrix-panel">
+                <div class="panel-title">
+                    <span>📊</span>
+                    <div>
+                        Rarity Weighting Matrix
+                        <div class="panel-subtitle">Comparison of active database vs simulated distributions</div>
+                    </div>
+                </div>
+                <table>
+                    <thead>
+                        <tr>
+                            <th>Rarity Tier</th>
+                            <th style="text-align: right; color: #a5b4fc;">Live Overhaul</th>
+                            <th style="text-align: right; color: rgba(255,255,255,0.4);">Live Legacy</th>
+                            <th style="text-align: right; color: var(--accent-cyan);">Simulated Overhaul</th>
+                            <th style="text-align: right; color: rgba(255,255,255,0.6);">Simulated Legacy</th>
+                        </tr>
+                    </thead>
+                    <tbody id="matrix-tbody">
+                        <!-- Tiers are injected dynamically -->
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+
+    <!-- Pity and Dry Spell Simulator Panel -->
+    <div class="panel pity-panel" style="margin-top: 24px;">
+        <div class="panel-title" style="border: none; padding-bottom: 0;">
+            <span>🍀</span>
+            <div>
+                Pity & Dry Spell Simulator
+                <div class="panel-subtitle">Model quadratic pity multipliers and boosted encounter rates for dry review spells</div>
+            </div>
+        </div>
+        
+        <div class="pity-grid" style="display: grid; grid-template-columns: 360px 1fr; gap: 24px;">
+            <!-- Pity Inputs -->
+            <div class="pity-controls" style="display: flex; flex-direction: column; gap: 20px;">
+                <!-- Selected Tier Dropdown -->
+                <div class="slider-group">
+                    <div class="slider-header">
+                        <span class="slider-label">Select Pokémon Tier</span>
+                    </div>
+                <div class="custom-dropdown-container">
+                    <div id="pity-tier-trigger" class="custom-dropdown-trigger">
+                        <span id="selected-tier-label">Ultra</span>
+                        <span style="font-size: 10px; color: var(--text-secondary); transition: transform 0.2s; transform-origin: center;" id="dropdown-arrow">▼</span>
+                    </div>
+                    <div id="pity-tier-options" class="custom-dropdown-options">
+                        <div class="dropdown-option" data-value="Ultra">Ultra</div>
+                        <div class="dropdown-option" data-value="Gmax">Gmax</div>
+                        <div class="dropdown-option" data-value="Starter">Starter</div>
+                        <div class="dropdown-option" data-value="Mega">Mega</div>
+                        <div class="dropdown-option" data-value="Legendary">Legendary</div>
+                        <div class="dropdown-option" data-value="Mythical">Mythical</div>
+                    </div>
+                </div>
+                </div>
+
+                <!-- Dry Encounters Slider -->
+                <div class="slider-group">
+                    <div class="slider-header">
+                        <span class="slider-label">Dry Encounters (Reviews without Spawn)</span>
+                        <div class="slider-value-container">
+                            <span class="slider-value" id="val-pity-dry">0</span>
+                        </div>
+                    </div>
+                    <div class="slider-input-wrapper">
+                        <input type="range" class="slider-input" id="slide-pity-dry" min="0" max="1000" value="0">
+                    </div>
+                </div>
+
+                <!-- Param Info Board -->
+                <div class="info-board" style="background: rgba(255,255,255,0.01); border: 1px solid var(--panel-border); border-radius: 8px; padding: 14px; display: flex; flex-direction: column; gap: 8px; font-size: 13px; color: var(--text-secondary);">
+                    <div style="display: flex; justify-content: space-between;">
+                        <span>Pity Threshold (T<sub>i</sub>):</span>
+                        <span id="info-pity-threshold" style="color: var(--text-primary); font-weight: 600;">100</span>
+                    </div>
+                    <div style="display: flex; justify-content: space-between;">
+                        <span>Pity Divisor:</span>
+                        <span id="info-pity-divisor" style="color: var(--text-primary); font-weight: 600;">50.0</span>
+                    </div>
+                    <div style="display: flex; justify-content: space-between; border-top: 1px solid rgba(255,255,255,0.03); padding-top: 8px;">
+                        <span>Multiplier Formula:</span>
+                        <span style="font-family: monospace; color: var(--accent-cyan);">1 + (Excess / 50)²</span>
+                    </div>
+                </div>
+            </div>
+
+            <!-- Pity Visualization & Stats -->
+            <div class="pity-viz-container" style="display: grid; grid-template-columns: 240px 1fr; gap: 24px;">
+                <!-- Pity Factor Display -->
+                <div style="display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 16px; background: rgba(0,0,0,0.1); border-radius: 12px; padding: 20px; text-align: center;">
+                    <div class="slider-label" style="font-size: 12px; text-transform: uppercase; letter-spacing: 0.5px;">Pity Multiplier</div>
+                    <div id="pity-multiplier-value" style="font-size: 36px; font-weight: 700; color: #00ff88; text-shadow: 0 0 10px rgba(0,255,136,0.2);">1.00x</div>
+                    <div class="info-board" style="width: 100%; border: none; padding: 0; background: transparent; display: flex; flex-direction: column; gap: 6px; font-size: 12px;">
+                        <div style="display: flex; justify-content: space-between;">
+                            <span>Base Rate:</span>
+                            <span id="pity-base-rate" style="color: var(--text-primary); font-weight: 600;">0.00%</span>
+                        </div>
+                        <div style="display: flex; justify-content: space-between; border-top: 1px solid rgba(255,255,255,0.05); padding-top: 6px;">
+                            <span>Boosted Rate:</span>
+                            <span id="pity-boosted-rate" style="color: #00ff88; font-weight: 700;">0.00%</span>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- Pity Multiplier Chart -->
+                <div class="canvas-wrapper" style="position: relative; min-height: 180px;">
+                    <canvas id="pity-graph"></canvas>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <!-- Qt WebChannel Integration -->
+    <script src="qrc:///qtwebchannel/qwebchannel.js"></script>
+    <script src="simulator.js"></script>
+</body>
+</html>

--- a/src/Ankimon/encounter_simulator/simulator.js
+++ b/src/Ankimon/encounter_simulator/simulator.js
@@ -1,0 +1,834 @@
+(function() {
+    // Rarity Tier color mapping & configuration
+    const TIERS_CONFIG = {
+        "Normal": { name: "Normal", color: "#8a93a5", key: "Normal" },
+        "Baby": { name: "Baby", color: "#ff7597", key: "Baby" },
+        "Ultra": { name: "Ultra", color: "#00e5ff", key: "Ultra" },
+        "Gmax": { name: "Gmax", color: "#bd00ff", key: "Gmax" },
+        "Starter": { name: "Starter", color: "#00ff88", key: "Starter" },
+        "Mega": { name: "Mega", color: "#ff0055", key: "Mega" },
+        "Legendary": { name: "Legendary", color: "#ffaa00", key: "Legendary" },
+        "Mythical": { name: "Mythical", color: "#7b2cff", key: "Mythical" }
+    };
+
+    // Exponential curve parameters (loaded dynamically from python OVERHAUL_TIER_PARAMS)
+    let TIER_PARAMS = {
+        "Normal": { base: 97.08, max_val: 85.20 },
+        "Baby": { base: 2.30, max_val: 2.50 },
+        "Ultra": { base: 0.25, max_val: 4.50 },
+        "Gmax": { base: 0.15, max_val: 2.50 },
+        "Starter": { base: 0.10, max_val: 1.80 },
+        "Mega": { base: 0.05, max_val: 1.50 },
+        "Legendary": { base: 0.05, max_val: 1.50 },
+        "Mythical": { base: 0.02, max_val: 0.50 }
+    };
+
+    let LEVEL_THRESHOLDS = {
+        "Starter": 30,
+        "Ultra": 30,
+        "Legendary": 50,
+        "Mega": 60,
+        "Gmax": 65,
+        "Mythical": 75
+    };
+
+    // EP mastery weights and caps (loaded dynamically from python)
+    let EP_WEIGHTS = {
+        trainerLevel: 0.25,
+        dexCompletion: 0.25,
+        reviewsDone: 0.25,
+        avgCp: 0.25
+    };
+
+    let CAPS = {
+        trainerLevel: 50.0,
+        avgCp: 16000.0
+    };
+
+    // Pity dynamic config values (loaded dynamically from python)
+    let TIER_PITY_THRESHOLDS = {
+        "Ultra": 100,
+        "Gmax": 150,
+        "Starter": 200,
+        "Mega": 250,
+        "Legendary": 250,
+        "Mythical": 600
+    };
+    let PITY_DIVISOR = 50.0;
+
+    // DOM Elements
+    const sliders = {
+        trainerLevel: document.getElementById('slide-trainer-level'),
+        dexCompletion: document.getElementById('slide-dex-completion'),
+        reviewsDone: document.getElementById('slide-reviews-done'),
+        dailyGoal: document.getElementById('slide-daily-goal'),
+        avgCp: document.getElementById('slide-avg-cp'),
+        mainLevel: document.getElementById('slide-main-level')
+    };
+
+    const bubbles = {
+        trainerLevel: document.getElementById('val-trainer-level'),
+        dexCompletion: document.getElementById('val-dex-completion'),
+        reviewsDone: document.getElementById('val-reviews-done'),
+        dailyGoal: document.getElementById('val-daily-goal'),
+        avgCp: document.getElementById('val-avg-cp'),
+        mainLevel: document.getElementById('val-main-level')
+    };
+
+    let selectedPityTier = "Ultra";
+
+    const pitySliders = {
+        get tierValue() { return selectedPityTier; },
+        dry: document.getElementById('slide-pity-dry')
+    };
+
+    const pityDisplays = {
+        dryVal: document.getElementById('val-pity-dry'),
+        threshold: document.getElementById('info-pity-threshold'),
+        divisor: document.getElementById('info-pity-divisor'),
+        multiplier: document.getElementById('pity-multiplier-value'),
+        baseRate: document.getElementById('pity-base-rate'),
+        boostedRate: document.getElementById('pity-boosted-rate')
+    };
+
+    const epValueDisplay = document.getElementById('ep-value');
+    const gaugeFill = document.getElementById('gauge-fill');
+    const matrixTbody = document.getElementById('matrix-tbody');
+    const canvas = document.getElementById('curves-graph');
+    const ctx = canvas.getContext('2d');
+    const pityCanvas = document.getElementById('pity-graph');
+    const pityCtx = pityCanvas ? pityCanvas.getContext('2d') : null;
+
+    let currentEP = 0.0;
+    let ratesData = null;
+    let liveState = null;
+
+    // Set up canvas sizing and high DPI support
+    function resizeAllCanvases() {
+        if (canvas) {
+            const rect = canvas.parentElement.getBoundingClientRect();
+            canvas.width = rect.width * window.devicePixelRatio;
+            canvas.height = rect.height * window.devicePixelRatio;
+            canvas.style.width = rect.width + 'px';
+            canvas.style.height = rect.height + 'px';
+            ctx.setTransform(1, 0, 0, 1, 0, 0);
+            ctx.scale(window.devicePixelRatio, window.devicePixelRatio);
+            drawGraph();
+        }
+
+        if (pityCanvas) {
+            const rect = pityCanvas.parentElement.getBoundingClientRect();
+            pityCanvas.width = rect.width * window.devicePixelRatio;
+            pityCanvas.height = rect.height * window.devicePixelRatio;
+            pityCanvas.style.width = rect.width + 'px';
+            pityCanvas.style.height = rect.height + 'px';
+            pityCtx.setTransform(1, 0, 0, 1, 0, 0);
+            pityCtx.scale(window.devicePixelRatio, window.devicePixelRatio);
+            drawPityGraph();
+        }
+    }
+
+    // Set initial canvas dimension and bind window resize
+    window.addEventListener('resize', resizeAllCanvases);
+    setTimeout(resizeAllCanvases, 100);
+
+    // Dynamic Graph Renderer
+    function drawGraph() {
+        if (!canvas.width || !canvas.height) return;
+        
+        const width = canvas.width / window.devicePixelRatio;
+        const height = canvas.height / window.devicePixelRatio;
+        
+        ctx.clearRect(0, 0, width, height);
+
+        // Chart Area Boundaries
+        const padding = { top: 20, right: 30, bottom: 30, left: 40 };
+        const chartWidth = width - padding.left - padding.right;
+        const chartHeight = height - padding.top - padding.bottom;
+
+        // 1. Draw Grid Lines and Labels
+        ctx.strokeStyle = 'rgba(255, 255, 255, 0.04)';
+        ctx.fillStyle = '#8f9cae';
+        ctx.font = '10px "Outfit", sans-serif';
+        ctx.lineWidth = 1;
+
+        // X-Axis Grid & Labels (EP)
+        for (let i = 0; i <= 10; i++) {
+            const epX = i * 10;
+            const x = padding.left + (i / 10) * chartWidth;
+            
+            ctx.beginPath();
+            ctx.moveTo(x, padding.top);
+            ctx.lineTo(x, padding.top + chartHeight);
+            ctx.stroke();
+
+            ctx.textAlign = 'center';
+            ctx.fillText(epX, x, padding.top + chartHeight + 15);
+        }
+
+        // Define the tiers we want to focus on and scale on the graph
+        const rareTiers = ["Baby", "Ultra", "Gmax", "Starter", "Mega", "Legendary", "Mythical"];
+
+        // Get simulated levels for threshold checks
+        const simulatedMainLevel = parseInt(sliders.mainLevel.value);
+
+        // Helper: calculate percentages for all tiers at any given EP
+        function getRatesAtEP(epVal) {
+            const weights = {};
+            for (const tier in TIER_PARAMS) {
+                const param = TIER_PARAMS[tier];
+                weights[tier] = param.base * Math.pow((param.max_val / param.base), (epVal / 100.0));
+                
+                // Gating threshold check
+                if (LEVEL_THRESHOLDS[tier] && simulatedMainLevel < LEVEL_THRESHOLDS[tier]) {
+                    weights[tier] = 0.0;
+                }
+            }
+
+            const sum = Object.values(weights).reduce((a, b) => a + b, 0);
+            const rates = {};
+            for (const tier in weights) {
+                rates[tier] = sum > 0 ? (weights[tier] / sum) * 100.0 : 0.0;
+            }
+            return rates;
+        }
+
+        // Calculate curves and find max percentage among active rare tiers to scale the chart dynamically
+        const points = 100;
+        const curvePaths = {};
+        let maxPlottedPercent = 0.1; // Baseline safety floor
+
+        for (const tier of rareTiers) {
+            curvePaths[tier] = [];
+        }
+
+        for (let i = 0; i <= points; i++) {
+            const epVal = (i / points) * 100;
+            const rates = getRatesAtEP(epVal);
+            const x = padding.left + (i / points) * chartWidth;
+
+            for (const tier of rareTiers) {
+                const pct = rates[tier] || 0.0;
+                if (pct > maxPlottedPercent) {
+                    maxPlottedPercent = pct;
+                }
+                curvePaths[tier].push({ x, rate: pct });
+            }
+        }
+
+        // Determine Y-axis max with 15% headroom, capped at a minimum of 0.5% for visual scaling
+        const yMax = Math.max(0.5, Math.ceil(maxPlottedPercent * 1.15 * 10) / 10);
+
+        // Y-Axis Grid & Labels (Percentage dynamically scaled to yMax)
+        const ySteps = 5;
+        for (let i = 0; i <= ySteps; i++) {
+            const pctY = (i / ySteps) * yMax;
+            const y = padding.top + chartHeight - (i / ySteps) * chartHeight;
+
+            ctx.beginPath();
+            ctx.moveTo(padding.left, y);
+            ctx.lineTo(padding.left + chartWidth, y);
+            ctx.stroke();
+
+            ctx.textAlign = 'right';
+            ctx.fillText(pctY.toFixed(2) + '%', padding.left - 8, y + 3);
+        }
+
+        // Label axis names
+        ctx.fillStyle = 'rgba(255, 255, 255, 0.3)';
+        ctx.font = '9px "Outfit", sans-serif';
+        ctx.textAlign = 'right';
+        ctx.fillText("EP (Encounter Potential) →", padding.left + chartWidth, padding.top + chartHeight + 28);
+
+        // 2. Stroke Curves (Rare encounters only)
+        for (const tier of rareTiers) {
+            const path = curvePaths[tier];
+            // Check if this tier has any non-zero points plotted (skip fully gated curves)
+            const isZero = path.every(pt => pt.rate === 0.0);
+            if (isZero) continue;
+
+            ctx.beginPath();
+            ctx.strokeStyle = TIERS_CONFIG[tier].color;
+            ctx.lineWidth = 2.5; // Thicker lines for clear rare visibility
+            ctx.lineJoin = 'round';
+            
+            const startY = padding.top + chartHeight - (path[0].rate / yMax) * chartHeight;
+            ctx.moveTo(path[0].x, startY);
+            for (let i = 1; i < path.length; i++) {
+                const y = padding.top + chartHeight - (path[i].rate / yMax) * chartHeight;
+                ctx.lineTo(path[i].x, y);
+            }
+            ctx.stroke();
+        }
+
+        // 3. Mark Current EP Line
+        const currentX = padding.left + (currentEP / 100.0) * chartWidth;
+        
+        ctx.beginPath();
+        ctx.strokeStyle = 'rgba(0, 229, 255, 0.4)';
+        ctx.lineWidth = 1.5;
+        ctx.setLineDash([4, 4]);
+        ctx.moveTo(currentX, padding.top);
+        ctx.lineTo(currentX, padding.top + chartHeight);
+        ctx.stroke();
+        ctx.setLineDash([]); // Reset dash
+
+        // Draw text box indicator for current EP
+        ctx.fillStyle = '#00e5ff';
+        ctx.beginPath();
+        ctx.arc(currentX, padding.top, 4, 0, 2 * Math.PI);
+        ctx.fill();
+
+        ctx.font = 'bold 9px "Outfit", sans-serif';
+        ctx.textAlign = 'center';
+        ctx.fillStyle = '#00e5ff';
+        ctx.fillText("EP: " + currentEP.toFixed(1), currentX, padding.top - 8);
+
+        // 4. Draw Current Value Dot on each Curve
+        const currentRates = getRatesAtEP(currentEP);
+        for (const tier of rareTiers) {
+            const pct = currentRates[tier] || 0.0;
+            const y = padding.top + chartHeight - (pct / yMax) * chartHeight;
+            
+            // Only draw dots for tiers that have a positive presence
+            if (pct > 0.0) {
+                ctx.beginPath();
+                ctx.fillStyle = TIERS_CONFIG[tier].color;
+                ctx.arc(currentX, y, 4.5, 0, 2 * Math.PI);
+                ctx.fill();
+                
+                ctx.beginPath();
+                ctx.strokeStyle = '#ffffff';
+                ctx.lineWidth = 1.2;
+                ctx.arc(currentX, y, 4.5, 0, 2 * Math.PI);
+                ctx.stroke();
+            }
+        }
+    }
+
+    // Update range bubbles locally for responsiveness
+    function updateBubbles() {
+        bubbles.trainerLevel.innerText = sliders.trainerLevel.value;
+        bubbles.dexCompletion.innerText = sliders.dexCompletion.value + '%';
+        bubbles.reviewsDone.innerText = sliders.reviewsDone.value;
+        bubbles.dailyGoal.innerText = sliders.dailyGoal.value;
+        bubbles.avgCp.innerText = sliders.avgCp.value;
+        bubbles.mainLevel.innerText = sliders.mainLevel.value;
+    }
+
+    // Collect slider values to form the state packet
+    function getSliderState() {
+        return {
+            trainer_level: parseInt(sliders.trainerLevel.value),
+            dex_completion: parseFloat(sliders.dexCompletion.value),
+            reviews_done: parseInt(sliders.reviewsDone.value),
+            daily_goal: parseInt(sliders.dailyGoal.value),
+            avg_cp: parseFloat(sliders.avgCp.value),
+            main_level: parseInt(sliders.mainLevel.value)
+        };
+    }
+
+    // Call Python backend and update page
+    function triggerCalculation() {
+        updateBubbles();
+        const state = getSliderState();
+
+        if (window.getRatesFromPython) {
+            window.getRatesFromPython(state, function(result) {
+                ratesData = result;
+                currentEP = result.ep;
+                updateUIElements(result);
+            });
+        } else {
+            // Fallback for visual local prototyping in standard browser
+            // Compute EP locally using dynamic weights and caps
+            const t_norm = Math.min((state.trainer_level / CAPS.trainerLevel) * 100.0, 100.0);
+            const d_norm = state.dex_completion;
+            const s_norm = Math.min((state.reviews_done / state.daily_goal) * 100.0, 100.0);
+            const c_norm = Math.min((state.avg_cp / CAPS.avgCp) * 100.0, 100.0);
+            currentEP = (EP_WEIGHTS.trainerLevel * t_norm) + 
+                        (EP_WEIGHTS.dexCompletion * d_norm) + 
+                        (EP_WEIGHTS.reviewsDone * s_norm) + 
+                        (EP_WEIGHTS.avgCp * c_norm);
+            currentEP = Math.max(0.0, Math.min(currentEP, 100.0));
+            
+            const localLocks = {};
+            for (const tier in LEVEL_THRESHOLDS) {
+                localLocks[tier] = state.main_level < LEVEL_THRESHOLDS[tier];
+            }
+            
+            updateUIElements({
+                ep: currentEP,
+                locks: localLocks,
+                live_overhaul: { "Normal": 90, "Baby": 10, "Ultra": 0, "Gmax": 0, "Starter": 0, "Mega": 0, "Legendary": 0, "Mythical": 0 },
+                live_legacy: { "Normal": 91, "Baby": 9, "Ultra": 0, "Gmax": 0, "Starter": 0, "Mega": 0, "Legendary": 0, "Mythical": 0 },
+                overhaul: { "Normal": 85, "Baby": 12, "Ultra": 3, "Gmax": 0, "Starter": 0, "Mega": 0, "Legendary": 0, "Mythical": 0 },
+                legacy: { "Normal": 88, "Baby": 10, "Ultra": 2, "Gmax": 0, "Starter": 0, "Mega": 0, "Legendary": 0, "Mythical": 0 }
+            });
+        }
+    }
+
+    // Refresh UI elements with backend calculation results
+    function updateUIElements(data) {
+        // 1. Update EP Value display and Gauge
+        epValueDisplay.innerText = data.ep.toFixed(1);
+        
+        // Gauge stroke dashoffset math: circle perimeter is 2 * PI * r = 2 * 3.14159 * 70 = ~440px
+        const perimeter = 440;
+        const offset = perimeter - (data.ep / 100.0) * perimeter;
+        gaugeFill.style.strokeDashoffset = offset;
+
+        // 2. Clear and Render Table Matrix
+        matrixTbody.innerHTML = '';
+        
+        for (const tier in TIERS_CONFIG) {
+            const config = TIERS_CONFIG[tier];
+            const liveOverhaulVal = data.live_overhaul[tier] !== undefined ? data.live_overhaul[tier].toFixed(3) + '%' : '0.000%';
+            const liveLegacyVal = data.live_legacy[tier] !== undefined ? data.live_legacy[tier].toFixed(3) + '%' : '0.000%';
+            const overhaulVal = data.overhaul[tier] !== undefined ? data.overhaul[tier].toFixed(3) + '%' : '0.000%';
+            const legacyVal = data.legacy[tier] !== undefined ? data.legacy[tier].toFixed(3) + '%' : '0.000%';
+            
+            const isLocked = data.locks[tier] === true;
+            const lockHtml = isLocked ? `<span class="lock-indicator" title="Locked: Main Pokémon below level threshold">🔒 Lvl ${LEVEL_THRESHOLDS[tier]}</span>` : '';
+
+            const tr = document.createElement('tr');
+            tr.innerHTML = `
+                <td>
+                    <div class="tier-cell">
+                        <span class="tier-indicator bg-${config.key.toLowerCase()}"></span>
+                        <span class="color-${config.key.toLowerCase()}">${config.name}</span>
+                        ${lockHtml}
+                    </div>
+                </td>
+                <td style="text-align: right; color: #a5b4fc;" class="percentage-value">${liveOverhaulVal}</td>
+                <td style="text-align: right; color: rgba(255,255,255,0.4);" class="percentage-value">${liveLegacyVal}</td>
+                <td style="text-align: right; color: var(--accent-cyan);" class="percentage-value">${overhaulVal}</td>
+                <td style="text-align: right; color: rgba(255,255,255,0.6);" class="percentage-value">${legacyVal}</td>
+            `;
+            matrixTbody.appendChild(tr);
+        }
+
+        // 3. Re-render graph curves and value markers
+        drawGraph();
+
+        // 4. Update Pity Simulator display
+        updatePitySimulator();
+    }
+
+    // =========================================================================
+    // Pity & Dry Spell Simulator Logic
+    // =========================================================================
+
+    function getOverhaulRatesWithPity(selectedPityTier, dryEncounters) {
+        const weights = {};
+        const simulatedMainLevel = parseInt(sliders.mainLevel.value);
+        
+        // 1. Calculate base weights
+        for (const tier in TIER_PARAMS) {
+            const param = TIER_PARAMS[tier];
+            weights[tier] = param.base * Math.pow((param.max_val / param.base), (currentEP / 100.0));
+            
+            // Gating threshold check
+            if (LEVEL_THRESHOLDS[tier] && simulatedMainLevel < LEVEL_THRESHOLDS[tier]) {
+                weights[tier] = 0.0;
+            }
+        }
+
+        // 2. Calculate pity multiplier for the selected tier
+        let pityMultiplier = 1.0;
+        if (selectedPityTier && TIER_PARAMS[selectedPityTier]) {
+            const t_i = TIER_PITY_THRESHOLDS[selectedPityTier] || 100;
+            const divisor = PITY_DIVISOR;
+            pityMultiplier = 1.0 + Math.pow(Math.max(0, (dryEncounters - t_i) / divisor), 2);
+            weights[selectedPityTier] *= pityMultiplier;
+        }
+
+        // 3. Re-normalize to get rates
+        const sum = Object.values(weights).reduce((a, b) => a + b, 0);
+        const rates = {};
+        for (const tier in weights) {
+            rates[tier] = sum > 0 ? (weights[tier] / sum) * 100.0 : 0.0;
+        }
+        return {
+            rates: rates,
+            multiplier: pityMultiplier
+        };
+    }
+
+    function updatePitySimulator() {
+        if (!pitySliders.dry) return;
+        
+        const tier = pitySliders.tierValue;
+        const dry = parseInt(pitySliders.dry.value);
+        
+        // Update DOM labels
+        pityDisplays.dryVal.innerText = dry;
+        
+        const threshold = TIER_PITY_THRESHOLDS[tier] || 100;
+        pityDisplays.threshold.innerText = threshold;
+        pityDisplays.divisor.innerText = PITY_DIVISOR.toFixed(1);
+        
+        // Calculate base rate (0 dry encounters)
+        const baseResult = getOverhaulRatesWithPity(tier, 0);
+        const baseRate = baseResult.rates[tier] || 0.0;
+        pityDisplays.baseRate.innerText = baseRate.toFixed(3) + "%";
+        
+        // Calculate boosted rate
+        const boostedResult = getOverhaulRatesWithPity(tier, dry);
+        const boostedRate = boostedResult.rates[tier] || 0.0;
+        pityDisplays.boostedRate.innerText = boostedRate.toFixed(3) + "%";
+        pityDisplays.multiplier.innerText = boostedResult.multiplier.toFixed(2) + "x";
+        
+        // Draw the pity curve graph
+        drawPityGraph();
+    }
+
+    function drawPityGraph() {
+        if (!pityCanvas || !pityCtx) return;
+        
+        const width = pityCanvas.width / window.devicePixelRatio;
+        const height = pityCanvas.height / window.devicePixelRatio;
+        
+        pityCtx.clearRect(0, 0, width, height);
+        
+        const padding = { top: 20, right: 30, bottom: 30, left: 40 };
+        const chartWidth = width - padding.left - padding.right;
+        const chartHeight = height - padding.top - padding.bottom;
+        
+        const tier = pitySliders.tierValue;
+        const currentDry = parseInt(pitySliders.dry.value);
+        const threshold = TIER_PITY_THRESHOLDS[tier] || 100;
+        const divisor = PITY_DIVISOR;
+        
+        const tierColor = TIERS_CONFIG[tier]?.color || '#00ff88';
+        
+        // Scale X-axis from 0 to 1000
+        const maxDry = 1000;
+        const maxMult = 1.0 + Math.pow(Math.max(0, (maxDry - threshold) / divisor), 2);
+        
+        const yMin = 1.0;
+        const yMax = Math.max(5.0, Math.ceil(maxMult * 1.05));
+        
+        // 1. Draw Grid Lines and Labels
+        pityCtx.strokeStyle = 'rgba(255, 255, 255, 0.04)';
+        pityCtx.fillStyle = '#8f9cae';
+        pityCtx.font = '9px "Outfit", sans-serif';
+        pityCtx.lineWidth = 1;
+        
+        // X-Axis Grid & Labels (Dry encounters from 0 to 1000, step 200)
+        for (let i = 0; i <= 5; i++) {
+            const xVal = i * 200;
+            const x = padding.left + (xVal / maxDry) * chartWidth;
+            
+            pityCtx.beginPath();
+            pityCtx.moveTo(x, padding.top);
+            pityCtx.lineTo(x, padding.top + chartHeight);
+            pityCtx.stroke();
+            
+            pityCtx.textAlign = 'center';
+            pityCtx.fillText(xVal, x, padding.top + chartHeight + 14);
+        }
+        
+        // Y-Axis Grid & Labels (Multiplier, step 4)
+        const ySteps = 4;
+        for (let i = 0; i <= ySteps; i++) {
+            const yVal = 1.0 + (i / ySteps) * (yMax - 1.0);
+            const y = padding.top + chartHeight - (i / ySteps) * chartHeight;
+            
+            pityCtx.beginPath();
+            pityCtx.moveTo(padding.left, y);
+            pityCtx.lineTo(padding.left + chartWidth, y);
+            pityCtx.stroke();
+            
+            pityCtx.textAlign = 'right';
+            pityCtx.fillText(yVal.toFixed(0) + 'x', padding.left - 8, y + 3);
+        }
+        
+        // Draw Axis Names
+        pityCtx.fillStyle = 'rgba(255, 255, 255, 0.3)';
+        pityCtx.font = '9px "Outfit", sans-serif';
+        pityCtx.textAlign = 'right';
+        pityCtx.fillText("Dry Encounters →", padding.left + chartWidth, padding.top + chartHeight + 26);
+        
+        // 2. Stroke Pity Curve
+        pityCtx.beginPath();
+        pityCtx.strokeStyle = tierColor;
+        pityCtx.lineWidth = 2.5;
+        pityCtx.lineJoin = 'round';
+        
+        const points = 100;
+        for (let i = 0; i <= points; i++) {
+            const xVal = (i / points) * maxDry;
+            const mult = 1.0 + Math.pow(Math.max(0, (xVal - threshold) / divisor), 2);
+            
+            const x = padding.left + (xVal / maxDry) * chartWidth;
+            const y = padding.top + chartHeight - ((mult - yMin) / (yMax - yMin)) * chartHeight;
+            
+            if (i === 0) {
+                pityCtx.moveTo(x, y);
+            } else {
+                pityCtx.lineTo(x, y);
+            }
+        }
+        pityCtx.stroke();
+        
+        // 3. Draw Threshold Marker Line (dashed vertical)
+        const threshX = padding.left + (threshold / maxDry) * chartWidth;
+        pityCtx.beginPath();
+        pityCtx.strokeStyle = 'rgba(255, 255, 255, 0.15)';
+        pityCtx.lineWidth = 1;
+        pityCtx.setLineDash([3, 3]);
+        pityCtx.moveTo(threshX, padding.top);
+        pityCtx.lineTo(threshX, padding.top + chartHeight);
+        pityCtx.stroke();
+        pityCtx.setLineDash([]);
+        
+        // Add threshold text label
+        pityCtx.fillStyle = 'rgba(255, 255, 255, 0.4)';
+        pityCtx.font = '9px "Outfit", sans-serif';
+        pityCtx.textAlign = 'center';
+        pityCtx.fillText(`Threshold: ${threshold}`, threshX, padding.top - 6);
+        
+        // 4. Mark Current Selected Value Point on Curve
+        const currentMult = 1.0 + Math.pow(Math.max(0, (currentDry - threshold) / divisor), 2);
+        const currentX = padding.left + (currentDry / maxDry) * chartWidth;
+        const currentY = padding.top + chartHeight - ((currentMult - yMin) / (yMax - yMin)) * chartHeight;
+        
+        // Draw vertical guide line for current value
+        pityCtx.beginPath();
+        pityCtx.strokeStyle = 'rgba(0, 255, 136, 0.25)';
+        pityCtx.lineWidth = 1;
+        pityCtx.setLineDash([2, 2]);
+        pityCtx.moveTo(currentX, currentY);
+        pityCtx.lineTo(currentX, padding.top + chartHeight);
+        pityCtx.stroke();
+        pityCtx.setLineDash([]);
+        
+        // Highlight active dot
+        pityCtx.beginPath();
+        pityCtx.fillStyle = '#00ff88';
+        pityCtx.arc(currentX, currentY, 5, 0, 2 * Math.PI);
+        pityCtx.fill();
+        
+        pityCtx.beginPath();
+        pityCtx.strokeStyle = '#ffffff';
+        pityCtx.lineWidth = 1.5;
+        pityCtx.arc(currentX, currentY, 5, 0, 2 * Math.PI);
+        pityCtx.stroke();
+        
+        // Draw bubble with current stats at active dot
+        pityCtx.fillStyle = '#00ff88';
+        pityCtx.font = 'bold 9px "Outfit", sans-serif';
+        pityCtx.textAlign = 'center';
+        pityCtx.fillText(`${currentMult.toFixed(2)}x`, currentX, currentY - 8);
+    }
+
+    let calcTimeout = null;
+
+    function handleSliderInput() {
+        // Instantly update local slider text bubbles for ultra-smooth feedback
+        updateBubbles();
+        
+        // Debounce the heavy PyQt/WebEngine evaluation calculations to prevent flickering
+        if (calcTimeout) {
+            clearTimeout(calcTimeout);
+        }
+        calcTimeout = setTimeout(triggerCalculation, 50);
+    }
+
+    function handleSliderChange() {
+        if (calcTimeout) {
+            clearTimeout(calcTimeout);
+        }
+        triggerCalculation();
+    }
+
+    // Bind event listeners to all sliders
+    for (const key in sliders) {
+        sliders[key].addEventListener('input', handleSliderInput);
+        sliders[key].addEventListener('change', handleSliderChange);
+    }
+
+    // Bind event listeners to pity simulator controls
+    if (pitySliders.dry) {
+        pitySliders.dry.addEventListener('input', function() {
+            pityDisplays.dryVal.innerText = pitySliders.dry.value;
+            updatePitySimulator();
+        });
+        pitySliders.dry.addEventListener('change', function() {
+            updatePitySimulator();
+        });
+    }
+
+    // Custom Styled Dropdown Click Interactivity (replaces native selects to prevent crashes)
+    const dropdownTrigger = document.getElementById('pity-tier-trigger');
+    const dropdownOptionsContainer = document.getElementById('pity-tier-options');
+    const dropdownArrow = document.getElementById('dropdown-arrow');
+    const selectedLabel = document.getElementById('selected-tier-label');
+    const optionElements = document.querySelectorAll('.dropdown-option');
+
+    if (dropdownTrigger && dropdownOptionsContainer) {
+        dropdownTrigger.addEventListener('click', function(e) {
+            e.stopPropagation();
+            dropdownOptionsContainer.classList.toggle('active');
+            if (dropdownArrow) {
+                dropdownArrow.style.transform = dropdownOptionsContainer.classList.contains('active') ? 'rotate(180deg)' : 'rotate(0deg)';
+            }
+        });
+
+        // Close dropdown when clicking outside
+        document.addEventListener('click', function() {
+            dropdownOptionsContainer.classList.remove('active');
+            if (dropdownArrow) {
+                dropdownArrow.style.transform = 'rotate(0deg)';
+            }
+        });
+
+        optionElements.forEach(option => {
+            option.addEventListener('click', function(e) {
+                e.stopPropagation();
+                selectedPityTier = this.getAttribute('data-value');
+                
+                // Update active highlighted classes
+                optionElements.forEach(opt => opt.classList.remove('selected'));
+                this.classList.add('selected');
+                
+                // Update selection label text
+                if (selectedLabel) {
+                    selectedLabel.innerText = selectedPityTier;
+                }
+                
+                // Collapse menu
+                dropdownOptionsContainer.classList.remove('active');
+                if (dropdownArrow) {
+                    dropdownArrow.style.transform = 'rotate(0deg)';
+                }
+                
+                // Trigger calculation / update
+                updatePitySimulator();
+            });
+        });
+        
+        // Mark default selection on startup
+        optionElements.forEach(option => {
+            if (option.getAttribute('data-value') === selectedPityTier) {
+                option.classList.add('selected');
+            }
+        });
+    }
+
+    // 5. PyQt6 QWebChannel Connection Wires
+    document.addEventListener("DOMContentLoaded", function() {
+        if (typeof qt !== "undefined" && qt.webChannelTransport) {
+            new QWebChannel(qt.webChannelTransport, function(channel) {
+                window.pyBridge = channel.objects.pyBridge;
+                
+                // Wire up the expected window helper
+                window.getRatesFromPython = function(sliderState, callback) {
+                    window.pyBridge.calculate_rates_js(JSON.stringify(sliderState)).then(function(resultJson) {
+                        callback(JSON.parse(resultJson));
+                    });
+                };
+
+                // Trigger initial load calculations from real python database values
+                // Python can query active save settings and update sliders on load
+                window.pyBridge.get_initial_state().then(function(stateJson) {
+                    const state = JSON.parse(stateJson);
+                    liveState = state;
+                    
+                    // Load dynamic config coefficients from Python dynamically!
+                    if (state.config) {
+                        const cfg = state.config;
+                        EP_WEIGHTS.trainerLevel = cfg.ep_weight_trainer_level;
+                        EP_WEIGHTS.dexCompletion = cfg.ep_weight_dex_completion;
+                        EP_WEIGHTS.reviewsDone = cfg.ep_weight_session_progress;
+                        EP_WEIGHTS.avgCp = cfg.ep_weight_core_team_power;
+                        
+                        CAPS.trainerLevel = cfg.trainer_level_cap;
+                        CAPS.avgCp = cfg.core_team_power_cap;
+                        
+                        if (cfg.tier_params) {
+                            for (const tier in cfg.tier_params) {
+                                const val = cfg.tier_params[tier];
+                                if (Array.isArray(val)) {
+                                    TIER_PARAMS[tier] = { base: val[0], max_val: val[1] };
+                                } else {
+                                    TIER_PARAMS[tier] = val;
+                                }
+                            }
+                        }
+                        if (cfg.level_thresholds) LEVEL_THRESHOLDS = cfg.level_thresholds;
+                        if (cfg.pity_thresholds) TIER_PITY_THRESHOLDS = cfg.pity_thresholds;
+                        if (cfg.pity_divisor) PITY_DIVISOR = cfg.pity_divisor;
+                    }
+
+                    // Dynamically adjust slider limits based on dynamic config caps from Python
+                    if (CAPS.trainerLevel) {
+                        sliders.trainerLevel.max = CAPS.trainerLevel;
+                    }
+                    if (CAPS.avgCp) {
+                        sliders.avgCp.min = 0; // Fix slider step alignment clamp bug!
+                        sliders.avgCp.max = CAPS.avgCp;
+                        // Set a step size that makes sense for the scale (e.g. 1/100 of the max, at least 50)
+                        sliders.avgCp.step = Math.max(50, Math.floor(CAPS.avgCp / 100));
+                    }
+
+                    // Render active system badge dynamically
+                    const systemBadge = document.getElementById('system-badge');
+                    if (systemBadge && state.active_system) {
+                        systemBadge.innerText = "Active System: " + state.active_system;
+                        if (state.active_system === "Overhaul") {
+                            systemBadge.style.borderColor = "rgba(0, 255, 136, 0.2)";
+                            systemBadge.style.background = "rgba(0, 255, 136, 0.1)";
+                            systemBadge.style.color = "#00ff88";
+                        } else {
+                            systemBadge.style.borderColor = "rgba(255, 170, 0, 0.2)";
+                            systemBadge.style.background = "rgba(255, 170, 0, 0.1)";
+                            systemBadge.style.color = "#ffaa00";
+                        }
+                    }
+                    
+                    sliders.trainerLevel.value = state.trainer_level;
+                    sliders.dexCompletion.value = state.dex_completion;
+                    sliders.reviewsDone.value = state.reviews_done;
+                    sliders.dailyGoal.value = state.daily_goal;
+                    sliders.avgCp.value = state.avg_cp;
+                    sliders.mainLevel.value = state.main_level;
+                    
+                    // Wire up the Reset to Live button
+                    const btnReset = document.getElementById("btn-reset");
+                    if (btnReset) {
+                        btnReset.addEventListener("click", function() {
+                            if (liveState) {
+                                sliders.trainerLevel.value = liveState.trainer_level;
+                                sliders.dexCompletion.value = liveState.dex_completion;
+                                sliders.reviewsDone.value = liveState.reviews_done;
+                                sliders.dailyGoal.value = liveState.daily_goal;
+                                sliders.avgCp.value = liveState.avg_cp;
+                                sliders.mainLevel.value = liveState.main_level;
+                                
+                                if (pitySliders.dry) pitySliders.dry.value = 0;
+                                selectedPityTier = "Ultra";
+                                if (selectedLabel) selectedLabel.innerText = "Ultra";
+                                optionElements.forEach(opt => {
+                                    opt.classList.remove('selected');
+                                    if (opt.getAttribute('data-value') === "Ultra") {
+                                        opt.classList.add('selected');
+                                    }
+                                });
+                                
+                                triggerCalculation();
+                            }
+                        });
+                    }
+                    
+                    triggerCalculation();
+                });
+            });
+        } else {
+            // Standard web prototyping load trigger
+            triggerCalculation();
+        }
+    });
+
+})();

--- a/src/Ankimon/functions/encounter_functions.py
+++ b/src/Ankimon/functions/encounter_functions.py
@@ -301,8 +301,13 @@ def calculate_mastery_index_ep(total_reviews, daily_average, trainer_level):
     return max(0.0, min(ep, 100.0))
 
 
-def load_pity_trackers() -> dict:
-    """Load the per-tier dry-spell counters persisted via the user_data table."""
+def load_pity_trackers(db=None) -> dict:
+    """Load the per-tier dry-spell counters persisted via the user_data table.
+
+    ``db`` defaults to :data:`services.db`. The encounter-rate simulator (F23)
+    injects an explicit provider so it can read the live pity counters
+    read-only without mutating the global service registry.
+    """
     default_pity = {
         "Ultra": 0,
         "Gmax": 0,
@@ -312,7 +317,8 @@ def load_pity_trackers() -> dict:
         "Mythical": 0,
     }
     try:
-        db = services.db
+        if db is None:
+            db = services.db
         if db is not None:
             stored = db.get_user_data("ankimon_pity_trackers")
             if isinstance(stored, dict):
@@ -334,12 +340,25 @@ def save_pity_trackers(trackers: dict):
         print(f"[Ankimon] Warning: Error saving pity trackers: {e}")
 
 
-def _modify_percentages_overhaul(total_reviews, daily_average, trainer_level):
+def _modify_percentages_overhaul(
+    total_reviews, daily_average, trainer_level, *, main_level=None, ep=None, db=None
+):
     """
     Overhaul calculation for encounter percentages based on the Mastery Index (EP),
     Exponential Rarity Scaling, and Independent Pity systems.
+
+    The ``main_level``/``ep``/``db`` arguments are simulation-injection hooks used
+    by the encounter-rate simulator (F23). They all default to the live behaviour
+    so ordinary callers are unaffected:
+
+    * ``ep`` — a pre-computed Mastery Index (0-100). When ``None`` it is derived
+      from live pokedex/team state via :func:`calculate_mastery_index_ep`.
+    * ``main_level`` — main-Pokémon level for the tier gates. When ``None`` the
+      live ``main_pokemon`` global is used.
+    * ``db`` — read-only provider for the pity lookup; defaults to services.db.
     """
-    ep = calculate_mastery_index_ep(total_reviews, daily_average, trainer_level)
+    if ep is None:
+        ep = calculate_mastery_index_ep(total_reviews, daily_average, trainer_level)
 
     # Generate base weights
     weights = {}
@@ -347,19 +366,22 @@ def _modify_percentages_overhaul(total_reviews, daily_average, trainer_level):
         weights[tier] = base * ((max_val / base) ** (ep / 100.0))
 
     # Apply level thresholds
-    level_val = (
-        main_pokemon.level
-        if main_pokemon
-        and hasattr(main_pokemon, "level")
-        and main_pokemon.level is not None
-        else 1
-    )
+    if main_level is not None:
+        level_val = main_level
+    else:
+        level_val = (
+            main_pokemon.level
+            if main_pokemon
+            and hasattr(main_pokemon, "level")
+            and main_pokemon.level is not None
+            else 1
+        )
     for tier, limit in OVERHAUL_LEVEL_THRESHOLDS.items():
         if level_val < limit:
             weights[tier] = 0.0
 
-    # Apply pity multipliers
-    pity_trackers = load_pity_trackers()
+    # Apply pity multipliers (read-only; simulation never persists trackers)
+    pity_trackers = load_pity_trackers(db=db)
     for tier in OVERHAUL_PITY_THRESHOLDS:
         p_i = pity_trackers.get(tier, 0)
         t_i = OVERHAUL_PITY_THRESHOLDS[tier]
@@ -379,18 +401,45 @@ def _modify_percentages_overhaul(total_reviews, daily_average, trainer_level):
 def modify_percentages(total_reviews, daily_average, trainer_level):
     """
     Modify Pokémon encounter percentages based on total reviews, trainer level, and main Pokémon level.
+
+    Thin dispatcher: routes to the overhaul or legacy calculation based on the
+    active system flag. The simulator (F23) calls the ``_modify_percentages_*``
+    helpers directly with injected state, so it never has to flip this module's
+    ``USE_OVERHAUL_ENCOUNTER_SYSTEM`` global.
     """
     if USE_OVERHAUL_ENCOUNTER_SYSTEM:
         return _modify_percentages_overhaul(total_reviews, daily_average, trainer_level)
+    return _modify_percentages_legacy(total_reviews, daily_average, trainer_level)
 
+
+def _modify_percentages_legacy(
+    total_reviews, daily_average, trainer_level, *, main_level=None
+):
+    """
+    Legacy calculation for encounter percentages (review-ratio buckets +
+    trainer-level boost + main-Pokémon-level tier gates).
+
+    ``main_level`` is a simulation-injection hook (F23); when ``None`` the live
+    ``main_pokemon`` global is used and the single-slot performance cache is
+    active. When a level is injected the cache is bypassed entirely so the
+    simulator can never read or poison the live gameplay cache.
+    """
     # None-safe: the module global is bound by core.bind_runtime_globals()
     # after composition; fall back to level 1 while unbound (mirrors the
     # guard in _modify_percentages_overhaul).
-    main_pokemon_level = main_pokemon.level if main_pokemon is not None else 1
+    if main_level is not None:
+        main_pokemon_level = main_level
+    else:
+        main_pokemon_level = main_pokemon.level if main_pokemon is not None else 1
+
+    # The simulator injects state; its inputs are not part of the cache key, so
+    # skip the cache read/write while simulating to keep the live cache honest.
+    simulating = main_level is not None
 
     # Performance Guard: Skip recalculation if inputs haven't changed
     if (
-        _percentages_cache["percentages"] is not None
+        not simulating
+        and _percentages_cache["percentages"] is not None
         and _percentages_cache["total_reviews"] == total_reviews
         and _percentages_cache["trainer_level"] == trainer_level
         and _percentages_cache["main_pokemon_level"] == main_pokemon_level
@@ -482,11 +531,12 @@ def modify_percentages(total_reviews, daily_average, trainer_level):
     for tier in percentages:
         percentages[tier] = (percentages[tier] / total) * 100 if total > 0 else 0
 
-    # Cache and return
-    _percentages_cache["percentages"] = percentages
-    _percentages_cache["total_reviews"] = total_reviews
-    _percentages_cache["trainer_level"] = trainer_level
-    _percentages_cache["main_pokemon_level"] = main_pokemon_level
+    # Cache and return (skip while simulating so the live cache stays clean)
+    if not simulating:
+        _percentages_cache["percentages"] = percentages
+        _percentages_cache["total_reviews"] = total_reviews
+        _percentages_cache["trainer_level"] = trainer_level
+        _percentages_cache["main_pokemon_level"] = main_pokemon_level
 
     return percentages
 

--- a/src/Ankimon/pyobj/encounter_simulator_dialog.py
+++ b/src/Ankimon/pyobj/encounter_simulator_dialog.py
@@ -1,0 +1,330 @@
+"""Encounter Rate Simulator — a self-contained QWebEngine dialog.
+
+Ported from BRRRR_Experimental and re-fitted onto main's service seam:
+
+* State is read through :data:`services` (``services.db`` / ``services.settings``
+  / ``services.tracker`` / ``services.main_pokemon`` / ``services.trainer_card``)
+  instead of ``aqt.mw`` and ``singletons``.
+* The simulation no longer monkeypatches ``mw.ankimon_db`` / ``main_pokemon`` /
+  ``business.calculate_cp_from_dict``. Instead the simulated Mastery Index (EP)
+  and main-Pokémon level are computed from the slider inputs and *injected* into
+  ``encounter_functions`` via keyword arguments; the pity counters are read
+  read-only through an explicit ``db`` provider (defaulting to ``services.db``).
+  Nothing global is mutated, so the live game state is untouched.
+
+The heavy ``QtWebEngine`` widgets are imported lazily inside ``__init__`` and the
+lighter Qt imports are guarded, so importing this module never requires Qt — the
+rate math (:meth:`SimulatorBridge.get_initial_state` /
+:meth:`EncounterSimulatorDialog.calculate_rates`) is exercised head-less in
+tests.
+
+This ships as a stand-alone dialog owning its own ``QWebEngineView`` +
+``QWebChannel``. When the shared web-shell host (Wave 4) lands, this screen can
+be re-hosted via ``WebShellHost.mount(...)``; see MERGE_ARCH_MAP.md §4.
+"""
+
+import json
+from pathlib import Path
+
+try:  # Qt is optional at import time so Tier-1 collection stays Qt-free.
+    from PyQt6.QtWidgets import QDialog, QVBoxLayout
+    from PyQt6.QtCore import QUrl, QObject, pyqtSlot, Qt
+    from PyQt6.QtGui import QColor
+except Exception:  # pragma: no cover - headless (PyQt6 not importable)
+    QDialog = object
+    QObject = object
+
+    def pyqtSlot(*_args, **_kwargs):
+        def _decorator(func):
+            return func
+
+        return _decorator
+
+
+from ..services import services
+from ..functions import encounter_functions as ef
+from .. import business
+from ..functions.pokedex_functions import (
+    search_pokedex,
+    search_pokedex_by_id,
+    safe_int,
+)
+
+
+class SimulatorBridge(QObject):
+    """Exposes slots to JavaScript via QWebChannel for retrieving initial state
+    and running real-time encounter-rate calculations."""
+
+    def __init__(self, dialog):
+        super().__init__()
+        self.dialog = dialog
+
+    @pyqtSlot(result=str)
+    def get_initial_state(self) -> str:
+        """Fetch the player's active live data to pre-populate simulator sliders."""
+        db = services.db
+        trainer_card = services.trainer_card
+        main_pokemon = services.main_pokemon
+        tracker = services.tracker
+        settings_obj = services.settings
+
+        # 1. Trainer Level
+        t_level = (
+            trainer_card.level if trainer_card and hasattr(trainer_card, "level") else 1
+        )
+
+        # 2. Dex Completion Percentage
+        d_pct = 0.0
+        try:
+            from ..functions.pokedex_functions import _load_pokedex_cache
+
+            pokedex_data = _load_pokedex_cache()
+            if pokedex_data and db is not None:
+                caught_ids = db.get_all_pokemon_ids()
+                caught_species = set()
+                for pid in caught_ids:
+                    if pid >= 10000:
+                        name = search_pokedex_by_id(pid)
+                        if name and name != "Pokémon not found":
+                            base_id = safe_int(search_pokedex(name, "species_id"))
+                            if base_id:
+                                caught_species.add(base_id)
+                    else:
+                        caught_species.add(pid)
+
+                unique_species_in_game = {
+                    safe_int(v.get("species_id"))
+                    for v in pokedex_data.values()
+                    if v.get("species_id")
+                }
+                unique_species_in_game.discard(0)
+                total_species_count = (
+                    len(unique_species_in_game) if unique_species_in_game else 1
+                )
+                d_pct = (
+                    len(caught_species & unique_species_in_game) / total_species_count
+                ) * 100.0
+        except Exception as e:
+            print(
+                f"[Ankimon Bridge] Warning: Could not calculate live Dex Completion: {e}"
+            )
+
+        # 3. Reviews Done
+        reviews = tracker.get_total_reviews() if tracker else 0
+
+        # 4. Daily Goal
+        daily_goal = 100
+        try:
+            if settings_obj:
+                daily_goal = int(settings_obj.get("battle.daily_average"))
+        except Exception:
+            pass
+
+        # 5. Average CP (top-6)
+        avg_cp = 10.0
+        try:
+            if db is not None:
+                all_pkmn = db.get_all_pokemon()
+                if all_pkmn:
+                    cps = []
+                    for p in all_pkmn:
+                        try:
+                            cps.append(business.calculate_cp_from_dict(p))
+                        except Exception:
+                            pass
+                    cps.sort(reverse=True)
+                    top_6 = cps[:6]
+                    avg_cp = sum(top_6) / len(top_6) if top_6 else 10.0
+        except Exception as e:
+            print(f"[Ankimon Bridge] Warning: Could not calculate live top-6 CP: {e}")
+
+        # 6. Main Pokémon Level
+        main_lvl = (
+            main_pokemon.level
+            if main_pokemon
+            and hasattr(main_pokemon, "level")
+            and main_pokemon.level is not None
+            else 1
+        )
+
+        # Which system is currently active in the Ankimon add-on
+        active_system = "Overhaul" if ef.USE_OVERHAUL_ENCOUNTER_SYSTEM else "Legacy"
+
+        # Package Overhaul configuration constants dynamically from encounter_functions
+        overhaul_config = {
+            "ep_weight_trainer_level": float(ef.EP_WEIGHT_TRAINER_LEVEL),
+            "ep_weight_dex_completion": float(ef.EP_WEIGHT_DEX_COMPLETION),
+            "ep_weight_session_progress": float(ef.EP_WEIGHT_SESSION_PROGRESS),
+            "ep_weight_core_team_power": float(ef.EP_WEIGHT_CORE_TEAM_POWER),
+            "trainer_level_cap": float(ef.TRAINER_LEVEL_CAP),
+            "core_team_power_cap": float(ef.CORE_TEAM_POWER_CAP),
+            "tier_params": ef.OVERHAUL_TIER_PARAMS,
+            "level_thresholds": ef.OVERHAUL_LEVEL_THRESHOLDS,
+            "pity_thresholds": ef.OVERHAUL_PITY_THRESHOLDS,
+            "pity_divisor": float(ef.OVERHAUL_PITY_DIVISOR),
+        }
+
+        state = {
+            "trainer_level": int(t_level),
+            "dex_completion": round(d_pct, 1),
+            "reviews_done": int(reviews),
+            "daily_goal": int(daily_goal),
+            "avg_cp": int(avg_cp),
+            "main_level": int(main_lvl),
+            "config": overhaul_config,
+            "active_system": active_system,
+        }
+        return json.dumps(state)
+
+    @pyqtSlot(str, result=str)
+    def calculate_rates_js(self, slider_state_json: str) -> str:
+        """Receive slider values, run the backend calc, return JSON weights."""
+        slider_state = json.loads(slider_state_json)
+        result = self.dialog.calculate_rates(slider_state)
+        return json.dumps(result)
+
+
+class EncounterSimulatorDialog(QDialog):
+    """Modern PyQt6 dialog housing the Encounter Rate Simulator web view.
+
+    Exposes the simulated mathematical weighting without duplicating the
+    balancing logic — it calls the real ``encounter_functions`` helpers with
+    injected slider state.
+    """
+
+    def __init__(self, addon_dir=None):
+        super().__init__()
+        # Resolve the addon directory (the package root, where the
+        # ``encounter_simulator/`` asset folder lives). Defaults to this
+        # package so the dialog is self-contained; a caller (menu glue or the
+        # future web-shell host) may pass an explicit path, e.g.
+        # ``mw.addonManager.addonFromModule(__name__)`` -> addons21/<id>.
+        self.addon_dir = (
+            Path(addon_dir)
+            if addon_dir is not None
+            else Path(__file__).resolve().parent.parent
+        )
+        self.setWindowTitle("Ankimon Encounter Rate Simulator")
+        self.resize(1100, 800)
+
+        # Allow minimizing/maximizing cleanly
+        self.setWindowFlags(self.windowFlags() | Qt.WindowType.WindowMinMaxButtonsHint)
+
+        # Setup Layout
+        layout = QVBoxLayout()
+        layout.setContentsMargins(0, 0, 0, 0)
+        self.setLayout(layout)
+
+        # QtWebEngine is imported lazily so importing this module never pulls in
+        # the (heavy, Chromium-backed) web engine — mirrors webshell/host.py.
+        from PyQt6.QtWebEngineWidgets import QWebEngineView
+        from PyQt6.QtWebChannel import QWebChannel
+
+        # Setup QWebEngineView
+        self.webview = QWebEngineView()
+        # Prevent white background loading flash
+        self.webview.page().setBackgroundColor(QColor(13, 15, 25))
+
+        # Configure WebChannel communication
+        self.channel = QWebChannel(self.webview)
+        self.bridge = SimulatorBridge(self)
+        self.channel.registerObject("pyBridge", self.bridge)
+        self.webview.page().setWebChannel(self.channel)
+
+        layout.addWidget(self.webview)
+
+        # Load local HTML file (qwebchannel.js is served by Qt via qrc:///)
+        html_path = self.addon_dir / "encounter_simulator" / "simulator.html"
+        self.webview.setUrl(QUrl.fromLocalFile(html_path.as_posix()))
+
+    def calculate_rates(self, slider_state: dict, db=None) -> dict:
+        """Compute live & simulated encounter rates for the given slider state.
+
+        Seam re-fit of exp's monkeypatching implementation:
+
+        * ``db`` is the database provider used for the *read-only* pity lookup
+          and (via ``services``) the live-rate math. It defaults to
+          ``services.db``; callers/tests may pass an explicit provider. The
+          global registry is never mutated.
+        * The simulated Mastery Index (``ep``) and main-Pokémon ``main_level``
+          are derived from the slider values and injected into
+          ``encounter_functions``' calculation helpers, so no CP/DB/level
+          globals are patched. This reproduces exp's simulated weighting while
+          keeping the gauge and the rate math self-consistent.
+        """
+        if db is None:
+            db = services.db
+
+        tracker = services.tracker
+        trainer_card = services.trainer_card
+        settings_obj = services.settings
+
+        # 1. Live rates reflect the player's *current* state (real db / team).
+        ef.clear_encounter_cache()
+        live_reviews = tracker.get_total_reviews() if tracker else 0
+        live_goal = 100
+        try:
+            if settings_obj:
+                live_goal = int(settings_obj.get("battle.daily_average"))
+        except Exception:
+            pass
+        live_trainer_lvl = (
+            trainer_card.level if trainer_card and hasattr(trainer_card, "level") else 1
+        )
+        live_overhaul_rates = ef._modify_percentages_overhaul(
+            live_reviews, live_goal, live_trainer_lvl
+        )
+        live_legacy_rates = ef._modify_percentages_legacy(
+            live_reviews, live_goal, live_trainer_lvl
+        )
+
+        # 2. Compute the simulated EP Mastery Index directly from the sliders.
+        #    (Same formula as calculate_mastery_index_ep, fed by slider values
+        #    instead of the live pokedex/team — this is what the gauge shows.)
+        daily_goal = slider_state["daily_goal"] or 1
+        t_norm = min(
+            (slider_state["trainer_level"] / ef.TRAINER_LEVEL_CAP) * 100.0, 100.0
+        )
+        d_norm = slider_state["dex_completion"]
+        s_norm = min((slider_state["reviews_done"] / daily_goal) * 100.0, 100.0)
+        c_norm = min((slider_state["avg_cp"] / ef.CORE_TEAM_POWER_CAP) * 100.0, 100.0)
+        simulated_ep = (
+            (ef.EP_WEIGHT_TRAINER_LEVEL * t_norm)
+            + (ef.EP_WEIGHT_DEX_COMPLETION * d_norm)
+            + (ef.EP_WEIGHT_SESSION_PROGRESS * s_norm)
+            + (ef.EP_WEIGHT_CORE_TEAM_POWER * c_norm)
+        )
+        simulated_ep = max(0.0, min(simulated_ep, 100.0))
+
+        # 3. Simulated rates: inject the slider-derived EP + main level. Pity is
+        #    read read-only from the provided db; nothing global is mutated.
+        overhaul_rates = ef._modify_percentages_overhaul(
+            slider_state["reviews_done"],
+            slider_state["daily_goal"],
+            slider_state["trainer_level"],
+            main_level=slider_state["main_level"],
+            ep=simulated_ep,
+            db=db,
+        )
+        legacy_rates = ef._modify_percentages_legacy(
+            slider_state["reviews_done"],
+            slider_state["daily_goal"],
+            slider_state["trainer_level"],
+            main_level=slider_state["main_level"],
+        )
+        ef.clear_encounter_cache()
+
+        # 4. Active tier locks from the level thresholds.
+        locks = {
+            tier: (slider_state["main_level"] < limit)
+            for tier, limit in ef.OVERHAUL_LEVEL_THRESHOLDS.items()
+        }
+
+        return {
+            "live_overhaul": live_overhaul_rates,
+            "live_legacy": live_legacy_rates,
+            "overhaul": overhaul_rates,
+            "legacy": legacy_rates,
+            "ep": simulated_ep,
+            "locks": locks,
+        }

--- a/src/Ankimon/pyobj/encounter_simulator_dialog.py
+++ b/src/Ankimon/pyobj/encounter_simulator_dialog.py
@@ -272,7 +272,7 @@ class EncounterSimulatorDialog(QDialog):
             trainer_card.level if trainer_card and hasattr(trainer_card, "level") else 1
         )
         live_overhaul_rates = ef._modify_percentages_overhaul(
-            live_reviews, live_goal, live_trainer_lvl
+            live_reviews, live_goal, live_trainer_lvl, db=db
         )
         live_legacy_rates = ef._modify_percentages_legacy(
             live_reviews, live_goal, live_trainer_lvl

--- a/tests/test_encounter_simulator.py
+++ b/tests/test_encounter_simulator.py
@@ -1,0 +1,415 @@
+"""Parity tests for the Encounter Rate Simulator (F23).
+
+The simulator dialog pulls in ``encounter_functions`` (a large aqt-dependent
+chain) and PyQt6. We mock those so the module imports Qt-free in the Tier-1
+environment, then exercise the *rate math* head-less:
+
+* :meth:`EncounterSimulatorDialog.calculate_rates` — the seam re-fit of exp's
+  monkeypatching implementation. It must inject the simulated state (Mastery
+  Index ``ep`` + ``main_level`` + a read-only ``db`` provider) into
+  ``encounter_functions`` **without** mutating any global (``mw`` / ``services``
+  / ``main_pokemon`` / ``business.calculate_cp_from_dict``).
+* :meth:`SimulatorBridge.get_initial_state` — the JS bootstrap payload.
+
+An offscreen construct-smoke (skipped when PyQt6/QtWebEngine is unavailable)
+covers the Qt wiring itself.
+"""
+
+import sys
+import json
+import types
+import importlib.util
+import unittest.mock as mock
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Isolated, Qt-free import of the dialog + encounter_functions.
+#
+# encounter_functions pulls in a large aqt-dependent chain; mock the heavy deps
+# so both modules import Qt-free in the Tier-1 environment (mirrors
+# tests/test_encounter_overhaul.py). We load via spec_from_file_location and
+# re-establish the ``Ankimon`` package stubs first, so collection order cannot
+# break us (another test module — e.g. test_database_manager — may have
+# replaced ``sys.modules["Ankimon.pyobj"]`` with a MagicMock). sys.modules is
+# restored afterwards so these mocks never leak into other tests.
+# ---------------------------------------------------------------------------
+_SRC = Path(__file__).parent.parent / "src"
+_orig_modules = dict(sys.modules)
+
+# Re-create real namespace-package stubs (with __path__) for relative imports.
+for _pkg in ("Ankimon", "Ankimon.functions", "Ankimon.pyobj"):
+    _mod = types.ModuleType(_pkg)
+    _mod.__path__ = [str(_SRC / _pkg.replace(".", "/"))]
+    _mod.__package__ = _pkg
+    sys.modules[_pkg] = _mod
+
+sys.modules["aqt"] = mock.MagicMock()
+sys.modules["aqt.qt"] = mock.MagicMock()
+sys.modules["aqt.utils"] = mock.MagicMock()
+# Force the dialog's guarded Qt import to fall back to head-less stubs, even in
+# the Qt env. Otherwise this (Tier-1) module would hold real QObject/QWidget
+# subclasses with no QApplication, which hangs/segfaults the interpreter at
+# teardown. The offscreen construct-smoke uses the real widgets in a subprocess.
+for _qt in (
+    "PyQt6.QtWidgets",
+    "PyQt6.QtCore",
+    "PyQt6.QtGui",
+    "PyQt6.QtWebEngineWidgets",
+    "PyQt6.QtWebChannel",
+):
+    sys.modules[_qt] = None
+
+for _module in [
+    "Ankimon.pyobj.ankimon_tracker",
+    "Ankimon.pyobj.pokemon_obj",
+    "Ankimon.pyobj.reviewer_obj",
+    "Ankimon.pyobj.test_window",
+    "Ankimon.pyobj.trainer_card",
+    "Ankimon.pyobj.InfoLogger",
+    "Ankimon.pyobj.evolution_window",
+    "Ankimon.pyobj.attack_dialog",
+    "Ankimon.pyobj.translator",
+    "Ankimon.pyobj.error_handler",
+    "Ankimon.functions.pokemon_functions",
+    "Ankimon.functions.pokedex_functions",
+    "Ankimon.functions.friendship_evolution",
+    "Ankimon.functions.trainer_functions",
+    "Ankimon.functions.badges_functions",
+    "Ankimon.functions.drawing_utils",
+    "Ankimon.utils",
+    "Ankimon.business",
+    "Ankimon.const",
+    "Ankimon.singletons",
+    "Ankimon.resources",
+]:
+    sys.modules[_module] = mock.MagicMock()
+
+
+def _load(name, relpath):
+    spec = importlib.util.spec_from_file_location(name, _SRC / relpath)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module  # register so dependents share this instance
+    spec.loader.exec_module(module)
+    return module
+
+
+ef = _load(
+    "Ankimon.functions.encounter_functions",
+    "Ankimon/functions/encounter_functions.py",
+)
+esd = _load(
+    "Ankimon.pyobj.encounter_simulator_dialog",
+    "Ankimon/pyobj/encounter_simulator_dialog.py",
+)
+_services = esd.services  # the real registry singleton, shared with ef
+
+# Restore: drop our heavy-dep mocks so the rest of the suite is unaffected.
+sys.modules.clear()
+sys.modules.update(_orig_modules)
+
+
+class _FakeDB:
+    """Minimal database provider — records writes so we can assert read-only."""
+
+    def __init__(self, pity=None):
+        self._pity = dict(pity or {})
+        self.set_calls = []
+
+    def get_all_pokemon_ids(self):
+        return []
+
+    def get_all_pokemon(self):
+        return []
+
+    def get_user_data(self, key):
+        if key == "ankimon_pity_trackers":
+            return dict(self._pity)
+        return None
+
+    def set_user_data(self, key, value):  # must never be hit by the simulator
+        self.set_calls.append((key, value))
+
+
+@pytest.fixture
+def sim_env():
+    """Populate the shared service registry + ef globals with fakes."""
+    fake_db = _FakeDB()
+    fake_tracker = mock.MagicMock()
+    fake_tracker.get_total_reviews.return_value = 100
+    fake_settings = mock.MagicMock()
+    fake_settings.get.return_value = 100
+    fake_trainer = SimpleNamespace(level=20)
+    fake_main = SimpleNamespace(level=50)
+
+    _services.reset()
+    _services.db = fake_db
+    _services.tracker = fake_tracker
+    _services.settings = fake_settings
+    _services.trainer_card = fake_trainer
+    _services.main_pokemon = fake_main
+
+    orig_ef_main = ef.main_pokemon
+    orig_flag = ef.USE_OVERHAUL_ENCOUNTER_SYSTEM
+    ef.main_pokemon = fake_main  # ef's bare global drives the live-rate path
+    ef.clear_encounter_cache()
+    try:
+        yield SimpleNamespace(db=fake_db, tracker=fake_tracker, settings=fake_settings)
+    finally:
+        ef.main_pokemon = orig_ef_main
+        ef.USE_OVERHAUL_ENCOUNTER_SYSTEM = orig_flag
+        ef.clear_encounter_cache()
+        _services.reset()
+
+
+def _calc(slider_state, db):
+    """Call calculate_rates unbound (it uses services, never ``self``)."""
+    return esd.EncounterSimulatorDialog.calculate_rates(object(), slider_state, db=db)
+
+
+def _expected_overhaul(ep, main_level, pity):
+    """Re-implementation of ef._modify_percentages_overhaul's post-EP pipeline."""
+    weights = {}
+    for tier, (base, max_val) in ef.OVERHAUL_TIER_PARAMS.items():
+        weights[tier] = base * ((max_val / base) ** (ep / 100.0))
+    for tier, limit in ef.OVERHAUL_LEVEL_THRESHOLDS.items():
+        if main_level < limit:
+            weights[tier] = 0.0
+    for tier in ef.OVERHAUL_PITY_THRESHOLDS:
+        p_i = pity.get(tier, 0)
+        t_i = ef.OVERHAUL_PITY_THRESHOLDS[tier]
+        mult = 1.0 + (max(0, (p_i - t_i) / ef.OVERHAUL_PITY_DIVISOR)) ** 2
+        weights[tier] = weights[tier] * mult
+    total = sum(weights.values())
+    return {t: (weights[t] / total * 100.0 if total > 0 else 0.0) for t in weights}
+
+
+# --- Structure + EP formula + locks (exp's documented example) --------------
+
+
+def test_calculate_rates_structure_ep_and_locks(sim_env):
+    slider_state = {
+        "trainer_level": 25,
+        "dex_completion": 50.0,
+        "reviews_done": 120,
+        "daily_goal": 100,
+        "avg_cp": 1500,
+        "main_level": 45,
+    }
+    result = _calc(slider_state, sim_env.db)
+
+    for key in ("live_overhaul", "live_legacy", "overhaul", "legacy", "ep", "locks"):
+        assert key in result
+
+    # EP = 0.25*(50 + 50 + 100 + 9.375) = 52.34375 (caps 50 / 16000, weights .25)
+    assert abs(result["ep"] - 52.34375) < 0.001
+
+    # main_level 45: Legendary gate (50) locks, Ultra gate (30) does not.
+    assert result["locks"]["Legendary"] is True
+    assert result["locks"]["Ultra"] is False
+
+
+# --- Simulated overhaul matches the algorithm exactly (injection wiring) -----
+
+
+def test_simulated_overhaul_matches_algorithm(sim_env):
+    slider_state = {
+        "trainer_level": 25,
+        "dex_completion": 50.0,
+        "reviews_done": 120,
+        "daily_goal": 100,
+        "avg_cp": 1500,
+        "main_level": 45,
+    }
+    result = _calc(slider_state, sim_env.db)
+    expected = _expected_overhaul(52.34375, 45, {})
+
+    assert set(result["overhaul"]) == set(expected)
+    for tier, exp_val in expected.items():
+        assert abs(result["overhaul"][tier] - exp_val) < 1e-6
+
+    # Level-gated tiers are exactly zero; the open tiers carry all the mass.
+    for locked in ("Legendary", "Mega", "Gmax", "Mythical", "Starter"):
+        assert result["overhaul"][locked] == 0.0
+    for open_tier in ("Normal", "Baby", "Ultra"):
+        assert result["overhaul"][open_tier] > 0.0
+    assert abs(sum(result["overhaul"].values()) - 100.0) < 1e-6
+
+
+# --- Simulation is read-only w.r.t. persisted pity / user_data --------------
+
+
+def test_simulation_does_not_persist_pity(sim_env):
+    slider_state = {
+        "trainer_level": 40,
+        "dex_completion": 80.0,
+        "reviews_done": 200,
+        "daily_goal": 100,
+        "avg_cp": 8000,
+        "main_level": 80,
+    }
+    _calc(slider_state, sim_env.db)
+    # The simulator must never write pity trackers or any user_data.
+    assert sim_env.db.set_calls == []
+
+
+# --- The read-only pity provider actually influences the weights ------------
+
+
+def test_injected_pity_boosts_that_tier(sim_env):
+    slider_state = {
+        "trainer_level": 40,
+        "dex_completion": 80.0,
+        "reviews_done": 200,
+        "daily_goal": 100,
+        "avg_cp": 8000,
+        "main_level": 80,  # unlocks every tier
+    }
+    baseline = _calc(slider_state, _FakeDB(pity={}))
+    # Ultra dry-spell well past its threshold (100) -> quadratic multiplier.
+    boosted = _calc(slider_state, _FakeDB(pity={"Ultra": 300}))
+
+    assert boosted["overhaul"]["Ultra"] > baseline["overhaul"]["Ultra"]
+    assert abs(sum(boosted["overhaul"].values()) - 100.0) < 1e-6
+
+
+# --- Simulated legacy honours level gates + Starter clamp -------------------
+
+
+def test_simulated_legacy_level_gates(sim_env):
+    slider_state = {
+        "trainer_level": 5,
+        "dex_completion": 10.0,
+        "reviews_done": 90,
+        "daily_goal": 100,
+        "avg_cp": 500,
+        "main_level": 10,  # below every rare-tier threshold
+    }
+    result = _calc(slider_state, sim_env.db)
+    legacy = result["legacy"]
+    for gated in ("Starter", "Ultra", "Legendary", "Mythical", "Mega", "Gmax"):
+        assert legacy.get(gated, 0) == 0
+    assert abs(sum(legacy.values()) - 100.0) < 0.001
+
+
+# --- get_initial_state returns a valid JS bootstrap payload -----------------
+
+
+def test_get_initial_state_payload(sim_env):
+    bridge = esd.SimulatorBridge(None)
+    state = json.loads(bridge.get_initial_state())
+
+    for key in (
+        "trainer_level",
+        "dex_completion",
+        "reviews_done",
+        "daily_goal",
+        "avg_cp",
+        "main_level",
+        "config",
+        "active_system",
+    ):
+        assert key in state
+
+    assert state["trainer_level"] == 20  # from services.trainer_card.level
+    assert state["reviews_done"] == 100  # from services.tracker
+    assert state["active_system"] in ("Overhaul", "Legacy")
+
+    cfg = state["config"]
+    assert cfg["trainer_level_cap"] == ef.TRAINER_LEVEL_CAP
+    assert cfg["core_team_power_cap"] == ef.CORE_TEAM_POWER_CAP
+    assert cfg["pity_divisor"] == ef.OVERHAUL_PITY_DIVISOR
+    assert cfg["level_thresholds"] == ef.OVERHAUL_LEVEL_THRESHOLDS
+
+
+# --- Offscreen Qt construct-smoke (skipped without QtWebEngine) -------------
+#
+# Constructing a real QWebEngineView spins up QtWebEngine's Chromium process,
+# which does not tear down cleanly at a normal Python/pytest exit (it hangs the
+# interpreter). We therefore run the construction in a throw-away subprocess
+# that ``os._exit(0)``s on success, so this real Qt smoke can never hang the
+# test runner. Skipped when QtWebEngine is unavailable (the Tier-1 env).
+
+_CONSTRUCT_SCRIPT = r"""
+import os, sys, types
+import unittest.mock as mock
+import importlib.util
+from pathlib import Path
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+try:
+    # QtWebEngine must be imported before the QApplication is created.
+    from PyQt6.QtWebEngineWidgets import QWebEngineView  # noqa: F401
+    from PyQt6.QtWebChannel import QWebChannel  # noqa: F401
+    from PyQt6.QtWidgets import QApplication
+except Exception:
+    print("NO_QTWEBENGINE", flush=True)
+    os._exit(0)
+
+SRC = Path(sys.argv[1])
+for _pkg in ("Ankimon", "Ankimon.functions", "Ankimon.pyobj"):
+    _m = types.ModuleType(_pkg)
+    _m.__path__ = [str(SRC / _pkg.replace(".", "/"))]
+    _m.__package__ = _pkg
+    sys.modules[_pkg] = _m
+# The dialog's __init__ touches only Qt; mock its aqt/logic deps.
+for _name in (
+    "aqt", "aqt.qt", "aqt.utils",
+    "Ankimon.services",
+    "Ankimon.functions.encounter_functions",
+    "Ankimon.business",
+    "Ankimon.functions.pokedex_functions",
+):
+    sys.modules[_name] = mock.MagicMock()
+
+_spec = importlib.util.spec_from_file_location(
+    "Ankimon.pyobj.encounter_simulator_dialog",
+    SRC / "Ankimon" / "pyobj" / "encounter_simulator_dialog.py",
+)
+_mod = importlib.util.module_from_spec(_spec)
+sys.modules[_spec.name] = _mod
+_spec.loader.exec_module(_mod)
+
+# A non-empty argv is required or QtWebEngine's Chromium CommandLine init
+# hangs ("the program name is not passed to QCoreApplication").
+app = QApplication.instance() or QApplication(["ankimon"])
+dialog = _mod.EncounterSimulatorDialog()
+assert dialog.webview is not None
+assert dialog.bridge is not None
+assert dialog.windowTitle() == "Ankimon Encounter Rate Simulator"
+print("CONSTRUCT_OK", flush=True)
+os._exit(0)
+"""
+
+
+def test_dialog_constructs_offscreen():
+    # Run entirely in a child process: importing PyQt6 in this (Tier-1) parent
+    # would segfault it at teardown without a QApplication, and constructing a
+    # real QWebEngineView never tears down cleanly under a normal interpreter
+    # exit. The child reports availability itself so the parent never imports Qt.
+    import os
+    import subprocess
+
+    env = dict(os.environ)
+    env["QT_QPA_PLATFORM"] = "offscreen"
+    env.setdefault(
+        "QTWEBENGINE_CHROMIUM_FLAGS",
+        "--no-sandbox --disable-gpu --disable-software-rasterizer",
+    )
+    env["QTWEBENGINE_DISABLE_SANDBOX"] = "1"
+
+    proc = subprocess.run(
+        [sys.executable, "-c", _CONSTRUCT_SCRIPT, str(_SRC)],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=120,
+        stdin=subprocess.DEVNULL,
+        start_new_session=True,  # isolate QtWebEngine's Chromium helper processes
+    )
+    detail = f"rc={proc.returncode}\nstdout={proc.stdout}\nstderr={proc.stderr}"
+    if "NO_QTWEBENGINE" in proc.stdout:
+        pytest.skip("QtWebEngine unavailable (Tier-1 env)")
+    assert "CONSTRUCT_OK" in proc.stdout, detail

--- a/tests/test_encounter_simulator.py
+++ b/tests/test_encounter_simulator.py
@@ -275,6 +275,35 @@ def test_injected_pity_boosts_that_tier(sim_env):
     assert abs(sum(boosted["overhaul"].values()) - 100.0) < 1e-6
 
 
+# --- The live overhaul path reads pity from the injected db (DI, not global) -
+
+
+def test_live_overhaul_uses_injected_db(sim_env):
+    """The *live* overhaul rates must read pity from the injected ``db`` provider
+    too — not from the global ``services.db``. Otherwise the DI provider only
+    reaches the simulated path and the live path silently leaks to global state,
+    which is exactly the global-state coupling the F23 DI refit exists to remove.
+
+    ``ef.main_pokemon.level == 50`` (the fixture) drives the live path's tier
+    gates, so Ultra (threshold 30) is unlocked and its pity boost is visible.
+    ``services.db`` is left at the fixture's empty-pity db, so a rate change can
+    only come from the ``db`` passed to ``calculate_rates``.
+    """
+    slider_state = {
+        "trainer_level": 25,
+        "dex_completion": 50.0,
+        "reviews_done": 120,
+        "daily_goal": 100,
+        "avg_cp": 1500,
+        "main_level": 45,
+    }
+    baseline = _calc(slider_state, _FakeDB(pity={}))
+    boosted = _calc(slider_state, _FakeDB(pity={"Ultra": 300}))
+
+    assert boosted["live_overhaul"]["Ultra"] > baseline["live_overhaul"]["Ultra"]
+    assert abs(sum(boosted["live_overhaul"].values()) - 100.0) < 1e-6
+
+
 # --- Simulated legacy honours level gates + Starter clamp -------------------
 
 


### PR DESCRIPTION
## What

Ports the **Encounter Rate Simulator** (F23) from `BRRRR_Experimental` onto the integration tip. It is a self-contained PyQt6 `QDialog` hosting a `QWebEngineView` + `QWebChannel` (`SimulatorBridge`) that renders a live/what-if encounter-rate playground: sliders for trainer level, Pokédex completion, reviews done, daily goal, average team CP and main-Pokémon level drive the real `encounter_functions` weighting math and display the resulting per-tier percentages, the EP Mastery Index gauge, and tier locks — for both the Legacy and Overhaul systems, side-by-side with the player's current live rates.

Manifest files (all net-new): `pyobj/encounter_simulator_dialog.py`, `encounter_simulator/simulator.html`, `encounter_simulator/simulator.js`, `tests/test_encounter_simulator.py`. `simulator.html` and `simulator.js` are ported **verbatim** (byte-identical to exp).

## Re-fit to seam (exp → main mapping)

exp reached into globals; every access is re-expressed through the service seam:

- `from aqt import mw` + `singletons.{main_pokemon,trainer_card,settings_obj,ankimon_tracker_obj}` → `services.db / services.trainer_card / services.main_pokemon / services.settings / services.tracker`.
- **THE CRUX** — exp's `calculate_rates()` *monkeypatched* `mw.ankimon_db = MockDB()`, `main_pokemon.level`, `trainer_card.level`, and both `business.calculate_cp_from_dict` / `ef.calculate_cp_from_dict`, then restored them. Replaced with **dependency injection**: `calculate_rates(slider_state, db=None)` defaults `db` to `services.db`; the simulated Mastery Index (`ep`) and `main_level` are computed from the slider inputs and injected as keyword args into `encounter_functions`' calculation helpers. **No global on `mw` or `services` is ever mutated.**
- To support that injection, `encounter_functions.py` (F22's merged file) gains additive, keyword-only hooks — `load_pity_trackers(db=None)`, `_modify_percentages_overhaul(*, main_level=None, ep=None, db=None)`, and an extracted `_modify_percentages_legacy(*, main_level=None)`. `modify_percentages` becomes a thin dispatcher with an **unchanged public signature**; every default reproduces the prior live path (see Guards). The simulator calls the `_modify_percentages_*` helpers directly, so it never flips the module's `USE_OVERHAUL_ENCOUNTER_SYSTEM` global.
- QtWebEngine widgets are imported **lazily inside `__init__`** and the lighter Qt imports are guarded, so importing the module never requires Qt (Tier-1 collection stays Qt-free). Assets resolve relative to the addon dir: `addon_dir` defaults to the package root and is `mw.addonManager.addonFromModule`-compatible; `simulator.html` references `qrc:///qtwebchannel/qwebchannel.js` (served by Qt) and `simulator.js` (relative to the loaded local file) — both resolve under main's addon layout.

## Parity notes

- **Simulated overhaul rates** match the algorithm exactly (verified against `_modify_percentages_overhaul`'s post-EP pipeline in `test_simulated_overhaul_matches_algorithm`). Deliberate, documented improvement over exp: exp's simulated EP was derived by round-tripping `dex_completion`/`avg_cp` through the `MockDB` (int-truncation + set-intersection noise) inside the rate calc, while its displayed EP gauge used the slider values directly — so exp's gauge and rate-calc EP could disagree by sub-integer noise. This port uses the single slider-derived `ep` for **both** the gauge and the injected rate calc, keeping them self-consistent; the deviation from exp is within that truncation noise. `c_norm`/`t_norm`/`s_norm` are numerically identical to exp's gauge formula (with an added `daily_goal or 1` zero-guard).
- **Live rates** (both systems) are computed with real state and no *simulated* injection — the live overhaul call forwards the same `db` provider (`db=db`) that `calculate_rates` received, which defaults to `services.db` (a no-op in production) and keeps the read-only pity lookup on the injected provider so tests stay isolated; `ep` and `main_level` are left at their live (`None`) defaults. Identical to exp's pre-override "live" pass, minus the `USE_OVERHAUL_ENCOUNTER_SYSTEM` global flipping.
- **Read-only:** pity is read via the injected `db` (defaults to the real `services.db`, exactly like exp's `MockDB.get_user_data` fall-through to `orig_db`); the simulator never writes pity trackers or any `user_data`.
- The parity test reuses exp's own documented worked example (slider set → `ep == 52.34375`, Legendary locked / Ultra unlocked at `main_level=45`) and adds algorithm-exact, read-only-pity, injected-pity-boost, legacy-level-gate, and `get_initial_state` payload tests. Post-snapshot exp hunks captured: the F23 files were unchanged between the inventory snapshot and exp tip `b04e4bec` (verbatim html/js confirm this).

## Guards confirmation

- Removed the `mw.ankimon_db` monkeypatch (F23 GUARDS-TO-REAPPLY) — all DB access is service-seam mediated; nothing global is mutated.
- Simulation is read-only w.r.t. persisted pity/user_data (asserted).
- F22 live behavior byte-identical: additive kw-only DI defaults; `modify_percentages` public signature unchanged; legacy perf-cache only bypassed while simulating; F22's Tier-1 tests still pass.
- QtWebEngine lazy/guarded → Tier-1 stays Qt-free.

## Deferred

- **Menu launcher → F36** (`menu_buttons.py`): exp registers the "Encounter Rate Simulator" QAction at `menu_buttons.py:384-389`; base has no reference. F36 must re-apply it. Dialog is reachable programmatically meanwhile.
- **Web-shell re-host → Wave 4:** ships self-contained; can be re-mounted on the shared host when it lands.
- The offscreen construct-smoke exercises real Qt only under a bare Qt interpreter (see Gates).

## Gates (independently re-verified by the reviewer vs baseline `f03f1fd9`)

compileall OK · ruff check = 10 errors, all pre-existing in `AnkimonWindow copy.py`, 0 in this unit's files · ruff format clean on all 3 modified/created .py files · Tier-1 pytest **310 passed / 36 skipped / 0 failed** (baseline 303/35/0; +7 passing +1 skipped from this unit — includes the review-fix regression test `test_live_overhaul_uses_injected_db`) · harness/check.py **9/9** · Qt tier: scaffolding **4 passed**, addon_integrity **1 passed**, probe_real_boot OK (reviewer_did_answer_card hooks == 3), probe_real_play OK · construct-smoke subprocess independently returns `CONSTRUCT_OK` in ~0.2s offscreen. `tests/test_encounter_simulator.py` is a Tier-1 (venv_t1) file; like its baseline sibling `test_encounter_overhaul.py` it must not be run under pytest-qt (teardown segfault from real Qt without a QApplication) — no defined gate runs it there.

## Attribution

Originally implemented by @hakimh2 (Encounter Rate Simulator) on BRRRR_Experimental; credited via `Co-authored-by` trailers on both commits (`Co-authored-by: Hakimh2 <74561421+hakimh2@users.noreply.github.com>`). Note: `AIbrahimv2` appears in the exp history of `encounter_functions.py`, but that authorship is the already-merged F22 overhaul (present in base `f03f1fd9`); the F23 edits to that file are purely additive porter-written DI glue and port no AIbrahimv2 hunk, so no additional trailer is warranted for this unit.

