### PR TITLE
feat: profile-close cache-clear hook (F20 scaffolding half)

### DIFF
--- a/src/Ankimon/profile_hooks.py
+++ b/src/Ankimon/profile_hooks.py
@@ -1,14 +1,38 @@
 from anki.hooks import addHook
 from aqt import gui_hooks, mw
 
+from .services import services
 from .singletons import settings_obj, logger
 from .utils import test_online_connectivity
 from .pyobj.ankimon_sync import setup_ankimon_sync_hooks, check_and_sync_pokemon_data
 from .pyobj.tip_of_the_day import show_tip_of_the_day
 from .pyobj.pokemon_trade import check_and_award_monthly_pokemon
 from .pyobj.error_handler import show_warning_with_traceback
+from .functions.pokedex_functions import clear_pokedex_caches
+from .functions.learnset_retrieval import clear_learnset_cache
+from .functions.encounter_functions import clear_encounter_cache
 
 sync_dialog = None
+
+# Cache-clear-on-close (F20): the pokedex / learnset / encounter in-memory
+# caches live for the whole Python process, so without this a profile switch
+# would carry the previous profile's cached tables into the next one. Dropping
+# them when the profile closes makes each profile start cleanly from disk.
+# The registration record lives on the services registry (F31 pattern) rather
+# than a module-level flag: it survives a re-execution of this module (an
+# add-on reload), so re-registering swaps the handler in place instead of
+# stacking a second copy onto gui_hooks.profile_will_close.
+_CLOSE_HANDLER_RECORD = "_profile_close_cache_clear_handler"
+
+
+def _on_profile_close():
+    """Clear all performance caches when the Anki session/profile ends."""
+    try:
+        clear_pokedex_caches()
+        clear_learnset_cache()
+        clear_encounter_cache()
+    except Exception as e:
+        logger.log("error", f"Error clearing caches on profile close: {e}")
 
 
 def _on_profile_did_open(online_connectivity):
@@ -89,3 +113,13 @@ def register_profile_hooks(
     addHook("profileLoaded", on_profile_loaded)
     gui_hooks.profile_did_open.append(_on_profile_did_open(online_connectivity))
     gui_hooks.profile_will_close.append(backup_manager.on_anki_close)
+
+    # Cache-clear-on-close, registered idempotently (F31 registry-anchored
+    # guard): drop the previously-recorded handler before appending, so a second
+    # boot / add-on reload swaps it in place of stacking a duplicate. gui_hooks'
+    # remove() tolerates an already-absent callback.
+    previous_close_handler = getattr(services, _CLOSE_HANDLER_RECORD, None)
+    if previous_close_handler is not None:
+        gui_hooks.profile_will_close.remove(previous_close_handler)
+    gui_hooks.profile_will_close.append(_on_profile_close)
+    setattr(services, _CLOSE_HANDLER_RECORD, _on_profile_close)

--- a/tests/test_profile_hooks.py
+++ b/tests/test_profile_hooks.py
@@ -1,0 +1,225 @@
+"""Characterization tests for the profile-close cache-clear hook (F20).
+
+Pins the two contracts of the ported scaffolding without Qt:
+
+* ``_on_profile_close()`` drops the three in-memory performance caches
+  (pokedex / learnset / encounter) and never lets an exception escape onto
+  Anki's ``profile_will_close`` hook chain.
+* The close handler is registered *idempotently*. Its registration record
+  lives on the services registry, so neither a second ``register_profile_hooks``
+  call nor a re-execution of the module (an add-on reload: new function objects,
+  surviving registry) can stack a second copy onto
+  ``gui_hooks.profile_will_close``.
+
+House pattern (same as tests/test_reload_safe_singletons.py): stub ``aqt`` +
+the heavy sibling modules in ``sys.modules``, exec the REAL profile_hooks.py
+under its dotted name, and give it a FRESH real ``services`` registry per test
+so the module-level record cannot leak between tests. ``gui_hooks`` hooks are
+plain lists — ``.append`` / ``.remove`` behave exactly like the aqt hook API
+this code uses, and an unmatched remove would fail loudly.
+"""
+
+import importlib.util
+import sys
+import types
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+_src = __import__("pathlib").Path(__file__).parent.parent / "src"
+
+
+def _stub_module(name, **attrs):
+    mod = types.ModuleType(name)
+    for key, value in attrs.items():
+        setattr(mod, key, value)
+    return mod
+
+
+def _fresh_services(monkeypatch):
+    """Exec a fresh, REAL services registry (isolated from other tests)."""
+    services_spec = importlib.util.spec_from_file_location(
+        "Ankimon.services", _src / "Ankimon" / "services.py"
+    )
+    services_mod = importlib.util.module_from_spec(services_spec)
+    monkeypatch.setitem(sys.modules, "Ankimon.services", services_mod)
+    services_spec.loader.exec_module(services_mod)
+    return services_mod.services
+
+
+def _fresh_gui_hooks():
+    """gui_hooks stub: plain lists, so an unmatched remove() fails loudly."""
+    return SimpleNamespace(profile_did_open=[], profile_will_close=[])
+
+
+def _exec_profile_hooks(monkeypatch, gui_hooks):
+    """Exec the real profile_hooks.py against stubbed siblings. Each call
+    returns a FRESH module object (fresh handler functions) — exactly what an
+    add-on reload produces — while ``Ankimon.services`` is left to the caller.
+
+    The three ``clear_*`` callables are separate MagicMocks so a test can assert
+    each was called (and so encounter_functions' real pokedex.json import-time
+    IO is never triggered)."""
+    clear_pokedex = MagicMock(name="clear_pokedex_caches")
+    clear_learnset = MagicMock(name="clear_learnset_cache")
+    clear_encounter = MagicMock(name="clear_encounter_cache")
+
+    monkeypatch.setitem(
+        sys.modules,
+        "anki.hooks",
+        _stub_module("anki.hooks", addHook=lambda *a, **k: None),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "aqt",
+        _stub_module("aqt", gui_hooks=gui_hooks, mw=SimpleNamespace()),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "Ankimon.singletons",
+        _stub_module(
+            "Ankimon.singletons",
+            settings_obj=MagicMock(name="settings_obj"),
+            logger=MagicMock(name="logger"),
+        ),
+    )
+    monkeypatch.setitem(
+        sys.modules, "Ankimon.utils",
+        _stub_module("Ankimon.utils", test_online_connectivity=lambda: False),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "Ankimon.pyobj.ankimon_sync",
+        _stub_module(
+            "Ankimon.pyobj.ankimon_sync",
+            setup_ankimon_sync_hooks=MagicMock(),
+            check_and_sync_pokemon_data=MagicMock(),
+        ),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "Ankimon.pyobj.tip_of_the_day",
+        _stub_module("Ankimon.pyobj.tip_of_the_day", show_tip_of_the_day=MagicMock()),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "Ankimon.pyobj.pokemon_trade",
+        _stub_module(
+            "Ankimon.pyobj.pokemon_trade",
+            check_and_award_monthly_pokemon=MagicMock(),
+        ),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "Ankimon.pyobj.error_handler",
+        _stub_module(
+            "Ankimon.pyobj.error_handler", show_warning_with_traceback=MagicMock()
+        ),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "Ankimon.functions.pokedex_functions",
+        _stub_module(
+            "Ankimon.functions.pokedex_functions", clear_pokedex_caches=clear_pokedex
+        ),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "Ankimon.functions.learnset_retrieval",
+        _stub_module(
+            "Ankimon.functions.learnset_retrieval", clear_learnset_cache=clear_learnset
+        ),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "Ankimon.functions.encounter_functions",
+        _stub_module(
+            "Ankimon.functions.encounter_functions",
+            clear_encounter_cache=clear_encounter,
+        ),
+    )
+
+    spec = importlib.util.spec_from_file_location(
+        "Ankimon.profile_hooks", _src / "Ankimon" / "profile_hooks.py"
+    )
+    profile_hooks = importlib.util.module_from_spec(spec)
+    monkeypatch.setitem(sys.modules, "Ankimon.profile_hooks", profile_hooks)
+    spec.loader.exec_module(profile_hooks)
+    profile_hooks._clears = (clear_pokedex, clear_learnset, clear_encounter)
+    return profile_hooks
+
+
+def _register(profile_hooks):
+    profile_hooks.register_profile_hooks(
+        online_connectivity=False,
+        backup_manager=MagicMock(on_anki_close=MagicMock()),
+        CatchPokemonHook=MagicMock(),
+        DefeatPokemonHook=MagicMock(),
+        add_catch_pokemon_hook=MagicMock(),
+        add_defeat_pokemon_hook=MagicMock(),
+        collected_pokemon_ids=set(),
+    )
+
+
+def test_on_profile_close_clears_all_caches(monkeypatch):
+    _fresh_services(monkeypatch)
+    gui_hooks = _fresh_gui_hooks()
+    profile_hooks = _exec_profile_hooks(monkeypatch, gui_hooks)
+
+    profile_hooks._on_profile_close()
+
+    for clear in profile_hooks._clears:
+        clear.assert_called_once_with()
+
+
+def test_on_profile_close_swallows_clear_errors(monkeypatch):
+    """A cache-clear failure must not propagate onto the profile-close chain."""
+    _fresh_services(monkeypatch)
+    gui_hooks = _fresh_gui_hooks()
+    profile_hooks = _exec_profile_hooks(monkeypatch, gui_hooks)
+    profile_hooks._clears[0].side_effect = RuntimeError("boom")
+
+    # Must not raise.
+    profile_hooks._on_profile_close()
+
+
+def test_cache_clear_hook_registered_once(monkeypatch):
+    _fresh_services(monkeypatch)
+    gui_hooks = _fresh_gui_hooks()
+    profile_hooks = _exec_profile_hooks(monkeypatch, gui_hooks)
+
+    _register(profile_hooks)
+
+    assert gui_hooks.profile_will_close.count(profile_hooks._on_profile_close) == 1
+
+
+def test_cache_clear_hook_idempotent_on_repeat_register(monkeypatch):
+    _fresh_services(monkeypatch)
+    gui_hooks = _fresh_gui_hooks()
+    profile_hooks = _exec_profile_hooks(monkeypatch, gui_hooks)
+
+    _register(profile_hooks)
+    _register(profile_hooks)
+
+    assert gui_hooks.profile_will_close.count(profile_hooks._on_profile_close) == 1
+
+
+def test_cache_clear_hook_idempotent_on_module_reexec(monkeypatch):
+    """The F31 failure this guards: re-executing profile_hooks (an add-on
+    reload) creates a NEW ``_on_profile_close`` object, so a module-level flag
+    would reset and remove-by-identity would miss the old handler. The
+    registry-stored record must swap the handler instead of stacking a copy."""
+    _fresh_services(monkeypatch)
+    gui_hooks = _fresh_gui_hooks()
+
+    mod1 = _exec_profile_hooks(monkeypatch, gui_hooks)
+    _register(mod1)
+
+    # Reload: fresh module + functions, same gui_hooks, surviving registry.
+    mod2 = _exec_profile_hooks(monkeypatch, gui_hooks)
+    assert mod2._on_profile_close is not mod1._on_profile_close
+    _register(mod2)
+
+    assert gui_hooks.profile_will_close.count(mod2._on_profile_close) == 1
+    assert mod1._on_profile_close not in gui_hooks.profile_will_close


### PR DESCRIPTION
## What
Ports the **scaffolding half of F20** — the profile-close cache-clear hook — onto the integration tip. When the Anki profile closes, the three in-memory caches introduced by the caching layer are cleared so a profile switch never serves stale data:

- `functions.pokedex_functions.clear_pokedex_caches`
- `functions.learnset_retrieval.clear_learnset_cache`
- `functions.encounter_functions.clear_encounter_cache`

Purely additive: `profile_hooks.py` +34/-0, plus 5 new tests (+225 lines).

## Split per the inventory row
`profile_hooks.py` is a hard collision file: main independently rewrote it (taskman connectivity, monthly/changelog wiring) while exp added QueryOp connectivity + mobile watermark bootstrap + this cache-clear hook. Per the F20 row split, **only the cache-clear scaffolding lands here**; the mobile watermark/session/badge bootstrap is deferred to the mobile-sync PR, and main's connectivity/monthly/changelog structure is untouched.

## Guards
- Registered idempotently via the F31 registry-anchored guard pattern (anchored on the services registry, remove-before-append) — safe under add-on reload and double registration.
- No mobile bootstrap, no QueryOp connectivity rewrite, no changes to main's existing hook structure.

## Verification
Two-tier gate on the branch tip (adversarially re-run by an independent verifier):
- compileall clean; ruff (`ci_ruff_check.toml`) = 10 pre-existing known-debt errors only.
- pytest Tier-1: **372 passed / 0 failed** / 54 skipped (367 baseline + 5 new F20 tests).
- harness/check.py 9/9 PASS.
- Qt: smoke + integrity 5 passed; probe_real_boot OK (`reviewer_did_answer_card` hooks == 3); probe_real_play OK.

## Attribution
Originally implemented by @hakimh2 on BRRRR_Experimental; credited via Co-authored-by trailer (`Hakimh2 <74561421+hakimh2@users.noreply.github.com>`). The broken `Your Name <you@example.com>` identity in the file history maps to Hakimh2.
