### PR TITLE
feat: QWebEngine web-shell host + Shop/Settings/Profile/Team screens (F11+F13+F18)

### DIFF
--- a/src/Ankimon/ankimon_items_web/LIVE_UPDATES.md
+++ b/src/Ankimon/ankimon_items_web/LIVE_UPDATES.md
@@ -1,0 +1,171 @@
+# Live updates for web screens
+
+How the Ankimon web shell keeps an **open** screen in sync with gameplay without
+a manual reload — e.g. the Profile screen updating its cash, caught count,
+highest Pokémon, XP bar and "Recently Caught" list as you review.
+
+This document is the contract for that mechanism so it can be reused (a future
+**Stats** screen, a live **Team** view, etc.).
+
+---
+
+## TL;DR
+
+A gameplay write site calls one screen-agnostic function:
+
+```python
+try:
+    from .singletons import notify_stats_changed   # `..singletons` from a subpackage
+    notify_stats_changed()
+except Exception:
+    pass
+```
+
+The open shell then refreshes **whichever screen is currently showing**, if that
+screen registered a refresher. Adding live updates to a new screen is ~3 small
+pieces (a refresher method, a dict entry, a JS receiver) — see
+[Add a new live screen](#add-a-new-live-screen).
+
+---
+
+## Data flow
+
+```
+ gameplay write site                     singletons.py            shop_obj.py (AnkimonItemsWeb)         <screen>.js
+ ───────────────────                     ─────────────            ────────────────────────────         ───────────
+ save_caught_pokemon()  ─┐
+ trainer_card.gain_xp() ─┼─►  notify_stats_changed()  ─►  refresh_live_screen()                          window.liveRefreshProfile(data)
+ battle_loop cash reward ┘     (best-effort, no-op       │   guards: visible? current screen        ┌─►   → re-render everything;
+ (…add more here…)             if window missing)        │   loaded? has a refresher?               │      new catches animate in
+                                                         │   coalesce → QTimer.singleShot(0)        │
+                                                         └─►  _run_live_refresh()                    │
+                                                              └─► _live_refreshers[screen]()  ───────┘
+                                                                   e.g. _push_profile_live():
+                                                                   runJavaScript("window.liveRefreshProfile(<json>)")
+```
+
+### The pieces
+
+| Layer | Symbol | Responsibility |
+|-------|--------|----------------|
+| Write site | (call) | After a stat-changing write, fire `notify_stats_changed()` (deferred import, wrapped in `try/except`). |
+| Bridge | `singletons.notify_stats_changed()` | Look up the live shell (`getattr(mw, "items_web_window", None)`), and if `is_alive`, call `win.refresh_live_screen()`. Never creates the window. |
+| Shell entry | `AnkimonItemsWeb.refresh_live_screen()` | Guard (visible + current screen loaded + has a refresher), then coalesce and schedule `_run_live_refresh` on the next event-loop turn. |
+| Shell dispatch | `AnkimonItemsWeb._live_refreshers` | `{screen: bound method}`. Only listed screens react. |
+| Shell push | `AnkimonItemsWeb._push_profile_live()` (etc.) | Build the payload and `runJavaScript("window.liveRefreshX(<json>)")`. |
+| Screen JS | `window.liveRefreshProfile(data)` (etc.) | Apply the fresh data to the DOM. |
+
+---
+
+## Why it's cheap (performance)
+
+The hooks are designed so they cost essentially **nothing** unless you're
+actually looking at a live screen:
+
+1. **Off-screen = near-free.** When the relevant screen isn't open/visible, the
+   whole chain is: a `getattr` on `mw`, an `is_alive()` (one `obj.objectName()`
+   call), and a few boolean checks in `refresh_live_screen()` — microseconds.
+   During normal review the reviewer is showing, not the shell, so this is the
+   usual path.
+2. **Coalesced.** Multiple `notify_stats_changed()` calls in the same event-loop
+   turn (e.g. a defeat that grants XP *and* a cash reward) collapse into a
+   single refresh via `QTimer.singleShot(0, …)` guarded by
+   `_live_refresh_pending`.
+3. **Deferred.** The refresh runs on the next event-loop turn, after the
+   triggering gameplay logic has finished and its DB writes have committed.
+4. **Diffed DOM.** `renderRecent` skips the rebuild when the list is unchanged,
+   so stat-only refreshes (cash/XP) don't churn the grid or interrupt the
+   in-flight "NEW" badge animation.
+
+The only non-trivial work — `get_profile_data()` (~a handful of small DB queries
++ sprite-path resolution + one `runJavaScript`) — happens **only when the screen
+is visible and something actually changed**, i.e. at most once per event-loop
+turn per gameplay event you're watching. That's imperceptible at human pace.
+
+> Keep payload builders cheap. If a future screen needs an expensive aggregate,
+> cache the immutable parts (as `_badge_grid` caches `badges.json` in
+> `_badge_defs_cache`) and recompute only what changes.
+
+---
+
+## Rules / gotchas
+
+- **GUI thread only.** `refresh_live_screen()` uses Qt (`QTimer`, `runJavaScript`)
+  so call `notify_stats_changed()` from the main/GUI thread (gameplay code
+  already runs there).
+- **Best-effort, always.** Every call site wraps the import + call in
+  `try/except: pass`. A UI failure must never break a catch/defeat/save.
+- **Never create the window.** The bridge uses `getattr(mw, "items_web_window",
+  None)` + `is_alive` — it must not call `get_items_window()` (that would *open*
+  the shell as a side effect of gameplay).
+- **Deferred import.** Import inside the function, not at module top:
+  `singletons` imports many gameplay modules, so a top-level import from those
+  modules back into `singletons` risks a circular import.
+- **JS receiver is optional at runtime.** Always guard:
+  `if (window.liveRefreshX) window.liveRefreshX(...)` — the screen may be an
+  older cached page without the function.
+
+---
+
+## Add a new live screen
+
+Example: a **Stats** screen that should update live.
+
+1. **JS receiver** in `stats.js`:
+   ```js
+   window.liveRefreshStats = function (data) {
+       if (!data) return;
+       state.data = data;
+       renderStats(data);   // your render; diff lists if you animate them
+   };
+   ```
+2. **Payload pusher** in `AnkimonItemsWeb` (`shop_obj.py`):
+   ```python
+   def _push_stats_live(self):
+       data = self.profile_data.get_stats_data()   # keep this cheap
+       js = ("if (window.liveRefreshStats) "
+             f"window.liveRefreshStats({json.dumps(data)});")
+       self.webview_stats.page().runJavaScript(js)
+   ```
+3. **Register it** in `__init__`:
+   ```python
+   self._live_refreshers = {
+       SCREEN_PROFILE: self._push_profile_live,
+       SCREEN_STATS:   self._push_stats_live,
+   }
+   ```
+
+That's it — every existing gameplay chokepoint now refreshes the Stats screen
+too, with the same guards/coalescing. No write-site changes needed.
+
+## Add a new gameplay trigger
+
+If a new event changes stats (e.g. selling an item, hatching an egg), drop this
+at that write site (after the value is persisted):
+
+```python
+try:
+    from ..singletons import notify_stats_changed   # adjust dots to your depth
+    notify_stats_changed()
+except Exception:
+    pass
+```
+
+Current triggers: `functions/encounter_functions.py:save_caught_pokemon`
+(catches), `pyobj/trainer_card.py:gain_xp` (XP/level/total XP),
+`battle_loop.py` cash-reward block (in-review cash). Stat changes that happen
+*inside* a shell screen (shop purchases, team edits) don't need a trigger — you
+navigate to see them, which reloads that screen.
+
+## Animating "new" items in a live list
+
+See `renderRecent` in `ankimon_profile_web/profile.js`:
+
+- Each item has a stable key (`id:` + `individual_id`, falling back to a
+  content key). A `shownRecentKeys` set tracks what's currently on screen.
+- On refresh, only keys **not** previously shown get the entrance class
+  (`.just-caught` → CSS `recent-pop` / `recent-ring` / `recent-tag`).
+- The initial render passes `animateNew=false` so re-opening the screen doesn't
+  spuriously animate.
+- `renderRecent` returns early when the ordered key list is unchanged, so the
+  badge animation runs uninterrupted across stat-only refreshes.

--- a/src/Ankimon/ankimon_items_web/nav-switcher.css
+++ b/src/Ankimon/ankimon_items_web/nav-switcher.css
@@ -1,0 +1,246 @@
+/* Shared dropdown nav-switcher styles for the unified Ankimon shell.
+ *
+ * One stylesheet for all five screens (Items, Ankidex, Profile, Team,
+ * Settings) — paired with ankimon_items_web/nav-switcher.js. Each page also
+ * loads its own stylesheet, which defines the theme custom properties
+ * (--accent-blue, --bg-card, --text-main, …) these rules consume. */
+
+.nav-switcher {
+    position: relative;
+}
+
+.nav-trigger {
+    width: 100%;
+    background: transparent;
+    border: 1px solid transparent;
+    color: inherit;
+    padding: 6px 10px;
+    border-radius: 10px;
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    cursor: pointer;
+    transition: 0.15s ease;
+    text-align: left;
+    font-family: inherit;
+}
+
+.nav-trigger:hover {
+    background: var(--bg-card);
+    border-color: var(--border-main);
+}
+
+.nav-trigger[aria-expanded="true"] {
+    background: var(--bg-card);
+    border-color: var(--accent-blue);
+}
+
+.nav-trigger .app-logo {
+    flex-shrink: 0;
+}
+
+.nav-trigger h1 {
+    flex: 1;
+    margin: 0;
+}
+
+.nav-chevron {
+    font-size: 0.9rem;
+    color: var(--text-muted);
+    transition: transform 0.2s ease;
+    margin-right: 2px;
+}
+
+.nav-trigger[aria-expanded="true"] .nav-chevron {
+    transform: rotate(180deg);
+    color: var(--accent-blue);
+}
+
+.nav-menu {
+    position: absolute;
+    top: calc(100% + 8px);
+    left: 0;
+    right: 0;
+    z-index: 200;
+    background: linear-gradient(180deg, var(--bg-card), var(--bg-darker));
+    border: 1px solid var(--border-main);
+    border-radius: 12px;
+    padding: 6px;
+    box-shadow: 0 14px 32px rgba(0, 0, 0, 0.55);
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    animation: navMenuPop 0.16s cubic-bezier(0.22, 1, 0.36, 1);
+    transform-origin: top left;
+}
+
+.nav-menu.hidden {
+    display: none;
+}
+
+@keyframes navMenuPop {
+    0%   { opacity: 0; transform: translateY(-6px) scale(0.97); }
+    100% { opacity: 1; transform: translateY(0)    scale(1); }
+}
+
+.nav-menu-item {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    width: 100%;
+    background: transparent;
+    border: 1px solid transparent;
+    color: var(--text-main);
+    padding: 10px 12px;
+    border-radius: 8px;
+    cursor: pointer;
+    font-family: inherit;
+    text-align: left;
+    transition: 0.15s ease;
+}
+
+.nav-menu-item:hover {
+    background: var(--bg-card-hover);
+    border-color: var(--border-main);
+    color: var(--text-bright);
+}
+
+.nav-menu-item.active {
+    background: rgba(88, 166, 255, 0.08);
+    border-color: rgba(88, 166, 255, 0.4);
+    color: var(--text-bright);
+}
+
+.nav-menu-item:disabled {
+    opacity: 0.45;
+    cursor: not-allowed;
+}
+
+.nav-menu-icon {
+    width: 34px;
+    height: 34px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--accent-blue);
+    flex-shrink: 0;
+}
+
+.nav-menu-item.active .nav-menu-icon {
+    color: var(--accent-blue);
+}
+
+.nav-menu-icon svg {
+    width: 28px;
+    height: 28px;
+}
+
+.nav-menu-icon img {
+    width: 30px;
+    height: 30px;
+    object-fit: contain;
+}
+
+.nav-menu-text {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+}
+
+.nav-menu-title {
+    font-size: 0.88rem;
+    font-weight: 700;
+    line-height: 1.15;
+}
+
+.nav-menu-desc {
+    font-size: 0.7rem;
+    color: var(--text-muted);
+    letter-spacing: 0.3px;
+    line-height: 1.2;
+}
+
+.nav-menu-status {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 0.6rem;
+    font-weight: 800;
+    text-transform: uppercase;
+    color: var(--accent-blue);
+    background: rgba(88, 166, 255, 0.10);
+    border: 1px solid rgba(88, 166, 255, 0.35);
+    padding: 2px 6px;
+    border-radius: 4px;
+    letter-spacing: 1px;
+}
+
+/* Standalone mode (no QWebChannel bridge) — hide the dropdown affordance so
+ * users don't see a non-functional switcher. It only makes sense inside the
+ * shell, which adds body.shell-mode once a NavBridge is wired. */
+body:not(.shell-mode) .nav-chevron,
+body:not(.shell-mode) .nav-menu {
+    display: none;
+}
+
+body:not(.shell-mode) .nav-trigger {
+    cursor: default;
+    pointer-events: none;
+}
+
+/* Gear icon (nav dropdown / sidebar logo); 18px in the menu, 32px when it
+ * doubles as the trigger logo via the .app-logo combo. */
+.icon-gear {
+    width: 18px;
+    height: 18px;
+    display: block;
+    color: var(--accent-blue);
+}
+
+.app-logo.icon-gear {
+    width: 32px;
+    height: 32px;
+}
+
+/* Pixel-art item sprite used as a screen's identity icon (Items potion,
+ * Team ball, …) — keep it crisp at the small icon scale. */
+.icon-item-sprite {
+    image-rendering: pixelated;
+    object-fit: contain;
+}
+
+/* Unresolved reviews dot indicators */
+.nav-trigger.has-unresolved {
+    position: relative;
+}
+
+.nav-trigger.has-unresolved::after {
+    content: '';
+    position: absolute;
+    top: 4px;
+    right: 4px;
+    width: 8px;
+    height: 8px;
+    background-color: var(--accent-red, #ff4444);
+    border-radius: 50%;
+    border: 1px solid var(--bg-card, #0d1117);
+}
+
+.nav-menu-item[data-screen="mobile"].has-unresolved {
+    position: relative;
+}
+
+.nav-menu-item[data-screen="mobile"].has-unresolved .nav-menu-title {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+}
+
+.nav-menu-item[data-screen="mobile"].has-unresolved .nav-menu-title::after {
+    content: '';
+    display: inline-block;
+    width: 8px;
+    height: 8px;
+    background-color: var(--accent-red, #ff4444);
+    border-radius: 50%;
+}
+

--- a/src/Ankimon/ankimon_items_web/nav-switcher.js
+++ b/src/Ankimon/ankimon_items_web/nav-switcher.js
@@ -1,0 +1,104 @@
+// Shared dropdown nav switcher for the unified Ankimon shell.
+//
+// One implementation for all five screens (Items, Ankidex, Profile, Team,
+// Settings) — open/close, click-outside, Escape, and routing menu clicks to
+// the NavBridge via nav.open<Screen>().
+//
+// IMPORTANT: this never creates its own QWebChannel when wireNavSwitcher() is
+// used. A page that already builds a channel must pass its `nav` to
+// wireNavSwitcher(nav) — creating a SECOND channel over the same transport
+// overwrites the first's `transport.onmessage`, so one of them never finishes
+// initializing. Pages with NO channel of their own (Ankidex) call
+// initNavSwitcher(), which builds the single channel and wires from it.
+
+(function () {
+    'use strict';
+
+    function methodFor(screen) {
+        if (!screen) return null;
+        return 'open' + screen.charAt(0).toUpperCase() + screen.slice(1);
+    }
+
+    window.updateNavSwitcherUnresolvedCount = function (count) {
+        const trigger = document.getElementById('nav-trigger');
+        const menu = document.getElementById('nav-menu');
+        if (!trigger || !menu) return;
+        if (count > 0) {
+            trigger.classList.add('has-unresolved');
+            const mobileItem = menu.querySelector('.nav-menu-item[data-screen="mobile"]');
+            if (mobileItem) {
+                mobileItem.classList.add('has-unresolved');
+            }
+        } else {
+            trigger.classList.remove('has-unresolved');
+            const mobileItem = menu.querySelector('.nav-menu-item[data-screen="mobile"]');
+            if (mobileItem) {
+                mobileItem.classList.remove('has-unresolved');
+            }
+        }
+    };
+
+    // Wire the dropdown to a NavBridge. Safe to call with a falsy nav
+    // (standalone / no bridge) — it just leaves the switcher hidden via the CSS
+    // body:not(.shell-mode) rule. The current screen's menu item carries the
+    // `active` class, so clicking it is a no-op (no needless reload).
+    window.wireNavSwitcher = function (nav) {
+        if (!nav) return;
+        document.body.classList.add('shell-mode');
+
+        const trigger = document.getElementById('nav-trigger');
+        const menu = document.getElementById('nav-menu');
+        if (!trigger || !menu) return;
+
+        const open = () => {
+            menu.classList.remove('hidden');
+            trigger.setAttribute('aria-expanded', 'true');
+        };
+        const close = () => {
+            menu.classList.add('hidden');
+            trigger.setAttribute('aria-expanded', 'false');
+        };
+
+        trigger.addEventListener('click', (e) => {
+            e.stopPropagation();
+            menu.classList.contains('hidden') ? open() : close();
+        });
+        document.addEventListener('click', (e) => {
+            if (!menu.classList.contains('hidden') &&
+                !menu.contains(e.target) && e.target !== trigger) {
+                close();
+            }
+        });
+        document.addEventListener('keydown', (e) => {
+            if (e.key === 'Escape' && !menu.classList.contains('hidden')) close();
+        });
+
+        menu.querySelectorAll('.nav-menu-item[data-screen]').forEach((item) => {
+            item.addEventListener('click', () => {
+                const screen = item.dataset.screen;
+                close();
+                if (item.classList.contains('active')) return;
+                const fn = methodFor(screen);
+                if (fn && typeof nav[fn] === 'function') nav[fn]();
+            });
+        });
+
+        // Initialize notification dot count
+        if (typeof nav.getPendingReviewsCount === 'function') {
+            nav.getPendingReviewsCount(function (count) {
+                window.updateNavSwitcherUnresolvedCount(count);
+            });
+        }
+    };
+
+    // For pages that have NO QWebChannel of their own (e.g. Ankidex): build the
+    // single channel here and wire from it. Pages that create their own channel
+    // must NOT call this — they call wireNavSwitcher(nav) from their callback.
+    window.initNavSwitcher = function () {
+        if (typeof qt === 'undefined' || !qt.webChannelTransport) return;
+        new QWebChannel(qt.webChannelTransport, function (channel) {
+            window.wireNavSwitcher(channel.objects && channel.objects.nav);
+        });
+    };
+})();
+

--- a/src/Ankimon/ankimon_items_web/settings.css
+++ b/src/Ankimon/ankimon_items_web/settings.css
@@ -1,0 +1,755 @@
+/* Settings screen — form-specific styles layered on top of shop.css. */
+
+/* --- Search input (shop.css's #pokemon-search / #shop-search rules don't
+ * apply to our #settings-search; mirror them here) --- */
+#settings-search {
+    width: 100%;
+    background: transparent;
+    border: none;
+    color: var(--text-main);
+    font-family: inherit;
+    font-size: 0.95rem;
+    outline: none;
+    padding-right: 30px;
+}
+
+#settings-search::placeholder {
+    color: var(--text-muted);
+    opacity: 0.7;
+}
+
+/* --- Sidebar group jumps --- */
+#group-jumps {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+}
+
+.group-jump {
+    width: 100%;
+    text-align: left;
+    background: transparent;
+    border: none;
+    color: var(--text-main);
+    padding: 8px 12px;
+    border-radius: 8px;
+    font-family: inherit;
+    font-size: 0.85rem;
+    font-weight: 500;
+    cursor: pointer;
+    transition: 0.15s ease;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
+}
+
+.group-jump:hover {
+    background: var(--bg-card);
+    color: var(--text-bright);
+}
+
+.group-jump.active {
+    background: rgba(88, 166, 255, 0.10);
+    color: var(--accent-blue);
+    font-weight: 600;
+    /* Left accent bar so the highlight reads as a clear "you are here"
+     * marker anchored to the title text. Inset box-shadow avoids the
+     * layout shift a border-left would cause. */
+    box-shadow: inset 3px 0 0 var(--accent-blue);
+}
+
+.group-jump-count {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 0.7rem;
+    color: var(--text-muted);
+    transition: color 0.15s ease;
+}
+
+.group-jump.active .group-jump-count {
+    color: var(--accent-blue);
+    opacity: 0.75;
+}
+
+/* --- Save action dirty pill --- */
+.dirty-pill {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 0.7rem;
+    font-weight: 700;
+    color: var(--accent-gold);
+    background: rgba(210, 153, 34, 0.12);
+    border: 1px solid rgba(210, 153, 34, 0.3);
+    padding: 1px 7px;
+    border-radius: 4px;
+}
+
+.dirty-pill.hidden {
+    display: none;
+}
+
+.icon-save {
+    width: 16px;
+    height: 16px;
+    flex-shrink: 0;
+    display: block;
+    color: var(--accent-blue);
+}
+
+/* Override .nav-action's red palette — Save isn't destructive like the
+ * Mart's reroll, so use a neutral blue tint at rest and green when dirty. */
+#save-btn {
+    background: linear-gradient(135deg,
+        rgba(88, 166, 255, 0.10),
+        rgba(88, 166, 255, 0.03));
+    border-color: rgba(88, 166, 255, 0.25);
+}
+
+#save-btn:hover:not(:disabled) {
+    background: linear-gradient(135deg,
+        rgba(88, 166, 255, 0.22),
+        rgba(88, 166, 255, 0.08));
+    border-color: var(--accent-blue);
+}
+
+#save-btn:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+}
+
+#save-btn.dirty {
+    background: linear-gradient(135deg,
+        rgba(63, 185, 80, 0.18),
+        rgba(63, 185, 80, 0.06));
+    border-color: rgba(63, 185, 80, 0.45);
+}
+
+#save-btn.dirty:hover:not(:disabled) {
+    background: linear-gradient(135deg,
+        rgba(63, 185, 80, 0.30),
+        rgba(63, 185, 80, 0.10));
+    border-color: var(--accent-green);
+}
+
+#save-btn.dirty .icon-save { color: var(--accent-green); }
+
+/* --- Top-bar discard --- */
+.settings-discard-btn {
+    background: transparent;
+    color: var(--text-muted);
+    border: 1px solid var(--border-main);
+    border-radius: 8px;
+    padding: 6px 14px;
+    font-family: inherit;
+    font-size: 0.8rem;
+    font-weight: 600;
+    cursor: pointer;
+    transition: 0.15s ease;
+}
+
+.settings-discard-btn:hover {
+    background: var(--bg-card-hover);
+    color: var(--accent-red);
+    border-color: rgba(248, 81, 73, 0.4);
+}
+
+.settings-discard-btn.hidden { display: none; }
+
+/* --- Group sections --- */
+.settings-group {
+    margin-bottom: 40px;
+}
+
+.settings-group.hidden { display: none; }
+
+.settings-group-header {
+    display: flex;
+    align-items: baseline;
+    gap: 12px;
+    margin-bottom: 18px;
+    padding-bottom: 10px;
+    border-bottom: 1px solid var(--border-main);
+}
+
+.settings-group-title {
+    font-size: 1.2rem;
+    font-weight: 800;
+    letter-spacing: -0.3px;
+    color: var(--text-bright);
+}
+
+.settings-group-count {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 0.75rem;
+    color: var(--text-muted);
+}
+
+/* Subgroups visually match top-level groups — same heading treatment,
+ * no card chrome. Slightly smaller heading preserves the implicit
+ * "nested under parent group" hierarchy without a visual container. */
+.settings-subgroup {
+    margin-top: 32px;
+}
+
+.settings-subgroup.hidden { display: none; }
+
+.settings-subgroup-title {
+    font-size: 1.05rem;
+    font-weight: 700;
+    letter-spacing: -0.2px;
+    color: var(--text-bright);
+    margin-bottom: 14px;
+    padding-bottom: 8px;
+    border-bottom: 1px solid var(--border-main);
+}
+
+/* --- Setting row --- */
+.setting-row {
+    display: grid;
+    grid-template-columns: 1fr 280px;
+    gap: 28px;
+    padding: 16px 0;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.04);
+    align-items: start;
+}
+
+.setting-row:last-child { border-bottom: none; }
+
+.setting-row.hidden { display: none; }
+
+.setting-row.dirty .setting-label::after {
+    content: '●';
+    color: var(--accent-gold);
+    margin-left: 6px;
+    font-size: 0.75rem;
+}
+
+.setting-info {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    min-width: 0;
+}
+
+.setting-label {
+    font-size: 0.92rem;
+    font-weight: 700;
+    color: var(--text-bright);
+    line-height: 1.3;
+}
+
+.setting-key {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 0.65rem;
+    color: var(--text-muted);
+    letter-spacing: 0.5px;
+    opacity: 0.7;
+}
+
+.setting-description {
+    font-size: 0.78rem;
+    color: var(--text-muted);
+    line-height: 1.5;
+    margin-top: 4px;
+    white-space: pre-wrap;
+}
+
+.setting-control {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    align-self: start;
+}
+
+/* --- Form controls --- */
+.setting-input {
+    width: 100%;
+    background: var(--bg-darker);
+    border: 1px solid var(--border-main);
+    color: var(--text-bright);
+    font-family: inherit;
+    font-size: 0.88rem;
+    padding: 9px 12px;
+    border-radius: 8px;
+    transition: 0.15s ease;
+    outline: none;
+}
+
+.setting-input:hover {
+    border-color: var(--text-muted);
+}
+
+.setting-input:focus {
+    border-color: var(--accent-blue);
+    box-shadow: 0 0 0 3px rgba(88, 166, 255, 0.12);
+}
+
+.setting-input.numeric {
+    font-family: 'JetBrains Mono', monospace;
+    text-align: right;
+}
+
+.setting-select {
+    width: 100%;
+    background: var(--bg-darker);
+    border: 1px solid var(--border-main);
+    color: var(--text-bright);
+    font-family: inherit;
+    font-size: 0.88rem;
+    padding: 9px 12px;
+    border-radius: 8px;
+    cursor: pointer;
+    appearance: none;
+    -webkit-appearance: none;
+    background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 24 24' fill='none' stroke='%238b949e' stroke-width='2.5' stroke-linecap='round' stroke-linejoin='round'><polyline points='6 9 12 15 18 9'/></svg>");
+    background-repeat: no-repeat;
+    background-position: right 12px center;
+    padding-right: 36px;
+}
+
+.setting-select:focus {
+    border-color: var(--accent-blue);
+    box-shadow: 0 0 0 3px rgba(88, 166, 255, 0.12);
+    outline: none;
+}
+
+/* --- Boolean toggle (segmented control style) --- */
+.setting-toggle {
+    display: inline-flex;
+    background: var(--bg-darker);
+    border: 1px solid var(--border-main);
+    border-radius: 8px;
+    padding: 3px;
+    gap: 2px;
+    width: 100%;
+}
+
+.setting-toggle-option {
+    flex: 1;
+    background: transparent;
+    border: none;
+    color: var(--text-muted);
+    font-family: inherit;
+    font-size: 0.8rem;
+    font-weight: 700;
+    padding: 6px 12px;
+    border-radius: 5px;
+    cursor: pointer;
+    transition: 0.15s ease;
+    letter-spacing: 0.5px;
+}
+
+.setting-toggle-option:hover {
+    color: var(--text-bright);
+}
+
+.setting-toggle-option.active {
+    background: var(--accent-blue);
+    color: #0d1117;
+}
+
+.setting-toggle-option.active.off {
+    background: var(--bg-card-hover);
+    color: var(--text-muted);
+}
+
+/* --- Validation hint --- */
+.setting-hint {
+    font-size: 0.7rem;
+    color: var(--text-muted);
+    font-family: 'JetBrains Mono', monospace;
+}
+
+.setting-hint.error {
+    color: var(--accent-red);
+}
+
+/* --- Responsive collapse on narrow widths --- */
+@media (max-width: 900px) {
+    .setting-row {
+        grid-template-columns: 1fr;
+        gap: 12px;
+    }
+    .setting-control { max-width: 320px; }
+}
+
+/* --- Chip group (used for gen toggles) --- */
+.setting-chips {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+}
+
+.setting-chip {
+    background: var(--bg-darker);
+    border: 1px solid var(--border-main);
+    color: var(--text-muted);
+    font-family: inherit;
+    font-size: 0.78rem;
+    font-weight: 700;
+    letter-spacing: 0.5px;
+    padding: 7px 12px;
+    border-radius: 8px;
+    cursor: pointer;
+    transition: 0.15s ease;
+    min-width: 60px;
+    text-align: center;
+}
+
+.setting-chip:hover:not(.active) {
+    color: var(--text-bright);
+    border-color: var(--text-muted);
+}
+
+.setting-chip.active {
+    background: var(--accent-blue);
+    border-color: var(--accent-blue);
+    color: #0d1117;
+    box-shadow: 0 0 12px rgba(88, 166, 255, 0.25);
+}
+
+.setting-chip.active:hover {
+    background: #79c0ff;
+    border-color: #79c0ff;
+}
+
+/* Chip rows are wider than form inputs — let them spill across the control column. */
+.setting-row:has(.setting-chips) {
+    grid-template-columns: 1fr 360px;
+}
+
+/* --- Section jump highlight --- */
+/* When the user clicks a section in the sidebar nav, briefly tint the
+ * landing section so they get a clear visual confirmation.
+ *
+ * Uses a ::before pseudo-element rather than box-shadow so we can apply
+ * an asymmetric inset: extend 14px above and on the sides, but crop 14px
+ * INTO the section's bottom — the last setting-row already has 16px of
+ * padding below its text, which the section bg would naturally pick up.
+ * Without the crop, the visible tinted area below the last row ends up
+ * ~30px (row padding + box-shadow extension) vs ~14px above the header.
+ * The crop balances both edges to ~14px. */
+.settings-group,
+.settings-subgroup {
+    position: relative;
+    /* isolation: isolate forces a new stacking context so the flash
+     * pseudo-element's z-index: -1 stays scoped inside the section
+     * (otherwise it escapes upward and renders behind opaque ancestor
+     * backgrounds, making the flash invisible). */
+    isolation: isolate;
+}
+
+.settings-group.flash-highlight::before,
+.settings-subgroup.flash-highlight::before {
+    content: '';
+    position: absolute;
+    /* top right bottom left — negative outsets, positive insets crop:
+     *   top: -14px  → tint extends 14px above section
+     *   bottom: 2px → tint crops 2px from section's bottom, leaving the
+     *                 last 14px of the row's 16px padding-bottom as tinted
+     *                 area below the last row's text. Matches the 14px above
+     *                 the header. */
+    inset: -14px -14px 2px -14px;
+    background: rgba(88, 166, 255, 0.16);
+    border-radius: 10px;
+    pointer-events: none;
+    z-index: -1;
+    animation: section-flash 1.2s ease-out forwards;
+}
+
+@keyframes section-flash {
+    0%   { opacity: 1; }
+    100% { opacity: 0; }
+}
+
+/* ── Wishlist control ──────────────────────────────────────────── */
+.setting-wishlist {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    min-width: 280px;
+}
+
+.wishlist-search-row {
+    position: relative;
+    display: flex;
+    gap: 8px;
+}
+
+.wishlist-add-btn {
+    background: var(--bg-card);
+    border: 1px solid var(--border);
+    color: var(--text-bright);
+    padding: 0 16px;
+    border-radius: 8px;
+    font-family: inherit;
+    font-size: 0.85rem;
+    font-weight: 600;
+    cursor: pointer;
+    transition: 0.15s ease;
+}
+
+.wishlist-add-btn:hover {
+    background: var(--accent-blue);
+    border-color: var(--accent-blue);
+    color: #0d1117;
+}
+
+.wishlist-dropdown {
+    position: absolute;
+    top: 100%;
+    left: 0;
+    right: 0;
+    z-index: 100;
+    background: var(--bg-card, #1a1f2e);
+    border: 1px solid var(--border, #2d3748);
+    border-radius: 6px;
+    max-height: 200px;
+    overflow-y: auto;
+    box-shadow: 0 4px 12px rgba(0,0,0,0.4);
+}
+
+.wishlist-option {
+    padding: 8px 12px;
+    cursor: pointer;
+    font-size: 0.875rem;
+    color: var(--text-primary, #e2e8f0);
+}
+
+.wishlist-option:hover {
+    background: var(--accent-blue, #4a90d9);
+    color: #fff;
+}
+
+.wishlist-chips {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+    min-height: 28px;
+}
+
+.wishlist-empty {
+    font-size: 0.8rem;
+    color: var(--text-muted, #718096);
+    font-style: italic;
+}
+
+.wishlist-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    padding: 3px 8px;
+    background: var(--accent-blue-muted, #2a4a6e);
+    border-radius: 12px;
+    font-size: 0.8rem;
+    color: var(--text-primary, #e2e8f0);
+}
+
+.wishlist-chip-remove {
+    background: none;
+    border: none;
+    color: var(--text-muted, #718096);
+    cursor: pointer;
+    font-size: 1rem;
+    line-height: 1;
+    padding: 0;
+}
+
+.wishlist-chip-remove:hover {
+    color: var(--accent-red, #e53e3e);
+}
+
+/* Choose from Caught button */
+.wishlist-action-row {
+    display: flex;
+    justify-content: flex-start;
+    margin-top: 4px;
+    width: 100%;
+}
+
+.wishlist-choose-btn {
+    width: 100%;
+    text-align: center;
+    background: rgba(74, 144, 217, 0.05);
+    border: 1px solid var(--border);
+    color: var(--accent-blue);
+    padding: 8px 12px;
+    border-radius: 8px;
+    font-family: inherit;
+    font-size: 0.85rem;
+    font-weight: 600;
+    cursor: pointer;
+    transition: 0.15s ease;
+    white-space: nowrap;
+}
+
+.wishlist-choose-btn:hover {
+    background: rgba(74, 144, 217, 0.12);
+    border-color: var(--accent-blue);
+}
+
+/* Wishlist Modal Popup */
+.wishlist-modal-backdrop {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background: rgba(15, 23, 42, 0.85); /* Solid dark slate alpha to replace blur filter (prevents GPU flickering) */
+    z-index: 1000;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    animation: wishlistFadeIn 0.2s ease-out;
+}
+
+.wishlist-modal-content {
+    background: var(--bg-card, #1a1f2e);
+    border: 1px solid var(--border, #2d3748);
+    border-radius: 12px;
+    width: 90%;
+    max-width: 500px;
+    max-height: 80vh;
+    display: flex;
+    flex-direction: column;
+    box-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
+    animation: wishlistSlideUp 0.2s cubic-bezier(0.34, 1.56, 0.64, 1);
+    overflow: hidden;
+}
+
+.wishlist-modal-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 16px;
+    border-bottom: 1px solid var(--border, #2d3748);
+}
+
+.wishlist-modal-title {
+    font-size: 1.1rem;
+    font-weight: 600;
+    color: var(--text-bright, #ffffff);
+    margin: 0;
+}
+
+.wishlist-modal-close {
+    background: none;
+    border: none;
+    color: var(--text-muted, #718096);
+    font-size: 1.8rem;
+    cursor: pointer;
+    line-height: 1;
+    padding: 0;
+    transition: color 0.15s ease;
+}
+
+.wishlist-modal-close:hover {
+    color: var(--accent-red, #e53e3e);
+}
+
+.wishlist-modal-body {
+    padding: 16px;
+    overflow-y: auto;
+    flex: 1;
+}
+
+.wishlist-modal-subtitle {
+    font-size: 0.85rem;
+    color: var(--text-muted, #718096);
+    margin-bottom: 16px;
+}
+
+/* Caught suggestions grid */
+.wishlist-suggestions-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(80px, 1fr));
+    gap: 10px;
+    padding-bottom: 8px;
+}
+
+.wishlist-suggestions-empty {
+    grid-column: 1 / -1;
+    text-align: center;
+    padding: 24px;
+    color: var(--text-muted, #718096);
+    font-size: 0.9rem;
+    font-style: italic;
+}
+
+/* Suggestion Card */
+.wishlist-suggestion-card {
+    background: rgba(255, 255, 255, 0.02);
+    border: 1px solid var(--border, #2d3748);
+    border-radius: 8px;
+    padding: 8px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    cursor: pointer;
+    transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1);
+    position: relative;
+    user-select: none;
+}
+
+.wishlist-suggestion-card:hover {
+    transform: translateY(-2px);
+    background: rgba(255, 255, 255, 0.06);
+    border-color: var(--accent-blue, #4a90d9);
+    box-shadow: 0 4px 12px rgba(74, 144, 217, 0.2);
+}
+
+.wishlist-suggestion-card.in-wishlist {
+    background: rgba(74, 144, 217, 0.15);
+    border-color: var(--accent-blue, #4a90d9);
+    box-shadow: inset 0 0 8px rgba(74, 144, 217, 0.2);
+}
+
+.wishlist-suggestion-card.in-wishlist::after {
+    content: '✓';
+    position: absolute;
+    top: 2px;
+    right: 6px;
+    font-size: 0.75rem;
+    color: var(--accent-blue, #4a90d9);
+    font-weight: bold;
+}
+
+.wishlist-suggestion-sprite {
+    width: 44px;
+    height: 44px;
+    image-rendering: pixelated;
+    object-fit: contain;
+    margin-bottom: 4px;
+}
+
+.wishlist-suggestion-name {
+    font-size: 0.7rem;
+    text-align: center;
+    color: var(--text-primary, #e2e8f0);
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    overflow: hidden;
+    width: 100%;
+}
+
+.wishlist-suggestion-card.in-wishlist .wishlist-suggestion-name {
+    color: var(--text-bright, #ffffff);
+    font-weight: 600;
+}
+
+/* Make search input expand gracefully in its row */
+.setting-wishlist .setting-input {
+    flex: 1;
+    min-width: 180px;
+}
+
+/* Animations */
+@keyframes wishlistFadeIn {
+    from { opacity: 0; }
+    to { opacity: 1; }
+}
+
+@keyframes wishlistSlideUp {
+    from { transform: translateY(30px); opacity: 0; }
+    to { transform: translateY(0); opacity: 1; }
+}
+

--- a/src/Ankimon/ankimon_items_web/settings.html
+++ b/src/Ankimon/ankimon_items_web/settings.html
@@ -1,0 +1,170 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Ankimon Settings</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <!-- Inline dark bg + skeleton placeholders so the user sees structure
+         instead of empty space while the external CSS + initial settings
+         data load. Real renderContent() clears the placeholders. -->
+    <style>
+        html { background: #0d1117; }
+        .skeleton {
+            background: #161b22;
+            border: 1px solid #30363d;
+            border-radius: 12px;
+            animation: skeleton-pulse 1.5s ease-in-out infinite;
+        }
+        .skeleton-section {
+            background: transparent;
+            border: none;
+            margin-bottom: 36px;
+            animation: none;
+        }
+        .skeleton-heading { height: 32px; width: 180px; margin-bottom: 18px; }
+        .skeleton-row { height: 64px; margin-bottom: 12px; }
+        @keyframes skeleton-pulse {
+            0%, 100% { opacity: 0.35; }
+            50%      { opacity: 0.6; }
+        }
+    </style>
+    <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700;800;900&family=JetBrains+Mono:wght@500;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="shop.css?v=20260633">
+    <link rel="stylesheet" href="settings.css">
+    <link rel="stylesheet" href="nav-switcher.css?v=20260633">
+    <script src="qrc:///qtwebchannel/qwebchannel.js"></script>
+</head>
+<body class="dark-mode">
+    <div class="app-container">
+
+        <!-- Sidebar -->
+        <aside class="sidebar">
+            <div class="sidebar-header">
+                <div id="nav-switcher" class="nav-switcher">
+                    <button id="nav-trigger" class="nav-trigger" type="button" aria-haspopup="true" aria-expanded="false">
+                        <img src="../user_files/sprites/items/x-speed.png" class="app-logo icon-item-sprite" alt="">
+                        <h1>SETTINGS</h1>
+                        <span class="nav-chevron">▾</span>
+                    </button>
+                    <div id="nav-menu" class="nav-menu hidden" role="menu">
+                        <button class="nav-menu-item" role="menuitem" data-screen="items">
+                            <span class="nav-menu-icon"><img src="../user_files/sprites/items/max-potion.png" class="icon-item-sprite" alt=""></span>
+                            <div class="nav-menu-text">
+                                <span class="nav-menu-title">Items</span>
+                                <span class="nav-menu-desc">Your inventory and today's Mart</span>
+                            </div>
+                        </button>
+                        <button class="nav-menu-item" role="menuitem" data-screen="ankidex">
+                            <span class="nav-menu-icon"><img src="../user_files/sprites/items/poke-ball.png" alt=""></span>
+                            <div class="nav-menu-text">
+                                <span class="nav-menu-title">Ankidex</span>
+                                <span class="nav-menu-desc">Browse caught Pokémon</span>
+                            </div>
+                        </button>
+                        <button class="nav-menu-item" role="menuitem" data-screen="team">
+                            <span class="nav-menu-icon"><img src="../user_files/sprites/items/great-ball.png" class="icon-item-sprite" alt=""></span>
+                            <div class="nav-menu-text">
+                                <span class="nav-menu-title">Team</span>
+                                <span class="nav-menu-desc">Your active 6 Pokémon</span>
+                            </div>
+                        </button>
+                        <button class="nav-menu-item" role="menuitem" data-screen="profile">
+                            <span class="nav-menu-icon"><img src="../user_files/sprites/items/water-gem.png" class="icon-item-sprite" alt=""></span>
+                            <div class="nav-menu-text">
+                                <span class="nav-menu-title">Profile</span>
+                                <span class="nav-menu-desc">Card, badges &amp; avatar</span>
+                            </div>
+                        </button>
+                        <button class="nav-menu-item active" role="menuitem" data-screen="settings">
+                            <span class="nav-menu-icon"><img src="../user_files/sprites/items/x-speed.png" class="icon-item-sprite" alt=""></span>
+                            <div class="nav-menu-text">
+                                <span class="nav-menu-title">Settings</span>
+                                <span class="nav-menu-desc">Configure Ankimon</span>
+                            </div>
+                        </button>
+                        <button class="nav-menu-item" role="menuitem" data-screen="mobile">
+                            <span class="nav-menu-icon"><img src="../user_files/sprites/items/elixir.png" class="icon-item-sprite" alt=""></span>
+                            <div class="nav-menu-text">
+                                <span class="nav-menu-title">Mobile & Web Reviews</span>
+                                <span class="nav-menu-desc">Pending mobile/web battles</span>
+                            </div>
+                        </button>
+                    </div>
+                </div>
+            </div>
+
+            <nav id="settings-nav" class="sidebar-nav">
+                <div class="nav-group">
+                    <label>Sections</label>
+                    <div id="group-jumps"></div>
+                </div>
+
+                <div class="nav-group">
+                    <label>Actions</label>
+                    <button id="save-btn" class="nav-item nav-action" title="Save all settings" disabled>
+                        <svg class="icon-save" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                            <path d="M19 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11l5 5v11a2 2 0 0 1-2 2z"/>
+                            <polyline points="17 21 17 13 7 13 7 21"/>
+                            <polyline points="7 3 7 8 15 8"/>
+                        </svg>
+                        <span style="flex: 1">Save Changes</span>
+                        <span id="dirty-count" class="dirty-pill hidden">0</span>
+                    </button>
+                </div>
+            </nav>
+
+            <div class="sidebar-footer">
+                <div class="shop-currency-card">
+                    <div class="currency-label-row">
+                        <span class="shop-currency-label">Status</span>
+                        <span class="currency-icon">⚙</span>
+                    </div>
+                    <div id="save-status" class="shop-currency-value">All saved</div>
+                </div>
+            </div>
+        </aside>
+
+        <!-- Main Content -->
+        <main class="main-content">
+            <header class="top-bar">
+                <div class="search-container">
+                    <div class="search-input-wrapper">
+                        <input type="text" id="settings-search" placeholder="Search settings... (Press /)">
+                        <button id="clear-search" class="clear-btn hidden" title="Clear search">×</button>
+                    </div>
+                </div>
+
+                <div class="top-actions">
+                    <button id="discard-btn" class="settings-discard-btn hidden" title="Discard unsaved changes">Discard</button>
+                </div>
+            </header>
+
+            <div class="content-scroll" style="padding: 20px 24px 64px;">
+                <div id="settings-content">
+                    <!-- Skeleton placeholders — cleared by renderContent()
+                         when initializeSettings() fires. -->
+                    <section class="skeleton-section">
+                        <div class="skeleton skeleton-heading"></div>
+                        <div class="skeleton skeleton-row"></div>
+                        <div class="skeleton skeleton-row"></div>
+                        <div class="skeleton skeleton-row"></div>
+                    </section>
+                    <section class="skeleton-section">
+                        <div class="skeleton skeleton-heading"></div>
+                        <div class="skeleton skeleton-row"></div>
+                        <div class="skeleton skeleton-row"></div>
+                    </section>
+                </div>
+                <div id="settings-empty" class="shop-empty hidden">No settings match your search.</div>
+            </div>
+        </main>
+    </div>
+
+    <div id="toast" class="shop-toast"></div>
+
+    <script src="nav-switcher.js?v=20260633"></script>
+    <script src="settings.js?v=20260633"></script>
+</body>
+</html>

--- a/src/Ankimon/ankimon_items_web/settings.js
+++ b/src/Ankimon/ankimon_items_web/settings.js
@@ -1,0 +1,880 @@
+// Settings screen — renders the group schema, tracks dirty state, persists
+// via the QWebChannel `settings` bridge object.
+
+(function () {
+    'use strict';
+
+    const state = {
+        data: null,           // raw payload from Python
+        edits: {},            // key → new value (only present if dirty)
+        search: '',
+        activeGroup: null,    // currently scrolled-into-view group label
+    };
+
+    let bridge = null;
+    let nav = null;
+
+    function initChannel(cb) {
+        if (typeof qt === 'undefined' || !qt.webChannelTransport) {
+            console.warn('qt.webChannelTransport unavailable — standalone mode');
+            cb(null);
+            return;
+        }
+        new QWebChannel(qt.webChannelTransport, function (channel) {
+            bridge = channel.objects && channel.objects.settings;
+            nav = channel.objects && channel.objects.nav;
+            window.bridge = bridge;
+            window.nav = nav;
+            cb(bridge);
+        });
+    }
+
+    window.initializeSettings = function (data) {
+        state.data = data || {groups: []};
+        state.edits = {};  // fresh data resets dirty state
+        renderAll();
+    };
+
+    // ---------- Rendering ----------
+    function renderAll() {
+        renderGroupJumps();
+        renderContent();
+        applySearchFilter();
+        updateDirtyUI();
+        // Re-run the spy after render so the active button reflects the
+        // post-render scroll position (in case the DOM rebuild moved things
+        // around).
+        updateActiveSection();
+    }
+
+    function renderGroupJumps() {
+        const container = document.getElementById('group-jumps');
+        // Build into a fragment then swap atomically to avoid a brief
+        // empty-state on every save refresh.
+        const frag = document.createDocumentFragment();
+        (state.data.groups || []).forEach((g) => {
+            const btn = document.createElement('button');
+            btn.className = 'group-jump';
+            btn.dataset.group = g.label;
+            const label = document.createElement('span');
+            label.textContent = g.label;
+            const count = document.createElement('span');
+            count.className = 'group-jump-count';
+            count.textContent = countSettings(g);
+            btn.appendChild(label);
+            btn.appendChild(count);
+            btn.addEventListener('click', () => scrollToGroup(g.label));
+            frag.appendChild(btn);
+        });
+        container.replaceChildren(frag);
+    }
+
+    function countSettings(group) {
+        let n = (group.settings || []).length;
+        (group.subgroups || []).forEach((s) => { n += (s.settings || []).length; });
+        return n;
+    }
+
+    function renderContent() {
+        const root = document.getElementById('settings-content');
+        // Build the whole settings tree into a fragment off-DOM, then swap
+        // it in atomically. Without this, every save → re-fetch cycle
+        // flashes an empty form area while ~60 rows rebuild sequentially.
+        const frag = document.createDocumentFragment();
+        (state.data.groups || []).forEach((group) => {
+            const groupEl = document.createElement('section');
+            groupEl.className = 'settings-group';
+            groupEl.dataset.group = group.label;
+
+            const header = document.createElement('div');
+            header.className = 'settings-group-header';
+            const title = document.createElement('h2');
+            title.className = 'settings-group-title';
+            title.textContent = group.label;
+            const count = document.createElement('span');
+            count.className = 'settings-group-count';
+            count.textContent = countSettings(group) + ' settings';
+            header.appendChild(title);
+            header.appendChild(count);
+            groupEl.appendChild(header);
+
+            (group.settings || []).forEach((s) => {
+                groupEl.appendChild(buildSettingRow(s));
+            });
+
+            (group.subgroups || []).forEach((sub) => {
+                const subEl = document.createElement('div');
+                subEl.className = 'settings-subgroup';
+                subEl.dataset.subgroup = sub.label;
+                const subTitle = document.createElement('div');
+                subTitle.className = 'settings-subgroup-title';
+                subTitle.textContent = sub.label;
+                subEl.appendChild(subTitle);
+                (sub.settings || []).forEach((s) => {
+                    subEl.appendChild(buildSettingRow(s));
+                });
+                groupEl.appendChild(subEl);
+            });
+
+            frag.appendChild(groupEl);
+        });
+        root.replaceChildren(frag);
+    }
+
+    function buildSettingRow(setting) {
+        const row = document.createElement('div');
+        row.className = 'setting-row';
+        row.dataset.key = setting.key;
+        row.dataset.label = (setting.label || '').toLowerCase();
+        row.dataset.desc = (setting.description || '').toLowerCase();
+
+        // Info column
+        const info = document.createElement('div');
+        info.className = 'setting-info';
+        const label = document.createElement('span');
+        label.className = 'setting-label';
+        label.textContent = setting.label;
+        info.appendChild(label);
+        // Config key only surfaces in dev mode — irrelevant noise otherwise.
+        if (state.data && state.data.dev_mode) {
+            const key = document.createElement('span');
+            key.className = 'setting-key';
+            key.textContent = setting.key;
+            info.appendChild(key);
+        }
+        if (setting.description) {
+            const desc = document.createElement('div');
+            desc.className = 'setting-description';
+            desc.innerHTML = setting.description;
+            info.appendChild(desc);
+        }
+        row.appendChild(info);
+
+        // Control column
+        const control = document.createElement('div');
+        control.className = 'setting-control';
+        control.appendChild(buildControl(setting));
+        row.appendChild(control);
+
+        return row;
+    }
+
+    function buildControl(setting) {
+        switch (setting.type) {
+            case 'boolean':
+                return buildToggle(setting);
+            case 'select':
+                return buildSelect(setting);
+            case 'int':
+            case 'float':
+                return buildNumberInput(setting);
+            case 'chips':
+                return buildChipGroup(setting);
+            case 'wishlist':
+                return buildWishlistControl(setting);
+            default:
+                return buildTextInput(setting);
+        }
+    }
+
+    function buildWishlistControl(setting) {
+        if (setting.names) {
+            state._wishlistNames = state._wishlistNames || {};
+            for (const [id, name] of Object.entries(setting.names)) {
+                state._wishlistNames[Number(id)] = name;
+            }
+        }
+
+        const wrap = document.createElement('div');
+        wrap.className = 'setting-wishlist';
+
+        // Search row: text input + buttons + dropdown
+        const searchRow = document.createElement('div');
+        searchRow.className = 'wishlist-search-row';
+
+        const input = document.createElement('input');
+        input.type = 'text';
+        input.className = 'setting-input';
+        input.placeholder = 'Search Pokémon name…';
+
+        const addBtn = document.createElement('button');
+        addBtn.type = 'button';
+        addBtn.className = 'wishlist-add-btn';
+        addBtn.textContent = 'Add';
+        addBtn.title = 'Add top search result';
+
+        const chooseBtn = document.createElement('button');
+        chooseBtn.type = 'button';
+        chooseBtn.className = 'wishlist-choose-btn';
+        chooseBtn.textContent = 'Choose from Caught…';
+        chooseBtn.title = 'Open dialog to select from caught Pokémon';
+
+        const dropdown = document.createElement('div');
+        dropdown.className = 'wishlist-dropdown hidden';
+
+        searchRow.append(input, addBtn, dropdown);
+
+        // Action row for Choose from Caught button
+        const actionRow = document.createElement('div');
+        actionRow.className = 'wishlist-action-row';
+        actionRow.append(chooseBtn);
+
+        // Chip list showing currently added Pokémon
+        const chipList = document.createElement('div');
+        chipList.className = 'wishlist-chips';
+
+        let activeModalBackdrop = null;
+        let activeModalGrid = null;
+        let caughtPokemon = [];
+
+        function getIds() {
+            return (currentValue(setting) || []).map(Number);
+        }
+
+        function togglePokemon(id, name) {
+            const current = getIds();
+            let next;
+            if (current.includes(id)) {
+                next = current.filter((v) => v !== id);
+            } else {
+                (state._wishlistNames = state._wishlistNames || {})[id] = name;
+                next = [...current, id];
+            }
+            setEdit(setting.key, next);
+            renderChips();
+            updateDirtyUI();
+            markRowDirty(setting.key);
+
+            if (activeModalGrid) {
+                renderModalGrid(activeModalGrid);
+            }
+        }
+
+        function addPokemon(id, name) {
+            const current = getIds();
+            if (!current.includes(id)) {
+                (state._wishlistNames = state._wishlistNames || {})[id] = name;
+                const next = [...current, id];
+                setEdit(setting.key, next);
+                renderChips();
+                updateDirtyUI();
+                markRowDirty(setting.key);
+
+                if (activeModalGrid) {
+                    renderModalGrid(activeModalGrid);
+                }
+            }
+            input.value = '';
+            dropdown.innerHTML = '';
+            dropdown.classList.add('hidden');
+        }
+
+        function renderChips() {
+            chipList.innerHTML = '';
+            const ids = getIds();
+            if (ids.length === 0) {
+                const empty = document.createElement('span');
+                empty.className = 'wishlist-empty';
+                empty.textContent = 'No Pokémon added yet.';
+                chipList.appendChild(empty);
+                return;
+            }
+            ids.forEach((id) => {
+                const chip = document.createElement('span');
+                chip.className = 'wishlist-chip';
+                const cached = (state._wishlistNames = state._wishlistNames || {});
+                chip.textContent = cached[id] ? `${cached[id]} (#${id})` : `#${id}`;
+                const x = document.createElement('button');
+                x.type = 'button';
+                x.textContent = '×';
+                x.className = 'wishlist-chip-remove';
+                x.title = 'Remove';
+                x.addEventListener('click', () => {
+                    const next = getIds().filter((v) => v !== id);
+                    setEdit(setting.key, next);
+                    renderChips();
+                    updateDirtyUI();
+                    markRowDirty(setting.key);
+
+                    if (activeModalGrid) {
+                        renderModalGrid(activeModalGrid);
+                    }
+                });
+                chip.appendChild(x);
+                chipList.appendChild(chip);
+            });
+        }
+        renderChips();
+
+        let lastResults = [];
+        let searchTimer = null;
+
+        const performSearch = () => {
+            const q = input.value.trim();
+            if (q.length < 2) {
+                dropdown.classList.add('hidden');
+                dropdown.innerHTML = '';
+                lastResults = [];
+                return;
+            }
+            if (!bridge || !bridge.searchPokemon) return;
+            bridge.searchPokemon(q, (res) => {
+                dropdown.innerHTML = '';
+                lastResults = (res && res.results) || [];
+                if (lastResults.length === 0) {
+                    dropdown.classList.add('hidden');
+                    return;
+                }
+                dropdown.classList.remove('hidden');
+                lastResults.forEach((r) => {
+                    const opt = document.createElement('div');
+                    opt.className = 'wishlist-option';
+                    opt.textContent = `${r.name} (#${r.id})`;
+                    opt.addEventListener('click', () => addPokemon(r.id, r.name));
+                    dropdown.appendChild(opt);
+                });
+            });
+        };
+
+        const handleAddTopResult = () => {
+            const q = input.value.trim();
+            if (q.length < 2) return;
+
+            if (lastResults.length > 0 && lastResults[0].name.toLowerCase().includes(q.toLowerCase())) {
+                addPokemon(lastResults[0].id, lastResults[0].name);
+                return;
+            }
+
+            if (!bridge || !bridge.searchPokemon) return;
+            clearTimeout(searchTimer);
+            bridge.searchPokemon(q, (res) => {
+                const results = (res && res.results) || [];
+                if (results.length > 0) {
+                    addPokemon(results[0].id, results[0].name);
+                }
+            });
+        };
+
+        input.addEventListener('input', () => {
+            clearTimeout(searchTimer);
+            searchTimer = setTimeout(performSearch, 250);
+        });
+
+        input.addEventListener('keydown', (e) => {
+            if (e.key === 'Enter') {
+                e.preventDefault();
+                handleAddTopResult();
+            }
+        });
+
+        addBtn.addEventListener('click', () => {
+            handleAddTopResult();
+        });
+
+        // Modal Suggestions logic
+        function renderModalGrid(grid) {
+            grid.innerHTML = '';
+            if (caughtPokemon.length === 0) {
+                const empty = document.createElement('div');
+                empty.className = 'wishlist-suggestions-empty';
+                empty.textContent = 'No caught Pokémon found.';
+                grid.appendChild(empty);
+                return;
+            }
+            const activeIds = getIds();
+            caughtPokemon.forEach((p) => {
+                const isInWishlist = activeIds.includes(p.id);
+
+                const card = document.createElement('div');
+                card.className = `wishlist-suggestion-card${isInWishlist ? ' in-wishlist' : ''}`;
+                card.title = `${p.name} (#${p.id})`;
+
+                const img = document.createElement('img');
+                img.className = 'wishlist-suggestion-sprite';
+                img.src = `../user_files/sprites/front_default/${p.id}.png`;
+                img.onerror = () => {
+                    img.src = '../user_files/sprites/front_default/0.png';
+                };
+
+                const nameLbl = document.createElement('div');
+                nameLbl.className = 'wishlist-suggestion-name';
+                nameLbl.textContent = p.name;
+
+                card.append(img, nameLbl);
+                card.addEventListener('click', () => togglePokemon(p.id, p.name));
+                grid.appendChild(card);
+            });
+        }
+
+        function openCaughtModal() {
+            if (activeModalBackdrop) return;
+
+            const backdrop = document.createElement('div');
+            backdrop.className = 'wishlist-modal-backdrop';
+            activeModalBackdrop = backdrop;
+
+            const content = document.createElement('div');
+            content.className = 'wishlist-modal-content';
+
+            const header = document.createElement('div');
+            header.className = 'wishlist-modal-header';
+
+            const title = document.createElement('h3');
+            title.className = 'wishlist-modal-title';
+            title.textContent = 'Select from Caught Pokémon';
+
+            const closeBtn = document.createElement('button');
+            closeBtn.type = 'button';
+            closeBtn.className = 'wishlist-modal-close';
+            closeBtn.textContent = '×';
+            closeBtn.title = 'Close';
+
+            const close = () => {
+                backdrop.remove();
+                activeModalBackdrop = null;
+                activeModalGrid = null;
+                document.removeEventListener('keydown', handleEsc);
+            };
+
+            const handleEsc = (e) => {
+                if (e.key === 'Escape') {
+                    close();
+                }
+            };
+
+            closeBtn.addEventListener('click', close);
+            backdrop.addEventListener('click', (e) => {
+                if (e.target === backdrop) close();
+            });
+            document.addEventListener('keydown', handleEsc);
+
+            header.append(title, closeBtn);
+
+            const body = document.createElement('div');
+            body.className = 'wishlist-modal-body';
+
+            const subtitle = document.createElement('div');
+            subtitle.className = 'wishlist-modal-subtitle';
+            subtitle.textContent = 'Toggle Pokémon below to add them to your Always-Catch Wishlist:';
+
+            const grid = document.createElement('div');
+            grid.className = 'wishlist-suggestions-grid';
+            activeModalGrid = grid;
+
+            body.append(subtitle, grid);
+            content.append(header, body);
+            backdrop.append(content);
+            document.body.appendChild(backdrop);
+
+            if (bridge && bridge.getCaughtPokemon) {
+                bridge.getCaughtPokemon((res) => {
+                    caughtPokemon = (res && res.results) || [];
+                    renderModalGrid(grid);
+                });
+            } else {
+                renderModalGrid(grid);
+            }
+        }
+
+        chooseBtn.addEventListener('click', openCaughtModal);
+
+        // Close dropdown on outside click
+        document.addEventListener('click', (e) => {
+            if (!searchRow.contains(e.target)) {
+                dropdown.classList.add('hidden');
+            }
+        });
+
+        wrap.append(searchRow, actionRow, chipList);
+        return wrap;
+    }
+
+    function buildChipGroup(setting) {
+        const wrap = document.createElement('div');
+        wrap.className = 'setting-chips';
+        (setting.chips || []).forEach((chip) => {
+            const btn = document.createElement('button');
+            btn.type = 'button';
+            btn.className = 'setting-chip';
+            btn.dataset.key = chip.key;
+            const current = (Object.prototype.hasOwnProperty.call(state.edits, chip.key))
+                ? state.edits[chip.key] : chip.value;
+            if (current) btn.classList.add('active');
+            btn.textContent = chip.label;
+            btn.addEventListener('click', () => {
+                const now = !btn.classList.contains('active');
+                // Manually track edits since chips don't go through setEdit's
+                // findSetting() lookup (each chip's "setting" is a sub-entry).
+                if (chip.value === now) {
+                    delete state.edits[chip.key];
+                } else {
+                    state.edits[chip.key] = now;
+                }
+                btn.classList.toggle('active', now);
+                updateDirtyUI();
+                markChipRowDirty(setting.key);
+            });
+            wrap.appendChild(btn);
+        });
+        return wrap;
+    }
+
+    function markChipRowDirty(rowKey) {
+        const row = document.querySelector(`.setting-row[data-key="${cssEscape(rowKey)}"]`);
+        if (!row) return;
+        const anyDirty = Array.from(row.querySelectorAll('.setting-chip')).some((c) =>
+            Object.prototype.hasOwnProperty.call(state.edits, c.dataset.key));
+        row.classList.toggle('dirty', anyDirty);
+    }
+
+    function buildToggle(setting) {
+        const wrap = document.createElement('div');
+        wrap.className = 'setting-toggle';
+        const current = currentValue(setting);
+        ['Enabled', 'Disabled'].forEach((label, i) => {
+            const isOn = (i === 0 && current) || (i === 1 && !current);
+            const btn = document.createElement('button');
+            btn.type = 'button';
+            btn.className = 'setting-toggle-option' + (isOn ? ' active' : '') + (i === 1 ? ' off' : '');
+            btn.textContent = label;
+            btn.addEventListener('click', () => {
+                setEdit(setting.key, i === 0);
+                renderAll();  // refresh control + dirty pip
+            });
+            wrap.appendChild(btn);
+        });
+        return wrap;
+    }
+
+    function buildSelect(setting) {
+        const sel = document.createElement('select');
+        sel.className = 'setting-select';
+        const current = currentValue(setting);
+        (setting.options || []).forEach((opt, i) => {
+            const o = document.createElement('option');
+            o.value = (opt.value === null || opt.value === undefined) ? '__null__' : String(opt.value);
+            o.textContent = opt.label;
+            if (opt.value === current) o.selected = true;
+            sel.appendChild(o);
+        });
+        sel.addEventListener('change', () => {
+            const raw = sel.value === '__null__' ? null : sel.value;
+            setEdit(setting.key, raw);
+            renderAll();
+        });
+        return sel;
+    }
+
+    function buildNumberInput(setting) {
+        const input = document.createElement('input');
+        input.type = 'text';  // text so range strings like "1-3" work too
+        input.className = 'setting-input numeric';
+        input.value = currentValue(setting);
+        input.addEventListener('input', () => {
+            const raw = input.value.trim();
+            // Allow ranges for cards_per_round; otherwise coerce to number.
+            if (setting.key === 'battle.cards_per_round' && raw.includes('-')) {
+                setEdit(setting.key, raw);
+            } else if (raw === '') {
+                setEdit(setting.key, raw);
+            } else {
+                const n = Number(raw);
+                setEdit(setting.key, Number.isFinite(n) ? n : raw);
+            }
+            updateDirtyUI();
+            markRowDirty(setting.key);
+        });
+        return input;
+    }
+
+    function buildTextInput(setting) {
+        const input = document.createElement('input');
+        input.type = 'text';
+        input.className = 'setting-input';
+        input.value = currentValue(setting) ?? '';
+        input.addEventListener('input', () => {
+            setEdit(setting.key, input.value);
+            updateDirtyUI();
+            markRowDirty(setting.key);
+        });
+        return input;
+    }
+
+    function currentValue(setting) {
+        if (Object.prototype.hasOwnProperty.call(state.edits, setting.key)) {
+            return state.edits[setting.key];
+        }
+        return setting.value;
+    }
+
+    // ---------- Edit tracking ----------
+    function setEdit(key, value) {
+        const original = findSetting(key);
+        if (!original) return;
+        if (deepEqual(original.value, value)) {
+            delete state.edits[key];
+        } else {
+            state.edits[key] = value;
+        }
+    }
+
+    function findSetting(key) {
+        for (const g of (state.data.groups || [])) {
+            for (const s of (g.settings || [])) {
+                if (s.key === key) return s;
+            }
+            for (const sub of (g.subgroups || [])) {
+                for (const s of (sub.settings || [])) {
+                    if (s.key === key) return s;
+                }
+            }
+        }
+        return null;
+    }
+
+    function deepEqual(a, b) {
+        if (a === b) return true;
+        if (typeof a !== typeof b) return false;
+        return JSON.stringify(a) === JSON.stringify(b);
+    }
+
+    function markRowDirty(key) {
+        document.querySelectorAll('.setting-row').forEach((row) => {
+            if (row.dataset.key !== key) return;
+            row.classList.toggle('dirty',
+                Object.prototype.hasOwnProperty.call(state.edits, key));
+        });
+    }
+
+    function updateDirtyUI() {
+        const n = Object.keys(state.edits).length;
+        const dirty = n > 0;
+        const saveBtn = document.getElementById('save-btn');
+        const discardBtn = document.getElementById('discard-btn');
+        const pill = document.getElementById('dirty-count');
+        const status = document.getElementById('save-status');
+        saveBtn.disabled = !dirty;
+        saveBtn.classList.toggle('dirty', dirty);
+        discardBtn.classList.toggle('hidden', !dirty);
+        if (dirty) {
+            pill.classList.remove('hidden');
+            pill.textContent = n;
+            status.textContent = n + ' unsaved';
+            status.style.color = 'var(--accent-gold)';
+        } else {
+            pill.classList.add('hidden');
+            status.textContent = 'All saved';
+            status.style.color = 'var(--accent-green)';
+        }
+        // Sync the row-level dirty markers (in case render rebuilt them)
+        document.querySelectorAll('.setting-row').forEach((row) => {
+            row.classList.toggle('dirty',
+                Object.prototype.hasOwnProperty.call(state.edits, row.dataset.key));
+        });
+    }
+
+    // ---------- Search ----------
+    function applySearchFilter() {
+        const q = state.search;
+        const empty = document.getElementById('settings-empty');
+        let visible = 0;
+        document.querySelectorAll('.settings-group').forEach((groupEl) => {
+            let groupVisible = 0;
+            groupEl.querySelectorAll('.setting-row').forEach((row) => {
+                const hit = !q || row.dataset.label.includes(q) || row.dataset.desc.includes(q);
+                row.classList.toggle('hidden', !hit);
+                if (hit) groupVisible++;
+            });
+            // Hide empty subgroups
+            groupEl.querySelectorAll('.settings-subgroup').forEach((sub) => {
+                const anyHit = Array.from(sub.querySelectorAll('.setting-row'))
+                    .some((r) => !r.classList.contains('hidden'));
+                sub.classList.toggle('hidden', !anyHit);
+            });
+            groupEl.classList.toggle('hidden', groupVisible === 0);
+            visible += groupVisible;
+        });
+        empty.classList.toggle('hidden', visible > 0);
+    }
+
+    // ---------- Save ----------
+    function onSave() {
+        if (!bridge) return;
+        const payload = {...state.edits};
+        if (Object.keys(payload).length === 0) return;
+        // Stringify so the bridge sees a stable `str` parameter — see the
+        // SettingsBridge.saveSettings comment for why we avoid passing the
+        // dict directly through QVariant.
+        bridge.saveSettings(JSON.stringify(payload), function (result) {
+            if (!result) return;
+            if (result.ok) {
+                const adj = (result.adjustments || []).join('\n');
+                const msg = adj ? result.message + '\n' + adj : result.message;
+                showToast(msg);
+                // Re-fetch fresh data so the UI reflects what was actually
+                // persisted (including any clamping).
+                bridge.getSettings(function (fresh) {
+                    if (fresh) window.initializeSettings(fresh);
+                });
+            } else {
+                showToast(result.message || 'Save failed', true);
+            }
+        });
+    }
+
+    function onDiscard() {
+        if (Object.keys(state.edits).length === 0) return;
+        state.edits = {};
+        renderAll();
+        showToast('Changes discarded');
+    }
+
+    function showToast(message, isError) {
+        if (!message) return;
+        const toast = document.getElementById('toast');
+        toast.textContent = message;
+        toast.classList.toggle('error', !!isError);
+        toast.classList.add('visible');
+        clearTimeout(toast._timer);
+        toast._timer = setTimeout(() => toast.classList.remove('visible'), 2800);
+    }
+
+    // ---------- Scroll spy / jumps ----------
+    //
+    // Approach (after several iterations):
+    // 1. Clicking a section in the sidebar SETS the active state directly
+    //    and suppresses the scroll-spy for 1.5s. This means the user's
+    //    explicit choice wins even when the scroll lands at max (e.g.
+    //    Generations near the bottom of a short page).
+    // 2. Otherwise the spy runs on scroll. The active section is the LAST
+    //    one whose top has crossed a reading line near the top of the
+    //    scroller — the classic "where am I" check.
+    // 3. When the user is at max scroll AND later sections couldn't reach
+    //    the line, fall back to whichever section's top is closest to
+    //    (just below) the line. That's how Study/Generations become
+    //    select-able via manual scrolling on short content.
+
+    let suppressSpyUntil = 0;
+    const READING_LINE_PX = 80;
+
+    function setActiveButton(label) {
+        if (label === state.activeGroup) return;
+        state.activeGroup = label;
+        document.querySelectorAll('.group-jump').forEach((b) => {
+            b.classList.toggle('active', b.dataset.group === label);
+        });
+    }
+
+    function scrollToGroup(label) {
+        const el = document.querySelector(`.settings-group[data-group="${cssEscape(label)}"]`);
+        const scroller = document.querySelector('.content-scroll');
+        if (!el || !scroller) return;
+        const elTop = el.getBoundingClientRect().top;
+        const scrollerTop = scroller.getBoundingClientRect().top;
+        const offsetWithinScroller = elTop - scrollerTop + scroller.scrollTop;
+        // 32px breathing room so the section header sits comfortably
+        // below the top-bar instead of butting up against it.
+        const target = Math.max(0, offsetWithinScroller - 32);
+        scroller.scrollTo({top: target, behavior: 'smooth'});
+        flashSection(el);
+        // Win against the spy: the user's click wins even if the resulting
+        // scroll position would normally activate a different section.
+        setActiveButton(label);
+        suppressSpyUntil = Date.now() + 1500;
+    }
+
+    function flashSection(el) {
+        // Brief tint so the user sees the jump landed on the right section.
+        // Re-trigger the animation if the class is already present
+        // (consecutive clicks on the same nav item).
+        el.classList.remove('flash-highlight');
+        // Force reflow so the animation restarts on re-add.
+        void el.offsetWidth;
+        el.classList.add('flash-highlight');
+    }
+
+    function cssEscape(s) {
+        return s.replace(/"/g, '\\"');
+    }
+
+    function updateActiveSection() {
+        if (Date.now() < suppressSpyUntil) return;
+        const scroller = document.querySelector('.content-scroll');
+        if (!scroller) return;
+        const sRect = scroller.getBoundingClientRect();
+        const sections = Array.from(document.querySelectorAll('.settings-group'))
+            .filter((g) => !g.classList.contains('hidden'));
+        if (!sections.length) return;
+
+        const readingLine = sRect.top + READING_LINE_PX;
+
+        // Primary: last section whose top has crossed the reading line.
+        let active = null;
+        sections.forEach((g) => {
+            if (g.getBoundingClientRect().top <= readingLine + 4) active = g;
+        });
+
+        // Fallback when we're at max scroll: short later sections that
+        // couldn't physically be scrolled past the line still need to be
+        // select-able. Pick whichever section's top is closest to (just
+        // below) the line.
+        const atMax = scroller.scrollHeight - scroller.scrollTop - scroller.clientHeight < 4;
+        if (atMax) {
+            let nearestBelow = null;
+            let nearestDist = Infinity;
+            sections.forEach((g) => {
+                const dist = g.getBoundingClientRect().top - readingLine;
+                if (dist > 0 && dist < nearestDist) {
+                    nearestDist = dist;
+                    nearestBelow = g;
+                }
+            });
+            if (nearestBelow) active = nearestBelow;
+        }
+
+        if (!active) active = sections[0];
+        setActiveButton(active.dataset.group);
+    }
+
+    // ---------- UI plumbing ----------
+    function bindUI() {
+        const search = document.getElementById('settings-search');
+        const clear = document.getElementById('clear-search');
+        search.addEventListener('input', () => {
+            state.search = search.value.trim().toLowerCase();
+            clear.classList.toggle('hidden', !state.search);
+            applySearchFilter();
+        });
+        clear.addEventListener('click', () => {
+            search.value = '';
+            state.search = '';
+            clear.classList.add('hidden');
+            applySearchFilter();
+        });
+
+        document.getElementById('save-btn').addEventListener('click', onSave);
+        document.getElementById('discard-btn').addEventListener('click', onDiscard);
+
+        const scroller = document.querySelector('.content-scroll');
+        if (scroller) scroller.addEventListener('scroll', updateActiveSection);
+
+        document.addEventListener('keydown', (e) => {
+            if (e.key === '/' && document.activeElement !== search) {
+                e.preventDefault();
+                search.focus();
+            } else if ((e.metaKey || e.ctrlKey) && e.key === 's') {
+                e.preventDefault();
+                onSave();
+            }
+        });
+    }
+
+    document.addEventListener('DOMContentLoaded', () => {
+        bindUI();
+        // Dropdown nav: wire from the shared switcher once the channel resolves
+        // so it has the live NavBridge. See ankimon_items_web/nav-switcher.js.
+        initChannel(() => {
+            if (window.wireNavSwitcher) window.wireNavSwitcher(nav);
+        });
+    });
+})();

--- a/src/Ankimon/ankimon_items_web/settings_schema.py
+++ b/src/Ankimon/ankimon_items_web/settings_schema.py
@@ -1,0 +1,261 @@
+"""Settings schema + validation for the web settings screen.
+
+Mirrors the hierarchical structure of the legacy QMainWindow settings_window.py
+so users see the same groups in the same order, but exposed as data so the
+web shell can render it.
+"""
+
+# Two-level group structure. Each group has a friendly-name list of settings
+# (matched against lang/setting_name.json) and optional subgroups.
+GROUPS = [
+    {
+        "label": "General",
+        "settings": [
+            "Trainer Name",
+            "Language",
+            "Show Tip of the Day On Startup",
+        ],
+        "subgroups": [
+            {
+                "label": "Technical Settings",
+                "settings": [
+                    "SSH Access",
+                    "Prevent Ankimon News on Startup",
+                    "AnkiWeb Sync",
+                    "Ankimon Leaderboard",
+                    "Developer Mode",
+                ],
+            },
+            {
+                "label": "Discord Integration",
+                "settings": [
+                    "Discord Rich Presence - Ankimon",
+                    "Discord Rich Presence - Quote Type",
+                ],
+            },
+        ],
+    },
+    {
+        "label": "Battle",
+        "settings": [],
+        "subgroups": [
+            {
+                "label": "Auto-Battle Rules",
+                "settings": [
+                    "Automatic Battle",
+                    "Always Catch Wishlist",
+                ],
+                "chip_group": {
+                    "label": "Always Catch Tiers",
+                    "description": (
+                        "In automatic battle mode, Pokémon of these tiers are always caught "
+                        "regardless of your collection status or mode setting. "
+                        "Shiny Pokémon are always caught automatically."
+                    ),
+                    "keys": [
+                        ("battle.auto_catch_legendary", "Legendary"),
+                        ("battle.auto_catch_mythical",  "Mythical"),
+                        ("battle.auto_catch_ultra",     "Ultra Beast"),
+                        ("battle.auto_catch_starter",   "Starter"),
+                        ("battle.auto_catch_mega",      "Mega"),
+                        ("battle.auto_catch_gmax",      "Gigantamax"),
+                        ("battle.auto_catch_regional",  "Regional Form"),
+                    ],
+                },
+            },
+            {
+                "label": "HUD & Mechanics",
+                "settings": [
+                    "Cards per Round",
+                    "Show Main Pokémon in Reviewer",
+                    "Hide HUD on Reviewer Startup",
+                    "Show Pokémon Buttons",
+                    "Pop-Up on Defeat",
+                    "Show Text Message Box in Reviewer",
+                    "Message Box Display Time",
+                    "Review Based Damage",
+                    "Auto-detect Time Zone",
+                    "Time Zone UTC Offset",
+                ],
+            },
+            {
+                "label": "Fight Hotkeys",
+                "settings": [
+                    "Key for Defeat",
+                    "Key for Catching",
+                    "Key for Team Cycling",
+                    "Key for Opening/Closing Ankimon",
+                    "Allow Choosing Moves",
+                ],
+            },
+            {
+                "label": "HP, XP and Level Settings",
+                "settings": [
+                    "HP Bar Configuration",
+                    "XP Bar Configuration",
+                    "XP Bar Location",
+                    "Remove Level Cap",
+                ],
+            },
+        ],
+    },
+    {
+        "label": "Styling",
+        "settings": [
+            "Styling in Reviewer",
+            "Team Overview in Deck Overview",
+            "Animate Time",
+            "HP Bar Thickness",
+            "Reviewer Image as GIF",
+            "View Main Pokémon Front",
+            "Show GIFs in Collection",
+        ],
+    },
+    {
+        "label": "Sound",
+        "settings": [
+            "Enable Sound Effects",
+            "Enable Sounds",
+            "Enable Battle Sounds",
+            "Volume",
+        ],
+    },
+    {
+        "label": "Study",
+        "settings": [
+            "Goal of Daily Average Cards",
+            "Card Max Time",
+            "Cash Reward Per Interval",
+            "Cards Per Cash Reward",
+        ],
+    },
+    {
+        "label": "Generations",
+        "settings": [
+            "Active Region",
+        ],
+        # The 9 per-generation booleans render as a single chip row instead of
+        # 9 separate Enabled/Disabled rows — much faster to scan and toggle.
+        "chip_group": {
+            "label": "Enabled Generations",
+            "description": (
+                "Toggle which generations can spawn. Disabled gens are "
+                "excluded from the encounter pool entirely; the Active Region "
+                "only biases spawns within the enabled set."
+            ),
+            "keys": [
+                ("misc.gen1", "Gen 1"),
+                ("misc.gen2", "Gen 2"),
+                ("misc.gen3", "Gen 3"),
+                ("misc.gen4", "Gen 4"),
+                ("misc.gen5", "Gen 5"),
+                ("misc.gen6", "Gen 6"),
+                ("misc.gen7", "Gen 7"),
+                ("misc.gen8", "Gen 8"),
+                ("misc.gen9", "Gen 9"),
+            ],
+        },
+    },
+    {
+        "label": "Mobile Reviews",
+        "settings": [
+            {
+                "key": "mobile.enabled",
+                "label": "Mobile Reviews Integration",
+                "description": "Expose reviews completed on AnkiMobile during syncing.",
+                "type": "boolean",
+            },
+            {
+                "key": "mobile.resolution_mode",
+                "label": "Mobile Resolution Mode",
+                "description": (
+                    "Choose how your synced mobile reviews are processed:<br>"
+                    "• <strong>Manual</strong>: Play through battles one-by-one with full combat animations under the Mobile Reviews tab, with the choice to manually override your active companion before starting each battle.<br>"
+                    "• <strong>Auto-Resolve</strong>: Automatically and silently resolve all pending battles in the background immediately after syncing, using optimal team matchups and payouts."
+                ),
+                "type": "select",
+                "options": [
+                    {"value": "manual", "label": "Manual"},
+                    {"value": "auto", "label": "Auto-Resolve"}
+                ]
+            }
+        ]
+    }
+]
+
+
+# Active region dropdown options — preserved verbatim from the legacy window.
+ACTIVE_REGION_OPTIONS = [
+    {"value": None, "label": "No Region"},
+    {"value": "kanto", "label": "Kanto (Gen 1)"},
+    {"value": "johto", "label": "Johto (Gen 2)"},
+    {"value": "hoenn", "label": "Hoenn (Gen 3)"},
+    {"value": "sinnoh", "label": "Sinnoh (Gen 4)"},
+    {"value": "unova", "label": "Unova (Gen 5)"},
+    {"value": "kalos", "label": "Kalos (Gen 6)"},
+    {"value": "alola", "label": "Alola (Gen 7)"},
+    {"value": "galar", "label": "Galar (Gen 8)"},
+    {"value": "hisui", "label": "Hisui (Gen 8)"},
+    {"value": "paldea", "label": "Paldea (Gen 9)"},
+]
+
+
+def validate_and_clamp(config):
+    """Apply the legacy window's save-time bounds. Returns (config, adjustments)
+    where adjustments is a list of human-readable strings describing what
+    was changed (empty if nothing was clamped)."""
+    adjustments = []
+
+    if "battle.cards_per_round" in config:
+        config["battle.cards_per_round"] = _coerce_cards_per_round(
+            config["battle.cards_per_round"]
+        )
+
+    if "trainer.cash_reward_interval" in config:
+        v = config["trainer.cash_reward_interval"]
+        if isinstance(v, int):
+            new_v = max(5, min(250, v))
+            if new_v != v:
+                config["trainer.cash_reward_interval"] = new_v
+                adjustments.append(
+                    f"Reward Interval adjusted to {new_v} (range 5–250)."
+                )
+
+    if "trainer.cash_reward_amount" in config:
+        amt = config["trainer.cash_reward_amount"]
+        if isinstance(amt, int):
+            new_amt = max(10, min(2000, amt))
+            interval = config.get("trainer.cash_reward_interval", 10)
+            max_allowed = interval * 100
+            if new_amt > max_allowed:
+                new_amt = max_allowed
+                adjustments.append(
+                    f"Reward Amount capped at {new_amt}¥ (100:1 ratio limit)."
+                )
+            elif new_amt != amt:
+                adjustments.append(
+                    f"Reward Amount adjusted to {new_amt}¥ (range 10–2000)."
+                )
+            config["trainer.cash_reward_amount"] = new_amt
+
+    return config, adjustments
+
+
+def _coerce_cards_per_round(value):
+    """Accept an int, the string "a-b" range, or fall back to 2 on garbage."""
+    if isinstance(value, int):
+        return 1 if value == 0 else value
+    text = str(value).strip()
+    try:
+        n = int(text)
+        return 1 if n == 0 else n
+    except ValueError:
+        pass
+    if "-" in text:
+        try:
+            a, b = (int(x) for x in text.split("-", 1))
+            low, high = min(a, b), max(a, b)
+            return f"{low}-{high}"
+        except ValueError:
+            pass
+    return 2

--- a/src/Ankimon/ankimon_items_web/shop.css
+++ b/src/Ankimon/ankimon_items_web/shop.css
@@ -1,0 +1,3711 @@
+:root {
+    /* Color Palette */
+    --bg-darker: #080a0c;
+    --bg-dark: #0d1117;
+    --bg-card: #161b22;
+    --bg-card-hover: #21262d;
+    --border-main: #30363d;
+    --text-main: #c9d1d9;
+    --text-muted: #8b949e;
+    --text-bright: #ffffff;
+    --accent-blue: #58a6ff;
+    --accent-red: #f85149;
+    --accent-gold: #d29922;
+    --accent-green: #3fb950;
+    
+    /* Type Colors */
+    --type-normal: #A8A77A; --type-fire: #EE8130; --type-water: #6390F0;
+    --type-electric: #F7D02C; --type-grass: #7AC74C; --type-ice: #96D9D6;
+    --type-fighting: #C22E28; --type-poison: #A33EA1; --type-ground: #E2BF65;
+    --type-flying: #A98FF3; --type-psychic: #F95587; --type-bug: #A6B91A;
+    --type-rock: #B6A136; --type-ghost: #735797; --type-dragon: #6F35FC;
+    --type-dark: #705746; --type-steel: #B7B7CE; --type-fairy: #D685AD;
+
+    /* Status Colors */
+    --status-caught: var(--accent-blue);
+    --status-seen: #8b949e;
+    --status-unseen: #30363d;
+    --status-shiny: var(--accent-gold);
+
+    /* Spacing & Sizing */
+    --sidebar-width: 260px;
+    --detail-width: 340px;
+    --header-height: 70px;
+    --transition-fast: 0.15s ease;
+    --transition-mid: 0.25s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+* {
+    box-sizing: border-box;
+    margin: 0;
+    padding: 0;
+    -webkit-user-select: none;
+    user-select: none;
+}
+
+body {
+    font-family: 'Outfit', sans-serif;
+    background: transparent;
+    color: var(--text-main);
+    height: 100vh;
+    overflow: hidden;
+}
+
+.app-container {
+    display: flex;
+    width: 100vw;
+    height: 100vh;
+    background: var(--bg-dark);
+    border-radius: 0;
+    overflow: hidden;
+    box-shadow: 0 20px 50px rgba(0,0,0,0.5);
+}
+
+/* Sidebar */
+.sidebar {
+    width: var(--sidebar-width);
+    background: var(--bg-darker);
+    border-right: 1px solid var(--border-main);
+    display: flex;
+    flex-direction: column;
+    flex-shrink: 0;
+}
+
+.sidebar-header {
+    padding: 24px;
+}
+
+.pokedex-logo {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+}
+
+.app-logo {
+    width: 32px;
+    height: 32px;
+    filter: drop-shadow(0 0 10px rgba(255, 255, 255, 0.2));
+}
+
+.pokedex-logo h1 {
+    font-size: 1.4rem;
+    font-weight: 800;
+    letter-spacing: -0.5px;
+    background: linear-gradient(to bottom, #fff, #ccc);
+    -webkit-background-clip: text;
+    background-clip: text;
+    -webkit-text-fill-color: transparent;
+}
+
+.logo-dot {
+    width: 14px;
+    height: 14px;
+    background: var(--accent-red);
+    border-radius: 50%;
+    box-shadow: 0 0 10px var(--accent-red);
+}
+
+.nav-item-icon {
+    width: 18px;
+    height: 18px;
+    object-fit: contain;
+}
+
+.sidebar-nav {
+    flex: 1;
+    overflow-y: auto;
+    padding: 0 16px;
+}
+
+.nav-group {
+    margin-bottom: 24px;
+}
+
+.nav-group label {
+    display: block;
+    font-size: 0.7rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    color: var(--text-muted);
+    letter-spacing: 1px;
+    margin-bottom: 12px;
+    margin-left: 8px;
+}
+
+.nav-item {
+    width: 100%;
+    text-align: left;
+    background: transparent;
+    border: none;
+    color: var(--text-main);
+    padding: 10px 12px;
+    border-radius: 8px;
+    font-size: 0.9rem;
+    font-weight: 500;
+    cursor: pointer;
+    transition: var(--transition-fast);
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    margin-bottom: 2px;
+}
+
+.nav-item:hover {
+    background: var(--bg-card);
+    color: var(--text-bright);
+}
+
+.nav-item.active {
+    background: var(--bg-card-hover);
+    color: var(--accent-blue);
+    font-weight: 600;
+}
+
+.sub-nav {
+    margin-top: 4px;
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+}
+
+.sub-nav .nav-item {
+    padding: 8px 12px 8px 16px;
+    font-size: 0.8rem;
+    color: var(--text-muted);
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 4px;
+}
+
+.gen-progress-mini {
+    width: 100%;
+    height: 3px;
+    background: rgba(255, 255, 255, 0.05);
+    border-radius: 2px;
+    overflow: hidden;
+}
+
+.gen-progress-mini-fill {
+    height: 100%;
+    background: var(--accent-blue);
+    width: 0%;
+    transition: width 0.5s ease;
+}
+
+.gen-info-row {
+    width: 100%;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+.gen-count-mini {
+    font-size: 0.7rem;
+    opacity: 0.7;
+}
+
+.type-grid {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 6px;
+}
+
+.type-filter {
+    height: 32px;
+    border-radius: 6px;
+    font-size: 0.7rem;
+    font-weight: 700;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: white;
+    text-transform: uppercase;
+    cursor: pointer;
+    opacity: 0.6;
+    transition: var(--transition-fast);
+}
+
+.type-filter:hover, .type-filter.active {
+    opacity: 1;
+    transform: translateY(-1px);
+}
+
+.sidebar-footer {
+    padding: 20px;
+    border-top: 1px solid var(--border-main);
+}
+
+.progress-card {
+    background: var(--bg-card);
+    padding: 16px;
+    border-radius: 12px;
+    border: 1px solid var(--border-main);
+}
+
+.progress-info {
+    display: flex;
+    justify-content: space-between;
+    font-size: 0.8rem;
+    font-weight: 600;
+    margin-bottom: 10px;
+}
+
+.progress-bar {
+    height: 6px;
+    background: var(--bg-darker);
+    border-radius: 3px;
+    overflow: hidden;
+    margin-bottom: 8px;
+}
+
+.progress-fill {
+    height: 100%;
+    background: linear-gradient(90deg, var(--accent-blue), #00d2ff);
+    box-shadow: 0 0 10px rgba(88, 166, 255, 0.4);
+    transition: width 0.5s ease-out;
+}
+
+.progress-stats {
+    font-size: 0.7rem;
+    color: var(--text-muted);
+    font-weight: 500;
+}
+
+/* Main Content */
+.main-content {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    min-width: 0;
+    overflow: hidden; /* Prevent entire main area from scrolling */
+}
+
+.top-bar {
+    height: var(--header-height);
+    padding: 0 24px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 24px;
+    border-bottom: 1px solid var(--border-main);
+}
+
+.search-container {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    background: var(--bg-darker);
+    border: 1px solid var(--border-main);
+    padding: 8px 16px;
+    border-radius: 12px;
+    width: 400px;
+    transition: var(--transition-fast);
+    position: relative;
+}
+
+.search-container:focus-within {
+    border-color: var(--accent-blue);
+    background: var(--bg-card);
+    box-shadow: 0 0 0 3px rgba(88, 166, 255, 0.1);
+}
+
+.search-icon {
+    width: 20px;
+    height: 20px;
+    background: url('../user_files/sprites/items/poke-ball.png') no-repeat center;
+    background-size: contain;
+    opacity: 0.7;
+}
+
+.search-icon i {
+    display: none;
+}
+
+#pokemon-search {
+    width: 100%;
+    background: transparent;
+    border: none;
+    color: var(--text-main);
+    font-family: inherit;
+    font-size: 0.95rem;
+    outline: none;
+    padding-right: 30px; /* Space for X button */
+}
+
+.search-input-wrapper {
+    position: relative;
+    flex: 1;
+    display: flex;
+    align-items: center;
+}
+
+.clear-btn {
+    position: absolute;
+    right: 0;
+    background: transparent;
+    border: none;
+    color: var(--text-muted);
+    font-size: 1.2rem;
+    cursor: pointer;
+    padding: 4px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: var(--transition-fast);
+    z-index: 5;
+}
+
+.clear-btn:hover {
+    color: var(--text-main);
+}
+
+.clear-btn.hidden {
+    display: none;
+}
+
+#sprite-toggle {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    background: var(--bg-darker);
+    border: 1px solid var(--border-main);
+    color: var(--text-main);
+}
+
+#sprite-toggle:hover {
+    border-color: var(--accent-blue);
+    background: var(--bg-card);
+}
+
+.top-actions {
+    display: flex;
+    align-items: center;
+    gap: 16px;
+}
+
+.meta-grid {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 12px;
+}
+
+.meta-item {
+    background: rgba(255, 255, 255, 0.02);
+    padding: 12px;
+    border-radius: 8px;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+}
+
+.meta-label {
+    font-size: 0.65rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    color: var(--text-muted);
+}
+
+.meta-value {
+    font-size: 0.9rem;
+    font-weight: 600;
+    color: var(--text-main);
+}
+
+.sort-control {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 0.85rem;
+    color: var(--text-muted);
+}
+
+#sort-mode {
+    background: var(--bg-darker);
+    border: 1px solid var(--border-main);
+    color: var(--text-main);
+    padding: 6px 12px;
+    border-radius: 6px;
+    outline: none;
+}
+
+.view-toggle {
+    display: flex;
+    background: var(--bg-darker);
+    border: 1px solid var(--border-main);
+    border-radius: 8px;
+    padding: 4px;
+}
+
+.view-btn {
+    width: 32px;
+    height: 32px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: transparent;
+    border: none;
+    color: var(--text-muted);
+    cursor: pointer;
+    border-radius: 6px;
+    transition: var(--transition-fast);
+}
+
+.view-btn.active {
+    background: var(--bg-card);
+    color: var(--accent-blue);
+}
+
+.filter-pills {
+    padding: 12px 24px;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    min-height: 52px;
+}
+
+.pill {
+    background: var(--bg-card);
+    border: 1px solid var(--border-main);
+    padding: 4px 12px;
+    border-radius: 20px;
+    font-size: 0.75rem;
+    font-weight: 600;
+    display: flex;
+    align-items: center;
+    gap: 6px;
+}
+
+.pill-remove {
+    cursor: pointer;
+    color: var(--accent-red);
+}
+
+.content-scroll {
+    flex: 1;
+    overflow-y: auto;
+    padding: 12px 24px 24px;
+}
+
+/* Generation Grouping */
+.gen-section {
+    margin-bottom: 48px;
+}
+
+.gen-header {
+    display: flex;
+    align-items: baseline;
+    gap: 16px;
+    margin-bottom: 24px;
+    padding-bottom: 12px;
+    border-bottom: 1px solid var(--border-main);
+}
+
+.gen-title {
+    font-size: 1.5rem;
+    font-weight: 800;
+    color: var(--text-bright);
+    letter-spacing: -0.5px;
+}
+
+.gen-count {
+    font-size: 0.85rem;
+    color: var(--text-muted);
+    font-weight: 500;
+}
+
+.gen-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
+    gap: 20px;
+}
+
+.pokemon-grid {
+    display: block; /* Sub-grids handle the layout */
+}
+
+/* Pokemon Card */
+.pokemon-card {
+    background: var(--bg-card);
+    border: 1px solid var(--border-main);
+    border-radius: 16px;
+    padding: 16px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    position: relative;
+    cursor: pointer;
+    transition: var(--transition-mid);
+    overflow: hidden;
+}
+
+.pokemon-card:hover {
+    transform: translateY(-4px);
+    border-color: var(--accent-blue);
+    background: var(--bg-card-hover);
+    box-shadow: 0 10px 25px rgba(0,0,0,0.4);
+}
+
+/* State-based card badges removed per user request */
+.state-badge {
+    display: none;
+}
+
+.pokemon-card.selected {
+    border-color: var(--accent-blue);
+    background: rgba(88, 166, 255, 0.05);
+    box-shadow: 0 0 0 2px var(--accent-blue);
+}
+
+.pokemon-card.state-unseen {
+    opacity: 0.6;
+}
+
+.pokemon-card.state-unseen .card-sprite img {
+    filter: brightness(0) invert(1) brightness(0.15); /* Solid dark grey silhouette */
+}
+
+.pokemon-card.state-seen {
+    border-color: rgba(255, 255, 255, 0.05);
+}
+
+.pokemon-card.state-seen .card-sprite img {
+    filter: brightness(0) invert(1) brightness(0.4); /* Solid light grey silhouette */
+}
+
+.pokemon-card.state-caught {
+    border-color: var(--accent-blue);
+    background: rgba(88, 166, 255, 0.03);
+}
+
+.card-id {
+    position: absolute;
+    top: 12px;
+    left: 14px;
+    font-size: 0.75rem;
+    font-weight: 800;
+    color: var(--text-muted);
+    font-family: 'JetBrains Mono', monospace;
+}
+
+.card-badges {
+    position: absolute;
+    top: 12px;
+    right: 12px;
+    display: flex;
+    gap: 4px;
+}
+
+.shiny-badge, .favorite-badge {
+    font-size: 0.8rem;
+}
+
+.card-sprite {
+    width: 96px;
+    height: 96px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    margin: 10px 0;
+}
+
+.card-sprite img {
+    max-width: 100%;
+    max-height: 100%;
+    image-rendering: pixelated;
+    transition: transform 0.3s cubic-bezier(0.175, 0.885, 0.32, 1.275);
+}
+
+
+
+.pokemon-card:hover .card-sprite img {
+    transform: scale(1.15);
+}
+
+.card-info {
+    text-align: center;
+    width: 100%;
+}
+
+.card-name {
+    display: block;
+    font-weight: 700;
+    font-size: 0.95rem;
+    text-transform: capitalize;
+    color: var(--text-bright);
+    margin-bottom: 8px;
+}
+
+.card-types {
+    display: flex;
+    justify-content: center;
+    gap: 4px;
+}
+
+.mini-type {
+    padding: 2px 8px;
+    border-radius: 4px;
+    font-size: 0.6rem;
+    font-weight: 800;
+    text-transform: uppercase;
+    color: white;
+}
+
+
+.pokemon-grid.list-view .gen-grid {
+    grid-template-columns: 1fr;
+    gap: 8px;
+}
+
+.pokemon-grid.list-view .pokemon-card {
+    flex-direction: row;
+    height: 60px;
+    padding: 0 16px;
+    justify-content: flex-start;
+    gap: 20px;
+}
+
+.pokemon-grid.list-view .card-id {
+    position: static;
+    width: 60px;
+}
+
+.pokemon-grid.list-view .card-sprite {
+    width: 40px;
+    height: 40px;
+    margin: 0;
+}
+
+.pokemon-grid.list-view .card-info {
+    text-align: left;
+    display: flex;
+    align-items: center;
+    gap: 20px;
+    flex: 1;
+}
+
+.pokemon-grid.list-view .card-name {
+    margin-bottom: 0;
+    width: 150px;
+}
+
+.pokemon-grid.list-view .card-badges {
+    position: static;
+}
+
+/* Detail Panel */
+.detail-panel {
+    width: var(--detail-width);
+    background: var(--bg-darker);
+    border-left: 1px solid var(--border-main);
+    display: flex;
+    flex-direction: column;
+    flex-shrink: 0;
+}
+
+.detail-placeholder {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    color: var(--text-muted);
+    padding: 60px 40px;
+    text-align: center;
+}
+
+.detail-placeholder h3 {
+    font-size: 1.2rem;
+    color: var(--text-main);
+    margin-bottom: 12px;
+    letter-spacing: 1px;
+    text-transform: uppercase;
+}
+
+.detail-placeholder p {
+    font-size: 0.9rem;
+    line-height: 1.5;
+    max-width: 200px;
+    opacity: 0.6;
+}
+
+.placeholder-icon {
+    width: 64px;
+    height: 64px;
+    margin: 0 auto 20px;
+    background: url('../user_files/sprites/items/poke-ball.png') no-repeat center;
+    background-size: contain;
+    opacity: 0.15;
+    filter: grayscale(1);
+}
+
+.detail-content {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    animation: fadeIn 0.3s ease-out;
+}
+
+.detail-header-fixed {
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    height: 60px;
+    z-index: 100;
+    pointer-events: none;
+}
+
+.detail-header-fixed .close-btn {
+    pointer-events: auto;
+}
+
+.detail-hero-scroll {
+    padding: 40px 24px 20px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    text-align: center;
+    position: relative;
+}
+
+.det-id-badge {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 0.85rem;
+    font-weight: 800;
+    color: var(--accent-blue);
+    margin-bottom: 8px;
+    opacity: 0.8;
+}
+
+.det-name-main {
+    font-size: 1.8rem;
+    font-weight: 800;
+    letter-spacing: -0.5px;
+    color: var(--text-bright);
+    margin-bottom: 12px;
+    text-transform: capitalize;
+}
+
+.det-status-row {
+    display: flex;
+    gap: 8px;
+    margin-bottom: 16px;
+}
+
+.det-status-pill {
+    padding: 2px 8px;
+    border-radius: 8px;
+    font-size: 0.55rem;
+    font-weight: 800;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+}
+
+.det-status-pill.caught { background: var(--accent-blue); color: #000; }
+.det-status-pill.seen { background: var(--bg-card); color: var(--text-muted); border: 1px solid var(--border-main); }
+.det-status-pill.unseen { background: transparent; color: var(--text-muted); border: 1px dashed var(--border-main); }
+
+.detail-body {
+    flex: 1;
+    overflow-y: auto;
+    padding: 0 24px 40px;
+}
+
+/* Sections */
+.det-section {
+    margin-bottom: 32px;
+    animation: fadeIn 0.4s ease-out;
+}
+
+.det-section-label {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 0.75rem;
+    font-weight: 800;
+    text-transform: uppercase;
+    color: var(--text-muted);
+    letter-spacing: 1.5px;
+    margin-bottom: 16px;
+}
+
+.det-section-label::after {
+    content: '';
+    flex: 1;
+    height: 1px;
+    background: linear-gradient(to right, var(--border-main), transparent);
+}
+
+.detail-id {
+    font-family: 'JetBrains Mono', monospace;
+    font-weight: 700;
+    color: var(--text-muted);
+}
+
+.close-btn {
+    position: absolute;
+    top: 20px;
+    right: 20px;
+    width: 32px;
+    height: 32px;
+    border-radius: 50%;
+    background: rgba(255, 255, 255, 0.05);
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    color: var(--text-muted);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    z-index: 10;
+    transition: all 0.2s ease;
+    font-size: 0.9rem;
+}
+
+.close-btn:hover {
+    background: rgba(255, 255, 255, 0.15);
+    color: var(--text-bright);
+    transform: rotate(90deg);
+}
+
+.detail-glow {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    width: 250px;
+    height: 250px;
+    z-index: 0;
+    pointer-events: none;
+    transition: opacity 0.3s ease;
+    border-radius: 50%;
+}
+
+#det-sprite {
+    width: 180px;
+    height: 180px;
+    image-rendering: pixelated;
+    position: relative;
+    z-index: 1;
+}
+
+.detail-types {
+    display: flex;
+    justify-content: center;
+    gap: 8px;
+    margin-top: 12px;
+}
+
+.type-filter {
+    padding: 6px 10px;
+    border-radius: 6px;
+    font-size: 0.75rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    cursor: pointer;
+    transition: var(--transition-fast);
+    opacity: 0.25;
+    border: 1px solid transparent;
+    color: white;
+}
+
+.type-filter.active {
+    opacity: 1;
+    border-color: rgba(255, 255, 255, 0.3);
+    box-shadow: 0 0 10px rgba(0, 0, 0, 0.2);
+}
+
+.type-filter:hover {
+    transform: translateY(-1px);
+    opacity: 0.8;
+}
+
+.type-badge {
+    padding: 6px 16px;
+    border-radius: 20px;
+    font-size: 0.75rem;
+    font-weight: 800;
+    text-transform: uppercase;
+    color: white;
+    box-shadow: 0 4px 10px rgba(0,0,0,0.2);
+}
+
+.detail-scroll {
+    flex: 1;
+    overflow-y: auto;
+    padding: 0 24px 24px;
+}
+
+.detail-section {
+    margin-top: 32px;
+}
+
+.detail-section h3 {
+    font-size: 0.8rem;
+    font-weight: 800;
+    text-transform: uppercase;
+    color: var(--text-muted);
+    letter-spacing: 1px;
+    margin-bottom: 16px;
+    border-bottom: 1px solid var(--border-main);
+    padding-bottom: 8px;
+}
+
+.stats-grid {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+.stat-item {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    margin-bottom: 0;
+}
+
+.stat-label {
+    display: flex;
+    justify-content: space-between;
+    font-size: 0.75rem;
+    font-weight: 700;
+    color: var(--text-muted);
+    text-transform: uppercase;
+}
+
+.stat-bar-bg {
+    height: 8px;
+    background: var(--bg-dark);
+    border-radius: 4px;
+    overflow: hidden;
+}
+
+.stat-bar-fill {
+    height: 100%;
+    background: var(--accent-blue);
+    border-radius: 4px;
+    width: 0;
+    transition: width 1s cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.stat-total {
+    margin-top: 20px;
+    padding: 12px;
+    background: var(--bg-card);
+    border-radius: 8px;
+    display: flex;
+    justify-content: space-between;
+    font-weight: 800;
+    font-size: 0.9rem;
+}
+
+.forms-grid {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    margin-top: 8px;
+}
+
+.form-chip {
+    background: var(--bg-card);
+    border: 1px solid var(--border-main);
+    padding: 6px 10px;
+    border-radius: 10px;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    cursor: pointer;
+    transition: var(--transition-fast);
+    font-size: 0.75rem;
+    font-weight: 600;
+}
+
+.form-chip:hover {
+    background: var(--bg-card-hover);
+    border-color: var(--accent-blue);
+}
+
+.form-chip.active {
+    background: rgba(88, 166, 255, 0.1);
+    border-color: var(--accent-blue);
+    color: var(--accent-blue);
+}
+
+.form-chip img {
+    width: 24px;
+    height: 24px;
+    image-rendering: pixelated;
+}
+
+.info-grid {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 16px;
+}
+
+/* Expansion Drawer */
+.expansion-drawer {
+    grid-column: 1 / -1;
+    background: var(--bg-darker);
+    border: 1px solid var(--accent-blue);
+    border-radius: 12px;
+    margin: 10px 0;
+    overflow: hidden;
+    animation: drawerSlideDown 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.drawer-content {
+    padding: 20px;
+    display: flex;
+    gap: 30px;
+    position: relative;
+}
+
+.drawer-forms {
+    flex: 1;
+}
+
+.drawer-forms h4 {
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    color: var(--text-muted);
+    margin-bottom: 12px;
+    letter-spacing: 1px;
+}
+
+.drawer-forms-list {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px;
+}
+
+.close-drawer {
+    position: absolute;
+    top: 15px;
+    right: 15px;
+    background: transparent;
+    border: none;
+    color: var(--text-muted);
+    font-size: 1.5rem;
+    cursor: pointer;
+}
+
+@keyframes drawerSlideDown {
+    from { opacity: 0; max-height: 0; transform: translateY(-10px); }
+    to { opacity: 1; max-height: 500px; transform: translateY(0); }
+}
+
+.pokemon-card.has-drawer {
+    border-color: var(--accent-blue);
+    background: rgba(88, 166, 255, 0.05);
+}
+
+.info-item {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+}
+
+.info-item label {
+    font-size: 0.7rem;
+    color: var(--text-muted);
+    font-weight: 600;
+}
+
+.info-item span {
+    font-weight: 700;
+    font-size: 0.9rem;
+}
+
+.evo-chain {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.evo-node {
+    background: var(--bg-card);
+    border: 1px solid var(--border-main);
+    border-radius: 12px;
+    padding: 12px 18px;
+    display: flex;
+    align-items: center;
+    gap: 16px;
+    cursor: pointer;
+    transition: var(--transition-fast);
+}
+
+
+.evo-info {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+}
+
+.evo-name {
+    font-size: 0.85rem;
+    font-weight: 700;
+    color: var(--text-bright);
+}
+
+.evo-id {
+    font-size: 0.7rem;
+    color: var(--text-muted);
+    font-family: 'JetBrains Mono', monospace;
+}
+
+.evo-node:hover {
+    background: var(--bg-card-hover);
+    border-color: var(--accent-blue);
+}
+
+.evo-sprite {
+    width: 40px;
+    height: 40px;
+    image-rendering: pixelated;
+}
+
+.evo-name {
+    font-size: 0.85rem;
+    font-weight: 600;
+    text-transform: capitalize;
+}
+
+/* Helpers */
+.hidden { display: none !important; }
+
+.btn {
+    padding: 8px 16px;
+    border-radius: 8px;
+    font-weight: 600;
+    font-size: 0.85rem;
+    cursor: pointer;
+    border: none;
+    transition: var(--transition-fast);
+}
+
+.btn-secondary {
+    background: var(--bg-card);
+    border: 1px solid var(--border-main);
+    color: var(--text-main);
+}
+
+.btn-secondary:hover {
+    background: var(--bg-card-hover);
+    border-color: var(--text-muted);
+}
+
+.empty-state {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    padding: 100px 40px;
+    text-align: center;
+    color: var(--text-muted);
+}
+
+.empty-icon {
+    width: 120px;
+    height: 120px;
+    margin: 0 auto 24px;
+    background: url('../user_files/sprites/items/poke-doll.png') no-repeat center;
+    background-size: contain;
+    filter: drop-shadow(0 10px 15px rgba(0, 0, 0, 0.3));
+}
+
+@keyframes fadeIn {
+    from { opacity: 0; transform: translateX(10px); }
+    to { opacity: 1; transform: translateX(0); }
+}
+
+/* Scrollbar */
+::-webkit-scrollbar {
+    width: 8px;
+}
+
+::-webkit-scrollbar-track {
+    background: transparent;
+}
+
+::-webkit-scrollbar-thumb {
+    background: var(--border-main);
+    border-radius: 10px;
+}
+
+::-webkit-scrollbar-thumb:hover {
+    background: var(--text-muted);
+}
+
+/* Lore / Description */
+.lore-section {
+    background: linear-gradient(135deg, rgba(255, 255, 255, 0.03) 0%, rgba(255, 255, 255, 0.01) 100%);
+    border-radius: 16px;
+    padding: 24px;
+    border: 1px solid rgba(255, 255, 255, 0.05);
+    position: relative;
+    overflow: hidden;
+}
+
+.lore-section::before {
+    content: '"';
+    position: absolute;
+    top: -10px;
+    left: 10px;
+    font-size: 4rem;
+    font-family: serif;
+    color: var(--accent-blue);
+    opacity: 0.1;
+}
+
+.dex-entry-text {
+    font-size: 1rem;
+    line-height: 1.7;
+    color: var(--text-main);
+    font-weight: 400;
+    margin: 0;
+    font-style: italic;
+    letter-spacing: 0.3px;
+    position: relative;
+    z-index: 1;
+}
+
+.callout-body {
+    font-size: 0.9rem;
+    color: var(--text-bright);
+    line-height: 1.4;
+    font-weight: 500;
+}
+
+/* ---- Briefing Hints ---- */
+.briefing-hint-card {
+    background: rgba(63, 185, 80, 0.08);
+    border: 1px solid rgba(63, 185, 80, 0.3);
+    border-radius: 8px;
+    padding: 12px 16px;
+    position: relative;
+    overflow: hidden;
+}
+
+.briefing-hint-card::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 3px;
+    height: 100%;
+    background: var(--accent-green);
+}
+
+.hint-header {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 0.6rem;
+    text-transform: uppercase;
+    color: var(--accent-green);
+    letter-spacing: 1px;
+    margin-bottom: 6px;
+    font-weight: 700;
+}
+
+.hint-body {
+    font-size: 0.85rem;
+    color: var(--text-main);
+    line-height: 1.4;
+}
+
+.hint-region-tag {
+    color: var(--accent-green);
+    font-weight: 700;
+    text-transform: capitalize;
+}
+
+.evo-disclaimer {
+    margin-top: 16px;
+    font-size: 0.75rem;
+    color: var(--text-muted);
+    line-height: 1.4;
+    padding: 10px;
+    border-radius: 8px;
+    background: rgba(255, 255, 255, 0.02);
+    border-left: 3px solid var(--border-main);
+}
+
+.detail-forms-list {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px;
+    margin-top: 12px;
+}
+
+.detail-form-item {
+    background: var(--bg-card);
+    border: 1px solid var(--border-main);
+    padding: 8px 12px;
+    border-radius: 8px;
+    cursor: pointer;
+    transition: var(--transition-fast);
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.detail-form-item:hover {
+    border-color: var(--accent-blue);
+    background: rgba(255, 255, 255, 0.05);
+}
+
+.detail-form-item.active {
+    border-color: var(--accent-blue);
+    background: rgba(88, 166, 255, 0.15);
+}
+
+.detail-form-item img {
+    width: 24px;
+    height: 24px;
+}
+
+.evo-condition {
+    font-size: 0.6rem;
+    font-weight: 800;
+    color: var(--accent-blue);
+    background: rgba(88, 166, 255, 0.1);
+    padding: 2px 6px;
+    border-radius: 4px;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    max-width: 80px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+
+
+/* Abilities */
+.abilities-list {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.ability-item {
+    background: rgba(255, 255, 255, 0.03);
+    border-radius: 12px;
+    padding: 12px 16px;
+    border: 1px solid rgba(255, 255, 255, 0.05);
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+}
+
+.ability-name-row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.ability-name {
+    font-size: 0.9rem;
+    font-weight: 700;
+    color: var(--text-bright);
+    text-transform: capitalize;
+}
+
+.ability-tag {
+    font-size: 0.6rem;
+    font-weight: 800;
+    background: rgba(88, 166, 255, 0.1);
+    color: var(--accent-blue);
+    padding: 2px 6px;
+    border-radius: 4px;
+    text-transform: uppercase;
+}
+
+/* ============================================================
+   DISCOVERY MAP — full layout system
+   ============================================================ */
+
+.discovery-view {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    background: #05070a; /* Deep tech background */
+    overflow: hidden;
+    position: relative;
+    color: #e0e6ed;
+}
+
+/* ---- Map Controls Overlay ---- */
+.map-controls-overlay {
+    position: absolute;
+    top: 20px;
+    left: 20px;
+    z-index: 1000;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    pointer-events: none;
+    transform: translateZ(0);
+    will-change: transform;
+}
+
+.overlay-zoom-btn {
+    width: 40px;
+    height: 40px;
+    background: rgba(13, 17, 23, 0.95);
+    border: 1px solid var(--border-main);
+    color: var(--text-bright);
+    border-radius: 8px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 1.2rem;
+    font-weight: 700;
+    cursor: pointer;
+    pointer-events: auto;
+    transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1);
+    box-shadow: 0 4px 12px rgba(0,0,0,0.3);
+}
+
+.overlay-zoom-btn:hover {
+    background: var(--bg-card-hover);
+    border-color: var(--accent-blue);
+    transform: translateY(-2px);
+    box-shadow: 0 6px 16px rgba(0,0,0,0.4);
+    color: var(--accent-blue);
+}
+
+.overlay-zoom-btn:active {
+    transform: translateY(0);
+}
+
+#map-btn-reset, #map-btn-center, #map-btn-collapse {
+    font-size: 1rem;
+}
+
+/* ---- Map Progress Overlay ---- */
+.map-progress-overlay {
+    position: absolute;
+    top: 24px;
+    right: 24px;
+    z-index: 1000;
+    background: rgba(13, 17, 23, 0.95);
+    border: 1px solid var(--border-main);
+    border-radius: 12px;
+    padding: 16px;
+    width: 280px;
+    box-shadow: 0 10px 30px rgba(0,0,0,0.5);
+    pointer-events: auto;
+    transform: translateZ(0);
+    will-change: transform;
+}
+
+.map-progress-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    font-size: 0.75rem;
+    font-weight: 600;
+    color: var(--text-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    margin-bottom: 6px;
+}
+
+#map-progress-percent {
+    color: var(--accent-blue);
+    font-weight: 900;
+}
+
+.map-progress-bar {
+    height: 6px;
+    background: rgba(255, 255, 255, 0.05);
+    border-radius: 3px;
+    overflow: hidden;
+    margin-bottom: 12px;
+}
+
+.map-progress-fill {
+    height: 100%;
+    background: linear-gradient(90deg, var(--accent-blue), #00d2ff);
+    box-shadow: 0 0 10px rgba(88, 166, 255, 0.4);
+    transition: width 0.3s ease-out;
+    will-change: width;
+    transform: translateZ(0);
+}
+
+.map-progress-stats {
+    display: flex;
+    justify-content: space-between;
+    font-size: 0.75rem;
+    font-weight: 700;
+    color: var(--text-bright);
+}
+
+/* ---- Two-panel body ---- */
+.map-body {
+    flex: 1;
+    display: flex;
+    overflow: hidden;
+    min-height: 0;
+}
+
+/* ---- Canvas area ---- */
+.map-canvas-area {
+    flex: 1;
+    overflow: auto;
+    position: relative;
+    cursor: grab;
+    background: var(--bg-dark);
+    background-image: 
+        linear-gradient(rgba(255,255,255,0.015) 1px, transparent 1px),
+        linear-gradient(90deg, rgba(255,255,255,0.015) 1px, transparent 1px);
+    background-size: 60px 60px;
+    contain: paint;
+}
+
+.map-canvas-area:active { cursor: grabbing; }
+
+.discovery-map-content {
+    position: relative;
+    transform-origin: 0 0;
+}
+
+.discovery-svg {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    pointer-events: none;
+    z-index: 1;
+    overflow: visible;
+    transform: translateZ(0);
+    backface-visibility: hidden;
+}
+
+.discovery-nodes {
+    position: absolute;
+    top: 0;
+    left: 0;
+    z-index: 10;
+    pointer-events: none;
+    transform: translateZ(0);
+    backface-visibility: hidden;
+}
+
+.discovery-tier-labels {
+    position: absolute;
+    top: 0;
+    left: 0;
+    z-index: 5;
+    pointer-events: none;
+}
+
+
+
+/* ---- Discovery Nodes ---- */
+.discovery-node {
+    position: absolute;
+    background: #12171e;
+    border: 1px solid rgba(88, 166, 255, 0.4);
+    border-radius: 12px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    pointer-events: auto;
+    transform: translate(-50%, -50%);
+    transition: border-color 0.1s ease, box-shadow 0.1s ease, transform 0.2s cubic-bezier(0.2, 0, 0, 1);
+    will-change: transform, border-color;
+    backface-visibility: hidden;
+    z-index: 11;
+    box-shadow: 0 2px 8px rgba(0,0,0,0.4);
+}
+
+.discovery-node:hover {
+    border-color: #00f2ff;
+    background: #1a222c;
+    box-shadow: 0 0 20px rgba(0, 242, 255, 0.15);
+}
+
+.discovery-node.selected {
+    border-color: #00f2ff;
+    background: #1c2632;
+    box-shadow: 0 0 30px rgba(0, 242, 255, 0.25);
+    z-index: 20;
+}
+
+.node-inner {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 3px;
+    width: 100%;
+    padding: 4px 6px;
+}
+
+.node-sprite {
+    width: 75%;
+    height: 75%;
+    object-fit: contain;
+    image-rendering: pixelated;
+    transition: transform 0.2s ease;
+}
+
+.node-label {
+    font-size: 2.7rem;
+    font-weight: 950;
+    color: var(--text-bright);
+    text-shadow: 0 2px 8px rgba(0,0,0,1);
+    text-align: center;
+    text-transform: capitalize;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    max-width: 90%;
+    letter-spacing: 0.2px;
+}
+
+.discovery-node:hover {
+    transform: translate(-50%, -50%) scale(1.12);
+    z-index: 20;
+}
+
+.discovery-node:hover .node-sprite {
+    transform: scale(1.05);
+}
+
+/* --- Node States Redesign --- */
+
+/* 1. CAUGHT (vis-2) */
+.discovery-node.vis-2 {
+    border-color: rgba(255, 255, 255, 0.3);
+    background: #1a222c;
+    box-shadow: 0 0 15px rgba(255, 255, 255, 0.05);
+}
+
+.discovery-node.vis-2::after {
+    content: '✓';
+    position: absolute;
+    top: -6px;
+    right: -6px;
+    width: 18px;
+    height: 18px;
+    background: var(--text-main);
+    color: var(--bg-darker);
+    border-radius: 50%;
+    font-size: 0.65rem;
+    font-weight: 900;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    line-height: 18px;
+    text-align: center;
+    box-shadow: 0 2px 4px rgba(0,0,0,0.3);
+}
+
+/* 2. SEEN BUT NOT CAUGHT (vis-1) */
+.discovery-node.vis-1 {
+    border-color: rgba(255, 255, 255, 0.15);
+    background: transparent;
+}
+
+/* 3. UNSEEN (vis-0) */
+.discovery-node.vis-0 {
+    border-color: rgba(255, 255, 255, 0.05);
+    background: transparent;
+}
+
+/* 4. LOCKED / NOT ENCOUNTERABLE */
+.discovery-node.state-restricted {
+    border-style: dashed;
+    border-color: rgba(255, 255, 255, 0.1);
+}
+
+.discovery-node.state-restricted::after {
+    content: '✕';
+    position: absolute;
+    top: -6px;
+    right: -6px;
+    width: 16px;
+    height: 16px;
+    background: rgba(255, 255, 255, 0.1);
+    color: var(--text-muted);
+    border-radius: 50%;
+    font-size: 0.6rem;
+    font-weight: 900;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    line-height: 16px;
+    text-align: center;
+}
+
+/* 5. SELECTED */
+.discovery-node.selected {
+    border-color: var(--accent-blue) !important;
+    background: rgba(88, 166, 255, 0.08) !important;
+    box-shadow: 0 0 0 2px var(--accent-blue), 0 6px 24px rgba(88, 166, 255, 0.25) !important;
+    transform: translate(-50%, -50%) scale(1.08) !important;
+    z-index: 25 !important;
+    animation: none !important;
+    opacity: 1 !important;
+}
+
+/* Tier sizing overrides applied by JS via width/height, but label font scales with tier */
+.discovery-node.tier-0 .node-label { font-size: 0.52rem; opacity: 0.6; }
+.discovery-node.tier-1 .node-label { font-size: 0.56rem; opacity: 0.7; }
+.discovery-node.tier-2 .node-label { font-size: 0.60rem; color: var(--text-main); opacity: 0.9; }
+.discovery-node.tier-3 .node-label { font-size: 0.65rem; color: var(--text-bright); font-weight: 800; opacity: 1; }
+
+.discovery-node.selected .node-label { opacity: 1; }
+
+/* Filter states */
+.discovery-node.map-filtered-out {
+    opacity: 0 !important;
+    pointer-events: none;
+}
+
+.discovery-node.state-collapsed {
+    transform: translate(-50%, -50%) scale(0.55);
+    opacity: 0.3;
+}
+
+/* ---- Connection Lines Redesign ---- */
+.discovery-line {
+    stroke: rgba(255, 255, 255, 0.05); /* Blocked / Unavailable / Default structure */
+    stroke-width: 2;
+    fill: none;
+    transition: all 0.2s ease;
+}
+
+/* Prerequisites that are fulfilled (Source Caught) */
+.discovery-line.line-met {
+    stroke: rgba(255, 255, 255, 0.25); /* Calm, resolved */
+    stroke-width: 3;
+}
+
+/* Fully completed path (Target Caught) */
+.discovery-line.line-completed {
+    stroke: rgba(255, 255, 255, 0.15); /* Calm */
+    stroke-width: 3;
+}
+
+/* Selected Chain */
+.discovery-line.line-active {
+    stroke: var(--accent-blue); /* Brightest, strongest */
+    stroke-width: 5;
+    stroke-opacity: 1;
+    z-index: 20;
+}
+
+/* If active AND met? Still accent blue, thick */
+.discovery-line.line-met.line-active, .discovery-line.line-completed.line-active {
+    stroke: var(--accent-blue);
+    stroke-opacity: 0.8;
+    stroke-width: 5;
+}
+
+/* ---- Mini-map ---- */
+.mini-map-container {
+    position: absolute;
+    bottom: 16px;
+    right: 16px;
+    background: rgba(13, 17, 23, 0.9);
+    border: 1px solid var(--border-main);
+    border-radius: 8px;
+    padding: 8px;
+    z-index: 100;
+}
+
+.mini-map-label {
+    font-size: 0.6rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+    color: var(--text-muted);
+    margin-bottom: 5px;
+    text-align: center;
+}
+
+.mini-map-canvas {
+    display: block;
+    border-radius: 4px;
+    border: 1px solid rgba(255,255,255,0.05);
+}
+
+.mini-map-viewport {
+    position: absolute;
+    border: 1.5px solid rgba(88,166,255,0.6);
+    border-radius: 2px;
+    background: rgba(88,166,255,0.07);
+    pointer-events: none;
+    /* positioned dynamically by JS; top/left offset by container padding */
+    top: 29px; /* label + margin-bottom + padding */
+    left: 8px;
+}
+
+/* ---- Chain Briefing Panel (Redesign) ---- */
+.chain-inspector {
+    width: 320px;
+    min-width: 320px;
+    flex-shrink: 0;
+    background: var(--bg-darker);
+    border-left: 1px solid var(--border-main);
+    display: flex;
+    flex-direction: column;
+    overflow-y: auto;
+    position: relative;
+    box-shadow: -10px 0 30px rgba(0,0,0,0.3);
+}
+
+.detail-placeholder, .briefing-placeholder {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    padding: 60px 40px;
+    text-align: center;
+    color: var(--text-muted);
+}
+
+.placeholder-icon {
+    font-size: 3.5rem;
+    margin-bottom: 24px;
+    opacity: 0.2;
+    filter: grayscale(1);
+    transition: all 0.5s ease;
+}
+
+.detail-placeholder:hover .placeholder-icon {
+    opacity: 0.4;
+    transform: scale(1.05);
+}
+
+.detail-placeholder h3, .briefing-placeholder h3 {
+    font-size: 1.1rem;
+    color: var(--text-main);
+    margin-bottom: 12px;
+    text-transform: uppercase;
+    letter-spacing: 1.5px;
+    font-weight: 800;
+}
+
+.detail-placeholder p, .briefing-placeholder p {
+    font-size: 0.85rem;
+    line-height: 1.6;
+    max-width: 240px;
+    margin: 0 auto;
+}
+
+.inspector-content {
+    padding: 24px;
+    display: flex;
+    flex-direction: column;
+    gap: 28px;
+    animation: slideInRight 0.4s cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+@keyframes slideInRight {
+    from { transform: translateX(20px); opacity: 0; }
+    to { transform: translateX(0); opacity: 1; }
+}
+
+
+
+/* 5. Chain Context */
+.insp-context-grid {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+}
+
+.insp-context-group {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.insp-context-sublabel {
+    font-size: 0.6rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    color: var(--text-muted);
+    opacity: 0.7;
+}
+
+.insp-context-list {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+}
+
+.insp-context-chip {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 6px 14px;
+    background: rgba(255,255,255,0.04);
+    border: 1px solid rgba(255,255,255,0.05);
+    border-radius: 24px;
+    font-size: 0.8rem;
+    font-weight: 600;
+    cursor: pointer;
+    transition: all 0.2s ease;
+}
+
+.insp-context-chip:hover {
+    background: rgba(255,255,255,0.08);
+    border-color: var(--accent-blue);
+    transform: translateY(-1px);
+}
+
+.insp-context-chip img {
+    width: 40px;
+    height: 40px;
+    object-fit: contain;
+    image-rendering: pixelated;
+}
+
+
+
+/* ---- Prereqs list (still used in main detail panel) ---- */
+.prereqs-list {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px;
+    margin-top: 10px;
+}
+
+.prereq-item {
+    width: 72px;
+    height: 84px;
+    background: var(--bg-card);
+    border: 1px solid var(--border-main);
+    border-radius: 12px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    position: relative;
+    transition: all 0.2s ease;
+    cursor: pointer;
+    padding-bottom: 4px;
+}
+
+.prereq-item:hover {
+    border-color: var(--accent-blue);
+    transform: translateY(-2px);
+}
+
+.prereq-item img {
+    width: 48px;
+    height: 48px;
+    image-rendering: pixelated;
+}
+
+.prereq-id {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 0.6rem;
+    font-weight: 700;
+    color: var(--text-muted);
+    margin-top: 2px;
+}
+
+.prereq-item.locked img {
+    filter: grayscale(1) brightness(0.2);
+    opacity: 0.3;
+}
+
+.prereq-item.caught::after {
+    content: '✓';
+    position: absolute;
+    top: -5px;
+    right: -5px;
+    width: 16px;
+    height: 16px;
+    background: var(--accent-green);
+    color: #000;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 0.6rem;
+    font-weight: 900;
+}
+
+.prereq-logic-label {
+    width: 100%;
+    font-size: 0.7rem;
+    color: var(--text-muted);
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    margin-bottom: 4px;
+    padding-left: 2px;
+}
+
+.ability-desc {
+    grid-column: 1 / -1;
+    font-size: 0.8rem;
+    line-height: 1.4;
+    color: var(--text-muted);
+    padding-top: 4px;
+    border-top: 1px solid rgba(255, 255, 255, 0.03);
+    margin-top: 4px;
+}
+
+/* ---- Panel Mode Switcher ---- */
+.panel-mode-switcher {
+    display: flex;
+    padding: 8px;
+    background: var(--bg-darker);
+    border-bottom: 1px solid var(--border-main);
+    gap: 4px;
+}
+
+.panel-mode-btn {
+    flex: 1;
+    background: transparent;
+    border: 1px solid transparent;
+    color: var(--text-muted);
+    padding: 6px 12px;
+    font-size: 0.8rem;
+    font-weight: 600;
+    border-radius: 6px;
+    cursor: pointer;
+    transition: all 0.2s ease;
+}
+
+.panel-mode-btn:hover {
+    color: var(--text-main);
+    background: rgba(255, 255, 255, 0.05);
+}
+
+.panel-mode-btn.active {
+    background: var(--bg-card);
+    border-color: var(--border-main);
+    color: var(--text-bright);
+    box-shadow: 0 2px 8px rgba(0,0,0,0.2);
+}
+
+/* ---- Chain Briefing View ---- */
+.briefing-content {
+    display: flex;
+    flex-direction: column;
+    flex: 1;
+    height: 100%;
+    overflow: hidden;
+}
+
+.briefing-header {
+    display: flex;
+    align-items: center;
+    padding: 20px;
+    gap: 16px;
+    border-bottom: 1px solid var(--border-main);
+    background: linear-gradient(180deg, rgba(255,255,255,0.02) 0%, transparent 100%);
+}
+
+#briefing-sprite {
+    width: 60px;
+    height: 60px;
+    object-fit: contain;
+    image-rendering: pixelated;
+    background: rgba(0,0,0,0.2);
+    border-radius: 8px;
+    padding: 4px;
+    border: 1px solid rgba(255,255,255,0.05);
+}
+
+.briefing-identity {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+}
+
+#briefing-id {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 0.75rem;
+    color: var(--text-muted);
+    font-weight: 700;
+}
+
+#briefing-name {
+    font-size: 1.4rem;
+    font-weight: 800;
+    color: var(--text-bright);
+    margin: 0;
+    line-height: 1.2;
+}
+
+.state-badge {
+    padding: 3px 10px;
+    border-radius: 20px;
+    font-size: 0.65rem;
+    font-weight: 800;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    border: 1px solid;
+    display: inline-block;
+    white-space: nowrap;
+}
+
+/* ---- Panel Mode Switcher ---- */
+.panel-mode-switcher {
+    display: flex;
+    gap: 2px;
+    padding: 8px 16px;
+    background: var(--bg-darker);
+    border-bottom: 1px solid var(--border-main);
+}
+
+.panel-mode-btn {
+    flex: 1;
+    padding: 8px;
+    background: transparent;
+    border: 1px solid transparent;
+    border-radius: 6px;
+    color: var(--text-muted);
+    font-size: 0.75rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    cursor: pointer;
+    transition: all 0.2s ease;
+}
+
+.panel-mode-btn:hover {
+    color: var(--text-bright);
+    background: rgba(255,255,255,0.03);
+}
+
+.panel-mode-btn.active {
+    background: rgba(88, 166, 255, 0.1);
+    color: var(--accent-blue);
+    border-color: rgba(88, 166, 255, 0.2);
+}
+
+.state-badge.locked { color: var(--text-muted); border-color: rgba(255,255,255,0.15); background: rgba(255,255,255,0.05); }
+.state-badge.available { color: var(--accent-blue); border-color: rgba(88,166,255,0.25); background: rgba(88,166,255,0.1); }
+.state-badge.in-progress { color: var(--accent-gold); border-color: rgba(210,153,34,0.25); background: rgba(210,153,34,0.1); }
+.state-badge.completed { color: var(--accent-green); border-color: rgba(63,185,80,0.25); background: rgba(63,185,80,0.1); }
+
+
+.briefing-scroll-area {
+    flex: 1;
+    overflow-y: auto;
+    padding: 20px;
+    display: flex;
+    flex-direction: column;
+    gap: 20px;
+}
+
+.briefing-section {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.briefing-summary {
+    font-size: 0.95rem;
+    line-height: 1.4;
+    color: var(--text-main);
+    margin: 0;
+}
+
+.briefing-callout {
+    background: rgba(88,166,255,0.08);
+    border: 1px solid rgba(88,166,255,0.3);
+    border-radius: 8px;
+    padding: 12px 16px;
+}
+
+.briefing-callout .callout-header {
+    font-size: 0.7rem;
+    text-transform: uppercase;
+    font-weight: 800;
+    color: var(--accent-blue);
+    margin-bottom: 4px;
+    letter-spacing: 0.5px;
+}
+
+.briefing-callout .callout-body {
+    font-size: 0.95rem;
+    font-weight: 600;
+    color: var(--text-bright);
+}
+
+.briefing-section-label {
+    font-size: 0.7rem;
+    text-transform: uppercase;
+    font-weight: 800;
+    color: var(--text-muted);
+    letter-spacing: 0.5px;
+    display: flex;
+    justify-content: space-between;
+    border-bottom: 1px solid var(--border-main);
+    padding-bottom: 4px;
+}
+
+.briefing-reqs-list {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+}
+
+.req-row {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 8px;
+    background: var(--bg-card);
+    border: 1px solid var(--border-main);
+    border-radius: 6px;
+    cursor: pointer;
+    transition: all 0.15s ease;
+}
+
+.req-row:hover {
+    border-color: rgba(255,255,255,0.2);
+    background: var(--bg-card-hover);
+}
+
+.req-sprite {
+    width: 32px;
+    height: 32px;
+    object-fit: contain;
+    image-rendering: pixelated;
+}
+
+.req-name {
+    flex: 1;
+    font-size: 0.9rem;
+    font-weight: 600;
+    color: var(--text-main);
+}
+
+.req-status {
+    font-size: 0.7rem;
+    font-weight: 700;
+    text-transform: uppercase;
+}
+
+.req-status.caught { color: var(--accent-green); }
+.req-status.seen { color: var(--text-main); }
+.req-status.missing { color: var(--text-muted); }
+.req-status.locked { color: var(--accent-red); opacity: 0.7; }
+
+.briefing-context-list {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    font-size: 0.8rem;
+    color: var(--text-muted);
+}
+/* ---- Global Close Button ---- */
+.detail-close-global {
+    position: absolute;
+    top: 12px;
+    right: 12px;
+    z-index: 100;
+    background: rgba(0, 0, 0, 0.4);
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    color: white;
+    width: 32px;
+    height: 32px;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    transition: all 0.2s ease;
+}
+
+.detail-close-global:hover {
+    background: rgba(255, 255, 255, 0.1);
+    transform: scale(1.1);
+}
+
+.detail-panel .hidden + .detail-close-global {
+    display: none; /* Hide if no content is visible? No, we handle this in JS visibility */
+}
+
+
+/* ====================================================================
+ * SHOP-SPECIFIC OVERRIDES (Phase 1)
+ * Everything above is verbatim from ankidex.css. Phase 2 will extract
+ * the intersection into web_shell/shell.css.
+ * ==================================================================== */
+
+/* --- Search input (shell CSS keys on #pokemon-search; mirror it here) --- */
+#shop-search {
+    width: 100%;
+    background: transparent;
+    border: none;
+    color: var(--text-main);
+    font-family: inherit;
+    font-size: 0.95rem;
+    outline: none;
+    padding-right: 30px;
+}
+
+#shop-search::placeholder {
+    color: var(--text-muted);
+    opacity: 0.7;
+}
+
+/* --- Sidebar tweaks --- */
+.nav-icon {
+    display: inline-flex;
+    width: 14px;
+    justify-content: center;
+    font-size: 0.7rem;
+    color: var(--accent-blue);
+}
+
+.nav-item.nav-action {
+    background: linear-gradient(135deg,
+        rgba(248, 81, 73, 0.12),
+        rgba(248, 81, 73, 0.04));
+    border: 1px solid rgba(248, 81, 73, 0.25);
+    color: var(--text-bright);
+    font-weight: 600;
+}
+
+.nav-item.nav-action:hover {
+    background: linear-gradient(135deg,
+        rgba(248, 81, 73, 0.25),
+        rgba(248, 81, 73, 0.10));
+    border-color: var(--accent-red);
+    color: var(--text-bright);
+}
+
+.nav-item.nav-action:disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
+}
+
+.reroll-cost-pill {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 0.7rem;
+    font-weight: 700;
+    color: var(--accent-gold);
+    background: rgba(210, 153, 34, 0.12);
+    border: 1px solid rgba(210, 153, 34, 0.3);
+    padding: 1px 7px;
+    border-radius: 4px;
+}
+
+/* --- Currency card (sidebar footer) — premium feel --- */
+.shop-currency-card {
+    margin: 16px;
+    padding: 18px 18px 16px;
+    background:
+        linear-gradient(135deg,
+            rgba(210, 153, 34, 0.10),
+            rgba(210, 153, 34, 0.02) 50%,
+            transparent),
+        var(--bg-card);
+    border: 1px solid var(--border-main);
+    border-radius: 14px;
+    position: relative;
+    overflow: hidden;
+}
+
+.shop-currency-card::before {
+    content: '';
+    position: absolute;
+    top: -40px;
+    right: -40px;
+    width: 120px;
+    height: 120px;
+    background: radial-gradient(circle, rgba(210, 153, 34, 0.18), transparent 60%);
+    pointer-events: none;
+}
+
+.currency-label-row {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 6px;
+    position: relative;
+    z-index: 1;
+}
+
+.shop-currency-label {
+    font-size: 0.7rem;
+    font-weight: 800;
+    text-transform: uppercase;
+    color: var(--text-muted);
+    letter-spacing: 1.5px;
+}
+
+.currency-icon {
+    font-size: 0.95rem;
+    opacity: 0.7;
+}
+
+.shop-currency-value {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 1.55rem;
+    font-weight: 700;
+    color: var(--accent-gold);
+    letter-spacing: -0.5px;
+    line-height: 1.1;
+    text-shadow: 0 0 24px rgba(210, 153, 34, 0.35);
+    position: relative;
+    z-index: 1;
+}
+
+.currency-sub {
+    font-size: 0.65rem;
+    color: var(--text-muted);
+    letter-spacing: 1px;
+    text-transform: uppercase;
+    margin-top: 4px;
+    opacity: 0.7;
+    position: relative;
+    z-index: 1;
+}
+
+/* --- Top bar count chips --- */
+.shop-stat-chip {
+    display: inline-flex;
+    flex-direction: column;
+    align-items: center;
+    background: var(--bg-card);
+    border: 1px solid var(--border-main);
+    border-radius: 10px;
+    padding: 6px 14px;
+    min-width: 58px;
+}
+
+.shop-stat-chip-label {
+    font-size: 0.6rem;
+    font-weight: 700;
+    color: var(--text-muted);
+    text-transform: uppercase;
+    letter-spacing: 1px;
+}
+
+.shop-stat-chip-value {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 1.1rem;
+    font-weight: 700;
+    color: var(--text-bright);
+    line-height: 1.2;
+}
+
+/* --- Section headers (use Ankidex's gradient-underline pattern) --- */
+.shop-section {
+    margin-bottom: 36px;
+}
+
+.shop-section-header {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    margin-bottom: 18px;
+}
+
+.shop-section-title {
+    font-size: 0.8rem;
+    font-weight: 800;
+    text-transform: uppercase;
+    letter-spacing: 2px;
+    color: var(--text-bright);
+    position: relative;
+    padding-left: 12px;
+}
+
+.shop-section-title::before {
+    content: '';
+    position: absolute;
+    left: 0;
+    top: 50%;
+    transform: translateY(-50%);
+    width: 4px;
+    height: 16px;
+    border-radius: 2px;
+    background: var(--accent-blue);
+}
+
+.shop-section-title.items::before { background: var(--accent-red); }
+.shop-section-title.tms::before { background: var(--accent-blue); }
+
+.shop-section-sub {
+    font-size: 0.7rem;
+    color: var(--text-muted);
+    letter-spacing: 0.5px;
+    flex: 1;
+    border-bottom: 1px dashed var(--border-main);
+    padding-bottom: 4px;
+    margin-left: 4px;
+}
+
+/* --- Grid uses Ankidex's pokemon-grid behaviour --- */
+.shop-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(170px, 1fr));
+    gap: 14px;
+    /* Scope reflow/paint to the grid so refreshing the cards (e.g. after
+     * a buy/use/reroll) doesn't cause perceptible layout shift elsewhere. */
+    contain: layout style;
+}
+
+/* --- Shop card — built on .pokemon-card hover + structure --- */
+.shop-card {
+    background: var(--bg-card);
+    border: 1px solid var(--border-main);
+    border-radius: 16px;
+    padding: 12px 12px 12px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    position: relative;
+    cursor: pointer;
+    transition: var(--transition-mid);
+    overflow: hidden;
+    height: 200px; /* Fixed, uniform height for all slots */
+    box-sizing: border-box;
+}
+
+.shop-card:hover {
+    transform: translateY(-4px);
+    border-color: var(--accent-blue);
+    background: var(--bg-card-hover);
+    box-shadow: 0 10px 25px rgba(0, 0, 0, 0.4);
+}
+
+.shop-card.selected {
+    border-color: var(--accent-blue);
+    background: rgba(88, 166, 255, 0.05);
+    box-shadow: 0 0 0 2px var(--accent-blue);
+}
+
+.shop-card.owned {
+    border-color: rgba(63, 185, 80, 0.4);
+}
+
+.shop-card.unaffordable {
+    opacity: 0.6;
+}
+
+.shop-card.unaffordable .shop-card-sprite img {
+    filter: grayscale(0.6);
+}
+
+/* Item type / category strip badge in corner */
+.shop-card-tag {
+    position: absolute;
+    top: 10px;
+    left: 12px;
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 0.6rem;
+    font-weight: 800;
+    text-transform: uppercase;
+    color: var(--text-muted);
+    letter-spacing: 1.2px;
+    max-width: 52%;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.shop-card-tag.items { color: var(--accent-red); }
+.shop-card-tag.tms { color: var(--accent-blue); }
+
+.shop-card-badges {
+    position: absolute;
+    top: 9px;
+    right: 10px;
+    display: flex;
+    gap: 4px;
+    max-width: 42%;
+    flex-wrap: wrap;
+    justify-content: flex-end;
+}
+
+.shop-card-badge {
+    font-size: 0.6rem;
+    font-weight: 800;
+    padding: 2px 6px;
+    border-radius: 4px;
+    letter-spacing: 1px;
+    text-transform: uppercase;
+}
+
+.shop-card-badge.owned {
+    color: var(--accent-green);
+    background: rgba(63, 185, 80, 0.12);
+    border: 1px solid rgba(63, 185, 80, 0.4);
+}
+
+.shop-card-badge.qty {
+    color: var(--text-bright);
+    background: var(--bg-darker);
+    border: 1px solid var(--border-main);
+    font-family: 'JetBrains Mono', monospace;
+}
+
+/* Sprite */
+.shop-card-sprite {
+    width: 80px;
+    height: 80px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    margin: 8px 0 6px;
+}
+
+.shop-card-sprite img {
+    /* width/height + object-fit so tiny TM discs scale up to fill the
+     * container while larger item sprites still fit naturally — both
+     * preserve aspect ratio. */
+    width: 100%;
+    height: 100%;
+    object-fit: contain;
+    image-rendering: pixelated;
+    transition: transform 0.3s cubic-bezier(0.175, 0.885, 0.32, 1.275);
+}
+
+.shop-card:hover .shop-card-sprite img {
+    transform: scale(1.15);
+}
+
+.shop-card-name {
+    display: block;
+    font-weight: 700;
+    font-size: 0.9rem;
+    text-align: center;
+    color: var(--text-bright);
+    margin-bottom: 4px;
+    line-height: 1.2;
+    min-height: 2.2em;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+/* TM move-type pill (uses Ankidex's --type-* colors) */
+.shop-card-types {
+    display: flex;
+    justify-content: center;
+    gap: 4px;
+    margin-bottom: 10px;
+    min-height: 18px;
+}
+
+.shop-card-types .mini-type {
+    padding: 2px 8px;
+    border-radius: 4px;
+    font-size: 0.6rem;
+    font-weight: 800;
+    text-transform: uppercase;
+    color: white;
+}
+
+/* Price pill — gold, like a type badge but currency-themed */
+.shop-card-price-pill {
+    padding: 5px 12px;
+    border-radius: 12px;
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 0.75rem;
+    font-weight: 700;
+    color: var(--accent-gold);
+    background: rgba(210, 153, 34, 0.12);
+    border: 1px solid rgba(210, 153, 34, 0.35);
+    box-shadow: 0 2px 8px rgba(210, 153, 34, 0.08);
+    letter-spacing: 0.3px;
+    margin-top: 6px; /* Push below tags-row when present */
+}
+
+.shop-card.unaffordable .shop-card-price-pill {
+    color: var(--accent-red);
+    background: rgba(248, 81, 73, 0.10);
+    border-color: rgba(248, 81, 73, 0.35);
+}
+
+/* --- Detail panel customization --- */
+.detail-sprite {
+    /* Fixed 180x180 container gives consistent hero proportions across all
+     * sprite sizes — tiny TM discs (~28px native) and large item sprites
+     * both land at the same visual scale. */
+    margin-top: 20px;
+    margin-bottom: 16px;
+    width: 180px;
+    height: 180px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    position: relative;
+    z-index: 1;
+}
+
+.detail-sprite img,
+.detail-sprite #det-sprite {
+    /* Override Ankidex's stretching 180x180 rule. object-fit:contain
+     * scales the image to fill the container while preserving its
+     * natural aspect ratio. */
+    width: 100%;
+    height: 100%;
+    object-fit: contain;
+    image-rendering: pixelated;
+}
+
+#det-id {
+    text-transform: uppercase;
+}
+
+.det-status-row .det-pill {
+    padding: 4px 10px;
+    border-radius: 10px;
+    font-size: 0.65rem;
+    font-weight: 800;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+}
+
+.det-pill.price {
+    color: var(--accent-gold);
+    background: rgba(210, 153, 34, 0.12);
+    border: 1px solid rgba(210, 153, 34, 0.4);
+    font-family: 'JetBrains Mono', monospace;
+}
+
+.det-pill.owned {
+    color: var(--accent-green);
+    background: rgba(63, 185, 80, 0.10);
+    border: 1px solid rgba(63, 185, 80, 0.4);
+}
+
+.det-pill.move-type {
+    color: white;
+}
+
+.dex-entry-text {
+    font-size: 0.9rem;
+    line-height: 1.55;
+    color: var(--text-main);
+}
+
+/* Move stats use Ankidex .stats-grid pattern */
+#det-move-stats .stat-item {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+}
+
+#det-move-stats .stat-label {
+    display: flex;
+    justify-content: space-between;
+    font-size: 0.7rem;
+    font-weight: 700;
+    color: var(--text-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+}
+
+#det-move-stats .stat-label .stat-val {
+    font-family: 'JetBrains Mono', monospace;
+    color: var(--text-bright);
+    font-weight: 800;
+    letter-spacing: 0;
+}
+
+#det-move-stats .stat-bar-bg {
+    height: 6px;
+    background: var(--bg-dark);
+    border-radius: 3px;
+    overflow: hidden;
+}
+
+#det-move-stats .stat-bar-fill {
+    height: 100%;
+    background: linear-gradient(90deg, var(--accent-blue), #79c0ff);
+    border-radius: 3px;
+    width: 0;
+    transition: width 0.6s cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+/* Purchase row */
+.purchase-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    background: var(--bg-card);
+    border: 1px solid var(--border-main);
+    border-radius: 12px;
+    padding: 14px 16px;
+    gap: 14px;
+}
+
+.purchase-price {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+}
+
+.purchase-label {
+    font-size: 0.65rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    color: var(--text-muted);
+    letter-spacing: 1px;
+}
+
+.purchase-value {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 1.4rem;
+    font-weight: 700;
+    color: var(--accent-gold);
+    line-height: 1;
+    text-shadow: 0 0 18px rgba(210, 153, 34, 0.3);
+}
+
+.det-buy-btn {
+    background: linear-gradient(135deg, var(--accent-blue), #4a8edb);
+    color: #0d1117;
+    border: none;
+    padding: 12px 28px;
+    border-radius: 10px;
+    font-family: 'Outfit', sans-serif;
+    font-size: 0.95rem;
+    font-weight: 800;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+    cursor: pointer;
+    transition: var(--transition-fast);
+    box-shadow: 0 4px 14px rgba(88, 166, 255, 0.3);
+}
+
+.det-buy-btn:hover:not(:disabled) {
+    transform: translateY(-1px);
+    box-shadow: 0 6px 20px rgba(88, 166, 255, 0.45);
+    background: linear-gradient(135deg, #79c0ff, var(--accent-blue));
+}
+
+.det-buy-btn:disabled {
+    background: var(--bg-card-hover);
+    color: var(--text-muted);
+    box-shadow: none;
+    cursor: not-allowed;
+}
+
+.affordability-hint {
+    margin-top: 10px;
+    font-size: 0.75rem;
+    color: var(--text-muted);
+    text-align: center;
+    min-height: 1em;
+}
+
+.affordability-hint.error {
+    color: var(--accent-red);
+}
+
+.affordability-hint.success {
+    color: var(--accent-green);
+}
+
+/* --- Empty state --- */
+.shop-empty {
+    grid-column: 1 / -1;
+    text-align: center;
+    color: var(--text-muted);
+    padding: 40px 20px;
+    font-size: 0.85rem;
+    border: 1px dashed var(--border-main);
+    border-radius: 12px;
+    background: rgba(255, 255, 255, 0.01);
+}
+
+/* --- Toast --- */
+.shop-toast {
+    position: fixed;
+    bottom: 28px;
+    left: 50%;
+    transform: translateX(-50%) translateY(20px);
+    background: linear-gradient(135deg, var(--bg-card), var(--bg-card-hover));
+    color: var(--text-bright);
+    border: 1px solid var(--accent-green);
+    border-radius: 10px;
+    padding: 12px 22px;
+    font-size: 0.88rem;
+    font-weight: 600;
+    box-shadow: 0 10px 30px rgba(0, 0, 0, 0.5);
+    opacity: 0;
+    transition: opacity 0.25s ease, transform 0.25s ease;
+    pointer-events: none;
+    z-index: 1000;
+    letter-spacing: 0.3px;
+}
+
+.shop-toast.visible {
+    opacity: 1;
+    transform: translateX(-50%) translateY(0);
+}
+
+.shop-toast.error {
+    border-color: var(--accent-red);
+    box-shadow: 0 10px 30px rgba(248, 81, 73, 0.25);
+}
+
+/* --- Close button visibility tweak for shop --- */
+.detail-close-global.hidden {
+    display: none;
+}
+
+/* --- Confirmation modal --- */
+.confirm-modal {
+    position: fixed;
+    inset: 0;
+    z-index: 1500;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    animation: fadeIn 0.18s ease-out;
+}
+
+.confirm-modal.hidden {
+    display: none;
+}
+
+.confirm-backdrop {
+    position: absolute;
+    inset: 0;
+    background: rgba(8, 10, 12, 0.7);
+}
+
+.confirm-card {
+    position: relative;
+    background: linear-gradient(160deg, var(--bg-card), var(--bg-darker));
+    border: 1px solid var(--border-main);
+    border-radius: 18px;
+    padding: 22px 24px 18px;
+    width: 340px;
+    max-width: calc(100vw - 40px);
+    box-shadow: 0 24px 60px rgba(0, 0, 0, 0.6);
+    text-align: center;
+    animation: confirmPop 0.22s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+@keyframes confirmPop {
+    0% { transform: scale(0.92); opacity: 0; }
+    100% { transform: scale(1); opacity: 1; }
+}
+
+.confirm-icon {
+    width: 40px;
+    height: 40px;
+    border-radius: 50%;
+    margin: 0 auto 10px;
+    background:
+        radial-gradient(circle at 30% 30%, rgba(248, 81, 73, 0.35), transparent 60%),
+        var(--bg-darker);
+    border: 1px solid rgba(248, 81, 73, 0.4);
+    color: var(--accent-red);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    box-shadow: 0 0 24px rgba(248, 81, 73, 0.18);
+}
+
+.confirm-title {
+    font-size: 1.1rem;
+    font-weight: 800;
+    color: var(--text-bright);
+    margin-bottom: 10px;
+    letter-spacing: -0.3px;
+}
+
+.confirm-cost {
+    font-family: 'JetBrains Mono', monospace;
+    color: var(--accent-gold);
+    font-weight: 700;
+}
+
+.confirm-summary {
+    display: flex;
+    align-items: baseline;
+    justify-content: center;
+    gap: 8px;
+    margin-bottom: 14px;
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 0.9rem;
+    font-weight: 700;
+}
+
+.confirm-summary-arrow {
+    color: var(--text-muted);
+    font-weight: 400;
+}
+
+.confirm-summary-suffix {
+    font-family: 'Outfit', sans-serif;
+    font-size: 0.75rem;
+    font-weight: 600;
+    color: var(--text-muted);
+    text-transform: uppercase;
+    letter-spacing: 1px;
+}
+
+.confirm-balance-value {
+    color: var(--accent-gold);
+}
+
+.confirm-summary.insufficient .confirm-balance-value {
+    color: var(--accent-red);
+}
+
+.confirm-skip {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    margin: 0 0 14px;
+    font-size: 0.78rem;
+    color: var(--text-muted);
+    cursor: pointer;
+    user-select: none;
+    transition: color 0.15s ease;
+}
+
+.confirm-skip:hover {
+    color: var(--text-bright);
+}
+
+.confirm-skip input[type="checkbox"] {
+    appearance: none;
+    -webkit-appearance: none;
+    width: 14px;
+    height: 14px;
+    margin: 0;
+    border-radius: 4px;
+    border: 1px solid var(--border-main);
+    background: var(--bg-darker);
+    cursor: pointer;
+    position: relative;
+    transition: var(--transition-fast);
+}
+
+.confirm-skip:hover input[type="checkbox"] {
+    border-color: var(--text-muted);
+}
+
+.confirm-skip input[type="checkbox"]:checked {
+    background: var(--accent-red);
+    border-color: var(--accent-red);
+}
+
+.confirm-skip input[type="checkbox"]:checked::after {
+    content: '';
+    position: absolute;
+    left: 3px;
+    top: 0px;
+    width: 4px;
+    height: 8px;
+    border: solid var(--text-bright);
+    border-width: 0 2px 2px 0;
+    transform: rotate(45deg);
+}
+
+.confirm-actions {
+    display: flex;
+    gap: 10px;
+}
+
+.confirm-btn {
+    flex: 1;
+    padding: 10px 16px;
+    border-radius: 10px;
+    font-family: 'Outfit', sans-serif;
+    font-size: 0.88rem;
+    font-weight: 700;
+    letter-spacing: 0.5px;
+    cursor: pointer;
+    transition: var(--transition-fast);
+    border: 1px solid transparent;
+}
+
+.confirm-btn.cancel {
+    background: transparent;
+    color: var(--text-muted);
+    border-color: var(--border-main);
+}
+
+.confirm-btn.cancel:hover {
+    background: var(--bg-card-hover);
+    color: var(--text-bright);
+    border-color: var(--text-muted);
+}
+
+.confirm-btn.primary {
+    background: linear-gradient(135deg, var(--accent-red), #c93b34);
+    color: var(--text-bright);
+    box-shadow: 0 4px 14px rgba(248, 81, 73, 0.3);
+}
+
+.confirm-btn.primary:hover:not(:disabled) {
+    transform: translateY(-1px);
+    box-shadow: 0 6px 18px rgba(248, 81, 73, 0.45);
+}
+
+.confirm-btn.primary:disabled {
+    background: var(--bg-card-hover);
+    color: var(--text-muted);
+    box-shadow: none;
+    cursor: not-allowed;
+}
+
+/* --- Pokémon picker modal (evolution + held items) --- */
+/* Picker reuses the `.pokemon-card` Ankidex visuals — same hover, same
+   sprite scaling. The team-specific bits (level pill, active outline,
+   held-item line) live in `.team-card` overrides below. */
+.picker-modal {
+    position: fixed;
+    inset: 0;
+    z-index: 1500;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    animation: fadeIn 0.18s ease-out;
+}
+
+.picker-modal.hidden {
+    display: none;
+}
+
+.picker-backdrop {
+    position: absolute;
+    inset: 0;
+    background: rgba(8, 10, 12, 0.7);
+}
+
+.picker-card {
+    position: relative;
+    background: linear-gradient(160deg, var(--bg-card), var(--bg-darker));
+    border: 1px solid var(--border-main);
+    border-radius: 18px;
+    width: min(960px, calc(100vw - 60px));
+    height: min(720px, calc(100vh - 60px));
+    box-shadow: 0 24px 60px rgba(0, 0, 0, 0.6);
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+    animation: confirmPop 0.18s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+.picker-header {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 12px;
+    padding: 18px 22px 14px;
+    border-bottom: 1px solid var(--border-main);
+    flex-shrink: 0;
+}
+
+.picker-header-text {
+    flex: 1;
+    min-width: 0;
+}
+
+.picker-title {
+    font-size: 1.1rem;
+    font-weight: 800;
+    color: var(--text-bright);
+    letter-spacing: -0.3px;
+    margin: 0;
+}
+
+.picker-subtitle {
+    margin: 4px 0 0;
+    font-size: 0.78rem;
+    color: var(--text-muted);
+    letter-spacing: 0.4px;
+    text-transform: uppercase;
+    font-weight: 600;
+}
+
+.picker-close {
+    background: transparent;
+    border: 1px solid transparent;
+    color: var(--text-muted);
+    width: 30px;
+    height: 30px;
+    border-radius: 8px;
+    font-size: 1rem;
+    cursor: pointer;
+    transition: var(--transition-fast);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+}
+
+.picker-close:hover {
+    background: var(--bg-card-hover);
+    color: var(--text-bright);
+    border-color: var(--border-main);
+}
+
+.picker-toolbar {
+    padding: 12px 22px 10px;
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    flex-shrink: 0;
+}
+
+.picker-search {
+    flex: 1;
+    box-sizing: border-box;
+    background: var(--bg-darker);
+    border: 1px solid var(--border-main);
+    border-radius: 10px;
+    padding: 9px 14px;
+    color: var(--text-bright);
+    font-family: 'Outfit', sans-serif;
+    font-size: 0.9rem;
+    transition: var(--transition-fast);
+}
+
+.picker-search:focus {
+    outline: none;
+    border-color: var(--accent-blue);
+    box-shadow: 0 0 0 3px rgba(88, 166, 255, 0.15);
+}
+
+.picker-count {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 0.78rem;
+    color: var(--text-muted);
+    padding: 4px 10px;
+    background: var(--bg-darker);
+    border: 1px solid var(--border-main);
+    border-radius: 8px;
+    flex-shrink: 0;
+    min-width: 36px;
+    text-align: center;
+    white-space: nowrap;
+}
+
+.picker-count.truncated {
+    color: var(--accent-blue);
+    border-color: rgba(88, 166, 255, 0.4);
+    background: rgba(88, 166, 255, 0.08);
+}
+
+.picker-more-hint {
+    grid-column: 1 / -1;
+    text-align: center;
+    color: var(--text-muted);
+    font-size: 0.82rem;
+    padding: 18px 12px 8px;
+    border-top: 1px dashed var(--border-main);
+    margin-top: 6px;
+}
+
+.picker-grid {
+    flex: 1;
+    overflow-y: auto;
+    padding: 8px 18px 12px;
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
+    gap: 14px;
+    align-content: start;
+}
+
+.picker-grid::-webkit-scrollbar {
+    width: 10px;
+}
+
+.picker-grid::-webkit-scrollbar-thumb {
+    background: var(--border-main);
+    border-radius: 5px;
+}
+
+.picker-grid::-webkit-scrollbar-thumb:hover {
+    background: var(--text-muted);
+}
+
+/* Team-card variant of pokemon-card — drops the per-card hover lift
+   (modal is finite, we want the grid to feel stable) but keeps the
+   sprite scale + border-glow on hover. Fixed dimensions ensure the
+   grid stays uniform whether sprites have decoded yet or not. */
+.pokemon-card.team-card {
+    /* Lock card dimensions so the grid doesn't reflow as sprites load
+       and missing/404 sprites don't collapse the row. */
+    min-height: 180px;
+    padding: 36px 12px 14px;       /* room for absolute level pill + marks */
+    justify-content: flex-start;
+    cursor: pointer;
+}
+
+.pokemon-card.team-card:hover {
+    transform: none;
+    border-color: var(--accent-blue);
+    background: var(--bg-card-hover);
+    box-shadow: 0 6px 18px rgba(0, 0, 0, 0.35);
+}
+
+.pokemon-card.team-card.is-main {
+    border-color: var(--accent-blue);
+    background: rgba(88, 166, 255, 0.05);
+    box-shadow: inset 0 0 0 1px rgba(88, 166, 255, 0.4);
+}
+
+/* Always reserve the full sprite footprint — `flex-shrink: 0` keeps the
+   container at 96×96 even when img hasn't loaded (no intrinsic size). */
+.pokemon-card.team-card .card-sprite {
+    width: 96px;
+    height: 96px;
+    flex-shrink: 0;
+    margin: 0 0 8px;
+}
+
+.pokemon-card.team-card .card-sprite img {
+    width: 96px;
+    height: 96px;
+    object-fit: contain;
+}
+
+.pokemon-card.team-card .card-info {
+    min-height: 22px;              /* reserve space for the name line */
+}
+.team-card-level {
+    position: absolute;
+    top: 10px;
+    left: 12px;
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 0.72rem;
+    font-weight: 800;
+    color: var(--text-bright);
+    padding: 2px 8px;
+    background: var(--bg-darker);
+    border: 1px solid var(--border-main);
+    border-radius: 6px;
+}
+
+.team-card-cp {
+    position: absolute;
+    top: 36px;
+    left: 12px;
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 0.68rem;
+    font-weight: 700;
+    color: #58a6ff;
+    padding: 1px 6px;
+    background: rgba(88, 166, 255, 0.1);
+    border: 1px solid rgba(88, 166, 255, 0.3);
+    border-radius: 4px;
+}
+
+.pokemon-card.team-card.is-eligible {
+    border-color: rgba(63, 185, 80, 0.4);
+    background: rgba(63, 185, 80, 0.02);
+    box-shadow: 0 0 12px rgba(63, 185, 80, 0.08);
+}
+
+.pokemon-card.team-card.is-eligible:hover {
+    border-color: rgba(63, 185, 80, 0.7);
+    box-shadow: 0 0 20px rgba(63, 185, 80, 0.2);
+}
+
+.team-card-marks {
+    position: absolute;
+    top: 10px;
+    right: 12px;
+    display: flex;
+    gap: 4px;
+    font-size: 0.85rem;
+}
+
+.team-card-marks .mark {
+    line-height: 1;
+}
+
+.team-card-marks .mark-main { color: var(--accent-blue); }
+.team-card-marks .mark-shiny { color: var(--accent-gold); }
+
+.team-card-meta {
+    margin-top: 6px;
+    font-size: 0.7rem;
+    color: var(--text-muted);
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    justify-content: center;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+}
+
+.team-card-meta .meta-held {
+    color: var(--accent-green);
+    font-weight: 700;
+}
+
+.picker-empty {
+    padding: 40px 22px;
+    text-align: center;
+    color: var(--text-muted);
+    font-size: 0.9rem;
+    flex: 1;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.picker-actions {
+    padding: 12px 22px 16px;
+    border-top: 1px solid var(--border-main);
+    display: flex;
+    justify-content: flex-end;
+    flex-shrink: 0;
+}
+
+.picker-actions .confirm-btn {
+    flex: 0 0 auto;
+    min-width: 110px;
+}
+
+/* --- Unified inventory: card-state additions --- */
+.nav-count {
+    margin-left: auto;
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 0.7rem;
+    font-weight: 700;
+    color: var(--text-muted);
+    background: var(--bg-darker);
+    border: 1px solid var(--border-main);
+    border-radius: 4px;
+    padding: 1px 6px;
+    min-width: 22px;
+    text-align: center;
+}
+
+.nav-item.active .nav-count {
+    color: var(--accent-blue);
+    border-color: rgba(88, 166, 255, 0.4);
+    background: rgba(88, 166, 255, 0.08);
+}
+
+.shop-card.owned-only {
+    border-color: rgba(63, 185, 80, 0.35);
+}
+
+.shop-card.in-shop-only {
+    border-color: rgba(248, 81, 73, 0.30);
+}
+
+.shop-card.in-shop-and-owned {
+    border-color: rgba(210, 153, 34, 0.40);
+}
+
+.shop-card-tag.owned-only { color: var(--accent-green); }
+.shop-card-tag.in-shop-only { color: var(--accent-red); }
+.shop-card-tag.in-shop-and-owned { color: var(--accent-gold); }
+.shop-card-tag.tm { color: var(--accent-blue); }
+
+.shop-card-tags-row {
+    display: flex;
+    gap: 4px;
+    flex-wrap: wrap;
+    justify-content: center;
+    margin-top: auto; /* Push down to the bottom area of the uniform height card */
+    margin-bottom: 0;
+    min-height: 18px;
+}
+
+.shop-card-tags-row .mini-type {
+    padding: 2px 8px;
+    border-radius: 4px;
+    font-size: 0.6rem;
+    font-weight: 800;
+    text-transform: uppercase;
+    color: white;
+}
+
+.shop-card-tags-row .cat-pill {
+    padding: 2px 8px;
+    border-radius: 4px;
+    font-size: 0.58rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    background: var(--bg-darker);
+    color: var(--text-muted);
+    border: 1px solid var(--border-main);
+}
+
+/* Detail panel: action buttons row */
+.actions-grid {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+}
+
+.det-action-btn {
+    width: 100%;
+    padding: 12px 18px;
+    border-radius: 10px;
+    font-family: 'Outfit', sans-serif;
+    font-size: 0.9rem;
+    font-weight: 800;
+    text-transform: uppercase;
+    letter-spacing: 0.8px;
+    cursor: pointer;
+    transition: var(--transition-fast);
+    border: none;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 10px;
+}
+
+.det-action-btn .det-action-meta {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 0.75rem;
+    font-weight: 700;
+    opacity: 0.85;
+    letter-spacing: 0;
+    text-transform: none;
+}
+
+.det-action-btn.buy {
+    background: linear-gradient(135deg, var(--accent-gold), #b58319);
+    color: #1a1308;
+    box-shadow: 0 4px 14px rgba(210, 153, 34, 0.28);
+}
+
+.det-action-btn.buy:hover:not(:disabled) {
+    transform: translateY(-1px);
+    box-shadow: 0 6px 20px rgba(210, 153, 34, 0.45);
+    background: linear-gradient(135deg, #f0b536, var(--accent-gold));
+}
+
+.det-action-btn.use {
+    background: linear-gradient(135deg, var(--accent-green), #2c8c3c);
+    color: #0a1f0e;
+    box-shadow: 0 4px 14px rgba(63, 185, 80, 0.28);
+}
+
+.det-action-btn.use:hover:not(:disabled) {
+    transform: translateY(-1px);
+    box-shadow: 0 6px 20px rgba(63, 185, 80, 0.45);
+    background: linear-gradient(135deg, #5ed16f, var(--accent-green));
+}
+
+.det-action-btn:disabled {
+    background: var(--bg-card-hover);
+    color: var(--text-muted);
+    box-shadow: none;
+    cursor: not-allowed;
+}
+
+.shop-empty.hidden { display: none; }
+
+/* --- In-grid section headers (used when both Items and TMs are visible) --- */
+.shop-section-header.inline {
+    grid-column: 1 / -1;
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    margin-top: 6px;
+    margin-bottom: 4px;
+}
+
+.shop-section-header.inline:first-child {
+    margin-top: 0;
+}
+
+/* --- Reroll icon (used in sidebar button and confirmation modal) --- */
+.icon-reroll {
+    width: 16px;
+    height: 16px;
+    flex-shrink: 0;
+    display: block;
+}
+
+.nav-item .icon-reroll {
+    color: var(--accent-red);
+}
+
+.confirm-icon .icon-reroll {
+    width: 18px;
+    height: 18px;
+}
+
+/* --- Equipped Items Styling --- */
+.shop-card.equipped {
+    border-color: rgba(255, 140, 0, 0.45); /* Orange/Amber outline for equipped items */
+    box-shadow: 0 0 10px rgba(255, 140, 0, 0.08);
+}
+
+.shop-card.equipped:hover {
+    border-color: rgba(255, 140, 0, 0.7);
+    box-shadow: 0 0 16px rgba(255, 140, 0, 0.18);
+}
+
+.shop-card-badge.equipped {
+    background: rgba(255, 140, 0, 0.15);
+    color: #ff8c00;
+    border: 1px solid rgba(255, 140, 0, 0.4);
+    font-weight: 800;
+}
+
+.shop-card-tag.equipped {
+    color: #ff8c00;
+}
+
+/* Equipped by list inside the side details panel */
+.equipped-list {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    margin-top: 6px;
+}
+
+.equipped-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 8px 12px;
+    background: var(--bg-darker);
+    border: 1px solid var(--border-main);
+    border-radius: 8px;
+}
+
+.equipped-poke-name {
+    font-family: 'Outfit', sans-serif;
+    font-size: 0.88rem;
+    font-weight: 700;
+    color: var(--text-bright);
+}
+
+.equipped-unequip-btn {
+    background: rgba(248, 81, 73, 0.1);
+    color: var(--accent-red);
+    border: 1px solid rgba(248, 81, 73, 0.3);
+    border-radius: 6px;
+    padding: 4px 10px;
+    font-family: 'Outfit', sans-serif;
+    font-size: 0.75rem;
+    font-weight: 700;
+    cursor: pointer;
+    transition: var(--transition-fast);
+}
+
+.equipped-unequip-btn:hover {
+    background: var(--accent-red);
+    color: white;
+    border-color: var(--accent-red);
+}
+

--- a/src/Ankimon/ankimon_items_web/shop.html
+++ b/src/Ankimon/ankimon_items_web/shop.html
@@ -1,0 +1,284 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Ankimon Items</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <!-- Inline dark bg so the first paint is dark, even before shop.css
+         finishes loading. Prevents the white flash between window-show
+         and full CSS application. Skeleton placeholders pulse dimly so
+         the main content area shows structure during the load window. -->
+    <style>
+        html { background: #0d1117; }
+        .skeleton {
+            background: #161b22;
+            border: 1px solid #30363d;
+            border-radius: 14px;
+            opacity: 0.5;
+            animation: skeleton-pulse 1.5s ease-in-out infinite;
+        }
+        .skeleton-card { height: 220px; }
+        @keyframes skeleton-pulse {
+            0%, 100% { opacity: 0.35; }
+            50%      { opacity: 0.6; }
+        }
+    </style>
+    <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700;800;900&family=JetBrains+Mono:wght@500;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="shop.css?v=20260633">
+    <link rel="stylesheet" href="nav-switcher.css?v=20260633">
+    <script src="qrc:///qtwebchannel/qwebchannel.js"></script>
+</head>
+<body class="dark-mode">
+    <div class="app-container">
+
+        <!-- Sidebar -->
+        <aside class="sidebar">
+            <div class="sidebar-header">
+                <div id="nav-switcher" class="nav-switcher">
+                    <button id="nav-trigger" class="nav-trigger" type="button" aria-haspopup="true" aria-expanded="false">
+                        <img src="../user_files/sprites/items/max-potion.png" class="app-logo icon-item-sprite" alt="">
+                        <h1>ITEMS</h1>
+                        <span class="nav-chevron">▾</span>
+                    </button>
+                    <div id="nav-menu" class="nav-menu hidden" role="menu">
+                        <button class="nav-menu-item active" role="menuitem" data-screen="items">
+                            <span class="nav-menu-icon"><img src="../user_files/sprites/items/max-potion.png" class="icon-item-sprite" alt=""></span>
+                            <div class="nav-menu-text">
+                                <span class="nav-menu-title">Items</span>
+                                <span class="nav-menu-desc">Your inventory and today's Mart</span>
+                            </div>
+                        </button>
+                        <button class="nav-menu-item" role="menuitem" data-screen="ankidex">
+                            <span class="nav-menu-icon"><img src="../user_files/sprites/items/poke-ball.png" alt=""></span>
+                            <div class="nav-menu-text">
+                                <span class="nav-menu-title">Ankidex</span>
+                                <span class="nav-menu-desc">Browse caught Pokémon</span>
+                            </div>
+                        </button>
+                        <button class="nav-menu-item" role="menuitem" data-screen="team">
+                            <span class="nav-menu-icon"><img src="../user_files/sprites/items/great-ball.png" class="icon-item-sprite" alt=""></span>
+                            <div class="nav-menu-text">
+                                <span class="nav-menu-title">Team</span>
+                                <span class="nav-menu-desc">Your active 6 Pokémon</span>
+                            </div>
+                        </button>
+                        <button class="nav-menu-item" role="menuitem" data-screen="profile">
+                            <span class="nav-menu-icon"><img src="../user_files/sprites/items/water-gem.png" class="icon-item-sprite" alt=""></span>
+                            <div class="nav-menu-text">
+                                <span class="nav-menu-title">Profile</span>
+                                <span class="nav-menu-desc">Card, badges &amp; avatar</span>
+                            </div>
+                        </button>
+                        <button class="nav-menu-item" role="menuitem" data-screen="settings">
+                            <span class="nav-menu-icon"><img src="../user_files/sprites/items/x-speed.png" class="icon-item-sprite" alt=""></span>
+                            <div class="nav-menu-text">
+                                <span class="nav-menu-title">Settings</span>
+                                <span class="nav-menu-desc">Configure Ankimon</span>
+                            </div>
+                        </button>
+                        <button class="nav-menu-item" role="menuitem" data-screen="mobile">
+                            <span class="nav-menu-icon"><img src="../user_files/sprites/items/elixir.png" class="icon-item-sprite" alt=""></span>
+                            <div class="nav-menu-text">
+                                <span class="nav-menu-title">Mobile & Web Reviews</span>
+                                <span class="nav-menu-desc">Pending mobile/web battles</span>
+                            </div>
+                        </button>
+                    </div>
+                </div>
+            </div>
+
+            <nav class="sidebar-nav">
+                <div class="nav-group">
+                    <label>View</label>
+                    <button class="nav-item active" data-filter="in_shop">
+                        <span class="nav-icon" style="color: var(--accent-red)">●</span>In Shop Today
+                        <span class="nav-count" id="count-in-shop">0</span>
+                    </button>
+                    <button class="nav-item" data-filter="owned">
+                        <span class="nav-icon" style="color: var(--accent-green)">●</span>In Your Bag
+                        <span class="nav-count" id="count-owned">0</span>
+                    </button>
+                </div>
+
+                <div class="nav-group">
+                    <label>Category</label>
+                    <button class="nav-item active" data-category="all">Any</button>
+                    <button class="nav-item" data-category="tm">TMs</button>
+                    <button class="nav-item" data-category="heal">Heal Items</button>
+                    <button class="nav-item" data-category="pokeball">Poké Balls</button>
+                    <button class="nav-item" data-category="evolution">Evolution</button>
+                    <button class="nav-item" data-category="fossil">Fossils</button>
+                </div>
+
+                <div class="nav-group">
+                    <label>Actions</label>
+                    <button id="reroll-btn" class="nav-item nav-action" title="Reroll today's stock">
+                        <svg class="icon-reroll" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                            <path d="M21 12a9 9 0 1 1-3-6.7"/>
+                            <path d="M21 3v5h-5"/>
+                        </svg>
+                        <span style="flex: 1">Reroll Stock</span>
+                        <span id="reroll-cost-label" class="reroll-cost-pill">100¥</span>
+                    </button>
+                </div>
+            </nav>
+
+            <div class="sidebar-footer">
+                <div class="shop-currency-card">
+                    <div class="currency-label-row">
+                        <span class="shop-currency-label">Wallet</span>
+                        <span class="currency-icon">💰</span>
+                    </div>
+                    <div id="currency-value" class="shop-currency-value">0¥</div>
+                    <div class="currency-sub">Trainer Funds</div>
+                </div>
+            </div>
+        </aside>
+
+        <!-- Main Content -->
+        <main class="main-content">
+            <header class="top-bar">
+                <div class="search-container">
+                    <div class="search-input-wrapper">
+                        <input type="text" id="shop-search" placeholder="Search items, TMs, moves... (Press /)">
+                        <button id="clear-search" class="clear-btn hidden" title="Clear search">×</button>
+                    </div>
+                </div>
+
+                <div class="top-actions">
+                    <div class="shop-stat-chip">
+                        <span class="shop-stat-chip-label">Shop</span>
+                        <span id="stat-shop" class="shop-stat-chip-value">0</span>
+                    </div>
+                    <div class="shop-stat-chip">
+                        <span class="shop-stat-chip-label">Owned</span>
+                        <span id="stat-owned" class="shop-stat-chip-value">0</span>
+                    </div>
+                </div>
+            </header>
+
+            <div class="content-scroll" style="padding: 20px 24px;">
+                <div id="items-grid" class="pokemon-grid shop-grid">
+                    <!-- Skeleton placeholders — cleared by render() on
+                         first push from Python. -->
+                    <div class="skeleton skeleton-card"></div>
+                    <div class="skeleton skeleton-card"></div>
+                    <div class="skeleton skeleton-card"></div>
+                    <div class="skeleton skeleton-card"></div>
+                    <div class="skeleton skeleton-card"></div>
+                    <div class="skeleton skeleton-card"></div>
+                </div>
+                <div id="empty-state" class="shop-empty hidden">No items match your filters.</div>
+            </div>
+        </main>
+
+        <!-- Detail Panel -->
+        <section class="detail-panel" id="detail-panel">
+            <button id="close-detail" class="close-btn detail-close-global hidden" title="Close panel">✕</button>
+
+            <div id="detail-placeholder" class="detail-placeholder">
+                <div class="placeholder-icon"></div>
+                <h3>Item Inspector</h3>
+                <p>Pick a card to see its effect, price, and what you can do with it.</p>
+            </div>
+
+            <div id="detail-content" class="detail-content hidden">
+                <div class="detail-body">
+                    <div class="detail-hero-scroll">
+                        <div id="det-glow" class="detail-glow"></div>
+                        <span id="det-id" class="det-id-badge">ITEM</span>
+                        <h2 id="det-name" class="det-name-main">Item Name</h2>
+
+                        <div class="det-status-row" id="det-status-row"></div>
+
+                        <div class="detail-sprite">
+                            <img id="det-sprite" src="" alt="">
+                        </div>
+                    </div>
+
+                    <div class="det-section">
+                        <div class="det-section-label">Effect</div>
+                        <p id="det-description" class="dex-entry-text"></p>
+                    </div>
+
+                    <div id="det-move-section" class="det-section hidden">
+                        <div class="det-section-label">Move Profile</div>
+                        <div id="det-move-stats" class="stats-grid"></div>
+                    </div>
+
+                    <div id="det-equipped-section" class="det-section hidden">
+                        <div class="det-section-label">Equipped By</div>
+                        <div id="det-equipped-list" class="equipped-list"></div>
+                    </div>
+
+                    <div class="det-section">
+                        <div class="det-section-label">Actions</div>
+                        <div id="det-actions" class="actions-grid"></div>
+                        <div id="det-hint" class="affordability-hint"></div>
+                    </div>
+                </div>
+            </div>
+        </section>
+    </div>
+
+    <div id="toast" class="shop-toast"></div>
+
+    <!-- Confirmation modal -->
+    <div id="confirm-modal" class="confirm-modal hidden" role="dialog" aria-modal="true">
+        <div class="confirm-backdrop"></div>
+        <div class="confirm-card">
+            <div class="confirm-icon">
+                <svg class="icon-reroll" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                    <path d="M21 12a9 9 0 1 1-3-6.7"/>
+                    <path d="M21 3v5h-5"/>
+                </svg>
+            </div>
+            <h3 id="confirm-title" class="confirm-title">Reroll Stock?</h3>
+            <div id="confirm-balance" class="confirm-summary">
+                <span id="confirm-cost" class="confirm-cost">100¥</span>
+                <span class="confirm-summary-arrow">→</span>
+                <span id="confirm-balance-value" class="confirm-balance-value">0¥</span>
+                <span class="confirm-summary-suffix">left</span>
+            </div>
+            <label class="confirm-skip">
+                <input id="confirm-skip" type="checkbox">
+                <span>Don't ask again today</span>
+            </label>
+            <div class="confirm-actions">
+                <button id="confirm-cancel" class="confirm-btn cancel">Cancel</button>
+                <button id="confirm-ok" class="confirm-btn primary">Confirm Reroll</button>
+            </div>
+        </div>
+    </div>
+
+    <!-- Pokémon picker modal (evolution items + held items) — reuses the
+         Ankidex card styling for a richer, faster grid. Choices are
+         pre-loaded with inventory data so opening is synchronous. -->
+    <div id="picker-modal" class="picker-modal hidden" role="dialog" aria-modal="true">
+        <div class="picker-backdrop"></div>
+        <div class="picker-card">
+            <div class="picker-header">
+                <div class="picker-header-text">
+                    <h3 id="picker-title" class="picker-title">Choose a Pokémon</h3>
+                    <p id="picker-subtitle" class="picker-subtitle">Item</p>
+                </div>
+                <button id="picker-close" class="picker-close" type="button" aria-label="Close">✕</button>
+            </div>
+            <div class="picker-toolbar">
+                <input id="picker-search" class="picker-search" type="text" placeholder="Filter by name, level, type…">
+                <span id="picker-count" class="picker-count">0</span>
+            </div>
+            <div id="picker-grid" class="picker-grid"></div>
+            <div id="picker-empty" class="picker-empty hidden">No Pokémon match that search.</div>
+            <div class="picker-actions">
+                <button id="picker-cancel" class="confirm-btn cancel">Cancel</button>
+            </div>
+        </div>
+    </div>
+
+    <script src="nav-switcher.js?v=20260633"></script>
+    <script src="shop.js?v=20260633"></script>
+</body>
+</html>

--- a/src/Ankimon/ankimon_items_web/shop.js
+++ b/src/Ankimon/ankimon_items_web/shop.js
@@ -1,0 +1,1154 @@
+// Ankimon Items — unified Mart + Bag web UI.
+// Talks to Python via QWebChannel (window.bridge) for buy / reroll / use.
+
+(function () {
+    'use strict';
+
+    const TYPE_COLORS = {
+        normal: '#A8A77A', fire: '#EE8130', water: '#6390F0',
+        electric: '#F7D02C', grass: '#7AC74C', ice: '#96D9D6',
+        fighting: '#C22E28', poison: '#A33EA1', ground: '#E2BF65',
+        flying: '#A98FF3', psychic: '#F95587', bug: '#A6B91A',
+        rock: '#B6A136', ghost: '#735797', dragon: '#6F35FC',
+        dark: '#705746', steel: '#B7B7CE', fairy: '#D685AD',
+    };
+
+    const CATEGORY_LABELS = {
+        tm: 'TM',
+        heal: 'Heal',
+        pokeball: 'Ball',
+        evolution: 'Evolution',
+        fossil: 'Fossil',
+        other: '',
+    };
+
+    const state = {
+        data: null,
+        filter: 'in_shop',     // in_shop | owned
+        category: 'all',       // all | tm | heal | pokeball | evolution | fossil
+        search: '',
+        selected: null,        // item name
+        picker: {
+            open: false,
+            item: null,        // item being applied
+            choices: null,     // null = not yet loaded, [] = empty team, [...] = cached
+            choicesContext: null, // Tracks item name or '__base__' to prevent stale stone data
+            loading: false,
+            search: '',
+        },
+    };
+
+    let bridge = null;
+    let nav = null;
+
+    function initChannel(callback) {
+        if (typeof qt === 'undefined' || !qt.webChannelTransport) {
+            console.warn('qt.webChannelTransport unavailable — standalone mode');
+            callback(null);
+            return;
+        }
+        new QWebChannel(qt.webChannelTransport, function (channel) {
+            bridge = channel.objects.bridge;
+            nav = channel.objects && channel.objects.nav;
+            window.bridge = bridge;
+            window.nav = nav;
+            callback(bridge);
+        });
+    }
+
+    function preloadImages(urls, callback) {
+        if (!urls || urls.length === 0) {
+            callback();
+            return;
+        }
+        let loaded = 0;
+        const target = urls.length;
+        urls.forEach((url) => {
+            const img = new Image();
+            img.onload = img.onerror = () => {
+                loaded++;
+                if (loaded === target) {
+                    callback();
+                }
+            };
+            img.src = url;
+        });
+    }
+
+    // Switch the View filter (in_shop | owned) and sync the sidebar buttons.
+    // Used both by the nav clicks and by a Python-forced initial view.
+    function setView(filter) {
+        if (filter !== 'in_shop' && filter !== 'owned') return;
+        state.filter = filter;
+        document.querySelectorAll('.nav-item[data-filter]').forEach((b) => {
+            b.classList.toggle('active', b.dataset.filter === filter);
+        });
+    }
+
+    // Entry from Python
+    window.initializeItems = function (data) {
+        state.data = data;
+        // A menu entry (Mart vs Item Bag) can request a starting view. This
+        // is a one-shot from Python — it's only present on the push that
+        // follows a menu click, so it won't override the user's own filtering.
+        if (data && data.initial_view) {
+            setView(data.initial_view);
+        }
+        const urls = (data.items || []).map((i) => i.image_url).filter(Boolean);
+        preloadImages(urls, function () {
+            render();
+        });
+    };
+
+    // ---------- Rendering ----------
+    function render() {
+        if (!state.data) return;
+        const items = state.data.items || [];
+
+        document.getElementById('currency-value').textContent =
+            formatMoney(state.data.cash) + '¥';
+
+        const rerollBtn = document.getElementById('reroll-btn');
+        const rerollCost = state.data.reroll_cost || 0;
+        document.getElementById('reroll-cost-label').textContent = rerollCost + '¥';
+        rerollBtn.disabled = state.data.cash < rerollCost;
+
+        const counts = countItems(items);
+        document.getElementById('count-in-shop').textContent = counts.in_shop;
+        document.getElementById('count-owned').textContent = counts.owned;
+        document.getElementById('stat-shop').textContent = counts.in_shop;
+        document.getElementById('stat-owned').textContent = counts.owned;
+
+        const visible = items.filter(matchesFilters);
+        const grid = document.getElementById('items-grid');
+        const empty = document.getElementById('empty-state');
+
+        if (visible.length === 0) {
+            grid.replaceChildren();
+            empty.classList.remove('hidden');
+            refreshDetailPanel();
+            return;
+        }
+        empty.classList.add('hidden');
+        // Keyed DOM Reconciliation to completely eliminate visual flicker:
+        // Instead of destroying and rebuilding all card DOM elements (which
+        // destroys <img> instances and triggers asynchronous image-decoding layout passes),
+        // we map existing cards by their item name and update/reorder them in-place.
+        const existingCards = Array.from(grid.querySelectorAll('.shop-card'));
+        const cardMap = new Map();
+        existingCards.forEach(card => {
+            const name = card.getAttribute('data-item-name');
+            if (name) cardMap.set(name, card);
+        });
+
+        const itemEntries = visible.filter((i) => !i.is_tm);
+        const tmEntries = visible.filter((i) => i.is_tm);
+        const splitSections = state.category === 'all'
+            && itemEntries.length > 0
+            && tmEntries.length > 0;
+
+        const targetElements = [];
+
+        if (splitSections) {
+            targetElements.push({type: 'header', kind: 'items', label: 'Items', count: itemEntries.length});
+            itemEntries.forEach((item) => targetElements.push({type: 'card', item}));
+            targetElements.push({type: 'header', kind: 'tms', label: 'TMs', count: tmEntries.length});
+            tmEntries.forEach((item) => targetElements.push({type: 'card', item}));
+        } else {
+            visible.forEach((item) => targetElements.push({type: 'card', item}));
+        }
+
+        const elementsList = targetElements.map(target => {
+            if (target.type === 'card') {
+                const existing = cardMap.get(target.item.name);
+                if (existing) {
+                    updateCard(existing, target.item);
+                    return existing;
+                } else {
+                    return buildCard(target.item);
+                }
+            } else {
+                // Find existing header or create a new one
+                let headerEl = grid.querySelector(`.shop-section-header .shop-section-title.${target.kind}`);
+                if (headerEl) {
+                    headerEl = headerEl.closest('.shop-section-header');
+                    const countEl = headerEl.querySelector('.shop-section-sub');
+                    if (countEl) {
+                        countEl.textContent = target.count + ' ' + (target.count === 1 ? 'entry' : 'entries');
+                    }
+                    return headerEl;
+                } else {
+                    return buildSectionHeader(target.label, target.kind, target.count);
+                }
+            }
+        });
+
+        // Remove obsolete elements
+        const activeSet = new Set(elementsList);
+        Array.from(grid.childNodes).forEach(node => {
+            if (!activeSet.has(node)) {
+                node.remove();
+            }
+        });
+
+        // Order elements in the grid in-place
+        elementsList.forEach((el, index) => {
+            if (grid.childNodes[index] !== el) {
+                grid.insertBefore(el, grid.childNodes[index] || null);
+            }
+        });
+
+        refreshDetailPanel();
+    }
+
+    function buildSectionHeader(label, kind, count) {
+        const header = document.createElement('div');
+        header.className = 'shop-section-header inline';
+        header.innerHTML =
+            '<span class="shop-section-title ' + kind + '">' + label + '</span>' +
+            '<span class="shop-section-sub">' + count + ' ' +
+                (count === 1 ? 'entry' : 'entries') + '</span>';
+        return header;
+    }
+
+    function countItems(items) {
+        const counts = {all: items.length, in_shop: 0, owned: 0};
+        items.forEach((i) => {
+            if (i.in_shop) counts.in_shop++;
+            if ((i.owned_quantity || 0) > 0 || (i.equipped_instances && i.equipped_instances.length > 0)) counts.owned++;
+        });
+        return counts;
+    }
+
+    function matchesFilters(item) {
+        if (state.filter === 'in_shop' && !item.in_shop) return false;
+        if (state.filter === 'owned' && (item.owned_quantity || 0) <= 0 && (!item.equipped_instances || item.equipped_instances.length === 0)) return false;
+        if (state.category !== 'all' && item.category !== state.category) return false;
+        if (state.search) {
+            const q = state.search.toLowerCase();
+            const hay = [
+                item.ui_name, item.name, item.move_type, item.category
+            ].filter(Boolean).join(' ').toLowerCase();
+            if (!hay.includes(q)) return false;
+        }
+        return true;
+    }
+
+    function cardStateClass(item) {
+        const inShop = item.in_shop;
+        const owned = (item.owned_quantity || 0) > 0 || (item.equipped_instances && item.equipped_instances.length > 0);
+        if (inShop && owned) return 'in-shop-and-owned';
+        if (inShop) return 'in-shop-only';
+        if (owned) return 'owned-only';
+        return '';
+    }
+
+    // Returns {label, cls} or null. Tag is suppressed when the filter context
+    // already communicates everything (e.g. "OWNED" tag in the Bag filter).
+    function cardTagFor(item) {
+        if (item.is_tm) return {label: 'TM', cls: 'tm'};
+
+        const owned = (item.owned_quantity || 0) > 0;
+        const inShop = !!item.in_shop;
+
+        if (inShop) {
+            return {
+                label: 'STOCK',
+                cls: owned ? 'in-shop-and-owned' : 'in-shop-only'
+            };
+        }
+        return null;
+    }
+
+    function updateCard(card, item) {
+        // Reset and update class list
+        card.className = 'shop-card pokemon-card-equivalent';
+        const stateCls = cardStateClass(item);
+        if (stateCls) card.classList.add(stateCls);
+        if (item.is_tm && (item.owned_quantity || 0) > 0) card.classList.add('owned');
+        if (item.in_shop && state.data.cash < (item.price || 0) &&
+            (!item.is_tm || (item.owned_quantity || 0) === 0)) {
+            card.classList.add('unaffordable');
+        }
+        if (item.equipped_instances && item.equipped_instances.length > 0) card.classList.add('equipped');
+        if (state.selected === item.name) card.classList.add('selected');
+
+        // Update tag
+        let tag = card.querySelector('.shop-card-tag');
+        const tagText = cardTagFor(item);
+        if (tagText) {
+            if (!tag) {
+                tag = document.createElement('div');
+                card.insertBefore(tag, card.firstChild);
+            }
+            tag.className = 'shop-card-tag ' + tagText.cls;
+            tag.textContent = tagText.label;
+        } else if (tag) {
+            tag.remove();
+        }
+
+        // Update badges
+        let badges = card.querySelector('.shop-card-badges');
+        if (!badges) {
+            badges = document.createElement('div');
+            badges.className = 'shop-card-badges';
+            const refNode = card.querySelector('.shop-card-tag') ? card.querySelector('.shop-card-tag').nextSibling : card.firstChild;
+            card.insertBefore(badges, refNode);
+        }
+        badges.innerHTML = '';
+        if ((item.owned_quantity || 0) > 0) {
+            if (item.is_tm) {
+                if (state.filter !== 'owned') {
+                    const badge = document.createElement('span');
+                    badge.className = 'shop-card-badge owned';
+                    badge.textContent = 'OWNED';
+                    badges.appendChild(badge);
+                }
+            } else {
+                const badge = document.createElement('span');
+                badge.className = 'shop-card-badge qty';
+                badge.textContent = 'x' + item.owned_quantity;
+                badges.appendChild(badge);
+            }
+        }
+        if (item.equipped_instances && item.equipped_instances.length > 0) {
+            const badge = document.createElement('span');
+            badge.className = 'shop-card-badge equipped';
+            badge.textContent = 'E x' + item.equipped_instances.length;
+            badges.appendChild(badge);
+        }
+
+        // Update sprite src if different (preserves img DOM instance to avoid flickering)
+        const img = card.querySelector('.shop-card-sprite img');
+        if (img && img.getAttribute('src') !== (item.image_url || '')) {
+            img.style.opacity = '1';
+            img.onerror = () => {
+                img.onerror = () => { img.style.opacity = '0.25'; };
+                img.src = '../user_files/sprites/front_default/0.png';
+                img.style.opacity = '0.25';
+            };
+            img.src = item.image_url || '';
+        }
+
+        // Update name
+        const nameEl = card.querySelector('.shop-card-name');
+        if (nameEl) {
+            nameEl.textContent = item.ui_name || item.name;
+        }
+
+        // Update price pill
+        let priceEl = card.querySelector('.shop-card-price-pill');
+        if (item.in_shop) {
+            if (!priceEl) {
+                priceEl = document.createElement('div');
+                priceEl.className = 'shop-card-price-pill';
+                card.appendChild(priceEl);
+            }
+            priceEl.textContent = formatMoney(item.price || 0) + '¥';
+        } else if (priceEl) {
+            priceEl.remove();
+        }
+    }
+
+    function buildCard(item) {
+        const card = document.createElement('div');
+        card.className = 'shop-card pokemon-card-equivalent';
+        card.setAttribute('data-item-name', item.name);
+        const stateCls = cardStateClass(item);
+        if (stateCls) card.classList.add(stateCls);
+        if (item.is_tm && (item.owned_quantity || 0) > 0) card.classList.add('owned');
+        if (item.in_shop && state.data.cash < (item.price || 0) &&
+            (!item.is_tm || (item.owned_quantity || 0) === 0)) {
+            card.classList.add('unaffordable');
+        }
+        if (item.equipped_instances && item.equipped_instances.length > 0) card.classList.add('equipped');
+        if (state.selected === item.name) card.classList.add('selected');
+
+        // Top-left tag — only show information the filter doesn't already imply.
+        const tag = document.createElement('div');
+        const tagText = cardTagFor(item);
+        if (tagText) {
+            tag.className = 'shop-card-tag ' + tagText.cls;
+            tag.textContent = tagText.label;
+            card.appendChild(tag);
+        }
+
+        // Top-right badges. TMs are binary (owned or not), so we surface a
+        // word "OWNED" instead of a redundant "x1" quantity — and suppress
+        // it entirely in the Bag view where every visible card is owned.
+        const badges = document.createElement('div');
+        badges.className = 'shop-card-badges';
+        if ((item.owned_quantity || 0) > 0) {
+            if (item.is_tm) {
+                if (state.filter !== 'owned') {
+                    const badge = document.createElement('span');
+                    badge.className = 'shop-card-badge owned';
+                    badge.textContent = 'OWNED';
+                    badges.appendChild(badge);
+                }
+            } else {
+                const badge = document.createElement('span');
+                badge.className = 'shop-card-badge qty';
+                badge.textContent = 'x' + item.owned_quantity;
+                badges.appendChild(badge);
+            }
+        }
+        if (item.equipped_instances && item.equipped_instances.length > 0) {
+            const badge = document.createElement('span');
+            badge.className = 'shop-card-badge equipped';
+            badge.textContent = 'E x' + item.equipped_instances.length;
+            badges.appendChild(badge);
+        }
+        card.appendChild(badges);
+
+        // Sprite
+        const spriteWrap = document.createElement('div');
+        spriteWrap.className = 'shop-card-sprite';
+        const img = document.createElement('img');
+        img.decoding = 'sync';
+        img.src = item.image_url || '';
+        img.alt = item.ui_name || item.name;
+        img.onerror = () => {
+            img.onerror = () => { img.style.opacity = '0.25'; };
+            img.src = '../user_files/sprites/front_default/0.png';
+            img.style.opacity = '0.25';
+        };
+        spriteWrap.appendChild(img);
+        card.appendChild(spriteWrap);
+
+        // Name
+        const name = document.createElement('div');
+        name.className = 'shop-card-name';
+        name.textContent = item.ui_name || item.name;
+        card.appendChild(name);
+
+        // Tags row: TM type + category
+        const tagsRow = document.createElement('div');
+        tagsRow.className = 'shop-card-tags-row';
+        if (item.is_tm && item.move_type) {
+            const t = document.createElement('span');
+            t.className = 'mini-type';
+            t.textContent = item.move_type;
+            t.style.background = TYPE_COLORS[item.move_type.toLowerCase()] || 'var(--border-main)';
+            tagsRow.appendChild(t);
+        } else if (CATEGORY_LABELS[item.category]) {
+            const c = document.createElement('span');
+            c.className = 'cat-pill';
+            c.textContent = CATEGORY_LABELS[item.category];
+            tagsRow.appendChild(c);
+        }
+        card.appendChild(tagsRow);
+
+        // Price pill (only if in_shop)
+        if (item.in_shop) {
+            const price = document.createElement('div');
+            price.className = 'shop-card-price-pill';
+            price.textContent = formatMoney(item.price || 0) + '¥';
+            card.appendChild(price);
+        }
+
+        card.addEventListener('click', () => selectItem(item.name));
+        return card;
+    }
+
+    function formatMoney(n) {
+        return (n || 0).toLocaleString();
+    }
+
+    // ---------- Detail panel ----------
+    function selectItem(name) {
+        state.selected = name;
+        render();
+    }
+
+    function refreshDetailPanel() {
+        const placeholder = document.getElementById('detail-placeholder');
+        const content = document.getElementById('detail-content');
+        const closeBtn = document.getElementById('close-detail');
+
+        if (!state.selected) {
+            placeholder.classList.remove('hidden');
+            content.classList.add('hidden');
+            closeBtn.classList.add('hidden');
+            return;
+        }
+
+        const item = (state.data.items || []).find((i) => i.name === state.selected);
+        if (!item) {
+            state.selected = null;
+            placeholder.classList.remove('hidden');
+            content.classList.add('hidden');
+            closeBtn.classList.add('hidden');
+            return;
+        }
+
+        placeholder.classList.add('hidden');
+        content.classList.remove('hidden');
+        closeBtn.classList.remove('hidden');
+        renderDetail(item);
+    }
+
+    function renderDetail(item) {
+        document.getElementById('det-id').textContent =
+            item.is_tm ? 'TM' : (CATEGORY_LABELS[item.category] || 'ITEM').toUpperCase();
+        document.getElementById('det-name').textContent = item.ui_name || item.name;
+
+        const statusRow = document.getElementById('det-status-row');
+        statusRow.innerHTML = '';
+
+        if (item.in_shop) {
+            const p = document.createElement('span');
+            p.className = 'det-pill price';
+            p.textContent = formatMoney(item.price || 0) + '¥';
+            statusRow.appendChild(p);
+        }
+        if ((item.owned_quantity || 0) > 0) {
+            const o = document.createElement('span');
+            o.className = 'det-pill owned';
+            o.textContent = item.is_tm ? 'Owned' : 'Owned x' + item.owned_quantity;
+            statusRow.appendChild(o);
+        }
+        if (item.is_tm && item.move_type) {
+            const t = document.createElement('span');
+            t.className = 'det-pill move-type';
+            t.textContent = item.move_type;
+            t.style.background = TYPE_COLORS[item.move_type.toLowerCase()] || 'var(--border-main)';
+            statusRow.appendChild(t);
+        }
+
+        const sprite = document.getElementById('det-sprite');
+        sprite.style.opacity = '1';
+        sprite.src = item.image_url || '';
+        sprite.alt = item.ui_name || item.name;
+        sprite.onerror = () => {
+            sprite.onerror = null;
+            sprite.src = '../user_files/sprites/front_default/0.png';
+            sprite.style.opacity = '0.25';
+        };
+
+        const glow = document.getElementById('det-glow');
+        const glowColor = item.is_tm && item.move_type
+            ? (TYPE_COLORS[item.move_type.toLowerCase()] || '#58a6ff')
+            : (item.in_shop ? '#d29922' : '#3fb950');
+        glow.style.background = `radial-gradient(circle, ${glowColor}55, transparent 70%)`;
+
+        document.getElementById('det-description').textContent =
+            item.description || 'No description available.';
+
+        // Move stats (TMs)
+        const moveSection = document.getElementById('det-move-section');
+        const moveStats = document.getElementById('det-move-stats');
+        moveStats.innerHTML = '';
+        if (item.is_tm && (item.move_power || item.move_accuracy || item.move_pp)) {
+            moveSection.classList.remove('hidden');
+            const rows = [
+                {label: 'Power', value: item.move_power, max: 250},
+                {label: 'Accuracy', value: item.move_accuracy, max: 100},
+                {label: 'PP', value: item.move_pp, max: 40},
+            ];
+            if (item.move_damage_class) {
+                rows.push({label: 'Category', value: item.move_damage_class, max: null});
+            }
+            rows.forEach((row) => {
+                if (row.value === null || row.value === undefined || row.value === '') return;
+                moveStats.appendChild(buildStatRow(row));
+            });
+            setTimeout(() => {
+                moveStats.querySelectorAll('.stat-bar-fill').forEach((el) => {
+                    el.style.width = el.dataset.targetWidth || '0%';
+                });
+            }, 50);
+        } else {
+            moveSection.classList.add('hidden');
+        }
+
+        // Equipped section
+        const equippedSection = document.getElementById('det-equipped-section');
+        const equippedList = document.getElementById('det-equipped-list');
+        equippedList.innerHTML = '';
+        if (item.equipped_instances && item.equipped_instances.length > 0) {
+            equippedSection.classList.remove('hidden');
+            item.equipped_instances.forEach((inst) => {
+                const row = document.createElement('div');
+                row.className = 'equipped-row';
+                
+                const name = document.createElement('span');
+                name.className = 'equipped-poke-name';
+                name.textContent = inst.name;
+                
+                const btn = document.createElement('button');
+                btn.className = 'equipped-unequip-btn';
+                btn.textContent = 'Unequip';
+                btn.onclick = () => onUnequip(inst.individual_id, item.name);
+                
+                row.appendChild(name);
+                row.appendChild(btn);
+                equippedList.appendChild(row);
+            });
+        } else {
+            equippedSection.classList.add('hidden');
+        }
+
+        // Actions
+        const actions = document.getElementById('det-actions');
+        actions.innerHTML = '';
+        const hint = document.getElementById('det-hint');
+        hint.textContent = '';
+        hint.className = 'affordability-hint';
+
+        const ownedQty = item.owned_quantity || 0;
+        const blockedTm = item.is_tm && ownedQty > 0;
+        const unaffordable = state.data.cash < (item.price || 0);
+
+        if (item.in_shop) {
+            const buy = document.createElement('button');
+            buy.className = 'det-action-btn buy';
+            if (blockedTm) {
+                buy.disabled = true;
+                buy.innerHTML = '<span>Already Owned</span>';
+            } else if (unaffordable) {
+                buy.disabled = true;
+                buy.innerHTML = '<span>Buy</span><span class="det-action-meta">Not Enough ¥</span>';
+            } else {
+                buy.innerHTML = '<span>Buy</span><span class="det-action-meta">' + formatMoney(item.price || 0) + '¥</span>';
+                buy.onclick = () => onBuy(item);
+            }
+            actions.appendChild(buy);
+        }
+
+        if (ownedQty > 0 && !item.is_tm) {
+            const use = document.createElement('button');
+            use.className = 'det-action-btn use';
+            const label = useLabelFor(item);
+            use.innerHTML = '<span>' + label + '</span><span class="det-action-meta">x' + ownedQty + '</span>';
+            use.onclick = () => onUse(item);
+            actions.appendChild(use);
+        }
+
+        if (actions.childElementCount === 0) {
+            hint.textContent = 'Nothing to do for this item right now.';
+        } else if (item.in_shop && unaffordable && !blockedTm) {
+            const shortBy = (item.price || 0) - state.data.cash;
+            hint.textContent = `Need ${formatMoney(shortBy)}¥ more to buy.`;
+            hint.classList.add('error');
+        } else if (item.in_shop && !blockedTm) {
+            const after = state.data.cash - (item.price || 0);
+            hint.textContent = `Balance after buy: ${formatMoney(after)}¥`;
+        }
+    }
+
+    function useLabelFor(item) {
+        switch (item.category) {
+            case 'heal': return 'Use on Active Pokémon';
+            case 'fossil': return 'Revive Fossil';
+            case 'pokeball': return 'Throw at Wild Pokémon';
+            case 'evolution': return 'Evolve a Pokémon';
+            default: return 'Give to a Pokémon';
+        }
+    }
+
+    function buildStatRow({label, value, max}) {
+        const row = document.createElement('div');
+        row.className = 'stat-item';
+        const labelEl = document.createElement('div');
+        labelEl.className = 'stat-label';
+        const lbl = document.createElement('span');
+        lbl.textContent = label;
+        const val = document.createElement('span');
+        val.className = 'stat-val';
+        val.textContent = value;
+        labelEl.appendChild(lbl);
+        labelEl.appendChild(val);
+        row.appendChild(labelEl);
+
+        if (max !== null) {
+            const bg = document.createElement('div');
+            bg.className = 'stat-bar-bg';
+            const fill = document.createElement('div');
+            fill.className = 'stat-bar-fill';
+            const numVal = typeof value === 'number' ? value : 0;
+            const pct = Math.max(0, Math.min(100, (numVal / max) * 100));
+            fill.dataset.targetWidth = pct + '%';
+            bg.appendChild(fill);
+            row.appendChild(bg);
+        }
+        return row;
+    }
+
+    function onUnequip(individualId, itemName) {
+        if (!bridge || !bridge.unequipItem) return;
+        bridge.unequipItem(individualId, itemName, function (result) {
+            if (!result) return;
+            showToast(result.message || (result.ok ? 'Unequipped!' : 'Unequip failed.'), !result.ok);
+            state.picker.choicesContext = null;
+        });
+    }
+
+    // ---------- Actions ----------
+    function onBuy(item) {
+        if (!bridge) return;
+        bridge.buy(item.name, !!item.is_tm, function (result) {
+            if (!result) return;
+            showToast(result.message || (result.ok ? 'Purchased!' : 'Purchase failed.'), !result.ok);
+        });
+    }
+
+    function onUse(item) {
+        if (!bridge) return;
+        // Evolution items and held items need a Pokémon target — open the
+        // in-shell picker instead of calling useItem (which would trigger
+        // the legacy QInputDialog in Python).
+        if (item.category === 'evolution' || item.category === 'other') {
+            openPicker(item);
+            return;
+        }
+        bridge.useItem(item.name, function (result) {
+            if (!result) return;
+            if (result.message) showToast(result.message, !result.ok);
+        });
+    }
+
+    function onReroll() {
+        if (!bridge) return;
+        bridge.reroll(function (result) {
+            if (!result) return;
+            showToast(result.message || (result.ok ? 'Stock rerolled!' : 'Reroll failed.'), !result.ok);
+        });
+    }
+
+    function showToast(message, isError) {
+        if (!message) return;
+        const toast = document.getElementById('toast');
+        toast.textContent = message;
+        toast.classList.toggle('error', !!isError);
+        toast.classList.add('visible');
+        clearTimeout(toast._timer);
+        toast._timer = setTimeout(() => toast.classList.remove('visible'), 2400);
+    }
+
+    // ---------- UI plumbing ----------
+    function bindUI() {
+        document.querySelectorAll('.nav-item[data-filter]').forEach((btn) => {
+            btn.addEventListener('click', () => {
+                setView(btn.dataset.filter);
+                render();
+            });
+        });
+
+        document.querySelectorAll('.nav-item[data-category]').forEach((btn) => {
+            btn.addEventListener('click', () => {
+                document.querySelectorAll('.nav-item[data-category]').forEach((b) =>
+                    b.classList.remove('active'));
+                btn.classList.add('active');
+                state.category = btn.dataset.category;
+                render();
+            });
+        });
+
+        const searchInput = document.getElementById('shop-search');
+        const clearBtn = document.getElementById('clear-search');
+        searchInput.addEventListener('input', (e) => {
+            state.search = e.target.value.trim();
+            clearBtn.classList.toggle('hidden', !state.search);
+            render();
+        });
+        clearBtn.addEventListener('click', () => {
+            searchInput.value = '';
+            state.search = '';
+            clearBtn.classList.add('hidden');
+            render();
+        });
+
+        document.getElementById('reroll-btn').addEventListener('click', openRerollConfirm);
+        document.getElementById('confirm-cancel').addEventListener('click', closeConfirm);
+        document.getElementById('confirm-modal').addEventListener('click', (e) => {
+            if (e.target.classList.contains('confirm-backdrop')) closeConfirm();
+        });
+        document.getElementById('confirm-ok').addEventListener('click', () => {
+            const skip = document.getElementById('confirm-skip');
+            if (skip && skip.checked && bridge && bridge.setSkipRerollConfirm) {
+                bridge.setSkipRerollConfirm(true, function () {});
+                // Optimistic — push_screen_data() will overwrite, but this
+                // keeps the flag set if the next click happens to land before
+                // the round-trip completes.
+                if (state.data) state.data.skip_reroll_confirm = true;
+            }
+            closeConfirm();
+            onReroll();
+        });
+
+        document.getElementById('close-detail').addEventListener('click', () => {
+            state.selected = null;
+            render();
+        });
+
+        document.addEventListener('keydown', (e) => {
+            if (e.key === 'Escape') {
+                const picker = document.getElementById('picker-modal');
+                const modal = document.getElementById('confirm-modal');
+                if (!picker.classList.contains('hidden')) {
+                    closePicker();
+                } else if (!modal.classList.contains('hidden')) {
+                    closeConfirm();
+                } else if (state.selected) {
+                    state.selected = null;
+                    render();
+                }
+            } else if (e.key === '/' && document.activeElement !== searchInput) {
+                // Don't grab '/' while typing in the picker search box.
+                const pickerSearch = document.getElementById('picker-search');
+                if (document.activeElement === pickerSearch) return;
+                e.preventDefault();
+                searchInput.focus();
+            } else if (e.key === 'Enter') {
+                const modal = document.getElementById('confirm-modal');
+                if (!modal.classList.contains('hidden')) {
+                    const ok = document.getElementById('confirm-ok');
+                    if (!ok.disabled) ok.click();
+                }
+            }
+        });
+    }
+
+    function openRerollConfirm() {
+        if (!state.data) return;
+        const cost = state.data.reroll_cost || 0;
+        const after = (state.data.cash || 0) - cost;
+        const insufficient = after < 0;
+
+        // "Don't ask again today" — skip the modal entirely when affordable.
+        // The insufficient case still falls through so the user sees the
+        // "Not Enough ¥" disabled-button feedback.
+        if (state.data.skip_reroll_confirm && !insufficient) {
+            onReroll();
+            return;
+        }
+
+        document.getElementById('confirm-cost').textContent = formatMoney(cost) + '¥';
+        const balance = document.getElementById('confirm-balance');
+        document.getElementById('confirm-balance-value').textContent = formatMoney(after) + '¥';
+        balance.classList.toggle('insufficient', insufficient);
+
+        const okBtn = document.getElementById('confirm-ok');
+        okBtn.disabled = insufficient;
+        okBtn.textContent = insufficient ? 'Not Enough ¥' : 'Confirm Reroll';
+
+        const skipCheckbox = document.getElementById('confirm-skip');
+        if (skipCheckbox) skipCheckbox.checked = false;
+
+        document.getElementById('confirm-modal').classList.remove('hidden');
+    }
+
+    function closeConfirm() {
+        document.getElementById('confirm-modal').classList.add('hidden');
+    }
+
+    // ---------- Pokémon picker (evolution items + held items) ----------
+    // Choices are lazy-fetched on first open (avoids shipping multi-MB
+    // payloads with every inventory push) and cached in state.picker.choices
+    // for the lifetime of the items window. Invalidated after team-mutating
+    // actions (useItemOnPokemon) so the next open reflects the change.
+    function openPicker(item) {
+        const isEvo = item.category === 'evolution';
+        const targetContext = isEvo ? item.name : '__base__';
+        
+        // If the current cache doesn't match the required context (specific stone
+        // or base list), we must fetch fresh data.
+        if (state.picker.choicesContext !== targetContext) {
+            state.picker.choices = null;
+        }
+        
+        state.picker.item = item;
+        state.picker.search = '';
+        state.picker.open = true;
+
+        document.getElementById('picker-title').textContent =
+            item.category === 'evolution' ? 'Evolve which Pokémon?' : 'Give to which Pokémon?';
+        document.getElementById('picker-subtitle').textContent =
+            (item.ui_name || item.name || '').toUpperCase();
+
+        const searchEl = document.getElementById('picker-search');
+        searchEl.value = '';
+
+        if (state.picker.choices === null) {
+            renderPickerLoading();
+            document.getElementById('picker-modal').classList.remove('hidden');
+            loadPickerChoices(item.name, targetContext, () => {
+                // Don't render if user closed the modal during fetch.
+                if (state.picker.open) renderPickerGrid();
+            });
+        } else {
+            // Render grid *before* showing the modal to avoid flicker
+            renderPickerGrid();
+            document.getElementById('picker-modal').classList.remove('hidden');
+        }
+        
+        // Auto-focus the search box so the user can type to filter.
+        setTimeout(() => searchEl.focus(), 0);
+    }
+
+    function loadPickerChoices(itemName, context, done) {
+        if (state.picker.loading || !bridge || !bridge.getPokemonChoices) {
+            if (done) done();
+            return;
+        }
+        state.picker.loading = true;
+        bridge.getPokemonChoices(itemName || '', function (result) {
+            state.picker.loading = false;
+            state.picker.choices = (result && result.choices) || [];
+            state.picker.choicesContext = context;
+            if (done) done();
+        });
+    }
+
+    function renderPickerLoading() {
+        const grid = document.getElementById('picker-grid');
+        const empty = document.getElementById('picker-empty');
+        const countEl = document.getElementById('picker-count');
+        empty.textContent = 'Loading your team…';
+        empty.classList.remove('hidden');
+        grid.replaceChildren();
+        grid.style.display = 'none';
+        countEl.textContent = '…';
+        countEl.classList.remove('truncated');
+    }
+
+    function closePicker() {
+        state.picker.open = false;
+        state.picker.item = null;
+        state.picker.search = '';
+        document.getElementById('picker-modal').classList.add('hidden');
+    }
+
+    // Hard cap on rendered cards — long-time players can have 10k+
+    // captured Pokémon, and rendering all of them blows out the DOM, the
+    // lazy-image queue, and any hope of a smooth open. Past the cap we
+    // require search to drill down (which is the natural UX for "pick
+    // one of many" anyway).
+    const PICKER_RENDER_CAP = 60;
+
+    function renderPickerGrid() {
+        const grid = document.getElementById('picker-grid');
+        const empty = document.getElementById('picker-empty');
+        const countEl = document.getElementById('picker-count');
+        let choices = state.picker.choices || [];
+
+        if (state.picker.choices === null) {
+            renderPickerLoading();
+            return;
+        }
+
+        // Only show eligible Pokémon for evolution items.
+        if (state.picker.item && state.picker.item.category === 'evolution') {
+            choices = choices.filter((c) => c.e === 1);
+        }
+
+        const q = state.picker.search.trim().toLowerCase();
+        // Compact field names from Python — see get_pokemon_choices:
+        //   id=individual_id, p=pokedex_id, n=name, l=level,
+        //   s=shiny, m=is_main, h=held_item, nk=nickname (if differs)
+        const matched = q
+            ? choices.filter((c) => {
+                const hay = [c.nk, c.n, c.h, String(c.l || ''), String(c.p || '')]
+                    .filter(Boolean).join(' ').toLowerCase();
+                return hay.includes(q);
+            })
+            : choices;
+
+        const visible = matched.slice(0, PICKER_RENDER_CAP);
+
+        // Count chip — show "60 / 16,626" when we capped, plain count otherwise.
+        if (matched.length > visible.length) {
+            countEl.textContent = `${visible.length} / ${matched.length.toLocaleString()}`;
+            countEl.title = `Showing ${visible.length} of ${matched.length} — type to narrow down`;
+            countEl.classList.add('truncated');
+        } else {
+            countEl.textContent = String(matched.length);
+            countEl.title = '';
+            countEl.classList.remove('truncated');
+        }
+
+        if (matched.length === 0) {
+            grid.replaceChildren();
+            empty.textContent = state.picker.choices.length === 0
+                ? "You don't have any Pokémon yet."
+                : 'No Pokémon match that search.';
+            empty.classList.remove('hidden');
+            grid.style.display = 'none';
+            return;
+        }
+        empty.classList.add('hidden');
+        grid.style.display = '';
+
+        const frag = document.createDocumentFragment();
+        visible.forEach((choice) => frag.appendChild(buildPickerCard(choice)));
+
+        // Footer row when truncated — gives the user an obvious "more
+        // exist, refine to see them" cue instead of leaving them guessing.
+        if (matched.length > visible.length) {
+            const more = document.createElement('div');
+            more.className = 'picker-more-hint';
+            more.textContent =
+                `+ ${(matched.length - visible.length).toLocaleString()} more — type a name or level to find a specific Pokémon`;
+            frag.appendChild(more);
+        }
+
+        grid.replaceChildren(frag);
+        grid.scrollTop = 0;
+    }
+
+    function buildPickerCard(choice) {
+        // Compact fields from Python: id, p, b (base_id), n, l, cp, s, m, h, nk.
+        // Match the Ankidex `.pokemon-card` shape so it picks up the same
+        // hover/sprite/border treatment automatically. Team-specific bits
+        // (level, CP, active/shiny marks, held item) layer on top.
+        const isMain = !!choice.m;
+        const isShiny = !!choice.s;
+        const isEligible = !!choice.e;
+        const heldItem = choice.h || '';
+        const nickname = choice.nk || '';
+        const name = choice.n || '';
+        const displayName = nickname || name || 'Unknown';
+
+        const card = document.createElement('div');
+        card.className = 'pokemon-card team-card state-caught';
+        if (isMain) card.classList.add('is-main');
+        if (isEligible) card.classList.add('is-eligible');
+
+        if (choice.l !== null && choice.l !== undefined) {
+            const lvl = document.createElement('div');
+            lvl.className = 'team-card-level';
+            lvl.textContent = 'Lv ' + choice.l;
+            card.appendChild(lvl);
+        }
+
+        if (choice.cp !== null && choice.cp !== undefined) {
+            const cp = document.createElement('div');
+            cp.className = 'team-card-cp';
+            cp.textContent = 'CP ' + choice.cp.toLocaleString();
+            card.appendChild(cp);
+        }
+
+        if (isMain || isShiny) {
+            const marks = document.createElement('div');
+            marks.className = 'team-card-marks';
+            if (isMain) {
+                const m = document.createElement('span');
+                m.className = 'mark mark-main';
+                m.textContent = '★';
+                m.title = 'Active Pokémon';
+                marks.appendChild(m);
+            }
+            if (isShiny) {
+                const s = document.createElement('span');
+                s.className = 'mark mark-shiny';
+                s.textContent = '✦';
+                s.title = 'Shiny';
+                marks.appendChild(s);
+            }
+            card.appendChild(marks);
+        }
+
+        const spriteWrap = document.createElement('div');
+        spriteWrap.className = 'card-sprite';
+        const img = document.createElement('img');
+        // Explicit width/height attrs lock layout space before the
+        // sprite request fires — without them, the img collapses to 0
+        // and the card's column-flex shrinks to just the level pill.
+        img.width = 96;
+        img.height = 96;
+        // Reconstruct sprite path on the JS side — avoids shipping a
+        // ~100-byte URL per Pokémon in the inventory payload.
+        img.src = `../user_files/sprites/front_default/${choice.p || 0}.png`;
+        img.alt = displayName;
+        img.onerror = () => {
+            // Stage 1 Fallback: Try the base species ID (choice.b) if different from choice.p.
+            // This handles regional/mega forms that don't have their own sprites.
+            if (choice.b && choice.b !== choice.p) {
+                const baseId = choice.b;
+                choice.b = null; // Prevent infinite loop if baseId also fails
+                img.src = `../user_files/sprites/front_default/${baseId}.png`;
+            } else {
+                // Stage 2 Fallback: Placeholder, then dim if even that fails.
+                img.onerror = () => { img.style.opacity = '0.25'; };
+                img.src = '../user_files/sprites/front_default/0.png';
+            }
+        };
+        spriteWrap.appendChild(img);
+        card.appendChild(spriteWrap);
+
+        const info = document.createElement('div');
+        info.className = 'card-info';
+        const nameEl = document.createElement('div');
+        nameEl.className = 'card-name';
+        nameEl.textContent = displayName;
+        info.appendChild(nameEl);
+
+        // Second line: held item (or species when nickname differs).
+        const metaParts = [];
+        if (heldItem) {
+            metaParts.push(`<span class="meta-held">Holds ${titleCase(heldItem)}</span>`);
+        } else if (nickname && name && nickname.toLowerCase() !== name.toLowerCase()) {
+            metaParts.push(titleCase(name));
+        }
+        if (metaParts.length > 0) {
+            const meta = document.createElement('div');
+            meta.className = 'team-card-meta';
+            meta.innerHTML = metaParts.join(' · ');
+            info.appendChild(meta);
+        }
+        card.appendChild(info);
+
+        card.addEventListener('click', () => onPickerChoose(choice));
+        return card;
+    }
+
+    function titleCase(s) {
+        return String(s || '').replace(/-/g, ' ').replace(
+            /\w\S*/g, (t) => t.charAt(0).toUpperCase() + t.slice(1).toLowerCase()
+        );
+    }
+
+    function onPickerChoose(choice) {
+        const item = state.picker.item;
+        if (!item || !bridge || !bridge.useItemOnPokemon) {
+            closePicker();
+            return;
+        }
+        closePicker();
+        // Held-item / evolution might change the team — invalidate so
+        // the next open re-fetches fresh data.
+        state.picker.choices = null;
+        // choice.id == individual_id in the compact payload.
+        bridge.useItemOnPokemon(item.name, choice.id, function (result) {
+            if (!result) return;
+            if (result.message) showToast(result.message, !result.ok);
+        });
+    }
+
+    function bindPickerUI() {
+        document.getElementById('picker-close').addEventListener('click', closePicker);
+        document.getElementById('picker-cancel').addEventListener('click', closePicker);
+        document.getElementById('picker-modal').addEventListener('click', (e) => {
+            if (e.target.classList.contains('picker-backdrop')) closePicker();
+        });
+        // Debounce search re-renders — typing fast in a 16k-row list
+        // shouldn't kick a full filter+render on every keystroke.
+        let searchTimer = null;
+        document.getElementById('picker-search').addEventListener('input', (e) => {
+            state.picker.search = e.target.value || '';
+            clearTimeout(searchTimer);
+            searchTimer = setTimeout(renderPickerGrid, 80);
+        });
+    }
+
+    document.addEventListener('DOMContentLoaded', () => {
+        bindUI();
+        bindPickerUI();
+        // Dropdown nav: wire from the shared switcher once the channel resolves
+        // so it has the live NavBridge. See ankimon_items_web/nav-switcher.js.
+        initChannel(() => {
+            if (window.wireNavSwitcher) window.wireNavSwitcher(window.nav);
+        });
+    });
+})();

--- a/src/Ankimon/ankimon_items_web/shop_obj.py
+++ b/src/Ankimon/ankimon_items_web/shop_obj.py
@@ -1079,6 +1079,11 @@ class AnkimonItemsWeb(QDialog):
         # ready, so just skip here.
         if self.current_screen not in self.ready_screens:
             return
+        # The persistent-singleton window can be reopened / switched back to after
+        # the captured-Pokémon DB changed externally (a catch during reviews, a
+        # release from the PC box). Drop the picker's roster cache on every screen
+        # (re)entry so the next getPokemonChoices() rebuilds from fresh DB state.
+        self._invalidate_pokemon_cache()
         if self.current_screen == SCREEN_ITEMS:
             data = self.get_inventory_data()
             # Apply a menu-requested View filter exactly once, atomically with
@@ -1142,6 +1147,12 @@ class AnkimonItemsWeb(QDialog):
         screen has a registered refresher. Several calls in the same event-loop
         turn coalesce into a single refresh (so e.g. a defeat that grants XP and
         a cash reward only triggers one re-render)."""
+        # A gameplay event may have added/removed/evolved a captured Pokémon, so
+        # the "Give Item"/"Evolve" picker's roster cache is now stale. Drop it up
+        # front — before the visibility/screen early-returns — so the cache is
+        # correct even when the event fires while the window is on a non-live
+        # screen (e.g. Items) or hidden.
+        self._invalidate_pokemon_cache()
         if not self.isVisible():
             return
         if self.current_screen not in self.ready_screens:
@@ -1766,9 +1777,14 @@ class AnkimonItemsWeb(QDialog):
                         target_data = pokedex_data.get(normalized_target) or pokedex_data.get(target_evo_name.lower())
 
                         if target_data and target_data.get("evoType") == "useItem":
-                            # required_item is normalized to match the input item_name (e.g. "Fire Stone" -> "fire-stone")
-                            required_item = (target_data.get("evoItem") or "").lower().replace(" ", "-")
-                            if required_item == item_name:
+                            # Normalize both sides by stripping spaces, hyphens and
+                            # apostrophes so pokedex.json display names (e.g.
+                            # "King's Rock") match items.csv identifiers (e.g.
+                            # "kings-rock"), which drop the apostrophe. Mirrors the
+                            # canonical logic in functions/pokedex_functions.py.
+                            required_item = (target_data.get("evoItem") or "").lower().replace(" ", "").replace("-", "").replace("'", "")
+                            normalized_item_name = (item_name or "").lower().replace(" ", "").replace("-", "").replace("'", "")
+                            if required_item == normalized_item_name:
                                 target_region = target_data.get("evoRegion")
 
                                 if target_region:

--- a/src/Ankimon/ankimon_items_web/shop_obj.py
+++ b/src/Ankimon/ankimon_items_web/shop_obj.py
@@ -1,0 +1,2157 @@
+"""Unified shell window — Items (Mart + Bag) and Ankidex live in one QDialog.
+
+The same QWebEngineView swaps between two screens by changing its URL. No
+window close/open flicker; the dropdown switcher in either screen calls back
+through QWebChannel to swap content in place.
+"""
+
+import json
+import random
+import math
+import os
+import time
+import traceback
+import threading
+import base64
+from datetime import datetime
+from aqt import QDialog, QVBoxLayout, QWebEngineView, mw
+from aqt.qt import Qt, QUrl, QFrame
+from PyQt6.QtCore import QObject, pyqtSlot, QTimer, QByteArray
+from PyQt6.QtGui import QColor
+from PyQt6.QtWebChannel import QWebChannel
+from PyQt6.QtWidgets import QStackedWidget
+import csv
+from ..utils import give_item
+
+try:
+    from ..utils import is_dev_mode
+except ImportError:  # dev helper not landed yet (thread-reload-and-misc-utils unit)
+
+    def is_dev_mode():
+        return False
+
+
+from ..resources import items_path, csv_file_items_cost, csv_file_descriptions
+from ..functions.pokedex_functions import (
+    find_details_move,
+    _load_pokedex_cache,
+    check_evolution_by_item,
+    return_id_for_item_name,
+)
+from ..business import calculate_cp_from_dict
+from ..ankimon_profile_web.profile_data import ProfileData
+from ..services import services
+from ..events import events
+
+# NOTE: functions/mobile_sync.py is a later (mobile) unit and is intentionally
+# NOT a module-load dependency of the web-shell host. The MobileBridge slots
+# lazy-import it in-method and degrade to a benign/neutral payload when it is
+# absent, so the host, shop, settings, profile and team screens all work with
+# mobile not yet installed.
+
+
+SCREEN_ITEMS = "items"
+SCREEN_ANKIDEX = "ankidex"
+SCREEN_SETTINGS = "settings"
+SCREEN_PROFILE = "profile"
+SCREEN_TEAM = "team"
+SCREEN_MOBILE = "mobile"
+SCREEN_HISTORY = "history"
+
+
+class NavBridge(QObject):
+    """Cross-screen navigation — exposed in all shell pages."""
+
+    def __init__(self, window):
+        super().__init__()
+        self._w = window
+
+    @pyqtSlot(result=int)
+    def getPendingReviewsCount(self) -> int:
+        try:
+            db = services.db
+            return db.get_pending_mobile_count() if db else 0
+        except Exception:
+            return 0
+
+    @pyqtSlot()
+    def openItems(self):
+        self._w.load_screen(SCREEN_ITEMS)
+
+    @pyqtSlot()
+    def openAnkidex(self):
+        self._w.load_screen(SCREEN_ANKIDEX)
+
+    @pyqtSlot()
+    def openSettings(self):
+        self._w.load_screen(SCREEN_SETTINGS)
+
+    @pyqtSlot()
+    def openProfile(self):
+        self._w.load_screen(SCREEN_PROFILE)
+
+    @pyqtSlot()
+    def openTeam(self):
+        self._w.load_screen(SCREEN_TEAM)
+
+    @pyqtSlot()
+    def openMobile(self):
+        self._w.load_screen(SCREEN_MOBILE)
+
+    @pyqtSlot()
+    def openHistory(self):
+        self._w.load_screen(SCREEN_HISTORY)
+
+
+
+class TrainerBridge(QObject):
+    """Profile-screen data + sprite-picker actions (delegates to ProfileData)."""
+
+    def __init__(self, window):
+        super().__init__()
+        self._w = window
+
+    @pyqtSlot(result="QVariant")
+    def getProfile(self):
+        return self._w.get_profile_payload()
+
+    @pyqtSlot(result="QVariant")
+    def getSprites(self):
+        return self._w.profile_data.get_sprite_data()
+
+    @pyqtSlot(str, result="QVariant")
+    def setSprite(self, name):
+        return self._w.profile_data.handle_set_sprite(name)
+
+    @pyqtSlot(str, result="QVariant")
+    def setName(self, name):
+        return self._w.profile_data.handle_set_name(name)
+
+
+class TeamBridge(QObject):
+    """Team-builder screen actions (delegates to ProfileData)."""
+
+    def __init__(self, window):
+        super().__init__()
+        self._w = window
+
+    @pyqtSlot(result="QVariant")
+    def getTeam(self):
+        return self._w.profile_data.get_team_data()
+
+    @pyqtSlot(result="QVariant")
+    def getRoster(self):
+        return self._w.profile_data.get_roster_data()
+
+    @pyqtSlot(str)
+    def saveSpriteMode(self, mode):
+        services.settings.set("ankidex.spriteMode", mode)
+
+    @pyqtSlot(int)
+    def saveCycleCount(self, count):
+        services.settings.set("controls.team_cycle_count", count)
+
+    @pyqtSlot(str, result=int)
+    def getCp(self, individual_id):
+        return self._w.profile_data._calc_cp(individual_id)
+
+    @pyqtSlot(str, result="QVariant")
+    def getMemberStats(self, individual_id):
+        # {cp, types} for a Pokémon just added to a slot (roster stubs omit both).
+        return self._w.profile_data.get_member_stats(individual_id)
+
+    # JSON string in (PyQt QVariant-list unwrap is unreliable on first call).
+    @pyqtSlot(str, str, str, result="QVariant")
+    def saveTeam(self, team_json, xp_share_id, companion_id):
+        try:
+            team_ids = json.loads(team_json) if team_json else []
+            if not isinstance(team_ids, list):
+                raise ValueError("team payload must be a list")
+        except (TypeError, ValueError) as e:
+            return {"ok": False, "message": f"Invalid team payload: {e}"}
+        return self._w.profile_data.handle_save_team(team_ids, xp_share_id or None, companion_id or None)
+
+
+class SettingsBridge(QObject):
+    """Settings-screen actions — only meaningful when Settings is loaded."""
+
+    def __init__(self, window):
+        super().__init__()
+        self._w = window
+
+    @pyqtSlot(result="QVariant")
+    def getSettings(self):
+        return self._w.get_settings_data()
+
+    # Accept a JSON-encoded string rather than a QVariant dict — PyQt's
+    # QVariant → dict auto-unwrap can fail on the first invocation
+    # (depending on Qt/PyQt versions), making the first save click error
+    # out while later clicks succeed. Round-tripping through JSON removes
+    # that ambiguity entirely.
+    @pyqtSlot(str, result="QVariant")
+    def saveSettings(self, payload_json):
+        try:
+            payload = json.loads(payload_json) if payload_json else {}
+        except (TypeError, ValueError) as e:
+            return {"ok": False, "message": f"Invalid payload JSON: {e}"}
+        return self._w.handle_save_settings(payload)
+
+    @pyqtSlot(str, result="QVariant")
+    def searchPokemon(self, query):
+        """Return up to 20 Pokédex entries whose name contains `query`."""
+        return self._w.handle_pokemon_search(query)
+
+    @pyqtSlot(result="QVariant")
+    def getCaughtPokemon(self):
+        """Return list of [{id, name, sprite_url}] for all caught/collected Pokémon."""
+        return self._w.handle_get_caught_pokemon()
+
+
+class ItemsBridge(QObject):
+    """Items-screen actions — only meaningful when Items is loaded."""
+
+    def __init__(self, window):
+        super().__init__()
+        self._w = window
+
+    @pyqtSlot(str, bool, result="QVariant")
+    def buy(self, item_name, is_tm):
+        result = self._w.handle_buy(item_name, bool(is_tm))
+        self._w.push_screen_data()
+        return result
+
+    @pyqtSlot(result="QVariant")
+    def reroll(self):
+        result = self._w.handle_reroll()
+        self._w.push_screen_data()
+        return result
+
+    @pyqtSlot(bool, result="QVariant")
+    def setSkipRerollConfirm(self, skip):
+        return self._w.handle_set_skip_reroll_confirm(bool(skip))
+
+    @pyqtSlot(str, result="QVariant")
+    def useItem(self, item_name):
+        result = self._w.handle_use(item_name)
+        self._w.push_screen_data()
+        return result
+
+    # In-shell Pokémon picker — replaces the legacy QInputDialog flow for
+    # evolution items + held items. JS calls getPokemonChoices() to populate
+    # the modal, then useItemOnPokemon() with the chosen individual_id.
+    @pyqtSlot(str, result="QVariant")
+    def getPokemonChoices(self, item_name=None):
+        return self._w.get_pokemon_choices(item_name)
+
+    @pyqtSlot(str, str, result="QVariant")
+    def useItemOnPokemon(self, item_name, individual_id):
+        result = self._w.handle_use_with_target(item_name, individual_id)
+        self._w.push_screen_data()
+        return result
+
+    @pyqtSlot(str, str, result="QVariant")
+    def unequipItem(self, individual_id, item_name):
+        result = self._w.handle_unequip_item(individual_id, item_name)
+        self._w.push_screen_data()
+        return result
+
+    # Back-compat: items.shop.js previously called bridge.openAnkidex; keep
+    # it as a passthrough so older cached pages still work.
+    @pyqtSlot()
+    def openAnkidex(self):
+        self._w.load_screen(SCREEN_ANKIDEX)
+
+
+class MobileBridge(QObject):
+    """Mobile reviews screen — data and actions."""
+
+    def __init__(self, window):
+        super().__init__()
+        self._w = window
+
+    @pyqtSlot(result="QVariant")
+    def getMobileStatus(self) -> dict:
+        """
+        Returns all data needed to render State 1 or State 2.
+        Called by mobile.js on page load and after actions.
+        """
+        try:
+            db = services.db
+            # 1. Count and ease breakdown in one GROUP BY query (lightweight)
+            rows = db.execute(
+                """SELECT ease, COUNT(*) as cnt FROM pending_mobile_battles
+                   WHERE resolved = 0 GROUP BY ease"""
+            ).fetchall()
+            pending_count = sum(r[1] for r in rows)
+
+            # Read settings for cards_per_round
+            from ..functions import mobile_sync
+            settings_obj = services.settings
+            cards_per_round, _ = mobile_sync._parse_cards_per_round(settings_obj)
+
+            # Read cached resolved count to compute total battle count quickly
+            cursor = db.execute("SELECT value FROM metadata WHERE key = 'mobile_resolved_encounters_count'")
+            row = cursor.fetchone()
+            resolved_battles = int(row[0]) if row else 0
+            battle_count = resolved_battles + math.ceil(pending_count / cards_per_round)
+
+            if pending_count == 0:
+                return {"pending_count": 0, "cap": 10000, "battle_count": 0}
+
+            # Populate ease breakdown from rows count
+            ease_breakdown = {"1": 0, "2": 0, "3": 0, "4": 0}
+            for row in rows:
+                ease_breakdown[str(row[0])] = row[1]
+
+            settings_obj = services.settings
+            main_pokemon = services.main_pokemon
+            trainer_card = services.trainer_card
+            ankimon_tracker_obj = services.tracker
+
+            # Get descriptive name for auto-battle setting
+            auto_battle_mode_names = {
+                0: "Manual (Auto-Resolve)",
+                1: "Auto-Catch",
+                2: "Auto-Defeat",
+                3: "Catch Uncollected"
+            }
+            auto_battle_val = 0
+            try:
+                auto_battle_val = int(settings_obj.get("battle.automatic_battle", 0))
+            except Exception:
+                pass
+            auto_battle_mode = auto_battle_mode_names.get(auto_battle_val, "Manual")
+
+            rare_catch_active = False
+            if settings_obj:
+                rare_catch_active = (
+                    settings_obj.get("battle.auto_catch_legendary", True)
+                    or settings_obj.get("battle.auto_catch_mythical", True)
+                    or settings_obj.get("battle.auto_catch_ultra", True)
+                    or settings_obj.get("battle.auto_catch_starter", True)
+                    or settings_obj.get("battle.auto_catch_mega", True)
+                    or settings_obj.get("battle.auto_catch_gmax", True)
+                    or settings_obj.get("battle.auto_catch_regional", True)
+                    or bool(settings_obj.get("battle.auto_catch_wishlist", []))
+                )
+
+            # Main Pokémon info for preview
+            main_pokemon_name = None
+            main_pokemon_level = None
+            main_pokemon_sprite = None
+            sprite_mode = "static"
+            if main_pokemon:
+                main_pokemon_name = main_pokemon.name
+                main_pokemon_level = main_pokemon.level
+                
+                from ..functions.sprite_functions import get_relative_sprite_path
+                main_pokemon_sprite = get_relative_sprite_path(
+                    main_pokemon.id, bool(main_pokemon.shiny), (main_pokemon.gender or "N"), main_pokemon.name, "gif"
+                )
+
+            if settings_obj:
+                sprite_mode = settings_obj.get(
+                    "ankidex.spriteMode",
+                    settings_obj.get("pokedex_v2.spriteMode", "static")
+                )
+
+            # Trigger async estimates calculation if there are pending reviews
+            estimates_loading = False
+            estimates = {
+                "xp": 0,
+                "encounters": 0,
+                "catches": 0,
+                "caught_list": [],
+                "is_truncated": False,
+                "total_reviews": 0,
+                "simulated_reviews": 0,
+                "cash": 0,
+            }
+            if pending_count > 0:
+                estimates_loading = True
+
+                trainer_card = services.trainer_card
+                ankimon_tracker_obj = services.tracker
+
+                def run_sim(col):
+                    reviews_rows_thread = db.execute(
+                        """SELECT id, revlog_id, card_id, ease, review_time, review_type, queued_at
+                           FROM pending_mobile_battles
+                           WHERE resolved = 0
+                           ORDER BY id ASC LIMIT 105"""
+                    ).fetchall()
+                    reviews_list_thread = [
+                        {
+                            "id": r[0],
+                            "revlog_id": r[1],
+                            "card_id": r[2],
+                            "ease": r[3],
+                            "review_time": r[4],
+                            "review_type": r[5],
+                            "queued_at": r[6],
+                        }
+                        for r in reviews_rows_thread
+                    ]
+                    if pending_count > len(reviews_list_thread):
+                        reviews_list_thread.extend([{"ease": 3}] * (pending_count - len(reviews_list_thread)))
+
+                    from ..functions.mobile_sync import simulate_pending_mobile_battles
+                    return simulate_pending_mobile_battles(
+                        reviews_list_thread,
+                        main_pokemon,
+                        settings_obj,
+                        trainer_card,
+                        ankimon_tracker_obj,
+                        ankimon_db=db
+                    )
+
+                def on_sim_success(sim_res):
+                    res_est = {
+                        "xp": sim_res["xp"],
+                        "encounters": sim_res["encounters"],
+                        "catches": sim_res.get("catches_count", len(sim_res["caught"])),
+                        "caught_list": sim_res["caught"],
+                        "is_truncated": sim_res.get("is_truncated", False),
+                        "total_reviews": sim_res.get("total_reviews", 0),
+                        "simulated_reviews": sim_res.get("simulated_reviews", 0),
+                        "cash": sim_res.get("cash", 0),
+                    }
+                    js = f"if (window.updateMobileEstimates) {{ window.updateMobileEstimates({json.dumps(res_est)}); }}"
+                    self._w.webview_mobile.page().runJavaScript(js)
+
+                if "PYTEST_CURRENT_TEST" in os.environ:
+                    sim_res = run_sim(None)
+                    estimates = {
+                        "xp": sim_res["xp"],
+                        "encounters": sim_res["encounters"],
+                        "catches": sim_res.get("catches_count", len(sim_res["caught"])),
+                        "caught_list": sim_res["caught"],
+                        "is_truncated": sim_res.get("is_truncated", False),
+                        "total_reviews": sim_res.get("total_reviews", 0),
+                        "simulated_reviews": sim_res.get("simulated_reviews", 0),
+                        "cash": sim_res.get("cash", 0),
+                    }
+                    estimates_loading = False
+                    battle_count = estimates["encounters"]
+                else:
+                    from aqt.operations import QueryOp
+                    QueryOp(
+                        parent=self._w,
+                        op=run_sim,
+                        success=on_sim_success
+                    ).without_collection().run_in_background()
+
+            return {
+                "pending_count": pending_count,
+                "pending_count_at_start": pending_count,
+                "cards_per_round": cards_per_round,
+                "battle_count": battle_count,
+                "cap": 10000,
+                "ease_breakdown": ease_breakdown,
+                "estimates": estimates,
+                "estimates_loading": estimates_loading,
+                "auto_battle_mode": auto_battle_mode,
+                "rare_catch_active": rare_catch_active,
+                "main_pokemon_name": main_pokemon_name,
+                "main_pokemon_level": main_pokemon_level,
+                "main_pokemon_sprite": main_pokemon_sprite,
+                "sprite_mode": sprite_mode,
+                "team_status": self.getTeamStatus(),
+            }
+        except Exception as e:
+            import traceback
+            logger = services.logger
+            if logger:
+                logger.log("error", f"getMobileStatus failed: {e}\n{traceback.format_exc()}")
+            return {"error": str(e), "pending_count": 0, "pending_count_at_start": 0, "cap": 10000}
+
+    @pyqtSlot(result="QVariant")
+    def getMobileHistory(self) -> list:
+        """Retrieves mobile battle history."""
+        try:
+            return services.db.get_mobile_history(limit=500)
+        except Exception as e:
+            return []
+
+    @pyqtSlot(result="QVariant")
+    def clearMobileHistory(self) -> bool:
+        """Clears mobile battle history."""
+        try:
+            return services.db.clear_mobile_history()
+        except Exception as e:
+            return False
+
+    @pyqtSlot(result="QVariant")
+    def dismissAll(self) -> dict:
+        """
+        Mark ALL pending battles as resolved without running any battle logic.
+        This is the escape hatch for users who don't want to replay.
+        """
+        try:
+            db = services.db
+            count_before = db.get_pending_mobile_count()
+            with db._get_connection() as conn:
+                conn.execute(
+                    "UPDATE pending_mobile_battles SET resolved=1, resolved_at=? WHERE resolved=0",
+                    (int(time.time() * 1000),)
+                )
+            from ..menu_buttons import update_mobile_badge
+            update_mobile_badge(0)
+            return {"dismissed": count_before, "success": True}
+        except Exception as e:
+            return {"success": False, "error": str(e)}
+
+    @pyqtSlot(result="QVariant")
+    def resolveAll(self) -> dict:
+        """
+        Runs the deterministic auto-resolve for all pending reviews, applying the exact same
+        encounters and outcomes simulated in the preview.
+        """
+        try:
+            # Lazy import: mobile_sync is a later unit; if absent, fall through
+            # to the benign error payload below instead of crashing the shell.
+            from ..functions.mobile_sync import resolve_all
+
+            db = services.db
+            settings_obj = services.settings
+            tracker = services.tracker
+            trainer_card = services.trainer_card
+            main_pokemon = services.main_pokemon
+            day_cutoff = mw.col.sched.day_cutoff if (mw and mw.col) else 0
+
+            return resolve_all(
+                db=db,
+                settings_obj=settings_obj,
+                tracker=tracker,
+                trainer_card=trainer_card,
+                main_pokemon=main_pokemon,
+                logger=services.logger,
+                day_cutoff=day_cutoff
+            )
+        except Exception as e:
+            import traceback
+            logger = services.logger
+            if logger:
+                logger.log("error", f"resolveAll failed: {e}\n{traceback.format_exc()}")
+            return {"success": False, "error": str(e)}
+
+    @pyqtSlot(int, result="QVariant")
+    def resolveChunk(self, limit: int) -> dict:
+        """
+        Resolves a chunk of pending battles up to the specified limit.
+        """
+        try:
+            # Lazy import: mobile_sync is a later unit — return a benign payload
+            # when it (or the mobile DB layer) is not present.
+            from ..functions.mobile_sync import resolve_all
+
+            db = services.db
+            settings_obj = services.settings
+            tracker = services.tracker
+            trainer_card = services.trainer_card
+            main_pokemon = services.main_pokemon
+            day_cutoff = mw.col.sched.day_cutoff if (mw and mw.col) else 0
+
+            res = resolve_all(
+                db=db,
+                settings_obj=settings_obj,
+                tracker=tracker,
+                trainer_card=trainer_card,
+                main_pokemon=main_pokemon,
+                logger=services.logger,
+                day_cutoff=day_cutoff,
+                limit=limit
+            )
+            if isinstance(res, dict) and res.get("success"):
+                res["done"] = (db.get_pending_mobile_count() == 0)
+            return res
+        except Exception as e:
+            return {"success": False, "error": str(e)}
+
+    @pyqtSlot()
+    def startBulkResolve(self):
+        """Starts bulk auto-resolve in a background thread."""
+        # Count safely — the mobile DB layer may not be present (mobile is a
+        # later unit); default to 0 rather than raising out of the slot.
+        try:
+            total = services.db.get_pending_mobile_count()
+        except Exception:
+            total = 0
+        self._bulk_progress = {
+            "processed": 0,
+            "total": total,
+            "resolved": 0,
+            "catches": 0,
+            "cash_gained": 0,
+            "trainer_xp_gained": 0,
+            "xp_gained": 0,
+            "caught_list": [],
+            "done": False,
+            "error": None
+        }
+        self._bulk_paused = False
+        self._bulk_stopped = False
+        self._bulk_refreshed = False
+
+        def bg_resolve():
+            try:
+                # Lazy import: absent mobile_sync surfaces as a benign progress
+                # error (done=True) instead of crashing the worker thread.
+                from ..functions.mobile_sync import resolve_all
+
+                def progress_cb(status, total=None):
+                    if isinstance(status, dict):
+                        self._bulk_progress.update(status)
+                    else:
+                        self._bulk_progress["processed"] = status
+                        if total is not None:
+                            self._bulk_progress["total"] = total
+                    
+                    import time
+                    while getattr(self, "_bulk_paused", False) and not getattr(self, "_bulk_stopped", False):
+                        time.sleep(0.1)
+                    
+                    if getattr(self, "_bulk_stopped", False):
+                        return False
+                    return True
+
+                res = resolve_all(
+                    db=services.db,
+                    settings_obj=services.settings,
+                    tracker=services.tracker,
+                    trainer_card=services.trainer_card,
+                    main_pokemon=services.main_pokemon,
+                    logger=services.logger,
+                    day_cutoff=mw.col.sched.day_cutoff if (mw and mw.col) else 0,
+                    limit=None,
+                    progress_callback=progress_cb
+                )
+                if res:
+                    if not res.get("success", True):
+                        raise Exception(res.get("error", "Unknown error in background resolve"))
+                    self._bulk_progress["processed"] = res.get("reviews_processed", 0)
+                    self._bulk_progress["resolved"] = res.get("resolved", 0)
+                    self._bulk_progress["catches"] = res.get("catches", 0)
+                    self._bulk_progress["cash_gained"] = res.get("cash_gained", 0)
+                    self._bulk_progress["trainer_xp_gained"] = res.get("trainer_xp_gained", 0)
+                    self._bulk_progress["xp_gained"] = res.get("xp_gained", 0)
+                    if res.get("caught_list"):
+                        self._bulk_progress["caught_list"] = res.get("caught_list")
+
+            except Exception as e:
+                import traceback
+                logger = services.logger
+                if logger:
+                    logger.log("error", f"bg_resolve failed: {e}\n{traceback.format_exc()}")
+                self._bulk_progress["error"] = f"{str(e)}\n{traceback.format_exc()}"
+            finally:
+                self._bulk_progress["done"] = True
+
+        thread = threading.Thread(target=bg_resolve, daemon=True)
+        thread.start()
+
+    @pyqtSlot()
+    def pauseBulkResolve(self):
+        self._bulk_paused = True
+
+    @pyqtSlot()
+    def resumeBulkResolve(self):
+        self._bulk_paused = False
+
+    @pyqtSlot()
+    def stopBulkResolve(self):
+        self._bulk_stopped = True
+
+    @pyqtSlot(result="QVariant")
+    def getBulkResolveProgress(self) -> dict:
+        progress = getattr(self, "_bulk_progress", {"done": True, "processed": 0, "total": 0}).copy()
+        progress["paused"] = getattr(self, "_bulk_paused", False)
+        # If it just finished, perform safe main-thread refreshes!
+        if progress.get("done") and not getattr(self, "_bulk_refreshed", False):
+            self._bulk_refreshed = True
+            try:
+                # Refresh trainer card
+                if services.trainer_card:
+                    services.trainer_card.refresh()
+                # Refresh active companion
+                if services.main_pokemon:
+                    from ..functions.update_main_pokemon import update_main_pokemon
+                    update_main_pokemon(services.main_pokemon)
+                # Update mobile badge safely on main thread
+                try:
+                    remaining = services.db.get_pending_mobile_count()
+                    from ..menu_buttons import update_mobile_badge
+                    update_mobile_badge(remaining)
+                except Exception: pass
+                # Live-refresh whatever screen is showing (self._w IS the shell
+                # window) and emit the seam signal for any cross-cutting
+                # listeners — replaces exp's singletons.notify_stats_changed().
+                self._w.refresh_live_screen()
+                events.emit("stats_changed")
+            except Exception as e:
+                import traceback
+                logger = services.logger
+                if logger:
+                    logger.log("error", f"Error refreshing singletons after bulk resolve: {e}\n{traceback.format_exc()}")
+        return progress
+    @pyqtSlot(str, result="QVariant")
+    def resolveNext(self, companion_id: str = "") -> dict:
+        try:
+            # Lazy import: mobile_sync is a later unit — benign error if absent.
+            from ..functions.mobile_sync import resolve_next
+
+            db = services.db
+            settings_obj = services.settings
+            tracker = services.tracker
+            trainer_card = services.trainer_card
+            main_pokemon = services.main_pokemon
+            day_cutoff = mw.col.sched.day_cutoff if (mw and mw.col) else 0
+
+            if "PYTEST_CURRENT_TEST" in os.environ:
+                res = resolve_next(
+                    companion_id=companion_id,
+                    db=db,
+                    settings_obj=settings_obj,
+                    tracker=tracker,
+                    trainer_card=trainer_card,
+                    main_pokemon=main_pokemon,
+                    logger=services.logger,
+                    day_cutoff=day_cutoff
+                )
+                if isinstance(res, dict) and "current_pending_outcome" in res:
+                    outcome = res["current_pending_outcome"]
+                    if outcome:
+                        outcome.update({
+                            "main_pokemon": main_pokemon,
+                            "trainer_card": trainer_card,
+                            "settings_obj": settings_obj,
+                        })
+                    self._current_pending_outcome = outcome
+                    return res["result"]
+                return res
+            else:
+                from aqt.operations import QueryOp
+
+                def run_sim(col):
+                    return resolve_next(
+                        companion_id=companion_id,
+                        db=db,
+                        settings_obj=settings_obj,
+                        tracker=tracker,
+                        trainer_card=trainer_card,
+                        main_pokemon=main_pokemon,
+                        logger=services.logger,
+                        day_cutoff=day_cutoff
+                    )
+
+                def on_sim_success(sim_res):
+                    if isinstance(sim_res, dict) and "current_pending_outcome" in sim_res:
+                        outcome = sim_res["current_pending_outcome"]
+                        if outcome:
+                            outcome.update({
+                                "main_pokemon": main_pokemon,
+                                "trainer_card": trainer_card,
+                                "settings_obj": settings_obj,
+                            })
+                        self._current_pending_outcome = outcome
+                        result_data = sim_res["result"]
+                    else:
+                        result_data = sim_res
+
+                    import json
+                    js = f"if (window.onResolveNextReady) {{ window.onResolveNextReady({json.dumps(result_data)}); }}"
+                    self._w.webview_mobile.page().runJavaScript(js)
+
+                QueryOp(
+                    parent=self._w,
+                    op=run_sim,
+                    success=on_sim_success
+                ).without_collection().run_in_background()
+
+                return {"loading": True}
+        except Exception as e:
+            import traceback
+            logger = services.logger
+            if logger:
+                logger.log("error", f"resolveNext failed: {e}\n{traceback.format_exc()}")
+            return {"success": False, "error": str(e)}
+
+    @pyqtSlot(str, result="QVariant")
+    def commitReplayOutcome(self, choice: str) -> dict:
+        try:
+            # Lazy import: mobile_sync is a later unit — benign error if absent.
+            from ..functions.mobile_sync import commit_replay_outcome
+
+            db = services.db
+            settings_obj = services.settings
+            trainer_card = services.trainer_card
+            main_pokemon = services.main_pokemon
+            achievements_dict = services.achievements
+            logger = services.logger
+            outcome_data = getattr(self, "_current_pending_outcome", None)
+
+            res = commit_replay_outcome(
+                choice=choice,
+                outcome_data=outcome_data,
+                db=db,
+                settings_obj=settings_obj,
+                trainer_card=trainer_card,
+                main_pokemon=main_pokemon,
+                achievements_dict=achievements_dict,
+                logger=logger
+            )
+            if res.get("success"):
+                self._current_pending_outcome = None
+            return res
+        except Exception as e:
+            import traceback
+            logger = services.logger
+            if logger:
+                logger.log("error", f"commitReplayOutcome failed: {e}\n{traceback.format_exc()}")
+            return {"success": False, "error": str(e)}
+
+    @pyqtSlot(str, result="QVariant")
+    def toggleMobileCompanion(self, individual_id: str) -> dict:
+        """Toggle a team member in/out of mobile.inactive_companions. Returns updated inactive list."""
+        try:
+            settings_obj = services.settings
+            inactive = settings_obj.get("mobile.inactive_companions", [])
+            if not isinstance(inactive, list):
+                inactive = []
+            inactive = [str(x) for x in inactive]
+            if individual_id in inactive:
+                inactive.remove(individual_id)
+            else:
+                inactive.append(individual_id)
+            settings_obj.set("mobile.inactive_companions", inactive)
+            return {"inactive": inactive, "success": True}
+        except Exception as e:
+            return {"success": False, "error": str(e)}
+
+    @pyqtSlot(result="QVariant")
+    def getTeamStatus(self) -> dict:
+        """Returns the current team with inactive flags for rendering the mobile team grid."""
+        try:
+            db = services.db
+            team_rows = db.get_team()
+            settings_obj = services.settings
+            inactive = set(settings_obj.get("mobile.inactive_companions", [])) if settings_obj else set()
+            from ..functions.sprite_functions import get_relative_sprite_path
+
+            team_list = []
+            for t in team_rows:
+                ind_id = t.get("individual_id")
+                if ind_id:
+                    if hasattr(db, "get_pokemon_by_individual_id"):
+                        data = db.get_pokemon_by_individual_id(ind_id)
+                    else:
+                        data = db.get_pokemon(ind_id)
+                    if data:
+                        from ..pyobj.pokemon_obj import PokemonObject
+                        pkmn = PokemonObject(**data)
+                        name = pkmn.display_name
+                        level = data.get("level", 5)
+                        shiny = bool(data.get("shiny", False))
+                        gender = data.get("gender") or "N"
+                        pkmn_id = data.get("id")
+                        pkmn_type = data.get("type", ["Normal"])
+                        if isinstance(pkmn_type, str):
+                            pkmn_type = [pkmn_type]
+                        
+                        sprite_path = get_relative_sprite_path(pkmn_id, shiny, gender, pkmn.name, "gif")
+                        is_inactive = ind_id in inactive
+
+                        team_list.append({
+                            "individual_id": ind_id,
+                            "name": name,
+                            "level": level,
+                            "sprite_path": sprite_path,
+                            "type": pkmn_type,
+                            "inactive": is_inactive
+                        })
+
+            return {"team": team_list, "inactive": list(inactive)}
+        except Exception as e:
+            return {"team": [], "inactive": [], "error": str(e)}
+
+    @pyqtSlot(result="QVariant")
+    def triggerAnkiSync(self) -> dict:
+        """
+        Triggers Anki's built-in synchronization on the main window.
+        """
+        try:
+            from aqt import mw
+            if hasattr(mw, "onSync"):
+                from aqt.qt import QTimer
+                QTimer.singleShot(0, mw.onSync)
+                return {"success": True}
+            else:
+                return {"success": False, "error": "mw.onSync not available"}
+        except Exception as e:
+            return {"success": False, "error": str(e)}
+
+
+class AnkimonItemsWeb(QDialog):
+    def __init__(self, addon_dir, shop_manager, item_window, ankimon_tracker,
+                 trainer_card=None, settings_obj=None, logger=None):
+        super().__init__()
+        self.addon_dir = addon_dir
+        self.shop_manager = shop_manager
+        self.item_window = item_window
+        self.ankimon_tracker = ankimon_tracker
+        # Profile + Team are folded into this shell so all five screens share
+        # one window and one dropdown. Their data lives in ProfileData.
+        self.profile_data = ProfileData(addon_dir, trainer_card, settings_obj, logger)
+        self._pending_profile_action = None
+        # Live updates: map of screen -> bound method that pushes fresh data to
+        # that screen. Only screens listed here react to gameplay events. To add
+        # a new live screen (e.g. a Stats screen), add an entry here, a matching
+        # _push_*_live method, and a window.liveRefreshX receiver in its JS.
+        # See ankimon_items_web/LIVE_UPDATES.md.
+        self._live_refreshers = {
+            SCREEN_PROFILE: self._push_profile_live,
+            SCREEN_MOBILE: self._push_mobile_live,
+            SCREEN_HISTORY: self._push_history_live,
+        }
+        self._live_refresh_pending = False
+        self.current_screen = None
+        self.setWindowTitle("Ankimon")
+
+        # Paint the shell dark from the first frame. The web views set their
+        # own page background, but the surrounding QDialog/QFrame/QStackedWidget
+        # would otherwise briefly show the light system palette while a screen
+        # loads — a visible flash on open.
+        self.setStyleSheet(
+            "QDialog, QFrame, QStackedWidget { background-color: #0d1117; }"
+        )
+
+        # Disabled WA_TranslucentBackground to prevent heavy window-level repaint
+        # flickering under Windows DWM when QWebEngineView re-composes or updates.
+        # self.setAttribute(Qt.WidgetAttribute.WA_TranslucentBackground)
+        self.setWindowFlags(
+            self.windowFlags()
+            | Qt.WindowType.WindowMaximizeButtonHint
+            | Qt.WindowType.WindowMinimizeButtonHint
+        )
+        self.resize(1180, 720)
+
+        layout = QVBoxLayout()
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(0)
+        self.setLayout(layout)
+
+        frame = QFrame()
+        frame.setContentsMargins(0, 0, 0, 0)
+        frame.setFrameStyle(QFrame.Shape.NoFrame)
+        frame.setLayout(QVBoxLayout())
+        frame.layout().setContentsMargins(0, 0, 0, 0)
+        layout.addWidget(frame)
+
+        self.stack = QStackedWidget()
+        frame.layout().addWidget(self.stack)
+
+        self.webview_items = QWebEngineView()
+        self.webview_ankidex = QWebEngineView()
+        self.webview_settings = QWebEngineView()
+        self.webview_profile = QWebEngineView()
+        self.webview_team = QWebEngineView()
+        self.webview_mobile = QWebEngineView()
+        self.webview_history = QWebEngineView()
+        self._views = {
+            SCREEN_ITEMS: self.webview_items,
+            SCREEN_ANKIDEX: self.webview_ankidex,
+            SCREEN_SETTINGS: self.webview_settings,
+            SCREEN_PROFILE: self.webview_profile,
+            SCREEN_TEAM: self.webview_team,
+            SCREEN_MOBILE: self.webview_mobile,
+            SCREEN_HISTORY: self.webview_history,
+        }
+
+        self.bridge = ItemsBridge(self)
+        self.nav = NavBridge(self)
+        self.settings_bridge = SettingsBridge(self)
+        self.trainer_bridge = TrainerBridge(self)
+        self.team_bridge = TeamBridge(self)
+        self._mobile_bridge = MobileBridge(self)
+
+        # Each screen gets its own channel, but every channel registers the
+        # same bridge objects so any page can navigate / call any action.
+        for screen, view in self._views.items():
+            view.setContextMenuPolicy(Qt.ContextMenuPolicy.NoContextMenu)
+            view.page().setBackgroundColor(QColor("#0d1117"))
+            self.stack.addWidget(view)
+
+            channel = QWebChannel(view)
+            channel.registerObject("bridge", self.bridge)
+            channel.registerObject("nav", self.nav)
+            channel.registerObject("settings", self.settings_bridge)
+            channel.registerObject("trainer", self.trainer_bridge)
+            channel.registerObject("team", self.team_bridge)
+            if screen in (SCREEN_MOBILE, SCREEN_HISTORY):
+                channel.registerObject("mobile", self._mobile_bridge)
+            view.page().setWebChannel(channel)
+
+
+            view.loadFinished.connect(
+                lambda ok, s=screen: self._on_screen_load_finished(ok, s)
+            )
+
+        self.loaded_screens = set()
+        # Screens whose first load has actually *finished* (loaded_screens
+        # only records that a load was kicked off). Used to decide whether a
+        # forced view can be pushed immediately or must wait for loadFinished.
+        self.ready_screens = set()
+        # One-shot Items View filter ('in_shop' | 'owned') requested by a menu
+        # entry (Mart vs Item Bag). Consumed by the next inventory push, then
+        # cleared so later pushes (buy/use/reroll) don't reset the user's view.
+        self.pending_view = None
+        # The first show() is fed by the open path; later re-shows refresh data.
+        self._shown_once = False
+
+        # Boot with Items by default; menu entries can call load_screen()
+        # before show() to pick a different initial screen.
+        self.load_screen(SCREEN_ITEMS)
+        self._restore_geometry()
+
+    # ------------------------------------------------------------------
+    # Screen switching
+    # ------------------------------------------------------------------
+    def load_screen(self, screen):
+        def do_load():
+            self.current_screen = screen
+            if screen == SCREEN_ITEMS:
+                title = "Ankimon — Items"
+                target_view = self.webview_items
+                path = self.addon_dir / "ankimon_items_web" / "shop.html"
+            elif screen == SCREEN_ANKIDEX:
+                title = "Ankimon — Ankidex"
+                target_view = self.webview_ankidex
+                path = self.addon_dir / "ankidex" / "ankidex.html"
+            elif screen == SCREEN_SETTINGS:
+                title = "Ankimon — Settings"
+                target_view = self.webview_settings
+                path = self.addon_dir / "ankimon_items_web" / "settings.html"
+            elif screen == SCREEN_PROFILE:
+                title = "Ankimon — Profile"
+                target_view = self.webview_profile
+                path = self.addon_dir / "ankimon_profile_web" / "profile.html"
+            elif screen == SCREEN_TEAM:
+                title = "Ankimon — Team"
+                target_view = self.webview_team
+                path = self.addon_dir / "ankimon_profile_web" / "team.html"
+            elif screen == SCREEN_MOBILE:
+                title = "Ankimon — Mobile Battles"
+                target_view = self.webview_mobile
+                path = self.addon_dir / "ankimon_mobile_web" / "mobile.html"
+            elif screen == SCREEN_HISTORY:
+                title = "Ankimon — Mobile History"
+                target_view = self.webview_history
+                path = self.addon_dir / "ankimon_mobile_web" / "history.html"
+            else:
+                return
+
+            self.setWindowTitle(title)
+            self.stack.setCurrentWidget(target_view)
+
+            if screen not in self.loaded_screens:
+                self.loaded_screens.add(screen)
+                target_view.setUrl(QUrl.fromLocalFile(path.as_posix()))
+            else:
+                self.push_screen_data()
+
+        # Save Ankidex prefs before navigating away
+        if self.current_screen == SCREEN_ANKIDEX and screen != SCREEN_ANKIDEX:
+            self._save_ankidex_prefs(callback=do_load)
+        else:
+            do_load()
+
+    def _on_screen_load_finished(self, ok, screen):
+        if not ok:
+            return
+        self.ready_screens.add(screen)
+        if self.current_screen == screen:
+            self.push_screen_data()
+
+    def push_screen_data(self):
+        # A screen can only receive data once its first load has finished.
+        # Pushing earlier is a no-op in JS and would wrongly consume one-shot
+        # state like pending_view — the loadFinished handler re-pushes once
+        # ready, so just skip here.
+        if self.current_screen not in self.ready_screens:
+            return
+        if self.current_screen == SCREEN_ITEMS:
+            data = self.get_inventory_data()
+            # Apply a menu-requested View filter exactly once, atomically with
+            # the render so it survives the async page load. Cleared after use
+            # so subsequent pushes don't clobber the user's own filter choice.
+            if self.pending_view is not None:
+                data["initial_view"] = self.pending_view
+                self.pending_view = None
+            js = f"if (window.initializeItems) window.initializeItems({json.dumps(data)});"
+            self.webview_items.page().runJavaScript(js)
+        elif self.current_screen == SCREEN_ANKIDEX:
+            data = self._get_ankidex_data()
+            js = f"if (window.initializeAnkidex) window.initializeAnkidex({json.dumps(data)});"
+            self.webview_ankidex.page().runJavaScript(js)
+        elif self.current_screen == SCREEN_SETTINGS:
+            data = self.get_settings_data()
+            js = f"if (window.initializeSettings) window.initializeSettings({json.dumps(data)});"
+            self.webview_settings.page().runJavaScript(js)
+        elif self.current_screen == SCREEN_PROFILE:
+            data = self.get_profile_payload()
+            js = f"if (window.initializeProfile) window.initializeProfile({json.dumps(data)});"
+            self.webview_profile.page().runJavaScript(js)
+        elif self.current_screen == SCREEN_TEAM:
+            data = self.profile_data.get_team_data()
+            js = f"if (window.initializeTeam) window.initializeTeam({json.dumps(data)});"
+            self.webview_team.page().runJavaScript(js)
+        elif self.current_screen == SCREEN_MOBILE:
+            data = self._mobile_bridge.getMobileStatus()
+            js = f"if (window.initializeMobile) window.initializeMobile({json.dumps(data)});"
+            self.webview_mobile.page().runJavaScript(js)
+        elif self.current_screen == SCREEN_HISTORY:
+            db = services.db
+            data = db.get_mobile_history() if db else []
+            js = f"if (window.initializeHistory) window.initializeHistory({json.dumps(data)});"
+            self.webview_history.page().runJavaScript(js)
+
+    def get_profile_payload(self):
+        """Profile data + a one-shot UI action ('sprite' opens the picker,
+        'badges' scrolls to the badge case), set by the menu entry points."""
+        data = self.profile_data.get_profile_data()
+        data["action"] = self._consume_profile_action()
+        return data
+
+    def _consume_profile_action(self):
+        action = self._pending_profile_action
+        self._pending_profile_action = None
+        return action
+
+    # ------------------------------------------------------------------
+    # Live updates — keep the open screen current after a gameplay event
+    # (catch, XP, cash, ...). Full pattern + how to add a new live screen:
+    # ankimon_items_web/LIVE_UPDATES.md
+    # ------------------------------------------------------------------
+    def refresh_live_screen(self):
+        """Entry point called by ``singletons.notify_stats_changed()`` after a
+        gameplay event. Refreshes whichever screen is currently showing **iff**
+        it supports live updates.
+
+        Cheap and safe to call from anywhere on the GUI thread: a no-op unless
+        the window is visible, the current screen is fully loaded, and that
+        screen has a registered refresher. Several calls in the same event-loop
+        turn coalesce into a single refresh (so e.g. a defeat that grants XP and
+        a cash reward only triggers one re-render)."""
+        if not self.isVisible():
+            return
+        if self.current_screen not in self.ready_screens:
+            return
+        if self.current_screen not in self._live_refreshers:
+            return
+        if self._live_refresh_pending:
+            return
+        self._live_refresh_pending = True
+        # Defer to the next event-loop turn: coalesces bursts and lets the
+        # triggering gameplay logic finish (DB writes are already committed).
+        QTimer.singleShot(0, self._run_live_refresh)
+
+    def _run_live_refresh(self):
+        self._live_refresh_pending = False
+        # Re-check — state may have changed before this deferred call ran.
+        # isVisible() raises RuntimeError if the dialog's C++ object was deleted
+        # (window closed) between scheduling this timer and it firing.
+        try:
+            if not self.isVisible() or self.current_screen not in self.ready_screens:
+                return
+        except RuntimeError:
+            return
+
+        # Update the navigation switcher notification dot in the active web view
+        active_view = self.stack.currentWidget()
+        if active_view:
+            try:
+                db = services.db
+                count = db.get_pending_mobile_count() if db else 0
+                active_view.page().runJavaScript(f"if (window.updateNavSwitcherUnresolvedCount) window.updateNavSwitcherUnresolvedCount({count});")
+            except Exception:
+                pass
+
+        refresher = self._live_refreshers.get(self.current_screen)
+        if refresher is None:
+            return
+        try:
+            refresher()
+        except Exception as e:
+            logger = services.logger
+            if logger:
+                logger.log("error", f"[Ankimon] live refresh failed ({self.current_screen}): {e}")
+
+    def _push_profile_live(self):
+        """Push a full Profile refresh (cash, caught, Pokédex, shinies, highest,
+        XP bar, team levels, recently caught). New catches animate into Recently
+        Caught; the JS diffs the list so stat-only changes don't re-render it."""
+        data = self.profile_data.get_profile_data()
+        js = (
+            "if (window.liveRefreshProfile) "
+            f"window.liveRefreshProfile({json.dumps(data)});"
+        )
+        self.webview_profile.page().runJavaScript(js)
+
+    def _push_mobile_live(self):
+        """Push a full Mobile reviews refresh when stats or pending reviews change."""
+        data = self._mobile_bridge.getMobileStatus()
+        js = (
+            "if (window.liveRefreshMobile) "
+            f"window.liveRefreshMobile({json.dumps(data)});"
+        )
+        self.webview_mobile.page().runJavaScript(js)
+
+    def _push_history_live(self):
+        """Push a history refresh when a mobile review outcome is committed."""
+        db = services.db
+        history_data = db.get_mobile_history() if db else []
+        js = (
+            "if (window.liveRefreshHistory) "
+            f"window.liveRefreshHistory({json.dumps(history_data)});"
+        )
+        self.webview_history.page().runJavaScript(js)
+
+    def _get_ankidex_data(self):
+        # Reuse the existing Ankidex singleton's data getter — keeps the
+        # dex query logic in one place.
+        from ..singletons import get_ankidex_window
+
+        ankidex = get_ankidex_window()
+        return ankidex.get_ankidex_data()
+
+    def _save_ankidex_prefs(self, callback=None):
+        def on_state_ready(state):
+            if state and isinstance(state, dict):
+                for key, val in state.items():
+                    services.settings.set(f"ankidex.{key}", val)
+            if callback:
+                callback()
+
+        self.webview_ankidex.page().runJavaScript(
+            "if (window.getAnkidexState) window.getAnkidexState();",
+            on_state_ready,
+        )
+
+    def show(self):
+        if self.isMinimized():
+            self.showNormal()
+        else:
+            super().show()
+        self.raise_()
+        self.activateWindow()
+
+    def _restore_geometry(self):
+        try:
+            geo = mw.pm.profile.get("ankimon.items_web_window.geometry")
+            if geo:
+                self.restoreGeometry(QByteArray(base64.b64decode(geo)))
+        except Exception:
+            pass
+
+    def _save_geometry(self):
+        try:
+            if not self.isMinimized():
+                mw.pm.profile["ankimon.items_web_window.geometry"] = base64.b64encode(
+                    bytes(self.saveGeometry())
+                ).decode()
+        except Exception:
+            pass
+
+    def closeEvent(self, event):
+        if self.current_screen == SCREEN_ANKIDEX:
+            self._save_ankidex_prefs()
+        self._save_geometry()
+        super().closeEvent(event)
+
+    def hideEvent(self, event):
+        self._save_geometry()
+        super().hideEvent(event)
+
+    def showEvent(self, event):
+        # The first show is fed by the open path (which pushes once the page
+        # is ready), so skip the redundant push here — that double render
+        # during load is what caused the flash. On later re-shows, refresh in
+        # case buy/use changed data while the window was hidden.
+        if self._shown_once:
+            self.push_screen_data()
+        else:
+            self._shown_once = True
+        super().showEvent(event)
+
+    # Back-compat alias for the bridge methods that still call update_ui_data.
+    def update_ui_data(self):
+        self.push_screen_data()
+
+    def handle_pokemon_search(self, query: str):
+        """Search the Pokédex by name substring. Returns {results: [{id, name}]}."""
+        from ..functions.pokedex_functions import _load_pokedex_cache, format_lore_name
+        from ..functions import encounter_data
+
+        query = (query or "").strip().lower()
+        if len(query) < 2:
+            return {"results": []}
+        pokedex = _load_pokedex_cache()
+        results = []
+        for internal_name, data in pokedex.items():
+            # Exclude alternate sub-forms of plate/drive/memory switching species to avoid redundancy
+            if internal_name.startswith("arceus") and internal_name != "arceus":
+                continue
+            if internal_name.startswith("silvally") and internal_name != "silvally":
+                continue
+            if internal_name.startswith("genesect") and internal_name != "genesect":
+                continue
+
+            name = data.get("name", internal_name)
+            pretty_name = format_lore_name(name)
+            if query in name.lower() or query in pretty_name.lower():
+                pid = data.get("actual_id") or data.get("species_id")
+                if pid and int(pid) > 0:
+                    pid_val = int(pid)
+                    if pid_val not in encounter_data.UNAVAILABLE:
+                        results.append({"id": pid_val, "name": pretty_name})
+            if len(results) >= 20:
+                break
+        results.sort(key=lambda r: r["name"].lower())
+        return {"results": results}
+
+    def handle_get_caught_pokemon(self):
+        """Get the list of caught/collected Pokémon for the quick-add panel."""
+        from ..utils import load_collected_pokemon_ids
+        from ..functions.pokedex_functions import _load_pokedex_cache, search_pokedex_by_id, get_pretty_name_for_id
+
+        caught_ids = load_collected_pokemon_ids()
+        results = []
+        pokedex = _load_pokedex_cache()
+
+        for pid in sorted(list(caught_ids)):
+            internal_name = search_pokedex_by_id(pid)
+            if internal_name and internal_name != "Pokémon not found":
+                pretty_name = get_pretty_name_for_id(pid)
+                results.append({
+                    "id": int(pid),
+                    "name": pretty_name,
+                })
+        # Sort by name alphabetically
+        results.sort(key=lambda r: r["name"].lower())
+        return {"results": results}
+
+    def get_inventory_data(self):
+        sm = self.shop_manager
+
+        # Today's stock (cached by PokemonShopManager.get_daily_items)
+        raw_items = sm.get_daily_items() or []
+        raw_tms = sm.get_daily_tms() or []
+        sm.todays_daily_items = raw_items
+        sm.todays_daily_tms = raw_tms
+
+        shop_index = {}
+        for entry in raw_items:
+            shop_index[entry["name"]] = {
+                "price": int(self._lookup_price(entry["name"]) or 0),
+                "is_tm": False,
+                "item_type": entry.get("item_type"),
+            }
+        for entry in raw_tms:
+            shop_index[entry["name"]] = {
+                "price": int(sm.tm_price or 0),
+                "is_tm": True,
+                "item_type": entry.get("item_type") or "TM",
+            }
+
+        # Player's bag (every owned item)
+        owned_rows = []
+        try:
+            owned_rows = services.db.get_all_items() or []
+        except Exception:
+            owned_rows = []
+
+        # Find all equipped items from Pokemon
+        equipped_by_map = {}
+        try:
+            all_pokemons = services.db.get_all_pokemon() or []
+            for pkm in all_pokemons:
+                held = pkm.get("held_item")
+                if held:
+                    if held not in equipped_by_map:
+                        equipped_by_map[held] = []
+                    equipped_by_map[held].append({
+                        "name": pkm.get("name", "Unknown"),
+                        "individual_id": pkm.get("individual_id")
+                    })
+        except Exception as e:
+            logger = services.logger
+            if logger:
+                logger.log("error", f"[Ankimon] get_all_pokemon failed in _get_mart_and_bag_data: {e}")
+
+        owned_index = {}
+        for row in owned_rows:
+            name = row.get("item_name") or row.get("name")
+            qty = int(row.get("quantity") or 0)
+            if not name or qty <= 0:
+                continue
+            owned_index[name] = {
+                "quantity": qty,
+                "category_id": row.get("category_id"),
+            }
+
+        all_names = sorted(set(shop_index.keys()) | set(owned_index.keys()) | set(equipped_by_map.keys()))
+
+        items = []
+        for name in all_names:
+            shop_entry = shop_index.get(name)
+            owned_entry = owned_index.get(name)
+            is_tm = bool(
+                (shop_entry or {}).get("is_tm")
+                or (owned_entry or {}).get("category_id") == 37
+            )
+            items.append(
+                self._serialize_item(
+                    name=name,
+                    is_tm=is_tm,
+                    in_shop=bool(shop_entry),
+                    shop_price=(shop_entry or {}).get("price"),
+                    item_type=(shop_entry or {}).get("item_type"),
+                    owned_quantity=(owned_entry or {}).get("quantity", 0),
+                    equipped_instances=equipped_by_map.get(name, []),
+                )
+            )
+
+        return {
+            "cash": int(sm.get_callback("trainer.cash") or 0),
+            "reroll_cost": int(sm.daily_items_reroll_cost or 0),
+            "skip_reroll_confirm": self._get_skip_reroll_today(),
+            "items": items,
+            # pokemon_choices intentionally NOT included — for players with
+            # 10k+ captures the payload is multiple MB. JS lazy-fetches via
+            # bridge.getPokemonChoices() on first picker open + caches.
+        }
+
+    def _get_skip_reroll_today(self):
+        # Stored as {"date": "YYYY-MM-DD", "skip": bool}. Treated as False
+        # whenever the date doesn't match today, which gives the "reset every
+        # day" behavior without needing a separate cleanup pass.
+        try:
+            data = services.db.get_user_data("shop_skip_reroll_confirm")
+        except Exception:
+            return False
+        if not isinstance(data, dict):
+            return False
+        if data.get("date") != datetime.now().strftime("%Y-%m-%d"):
+            return False
+        return bool(data.get("skip"))
+
+    def handle_set_skip_reroll_confirm(self, skip):
+        try:
+            services.db.set_user_data(
+                "shop_skip_reroll_confirm",
+                {"date": datetime.now().strftime("%Y-%m-%d"), "skip": bool(skip)},
+            )
+        except Exception as e:
+            return {"ok": False, "message": str(e)}
+        return {"ok": True}
+
+    def _serialize_item(
+        self, name, is_tm, in_shop, shop_price, item_type, owned_quantity, equipped_instances=None
+    ):
+        ui_name = name.replace("-", " ").title()
+        entry = {
+            "name": name,
+            "ui_name": ui_name,
+            "is_tm": is_tm,
+            "in_shop": in_shop,
+            "price": int(shop_price) if shop_price is not None else None,
+            "owned_quantity": int(owned_quantity or 0),
+            "item_type": item_type,
+            "category": self._categorize(name, is_tm),
+            "equipped_instances": equipped_instances or [],
+        }
+
+        if is_tm:
+            move = find_details_move(name) or {}
+            move_type = move.get("type") or "Normal"
+            entry["image_url"] = QUrl.fromLocalFile(
+                str(items_path / f"Bag_TM_{move_type}_SV_Sprite.png")
+            ).toString()
+            short_desc = move.get("shortDesc") or ""
+            entry["description"] = (
+                f"Teaches a compatible Pokémon the move {ui_name}."
+                + (f" {short_desc}" if short_desc else "")
+            )
+            entry["move_type"] = move_type
+            entry["move_power"] = self._coerce_int(move.get("basePower"))
+            accuracy = move.get("accuracy")
+            entry["move_accuracy"] = (
+                "—" if accuracy is True else self._coerce_int(accuracy)
+            )
+            entry["move_pp"] = self._coerce_int(move.get("pp"))
+            entry["move_damage_class"] = (move.get("category") or "").title() or None
+        else:
+            entry["image_url"] = QUrl.fromLocalFile(
+                str(items_path / f"{name}.png")
+            ).toString()
+            entry["description"] = (
+                self._lookup_description(name) or f"A useful item: {ui_name}"
+            )
+
+        return entry
+
+    def _categorize(self, name, is_tm):
+        """Bucket items into the same groups the legacy bag exposed."""
+        if is_tm:
+            return "tm"
+        bag = self.item_window
+        if bag is not None:
+            if name in getattr(bag, "hp_heal_items", {}):
+                return "heal"
+            if name in getattr(bag, "fossil_pokemon", {}):
+                return "fossil"
+            if name in getattr(bag, "pokeball_chances", {}):
+                return "pokeball"
+            if name in getattr(bag, "evolution_items", set()):
+                return "evolution"
+        return "other"
+
+    def _lookup_price(self, name):
+        entry = self._items_csv.get(name)
+        return entry["cost"] if entry else 0
+
+    def _lookup_description(self, name):
+        entry = self._items_csv.get(name)
+        if not entry:
+            return None
+        try:
+            lang = int(self.shop_manager.settings_obj.get("misc.language") or 9)
+        except (TypeError, ValueError):
+            lang = 9
+        if lang == 14:  # es_latam → fall back to es per legacy behaviour
+            lang = 7
+        return self._descriptions.get((entry["id"], lang))
+
+    @property
+    def _items_csv(self):
+        """{identifier: {"id": int, "cost": int}} — items.csv loaded once."""
+        cached = getattr(self, "_items_csv_cache", None)
+        if cached is not None:
+            return cached
+        index = {}
+        try:
+            with open(csv_file_items_cost, mode="r", newline="", encoding="utf-8") as f:
+                for row in csv.DictReader(f):
+                    try:
+                        index[row["identifier"]] = {
+                            "id": int(row["id"]),
+                            "cost": int(row["cost"]),
+                        }
+                    except (KeyError, ValueError):
+                        continue
+        except OSError:
+            pass
+        self._items_csv_cache = index
+        return index
+
+    @property
+    def _descriptions(self):
+        """{(item_id, language_id): flavor_text} — item_flavor_text.csv loaded once."""
+        cached = getattr(self, "_descriptions_cache", None)
+        if cached is not None:
+            return cached
+        index = {}
+        try:
+            with open(csv_file_descriptions, mode="r", encoding="utf-8") as f:
+                for row in csv.DictReader(f):
+                    try:
+                        key = (int(row["item_id"]), int(row["language_id"]))
+                    except (KeyError, ValueError):
+                        continue
+                    # First occurrence wins (legacy get_item_description does the same).
+                    index.setdefault(key, row.get("flavor_text"))
+        except OSError:
+            pass
+        self._descriptions_cache = index
+        return index
+
+    @staticmethod
+    def _coerce_int(value):
+        try:
+            if value in (None, "", "—"):
+                return None
+            if isinstance(value, bool):
+                return None
+            return int(value)
+        except (TypeError, ValueError):
+            return None
+
+    # ------------------------------------------------------------------
+    # Actions (JS → Python)
+    # ------------------------------------------------------------------
+    def handle_buy(self, item_name, is_tm):
+        item = self._find_serialized(item_name)
+        if not item or not item.get("in_shop"):
+            return {"ok": False, "message": "Item is not in today's stock."}
+
+        ui_name = item["ui_name"]
+        price = int(item.get("price") or 0)
+        cash = int(self.shop_manager.get_callback("trainer.cash") or 0)
+
+        if is_tm and item.get("owned_quantity", 0) > 0:
+            return {"ok": False, "message": f"{ui_name} is already owned."}
+        if cash < price:
+            return {"ok": False, "message": "Not enough money."}
+
+        try:
+            self.shop_manager.set_callback("trainer.cash", int(cash - price))
+            give_item(item_name, item.get("item_type") if is_tm else None)
+        except Exception as e:
+            self.shop_manager.set_callback("trainer.cash", cash)
+            return {"ok": False, "message": f"Purchase failed: {e}"}
+
+        return {"ok": True, "message": f"Bought {ui_name} for {price}¥"}
+
+    def handle_reroll(self):
+        sm = self.shop_manager
+        cost = int(sm.daily_items_reroll_cost or 0)
+        cash = int(sm.get_callback("trainer.cash") or 0)
+        if cash < cost:
+            return {"ok": False, "message": "Not enough money to reroll."}
+
+        # Compute new stock + write to DB first; only deduct cash once the
+        # write succeeds. Otherwise a DB failure could swallow the reroll
+        # cost with nothing to show for it.
+        from ..pyobj.ankimon_shop import DAILY_ITEMS_POOL
+
+        random.seed()
+        # Clamp sample sizes — random.sample raises if asked for more entries
+        # than the pool contains, which would crash the bridge call.
+        tm_pool = sm.get_tm_pool()
+        num_items = min(sm.number_of_daily_items, len(DAILY_ITEMS_POOL))
+        num_tms = min(sm.number_of_daily_items, len(tm_pool))
+        new_items = random.sample(DAILY_ITEMS_POOL, num_items)
+        new_tms = random.sample(tm_pool, num_tms)
+
+        try:
+            services.db.set_user_data(
+                "todays_shop",
+                {
+                    "items": new_items,
+                    "technical_machines": new_tms,
+                    "date": datetime.now().strftime("%Y-%m-%d"),
+                },
+            )
+            sm.todays_daily_items = new_items
+            sm.todays_daily_tms = new_tms
+            sm.set_callback("trainer.cash", int(cash - cost))
+        except Exception as e:
+            return {"ok": False, "message": f"Reroll failed: {e}"}
+
+        return {"ok": True, "message": f"Rerolled stock for {cost}¥"}
+
+    def handle_use(self, item_name):
+        item = self._find_serialized(item_name)
+        if not item:
+            return {"ok": False, "message": "Item not found in your bag."}
+        if (item.get("owned_quantity") or 0) <= 0:
+            return {"ok": False, "message": "You don't own that item."}
+        if self.item_window is None:
+            return {"ok": False, "message": "Item bag service unavailable."}
+        item_type = item.get("item_type") or ("TM" if item.get("is_tm") else None)
+        result = self.item_window.dispatch_use(item_name, item_type)
+        # Fossils + healing main can change team data (new entry / hp).
+        if item.get("category") in ("fossil", "heal"):
+            self._invalidate_pokemon_cache()
+        return result
+
+    def _invalidate_pokemon_cache(self):
+        self._pokemon_choices_cache = None
+
+    def get_pokemon_choices(self, item_name=None):
+        """Return the player's Pokémon team for the in-shell picker.
+
+        Enhancements:
+        - Calculates CP for each Pokémon.
+        - Provides base species ID ('b') for sprite fallbacks.
+        - Checks evolution eligibility ('e') if an evolution item is used.
+        - Sorts by eligibility (top), then active status, then level, then name.
+        - Utilizes an instance cache for base results to maintain O(1) speed
+          for repeated opens with non-evolution items.
+        """
+        # Determine if we need specific eligibility data
+        is_evo_item = False
+        if item_name:
+            # We assume non-TM here; if it was a TM, useItemOnPokemon wouldn't be called.
+            is_evo_item = (self._categorize(item_name, False) == "evolution")
+
+        cached = getattr(self, "_pokemon_choices_cache", None)
+        # If not an evolution item, we can safely return the base cache (if it exists).
+        # This keeps the "Give Item" picker snappy even with 10k+ Pokémon.
+        if not is_evo_item and cached is not None:
+            return cached
+
+        try:
+            pokemons = services.db.get_all_pokemon() or []
+        except Exception as e:
+            logger = services.logger
+            if logger:
+                logger.log("error", f"[Ankimon] get_pokemon_choices: get_all_pokemon failed: {e}")
+            return {"choices": []}
+
+        # Active Pokémon's individual_id (so we can flag it in the UI).
+        main_individual_id = None
+        bag = self.item_window
+        if bag is not None and getattr(bag, "main_pokemon", None):
+            main_individual_id = getattr(bag.main_pokemon, "individual_id", None)
+
+        pokedex_data = _load_pokedex_cache()
+        from ..functions.pokedex_functions import search_pokedex_by_id
+
+        # Pre-fetch the region setting to avoid repeated lookups
+        active_region = None
+        if services.settings:
+            active_region = services.settings.get("misc.active_region")
+            if active_region:
+                active_region = active_region.strip()
+
+        choices = []
+        for data in pokemons:
+            if not isinstance(data, dict):
+                continue
+            individual_id = data.get("individual_id")
+            pokedex_id = data.get("id")
+            name = data.get("name")
+            if not individual_id or not name:
+                continue
+
+            nickname = (data.get("nickname") or "").strip()
+            held_item = data.get("held_item") or ""
+            level = data.get("level")
+            shiny = bool(data.get("shiny"))
+            is_main = bool(main_individual_id and individual_id == main_individual_id)
+
+            # Resolve internal name using the optimized pokedex index
+            internal_name = search_pokedex_by_id(pokedex_id)
+            p_details = pokedex_data.get(internal_name)
+
+            # Sprite fallback: get base species_id
+            base_id = pokedex_id
+            if p_details:
+                base_id = p_details.get("species_id") or pokedex_id
+
+            entry = {
+                "id": individual_id,
+                "p": pokedex_id or 0,
+                "b": base_id or 0,
+                "n": name,
+                "l": int(level) if level is not None else None,
+                "cp": calculate_cp_from_dict(data),
+            }
+            if shiny:
+                entry["s"] = 1
+            if is_main:
+                entry["m"] = 1
+            if held_item:
+                entry["h"] = held_item
+            if nickname and nickname.lower() != (name or "").lower():
+                entry["nk"] = nickname
+
+            # Evolution eligibility (Optimized inline to avoid file I/O)
+            if is_evo_item and item_name and p_details:
+                evo_list = p_details.get("evos")
+                if evo_list:
+                    for target_evo_name in evo_list:
+                        normalized_target = target_evo_name.lower().replace(" ", "").replace("-", "").replace("'", "").replace(".", "").replace(":", "")
+                        target_data = pokedex_data.get(normalized_target) or pokedex_data.get(target_evo_name.lower())
+
+                        if target_data and target_data.get("evoType") == "useItem":
+                            # required_item is normalized to match the input item_name (e.g. "Fire Stone" -> "fire-stone")
+                            required_item = (target_data.get("evoItem") or "").lower().replace(" ", "-")
+                            if required_item == item_name:
+                                target_region = target_data.get("evoRegion")
+
+                                if target_region:
+                                    if active_region and active_region.lower() == target_region.lower():
+                                        entry["e"] = 1
+                                        break
+                                else:
+                                    # Standard form is only allowed if there is no regional sibling for this region/method
+                                    has_matching_regional_sibling = False
+                                    for sibling_name in evo_list:
+                                        sib_norm = sibling_name.lower().replace(" ", "").replace("-", "").replace("'", "").replace(".", "").replace(":", "")
+                                        sib_data = pokedex_data.get(sib_norm) or pokedex_data.get(sibling_name.lower())
+                                        if sib_data and sib_data.get("evoRegion") and active_region and sib_data.get("evoRegion").lower() == active_region.lower():
+                                            if sib_data.get("evoType") == target_data.get("evoType") and (sib_data.get("evoItem") or "").lower() == (target_data.get("evoItem") or "").lower():
+                                                has_matching_regional_sibling = True
+                                                break
+                                    if not has_matching_regional_sibling:
+                                        entry["e"] = 1
+                                        break
+
+            choices.append(entry)
+
+        # Eligible first, then active first, then level (high → low), then alphabetical.
+        choices.sort(
+            key=lambda c: (
+                not c.get("e"),
+                not c.get("m"),
+                -(c.get("l") or 0),
+                (c.get("nk") or c.get("n") or "").lower(),
+            )
+        )
+        result = {"choices": choices}
+        # Update the base cache if this was a non-evolution run.
+        if not is_evo_item:
+            self._pokemon_choices_cache = result
+        return result
+    def handle_use_with_target(self, item_name, individual_id):
+        """Apply an item to a specific Pokémon (chosen via the in-shell
+        picker). Bypasses dispatch_use's QInputDialog branches by calling
+        the underlying item_window helpers directly with the id."""
+        item = self._find_serialized(item_name)
+        if not item:
+            return {"ok": False, "message": "Item not found in your bag."}
+        if (item.get("owned_quantity") or 0) <= 0:
+            return {"ok": False, "message": "You don't own that item."}
+        if self.item_window is None:
+            return {"ok": False, "message": "Item bag service unavailable."}
+        if not individual_id:
+            return {"ok": False, "message": "No Pokémon selected."}
+
+        bag = self.item_window
+        # Either branch below mutates the team (held-item or evolution),
+        # so invalidate up front regardless of which path runs.
+        self._invalidate_pokemon_cache()
+        try:
+            if item.get("category") == "evolution":
+                # Check_Evo_Item needs the pre-evo's pokedex id to match
+                # against the evolution table. Pull it from the proven
+                # get_pokemon() API.
+                pokemon_data = None
+                try:
+                    pokemon_data = services.db.get_pokemon(individual_id)
+                except Exception as e:
+                    logger = services.logger
+                    if logger:
+                        logger.log("error", f"[Ankimon] get_pokemon({individual_id}) failed: {e}")
+                pokedex_id = (pokemon_data or {}).get("id")
+                if not pokedex_id:
+                    return {"ok": False, "message": "Could not look up that Pokémon."}
+                bag.Check_Evo_Item(individual_id, pokedex_id, item_name)
+                return {"ok": True, "message": ""}
+
+            # Held items (and anything else routed through the give-item
+            # flow) — the legacy method already surfaces success/error via
+            # log_and_showinfo, so we just return an empty message.
+            bag._give_held_item_by_id(individual_id, item_name)
+            return {"ok": True, "message": ""}
+        except Exception as e:
+            return {"ok": False, "message": f"Use failed: {e}"}
+
+    def handle_unequip_item(self, individual_id, item_name):
+        """Unequip a held item from a specific Pokémon and return it to the bag."""
+        if not individual_id:
+            return {"ok": False, "message": "No Pokémon selected."}
+        
+        self._invalidate_pokemon_cache()
+        try:
+            from ..pyobj.pokemon_obj import PokemonObject
+            pokemon_data = services.db.get_pokemon(individual_id)
+            if not pokemon_data:
+                return {"ok": False, "message": "Could not find that Pokémon."}
+            
+            pokemon_obj = PokemonObject.from_dict(pokemon_data)
+            if pokemon_obj.held_item != item_name:
+                return {"ok": False, "message": "That Pokémon is not holding this item."}
+                
+            pokemon_obj.remove_held_item()
+            
+            # Refresh open legacy item bag if it exists
+            if self.item_window is not None:
+                self.item_window.renewWidgets()
+                
+            # Also refresh open PC Box window
+            from ..singletons import pokemon_pc, is_alive
+            if is_alive(pokemon_pc):
+                pokemon_pc.refresh_gui()
+                
+            return {"ok": True, "message": f"Unequipped {item_name.replace('-', ' ').title()} from {pokemon_data.get('name')}."}
+        except Exception as e:
+            return {"ok": False, "message": f"Unequip failed: {e}"}
+
+    def _find_serialized(self, item_name):
+        data = self.get_inventory_data()
+        for entry in data["items"]:
+            if entry["name"] == item_name:
+                return entry
+        return None
+
+    # ------------------------------------------------------------------
+    # Settings screen
+    # ------------------------------------------------------------------
+    def get_settings_data(self):
+        """Build the schema + current values payload for the Settings screen."""
+        from . import settings_schema
+
+        settings_obj = self.shop_manager.settings_obj
+        # Refresh config from disk so external edits are picked up.
+        try:
+            config = settings_obj.load_config()
+        except Exception:
+            config = settings_obj.config
+
+        name_map = self._load_lang_json("setting_name.json")
+        desc_map = self._load_lang_json("setting_description.json")
+        # Reverse the friendly_name → key map so we can resolve friendly names
+        # from the schema back to their config keys.
+        key_by_friendly = {v: k for k, v in name_map.items()}
+
+        groups = []
+        for group_def in settings_schema.GROUPS:
+            settings = self._serialize_settings_list(
+                group_def.get("settings", []),
+                key_by_friendly,
+                name_map,
+                desc_map,
+                config,
+            )
+            # Append a chip-group as one composite setting after the regular
+            # settings — keeps it in the same scroll section.
+            chip_def = group_def.get("chip_group")
+            if chip_def:
+                settings.append(self._serialize_chip_group(chip_def, config))
+            group = {
+                "label": group_def["label"],
+                "settings": settings,
+                "subgroups": [],
+            }
+            for sub in group_def.get("subgroups", []):
+                sub_settings = self._serialize_settings_list(
+                    sub.get("settings", []),
+                    key_by_friendly,
+                    name_map,
+                    desc_map,
+                    config,
+                )
+                sub_chip_def = sub.get("chip_group")
+                if sub_chip_def:
+                    sub_settings.append(self._serialize_chip_group(sub_chip_def, config))
+                group["subgroups"].append(
+                    {
+                        "label": sub["label"],
+                        "settings": sub_settings,
+                    }
+                )
+            groups.append(group)
+        return {"groups": groups, "dev_mode": bool(is_dev_mode())}
+
+    @staticmethod
+    def _serialize_chip_group(chip_def, config):
+        chips = []
+        for key, chip_label in chip_def["keys"]:
+            chips.append(
+                {
+                    "key": key,
+                    "label": chip_label,
+                    "value": bool(config.get(key, False)),
+                }
+            )
+        return {
+            "key": "__chips__" + chip_def["label"].lower().replace(" ", "_"),
+            "label": chip_def["label"],
+            "description": chip_def.get("description", ""),
+            "type": "chips",
+            "chips": chips,
+        }
+
+    def _serialize_settings_list(
+        self, friendly_names, key_by_friendly, name_map, desc_map, config
+    ):
+        out = []
+        for friendly in friendly_names:
+            if isinstance(friendly, dict):
+                key = friendly["key"]
+                if key not in config:
+                    continue
+                entry = {
+                    "key": key,
+                    "label": friendly.get("label", ""),
+                    "description": friendly.get("description", ""),
+                    "value": config.get(key),
+                    "type": friendly.get("type", "text"),
+                }
+                if "options" in friendly:
+                    entry["options"] = friendly["options"]
+                out.append(entry)
+            else:
+                key = key_by_friendly.get(friendly)
+                if not key or key not in config:
+                    continue
+                out.append(
+                    self._serialize_setting(
+                        key,
+                        friendly,
+                        name_map,
+                        desc_map,
+                        config.get(key),
+                    )
+                )
+        return out
+
+    @staticmethod
+    def _serialize_setting(key, friendly, name_map, desc_map, value):
+        from . import settings_schema
+
+        entry = {
+            "key": key,
+            "label": friendly,
+            "description": desc_map.get(key, ""),
+            "value": value,
+        }
+
+        if key == "battle.auto_catch_wishlist":
+            entry["type"] = "wishlist"
+            from ..functions.pokedex_functions import get_pretty_name_for_id
+            names_dict = {}
+            if isinstance(value, list):
+                for pid in value:
+                    try:
+                        pid_int = int(pid)
+                        names_dict[pid_int] = get_pretty_name_for_id(pid_int)
+                    except Exception:
+                        names_dict[pid] = f"#{pid}"
+            entry["names"] = names_dict
+            return entry
+        if key == "misc.active_region":
+            entry["type"] = "select"
+            entry["options"] = settings_schema.ACTIVE_REGION_OPTIONS
+        elif isinstance(value, bool):
+            entry["type"] = "boolean"
+        elif isinstance(value, int):
+            entry["type"] = "int"
+        elif isinstance(value, float):
+            entry["type"] = "float"
+        else:
+            entry["type"] = "text"
+        return entry
+
+    def _load_lang_json(self, filename):
+        import json as _json
+
+        cache_attr = f"_lang_{filename.replace('.', '_')}_cache"
+        cached = getattr(self, cache_attr, None)
+        if cached is not None:
+            return cached
+        path = self.addon_dir / "lang" / filename
+        try:
+            with open(path, "r", encoding="utf-8") as f:
+                data = _json.load(f)
+        except (OSError, _json.JSONDecodeError):
+            data = {}
+        setattr(self, cache_attr, data)
+        return data
+
+    def handle_save_settings(self, payload):
+        """Apply the JS-side payload, run legacy bounds checks, persist."""
+        from . import settings_schema
+
+        if not isinstance(payload, dict):
+            return {"ok": False, "message": "Invalid payload."}
+
+        settings_obj = self.shop_manager.settings_obj
+        try:
+            config = settings_obj.load_config()
+        except Exception:
+            config = dict(settings_obj.config)
+
+        # Snapshot what's on disk so we can skip writes for unchanged keys
+        # after clamping (avoids spurious observer notifications).
+        original_config = dict(config)
+
+        # Coerce incoming values back to the type of the existing config
+        # entry so e.g. an int field doesn't silently become a string.
+        try:
+            for raw_key, raw_val in payload.items():
+                key = str(raw_key)
+                if key not in config:
+                    continue
+                config[key] = self._coerce_incoming(config[key], raw_val)
+        except ValueError as e:
+            return {"ok": False, "message": f"Validation error: {e}"}
+
+        config, adjustments = settings_schema.validate_and_clamp(config)
+
+        try:
+            changed = False
+            for key, val in config.items():
+                if original_config.get(key) != val:
+                    settings_obj.set(key, val)
+                    changed = True
+            if changed:
+                # Settings.save_config(config) requires the dict — passing
+                # the fully-merged config persists every key in one write.
+                settings_obj.save_config(config)
+        except Exception as e:
+            return {"ok": False, "message": f"Save failed: {e}"}
+
+        self._refresh_reviewer_hotkeys(config)
+
+        if adjustments:
+            return {
+                "ok": True,
+                "message": "Saved (with adjustments).",
+                "adjustments": adjustments,
+            }
+        return {"ok": True, "message": "Settings saved."}
+
+    @staticmethod
+    def _coerce_incoming(existing, incoming):
+        """Match the new value's type to the existing config entry so a
+        text-input UI doesn't accidentally rewrite an int field as a str.
+        Raises ValueError for non-coercible numeric input — caller surfaces
+        the failure rather than silently writing garbage to config."""
+        if isinstance(existing, list):
+            if isinstance(incoming, list):
+                # Accept only integer IDs; silently drop anything non-numeric.
+                return [int(x) for x in incoming if str(x).lstrip('-').isdigit()]
+            return existing  # reject non-list payloads silently
+        if isinstance(existing, bool):
+            return bool(incoming)
+        if isinstance(existing, int) and not isinstance(existing, bool):
+            try:
+                return int(incoming)
+            except (TypeError, ValueError):
+                # Range strings (e.g. "1-3" for cards_per_round) pass through;
+                # validate_and_clamp's _coerce_cards_per_round normalizes them.
+                if isinstance(incoming, str) and "-" in incoming:
+                    return incoming
+                raise ValueError(f"Expected integer, got {incoming!r}")
+        if isinstance(existing, float):
+            try:
+                return float(incoming)
+            except (TypeError, ValueError):
+                raise ValueError(f"Expected float, got {incoming!r}")
+        if existing is None:
+            # active_region accepts None or a string region name
+            return incoming if incoming not in ("", None, "None") else None
+        return incoming if incoming is None else str(incoming)
+
+    @staticmethod
+    def _refresh_reviewer_hotkeys(config):
+        try:
+            from ..reviewer_ui import setup_reviewer_ui
+
+            setup_reviewer_ui(
+                config.get("controls.catch_key", "6"),
+                config.get("controls.defeat_key", "5"),
+                config.get("controls.pokemon_buttons", True),
+                config.get("controls.team_cycle_key", "9"),
+            )
+        except Exception:
+            # Best-effort — settings still saved even if the hook fails.
+            pass
+
+
+# _attribute_xp_and_evs_to_companion has been moved to functions.mobile_sync
+

--- a/src/Ankimon/ankimon_profile_web/profile.css
+++ b/src/Ankimon/ankimon_profile_web/profile.css
@@ -1,0 +1,1058 @@
+/* Profile shell — self-contained styles for the Trainer Card + Team screens.
+ * Theme tokens are copied from ankimon_items_web/shop.css so the Profile shell
+ * stays visually identical to the rest of the addon while remaining an
+ * independent module (no cross-import of the Items shell's CSS). */
+
+:root {
+    --bg-darker: #080a0c;
+    --bg-dark: #0d1117;
+    --bg-card: #161b22;
+    --bg-card-hover: #21262d;
+    --border-main: #30363d;
+    --text-main: #c9d1d9;
+    --text-muted: #8b949e;
+    --text-bright: #ffffff;
+    --accent-blue: #58a6ff;
+    --accent-red: #f85149;
+    --accent-gold: #d29922;
+    --accent-green: #3fb950;
+
+    --sidebar-width: 260px;
+    --transition-fast: 0.15s ease;
+}
+
+* {
+    box-sizing: border-box;
+    margin: 0;
+    padding: 0;
+}
+
+html { background: var(--bg-dark); }
+
+body {
+    font-family: 'Outfit', sans-serif;
+    background: var(--bg-dark);
+    color: var(--text-main);
+    height: 100vh;
+    overflow: hidden;
+}
+
+.app-container {
+    display: flex;
+    height: 100vh;
+    background: var(--bg-dark);
+}
+
+/* ---------------- Sidebar ---------------- */
+.sidebar {
+    width: var(--sidebar-width);
+    flex-shrink: 0;
+    background: var(--bg-darker);
+    border-right: 1px solid var(--border-main);
+    display: flex;
+    flex-direction: column;
+}
+
+.sidebar-header { padding: 24px; }
+.sidebar-body { padding: 8px 16px; flex: 1; overflow-y: auto; }
+.sidebar-footer { padding: 16px; border-top: 1px solid var(--border-main); }
+
+.app-logo {
+    width: 32px;
+    height: 32px;
+    filter: drop-shadow(0 0 10px rgba(255, 255, 255, 0.2));
+}
+
+/* Little summary cards in the sidebar footer (cash, league, etc.) */
+.stat-pill {
+    background: var(--bg-card);
+    border: 1px solid var(--border-main);
+    border-radius: 12px;
+    padding: 12px 14px;
+    margin-bottom: 10px;
+}
+.stat-pill-label {
+    font-size: 0.7rem;
+    text-transform: uppercase;
+    letter-spacing: 0.6px;
+    color: var(--text-muted);
+}
+.stat-pill-value {
+    font-size: 1.05rem;
+    font-weight: 800;
+    color: var(--text-bright);
+    margin-top: 2px;
+}
+
+/* ---------------- Main content ---------------- */
+.main-content {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+}
+.top-bar {
+    height: 64px;
+    flex-shrink: 0;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 0 24px;
+    border-bottom: 1px solid var(--border-main);
+}
+.top-bar h2 { font-size: 1.15rem; font-weight: 800; color: var(--text-bright); }
+/* Profile drops its (redundant) title — keep the bar as a borderless spacer so
+   the content still lines up with the sidebar rail. */
+.top-bar-blank { border-bottom: none; }
+.content-scroll { flex: 1; overflow-y: auto; padding: 24px; }
+
+/* ---------------- Buttons ---------------- */
+.btn {
+    font-family: inherit;
+    font-size: 0.85rem;
+    font-weight: 700;
+    border-radius: 9px;
+    padding: 9px 16px;
+    border: 1px solid var(--border-main);
+    background: var(--bg-card);
+    color: var(--text-main);
+    cursor: pointer;
+    transition: var(--transition-fast);
+}
+.btn:hover { background: var(--bg-card-hover); color: var(--text-bright); }
+.btn-primary {
+    background: var(--accent-blue);
+    border-color: var(--accent-blue);
+    color: #06111f;
+}
+.btn-primary:hover { filter: brightness(1.08); background: var(--accent-blue); }
+.btn-primary:disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
+    filter: none;
+}
+.btn-danger { color: var(--accent-red); border-color: rgba(248, 81, 73, 0.4); }
+.btn-danger:hover { background: rgba(248, 81, 73, 0.12); color: var(--accent-red); }
+
+/* ---------------- Trainer Card screen ---------------- */
+.card-shell {
+    max-width: 760px;
+    margin: 0 auto;
+    display: grid;
+    grid-template-columns: 260px 1fr;
+    gap: 24px;
+}
+.card-portrait {
+    background: linear-gradient(160deg, var(--bg-card), var(--bg-darker));
+    border: 1px solid var(--border-main);
+    border-radius: 18px;
+    padding: 20px;
+    text-align: center;
+}
+.card-portrait img {
+    width: 180px;
+    height: 180px;
+    object-fit: contain;
+    image-rendering: pixelated;
+    border: 2px solid var(--accent-blue);
+    border-radius: 14px;
+    background: var(--bg-dark);
+}
+.card-portrait .no-sprite {
+    width: 180px;
+    height: 180px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border: 2px dashed var(--border-main);
+    border-radius: 14px;
+    color: var(--text-muted);
+    font-size: 0.8rem;
+    margin: 0 auto;
+}
+.card-name { font-size: 1.4rem; font-weight: 900; color: var(--text-bright); margin-top: 14px; }
+.card-handle { color: var(--text-muted); font-size: 0.85rem; }
+
+.card-info { display: flex; flex-direction: column; gap: 14px; }
+.card-row {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    background: var(--bg-card);
+    border: 1px solid var(--border-main);
+    border-radius: 12px;
+    padding: 12px 16px;
+}
+.card-row-label { color: var(--text-muted); font-size: 0.8rem; text-transform: uppercase; letter-spacing: 0.5px; }
+.card-row-value { color: var(--text-bright); font-weight: 700; }
+
+/* XP bar */
+.xp-track {
+    height: 10px;
+    background: var(--bg-darker);
+    border: 1px solid var(--border-main);
+    border-radius: 99px;
+    overflow: hidden;
+    margin-top: 8px;
+}
+.xp-fill {
+    height: 100%;
+    background: linear-gradient(90deg, var(--accent-blue), var(--accent-green));
+    transition: width 0.4s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+/* Current-team strip on the card */
+.team-strip { display: flex; gap: 10px; flex-wrap: wrap; margin-top: 6px; }
+.team-chip {
+    width: 64px;
+    text-align: center;
+}
+.team-chip img {
+    width: 56px; height: 56px; object-fit: contain; image-rendering: pixelated;
+    background: var(--bg-card); border: 1px solid var(--border-main); border-radius: 10px;
+}
+.team-chip span { display: block; font-size: 0.65rem; color: var(--text-muted); margin-top: 2px; }
+.team-empty { color: var(--text-muted); font-size: 0.85rem; font-style: italic; }
+
+/* ---------------- Team builder screen ---------------- */
+/* Fills width (capped) + height like the Profile dashboard. 6 slots = 3×2; the
+   rows grow on tall windows so the cards (and sprites) scale up. */
+.team-grid {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    grid-auto-rows: minmax(210px, 1fr);
+    gap: 16px;
+    max-width: 1120px;
+    width: 100%;
+    min-height: 100%;
+    margin: 0 auto;
+}
+@media (max-width: 720px) {
+    .team-grid { grid-template-columns: repeat(2, 1fr); }
+}
+.slot {
+    position: relative;
+    background: linear-gradient(160deg, var(--bg-card), var(--bg-darker));
+    border: 1px solid var(--border-main);
+    border-radius: 16px;
+    padding: 14px;
+    display: flex; flex-direction: column; align-items: center; justify-content: center;
+    gap: 8px; min-height: 0;
+    transition: var(--transition-fast);
+}
+.slot.filled { cursor: pointer; }
+.slot.filled:hover {
+    border-color: var(--accent-blue);
+    transform: translateY(-2px);
+    box-shadow: 0 12px 26px rgba(0, 0, 0, 0.4);
+}
+.slot.empty { border-style: dashed; cursor: pointer; }
+.slot.empty:hover { border-color: var(--accent-blue); background: var(--bg-card); }
+.slot.xp-share {
+    border-color: rgba(210, 153, 34, 0.6);
+    box-shadow: 0 0 0 1px rgba(210, 153, 34, 0.45) inset;
+}
+
+.slot-num { position: absolute; top: 10px; left: 12px; font-size: 0.66rem; font-weight: 700; color: var(--text-muted); }
+.slot-rotation-badge {
+    margin-left: 5px;
+    font-size: 0.8rem;
+    color: var(--accent-blue);
+    vertical-align: middle;
+    cursor: help;
+    text-shadow: 0 0 5px rgba(88, 166, 255, 0.4);
+}
+.slot-corner {
+    position: absolute; top: 8px; width: 26px; height: 26px;
+    display: flex; align-items: center; justify-content: center;
+    border-radius: 8px; border: 1px solid var(--border-main);
+    background: rgba(0, 0, 0, 0.35); color: var(--text-muted);
+    cursor: pointer; font-size: 0.85rem; line-height: 1; transition: var(--transition-fast);
+    z-index: 2;
+    opacity: 0; pointer-events: none;   /* hidden until the slot is hovered/focused */
+}
+/* Reveal both corner buttons on hover or keyboard focus within the slot. */
+.slot.filled:hover .slot-corner,
+.slot.filled:focus-within .slot-corner,
+.slot-corner:focus-visible { opacity: 1; pointer-events: auto; }
+.slot-corner:hover { color: var(--text-bright); border-color: var(--accent-blue); background: var(--bg-card-hover); }
+.slot-remove { right: 8px; }
+.slot-remove:hover { color: var(--accent-red); border-color: rgba(248, 81, 73, 0.5); }
+.slot-star { right: 40px; }
+/* The active XP-Share star stays visible even when the slot isn't hovered. With
+   the ✕ hidden, park it in the top-right corner (where the ✕ would sit) so it
+   doesn't look stranded; it slides back beside the ✕ once the slot is hovered. */
+.slot-star.on { color: var(--accent-gold); border-color: rgba(210, 153, 34, 0.6); background: rgba(210, 153, 34, 0.14); opacity: 1; pointer-events: auto; right: 8px; }
+.slot.filled:hover .slot-star.on,
+.slot.filled:focus-within .slot-star.on { right: 40px; }
+
+.slot-sprite-wrap {
+    flex: 1 1 auto; min-height: 80px; max-height: 148px; width: 100%;
+    position: relative; display: flex; align-items: center; justify-content: center;
+    margin-top: 8px;
+}
+.slot-sprite-wrap img {
+    position: absolute; inset: 0; width: 100%; height: 100%;
+    object-fit: contain; image-rendering: pixelated;
+    filter: drop-shadow(0 5px 9px rgba(0, 0, 0, 0.45));
+}
+.slot-name {
+    font-weight: 800; color: var(--text-bright); text-align: center; font-size: 0.95rem;
+    white-space: nowrap; overflow: hidden; text-overflow: ellipsis; max-width: 100%;
+}
+.slot-types { display: flex; gap: 5px; flex-wrap: wrap; justify-content: center; }
+.type-badge {
+    font-size: 0.6rem; font-weight: 800; text-transform: uppercase; letter-spacing: 0.4px;
+    color: #fff; padding: 2px 8px; border-radius: 999px;
+    text-shadow: 0 1px 1px rgba(0, 0, 0, 0.4);
+}
+.slot-stats { display: flex; gap: 14px; }
+.slot-stat { display: flex; flex-direction: column; align-items: center; }
+.slot-stat .v { font-size: 0.92rem; font-weight: 800; color: var(--text-bright); line-height: 1; }
+.slot-stat .k { font-size: 0.55rem; text-transform: uppercase; letter-spacing: 0.5px; color: var(--text-muted); margin-top: 3px; }
+
+.slot-empty-icon { font-size: 2.4rem; color: var(--border-main); line-height: 1; }
+.slot-empty-label { font-weight: 700; color: var(--text-muted); font-size: 0.88rem; }
+.slot-empty-sub { font-size: 0.72rem; color: var(--text-muted); }
+
+.slot-switch-hint {
+    position: absolute; left: 0; right: 0; bottom: 0;
+    padding: 7px; text-align: center;
+    font-size: 0.66rem; font-weight: 700; color: var(--accent-blue);
+    background: linear-gradient(to top, var(--bg-darker), transparent);
+    border-radius: 0 0 16px 16px;
+    opacity: 0; transition: opacity 0.15s; pointer-events: none;
+}
+.slot.filled:hover .slot-switch-hint { opacity: 1; }
+
+/* Team overview sidebar */
+/* Summary stat tiles: two small (Pokémon, Avg Level) + a full-width Total CP
+   hero. */
+.team-summary {
+    display: grid; grid-template-columns: 1fr 1fr; gap: 8px;
+    margin-bottom: 16px;
+}
+.ts-tile {
+    background: var(--bg-card); border: 1px solid var(--border-main);
+    border-radius: 12px; padding: 11px 13px;
+}
+.ts-tile .tv { font-size: 1.2rem; font-weight: 900; color: var(--text-bright); line-height: 1; }
+.ts-tile .tk {
+    font-size: 0.6rem; text-transform: uppercase; letter-spacing: 0.6px;
+    color: var(--text-muted); font-weight: 700; margin-top: 6px;
+}
+.ts-tile.hero {
+    grid-column: 1 / -1;
+    background: linear-gradient(135deg, rgba(88, 166, 255, 0.13), var(--bg-card));
+    border-color: rgba(88, 166, 255, 0.3);
+}
+.ts-tile.hero .tv { font-size: 1.75rem; }
+.ts-tile.hero .tk { color: var(--accent-blue); }
+.ts-section { margin-bottom: 16px; }
+.ts-section-title {
+    font-size: 0.66rem; text-transform: uppercase; letter-spacing: 0.6px;
+    color: var(--text-muted); font-weight: 700; margin-bottom: 9px;
+}
+/* Fill the column's height: summary pinned top, the type-analysis block grows
+   to fill, XP Share sits just above Save. Rather than stretch the gaps between
+   sections, the chips THEMSELVES scale with viewport height (see
+   `.type-coverage` below), so they grow to occupy the space on tall screens. */
+.team-rail { display: flex; flex-direction: column; }
+.ts-analysis {
+    flex: 1 0 auto;
+    display: flex; flex-direction: column; justify-content: space-between;
+    gap: clamp(16px, 1.8vh, 26px);
+}
+.ts-analysis .ts-section { margin-bottom: 0; }
+.ts-xpshare { margin-bottom: 16px; }   /* sits between the summary and the analysis */
+.ts-cycle { margin-bottom: 16px; }
+.cycle-select {
+    width: 100%;
+    background: var(--bg-card);
+    border: 1px solid var(--border-main);
+    color: var(--text-main);
+    padding: 9px 12px;
+    border-radius: 9px;
+    font-family: inherit;
+    font-size: 0.82rem;
+    font-weight: 600;
+    cursor: pointer;
+    transition: var(--transition-fast);
+    outline: none;
+    appearance: none;
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 12 12'%3E%3Cpath fill='%238b949e' d='M2 4.5l4 4 4-4'/%3E%3C/svg%3E");
+    background-repeat: no-repeat;
+    background-position: right 12px center;
+}
+.cycle-select:hover {
+    border-color: var(--accent-blue);
+    background-color: var(--bg-card-hover);
+}
+.cycle-select:focus {
+    border-color: var(--accent-blue);
+    box-shadow: 0 0 0 2px rgba(88, 166, 255, 0.15);
+}
+
+/* XP Share holder — a gold-tinted mini-card with the holder's sprite. */
+/* Vertical, whole-card-pressable (like a team slot): the sprite sits directly on
+   the card (no inner frame), the name shows in full, and "Change" is a
+   hover-revealed hint at the bottom. */
+.xps-card {
+    position: relative;
+    display: flex; flex-direction: column; align-items: center; text-align: center;
+    gap: 8px;
+    background: linear-gradient(160deg, rgba(210, 153, 34, 0.12), var(--bg-card));
+    border: 1px solid rgba(210, 153, 34, 0.4);
+    border-radius: 12px; padding: 16px 12px 22px;
+    cursor: pointer; transition: var(--transition-fast);
+}
+.xps-card:hover {
+    border-color: var(--accent-gold);
+    transform: translateY(-2px);
+    box-shadow: 0 10px 22px rgba(0, 0, 0, 0.35);
+}
+.xps-sprite {
+    width: 72px; height: 72px; flex-shrink: 0;
+    object-fit: contain; image-rendering: pixelated;
+    filter: drop-shadow(0 4px 8px rgba(0, 0, 0, 0.45));
+}
+.xps-name {
+    font-weight: 800; color: var(--text-bright); font-size: 0.98rem;
+    line-height: 1.2; word-break: break-word;
+}
+.xps-lv { font-size: 0.74rem; color: var(--accent-gold); font-weight: 700; margin-top: 3px; }
+.xps-change-hint {
+    position: absolute; left: 0; right: 0; bottom: 0;
+    padding: 7px; text-align: center;
+    font-size: 0.66rem; font-weight: 800; color: var(--accent-gold);
+    text-transform: uppercase; letter-spacing: 0.4px;
+    background: linear-gradient(to top, var(--bg-darker), transparent);
+    border-radius: 0 0 12px 12px;
+    opacity: 0; transition: opacity 0.15s; pointer-events: none;
+}
+.xps-card:hover .xps-change-hint { opacity: 1; }
+.xps-empty {
+    width: 100%; background: var(--bg-card); border: 1px dashed var(--border-main);
+    color: var(--text-muted); font-family: inherit; font-size: 0.82rem; font-weight: 700;
+    padding: 13px; border-radius: 12px; cursor: pointer; transition: var(--transition-fast);
+}
+.xps-empty:hover { border-color: var(--accent-gold); color: var(--text-bright); }
+/* Sidebar chips fill the column on tall screens by growing VERTICALLY — taller
+   pills (scaled top/bottom padding) + bigger row gaps — while font size and
+   horizontal padding stay fixed so the wrapping (chips-per-row) never changes.
+   That keeps the height predictable (no accidental overflow) as it scales.
+   Scoped to .type-coverage; the per-card .type-badge is untouched. */
+.type-coverage { display: flex; flex-wrap: wrap; column-gap: 8px; row-gap: clamp(6px, calc(1.6vh - 10px), 18px); }
+.type-coverage .type-badge {
+    font-size: 0.66rem;
+    /* calc(vh − offset): the steep slope + large offset keep pills compact at
+       ~1040px (≈4.5px, no overflow) but climb fast on taller screens so they
+       grow to fill the column, capped at 20px. */
+    padding: clamp(4px, calc(2.3vh - 19.5px), 20px) 12px;
+}
+.coverage-empty { font-size: 0.78rem; color: var(--text-muted); font-style: italic; }
+/* weakness chip count — how many team members are weak to that type */
+.wk-count {
+    margin-left: 5px; padding: 0 5px;
+    background: rgba(0, 0, 0, 0.38); border-radius: 999px;
+    font-size: 0.9em; font-weight: 800;
+}
+
+/* Roster picker modal */
+.modal-overlay {
+    position: fixed; inset: 0;
+    background: rgba(1, 4, 9, 0.72);
+    display: flex; align-items: center; justify-content: center;
+    z-index: 500;
+}
+.modal-overlay.hidden { display: none; }
+.modal {
+    width: min(560px, 92vw);
+    max-height: 80vh;
+    background: var(--bg-card);
+    border: 1px solid var(--border-main);
+    border-radius: 16px;
+    display: flex; flex-direction: column;
+    overflow: hidden;
+}
+.modal-head {
+    padding: 16px 18px;
+    border-bottom: 1px solid var(--border-main);
+    display: flex; align-items: center; gap: 10px;
+}
+.modal-head h3 { flex: 1; font-size: 1rem; color: var(--text-bright); }
+.modal-search {
+    width: 100%;
+    background: var(--bg-darker);
+    border: 1px solid var(--border-main);
+    border-radius: 9px;
+    color: var(--text-main);
+    padding: 9px 12px;
+    font-family: inherit;
+    font-size: 0.85rem;
+    margin: 12px 18px 0;
+    width: calc(100% - 36px);
+}
+.modal-search:focus { outline: none; border-color: var(--accent-blue); }
+.roster-list { overflow-y: auto; padding: 12px 18px 18px; display: flex; flex-direction: column; gap: 6px; }
+.roster-row {
+    display: flex; align-items: center; gap: 12px;
+    background: var(--bg-darker);
+    border: 1px solid var(--border-main);
+    border-radius: 10px;
+    padding: 8px 12px;
+    cursor: pointer;
+    transition: var(--transition-fast);
+}
+.roster-row:hover { background: var(--bg-card-hover); border-color: var(--accent-blue); }
+.roster-row img { width: 44px; height: 44px; object-fit: contain; image-rendering: pixelated; }
+.roster-row .r-name { flex: 1; font-weight: 700; color: var(--text-bright); }
+.roster-row .r-meta { font-size: 0.75rem; color: var(--text-muted); }
+.roster-row.in-team { opacity: 0.45; pointer-events: none; }
+.roster-row.current { border-color: var(--accent-gold); box-shadow: 0 0 0 1px var(--accent-gold) inset; }
+.shiny-dot { color: var(--accent-gold); font-size: 0.8rem; }
+
+/* Roster picker: fixed-size wide modal + search/filter toolbar + a card grid
+   (mirrors the sprite picker). */
+.picker-modal { width: min(900px, 95vw); height: min(760px, 86vh); }
+.picker-toolbar {
+    display: flex; align-items: center; gap: 10px;
+    padding: 14px 18px;
+    border-bottom: 1px solid var(--border-main);
+    flex-shrink: 0;
+}
+.picker-toolbar .modal-search { margin: 0; width: auto; flex: 1; min-width: 120px; }
+.picker-body {
+    flex: 1; min-height: 0; overflow-y: auto;
+    padding: 16px 18px 18px;
+    display: flex; flex-direction: column;
+}
+.picker-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(148px, 1fr));
+    gap: 12px;
+    flex: 0 0 auto; align-content: start;
+}
+.roster-card {
+    position: relative;
+    background: var(--bg-darker); border: 1px solid var(--border-main);
+    border-radius: 12px; padding: 12px 10px 10px;
+    display: flex; flex-direction: column; align-items: center; gap: 6px;
+    text-align: center; cursor: pointer; transition: var(--transition-fast);
+}
+.roster-card:hover {
+    border-color: var(--accent-blue); background: var(--bg-card);
+    transform: translateY(-2px); box-shadow: 0 10px 22px rgba(0, 0, 0, 0.35);
+}
+.roster-card.in-team { opacity: 0.4; pointer-events: none; }
+.roster-card.current { border-color: var(--accent-gold); box-shadow: 0 0 0 1px var(--accent-gold) inset; }
+.rc-sprite {
+    width: 60px; height: 60px; object-fit: contain; image-rendering: pixelated;
+    filter: drop-shadow(0 3px 6px rgba(0, 0, 0, 0.4));
+}
+.rc-name {
+    font-weight: 800; color: var(--text-bright); font-size: 0.82rem;
+    white-space: nowrap; overflow: hidden; text-overflow: ellipsis; max-width: 100%;
+}
+.rc-types { display: flex; gap: 4px; flex-wrap: wrap; justify-content: center; }
+.rc-stats { display: flex; gap: 4px; align-items: baseline; font-size: 0.66rem; color: var(--text-muted); }
+.rc-stats .rc-cp { color: var(--text-bright); font-weight: 800; }
+.rc-tag { font-size: 0.6rem; font-weight: 700; text-transform: uppercase; letter-spacing: 0.4px; color: var(--text-muted); }
+.icon-btn {
+    background: transparent; border: none; color: var(--text-muted);
+    font-size: 1.3rem; cursor: pointer; line-height: 1;
+}
+.icon-btn:hover { color: var(--text-bright); }
+
+/* ---------------- Trainer Sprite picker ---------------- */
+.bar-search {
+    background: var(--bg-darker);
+    border: 1px solid var(--border-main);
+    border-radius: 9px;
+    color: var(--text-main);
+    padding: 8px 12px;
+    font-family: inherit;
+    font-size: 0.85rem;
+    width: 240px;
+}
+.bar-search:focus { outline: none; border-color: var(--accent-blue); }
+
+.sprite-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(104px, 1fr));
+    gap: 12px;
+    flex: 0 0 auto;          /* keep natural height; the body scrolls */
+    align-content: start;
+}
+.sprite-card {
+    background: var(--bg-card);
+    border: 1px solid var(--border-main);
+    border-radius: 12px;
+    padding: 12px 10px;
+    text-align: center;
+    cursor: pointer;
+    transition: var(--transition-fast);
+}
+.sprite-card:hover { background: var(--bg-card-hover); border-color: var(--accent-blue); }
+.sprite-card.selected {
+    border-color: var(--accent-blue);
+    box-shadow: 0 0 0 2px var(--accent-blue) inset;
+}
+.sprite-card img {
+    width: 90px; height: 90px;
+    object-fit: contain;
+    image-rendering: pixelated;
+}
+.sprite-card .sprite-label {
+    font-size: 0.72rem;
+    color: var(--text-muted);
+    margin-top: 6px;
+    display: block;
+    word-break: break-word;
+}
+.sprite-card.selected .sprite-label { color: var(--text-bright); font-weight: 700; }
+
+/* ---------------- Profile dashboard ---------------- */
+.profile-page {
+    width: 100%;
+    min-height: 100%;          /* fill the scroll viewport so panels can grow */
+    display: flex;
+    flex-direction: column;
+    gap: 18px;
+}
+
+/* Vertical-fill: the two media-grid panels (Team, Recently Caught) grow to
+   absorb slack on tall windows; the stat tiles and badge case keep their
+   natural height. Scoped to .profile-page so the Team screen is untouched. */
+.profile-page > .stat-tiles,
+.profile-page > .panel { flex: 0 0 auto; }
+.profile-page > .panel.panel-fill {
+    /* grow to absorb slack, but never shrink below the grid's natural height
+       (shrinking would let the rows overflow into the panel below). */
+    flex: 1 0 auto;
+    display: flex;
+    flex-direction: column;
+}
+.panel.panel-fill .panel-title { flex: 0 0 auto; }
+.panel.panel-fill .team-showcase {
+    flex: 1 1 auto;
+    align-content: stretch;
+    grid-auto-rows: minmax(124px, 1fr);   /* rows stretch to fill the panel */
+}
+
+/* Sidebar profile rail — trainer identity (avatar, name, league, level/XP) */
+.profile-rail {
+    display: flex; flex-direction: column; align-items: center;
+    gap: 10px; text-align: center; padding: 8px 4px;
+    min-height: 100%; box-sizing: border-box;
+}
+.rail-avatar { cursor: pointer; }
+.rail-avatar img {
+    display: block; margin: 0 auto;
+    width: 180px; height: 180px;
+    object-fit: contain; image-rendering: pixelated;
+    border: 2px solid var(--accent-blue);
+    border-radius: 16px;
+    background: var(--bg-dark);
+    transition: border-color var(--transition-fast);
+}
+.rail-avatar:hover img { border-color: var(--accent-gold); }
+.rail-avatar .no-sprite {
+    width: 180px; height: 180px; margin: 0 auto;
+    display: flex; align-items: center; justify-content: center;
+    border: 2px dashed var(--border-main);
+    border-radius: 16px;
+    color: var(--text-muted); font-size: 0.8rem;
+}
+.rail-avatar .change-hint { margin-top: 10px; }
+.rail-avatar:hover .change-hint { color: var(--accent-gold); border-color: var(--accent-gold); }
+
+.rail-meta { display: flex; flex-direction: column; align-items: center; gap: 10px; width: 100%; flex: 1; }
+.rail-name { font-size: 1.35rem; font-weight: 900; color: var(--text-bright); line-height: 1.1; word-break: break-word; cursor: pointer; border-radius: 8px; outline: none; }
+.rename-hint { margin-left: 6px; font-size: 0.8rem; color: var(--text-muted); opacity: 0; transition: opacity 0.15s ease; vertical-align: middle; }
+.rail-name:hover .rename-hint, .rail-name:focus-visible .rename-hint { opacity: 1; color: var(--accent-gold); }
+.rail-name-input { font-size: 1.35rem; font-weight: 900; color: var(--text-bright); font-family: inherit; text-align: center; background: var(--bg-darker); border: 1px solid var(--accent-blue); border-radius: 8px; padding: 2px 10px; width: 100%; max-width: 220px; outline: none; box-sizing: border-box; }
+.league-chip {
+    display: inline-flex; align-items: center; gap: 6px;
+    background: rgba(210, 153, 34, 0.12);
+    border: 1px solid rgba(210, 153, 34, 0.5);
+    color: var(--accent-gold);
+    font-size: 0.74rem; font-weight: 800;
+    text-transform: uppercase; letter-spacing: 0.5px;
+    padding: 4px 12px; border-radius: 99px;
+}
+.rail-xp { width: 100%; margin-top: auto; padding-top: 16px; border-top: 1px solid var(--border-main); }
+.rail-xp-head { display: flex; justify-content: center; margin-bottom: 7px; }
+.rail-xp-level { font-weight: 800; color: var(--text-bright); font-size: 0.85rem; }
+.rail-xp-val { color: var(--text-muted); font-size: 0.72rem; margin-top: 7px; }
+.rail-xp-next { color: var(--accent-blue); font-size: 0.7rem; font-weight: 600; margin-top: 5px; }
+
+.rail-divider { width: 100%; height: 1px; background: var(--border-main); margin: 4px 0; }
+/* Featured Pokémon — plain (no card). The sprites flex-grow with the rail's
+   height so they scale up on taller windows (capped below the avatar so the
+   trainer sprite stays the hero) and shrink to fit shorter ones. */
+.rail-info {
+    width: 100%; flex: 1;
+    display: flex; flex-direction: column; align-items: center;
+    gap: 8px; padding: 4px 0;
+}
+.rail-poke {
+    flex: 1; min-height: 0; width: 100%;
+    display: flex; flex-direction: column; align-items: center; justify-content: center;
+    gap: 6px; text-align: center;
+}
+.rail-poke-sprite {
+    flex: 1; min-height: 52px; max-height: 130px; width: 100%;
+    position: relative;
+    display: flex; align-items: center; justify-content: center;
+}
+/* Absolute so the sprite fills the flex-allocated area without feeding its
+   intrinsic size back into the layout. */
+.rail-poke-sprite img {
+    position: absolute; inset: 0;
+    width: 100%; height: 100%;
+    object-fit: contain; image-rendering: pixelated;
+    filter: drop-shadow(0 4px 8px rgba(0, 0, 0, 0.4));
+}
+.rail-poke-sprite svg { width: auto; height: 56px; max-height: 70%; }
+.rail-poke-name { font-size: 0.95rem; font-weight: 800; color: var(--text-bright); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; max-width: 100%; }
+.rail-poke-label { font-size: 0.6rem; text-transform: uppercase; letter-spacing: 0.5px; color: var(--text-muted); }
+
+/* Stat tiles (collection rundown across the top of the dashboard) */
+.stat-tiles {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+    gap: 14px;
+}
+.stat-tile {
+    background: var(--bg-card);
+    border: 1px solid var(--border-main);
+    border-radius: 14px;
+    padding: 15px 18px;
+}
+.stat-tile .st-value { font-size: 1.5rem; font-weight: 900; color: var(--text-bright); line-height: 1; }
+.stat-tile .st-label {
+    font-size: 0.7rem; text-transform: uppercase; letter-spacing: 0.5px;
+    color: var(--text-muted); margin-top: 7px;
+}
+
+/* Panels (info / team / badges) */
+.panel {
+    background: var(--bg-card);
+    border: 1px solid var(--border-main);
+    border-radius: 16px;
+    padding: 16px 18px;
+}
+.panel-title {
+    font-size: 0.72rem; text-transform: uppercase; letter-spacing: 0.6px;
+    color: var(--text-muted); font-weight: 700;
+    display: flex; align-items: center; justify-content: space-between;
+    margin-bottom: 12px;
+}
+.panel-title .count { color: var(--accent-blue); font-weight: 800; }
+.profile-cols { display: grid; grid-template-columns: 1fr 1fr; gap: 18px; align-items: start; }
+@media (max-width: 720px) {
+    .profile-cols { grid-template-columns: 1fr; }
+    .hero-card { grid-template-columns: 1fr; }
+}
+
+/* Info rows */
+.info-row {
+    display: flex; justify-content: space-between; align-items: baseline; gap: 12px;
+    padding: 10px 0; border-bottom: 1px solid var(--border-main);
+}
+.info-row:last-child { border-bottom: none; }
+.info-row .k { color: var(--text-muted); font-size: 0.85rem; }
+.info-row .v { color: var(--text-bright); font-weight: 700; text-align: right; }
+
+/* Team showcase */
+.team-showcase { display: grid; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); gap: 12px; }
+.team-mini {
+    position: relative;
+    background: var(--bg-darker); border: 1px solid var(--border-main);
+    border-radius: 12px; padding: 14px 8px; text-align: center;
+    display: flex; flex-direction: column; align-items: center; gap: 6px;
+    min-height: 128px; justify-content: center;
+}
+.team-mini.empty { border-style: dashed; }
+/* Sprite area flex-grows so the sprite scales up on taller cards (capped) and
+   stays compact on short ones — same trick as the sidebar rail. */
+.tm-sprite {
+    flex: 1 1 auto; min-height: 60px; max-height: 136px; width: 100%;
+    position: relative;
+    display: flex; align-items: center; justify-content: center;
+}
+.tm-sprite img {
+    position: absolute; inset: 0;
+    width: 100%; height: 100%;
+    object-fit: contain; image-rendering: pixelated;
+}
+.team-mini .tm-name { font-size: 0.82rem; font-weight: 700; color: var(--text-bright); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; max-width: 100%; }
+.team-mini .tm-lv { font-size: 0.72rem; color: var(--text-muted); }
+.team-mini .tm-empty { font-size: 1.8rem; color: var(--border-main); }
+.manage-link {
+    background: transparent; border: none; color: var(--accent-blue);
+    font-family: inherit; font-size: 0.74rem; font-weight: 700; cursor: pointer; padding: 0;
+}
+.manage-link:hover { text-decoration: underline; }
+
+/* New-catch enter animation — played on the card pushed live into the
+   Recently Caught list when a Pokémon is caught while this screen is open. */
+@keyframes recent-pop {
+    0%   { opacity: 0; transform: scale(0.8) translateY(10px); }
+    55%  { opacity: 1; transform: scale(1.05) translateY(0); }
+    100% { opacity: 1; transform: scale(1); }
+}
+@keyframes recent-ring {
+    0%   { box-shadow: 0 0 0 0 rgba(63, 185, 80, 0.55); border-color: var(--accent-green); }
+    100% { box-shadow: 0 0 0 10px rgba(63, 185, 80, 0); border-color: var(--border-main); }
+}
+@keyframes recent-tag {
+    0%      { opacity: 0; transform: translateY(-4px) scale(0.9); }
+    8%, 86% { opacity: 1; transform: translateY(0) scale(1); }
+    100%    { opacity: 0; transform: translateY(-5px); }
+}
+.team-mini.just-caught {
+    animation: recent-pop 0.5s cubic-bezier(0.22, 1, 0.36, 1),
+               recent-ring 1.3s ease-out 0.12s;
+    z-index: 2;
+}
+.team-mini.just-caught::after {
+    content: 'NEW';
+    position: absolute; top: 11px; right: 11px;
+    background: var(--accent-green); color: #06210d;
+    font-size: 0.54rem; font-weight: 800; letter-spacing: 0.5px;
+    padding: 2px 6px; border-radius: 999px;
+    /* Linger ~4.5s (held visible to 86%, then fades) so the catch is easy to
+       spot; the recent grid isn't re-rendered on stat-only refreshes so the
+       badge runs its full course unless a newer catch supersedes it. */
+    animation: recent-tag 4.5s ease-out forwards;
+}
+
+/* ---------------- Profile: clickable avatar ---------------- */
+.card-portrait.clickable { cursor: pointer; }
+.card-portrait.clickable img,
+.card-portrait.clickable .no-sprite { transition: border-color var(--transition-fast); }
+.card-portrait.clickable:hover img,
+.card-portrait.clickable:hover .no-sprite { border-color: var(--accent-gold); }
+.change-hint {
+    display: inline-block;
+    margin-top: 10px;
+    background: var(--bg-card);
+    border: 1px solid var(--border-main);
+    color: var(--text-muted);
+    font-size: 0.7rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    padding: 4px 12px;
+    border-radius: 99px;
+}
+.card-portrait.clickable:hover .change-hint { color: var(--accent-gold); border-color: var(--accent-gold); }
+
+/* ---------------- Profile: badge case ---------------- */
+.profile-section { max-width: 760px; margin: 28px auto 0; }
+.section-title { font-size: 1rem; font-weight: 800; color: var(--text-bright); margin: 0 0 14px; }
+.section-title .muted { color: var(--text-muted); font-weight: 600; font-size: 0.8rem; }
+.badge-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(84px, 1fr)); gap: 14px; }
+.badge-cell {
+    position: relative;
+    aspect-ratio: 1;
+    background: var(--bg-card);
+    border: 1px solid var(--border-main);
+    border-radius: 14px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+.badge-cell img { width: 62%; height: 62%; object-fit: contain; image-rendering: pixelated; }
+.badge-cell.locked img { filter: grayscale(100%) brightness(0.55); }
+.badge-cell .badge-tip {
+    position: absolute;
+    bottom: calc(100% + 6px);
+    left: 50%;
+    transform: translateX(-50%);
+    background: rgba(0, 0, 0, 0.92);
+    color: #fff;
+    font-size: 0.7rem;
+    padding: 4px 8px;
+    border-radius: 6px;
+    white-space: nowrap;
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.2s;
+    z-index: 5;
+}
+.badge-cell:hover .badge-tip { opacity: 1; }
+
+/* Sprite picker modal body (reuses .modal + .sprite-grid). Flex column so the
+   grid scrolls and the empty state can center; fills the fixed-height modal. */
+.sprite-modal-body {
+    flex: 1; min-height: 0; overflow-y: auto;
+    padding: 16px 22px 18px;
+    display: flex; flex-direction: column;
+}
+
+/* Sprite picker: FIXED-size modal (doesn't resize as you filter) + the
+   Type / Gen / Sex filter rows. */
+#sprite-modal .modal { width: min(960px, 95vw); height: min(760px, 86vh); }
+/* Condensed filters: search + Type / Gen / Sex dropdowns inline in one row. */
+.sprite-toolbar {
+    display: flex; align-items: center; gap: 10px;
+    padding: 14px 22px;
+    border-bottom: 1px solid var(--border-main);
+    flex-shrink: 0;
+}
+.sprite-toolbar .modal-search { margin: 0; width: auto; flex: 1; min-width: 120px; }
+.sprite-count { flex-shrink: 0; font-size: 0.66rem; color: var(--text-muted); white-space: nowrap; }
+
+.filter-select { position: relative; flex-shrink: 0; }
+.fs-trigger {
+    display: flex; align-items: center; gap: 7px;
+    background: var(--bg-darker); border: 1px solid var(--border-main);
+    color: var(--text-muted); font-family: inherit; font-size: 0.78rem; font-weight: 700;
+    padding: 9px 13px; border-radius: 9px; cursor: pointer; white-space: nowrap;
+    transition: var(--transition-fast);
+}
+.fs-trigger:hover { border-color: var(--accent-blue); color: var(--text-bright); }
+.filter-select.active .fs-trigger {
+    border-color: var(--accent-blue); color: var(--text-bright);
+    background: rgba(88, 166, 255, 0.10);
+}
+.fs-chevron { font-size: 0.7rem; color: var(--text-muted); transition: transform 0.2s ease; }
+.filter-select.open .fs-chevron { transform: rotate(180deg); color: var(--accent-blue); }
+.fs-menu {
+    position: absolute; top: calc(100% + 6px); right: 0;
+    min-width: 170px; max-height: 320px; overflow-y: auto;
+    background: linear-gradient(180deg, var(--bg-card), var(--bg-darker));
+    border: 1px solid var(--border-main); border-radius: 10px;
+    padding: 6px; z-index: 50;
+    box-shadow: 0 14px 32px rgba(0, 0, 0, 0.55);
+    display: flex; flex-direction: column; gap: 2px;
+    animation: navMenuPop 0.16s cubic-bezier(0.22, 1, 0.36, 1);
+}
+.fs-option {
+    display: block; width: 100%; text-align: left;
+    background: transparent; border: 1px solid transparent;
+    color: var(--text-main); font-family: inherit; font-size: 0.8rem; font-weight: 600;
+    padding: 7px 10px; border-radius: 7px; cursor: pointer; white-space: nowrap;
+    transition: var(--transition-fast);
+}
+.fs-option:hover { background: var(--bg-card-hover); color: var(--text-bright); }
+.fs-option.active {
+    background: rgba(88, 166, 255, 0.14);
+    border-color: rgba(88, 166, 255, 0.4); color: var(--text-bright);
+}
+.sprite-card .sprite-sub {
+    display: block; margin-top: 2px;
+    font-size: 0.62rem; color: var(--text-muted);
+    white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+}
+.sprite-card.selected .sprite-sub { color: var(--accent-blue); }
+
+/* Empty state — mirrors the Ankidex's (icon + heading + hint + reset). */
+.empty-state {
+    flex: 1;
+    display: flex; flex-direction: column; align-items: center; justify-content: center;
+    padding: 40px 20px; text-align: center; color: var(--text-muted);
+}
+.empty-state h2 { margin: 0 0 12px; line-height: 1.3; color: var(--text-bright); font-size: 1.05rem; }
+.empty-state p { margin: 0 0 24px; line-height: 1.5; }
+.empty-icon {
+    width: 110px; height: 110px; margin: 0 0 22px;
+    background: url('../user_files/sprites/items/poke-doll.png') no-repeat center;
+    background-size: contain;
+    filter: drop-shadow(0 10px 15px rgba(0, 0, 0, 0.3));
+}
+
+/* ---------------- Toast ---------------- */
+.toast {
+    position: fixed;
+    bottom: 22px; left: 50%; transform: translateX(-50%) translateY(20px);
+    background: var(--bg-card);
+    border: 1px solid var(--border-main);
+    color: var(--text-bright);
+    padding: 11px 20px;
+    border-radius: 10px;
+    font-size: 0.85rem; font-weight: 600;
+    box-shadow: 0 12px 30px rgba(0, 0, 0, 0.5);
+    opacity: 0; pointer-events: none;
+    transition: opacity 0.2s ease, transform 0.2s ease;
+    z-index: 600;
+}
+.toast.show { opacity: 1; transform: translateX(-50%) translateY(0); }
+.toast.error { border-color: var(--accent-red); }
+.toast.success { border-color: var(--accent-green); }
+
+/* ---------------- Skeleton ---------------- */
+.skeleton {
+    background: var(--bg-card);
+    border: 1px solid var(--border-main);
+    border-radius: 12px;
+    animation: skeleton-pulse 1.5s ease-in-out infinite;
+}
+@keyframes skeleton-pulse {
+    0%, 100% { opacity: 0.35; }
+    50%      { opacity: 0.6; }
+}
+
+.hidden { display: none !important; }
+
+/* ---------------- Scrollbars (match the dark theme) ----------------
+   Same ::-webkit-scrollbar rules as the Items/Ankidex shells so every screen
+   renders an identical dark scrollbar — the default light one otherwise stands
+   out against the dark UI. */
+::-webkit-scrollbar { width: 8px; height: 8px; }
+::-webkit-scrollbar-track { background: transparent; }
+::-webkit-scrollbar-thumb { background: var(--border-main); border-radius: 10px; }
+::-webkit-scrollbar-thumb:hover { background: var(--text-muted); }
+::-webkit-scrollbar-corner { background: transparent; }
+
+.top-actions {
+    display: flex;
+    align-items: center;
+    gap: 16px;
+}
+#sprite-toggle {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    background: var(--bg-darker);
+    border: 1px solid var(--border-main);
+    color: var(--text-main);
+}
+#sprite-toggle:hover {
+    border-color: var(--accent-blue);
+    background: var(--bg-card);
+}
+
+/* Iframe mode overrides for embedded team page */
+body.in-iframe .sidebar-header {
+    display: none !important;
+}
+body.in-iframe .top-bar {
+    display: none !important;
+}
+
+/* Companion picker mode overrides */
+body.companion-picker-only .app-container {
+    display: none !important;
+}
+body.companion-picker-only #picker {
+    position: absolute;
+    inset: 0;
+    background: transparent;
+    display: flex;
+    align-items: stretch;
+    justify-content: stretch;
+    z-index: 500;
+}
+body.companion-picker-only #picker .picker-modal {
+    width: 100%;
+    height: 100%;
+    max-height: none;
+    border: none;
+    border-radius: 0;
+}
+
+

--- a/src/Ankimon/ankimon_profile_web/profile.html
+++ b/src/Ankimon/ankimon_profile_web/profile.html
@@ -1,0 +1,160 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Ankimon Profile</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <style>
+        html { background: #0d1117; }
+        .skeleton { background: #161b22; border: 1px solid #30363d; border-radius: 12px; animation: sk 1.5s ease-in-out infinite; }
+        @keyframes sk { 0%,100% { opacity: .35 } 50% { opacity: .6 } }
+    </style>
+    <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700;800;900&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="profile.css?v=20260633">
+    <link rel="stylesheet" href="../ankimon_items_web/nav-switcher.css?v=20260633">
+    <script src="qrc:///qtwebchannel/qwebchannel.js"></script>
+</head>
+<body class="dark-mode">
+    <div class="app-container">
+        <aside class="sidebar">
+            <div class="sidebar-header">
+                <div id="nav-switcher" class="nav-switcher">
+                    <button id="nav-trigger" class="nav-trigger" type="button" aria-haspopup="true" aria-expanded="false">
+                        <img src="../user_files/sprites/items/water-gem.png" class="app-logo icon-item-sprite" alt="">
+                        <h1>PROFILE</h1>
+                        <span class="nav-chevron">▾</span>
+                    </button>
+                    <div id="nav-menu" class="nav-menu hidden" role="menu">
+                        <button class="nav-menu-item" role="menuitem" data-screen="items">
+                            <span class="nav-menu-icon"><img src="../user_files/sprites/items/max-potion.png" class="icon-item-sprite" alt=""></span>
+                            <div class="nav-menu-text">
+                                <span class="nav-menu-title">Items</span>
+                                <span class="nav-menu-desc">Your inventory and today's Mart</span>
+                            </div>
+                        </button>
+                        <button class="nav-menu-item" role="menuitem" data-screen="ankidex">
+                            <span class="nav-menu-icon"><img src="../user_files/sprites/items/poke-ball.png" alt=""></span>
+                            <div class="nav-menu-text">
+                                <span class="nav-menu-title">Ankidex</span>
+                                <span class="nav-menu-desc">Browse caught Pokémon</span>
+                            </div>
+                        </button>
+                        <button class="nav-menu-item" role="menuitem" data-screen="team">
+                            <span class="nav-menu-icon"><img src="../user_files/sprites/items/great-ball.png" class="icon-item-sprite" alt=""></span>
+                            <div class="nav-menu-text">
+                                <span class="nav-menu-title">Team</span>
+                                <span class="nav-menu-desc">Your active 6 Pokémon</span>
+                            </div>
+                        </button>
+                        <button class="nav-menu-item active" role="menuitem" data-screen="profile">
+                            <span class="nav-menu-icon"><img src="../user_files/sprites/items/water-gem.png" class="icon-item-sprite" alt=""></span>
+                            <div class="nav-menu-text">
+                                <span class="nav-menu-title">Profile</span>
+                                <span class="nav-menu-desc">Card, badges &amp; avatar</span>
+                            </div>
+                        </button>
+                        <button class="nav-menu-item" role="menuitem" data-screen="settings">
+                            <span class="nav-menu-icon"><img src="../user_files/sprites/items/x-speed.png" class="icon-item-sprite" alt=""></span>
+                            <div class="nav-menu-text">
+                                <span class="nav-menu-title">Settings</span>
+                                <span class="nav-menu-desc">Configure Ankimon</span>
+                            </div>
+                        </button>
+                        <button class="nav-menu-item" role="menuitem" data-screen="mobile">
+                            <span class="nav-menu-icon"><img src="../user_files/sprites/items/elixir.png" class="icon-item-sprite" alt=""></span>
+                            <div class="nav-menu-text">
+                                <span class="nav-menu-title">Mobile &amp; Web Reviews</span>
+                                <span class="nav-menu-desc">Pending mobile/web battles</span>
+                            </div>
+                        </button>
+                    </div>
+                </div>
+            </div>
+            <div class="sidebar-body">
+                <div class="profile-rail">
+                    <div class="rail-avatar" id="avatar-btn" title="Change trainer sprite">
+                        <div class="skeleton" style="width:180px;height:180px;border-radius:16px;margin:0 auto;"></div>
+                    </div>
+                    <div class="rail-meta" id="rail-meta">
+                        <div class="skeleton" style="height:24px;width:130px;"></div>
+                        <div class="skeleton" style="height:80px;width:100%;"></div>
+                    </div>
+                    <div class="rail-xp" id="rail-xp"></div>
+                </div>
+            </div>
+        </aside>
+
+        <main class="main-content">
+            <!-- "PROFILE" is already named by the nav label, so instead of a
+                 redundant title the bar carries a friendly greeting that frames
+                 the stats below. The greeting text is set by profile.js. -->
+            <header class="top-bar">
+                <h2 id="pf-greeting">Welcome back</h2>
+                <span style="font-size:.8rem;color:var(--text-muted);">Here's your journey so far.</span>
+            </header>
+            <div class="content-scroll">
+                <div class="profile-page">
+                    <div class="stat-tiles" id="stat-tiles">
+                        <div class="skeleton" style="height:74px;"></div>
+                        <div class="skeleton" style="height:74px;"></div>
+                        <div class="skeleton" style="height:74px;"></div>
+                        <div class="skeleton" style="height:74px;"></div>
+                        <div class="skeleton" style="height:74px;"></div>
+                    </div>
+
+                    <section class="panel panel-fill">
+                        <div class="panel-title">
+                            Team
+                            <button class="manage-link" id="manage-team" type="button">Manage →</button>
+                        </div>
+                        <div class="team-showcase" id="team-showcase"></div>
+                    </section>
+
+                    <section class="panel panel-fill" id="recent-section">
+                        <div class="panel-title">Recently Caught</div>
+                        <div class="team-showcase" id="recent-grid"></div>
+                    </section>
+
+                    <section class="panel" id="badges-section">
+                        <div class="panel-title">Badges <span class="count" id="badge-summary"></span></div>
+                        <div class="badge-grid" id="badge-grid"></div>
+                    </section>
+                </div>
+            </div>
+        </main>
+    </div>
+
+    <!-- Sprite picker (opened by clicking the avatar) -->
+    <div id="sprite-modal" class="modal-overlay hidden">
+        <div class="modal">
+            <div class="modal-head">
+                <h3>Choose Trainer Sprite</h3>
+                <button class="icon-btn" id="sprite-close" title="Close">×</button>
+            </div>
+            <div class="sprite-toolbar" id="sprite-toolbar">
+                <input type="text" id="sprite-search" class="modal-search" placeholder="Search sprites...">
+                <div class="filter-select" id="fs-cat"></div>
+                <div class="filter-select" id="fs-gen"></div>
+                <div class="filter-select" id="fs-sex"></div>
+                <span class="sprite-count" id="sprite-count"></span>
+            </div>
+            <div class="sprite-modal-body">
+                <div class="sprite-grid" id="sprite-grid"></div>
+                <div class="empty-state hidden" id="sprite-empty">
+                    <div class="empty-icon"></div>
+                    <h2>No sprites found</h2>
+                    <p>Try adjusting your search or filters.</p>
+                    <button class="btn btn-primary" id="sprite-clear-filters" type="button">Clear filters</button>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div id="toast" class="toast"></div>
+
+    <script src="../ankimon_items_web/nav-switcher.js?v=20260633"></script>
+    <script src="profile.js?v=20260632"></script>
+</body>
+</html>

--- a/src/Ankimon/ankimon_profile_web/profile.js
+++ b/src/Ankimon/ankimon_profile_web/profile.js
@@ -1,0 +1,619 @@
+// Profile screen — trainer identity card + badge case, with the sprite picker
+// folded in as an avatar-click modal. Python pushes data via
+// window.initializeProfile(); the sprite list is lazy-loaded when the modal
+// first opens. Opened standalone (no qt bridge) it renders mock data.
+
+(function () {
+    'use strict';
+
+    const SPRITE_BASE = '../user_files/sprites/front_default';   // team strip
+    const BADGE_BASE = '../user_files/sprites/badges';
+    const TRAINER_BASE = '../addon_sprites/trainers';
+
+    const state = {
+        data: null,
+        sprites: null,        // null = not loaded yet
+        spriteGens: [],       // [{key,label}] generation filter chips
+        spriteCats: [],       // [category] type filter chips
+        spriteGenders: [],    // [{key,label}] sex filter chips
+        spriteCurrent: '',
+        spriteSearch: '',
+        spriteGen: 'all',
+        spriteCat: 'all',
+        spriteSex: 'all',
+    };
+    let trainer = null;
+
+    function esc(s) {
+        const d = document.createElement('div');
+        d.textContent = s == null ? '' : String(s);
+        return d.innerHTML;
+    }
+    function num(n) { return (Number(n) || 0).toLocaleString(); }
+    // Pokémon names arrive lowercase from the DB ("dragonite", "mr-mime");
+    // capitalize each word segment for display.
+    function capName(s) {
+        return String(s == null ? '' : s).replace(
+            /(^|[\s\-/])([a-z])/g,
+            (_, sep, c) => sep + c.toUpperCase()
+        );
+    }
+
+    function pkmnSprite(stub) {
+        if (!stub || !stub.p) return SPRITE_BASE + '/0.png';
+        return stub.s ? SPRITE_BASE + '/shiny/' + stub.p + '.png'
+                      : SPRITE_BASE + '/' + stub.p + '.png';
+    }
+
+    // ---------------- Render ----------------
+    function render(animateRecent) {
+        const data = state.data;
+        if (!data) return;
+        const hr = new Date().getHours();
+        const part = hr < 12 ? 'Good morning' : (hr < 18 ? 'Good afternoon' : 'Good evening');
+        setText('pf-greeting', data.name ? `${part}, ${data.name}!` : `${part}!`);
+        renderRail(data);
+        renderStatTiles(data);
+        renderTeamShowcase(data.team);
+        renderRecent(data.recent, !!animateRecent);
+        renderBadges(data.badge_grid);
+    }
+
+    function renderRail(data) {
+        const avatar = document.getElementById('avatar-btn');
+        avatar.innerHTML =
+            (data.sprite_url
+                ? `<img src="${esc(data.sprite_url)}" alt="${esc(data.name)}" onerror="this.onerror=null;this.src='${TRAINER_BASE}/red.png';">`
+                : `<div class="no-sprite">No sprite</div>`)
+            + `<span class="change-hint">✎ Change sprite</span>`;
+
+        // Fallback icons (only shown when a Pokémon sprite can't be resolved).
+        const ICON_FAV = '<svg viewBox="0 0 24 24" fill="none" stroke="#f85149" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 1 0-7.78 7.78L12 21.23l8.84-8.84a5.5 5.5 0 0 0 0-7.78z"/></svg>';
+        const ICON_HI = '<svg viewBox="0 0 24 24" fill="none" stroke="#d29922" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="22 7 13.5 15.5 8.5 10.5 2 17"/><polyline points="16 7 22 7 22 13"/></svg>';
+        const ICON_FR = '<svg viewBox="0 0 24 24" fill="none" stroke="#3fb950" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><path d="M8 14s1.5 2 4 2 4-2 4-2"/><line x1="9" y1="9" x2="9.01" y2="9"/><line x1="15" y1="9" x2="15.01" y2="9"/></svg>';
+        const pokeItem = (stub, fallback, nameVal, label) => {
+            const hero = (stub && stub.sprite)
+                ? `<img src="${esc(stub.sprite)}" alt="" onerror="this.onerror=null;this.src='${SPRITE_BASE}/0.png';">`
+                : fallback;
+            return `<div class="rail-poke"><div class="rail-poke-sprite">${hero}</div>` +
+                `<div class="rail-poke-name">${nameVal}</div>` +
+                `<div class="rail-poke-label">${label}</div></div>`;
+        };
+        const fav = data.favorite;
+        const hi = data.highest;
+        const fr = data.friendship;
+        const favVal = (fav && fav.n) ? esc(fav.n) : esc(data.favorite_pokemon);
+        const hiVal = (hi && hi.n) ? esc(hi.n) : esc(data.highest_level_pokemon);
+        const hiLabel = (hi && hi.l) ? `Highest · Lv ${esc(hi.l)}` : 'Highest Level';
+        const frVal = (fr && fr.n) ? esc(fr.n) : '—';
+        document.getElementById('rail-meta').innerHTML = `
+            <div class="rail-name" id="rail-name" role="button" tabindex="0" title="Click to rename">${esc(data.name)}<span class="rename-hint" aria-hidden="true">✎</span></div>
+            <span class="league-chip">★ ${esc(data.league)}</span>
+            <div class="rail-divider"></div>
+            <div class="rail-info">
+                ${pokeItem(fav, ICON_FAV, favVal, 'Favorite Pokémon')}
+                ${pokeItem(hi, ICON_HI, hiVal, hiLabel)}
+                ${pokeItem(fr, ICON_FR, frVal, 'Best Friend')}
+            </div>`;
+
+        // Level/XP + Total XP live at the bottom of the rail as a progress footer.
+        const xp = Number(data.xp) || 0;
+        const xpNext = Number(data.xp_for_next_level) || 0;
+        const pct = xpNext > 0 ? Math.min(100, Math.round((xp / xpNext) * 100)) : 0;
+        const remaining = Math.max(0, xpNext - xp);
+        document.getElementById('rail-xp').innerHTML = `
+            <div class="rail-xp-head"><span class="rail-xp-level">Level ${esc(data.level)}</span></div>
+            <div class="xp-track"><div class="xp-fill" style="width:${pct}%"></div></div>
+            <div class="rail-xp-val">${num(xp)} / ${num(xpNext)} XP</div>
+            ${xpNext > 0 ? `<div class="rail-xp-next">${num(remaining)} XP to next level</div>` : ''}`;
+    }
+
+    function renderTeamShowcase(team) {
+        team = team || [];
+        let html = '';
+        for (let i = 0; i < 6; i++) {
+            const m = team[i];
+            if (m) {
+                html += `<div class="team-mini">
+                    <div class="tm-sprite"><img src="${m.sprite || pkmnSprite(m)}" alt="${esc(m.n)}" onerror="this.onerror=null;this.src='${SPRITE_BASE}/0.png';"></div>
+                    <div class="tm-name">${esc(capName(m.n))}</div>
+                    <div class="tm-lv">Lv ${esc(m.l)}</div>
+                </div>`;
+            } else {
+                html += `<div class="team-mini empty"><div class="tm-empty">+</div></div>`;
+            }
+        }
+        document.getElementById('team-showcase').innerHTML = html;
+    }
+
+    // Stable keys for the Recently-Caught cards so a live update can tell which
+    // card is genuinely new (→ plays the enter animation) vs. already on screen.
+    const shownRecentKeys = new Set();
+    let shownRecentOrder = [];
+    function recentKey(m) {
+        if (!m) return '';
+        return (m.id != null) ? 'id:' + m.id : [m.p, m.n, m.l].join('|');
+    }
+    function sameOrder(a, b) {
+        if (a.length !== b.length) return false;
+        for (let i = 0; i < a.length; i++) if (a[i] !== b[i]) return false;
+        return true;
+    }
+
+    function renderRecent(recent, animateNew) {
+        recent = recent || [];
+        const el = document.getElementById('recent-grid');
+        if (!recent.length) {
+            el.innerHTML = '<div style="color:var(--text-muted);padding:8px;">No Pokémon caught yet.</div>';
+            shownRecentKeys.clear();
+            shownRecentOrder = [];
+            return;
+        }
+        const keys = recent.map(recentKey);
+        // If the list is unchanged (same Pokémon, same order), leave the DOM
+        // alone — a rebuild would interrupt in-flight animations like the
+        // lingering "NEW" badge. Stat-only refreshes (cash/XP) land here.
+        if (sameOrder(keys, shownRecentOrder)) return;
+        el.innerHTML = recent.map((m, i) => {
+            const isNew = animateNew && !shownRecentKeys.has(keys[i]);
+            return `<div class="team-mini${isNew ? ' just-caught' : ''}">
+                <div class="tm-sprite"><img src="${m.sprite || pkmnSprite(m)}" alt="${esc(m.n)}" onerror="this.onerror=null;this.src='${SPRITE_BASE}/0.png';"></div>
+                <div class="tm-name">${esc(capName(m.n))}${m.s ? ' <span class="shiny-dot">★</span>' : ''}</div>
+                <div class="tm-lv">Lv ${esc(m.l)}</div>
+            </div>`;
+        }).join('');
+        shownRecentKeys.clear();
+        keys.forEach((k) => shownRecentKeys.add(k));
+        shownRecentOrder = keys;
+    }
+
+    function renderStatTiles(data) {
+        const caught = Number(data.caught) || 0;
+        const shinies = Number(data.shinies) || 0;
+        const shinyRate = (caught > 0 && shinies > 0)
+            ? '1 in ' + Math.round(caught / shinies).toLocaleString()
+            : '—';
+        const tiles = [
+            ['Cash', num(data.cash) + ' ¥', 'var(--accent-gold)'],
+            ['Caught', num(data.caught), 'var(--accent-green)'],
+            ['Pokédex', num(data.dex_seen), 'var(--accent-blue)'],
+            ['Shinies', num(data.shinies), 'var(--accent-gold)'],
+            ['Total XP', num(data.total_xp), 'var(--accent-blue)'],
+            ['Shiny Rate', shinyRate, 'var(--accent-red)'],
+        ];
+        document.getElementById('stat-tiles').innerHTML = tiles.map((t) =>
+            `<div class="stat-tile" style="border-top:2px solid ${t[2]}">
+                <div class="st-value">${t[1]}</div>
+                <div class="st-label">${t[0]}</div>
+            </div>`
+        ).join('');
+    }
+
+    function renderBadges(grid) {
+        grid = grid || [];
+        const el = document.getElementById('badge-grid');
+        const unlocked = grid.filter((b) => b.unlocked).length;
+        setText('badge-summary', grid.length ? `${unlocked} / ${grid.length} earned` : '');
+        if (!grid.length) {
+            el.innerHTML = '<div style="color:var(--text-muted);">No badges defined.</div>';
+            return;
+        }
+        const frag = document.createDocumentFragment();
+        grid.forEach((b) => {
+            const cell = document.createElement('div');
+            cell.className = 'badge-cell' + (b.unlocked ? '' : ' locked');
+            cell.innerHTML = `
+                <img src="${BADGE_BASE}/${b.id}.png" alt="${esc(b.name)}"
+                     onerror="this.onerror=null;this.src='${BADGE_BASE}/default.png';">
+                <span class="badge-tip">${esc(b.name)}</span>`;
+            frag.appendChild(cell);
+        });
+        el.replaceChildren(frag);
+    }
+
+    function setText(id, text) {
+        const el = document.getElementById(id);
+        if (el) el.textContent = text;
+    }
+
+    // ---------------- Sprite picker modal ----------------
+    function openSpriteModal() {
+        document.getElementById('sprite-modal').classList.remove('hidden');
+        const search = document.getElementById('sprite-search');
+        search.value = '';
+        state.spriteSearch = '';
+        state.spriteGen = 'all';
+        state.spriteCat = 'all';
+        state.spriteSex = 'all';
+
+        if (state.sprites === null) {
+            renderSpriteGrid('Loading…');
+            if (trainer && trainer.getSprites) {
+                trainer.getSprites().then((res) => {
+                    state.sprites = (res && res.sprites) || [];
+                    state.spriteGens = (res && res.generations) || [];
+                    state.spriteCats = (res && res.categories) || [];
+                    state.spriteGenders = (res && res.genders) || [];
+                    state.spriteCurrent = (res && res.current) || state.spriteCurrent;
+                    buildSpriteToolbar();
+                    renderSpriteGrid();
+                });
+            } else {
+                state.sprites = [];
+                buildSpriteToolbar();
+                renderSpriteGrid();
+            }
+        } else {
+            buildSpriteToolbar();
+            renderSpriteGrid();
+        }
+        setTimeout(() => search.focus(), 0);
+    }
+
+    // Condensed filters: Type / Gen / Sex each become a compact dropdown that
+    // sits inline with the search bar. Built from the lists the bridge ships.
+    function buildSpriteToolbar() {
+        const cats = (state.spriteCats || []).map((c) => ({ key: c, label: c }));
+        renderFilterSelect('fs-cat', 'cat', 'Type', cats, state.spriteCat);
+        renderFilterSelect('fs-gen', 'gen', 'Gen', state.spriteGens || [], state.spriteGen);
+        renderFilterSelect('fs-sex', 'sex', 'Sex', state.spriteGenders || [], state.spriteSex);
+    }
+
+    function closeAllFilterMenus() {
+        document.querySelectorAll('#sprite-toolbar .filter-select.open').forEach((s) => {
+            s.classList.remove('open');
+            const menu = s.querySelector('.fs-menu');
+            if (menu) menu.classList.add('hidden');
+            const t = s.querySelector('.fs-trigger');
+            if (t) t.setAttribute('aria-expanded', 'false');
+        });
+    }
+
+    // One dropdown: a trigger showing the dimension name (when "All") or the
+    // chosen value, plus a themed menu of options.
+    function renderFilterSelect(hostId, which, dimLabel, items, selected) {
+        const host = document.getElementById(hostId);
+        if (!host) return;
+        if (!items.length) { host.className = 'filter-select hidden'; host.innerHTML = ''; return; }
+        const curItem = (selected !== 'all') ? items.find((it) => it.key === selected) : null;
+        const triggerText = curItem ? curItem.label : dimLabel;
+        const active = selected !== 'all';
+        const opt = (label, val, on) =>
+            `<button class="fs-option${on ? ' active' : ''}" type="button" role="menuitem" data-val="${esc(val)}">${esc(label)}</button>`;
+        host.className = 'filter-select' + (active ? ' active' : '');
+        host.innerHTML = `
+            <button class="fs-trigger" type="button" aria-haspopup="true" aria-expanded="false">
+                <span class="fs-value">${esc(triggerText)}</span>
+                <span class="fs-chevron">▾</span>
+            </button>
+            <div class="fs-menu hidden" role="menu">
+                ${opt('All', 'all', selected === 'all')}
+                ${items.map((it) => opt(it.label, it.key, selected === it.key)).join('')}
+            </div>`;
+        const trigger = host.querySelector('.fs-trigger');
+        const menu = host.querySelector('.fs-menu');
+        trigger.addEventListener('click', (e) => {
+            e.stopPropagation();
+            const willOpen = menu.classList.contains('hidden');
+            closeAllFilterMenus();
+            if (willOpen) {
+                menu.classList.remove('hidden');
+                host.classList.add('open');
+                trigger.setAttribute('aria-expanded', 'true');
+            }
+        });
+        menu.querySelectorAll('.fs-option').forEach((o) => {
+            o.addEventListener('click', (e) => {
+                e.stopPropagation();
+                const val = o.getAttribute('data-val');
+                if (which === 'cat') state.spriteCat = val;
+                else if (which === 'gen') state.spriteGen = val;
+                else state.spriteSex = val;
+                buildSpriteToolbar();
+                renderSpriteGrid();
+            });
+        });
+    }
+
+    function closeSpriteModal() {
+        document.getElementById('sprite-modal').classList.add('hidden');
+    }
+
+    function renderSpriteGrid(placeholder) {
+        const grid = document.getElementById('sprite-grid');
+        const empty = document.getElementById('sprite-empty');
+        if (placeholder) {
+            if (empty) empty.classList.add('hidden');
+            grid.classList.remove('hidden');
+            grid.innerHTML = `<div style="color:var(--text-muted);padding:12px;">${esc(placeholder)}</div>`;
+            return;
+        }
+        const q = state.spriteSearch.toLowerCase();
+        const gen = state.spriteGen || 'all';
+        const cat = state.spriteCat || 'all';
+        const sex = state.spriteSex || 'all';
+        const list = (state.sprites || []).filter((s) => {
+            if (gen !== 'all' && (s.gen || 'other') !== gen) return false;
+            if (cat !== 'all' && s.category !== cat) return false;
+            if (sex !== 'all' && (s.gender || '') !== sex) return false;
+            if (q && !((s.label || '').toLowerCase().includes(q)
+                     || (s.name || '').toLowerCase().includes(q)
+                     || (s.sublabel || '').toLowerCase().includes(q))) return false;
+            return true;
+        });
+        const countEl = document.getElementById('sprite-count');
+        if (countEl) countEl.textContent = list.length + (list.length === 1 ? ' sprite' : ' sprites');
+        if (!list.length) {
+            grid.classList.add('hidden');
+            grid.innerHTML = '';
+            if (empty) empty.classList.remove('hidden');
+            return;
+        }
+        if (empty) empty.classList.add('hidden');
+        grid.classList.remove('hidden');
+        const frag = document.createDocumentFragment();
+        list.forEach((s) => {
+            const card = document.createElement('div');
+            card.className = 'sprite-card' + (s.name === state.spriteCurrent ? ' selected' : '');
+            card.innerHTML = `
+                <img src="${esc(s.url)}" alt="${esc(s.label)}" onerror="this.style.visibility='hidden';">
+                <span class="sprite-label">${esc(s.label)}</span>
+                ${s.sublabel ? `<span class="sprite-sub">${esc(s.sublabel)}</span>` : ''}`;
+            card.addEventListener('click', () => chooseSprite(s));
+            frag.appendChild(card);
+        });
+        grid.replaceChildren(frag);
+    }
+
+    function chooseSprite(sprite) {
+        const prev = state.spriteCurrent;
+        const prevUrl = state.data ? state.data.sprite_url : null;
+        state.spriteCurrent = sprite.name;
+        // Optimistically update the avatar + close the modal.
+        if (state.data) state.data.sprite_url = sprite.url;
+        render();
+        closeSpriteModal();
+        if (trainer && trainer.setSprite) {
+            trainer.setSprite(sprite.name).then((res) => {
+                if (res && res.ok) {
+                    toast(res.message || 'Trainer sprite updated.', 'success');
+                } else {
+                    // Backend rejected it — roll the optimistic avatar back.
+                    state.spriteCurrent = prev;
+                    if (state.data) state.data.sprite_url = prevUrl;
+                    render();
+                    toast((res && res.message) || 'Failed to set sprite.', 'error');
+                }
+            });
+        } else {
+            toast('Selected (preview — no backend).', 'success');
+        }
+    }
+
+    let toastTimer = null;
+    function toast(msg, kind) {
+        const el = document.getElementById('toast');
+        el.textContent = msg;
+        el.className = 'toast show' + (kind ? ' ' + kind : '');
+        if (toastTimer) clearTimeout(toastTimer);
+        toastTimer = setTimeout(() => { el.className = 'toast'; }, 2400);
+    }
+
+    // ---------------- Rename trainer ----------------
+    // Inline edit on the rail name: click (or Enter/Space when focused) swaps it
+    // for an input; Enter commits, Escape OR blur (clicking away) cancels — so
+    // clicking elsewhere never silently saves a half-typed name. Mirrors the
+    // sprite flow: optimistic update + bridge call + toast, reverting on failure.
+    let renaming = false;
+    function startRename() {
+        if (renaming || !state.data) return;
+        const el = document.getElementById('rail-name');
+        if (!el) return;
+        renaming = true;
+        const current = state.data.name || '';
+        const input = document.createElement('input');
+        input.type = 'text';
+        input.className = 'rail-name-input';
+        input.value = current;
+        input.maxLength = 24;
+        input.setAttribute('aria-label', 'Trainer name');
+        el.replaceWith(input);
+        input.focus();
+        input.select();
+        let done = false;
+        const finish = (commit) => {
+            if (done) return;
+            done = true;
+            renaming = false;
+            const val = input.value.trim();
+            if (commit && val && val !== current) saveName(val);
+            else render();
+        };
+        input.addEventListener('keydown', (e) => {
+            if (e.key === 'Enter') { e.preventDefault(); finish(true); }
+            else if (e.key === 'Escape') { e.preventDefault(); finish(false); }
+        });
+        input.addEventListener('blur', () => finish(false));
+    }
+    function saveName(name) {
+        const prev = state.data.name;
+        state.data.name = name;     // optimistic
+        render();
+        if (trainer && trainer.setName) {
+            trainer.setName(name).then((res) => {
+                if (res && res.ok) {
+                    state.data.name = res.name || name;
+                    toast(res.message || 'Trainer name updated.', 'success');
+                } else {
+                    state.data.name = prev;
+                    toast((res && res.message) || 'Failed to update name.', 'error');
+                }
+                render();
+            });
+        } else {
+            toast('Renamed (preview — no backend).', 'success');
+        }
+    }
+
+    // ---------------- Init ----------------
+    function handleAction(action) {
+        if (action === 'sprite') openSpriteModal();
+        else if (action === 'badges') {
+            const sec = document.getElementById('badges-section');
+            if (sec) sec.scrollIntoView({ behavior: 'smooth', block: 'start' });
+        }
+    }
+
+    window.initializeProfile = function (data) {
+        state.data = data || {};
+        render();
+        handleAction(state.data.action);
+    };
+
+    // Live refresh pushed by Python after a gameplay event (catch, defeat XP,
+    // cash reward, level-up) while this screen is open — re-renders every stat.
+    // Newly caught Pokémon animate into Recently Caught; renderRecent's id-diff
+    // means unchanged cards don't re-animate, so cash/XP-only changes are quiet.
+    window.liveRefreshProfile = function (data) {
+        if (!data) return;
+        state.data = data;
+        render(true);
+    };
+
+    function wireStaticControls() {
+        // The hero avatar persists across renders, so wire it once here.
+        document.getElementById('avatar-btn').addEventListener('click', openSpriteModal);
+        // Inline rename: #rail-meta persists across renders (its children are
+        // rebuilt), so delegate the click/keydown here rather than on .rail-name.
+        const railMeta = document.getElementById('rail-meta');
+        if (railMeta) {
+            railMeta.addEventListener('click', (e) => {
+                if (e.target.closest('.rail-name')) startRename();
+            });
+            railMeta.addEventListener('keydown', (e) => {
+                const t = e.target;
+                if ((e.key === 'Enter' || e.key === ' ') && t.classList && t.classList.contains('rail-name')) {
+                    e.preventDefault();
+                    startRename();
+                }
+            });
+        }
+        const manage = document.getElementById('manage-team');
+        if (manage) {
+            manage.addEventListener('click', () => {
+                if (window.nav && window.nav.openTeam) window.nav.openTeam();
+            });
+        }
+        document.getElementById('sprite-close').addEventListener('click', closeSpriteModal);
+        document.getElementById('sprite-search').addEventListener('input', (e) => {
+            state.spriteSearch = e.target.value || '';
+            renderSpriteGrid();
+        });
+        const clearBtn = document.getElementById('sprite-clear-filters');
+        if (clearBtn) {
+            clearBtn.addEventListener('click', () => {
+                state.spriteSearch = '';
+                state.spriteGen = 'all';
+                state.spriteCat = 'all';
+                state.spriteSex = 'all';
+                const s = document.getElementById('sprite-search');
+                if (s) s.value = '';
+                buildSpriteToolbar();
+                renderSpriteGrid();
+            });
+        }
+        document.getElementById('sprite-modal').addEventListener('click', (e) => {
+            if (e.target.id === 'sprite-modal') closeSpriteModal();
+        });
+        // Clicking anywhere else closes an open filter dropdown (trigger/option
+        // clicks stopPropagation, so they don't trigger this).
+        document.addEventListener('click', closeAllFilterMenus);
+        document.addEventListener('keydown', (e) => {
+            if (e.key !== 'Escape') return;
+            if (document.querySelector('#sprite-toolbar .filter-select.open')) {
+                closeAllFilterMenus();
+            } else {
+                closeSpriteModal();
+            }
+        });
+    }
+
+    function init() {
+        wireStaticControls();
+
+        if (typeof qt === 'undefined' || !qt.webChannelTransport) {
+            state.spriteCurrent = 'red';
+            state.sprites = [
+                { name: 'red', label: 'Red', sublabel: 'Gen 1', url: TRAINER_BASE + '/red.png', gen: '1', category: 'Characters', gender: '' },
+                { name: 'blue', label: 'Blue', sublabel: 'Gen 1 · RB Champion', url: TRAINER_BASE + '/blue.png', gen: '1', category: 'Characters', gender: '' },
+                { name: 'ethan', label: 'Ethan', sublabel: 'Gen 2', url: TRAINER_BASE + '/ethan.png', gen: '2', category: 'Characters', gender: '' },
+                { name: 'leaf', label: 'Leaf', sublabel: 'Gen 3', url: TRAINER_BASE + '/leaf.png', gen: '3', category: 'Characters', gender: '' },
+                { name: 'acetrainer', label: 'Ace Trainer', sublabel: 'Gen 6 · XY', url: TRAINER_BASE + '/ethan.png', gen: '6', category: 'Trainer', gender: 'm' },
+                { name: 'acetrainerf', label: 'Ace Trainer', sublabel: 'Gen 3', url: TRAINER_BASE + '/leaf.png', gen: '3', category: 'Trainer', gender: 'f' },
+                { name: 'acetrainercouple', label: 'Ace Trainer Couple', sublabel: 'Gen 3', url: TRAINER_BASE + '/red.png', gen: '3', category: 'Trainer', gender: '' },
+                { name: 'swimmerf', label: 'Swimmer', sublabel: 'Gen 3', url: TRAINER_BASE + '/leaf.png', gen: '3', category: 'Athletic', gender: 'f' },
+                { name: 'nurse', label: 'Nurse', sublabel: 'Gen 4', url: TRAINER_BASE + '/leaf.png', gen: '4', category: 'Medical', gender: 'f' },
+                { name: 'scientist', label: 'Scientist', sublabel: 'Gen 1', url: TRAINER_BASE + '/red.png', gen: '1', category: 'Science', gender: 'm' },
+                { name: 'youngster', label: 'Youngster', sublabel: 'Gen 2', url: TRAINER_BASE + '/ethan.png', gen: '2', category: 'Youth', gender: 'm' },
+                { name: 'gentleman', label: 'Gentleman', sublabel: 'Gen 1', url: TRAINER_BASE + '/red.png', gen: '1', category: 'Elegant', gender: 'm' },
+                { name: 'psychic', label: 'Psychic', sublabel: 'Gen 1', url: TRAINER_BASE + '/blue.png', gen: '1', category: 'Mystic', gender: 'm' },
+                { name: 'guitarist', label: 'Guitarist', sublabel: 'Gen 3', url: TRAINER_BASE + '/ethan.png', gen: '3', category: 'Performer', gender: 'm' },
+                { name: 'aaron', label: 'Aaron', sublabel: '', url: TRAINER_BASE + '/blue.png', gen: 'other', category: 'Characters', gender: '' },
+            ];
+            state.spriteGens = [
+                { key: '1', label: 'Gen 1' }, { key: '2', label: 'Gen 2' },
+                { key: '3', label: 'Gen 3' }, { key: '4', label: 'Gen 4' },
+                { key: '6', label: 'Gen 6' }, { key: 'other', label: 'Other' },
+            ];
+            state.spriteCats = ['Characters', 'Trainer', 'Athletic', 'Youth', 'Elegant', 'Mystic', 'Science', 'Performer', 'Medical'];
+            state.spriteGenders = [{ key: 'm', label: '♂ Male' }, { key: 'f', label: '♀ Female' }];
+            window.initializeProfile({
+                name: 'Red', trainer_id: 'PKMN-0001', sprite_url: TRAINER_BASE + '/red.png',
+                level: 7, xp: 320, total_xp: 5400, xp_for_next_level: 900,
+                badges: 2, cash: 12500, favorite_pokemon: 'Pikachu',
+                highest_level_pokemon: 'Charizard (Level 52)', league: 'Ace',
+                caught: 142, dex_seen: 89, shinies: 5, highest_level: 52,
+                favorite: { n: 'Pikachu', sprite: SPRITE_BASE + '/25.png' },
+                highest: { n: 'Charizard', l: 52, sprite: SPRITE_BASE + '/6.png' },
+                friendship: { n: 'Snorlax', fr: 220, sprite: SPRITE_BASE + '/143.png' },
+                recent: [
+                    { id: 'r1', p: 130, n: 'gyarados', l: 39 }, { id: 'r2', p: 94, n: 'gengar', l: 36 },
+                    { id: 'r3', p: 6, n: 'charizard', l: 52, s: 1 }, { id: 'r4', p: 3, n: 'venusaur', l: 41 },
+                    { id: 'r5', p: 143, n: 'snorlax', l: 30 }, { id: 'r6', p: 9, n: 'blastoise', l: 44 },
+                ],
+                team: [
+                    { id: '1', p: 25, n: 'Pikachu', l: 18 },
+                    { id: '2', p: 6, n: 'Charizard', l: 52, s: 1 },
+                    { id: '3', p: 9, n: 'Blastoise', l: 44 },
+                ],
+                badge_grid: [
+                    { id: 1, name: 'Boulder Badge', unlocked: true },
+                    { id: 2, name: 'Cascade Badge', unlocked: true },
+                    { id: 3, name: 'Thunder Badge', unlocked: false },
+                    { id: 4, name: 'Rainbow Badge', unlocked: false },
+                    { id: 5, name: 'Soul Badge', unlocked: false },
+                ],
+            });
+            return;
+        }
+
+        new QWebChannel(qt.webChannelTransport, function (channel) {
+            trainer = channel.objects && channel.objects.trainer;
+            const nav = channel.objects && channel.objects.nav;
+            window.trainer = trainer;
+            window.nav = nav;
+            // Wire the dropdown from THIS channel's nav — see ankimon_items_web/nav-switcher.js
+            // for why we don't open a second channel.
+            if (window.wireNavSwitcher) window.wireNavSwitcher(nav);
+            if (trainer && trainer.getProfile) {
+                trainer.getProfile().then(window.initializeProfile);
+            }
+        });
+    }
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', init);
+    } else {
+        init();
+    }
+})();

--- a/src/Ankimon/ankimon_profile_web/profile_data.py
+++ b/src/Ankimon/ankimon_profile_web/profile_data.py
@@ -1,0 +1,861 @@
+"""Data layer for the Profile + Team screens.
+
+Plain (non-Qt) helper so the unified shell (``ankimon_items_web/shop_obj.py``)
+can host the Profile and Team screens without duplicating their data logic.
+Reads/writes the trainer card, captured-Pokémon DB and settings; builds the
+payloads the profile.js / team.js pages consume.
+"""
+
+import json
+import re
+
+from ..services import services
+
+from ..utils import get_all_sprites, POKEMON_NAME_LOOKUP
+from ..resources import trainer_sprites_path
+
+MAX_TEAM_SIZE = 6
+
+# Base species that legitimately end in "mega" / "max" and are NOT form names.
+_NOT_FORMS = {"yanmega"}
+
+
+def _capitalize_name(s):
+    """Capitalize the first letter of each word segment, preserving separators
+    (so "mr-mime" -> "Mr-Mime", "dragonite" -> "Dragonite")."""
+    return re.sub(r"(^|[\s\-/])([a-z])", lambda m: m.group(1) + m.group(2).upper(), str(s))
+
+
+def _species_name(s):
+    """Canonical species display name via the shared utils.POKEMON_NAME_LOOKUP
+    (single source of truth — e.g. "mrmime" -> "Mr. Mime"), falling back to
+    segment-wise capitalization for names the lookup doesn't cover."""
+    s = str(s)
+    key = s.replace(" ", "").replace("-", "").replace("_", "").lower()
+    return POKEMON_NAME_LOOKUP.get(key) or _capitalize_name(s)
+
+
+def format_pokemon_name(raw):
+    """Display name for a Pokémon. Reformats stored form names like
+    "baxcaliburmega" -> "Mega Baxcalibur", "xgmax" -> "Gmax X"; the plain
+    species name is resolved through the shared canonical lookup
+    (utils.POKEMON_NAME_LOOKUP). Yanmega (a real base species) is left alone."""
+    if not raw:
+        return ""
+    s = str(raw)
+    low = s.lower()
+    if low not in _NOT_FORMS:
+        m = re.match(r"^(.+?)mega([xy])$", low)
+        if m:
+            return "Mega " + _species_name(m.group(1)) + " " + m.group(2).upper()
+        m = re.match(r"^(.+?)mega$", low)
+        if m:
+            return "Mega " + _species_name(m.group(1))
+        m = re.match(r"^(.+?)gigantamax$", low)
+        if m:
+            return "Gigantamax " + _species_name(m.group(1))
+        m = re.match(r"^(.+?)gmax$", low)
+        if m:
+            return "Gmax " + _species_name(m.group(1))
+    from ..functions.pokedex_functions import format_lore_name
+    return format_lore_name(_species_name(s))
+
+
+def _format_with_level(s):
+    """Reformat a "name (Level N)" string, leaving the level suffix intact."""
+    if not s:
+        return s
+    m = re.match(r"^(.*?)(\s*\(Level\s*\d+\))\s*$", str(s), re.IGNORECASE)
+    if m:
+        return format_pokemon_name(m.group(1).strip()) + " " + m.group(2).strip()
+    return format_pokemon_name(s)
+
+
+# ------------------------------------------------------------------
+# Trainer-sprite descriptions for the sprite-picker modal. ~1400 sprites are
+# named like "acetrainerf-gen6xy"; this turns each into a pretty label
+# ("Ace Trainer"), a generation/variant sublabel ("Gen 6 · XY"), a browsing
+# category and a gender ("m"/"f"/""). Gender is a FILTER only — it is never
+# shown in the label (both sexes read the same).
+# ------------------------------------------------------------------
+_SPRITE_GEN_RE = re.compile(r"^gen(\d+)([a-z0-9]*)$")
+
+_SPRITE_VARIANT = {
+    "rb": "RB", "rby": "RBY", "jp": "JP", "rs": "RS", "dp": "DP", "pt": "Pt",
+    "bw": "BW", "bw2": "BW2", "xy": "XY", "oras": "ORAS", "frlg": "FRLG",
+    "lgpe": "LGPE", "usum": "USUM", "sm": "SM", "hgss": "HGSS", "gs": "GS",
+    "champion": "Champion", "title": "Title", "kanto": "Kanto", "johto": "Johto",
+    "two": "II", "main": "Main", "c": "C", "masters": "Masters", "anime": "Anime",
+    "casual": "Casual", "s": "Scarlet", "v": "Violet", "pwt": "PWT",
+    "isekai": "Isekai", "shuffle": "Shuffle",
+}
+_SPRITE_VKEYS = sorted(_SPRITE_VARIANT, key=len, reverse=True)
+
+# Greedy word-split vocabulary: compound class names → spaced display form.
+# Longest match wins, so whole compounds ("acetrainer") beat their pieces; a
+# token is only split if the WHOLE thing is consumed, so single-word named
+# characters ("misty") fall back to plain capitalization and aren't mangled.
+_SPRITE_VOCAB = {
+    "acetrainer": "Ace Trainer", "cooltrainer": "Cool Trainer",
+    "blackbelt": "Black Belt", "birdkeeper": "Bird Keeper",
+    "bugcatcher": "Bug Catcher", "schoolkid": "School Kid", "richboy": "Rich Boy",
+    "supernerd": "Super Nerd", "youngcouple": "Young Couple",
+    "aromalady": "Aroma Lady", "parasollady": "Parasol Lady",
+    "dragontamer": "Dragon Tamer", "ruinmaniac": "Ruin Maniac",
+    "pokemaniac": "Poké Maniac", "pokefan": "Poké Fan",
+    "pokemonbreeder": "Pokémon Breeder", "pokemonranger": "Pokémon Ranger",
+    "battlegirl": "Battle Girl", "ltsurge": "Lt. Surge", "hexmaniac": "Hex Maniac",
+    "ninjaboy": "Ninja Boy", "kimonogirl": "Kimono Girl", "officeworker": "Office Worker",
+    "risingstar": "Rising Star", "rollerskater": "Roller Skater", "crushgirl": "Crush Girl",
+    "securitycorps": "Security Corps", "skytrainer": "Sky Trainer",
+    "rocketexecutive": "Rocket Executive", "aetherfoundation": "Aether Foundation",
+    "aetheremployee": "Aether Employee", "leaguestaff": "League Staff",
+    "scubadiver": "Scuba Diver", "streetthug": "Street Thug", "depotagent": "Depot Agent",
+    "firebreather": "Fire Breather", "nurseryaide": "Nursery Aide",
+    "furisodegirl": "Furisode Girl", "fairytalegirl": "Fairy Tale Girl",
+    "schoolgirl": "School Girl", "youngathlete": "Young Athlete", "poffincook": "Poffin Cook",
+    # multi-word named characters
+    "cedricjuniper": "Cedric Juniper", "crasherwake": "Crasher Wake",
+    "jessiejames": "Jessie & James", "tateandliza": "Tate & Liza",
+    "shadowtriad": "Shadow Triad", "pearlclanmember": "Pearl Clan Member",
+    "diamondclanmember": "Diamond Clan Member", "pokemoncenterlady": "Pokémon Center Lady",
+    # atomic pieces (compounds above win via longest-match)
+    "triathlete": "Triathlete", "biker": "Biker", "runner": "Runner", "swimmer": "Swimmer",
+    "trainer": "Trainer", "couple": "Couple", "grunt": "Grunt", "worker": "Worker",
+    "star": "Star", "snow": "Snow", "skater": "Skater", "team": "Team", "aqua": "Aqua",
+    "magma": "Magma", "rocket": "Rocket", "skull": "Skull", "flare": "Flare",
+    "galactic": "Galactic", "plasma": "Plasma", "yell": "Yell", "girl": "Girl",
+    "boy": "Boy", "jr": "Jr.",
+}
+_SPRITE_VKEYS_WORDS = sorted(_SPRITE_VOCAB, key=len, reverse=True)
+
+# Inherently single-gender classes that don't follow the …f / …m sibling
+# convention — supplements the data-driven gender detection below.
+_SPRITE_FEMALE_ROLES = {
+    "lass", "beauty", "madame", "lady", "nurse", "idol", "waitress", "kimonogirl",
+    "cowgirl", "showgirl", "crushgirl", "policewoman", "battlegirl", "aromalady",
+    "parasollady", "beautician", "furisodegirl", "fairytalegirl", "schoolgirl",
+    "picnicker",
+}
+_SPRITE_MALE_ROLES = {
+    "youngster", "gentleman", "blackbelt", "richboy", "cueball", "fisherman",
+    "policeman", "cameraman", "ninjaboy", "sailor", "biker", "bugcatcher",
+    "burglar", "gambler", "guitarist", "schoolboy",
+}
+
+# (category, keyword substrings) — first match wins; unmatched → "Characters"
+# (the big bucket of named people, browsed via search).
+_SPRITE_CATEGORIES = [
+    ("Medical", ("nurse", "doctor", "medic", "joy")),
+    ("Science", ("scientist", "supernerd", "nerd", "engineer", "researcher", "professor")),
+    ("Mystic", ("psychic", "hex", "medium", "channeler", "mystic", "fortune", "seer", "witch", "shaman", "sage", "monk", "cultist")),
+    ("Athletic", ("blackbelt", "battlegirl", "swimmer", "hiker", "fisherman", "sailor", "biker", "cyclist", "crusher", "karate", "wrestler", "jogger", "runner", "tuber", "skier", "roughneck", "cueball", "athlete", "boarder")),
+    ("Outdoors", ("bugcatcher", "birdkeeper", "camper", "picnicker", "ranger", "aromalady", "gardener", "worker", "ruinmaniac", "dragontamer", "hunter", "farmer", "breeder", "kindler", "backpacker", "collector")),
+    ("Performer", ("guitarist", "artist", "juggler", "dancer", "musician", "comedian", "idol", "singer", "painter", "actor", "actress", "entertainer", "performer", "magician", "clown", "poet")),
+    ("Youth", ("youngster", "lass", "schoolkid", "twins", "preschooler", "child", "student", "youngcouple", "schoolboy", "schoolgirl", "kindergarten")),
+    ("Elegant", ("lady", "madame", "gentleman", "richboy", "socialite", "butler", "maid", "parasollady", "aristocrat", "noble", "beauty", "waiter", "waitress", "rich")),
+    ("Official", ("policeman", "officer", "guard", "soldier", "grunt", "rocket", "aqua", "magma", "galactic", "plasma", "flare", "skull", "yell", "admin", "interviewer", "cameraman")),
+    ("Trainer", ("acetrainer", "cooltrainer", "pokefan", "pokemaniac", "veteran", "trainer", "expert", "tamer", "gambler", "gamer", "burglar", "tourist", "ninjaboy")),
+]
+_SPRITE_CATEGORY_ORDER = [
+    "Characters", "Trainer", "Athletic", "Outdoors", "Youth", "Elegant",
+    "Mystic", "Science", "Performer", "Official", "Medical",
+]
+
+
+def _split_sprite_variant(v):
+    """Unpack a run-together variant suffix like 'rbchampion' → 'RB Champion'."""
+    out = []
+    i = 0
+    while i < len(v):
+        for k in _SPRITE_VKEYS:
+            if v.startswith(k, i):
+                out.append(_SPRITE_VARIANT[k])
+                i += len(k)
+                break
+        else:
+            rest = v[i:]
+            out.append(rest.upper() if len(rest) <= 4 else rest.title())
+            break
+    return " ".join(out)
+
+
+def _categorize_sprite(name):
+    base = re.sub(r"gen\d+[a-z0-9]*", "", name)
+    base = " " + base.replace("-", " ") + " "
+    base = re.sub(r"\d+", " ", base).lower()
+    for cat, kws in _SPRITE_CATEGORIES:
+        for kw in kws:
+            if kw in base:
+                return cat
+    return "Characters"
+
+
+def _pretty_role(root):
+    """Greedy word-split a class root into spaced display form, else capitalize.
+    Only used when the WHOLE token is a chain of known words — named characters
+    (not in the vocab) fall back to plain capitalization."""
+    out = []
+    i = 0
+    while i < len(root):
+        for k in _SPRITE_VKEYS_WORDS:
+            if root.startswith(k, i):
+                out.append(_SPRITE_VOCAB[k])
+                i += len(k)
+                break
+        else:
+            return (root[:1].upper() + root[1:]) if root else root
+    return " ".join(out)
+
+
+def _parse_sprite_gender(role, roles):
+    """(gender, root) for a role segment — gender is 'm'/'f'/'' and root is the
+    role with any gender suffix stripped. Data-driven (a …f/…m sibling exists)
+    with a small curated fallback for inherently single-gender classes."""
+    if role.endswith("f") and (role[:-1] in roles or (role[:-1] + "m") in roles):
+        return "f", role[:-1]
+    if role.endswith("m") and (role[:-1] + "f") in roles:
+        return "m", role[:-1]
+    if (role + "f") in roles:
+        return "m", role
+    if role in _SPRITE_FEMALE_ROLES:
+        return "f", role
+    if role in _SPRITE_MALE_ROLES:
+        return "m", role
+    return "", role
+
+
+def _describe_sprite(name, roles):
+    """(label, sublabel, gen|None, category, gender) for one sprite filename
+    stem. ``roles`` is the set of all first segments. Gender is for filtering
+    only and is never appended to the label."""
+    parts = name.split("-")
+    role = parts[0]
+    gender, root = _parse_sprite_gender(role, roles)
+    label = _pretty_role(root)
+
+    gen = None
+    subs = []
+    for p in parts[1:]:
+        m = _SPRITE_GEN_RE.match(p)
+        if m:
+            gen = int(m.group(1))
+            var = m.group(2)
+            subs.append("Gen " + str(gen) + (" · " + _split_sprite_variant(var) if var else ""))
+        else:
+            mm = re.match(r"^([a-z]+)(\d*)$", p)
+            if mm:
+                txt = _split_sprite_variant(mm.group(1))
+                subs.append(txt + (" " + mm.group(2) if mm.group(2) else ""))
+            else:
+                subs.append(p.title())
+    return label, " · ".join(subs), gen, _categorize_sprite(name), gender
+
+
+class ProfileData:
+    def __init__(self, addon_dir, trainer_card, settings_obj, logger):
+        self.addon_dir = addon_dir
+        self.trainer_card = trainer_card
+        self.settings_obj = settings_obj
+        self.logger = logger
+        # Roster is parsed once on first picker open, then reused. Cleared by a
+        # successful team save (which can change levels/membership downstream).
+        self._roster_cache = None
+
+    # ------------------------------------------------------------------
+    # Profile (identity + badge case)
+    # ------------------------------------------------------------------
+    def get_profile_data(self):
+        tc = self.trainer_card
+        try:
+            tc.refresh()
+        except Exception as e:
+            print(f"[Ankimon] profile: trainer_card.refresh failed: {e}")
+
+        try:
+            sprite_name = self.settings_obj.get("trainer.sprite") or ""
+        except Exception:
+            sprite_name = ""
+
+        def _safe(getter, default=None):
+            try:
+                return getter()
+            except Exception:
+                return default
+
+        data = {
+            "name": getattr(tc, "trainer_name", "") or "Trainer",
+            "trainer_id": getattr(tc, "trainer_id", ""),
+            "sprite_url": (
+                f"../addon_sprites/trainers/{sprite_name}.png" if sprite_name else ""
+            ),
+            "level": _safe(lambda: int(tc.level), 1),
+            "xp": _safe(lambda: int(tc.xp), 0),
+            "total_xp": _safe(lambda: int(tc.total_xp), 0),
+            "xp_for_next_level": _safe(lambda: int(tc.xp_for_next_level()), 0),
+            "badges": _safe(lambda: int(tc.badge_count()), 0),
+            "cash": _safe(lambda: int(tc.cash), 0),
+            "favorite_pokemon": format_pokemon_name(
+                getattr(tc, "favorite_pokemon", "") or "None"
+            ),
+            "highest_level_pokemon": _format_with_level(
+                _safe(lambda: tc.get_highest_level_pokemon(), "None") or "None"
+            ),
+            "favorite": self._favorite_stub(),
+            "highest": self._highest_stub(),
+            "friendship": self._friendship_stub(),
+            "league": getattr(tc, "league", "") or "unranked",
+            "team": self._team_member_stubs(),
+            "recent": self._recent_catches(),
+            "badge_grid": self._badge_grid(),
+        }
+        data.update(self._collection_stats())
+        return data
+
+    def _collection_stats(self):
+        """Cheap COUNT/aggregate stats for the profile dashboard."""
+        db = services.db
+
+        def _q(fn, default=0):
+            try:
+                return int(fn() or 0)
+            except Exception:
+                return default
+
+        # 1. Retrieve all caught IDs using the database manager's comprehensive set method
+        # (which merges active captured, released history, and explicit caught history).
+        try:
+            caught_ids = db.get_all_pokemon_ids() or set()
+        except Exception:
+            caught_ids = set()
+
+        # 2. Map all caught IDs to their base species_id (deduplicating Megas, Gmax, and forms)
+        from ..functions.pokedex_functions import _load_pokedex_cache, search_pokedex_by_id, safe_int
+        pokedex = _load_pokedex_cache()
+        caught_species = set()
+        
+        for pid in caught_ids:
+            internal_name = search_pokedex_by_id(pid)
+            if internal_name and internal_name in pokedex:
+                info = pokedex[internal_name]
+                species_id = safe_int(info.get("species_id")) or pid
+                caught_species.add(species_id)
+            else:
+                caught_species.add(pid)
+
+        dex = len(caught_species)
+
+        return {
+            "caught": _q(lambda: db.get_pokemon_count()),
+            "dex_seen": dex,
+            "shinies": _q(lambda: db.get_shiny_count()),
+            "highest_level": _q(lambda: self.trainer_card.highest_pokemon_level()),
+        }
+
+    def _favorite_stub(self):
+        """The trainer's main/favorite Pokémon as {n, sprite} (or None)."""
+        try:
+            row = services.db.execute(
+                "SELECT pokedex_id, name, shiny, json_extract(data, '$.gender') "
+                "FROM captured_pokemon WHERE is_main = 1 LIMIT 1"
+            ).fetchone()
+        except Exception:
+            row = None
+        if not row or not row[1]:
+            return None
+        p = {"id": row[0] or 0, "name": row[1], "shiny": bool(row[2]), "gender": row[3]}
+        return {"n": format_pokemon_name(row[1]), "sprite": self._sprite_url(p)}
+
+    def _highest_stub(self):
+        """The highest-level captured Pokémon as {n, l, sprite} (or None)."""
+        try:
+            row = services.db.execute(
+                "SELECT pokedex_id, name, level, shiny, json_extract(data, '$.gender') "
+                "FROM captured_pokemon WHERE level IS NOT NULL ORDER BY level DESC LIMIT 1"
+            ).fetchone()
+        except Exception:
+            row = None
+        if not row or not row[1]:
+            return None
+        p = {"id": row[0] or 0, "name": row[1], "shiny": bool(row[3]), "gender": row[4]}
+        return {
+            "n": format_pokemon_name(row[1]),
+            "l": int(row[2]) if row[2] is not None else 0,
+            "sprite": self._sprite_url(p),
+        }
+
+    def _friendship_stub(self):
+        """The highest-friendship captured Pokémon (the trainer's BFF) as
+        {n, fr, sprite} (or None). friendship lives in data.$.friendship."""
+        try:
+            row = services.db.execute(
+                "SELECT pokedex_id, name, shiny, json_extract(data, '$.gender'), "
+                "json_extract(data, '$.friendship') AS fr "
+                "FROM captured_pokemon WHERE name IS NOT NULL "
+                "ORDER BY fr DESC LIMIT 1"
+            ).fetchone()
+        except Exception:
+            row = None
+        if not row or not row[1]:
+            return None
+        p = {"id": row[0] or 0, "name": row[1], "shiny": bool(row[2]), "gender": row[3]}
+        try:
+            fr_val = int(row[4]) if row[4] is not None else 0
+        except (ValueError, TypeError):
+            fr_val = 0
+        return {
+            "n": format_pokemon_name(row[1]),
+            "fr": fr_val,
+            "sprite": self._sprite_url(p),
+        }
+
+    def _badge_grid(self):
+        """All badges as {id, name, unlocked} for the Profile badge case.
+
+        Badge definitions never change at runtime, so the badges.json read is
+        cached on the instance — the live refresh re-runs this per gameplay
+        event, and re-reading the file each time would be wasteful. Only the
+        unlocked set (cheap, from trainer_card) is recomputed."""
+        definitions = getattr(self, "_badge_defs_cache", None)
+        if definitions is None:
+            try:
+                badges_path = self.addon_dir / "addon_files" / "badges.json"
+                with open(badges_path, "r", encoding="utf-8") as f:
+                    definitions = json.load(f)
+            except Exception as e:
+                print(f"[Ankimon] profile: failed to load badges.json: {e}")
+                definitions = {}
+            self._badge_defs_cache = definitions
+
+        unlocked = set()
+        try:
+            for b in getattr(self.trainer_card, "badges", []) or []:
+                unlocked.add(int(b))
+        except (TypeError, ValueError):
+            pass
+
+        grid = []
+        for raw_id, name in definitions.items():
+            if not name or name.lower() in ("changed", "add"):
+                continue
+            try:
+                bid = int(raw_id)
+            except (TypeError, ValueError):
+                continue
+            grid.append({"id": bid, "name": name, "unlocked": bid in unlocked})
+        return grid
+
+    # ------------------------------------------------------------------
+    # Team data
+    # ------------------------------------------------------------------
+    def _team_member_stubs(self):
+        """Ordered current-team members as lightweight render stubs."""
+        try:
+            team_data = services.db.get_team() or []
+        except Exception:
+            return []
+
+        ordered_ids = [
+            str(t.get("individual_id"))
+            for t in team_data
+            if t.get("individual_id")
+        ]
+        if not ordered_ids:
+            return []
+
+        try:
+            rows = services.db.get_pokemons_by_individual_ids(ordered_ids) or []
+        except Exception:
+            return []
+        by_id = {str(p.get("individual_id")): p for p in rows}
+
+        stubs = []
+        for ind_id in ordered_ids:
+            p = by_id.get(ind_id)
+            if not p:
+                continue
+            stub = {
+                "id": ind_id,
+                "p": p.get("id") or 0,
+                "n": format_pokemon_name(p.get("name") or "?"),
+                "l": int(p.get("level") or 0),
+                "sprite": self._sprite_url(p),
+                "types": self._pokemon_types(p.get("name")),
+            }
+            if p.get("shiny"):
+                stub["s"] = 1
+            stubs.append(stub)
+        return stubs
+
+    def _pokemon_types(self, raw_name):
+        """Type list (title-cased) for a species — drives the team cards' type
+        badges + coverage. Uses the cached pokedex, so it's cheap per member."""
+        if not raw_name:
+            return []
+        try:
+            from ..functions.pokedex_functions import search_pokedex
+
+            t = search_pokedex(raw_name, "types")
+        except Exception:
+            return []
+        if not isinstance(t, list):
+            return []
+        return [str(x).title() for x in t if x]
+
+    def get_member_stats(self, individual_id):
+        """On-demand {cp, types} for a Pokémon just dropped into a slot — roster
+        stubs omit both to stay light for big collections, so the team card
+        fetches them when the Pokémon is added."""
+        cp = self._calc_cp(individual_id)
+        types = []
+        try:
+            p = services.db.get_pokemon(individual_id)
+            if p:
+                types = self._pokemon_types(p.get("name"))
+        except Exception:
+            pass
+        return {"cp": cp, "types": types}
+
+    def _sprite_url(self, p):
+        """Web URL for a Pokémon's front sprite, resolved by the addon's own
+        sprite logic (which handles Mega/Gmax/forms, shiny and gender — the
+        pokedex_id alone is NOT enough for megas). Only call this for small
+        sets (team, recent), never the whole collection."""
+        try:
+            from ..functions.sprite_functions import get_sprite_path
+
+            abs_path = str(get_sprite_path(
+                "front", "png", p.get("id"),
+                bool(p.get("shiny")), (p.get("gender") or "N"), p.get("name"),
+            ))
+            # Convert the absolute sprite path to a path relative to a web page
+            # (all pages live one level under addon_dir). Locate the known
+            # sprites root rather than relying on relative_to, which is fragile
+            # when addon_dir is a symlink.
+            norm = abs_path.replace("\\", "/")
+            marker = "user_files/sprites/"
+            idx = norm.find(marker)
+            return ("../" + norm[idx:]) if idx != -1 else None
+        except Exception as e:
+            print(f"[Ankimon] profile: sprite url failed: {e}")
+            return None
+
+    def _recent_catches(self):
+        """The 6 most recently caught Pokémon as render stubs with resolved
+        sprites. Ordered by rowid (row insertion order) DESC — individual_id is
+        a random key, so it can't be used for recency; rowid tracks capture
+        order since new catches INSERT a new row."""
+        try:
+            cursor = services.db.execute(
+                """
+                SELECT individual_id, name, level, pokedex_id, shiny,
+                       json_extract(data, '$.gender') AS gender
+                FROM captured_pokemon
+                ORDER BY rowid DESC
+                LIMIT 6
+                """
+            )
+            rows = cursor.fetchall()
+        except Exception as e:
+            print(f"[Ankimon] profile: recent catches query failed: {e}")
+            return []
+
+        out = []
+        for row in rows:
+            name = row[1]
+            if not name:
+                continue
+            p = {
+                "id": row[3] or 0,
+                "name": name,
+                "shiny": bool(row[4]),
+                "gender": row[5],
+            }
+            stub = {
+                "id": row[0],
+                "p": row[3] or 0,
+                "n": format_pokemon_name(name),
+                "l": int(row[2]) if row[2] is not None else 0,
+                "sprite": self._sprite_url(p),
+            }
+            if row[4]:
+                stub["s"] = 1
+            out.append(stub)
+        return out
+
+    def get_team_data(self):
+        members = self._team_member_stubs()
+        for m in members:
+            m["cp"] = self._calc_cp(m["id"])
+
+        try:
+            xp_share = self.settings_obj.get("trainer.xp_share") or None
+            cycle_count = self.settings_obj.get("controls.team_cycle_count", 3)
+        except Exception:
+            xp_share = None
+            cycle_count = 3
+
+        sprite_mode = self.settings_obj.get(
+            "ankidex.spriteMode",
+            self.settings_obj.get("pokedex_v2.spriteMode", "static")
+        )
+
+        main_pkmn = services.db.get_main_pokemon()
+        companion_id = main_pkmn.get("individual_id") if main_pkmn else None
+
+        return {
+            "max_size": MAX_TEAM_SIZE,
+            "team": members,
+            "xp_share": str(xp_share) if xp_share else None,
+            "xp_share_info": self._resolve_stub(xp_share, members) if xp_share else None,
+            "companion": str(companion_id) if companion_id else None,
+            "companion_info": self._resolve_stub(companion_id, members) if companion_id else None,
+            "sprite_mode": sprite_mode,
+            "team_cycle_count": cycle_count,
+        }
+
+    def _resolve_stub(self, individual_id, members=None):
+        """Render stub for one Pokémon by individual_id — reuses a team member
+        if present, otherwise does a single DB lookup."""
+        ind_id = str(individual_id)
+        for m in members or []:
+            if str(m.get("id")) == ind_id:
+                stub = {"id": m["id"], "p": m["p"], "n": m["n"], "l": m["l"]}
+                if m.get("s"):
+                    stub["s"] = 1
+                if m.get("sprite"):
+                    stub["sprite"] = m["sprite"]
+                return stub
+        try:
+            p = services.db.get_pokemon(ind_id)
+        except Exception:
+            p = None
+        if not p:
+            return None
+        stub = {
+            "id": ind_id,
+            "p": p.get("id") or 0,
+            "n": format_pokemon_name(p.get("name") or "?"),
+            "l": int(p.get("level") or 0),
+            "sprite": self._sprite_url(p),
+        }
+        if p.get("shiny"):
+            stub["s"] = 1
+        return stub
+
+    def get_roster_data(self):
+        """Every captured Pokémon as a pick stub (cached on instance). Carries
+        CP (read from the stored data JSON — cheap, no per-Pokémon recompute) and
+        types so the picker can show rich cards, filter by type, and sort by CP.
+        Default order is CP desc."""
+        if self._roster_cache is not None:
+            return self._roster_cache
+
+        try:
+            cursor = services.db.execute(
+                """
+                SELECT individual_id, name, level, pokedex_id, shiny,
+                       json_extract(data, '$.cp') AS cp
+                FROM captured_pokemon
+                ORDER BY COALESCE(json_extract(data, '$.cp'), 0) DESC,
+                         level DESC, name ASC
+                """
+            )
+            rows = cursor.fetchall()
+        except Exception as e:
+            print(f"[Ankimon] profile: get_roster_data query failed: {e}")
+            return {"choices": []}
+
+        choices = []
+        for row in rows:
+            ind_id = row[0]
+            name = row[1]
+            if not ind_id or not name:
+                continue
+            pid = row[3] or 0
+            shiny = bool(row[4])
+            entry = {
+                "id": ind_id,
+                "p": pid,
+                "n": format_pokemon_name(name),
+                "l": int(row[2]) if row[2] is not None else 0,
+                "cp": int(row[5]) if row[5] is not None else 0,
+                "types": self._pokemon_types(name),
+            }
+            if shiny:
+                entry["s"] = 1
+            # Mega/Gmax & other forme ids (>= 10000) have no sprite at
+            # front_default/<id>.png — the stored pokedex_id is a forme id. Resolve
+            # via the addon's own sprite logic (get_sprite_path), which falls back
+            # to the base species sprite, so the picker matches every other screen.
+            # Only a handful of owned Pokémon are formes, so these filesystem
+            # lookups are cheap and run once (the roster is cached on the instance).
+            nl = name.lower()
+            if pid >= 10000 or "mega" in nl or "gmax" in nl or "gigantamax" in nl:
+                sprite = self._sprite_url(
+                    {"id": pid, "name": name, "shiny": shiny, "gender": None}
+                )
+                if sprite:
+                    entry["sprite"] = sprite
+            choices.append(entry)
+
+        result = {"choices": choices}
+        self._roster_cache = result
+        return result
+
+    def _calc_cp(self, individual_id):
+        """Pokémon-GO-style CP for one Pokémon (team slots only).
+
+        Prefer the *stored* cp — the same value the roster picker and Ankidex
+        show — so every screen agrees. Recompute when it's missing or zero
+        (a stored 0 is garbage — CP floors at 10), via calculate_cp_from_dict
+        (which correctly falls back from '$.base_stats' to '$.stats'): most
+        Pokémon keep their base stats under '$.stats' and have no
+        '$.base_stats', so reading base_stats alone made them compute a
+        garbage (~min) CP."""
+        try:
+            data = services.db.get_pokemon(individual_id)
+            if not data:
+                return 0
+            cp = data.get("cp")
+            if not cp:
+                from ..business import calculate_cp_from_dict
+                cp = calculate_cp_from_dict(data)
+            return int(cp or 0)
+        except Exception as e:
+            print(f"[Ankimon] profile: CP calc failed for {individual_id}: {e}")
+            return 0
+
+    def handle_save_team(self, team_ids, xp_share_id, companion_id):
+        """Persist the chosen team + XP Share + Active Companion (any owned Pokémon)."""
+        seen = set()
+        clean_ids = []
+        for raw in team_ids or []:
+            ind_id = str(raw) if raw is not None else ""
+            if not ind_id or ind_id in seen:
+                continue
+            seen.add(ind_id)
+            clean_ids.append(ind_id)
+            if len(clean_ids) >= MAX_TEAM_SIZE:
+                break
+
+        team_data = [{"individual_id": ind_id} for ind_id in clean_ids]
+        xp_share_id = str(xp_share_id) if xp_share_id else None
+        companion_id = str(companion_id) if companion_id else None
+
+        try:
+            self.settings_obj.set("trainer.team", team_data)
+            self.settings_obj.set("trainer.xp_share", xp_share_id)
+            services.db.save_team(team_data)
+            if companion_id:
+                services.db.set_main_pokemon(companion_id)
+                from ..functions.update_main_pokemon import update_main_pokemon
+                update_main_pokemon(services.main_pokemon)
+        except Exception as e:
+            return {"ok": False, "message": f"Failed to save team: {e}"}
+
+        try:
+            if self.trainer_card is not None:
+                self.trainer_card.reload_team()
+        except Exception:
+            pass
+
+        self._roster_cache = None
+        return {"ok": True, "message": "Team saved.", "count": len(team_data)}
+
+    # ------------------------------------------------------------------
+    # Trainer sprite picker
+    # ------------------------------------------------------------------
+    def get_sprite_data(self):
+        try:
+            names = sorted(get_all_sprites(trainer_sprites_path))
+        except Exception as e:
+            print(f"[Ankimon] profile: get_all_sprites failed: {e}")
+            names = []
+        try:
+            current = self.settings_obj.get("trainer.sprite") or ""
+        except Exception:
+            current = ""
+
+        # Set of role bases (first "-" segment) — lets _describe_sprite detect
+        # female ("…f") variants only when the base class is itself a sprite.
+        roles = {n.split("-")[0] for n in names}
+        sprites = []
+        present_gens = set()
+        present_cats = set()
+        present_sex = set()
+        for name in names:
+            label, sublabel, gen, category, gender = _describe_sprite(name, roles)
+            gen_key = str(gen) if gen else "other"
+            present_gens.add(gen_key)
+            present_cats.add(category)
+            if gender:
+                present_sex.add(gender)
+            sprites.append(
+                {
+                    "name": name,
+                    "label": label,
+                    "sublabel": sublabel,
+                    "gen": gen_key,
+                    "category": category,
+                    "gender": gender,
+                    "url": f"../addon_sprites/trainers/{name}.png",
+                }
+            )
+
+        # Filter chips, in a stable order, listing only what's actually present.
+        generations = [
+            {"key": str(i), "label": f"Gen {i}"}
+            for i in range(1, 10)
+            if str(i) in present_gens
+        ]
+        if "other" in present_gens:
+            generations.append({"key": "other", "label": "Other"})
+        categories = [c for c in _SPRITE_CATEGORY_ORDER if c in present_cats]
+        genders = []
+        if "m" in present_sex:
+            genders.append({"key": "m", "label": "♂ Male"})
+        if "f" in present_sex:
+            genders.append({"key": "f", "label": "♀ Female"})
+
+        return {
+            "sprites": sprites,
+            "generations": generations,
+            "categories": categories,
+            "genders": genders,
+            "current": current,
+        }
+
+    def handle_set_sprite(self, name):
+        if not name:
+            return {"ok": False, "message": "No sprite selected."}
+        try:
+            self.settings_obj.set("trainer.sprite", name)
+        except Exception as e:
+            return {"ok": False, "message": f"Failed to set sprite: {e}"}
+        try:
+            if self.trainer_card is not None:
+                self.trainer_card.refresh()
+        except Exception:
+            pass
+        return {"ok": True, "message": "Trainer sprite updated.", "current": name}
+
+    def handle_set_name(self, name):
+        """Persist a new trainer name (settings + trainer_card). Mirrors
+        handle_set_sprite: trims, rejects empty, caps length, refreshes the
+        trainer card so the in-memory name updates."""
+        name = (name or "").strip()
+        if not name:
+            return {"ok": False, "message": "Name can't be empty."}
+        if len(name) > 24:
+            name = name[:24]
+        try:
+            self.settings_obj.set("trainer.name", name)
+        except Exception as e:
+            return {"ok": False, "message": f"Failed to set name: {e}"}
+        try:
+            if self.trainer_card is not None:
+                self.trainer_card.refresh()
+        except Exception:
+            pass
+        return {"ok": True, "message": "Trainer name updated.", "name": name}

--- a/src/Ankimon/ankimon_profile_web/team.html
+++ b/src/Ankimon/ankimon_profile_web/team.html
@@ -1,0 +1,181 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Ankimon Team</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <style>
+        html { background: #0d1117; }
+        .skeleton { background: #161b22; border: 1px solid #30363d; border-radius: 14px; animation: sk 1.5s ease-in-out infinite; }
+        @keyframes sk { 0%,100% { opacity: .35 } 50% { opacity: .6 } }
+    </style>
+    <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700;800;900&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="profile.css?v=20260633">
+    <link rel="stylesheet" href="../ankimon_items_web/nav-switcher.css?v=20260633">
+    <script src="qrc:///qtwebchannel/qwebchannel.js"></script>
+</head>
+<body class="dark-mode">
+    <div class="app-container">
+        <aside class="sidebar">
+            <div class="sidebar-header">
+                <div id="nav-switcher" class="nav-switcher">
+                    <button id="nav-trigger" class="nav-trigger" type="button" aria-haspopup="true" aria-expanded="false">
+                        <img src="../user_files/sprites/items/great-ball.png" class="app-logo icon-item-sprite" alt="">
+                        <h1>TEAM</h1>
+                        <span class="nav-chevron">▾</span>
+                    </button>
+                    <div id="nav-menu" class="nav-menu hidden" role="menu">
+                        <button class="nav-menu-item" role="menuitem" data-screen="items">
+                            <span class="nav-menu-icon"><img src="../user_files/sprites/items/max-potion.png" class="icon-item-sprite" alt=""></span>
+                            <div class="nav-menu-text">
+                                <span class="nav-menu-title">Items</span>
+                                <span class="nav-menu-desc">Your inventory and today's Mart</span>
+                            </div>
+                        </button>
+                        <button class="nav-menu-item" role="menuitem" data-screen="ankidex">
+                            <span class="nav-menu-icon"><img src="../user_files/sprites/items/poke-ball.png" alt=""></span>
+                            <div class="nav-menu-text">
+                                <span class="nav-menu-title">Ankidex</span>
+                                <span class="nav-menu-desc">Browse caught Pokémon</span>
+                            </div>
+                        </button>
+                        <button class="nav-menu-item active" role="menuitem" data-screen="team">
+                            <span class="nav-menu-icon"><img src="../user_files/sprites/items/great-ball.png" class="icon-item-sprite" alt=""></span>
+                            <div class="nav-menu-text">
+                                <span class="nav-menu-title">Team</span>
+                                <span class="nav-menu-desc">Your active 6 Pokémon</span>
+                            </div>
+                        </button>
+                        <button class="nav-menu-item" role="menuitem" data-screen="profile">
+                            <span class="nav-menu-icon"><img src="../user_files/sprites/items/water-gem.png" class="icon-item-sprite" alt=""></span>
+                            <div class="nav-menu-text">
+                                <span class="nav-menu-title">Profile</span>
+                                <span class="nav-menu-desc">Card, badges &amp; avatar</span>
+                            </div>
+                        </button>
+                        <button class="nav-menu-item" role="menuitem" data-screen="settings">
+                            <span class="nav-menu-icon"><img src="../user_files/sprites/items/x-speed.png" class="icon-item-sprite" alt=""></span>
+                            <div class="nav-menu-text">
+                                <span class="nav-menu-title">Settings</span>
+                                <span class="nav-menu-desc">Configure Ankimon</span>
+                            </div>
+                        </button>
+                        <button class="nav-menu-item" role="menuitem" data-screen="mobile">
+                            <span class="nav-menu-icon"><img src="../user_files/sprites/items/elixir.png" class="icon-item-sprite" alt=""></span>
+                            <div class="nav-menu-text">
+                                <span class="nav-menu-title">Mobile &amp; Web Reviews</span>
+                                <span class="nav-menu-desc">Pending mobile/web battles</span>
+                            </div>
+                        </button>
+                    </div>
+                </div>
+            </div>
+            <div class="sidebar-body team-rail">
+                <div class="team-summary">
+                    <div class="ts-tile"><div class="tv" id="ts-count">0 / 6</div><div class="tk">Pokémon</div></div>
+                    <div class="ts-tile"><div class="tv" id="ts-avg">—</div><div class="tk">Avg Level</div></div>
+                    <div class="ts-tile hero"><div class="tv" id="ts-cp">—</div><div class="tk">Total CP</div></div>
+                </div>
+                <div class="ts-section ts-xpshare">
+                    <div class="ts-section-title">XP Share</div>
+                    <div class="xpshare-holder" id="xpshare-holder"></div>
+                </div>
+
+                <div class="ts-section ts-cycle">
+                    <div class="ts-section-title">Team Rotation (Hotkey 9)</div>
+                    <select id="cycle-select" class="cycle-select">
+                        <option value="1">Disabled (1)</option>
+                        <option value="2">First 2 Members</option>
+                        <option value="3">First 3 Members</option>
+                        <option value="4">First 4 Members</option>
+                        <option value="5">First 5 Members</option>
+                        <option value="6">All 6 Members</option>
+                    </select>
+                </div>
+                <div class="ts-analysis">
+                    <div class="ts-section">
+                        <div class="ts-section-title">Strengths</div>
+                        <div class="type-coverage" id="strengths"></div>
+                    </div>
+                    <div class="ts-section">
+                        <div class="ts-section-title">Weaknesses</div>
+                        <div class="type-coverage" id="weaknesses"></div>
+                    </div>
+                    <div class="ts-section">
+                        <div class="ts-section-title">Resistances</div>
+                        <div class="type-coverage" id="resistances"></div>
+                    </div>
+                </div>
+            </div>
+            <div class="sidebar-footer">
+                <button id="save-btn" class="btn btn-primary" style="width:100%;" disabled>Save Team</button>
+                <div id="save-status" style="text-align:center;font-size:.72rem;color:var(--text-muted);margin-top:8px;">All saved</div>
+            </div>
+        </aside>
+
+        <main class="main-content">
+            <header class="top-bar">
+                <div>
+                    <h2>Choose Your Team</h2>
+                    <span style="font-size:.8rem;color:var(--text-muted);">Click a slot to add or switch · ★ sets XP Share · ✕ removes</span>
+                </div>
+                <div class="top-actions">
+                    <button id="sprite-toggle" class="btn" title="Toggle Static/Animated Sprites">
+                        <span id="sprite-toggle-text">Static</span>
+                    </button>
+                </div>
+            </header>
+            <div class="content-scroll">
+                <div class="team-grid" id="team-grid">
+                    <div class="skeleton" style="height:200px;"></div>
+                    <div class="skeleton" style="height:200px;"></div>
+                    <div class="skeleton" style="height:200px;"></div>
+                    <div class="skeleton" style="height:200px;"></div>
+                    <div class="skeleton" style="height:200px;"></div>
+                    <div class="skeleton" style="height:200px;"></div>
+                </div>
+            </div>
+        </main>
+    </div>
+
+    <!-- Roster picker -->
+    <div id="picker" class="modal-overlay hidden">
+        <div class="modal picker-modal">
+            <div class="modal-head">
+                <h3 id="picker-title">Choose a Pokémon</h3>
+                <button class="icon-btn" id="picker-close" title="Close">×</button>
+            </div>
+            <div class="picker-toolbar" id="picker-toolbar">
+                <input type="text" id="picker-search" class="modal-search" placeholder="Search by name...">
+                <div class="filter-select" id="pf-type"></div>
+                <div class="filter-select" id="pf-sort"></div>
+                <span class="sprite-count" id="picker-count"></span>
+            </div>
+            <div class="picker-body">
+                <div class="picker-grid" id="roster-list"></div>
+                <div class="empty-state hidden" id="picker-empty">
+                    <div class="empty-icon"></div>
+                    <h2>No Pokémon found</h2>
+                    <p>Try adjusting your search or filters.</p>
+                    <button class="btn btn-primary" id="picker-clear" type="button">Clear filters</button>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div id="toast" class="toast"></div>
+
+    <script>
+        if (window.self !== window.top) {
+            document.body.classList.add('in-iframe');
+        }
+        if (window.location.search.includes('mode=companion-picker')) {
+            document.body.classList.add('companion-picker-only');
+        }
+    </script>
+    <script src="../ankimon_items_web/nav-switcher.js?v=20260633"></script>
+    <script src="team.js?v=20260632"></script>
+</body>
+</html>

--- a/src/Ankimon/ankimon_profile_web/team.js
+++ b/src/Ankimon/ankimon_profile_web/team.js
@@ -1,0 +1,760 @@
+// Team builder — assign up to 6 Pokémon + an XP Share target, then Save.
+//
+// Initial push (window.initializeTeam) carries only the current team + xp_share
+// (small). The full roster is lazy-loaded via team.getRoster() the first time a
+// slot picker opens, then cached. Per-slot CP is fetched on demand with
+// team.getCp() since roster stubs omit it for performance.
+
+(function () {
+    'use strict';
+
+    const SPRITE_BASE = '../user_files/sprites/front_default';
+    const FALLBACK = SPRITE_BASE + '/0.png';
+
+    const state = {
+        team: [null, null, null, null, null, null],
+        xpShare: null,         // individual_id of the XP Share holder (any owned Pokémon)
+        xpShareInfo: null,     // display stub for the holder (may be benched)
+        companion: null,
+        companionInfo: null,
+        maxSize: 6,
+        teamCycleCount: 3,     // limit for hotkey 9 rotation
+        roster: null,          // null = not loaded yet
+        dirty: false,
+        pickerSlot: null,
+        pickerMode: 'slot',    // 'slot' (fill a team slot) | 'xpshare' (pick XP Share)
+        rosterType: 'all',     // picker Type filter
+        rosterSort: 'cp',      // picker Sort: 'cp' | 'level' | 'name'
+        spriteMode: 'static',
+    };
+
+    const isCompanionPicker = false;
+    let teamBridge = null;
+
+    function spriteUrl(stub, mode = state.spriteMode) {
+        if (!stub) return FALLBACK;
+        let base = stub.sprite;
+        if (!base) {
+            const isShiny = !!stub.s;
+            const id = stub.p;
+            if (!id) return FALLBACK;
+            if (mode === 'animated') {
+                return isShiny
+                    ? `../user_files/sprites/front_default_gif/shiny/${id}.gif`
+                    : `../user_files/sprites/front_default_gif/${id}.gif`;
+            }
+            return isShiny
+                ? `../user_files/sprites/front_default/shiny/${id}.png`
+                : `../user_files/sprites/front_default/${id}.png`;
+        }
+        if (mode === 'animated') {
+            return base.replace('/front_default/', '/front_default_gif/').replace('.png', '.gif');
+        }
+        return base;
+    }
+
+    function esc(s) {
+        const d = document.createElement('div');
+        d.textContent = s == null ? '' : String(s);
+        return d.innerHTML;
+    }
+    function num(n) { return (Number(n) || 0).toLocaleString(); }
+    function setText(id, t) { const el = document.getElementById(id); if (el) el.textContent = t; }
+
+    // Standard Pokémon type colours for the badges + coverage chips.
+    const TYPE_COLORS = {
+        Normal: '#9099a1', Fire: '#ff9d55', Water: '#4d90d5', Electric: '#f3d23b',
+        Grass: '#63bc5a', Ice: '#74cec0', Fighting: '#ce4069', Poison: '#ab6ac8',
+        Ground: '#d97845', Flying: '#8fa9de', Psychic: '#fa7179', Bug: '#90c12c',
+        Rock: '#c7b78b', Ghost: '#5269ad', Dragon: '#0c6ac8', Dark: '#5a5366',
+        Steel: '#5a8ea1', Fairy: '#ec8fe6',
+    };
+    function typeBadge(t) {
+        const c = TYPE_COLORS[t] || '#6b727c';
+        return `<span class="type-badge" style="background:${c};">${esc(t)}</span>`;
+    }
+
+    // Type effectiveness chart (attacking -> defending), only the non-1× cells.
+    // Used to compute the team's collective defensive weaknesses. This is the
+    // modern (Gen 6+) chart and is intentionally INDEPENDENT of the battle
+    // engine's addon_files/eff_chart.json, which holds older/simplified values
+    // (e.g. Ghost→Psychic 0, Dark→Fighting 2×) for a rough Present-Power
+    // heuristic — do not "unify" them or the team analysis would regress.
+    const ALL_TYPES = [
+        'Normal', 'Fire', 'Water', 'Electric', 'Grass', 'Ice', 'Fighting', 'Poison',
+        'Ground', 'Flying', 'Psychic', 'Bug', 'Rock', 'Ghost', 'Dragon', 'Dark', 'Steel', 'Fairy',
+    ];
+    const TYPE_FX = {
+        Normal: { Rock: .5, Ghost: 0, Steel: .5 },
+        Fire: { Fire: .5, Water: .5, Grass: 2, Ice: 2, Bug: 2, Rock: .5, Dragon: .5, Steel: 2 },
+        Water: { Fire: 2, Water: .5, Grass: .5, Ground: 2, Rock: 2, Dragon: .5 },
+        Electric: { Water: 2, Electric: .5, Grass: .5, Ground: 0, Flying: 2, Dragon: .5 },
+        Grass: { Fire: .5, Water: 2, Grass: .5, Poison: .5, Ground: 2, Flying: .5, Bug: .5, Rock: 2, Dragon: .5, Steel: .5 },
+        Ice: { Fire: .5, Water: .5, Grass: 2, Ice: .5, Ground: 2, Flying: 2, Dragon: 2, Steel: .5 },
+        Fighting: { Normal: 2, Ice: 2, Poison: .5, Flying: .5, Psychic: .5, Bug: .5, Rock: 2, Ghost: 0, Dark: 2, Steel: 2, Fairy: .5 },
+        Poison: { Grass: 2, Poison: .5, Ground: .5, Rock: .5, Ghost: .5, Steel: 0, Fairy: 2 },
+        Ground: { Fire: 2, Electric: 2, Grass: .5, Poison: 2, Flying: 0, Bug: .5, Rock: 2, Steel: 2 },
+        Flying: { Electric: .5, Grass: 2, Fighting: 2, Bug: 2, Rock: .5, Steel: .5 },
+        Psychic: { Fighting: 2, Poison: 2, Psychic: .5, Dark: 0, Steel: .5 },
+        Bug: { Fire: .5, Grass: 2, Fighting: .5, Poison: .5, Flying: .5, Psychic: 2, Ghost: .5, Dark: 2, Steel: .5, Fairy: .5 },
+        Rock: { Fire: 2, Ice: 2, Fighting: .5, Ground: .5, Flying: 2, Bug: 2, Steel: .5 },
+        Ghost: { Normal: 0, Psychic: 2, Ghost: 2, Dark: .5 },
+        Dragon: { Dragon: 2, Steel: .5, Fairy: 0 },
+        Dark: { Fighting: .5, Psychic: 2, Ghost: 2, Dark: .5, Fairy: .5 },
+        Steel: { Fire: .5, Water: .5, Electric: .5, Ice: 2, Rock: 2, Steel: .5, Fairy: 2 },
+        Fairy: { Fire: .5, Fighting: 2, Poison: .5, Dragon: 2, Dark: 2, Steel: .5 },
+    };
+    function defMultiplier(attacking, defendingTypes) {
+        const row = TYPE_FX[attacking] || {};
+        let m = 1;
+        defendingTypes.forEach((d) => { m *= (d in row ? row[d] : 1); });
+        return m;
+    }
+    // {attackingType: count} across the filled team, for a given test on the
+    // defensive multiplier (>1 = weak, <1 = resists/immune).
+    function teamDefense(filled, test) {
+        const counts = {};
+        filled.forEach((m) => {
+            const types = (m.types || []).filter(Boolean);
+            if (!types.length) return;
+            ALL_TYPES.forEach((atk) => {
+                if (test(defMultiplier(atk, types))) counts[atk] = (counts[atk] || 0) + 1;
+            });
+        });
+        return counts;
+    }
+    // {opposingType: number-of-members-that-hit-it-super-effectively} — STAB-based
+    // offensive coverage (the types the team is strong against).
+    function teamStrengths(filled) {
+        const counts = {};
+        filled.forEach((m) => {
+            const types = (m.types || []).filter(Boolean);
+            if (!types.length) return;
+            ALL_TYPES.forEach((def) => {
+                if (types.some((t) => (TYPE_FX[t] || {})[def] > 1)) {
+                    counts[def] = (counts[def] || 0) + 1;
+                }
+            });
+        });
+        return counts;
+    }
+    function weakBadge(t, count) {
+        const c = TYPE_COLORS[t] || '#6b727c';
+        const cnt = count > 1 ? `<span class="wk-count">${count}</span>` : '';
+        return `<span class="type-badge" style="background:${c};">${esc(t)}${cnt}</span>`;
+    }
+    // Render a {type: count} map into a container, sorted by count desc.
+    function renderTypeCounts(elId, counts, emptyMsg) {
+        const el = document.getElementById(elId);
+        if (!el) return;
+        const order = Object.keys(counts).sort((a, b) =>
+            (counts[b] - counts[a]) || (ALL_TYPES.indexOf(a) - ALL_TYPES.indexOf(b)));
+        el.innerHTML = order.length
+            ? order.map((t) => weakBadge(t, counts[t])).join('')
+            : `<span class="coverage-empty">${esc(emptyMsg)}</span>`;
+    }
+
+    // ---------------- Render ----------------
+    function renderTeam() {
+        const grid = document.getElementById('team-grid');
+        const frag = document.createDocumentFragment();
+
+        for (let i = 0; i < state.maxSize; i++) {
+            const m = state.team[i];
+            const slot = document.createElement('div');
+            const isXp = !!(m && state.xpShare && String(m.id) === String(state.xpShare));
+            slot.className = 'slot ' + (m ? 'filled' : 'empty') + (isXp ? ' xp-share' : '');
+
+            if (m) {
+                const cp = (m.cp === undefined || m.cp === null) ? '—' : num(m.cp);
+                const types = (m.types || []).map(typeBadge).join('');
+                const hasCycle = state.teamCycleCount > 1 && i < state.teamCycleCount;
+                const cycleBadge = hasCycle ? '<span class="slot-rotation-badge" title="Cycled via Hotkey 9">↻</span>' : '';
+
+                slot.title = 'Click to switch';
+                slot.innerHTML = `
+                    <span class="slot-num">${i + 1}${cycleBadge}</span>
+                    <button class="slot-corner slot-star${isXp ? ' on' : ''}" data-act="xp" data-slot="${i}"
+                            title="${isXp ? 'Remove XP Share' : 'Set as XP Share'}">★</button>
+                    <button class="slot-corner slot-remove" data-act="remove" data-slot="${i}" title="Remove">✕</button>
+                    <div class="slot-sprite-wrap"><img src="${spriteUrl(m)}" alt="${esc(m.n)}"
+                         onerror="if (this.src.indexOf('_gif') !== -1) { this.src = this.src.replace('_gif', '').replace('.gif', '.png'); } else { this.onerror=null; this.src='${FALLBACK}'; }"></div>
+                    <div class="slot-name">${esc(m.n)}${m.s ? ' <span class="shiny-dot">★</span>' : ''}</div>
+                    ${types ? `<div class="slot-types">${types}</div>` : ''}
+                    <div class="slot-stats">
+                        <div class="slot-stat"><span class="v">${esc(m.l)}</span><span class="k">Level</span></div>
+                        <div class="slot-stat"><span class="v">${cp}</span><span class="k">CP</span></div>
+                    </div>
+                    <div class="slot-switch-hint">⇄ Switch</div>`;
+                slot.addEventListener('click', () => openPicker(i));
+            } else {
+                slot.innerHTML = `
+                    <span class="slot-num">${i + 1}</span>
+                    <div class="slot-empty-icon">+</div>
+                    <div class="slot-empty-label">Add Pokémon</div>
+                    <div class="slot-empty-sub">Slot ${i + 1}</div>`;
+                slot.addEventListener('click', () => openPicker(i));
+            }
+            frag.appendChild(slot);
+        }
+        grid.replaceChildren(frag);
+
+        // Corner buttons (★ XP Share, ✕ remove) override the card's click-to-switch.
+        grid.querySelectorAll('[data-act]').forEach((btn) => {
+            const i = Number(btn.dataset.slot);
+            btn.addEventListener('click', (e) => {
+                e.stopPropagation();
+                if (btn.dataset.act === 'remove') removeSlot(i);
+                else if (btn.dataset.act === 'xp') toggleXp(i);
+            });
+        });
+
+        renderSummary();
+        renderXpShare();
+    }
+
+    function toggleXp(slot) {
+        const m = state.team[slot];
+        if (!m) return;
+        if (state.xpShare && String(m.id) === String(state.xpShare)) setXpShare(null);
+        else setXpShare(m);
+    }
+
+    // Sidebar team overview: filled count, average level, total CP, type coverage.
+    function renderSummary() {
+        const filled = state.team.filter(Boolean);
+        setText('ts-count', filled.length + ' / ' + state.maxSize);
+        const avg = filled.length
+            ? Math.round(filled.reduce((s, m) => s + (Number(m.l) || 0), 0) / filled.length)
+            : null;
+        setText('ts-avg', avg == null ? '—' : String(avg));
+        const cps = filled.map((m) => Number(m.cp)).filter((v) => !isNaN(v));
+        setText('ts-cp', cps.length ? num(cps.reduce((s, v) => s + v, 0)) : '—');
+
+        // Matchup analysis (counts = how many members are involved):
+        //  Strengths  = opposing types the team hits super-effectively (offense)
+        //  Weaknesses = types that hit the team super-effectively (defense)
+        //  Resistances = types the team resists / is immune to (defense)
+        renderTypeCounts('strengths', teamStrengths(filled), 'Add Pokémon to see strengths');
+        renderTypeCounts('weaknesses', teamDefense(filled, (mult) => mult > 1), 'Add Pokémon to see weaknesses');
+        renderTypeCounts('resistances', teamDefense(filled, (mult) => mult < 1), 'Add Pokémon to see resistances');
+    }
+
+    function renderXpShare() {
+        const holder = document.getElementById('xpshare-holder');
+        if (!holder) return;
+        // The holder may be benched, so prefer the resolved stub; fall back to a
+        // team member if it happens to be on the team.
+        let m = state.xpShareInfo;
+        if (!m && state.xpShare) {
+            m = state.team.find((p) => p && String(p.id) === String(state.xpShare)) || null;
+        }
+        if (m) {
+            holder.innerHTML = `
+                <div class="xps-card" title="Change XP Share">
+                    <img class="xps-sprite" src="${spriteUrl(m)}" alt="${esc(m.n)}"
+                         onerror="if (this.src.indexOf('_gif') !== -1) { this.src = this.src.replace('_gif', '').replace('.gif', '.png'); } else { this.onerror=null; this.src='${FALLBACK}'; }">
+                    <div class="xps-name">${esc(m.n)}${m.s ? ' <span class="shiny-dot">★</span>' : ''}</div>
+                    <div class="xps-lv">★ Lv ${esc(m.l)}</div>
+                    <div class="xps-change-hint">⇄ Change</div>
+                </div>`;
+        } else {
+            holder.innerHTML = '<button class="xps-empty" type="button">+ Set XP Share</button>';
+        }
+        // Whole card is the trigger (like a team slot) — opens the XP Share picker.
+        const trigger = holder.querySelector('.xps-card, .xps-empty');
+        if (trigger) trigger.addEventListener('click', openXpSharePicker);
+    }
+
+
+
+    // ---------------- Slot actions ----------------
+    function removeSlot(slot) {
+        // XP Share is independent of team membership now — removing a Pokémon
+        // from a slot leaves it owned, so we keep it as the XP Share holder.
+        state.team[slot] = null;
+        markDirty();
+        renderTeam();
+    }
+
+    function assignSlot(slot, stub) {
+        // Copy so editing one slot can't alias another / the roster entry.
+        const member = { id: stub.id, p: stub.p, n: stub.n, l: stub.l };
+        if (stub.s) member.s = 1;
+        if (stub.sprite) member.sprite = stub.sprite;   // carry the resolved forme/mega sprite (else it'd 404 to 0.png)
+        if (stub.types) member.types = stub.types;
+        if (stub.cp != null) member.cp = stub.cp;   // stored CP from the roster (shown instantly)
+        state.team[slot] = member;
+        markDirty();
+        renderTeam();
+        // Refresh CP/types from the live data (recomputed) for the added Pokémon.
+        if (teamBridge && teamBridge.getMemberStats) {
+            teamBridge.getMemberStats(String(stub.id)).then((res) => {
+                const cur = state.team[slot];
+                if (cur && String(cur.id) === String(stub.id) && res) {
+                    if (res.cp != null) cur.cp = res.cp;   // don't clobber the shown CP with a missing value
+                    cur.types = res.types || cur.types || [];
+                    renderTeam();
+                }
+            });
+        }
+    }
+
+    // ---------------- XP Share ----------------
+    function setXpShare(stub) {
+        if (stub) {
+            state.xpShare = String(stub.id);
+            state.xpShareInfo = { id: stub.id, p: stub.p, n: stub.n, l: stub.l };
+            if (stub.s) state.xpShareInfo.s = 1;
+            if (stub.sprite) state.xpShareInfo.sprite = stub.sprite;
+        } else {
+            state.xpShare = null;
+            state.xpShareInfo = null;
+        }
+        markDirty();
+        renderTeam();
+    }
+
+    // ---------------- Roster picker ----------------
+    function setPickerTitle(text) {
+        const el = document.getElementById('picker-title');
+        if (el) el.textContent = text;
+    }
+
+    function ensureRoster(done) {
+        if (state.roster !== null) { done(); return; }
+        renderRosterList('Loading…');
+        if (teamBridge && teamBridge.getRoster) {
+            teamBridge.getRoster().then((res) => {
+                state.roster = (res && res.choices) || [];
+                done();
+            });
+        } else {
+            state.roster = [];
+            done();
+        }
+    }
+
+    function openPicker(slot) {
+        state.pickerMode = 'slot';
+        state.pickerSlot = slot;
+        setPickerTitle('Choose a Pokémon');
+        resetPickerControls();
+        showPicker(true);
+        ensureRoster(() => { buildPickerFilters(); renderRosterList(); });
+    }
+
+    function openXpSharePicker() {
+        state.pickerMode = 'xpshare';
+        state.pickerSlot = null;
+        setPickerTitle('Choose XP Share Pokémon');
+        resetPickerControls();
+        showPicker(true);
+        ensureRoster(() => { buildPickerFilters(); renderRosterList(); });
+    }
+
+    function resetPickerControls() {
+        const s = document.getElementById('picker-search');
+        if (s) s.value = '';
+        state.rosterType = 'all';
+        state.rosterSort = 'cp';
+    }
+
+    function showPicker(show) {
+        document.getElementById('picker').classList.toggle('hidden', !show);
+        if (!show) closePickerMenus();
+        if (show) {
+            const s = document.getElementById('picker-search');
+            setTimeout(() => s.focus(), 0);
+        }
+    }
+
+    // ---- Picker filter dropdowns (Type + Sort) — mirrors the sprite picker ----
+    function closePickerMenus() {
+        document.querySelectorAll('#picker-toolbar .filter-select.open').forEach((s) => {
+            s.classList.remove('open');
+            const menu = s.querySelector('.fs-menu');
+            if (menu) menu.classList.add('hidden');
+            const t = s.querySelector('.fs-trigger');
+            if (t) t.setAttribute('aria-expanded', 'false');
+        });
+    }
+
+    function renderPickerSelect(hostId, which, opts) {
+        const host = document.getElementById(hostId);
+        if (!host) return;
+        const items = opts.items || [];
+        const sel = opts.selected;
+        const hasAll = !!opts.allLabel;
+        if (hasAll && !items.length) { host.className = 'filter-select hidden'; host.innerHTML = ''; return; }
+        const cur = items.find((it) => it.key === sel);
+        const triggerText = (hasAll && sel === 'all')
+            ? opts.allLabel
+            : (opts.prefix || '') + (cur ? cur.label : (opts.allLabel || ''));
+        const active = hasAll && sel !== 'all';
+        const opt = (label, val, on) =>
+            `<button class="fs-option${on ? ' active' : ''}" type="button" data-val="${esc(val)}">${esc(label)}</button>`;
+        host.className = 'filter-select' + (active ? ' active' : '');
+        const optsHtml = (hasAll ? opt('All', 'all', sel === 'all') : '')
+            + items.map((it) => opt(it.label, it.key, sel === it.key)).join('');
+        host.innerHTML = `
+            <button class="fs-trigger" type="button" aria-haspopup="true" aria-expanded="false">
+                <span class="fs-value">${esc(triggerText)}</span>
+                <span class="fs-chevron">▾</span>
+            </button>
+            <div class="fs-menu hidden" role="menu">${optsHtml}</div>`;
+        const trigger = host.querySelector('.fs-trigger');
+        const menu = host.querySelector('.fs-menu');
+        trigger.addEventListener('click', (e) => {
+            e.stopPropagation();
+            const willOpen = menu.classList.contains('hidden');
+            closePickerMenus();
+            if (willOpen) {
+                menu.classList.remove('hidden');
+                host.classList.add('open');
+                trigger.setAttribute('aria-expanded', 'true');
+            }
+        });
+        menu.querySelectorAll('.fs-option').forEach((o) => {
+            o.addEventListener('click', (e) => {
+                e.stopPropagation();
+                const val = o.getAttribute('data-val');
+                if (which === 'type') state.rosterType = val;
+                else state.rosterSort = val;
+                buildPickerFilters();
+                renderRosterList();
+            });
+        });
+    }
+
+    function buildPickerFilters() {
+        const present = new Set();
+        (state.roster || []).forEach((c) => (c.types || []).forEach((t) => present.add(t)));
+        const typeItems = ALL_TYPES.filter((t) => present.has(t)).map((t) => ({ key: t, label: t }));
+        renderPickerSelect('pf-type', 'type', { items: typeItems, selected: state.rosterType, allLabel: 'Type' });
+        renderPickerSelect('pf-sort', 'sort', {
+            items: [{ key: 'cp', label: 'CP' }, { key: 'level', label: 'Level' }, { key: 'name', label: 'Name' }],
+            selected: state.rosterSort, prefix: '↕ ',
+        });
+    }
+
+    function renderRosterList(placeholder) {
+        const list = document.getElementById('roster-list');
+        const empty = document.getElementById('picker-empty');
+        if (placeholder) {
+            if (empty) empty.classList.add('hidden');
+            list.classList.remove('hidden');
+            list.innerHTML = `<div style="color:var(--text-muted);padding:12px;">${esc(placeholder)}</div>`;
+            return;
+        }
+        const xpMode = state.pickerMode === 'xpshare';
+        const companionMode = state.pickerMode === 'companion';
+        const q = (document.getElementById('picker-search').value || '').toLowerCase();
+        const typeF = state.rosterType || 'all';
+        const sort = state.rosterSort || 'cp';
+        // In slot mode, Pokémon already in OTHER slots can't be added twice.
+        const taken = (xpMode || companionMode) ? new Set() : new Set(
+            state.team.map((m, i) => (m && i !== state.pickerSlot ? String(m.id) : null)).filter(Boolean)
+        );
+        let choices = (state.roster || []).filter((c) => {
+            if (typeF !== 'all' && (c.types || []).indexOf(typeF) < 0) return false;
+            if (q && (c.n || '').toLowerCase().indexOf(q) < 0) return false;
+            return true;
+        });
+        choices = choices.slice().sort((a, b) => {
+            if (sort === 'name') return (a.n || '').localeCompare(b.n || '');
+            if (sort === 'level') return (b.l || 0) - (a.l || 0) || (a.n || '').localeCompare(b.n || '');
+            return (b.cp || 0) - (a.cp || 0) || (a.n || '').localeCompare(b.n || '');   // CP (default)
+        });
+
+        const countEl = document.getElementById('picker-count');
+        if (countEl) countEl.textContent = choices.length + ' Pokémon';
+
+        if (!choices.length && !xpMode && !companionMode) {
+            list.classList.add('hidden');
+            list.innerHTML = '';
+            if (empty) empty.classList.remove('hidden');
+            return;
+        }
+        if (empty) empty.classList.add('hidden');
+        list.classList.remove('hidden');
+
+        const frag = document.createDocumentFragment();
+        // XP Share mode: a "No XP Share" clear card pinned first.
+        if (xpMode) {
+            const none = document.createElement('div');
+            none.className = 'roster-card' + (!state.xpShare ? ' current' : '');
+            none.innerHTML = `
+                <div class="rc-sprite" style="display:flex;align-items:center;justify-content:center;color:var(--text-muted);font-size:1.7rem;">✕</div>
+                <div class="rc-name" style="color:var(--text-muted);">No XP Share</div>`;
+            none.addEventListener('click', () => { setXpShare(null); showPicker(false); });
+            frag.appendChild(none);
+        }
+        const CAP = 200;
+        choices.slice(0, CAP).forEach((c) => {
+            const inTeam = (!xpMode && !companionMode) && taken.has(String(c.id));
+            const isCurrent = xpMode 
+                ? String(state.xpShare) === String(c.id)
+                : (companionMode ? String(state.companion) === String(c.id) : false);
+            const card = document.createElement('div');
+            card.className = 'roster-card' + (inTeam ? ' in-team' : '') + (isCurrent ? ' current' : '');
+            const types = (c.types || []).map(typeBadge).join('');
+            const cp = (c.cp != null && c.cp > 0) ? num(c.cp) : '—';
+            card.innerHTML = `
+                <img class="rc-sprite" src="${spriteUrl(c)}" alt="${esc(c.n)}" onerror="if (this.src.indexOf('_gif') !== -1) { this.src = this.src.replace('_gif', '').replace('.gif', '.png'); } else { this.onerror=null; this.src='${FALLBACK}'; }">
+                <div class="rc-name">${esc(c.n)}${c.s ? ' <span class="shiny-dot">★</span>' : ''}</div>
+                ${types ? `<div class="rc-types">${types}</div>` : ''}
+                <div class="rc-stats"><span>Lv ${esc(c.l)}</span><span>·</span><span class="rc-cp">${cp}</span><span>CP</span></div>
+                ${inTeam ? '<div class="rc-tag">On team</div>' : (isCurrent ? '<div class="rc-tag">Current</div>' : '')}`;
+            if (!inTeam) {
+                card.addEventListener('click', () => {
+                    if (xpMode) {
+                        setXpShare(c);
+                    } else if (companionMode) {
+                        setCompanion(c);
+                    } else {
+                        assignSlot(state.pickerSlot, c);
+                    }
+                    showPicker(false);
+                    if (companionMode && isCompanionPicker) {
+                        saveTeam().then((res) => {
+                            if (res && res.ok && window.parent && window.parent.closeCompanionPicker) {
+                                window.parent.closeCompanionPicker();
+                            }
+                        }).catch((err) => {
+                            console.error('Companion auto-save failed:', err);
+                        });
+                    }
+                });
+            }
+            frag.appendChild(card);
+        });
+        list.replaceChildren(frag);
+        if (choices.length > CAP) {
+            const more = document.createElement('div');
+            more.style.cssText = 'grid-column:1/-1;color:var(--text-muted);padding:10px;text-align:center;font-size:.78rem;';
+            more.textContent = `Showing top ${CAP} of ${choices.length}. Refine your search or filters.`;
+            list.appendChild(more);
+        }
+    }
+
+    // ---------------- Save / dirty ----------------
+    function markDirty() {
+        state.dirty = true;
+        updateSaveUI();
+    }
+
+    function updateSaveUI() {
+        const btn = document.getElementById('save-btn');
+        const status = document.getElementById('save-status');
+        btn.disabled = !state.dirty;
+        status.textContent = state.dirty ? 'Unsaved changes' : 'All saved';
+    }
+
+    function saveTeam() {
+        if (!state.dirty) return Promise.resolve({ ok: true });
+        const ids = state.team.filter(Boolean).map((m) => String(m.id));
+        if (!teamBridge || !teamBridge.saveTeam) {
+            toast('Saved (preview — no backend).', 'success');
+            state.dirty = false;
+            updateSaveUI();
+            return Promise.resolve({ ok: true });
+        }
+        return teamBridge.saveTeam(JSON.stringify(ids), state.xpShare || '', '').then((res) => {
+            if (res && res.ok) {
+                state.dirty = false;
+                updateSaveUI();
+                toast(res.message || 'Team saved.', 'success');
+                return res;
+            } else {
+                toast((res && res.message) || 'Save failed.', 'error');
+                throw new Error((res && res.message) || 'Save failed');
+            }
+        });
+    }
+
+    let toastTimer = null;
+    function toast(msg, kind) {
+        const el = document.getElementById('toast');
+        el.textContent = msg;
+        el.className = 'toast show' + (kind ? ' ' + kind : '');
+        if (toastTimer) clearTimeout(toastTimer);
+        toastTimer = setTimeout(() => { el.className = 'toast'; }, 2600);
+    }
+
+    // ---------------- Init ----------------
+    function applyData(data) {
+        data = data || {};
+        state.maxSize = data.max_size || 6;
+        const team = (data.team || []).slice(0, state.maxSize);
+        state.team = [];
+        for (let i = 0; i < state.maxSize; i++) state.team.push(team[i] || null);
+        state.xpShare = data.xp_share ? String(data.xp_share) : null;
+        state.xpShareInfo = data.xp_share_info || null;
+        state.companion = null;
+        state.companionInfo = null;
+        state.spriteMode = data.sprite_mode || 'static';
+        state.teamCycleCount = data.team_cycle_count || 3;
+
+        const cycleSelect = document.getElementById('cycle-select');
+        if (cycleSelect) cycleSelect.value = state.teamCycleCount;
+
+        const text = document.getElementById('sprite-toggle-text');
+        if (text) {
+            text.textContent = state.spriteMode === 'static' ? 'Static' : 'Animated';
+        }
+        state.dirty = false;
+        // Membership changed underneath us → force a roster reload next open.
+        state.roster = null;
+        renderTeam();
+        updateSaveUI();
+        if (isCompanionPicker) {
+            openCompanionPicker();
+        }
+    }
+
+    window.initializeTeam = applyData;
+
+    function wireStaticControls() {
+        document.getElementById('save-btn').addEventListener('click', saveTeam);
+        
+        const cycleSelect = document.getElementById('cycle-select');
+        if (cycleSelect) {
+            cycleSelect.addEventListener('change', (e) => {
+                const count = parseInt(e.target.value, 10) || 3;
+                state.teamCycleCount = count;
+                renderTeam();
+                if (teamBridge && teamBridge.saveCycleCount) {
+                    teamBridge.saveCycleCount(count);
+                }
+            });
+        }
+
+        // XP Share button is rendered dynamically inside #xpshare-holder (see
+        // renderXpShare), so it's wired there, not here.
+        const spriteBtn = document.getElementById('sprite-toggle');
+        if (spriteBtn) {
+            spriteBtn.addEventListener('click', () => {
+                state.spriteMode = state.spriteMode === 'static' ? 'animated' : 'static';
+                const text = document.getElementById('sprite-toggle-text');
+                if (text) {
+                    text.textContent = state.spriteMode === 'static' ? 'Static' : 'Animated';
+                }
+                renderTeam();
+                renderRosterList();
+                if (teamBridge && teamBridge.saveSpriteMode) {
+                    teamBridge.saveSpriteMode(state.spriteMode);
+                }
+            });
+        }
+        document.getElementById('picker-close').addEventListener('click', () => {
+            showPicker(false);
+            if (isCompanionPicker && window.parent && window.parent.closeCompanionPicker) {
+                window.parent.closeCompanionPicker();
+            }
+        });
+        document.getElementById('picker-search').addEventListener('input', () => renderRosterList());
+        document.getElementById('picker').addEventListener('click', (e) => {
+            if (e.target.id === 'picker') {
+                showPicker(false);
+                if (isCompanionPicker && window.parent && window.parent.closeCompanionPicker) {
+                    window.parent.closeCompanionPicker();
+                }
+            }
+        });
+        const pickerClear = document.getElementById('picker-clear');
+        if (pickerClear) {
+            pickerClear.addEventListener('click', () => {
+                resetPickerControls();
+                buildPickerFilters();
+                renderRosterList();
+            });
+        }
+        // Clicking elsewhere closes an open picker filter dropdown (trigger/option
+        // clicks stopPropagation, so they don't trigger this).
+        document.addEventListener('click', closePickerMenus);
+        document.addEventListener('keydown', (e) => {
+            if (e.key === 'Escape') {
+                if (document.querySelector('#picker-toolbar .filter-select.open')) { closePickerMenus(); return; }
+                showPicker(false);
+                if (isCompanionPicker && window.parent && window.parent.closeCompanionPicker) {
+                    window.parent.closeCompanionPicker();
+                }
+                return;
+            }
+            // Cmd/Ctrl+S saves the team (matches the Settings screen).
+            if ((e.metaKey || e.ctrlKey) && (e.key === 's' || e.key === 'S')) {
+                e.preventDefault();
+                saveTeam();
+            }
+        });
+    }
+
+    function init() {
+        wireStaticControls();
+
+        if (typeof qt === 'undefined' || !qt.webChannelTransport) {
+            // Standalone preview or iframe picker mode reusing parent channel
+            if (window.self !== window.top && window.parent && window.parent.parentChannel) {
+                teamBridge = window.parent.parentChannel.objects.team;
+                const nav = window.parent.parentChannel.objects.nav;
+                window.team = teamBridge;
+                window.nav = nav;
+                if (window.wireNavSwitcher) window.wireNavSwitcher(nav);
+                if (teamBridge && teamBridge.getTeam) {
+                    teamBridge.getTeam().then(applyData);
+                }
+                return;
+            }
+
+            // Standalone preview. applyData() resets state.roster to null
+            // (production reloads it from the bridge), so seed the mock roster
+            // *after* it for the no-bridge picker to have something to show.
+            applyData({
+                max_size: 6,
+                xp_share: '2',
+                xp_share_info: { id: '2', p: 6, n: 'Charizard', l: 52, s: 1 },
+                team: [
+                    { id: '1', p: 25, n: 'Pikachu', l: 18, cp: 820, types: ['Electric'] },
+                    { id: '2', p: 6, n: 'Charizard', l: 52, s: 1, cp: 2410, types: ['Fire', 'Flying'] },
+                    { id: '3', p: 9, n: 'Blastoise', l: 44, cp: 2180, types: ['Water'] },
+                    { id: '4', p: 3, n: 'Venusaur', l: 41, cp: 2090, types: ['Grass', 'Poison'] },
+                    { id: '5', p: 94, n: 'Gengar', l: 36, cp: 1760, types: ['Ghost', 'Poison'] },
+                    { id: '6', p: 143, n: 'Snorlax', l: 30, cp: 1980, types: ['Normal'] },
+                ],
+            });
+            state.roster = [
+                { id: '1', p: 25, n: 'Pikachu', l: 18, cp: 820, types: ['Electric'] },
+                { id: '2', p: 6, n: 'Charizard', l: 52, s: 1, cp: 2410, types: ['Fire', 'Flying'] },
+                { id: '3', p: 9, n: 'Blastoise', l: 44, cp: 2180, types: ['Water'] },
+                { id: '4', p: 3, n: 'Venusaur', l: 41, cp: 2090, types: ['Grass', 'Poison'] },
+                { id: '5', p: 94, n: 'Gengar', l: 36, cp: 1760, types: ['Ghost', 'Poison'] },
+                { id: '6', p: 130, n: 'Gyarados', l: 39, cp: 2230, types: ['Water', 'Flying'] },
+                { id: '7', p: 143, n: 'Snorlax', l: 30, cp: 1980, types: ['Normal'] },
+                // Forme id with no front_default/<id>.png; resolved sprite falls back
+                // to the base species (998) — dev demo of the mega sprite fix.
+                { id: '8', p: 10325, n: 'Mega Baxcalibur', l: 60, cp: 3050, types: ['Dragon', 'Ice'], sprite: SPRITE_BASE + '/998.png' },
+            ];
+            return;
+        }
+
+        new QWebChannel(qt.webChannelTransport, function (channel) {
+            teamBridge = channel.objects && channel.objects.team;
+            const nav = channel.objects && channel.objects.nav;
+            window.team = teamBridge;
+            window.nav = nav;
+            // Wire the dropdown from THIS channel's nav — see ankimon_items_web/nav-switcher.js
+            // for why we don't open a second channel.
+            if (window.wireNavSwitcher) window.wireNavSwitcher(nav);
+            if (teamBridge && teamBridge.getTeam) {
+                teamBridge.getTeam().then(applyData);
+            }
+        });
+    }
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', init);
+    } else {
+        init();
+    }
+})();

--- a/src/Ankimon/pyobj/ankimon_shop.py
+++ b/src/Ankimon/pyobj/ankimon_shop.py
@@ -23,6 +23,7 @@ from aqt.qt import (
 )
 from aqt.theme import theme_manager
 
+from ..services import services
 from ..functions.pokedex_functions import find_details_move
 
 from ..utils import give_item, daily_item_list, get_item_price, get_item_description
@@ -381,7 +382,7 @@ class PokemonShopManager:
         # Check inventory for owned status
         owned_quantity = 0
         try:
-            db_item = mw.ankimon_db.get_item(item["name"])
+            db_item = services.db.get_item(item["name"])
             if db_item:
                 owned_quantity = db_item.get("quantity", 0)
         except Exception:
@@ -444,7 +445,7 @@ class PokemonShopManager:
 
     def get_daily_items(self):
         """Generate daily items based on the current date."""
-        db = mw.ankimon_db
+        db = services.db
         shop_data = db.get_user_data("todays_shop")
         if shop_data:
             if shop_data.get("items") and shop_data.get("date") == datetime.now().strftime("%Y-%m-%d"):
@@ -456,7 +457,7 @@ class PokemonShopManager:
 
     def get_daily_tms(self):
         """Works like get_daily_items, but for TMs"""
-        db = mw.ankimon_db
+        db = services.db
         shop_data = db.get_user_data("todays_shop")
         if shop_data:
             if shop_data.get("technical_machines") and shop_data.get("date") == datetime.now().strftime("%Y-%m-%d"):
@@ -468,6 +469,12 @@ class PokemonShopManager:
         return random.sample(tm_pool, self.number_of_daily_items)
 
     def get_tm_pool(self) -> list[str]:
+        # Cached: pokemon_tm_learnset.json is immutable at runtime, and this
+        # is on the hot path of the Items window's data fetch.
+        cached = getattr(self, "_tm_pool_cache", None)
+        if cached is not None:
+            return cached
+
         with open(pokemon_tm_learnset_path, "r") as f:
             pokemon_tm_learnset = json.load(f)
 
@@ -489,6 +496,7 @@ class PokemonShopManager:
         # Ensure deterministic order
         all_tms.sort(key=lambda tm: tm["name"])
 
+        self._tm_pool_cache = all_tms
         return all_tms
 
     def buy_item(self, item, item_type: Union[str, None] = None):
@@ -595,7 +603,7 @@ class PokemonShopManager:
             "technical_machines": self.todays_daily_tms,
             "date": datetime.now().strftime("%Y-%m-%d"),
         }
-        mw.ankimon_db.set_user_data("todays_shop", data)
+        services.db.set_user_data("todays_shop", data)
 
         # Now refresh the window - it will load from the updated JSON file
         self.toggle_window()

--- a/src/Ankimon/pyobj/ankimon_shop.py
+++ b/src/Ankimon/pyobj/ankimon_shop.py
@@ -468,7 +468,7 @@ class PokemonShopManager:
         random.seed(seed)
         return random.sample(tm_pool, self.number_of_daily_items)
 
-    def get_tm_pool(self) -> list[str]:
+    def get_tm_pool(self) -> list[dict]:
         # Cached: pokemon_tm_learnset.json is immutable at runtime, and this
         # is on the hot path of the Items window's data fetch.
         cached = getattr(self, "_tm_pool_cache", None)

--- a/src/Ankimon/singletons.py
+++ b/src/Ankimon/singletons.py
@@ -329,10 +329,37 @@ def get_pokemon_pc():
     return win
 
 
+# The unified Ankimon web shell (F11/F13/F18): Items/Shop, Settings, Profile and
+# Team all live in this one QDialog (one window, one dropdown navigator). Lazy +
+# reload-safe like the other window factories, but not registry-backed — it is a
+# pure GUI window, so it lives in its own module-level cache with an is_alive()
+# liveness check (a shell whose C++ object was deleted is rebuilt, not handed out
+# dead). Seam-correct: constructed from the services-resolved core objects above,
+# never from mw.* (F31 keeps mw coupling out of this module, NR-04).
+_items_web_window = None
+
+
+def get_items_window():
+    global _items_web_window
+    if is_alive(_items_web_window):
+        return _items_web_window
+    from .ankimon_items_web.shop_obj import AnkimonItemsWeb
+
+    _items_web_window = AnkimonItemsWeb(
+        addon_dir,
+        shop_manager=shop_manager,
+        item_window=get_item_window(),
+        ankimon_tracker=ankimon_tracker_obj,
+        trainer_card=trainer_card,
+        settings_obj=settings_obj,
+        logger=logger,
+    )
+    return _items_web_window
+
+
 # DEFERRED seam points (do NOT add here in F31):
-# * get_items_window() -> ankimon_items_web / web-shell Items screen and
-#   get_ankidex_window() -> ankidex/ SPA land with F36 (their modules do not
-#   exist on this base yet); mount via webshell host per MERGE_ARCH_MAP §4.
+# * get_ankidex_window() -> ankidex/ SPA lands with a later unit (its module
+#   does not exist on this base yet); mount via webshell host per §4.
 # * get_nature_chart() -> gui_entities.NatureTableWidget lands with F36 (the
 #   widget does not exist on this base yet).
 # * notify_stats_changed() (QWebChannel live-update push) belongs to the

--- a/tests/test_profile_pokedex_completion.py
+++ b/tests/test_profile_pokedex_completion.py
@@ -1,0 +1,187 @@
+"""Profile Pokédex-completion count (F18).
+
+Dynamically loads the real ``AnkimonDB`` + ``ProfileData`` (+ the real
+``pokedex_functions`` for its dedup helpers) against lightweight stand-ins for
+the aqt/anki and sibling Ankimon modules, so the pure data logic can be exercised
+without an Anki runtime.
+
+Hermetic: every ``sys.modules`` entry is installed via ``monkeypatch.setitem``
+so it is restored at teardown — the module-level stand-ins do NOT leak into the
+rest of the Tier-1 suite. ProfileData reads state through the service seam
+(``services.db``), not ``aqt.mw``, so the test injects the real temp DB there.
+"""
+
+import sys
+import types
+import importlib.util
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+_src = Path(__file__).parent.parent / "src"
+
+
+class MockLogger:
+    def log(self, level, msg):
+        pass
+
+    def log_and_showinfo(self, level, msg):
+        pass
+
+    def _log(self, level, msg):
+        pass
+
+
+def _load_module(name, filepath, monkeypatch):
+    """Load a real source file under ``name``, registered (and later restored)
+    through monkeypatch so it never leaks into the wider test session."""
+    spec = importlib.util.spec_from_file_location(name, filepath)
+    mod = importlib.util.module_from_spec(spec)
+    monkeypatch.setitem(sys.modules, name, mod)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture
+def profile_env(tmp_path, monkeypatch):
+    """Hermetic loader for AnkimonDB + ProfileData + pokedex_functions."""
+
+    # --- aqt / anki stand-ins (never actually exercised here) ---
+    for name in [
+        "aqt", "aqt.qt", "aqt.utils", "aqt.gui_hooks", "aqt.operations",
+        "aqt.reviewer", "aqt.webview", "aqt.main",
+        "anki", "anki.hooks", "anki.collection", "anki.models",
+        "anki.notes", "anki.template", "anki.buildinfo",
+    ]:
+        monkeypatch.setitem(sys.modules, name, MagicMock())
+
+    class MockResources:
+        user_path = tmp_path
+
+        def __getattr__(self, name):
+            return tmp_path / name
+
+    # --- Ankimon parent-package stand-ins so relative imports resolve without
+    #     pulling the aqt-coupled addon composition root. ---
+    monkeypatch.setitem(sys.modules, "Ankimon", types.ModuleType("Ankimon"))
+    monkeypatch.setitem(sys.modules, "Ankimon.resources", MockResources())
+    monkeypatch.setitem(sys.modules, "Ankimon.singletons", MagicMock())
+    monkeypatch.setitem(sys.modules, "Ankimon.utils", MagicMock())
+    monkeypatch.setitem(sys.modules, "Ankimon.pyobj", MagicMock())
+    monkeypatch.setitem(sys.modules, "Ankimon.functions", types.ModuleType("Ankimon.functions"))
+    monkeypatch.setitem(
+        sys.modules,
+        "Ankimon.ankimon_profile_web",
+        types.ModuleType("Ankimon.ankimon_profile_web"),
+    )
+
+    # Service seam stand-in: the test injects the real temp DB onto services.db.
+    services_mod = types.ModuleType("Ankimon.services")
+    services_mod.services = types.SimpleNamespace(db=None, main_pokemon=None, settings=None)
+    monkeypatch.setitem(sys.modules, "Ankimon.services", services_mod)
+
+    # pokedex_functions imports these sibling modules at top level; the test
+    # path never calls into them, so lightweight mocks satisfy the imports.
+    monkeypatch.setitem(sys.modules, "Ankimon.pyobj.error_handler", MagicMock())
+    monkeypatch.setitem(sys.modules, "Ankimon.pyobj.pokemon_obj", MagicMock())
+    monkeypatch.setitem(sys.modules, "Ankimon.functions.learnset_retrieval", MagicMock())
+
+    # --- load the real modules under test against the stand-ins ---
+    db_mod = _load_module(
+        "Ankimon.pyobj.database_manager",
+        _src / "Ankimon" / "pyobj" / "database_manager.py",
+        monkeypatch,
+    )
+    monkeypatch.setattr(db_mod, "user_path", tmp_path, raising=False)
+
+    pf = _load_module(
+        "Ankimon.functions.pokedex_functions",
+        _src / "Ankimon" / "functions" / "pokedex_functions.py",
+        monkeypatch,
+    )
+
+    profile_mod = _load_module(
+        "Ankimon.ankimon_profile_web.profile_data",
+        _src / "Ankimon" / "ankimon_profile_web" / "profile_data.py",
+        monkeypatch,
+    )
+
+    db = db_mod.AnkimonDB(MockLogger())
+
+    return types.SimpleNamespace(
+        db=db,
+        ProfileData=profile_mod.ProfileData,
+        pf=pf,
+        services=services_mod.services,
+    )
+
+
+def test_profile_pokedex_completion(profile_env):
+    """
+    Verifies that the Profile Pokédex count (ProfileData._collection_stats,
+    routed through the service seam ``services.db``):
+    1. Deduplicates special forms (Megas, regional variants) to their base
+       species_id, so a Mega and its base species count once.
+    2. Counts currently-owned box Pokémon.
+
+    NOTE: exp's version also folded in released-history and explicitly-marked
+    caught IDs (the ``get_all_pokemon_ids`` history/caught merge +
+    ``mark_as_caught``). That merge is a separate, later pokedex-completion DB
+    leaf that is not part of this web-shell unit, so this test exercises the
+    dedup path against currently-owned Pokémon only.
+    """
+    db = profile_env.db
+    pf = profile_env.pf
+    ProfileData = profile_env.ProfileData
+
+    # Region-returning settings stub + inject the real DB onto the seam.
+    settings_obj = MagicMock()
+    settings_obj.get.return_value = "red"
+    profile_env.services.db = db
+    profile_env.services.settings = settings_obj
+
+    # Miniature in-memory Pokédex caches (bypass the JSON file load).
+    pf._pokedex_cache = {
+        "charizard": {"species_id": 6, "actual_id": 3, "name": "Charizard"},
+        "charizardmega": {"species_id": 6, "actual_id": 10091, "name": "Charizard-Mega-X"},
+        "bulbasaur": {"species_id": 1, "actual_id": 1, "name": "Bulbasaur"},
+        "vulpix": {"species_id": 37, "actual_id": 37, "name": "Vulpix"},
+        "vulpixalola": {"species_id": 37, "actual_id": 10100, "name": "Vulpix-Alola"},
+    }
+    pf._pokedex_id_index = {
+        3: "charizard",
+        10091: "charizardmega",
+        1: "bulbasaur",
+        37: "vulpix",
+        10100: "vulpixalola",
+    }
+
+    # Currently-owned box Pokémon spanning a base species, its Mega, and a
+    # regional form of a different species. The Mega must dedupe onto the base
+    # species, so the dex count treats 4 owned Pokémon as 3 species.
+    db.save_pokemon({"individual_id": "c1", "id": 3, "name": "Charizard", "level": 50, "shiny": False})
+    # Mega Charizard X (species_id 6) -> deduplicated onto base Charizard.
+    db.save_pokemon({"individual_id": "c2", "id": 10091, "name": "Charizard-Mega-X", "level": 60, "shiny": False})
+    db.save_pokemon({"individual_id": "b1", "id": 1, "name": "Bulbasaur", "level": 15, "shiny": False})
+    # Alolan Vulpix (species_id 37) — regional form of Vulpix.
+    db.save_pokemon({"individual_id": "v1", "id": 10100, "name": "Vulpix-Alola", "level": 20, "shiny": False})
+
+    trainer_card = MagicMock()
+    trainer_card.highest_pokemon_level.return_value = 60
+    profile = ProfileData(
+        addon_dir=Path("/tmp"),
+        trainer_card=trainer_card,
+        settings_obj=settings_obj,
+        logger=MagicMock(),
+    )
+
+    stats = profile._collection_stats()
+
+    # Caught currently in box = 4 (2 Charizards + Bulbasaur + Alolan Vulpix).
+    assert stats["caught"] == 4
+    # Dex unique base species caught = 3 (species 6 + 1 + 37); Mega Charizard X
+    # dedupes onto base Charizard (species 6).
+    assert stats["dex_seen"] == 3
+    assert stats["shinies"] == 0
+    assert stats["highest_level"] == 60


### PR DESCRIPTION
## What
Ports the QWebEngine **web-shell HOST** plus its three bundled screens onto the integration tip, re-fitted to main's service seam. This is the foundational scaffolding for Wave 4 — every later web screen (Ankidex, Mobile Reviews, nav menu) mounts on it.

- **Host** — `ankimon_items_web/shop_obj.py`: `AnkimonItemsWeb(QDialog)` single-window shell with QWebChannel bridges (`NavBridge`, `TrainerBridge`, `TeamBridge`, `SettingsBridge`, `ItemsBridge`, `MobileBridge`) swapping screens in place.
- **F11 Shop** — `shop.{html,css,js}` + the `_tm_pool_cache` memoization on `get_tm_pool` in `pyobj/ankimon_shop.py` (immutable learnset, hot path; ~16-line delta 3-wayed onto main's file, not a wholesale replace).
- **F13 Settings** — schema-driven settings screen (`settings.{html,css,js}` + `settings_schema.py` GROUPS render contract).
- **F18 Profile & Team** — `ankimon_profile_web/` screens + `profile_data.py` data provider (bundled: the host constructs `ProfileData` in `__init__`).
- `singletons.py`: reload-safe lazy `get_items_window()` factory with module-level cache + `is_alive()` reuse, following the existing factory idiom.

## Seam re-fit
- `shop_obj.py`: `mw.ankimon_db → services.db`, `mw.settings_obj → services.settings`, `main_pokemon`/`trainer_card`/`tracker`/`logger`/`achievements` → `services.*`; `singletons.notify_stats_changed()` → `refresh_live_screen()` + `events.emit('stats_changed')`. Genuine Anki APIs stay direct (`mw.col.sched.day_cutoff`, `mw.pm.profile`, `mw.onSync`, Qt construction).
- `profile_data.py`: `from aqt import mw` removed; all 14 `mw.ankimon_db` sites → `services.db`, `mw.main_pokemon` → `services.main_pokemon`.
- `ankimon_shop.py`: 4 `mw.ankimon_db` sites → `services.db`.

## Mobile decoupled (lazy)
The exp file hard-imported `functions/mobile_sync` at module top; that engine is a **later Wave-4 PR**. Here the two module-top mobile imports are converted to lazy in-method imports inside the `MobileBridge` slots, each guarded to return a benign payload when `mobile_sync` is absent. Verified headless: importing `shop_obj` does **not** pull `mobile_sync` into `sys.modules`; `AnkimonItemsWeb` constructs with a real `QWebEngineView`; `getMobileStatus()`/`resolveChunk()` degrade benignly. `is_dev_mode` gets a local `False` fallback until the dev-mode helper lands (mirrors main's `reviewer_ui.py`).

## Guards
- Host + Shop/Settings/Profile/Team all functional with mobile absent.
- No edits to `item_window.py`, `battle_loop.py`, or `__init__.py` (owned by sibling Wave-4 PRs).
- `test_profile_pokedex_completion.py` adapted to the seam and made hermetic — exp's version called `setup_mocks()` at module import, polluting `sys.modules` and breaking 43 unrelated tests; now a monkeypatch-scoped fixture. exp's `mark_as_caught`/released-history coverage is deferred to the pokedex-completion DB leaf (F25 deferred hunks) that owns those methods.

## Verification
Two-tier gate on the branch tip (adversarially re-run by an independent verifier):
- compileall clean; ruff (`ci_ruff_check.toml`) = 10 pre-existing known-debt errors only (0 in changed files).
- pytest Tier-1: **368 passed / 0 failed** / 54 skipped (367 baseline + 1 new).
- harness/check.py 9/9 PASS.
- Qt: smoke + integrity 5 passed; probe_real_boot OK (`reviewer_did_answer_card` hooks == 3); probe_real_play OK.
- Headless construction probe: `get_items_window()` cached/idempotent, MobileBridge registered, no `mobile_sync` import.

## Attribution
Originally implemented by @hakimh2 and @AIbrahimv2 on BRRRR_Experimental; credited via Co-authored-by trailers (`Hakimh2 <74561421+hakimh2@users.noreply.github.com>`, `AIbrahimv2 <66210743+AIbrahimv2@users.noreply.github.com>`). The broken `Your Name <you@example.com>` identity in the file history maps to Hakimh2.
