### PR TITLE
feat: items/bag web seam — dispatch_use + held-item liveness guards (F12)

### DIFF
--- a/src/Ankimon/pyobj/item_window.py
+++ b/src/Ankimon/pyobj/item_window.py
@@ -43,7 +43,8 @@ from ..functions.pokedex_functions import (
 from ..resources import icon_path, items_path, csv_file_items_cost, poke_evo_path
 from ..functions.badges_functions import check_for_badge, receive_badge
 from ..functions.pokemon_functions import save_fossil_pokemon
-from ..utils import play_effect_sound
+from ..services import services
+from ..utils import play_effect_sound, is_alive
 from .error_handler import show_warning_with_traceback
 
 # At the moment when I write this line, "UserRole" is defined as UserRole 1000 in the Ankimon __init__.py file. IDK what it's about.
@@ -188,6 +189,8 @@ class ItemWindow(QWidget):
         self.resize(initial_width, initial_height)
 
     def renewWidgets(self):
+        if not is_alive(self.contentLayout):
+            return
         # Clear the existing widgets from the content layout
         for i in reversed(range(self.contentLayout.count())):
             widget = self.contentLayout.itemAt(i).widget()
@@ -287,19 +290,24 @@ class ItemWindow(QWidget):
             self.logger.log_and_showinfo("error", "No Pokemon selected.")
             return
         try:
-            db = mw.ankimon_db
+            db = services.db
             target_pokemon_data = db.get_pokemon(individual_id)
 
             if target_pokemon_data:
                 pokemon_obj = PokemonObject.from_dict(target_pokemon_data)
                 pokemon_obj.give_held_item(item_name)
-                                
+
                 # Sync the main_pokemon singleton if it's the target
                 if self.main_pokemon and self.main_pokemon.individual_id == individual_id:
                     self.main_pokemon.held_item = item_name
-                   
+
                 self.logger.log_and_showinfo("info", f"{item_name} was given to {target_pokemon_data.get('name')}.")
                 self.renewWidgets()
+
+                # Refresh open PC Box window
+                from ..singletons import pokemon_pc
+                if is_alive(pokemon_pc):
+                    pokemon_pc.refresh_gui()
             else:
                 self.logger.log_and_showinfo("error", "Could not find Pokemon data.")
 
@@ -390,9 +398,60 @@ class ItemWindow(QWidget):
 
         return item_frame_widget
 
+    def dispatch_use(self, item_name: str, item_type: Optional[str] = None) -> dict:
+        """Invoke the right use-action for an item without requiring the bag UI
+        to be visible. Returns {ok, message} for callers that want to surface
+        a result (e.g. the web Items window's toast).
+
+        The branching mirrors ItemLabel above; keep them in sync if rules change.
+        """
+        name = (item_name or "").lower()
+        if item_type == "TM":
+            return {
+                "ok": False,
+                "message": "TMs are taught from the move-learning flow, not used directly.",
+            }
+        try:
+            if name in self.hp_heal_items:
+                if not self.main_pokemon:
+                    return {"ok": False, "message": "No active Pokémon to heal."}
+                hp_heal = self.hp_heal_items[name]
+                self.Check_Heal_Item(
+                    self.main_pokemon.name, hp_heal, name, self.achievements
+                )
+                return {
+                    "ok": True,
+                    "message": f"Healed {self.main_pokemon.name} with {name}.",
+                }
+            if name in self.fossil_pokemon:
+                fossil_id = self.fossil_pokemon[name]
+                fossil_pokemon_name = search_pokedex_by_id(fossil_id)
+                if self.Evolve_Fossil(name, fossil_id, fossil_pokemon_name):
+                    return {"ok": True, "message": f"Revived {fossil_pokemon_name}."}
+                return {
+                    "ok": False,
+                    "message": f"Failed to revive {fossil_pokemon_name}.",
+                }
+            if name in self.pokeball_chances:
+                self.Handle_Pokeball(name)
+                return {"ok": True, "message": f"Threw {name}."}
+            if name in self.evolution_items:
+                self._prompt_and_check_evo_item(name)
+                return {"ok": True, "message": ""}
+            if (
+                name in GiveItemWindow.NOT_YET_IMPLEMENTED_ITEMS
+                or name.endswith("-berry")
+                or name.endswith("-gem")
+            ):
+                return {"ok": False, "message": "This item isn't usable yet."}
+            self._prompt_and_give_held_item(name)
+            return {"ok": True, "message": ""}
+        except Exception as e:
+            return {"ok": False, "message": f"Use failed: {e}"}
+
     def PokemonList(self, comboBox):
         try:
-            db = mw.ankimon_db
+            db = services.db
             pokemon_list = db.execute("SELECT name, individual_id, pokedex_id FROM captured_pokemon").fetchall()
             if pokemon_list:
                 for pokemon in pokemon_list:
@@ -413,7 +472,7 @@ class ItemWindow(QWidget):
             return self._pokemon_choices_cache
         choices = []
         try:
-            db = mw.ankimon_db
+            db = services.db
             rows = db.execute("SELECT name, individual_id, pokedex_id FROM captured_pokemon").fetchall()
             for row in rows:
                 name, individual_id, poke_id = row[0], row[1], row[2]
@@ -452,9 +511,14 @@ class ItemWindow(QWidget):
         individual_id, prevo_id = selected
         self.Check_Evo_Item(individual_id, prevo_id, item_name)
 
-    def Evolve_Fossil(self, item_name: str, fossil_id: int, fossil_poke_name: str):
+    def Evolve_Fossil(
+        self, item_name: str, fossil_id: int, fossil_poke_name: str
+    ) -> bool:
+        """Revive a fossil into its corresponding Pokémon. Returns True on
+        success, False if another item action is already running or revival
+        threw. Existing PyQt button callers ignore the return value."""
         if self._item_action_in_progress:
-            return
+            return False
         self._item_action_in_progress = True
         try:
             if not isinstance(fossil_id, int):
@@ -464,9 +528,12 @@ class ItemWindow(QWidget):
             self.delete_item(item_name)
             self.starter_window.display_fossil_pokemon(fossil_id, fossil_poke_name)
             from ..singletons import pokemon_pc
-            pokemon_pc.refresh_pokemon_grid()
+            if is_alive(pokemon_pc):
+                pokemon_pc.refresh_pokemon_grid()
+            return True
         except Exception as e:
             show_warning_with_traceback(parent=self, exception=e, message=f"Error using fossil item '{item_name}'")
+            return False
         finally:
             self._item_action_in_progress = False
 
@@ -506,7 +573,7 @@ class ItemWindow(QWidget):
 
     def delete_item(self, item_name: str):
         # Update database directly for performance
-        mw.ankimon_db.update_item_quantity(item_name, -1)
+        services.db.update_item_quantity(item_name, -1)
         self.renewWidgets()
 
     def Check_Heal_Item(self, prevo_name: str, heal_points: int, item_name: str, achievements):
@@ -529,6 +596,9 @@ class ItemWindow(QWidget):
             if evo_id:
                 # Perform your action when the item matches the Pokémon's evolution item
                 self.logger.log_and_showinfo("info", "Pokemon Evolution is fitting !")
+                if not is_alive(self.evo_window):
+                    from ..singletons import get_evo_window
+                    self.evo_window = get_evo_window()
                 self.evo_window.ask_pokemon_evo(individual_id, prevo_id, evo_id)
             else:
                 self.logger.log_and_showinfo("info", "This Pokemon does not need this item.")
@@ -567,7 +637,7 @@ class ItemWindow(QWidget):
 
     def write_items_file(self, itembag_list: list[Any]):
         """Writes items to the database. Legacy method kept for compatibility."""
-        db = mw.ankimon_db
+        db = services.db
         for item in itembag_list:
             item_id = item.get("id")
             item_name = item.get("item") or item.get("item_name", "")
@@ -590,7 +660,7 @@ class ItemWindow(QWidget):
         Returns items in the expected format for the UI, using SQL columns for efficiency.
         """
         try:
-            db = mw.ankimon_db
+            db = services.db
             items = db.get_all_items()
             # Convert database format to UI format
             result = []
@@ -648,6 +718,8 @@ class ItemWindow(QWidget):
         return normalized
 
     def clear_layout(self, layout):
+        if not is_alive(layout):
+            return
         while layout.count():
             item = layout.takeAt(0)
             widget = item.widget()

--- a/src/Ankimon/pyobj/item_window.py
+++ b/src/Ankimon/pyobj/item_window.py
@@ -304,10 +304,11 @@ class ItemWindow(QWidget):
                 self.logger.log_and_showinfo("info", f"{item_name} was given to {target_pokemon_data.get('name')}.")
                 self.renewWidgets()
 
-                # Refresh open PC Box window
-                from ..singletons import pokemon_pc
-                if is_alive(pokemon_pc):
-                    pokemon_pc.refresh_gui()
+                # Refresh open PC Box window. Read services.pokemon_pc directly:
+                # `from ..singletons import pokemon_pc` lands in the lazy __getattr__
+                # factory and would force-construct a PC window the user never opened.
+                if is_alive(services.pokemon_pc):
+                    services.pokemon_pc.refresh_gui()
             else:
                 self.logger.log_and_showinfo("error", "Could not find Pokemon data.")
 
@@ -526,10 +527,17 @@ class ItemWindow(QWidget):
             save_fossil_pokemon(fossil_id)
             self._pokemon_choices_cache = None
             self.delete_item(item_name)
+            # Re-fetch the starter window if its C++ side was deleted (mirrors the
+            # evo_window guard in Check_Evo_Item); a cached-but-dead reference would
+            # raise RuntimeError inside display_fossil_pokemon.
+            if not is_alive(self.starter_window):
+                from ..singletons import get_starter_window
+                self.starter_window = get_starter_window()
             self.starter_window.display_fossil_pokemon(fossil_id, fossil_poke_name)
-            from ..singletons import pokemon_pc
-            if is_alive(pokemon_pc):
-                pokemon_pc.refresh_pokemon_grid()
+            # Read services.pokemon_pc directly rather than importing pokemon_pc from
+            # singletons, which would force-construct a PC window the user never opened.
+            if is_alive(services.pokemon_pc):
+                services.pokemon_pc.refresh_pokemon_grid()
             return True
         except Exception as e:
             show_warning_with_traceback(parent=self, exception=e, message=f"Error using fossil item '{item_name}'")

--- a/tests/test_held_items.py
+++ b/tests/test_held_items.py
@@ -1,0 +1,286 @@
+"""Held-item lifecycle tests (F12).
+
+These self-mock ``aqt``/``anki`` and force-load the real ``database_manager`` /
+``utils`` / ``pokemon_obj`` modules so the held-item give/remove logic can be
+exercised without an Anki runtime. On main's org that logic runs through the
+service seam (``services.db`` / ``services.main_pokemon``), so the fixture wires
+the temp DB onto ``services`` with auto-reverting ``patch.object``.
+
+IMPORTANT (blast-radius): all ``sys.modules`` mutation and module force-loading
+happens **inside the fixture**, never at import time, and is snapshot/restored on
+teardown. Doing it at module scope would leave a mock-bound ``Ankimon.utils`` in
+``sys.modules`` at collection time and break unrelated Tier-1 tests
+(e.g. test_ankimon_tracker) that later import the real module.
+"""
+
+import sys
+import csv
+import pytest
+import importlib.util
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+import types
+
+_src = Path(__file__).parent.parent / "src"
+
+# sys.modules keys this file mocks / force-loads. Snapshotted and restored around
+# the fixture so nothing leaks into the rest of the Tier-1 suite.
+_MANAGED_KEYS = (
+    "aqt", "aqt.qt", "aqt.utils", "aqt.gui_hooks", "aqt.operations",
+    "aqt.reviewer", "aqt.webview", "aqt.main", "aqt.operations.QueryOp", "aqt.theme",
+    "anki", "anki.hooks", "anki.collection", "anki.models", "anki.notes",
+    "anki.template", "anki.buildinfo",
+    "Ankimon.resources", "Ankimon.singletons", "Ankimon.business",
+    "Ankimon.pyobj.database_manager", "Ankimon.utils", "Ankimon.pyobj.pokemon_obj",
+)
+
+# Module-global class handles, (re)assigned by the fixture. Placeholders only —
+# no module is imported at collection time.
+AnkimonDB = None
+PokemonObject = None
+
+
+def _snapshot_modules():
+    return {k: sys.modules.get(k) for k in _MANAGED_KEYS}
+
+
+def _restore_modules(snap):
+    for k, v in snap.items():
+        if v is None:
+            sys.modules.pop(k, None)
+        else:
+            sys.modules[k] = v
+
+
+def setup_mocks():
+    # Mock aqt/anki namespaces force unconditionally
+    for name in [
+        "aqt", "aqt.qt", "aqt.utils", "aqt.gui_hooks", "aqt.operations",
+        "aqt.reviewer", "aqt.webview", "aqt.main", "aqt.operations.QueryOp", "aqt.theme",
+        "anki", "anki.hooks", "anki.collection", "anki.models", "anki.notes", "anki.template", "anki.buildinfo"
+    ]:
+        sys.modules[name] = MagicMock()
+
+    # 1. Force Register packages with __path__ so relative imports resolve
+    for _pkg in ("Ankimon", "Ankimon.functions", "Ankimon.pyobj"):
+        _mod = sys.modules.get(_pkg)
+        if not _mod or isinstance(_mod, MagicMock) or not hasattr(_mod, "__path__"):
+            _mod = types.ModuleType(_pkg)
+            sys.modules[_pkg] = _mod
+
+        # Always ensure package settings are set
+        _mod.__path__ = [str(_src / _pkg.replace(".", "/"))]
+        _mod.__package__ = _pkg
+
+    # Define a robust mock for resources
+    class MockResources:
+        user_path = Path("/tmp")
+        csv_file_items_cost = Path("/tmp/items.csv")
+        items_path = Path("/tmp/items.json")
+        badges_path = Path("/tmp/badges.json")
+        mypokemon_path = Path("/tmp/mypokemon.json")
+        mainpokemon_path = Path("/tmp/mainpokemon.json")
+        pokedex_path = _src / "Ankimon" / "data_files" / "pokedex.json"
+        def __getattr__(self, name): return Path("/tmp") / name
+
+    sys.modules["Ankimon.resources"] = MockResources()
+    sys.modules["Ankimon.singletons"] = MagicMock()
+
+    # Pre-configure Ankimon.business Mock unconditionally
+    business_mock = MagicMock()
+    business_mock.pokemon_go_raw_stats.return_value = (100, 100, 100)
+    business_mock.calculate_pokemon_go_cp.return_value = 500
+    sys.modules["Ankimon.business"] = business_mock
+
+
+# Dynamically load modules to bypass mock pollution from other test files
+def force_load_module(name, filepath):
+    spec = importlib.util.spec_from_file_location(name, filepath)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+class MockLogger:
+    def log(self, level, msg): pass
+    def log_and_showinfo(self, level, msg): pass
+    def _log(self, level, msg): pass
+
+
+@pytest.fixture
+def temp_env(tmp_path):
+    """Temporary DB + service-seam wiring for held-item logic.
+
+    On main's org, ``PokemonObject.give_held_item`` / ``remove_held_item`` and
+    ``utils.give_item`` reach the database and the in-memory main-Pokemon through
+    the service seam (``services.db`` / ``services.main_pokemon``), not through
+    ``aqt.mw``. So this wires the temp DB onto ``services`` with ``patch.object``
+    (auto-reverting, so the temp DB never leaks into the rest of the Tier-1 suite)
+    rather than monkeypatching ``mw`` (pokemon_obj no longer imports ``mw`` at all).
+    """
+    snap = _snapshot_modules()
+    setup_mocks()
+    try:
+        csv_file_path = tmp_path / "items.csv"
+
+        # Force reload the real modules fresh, isolated from other tests.
+        db_mod_fresh = force_load_module("Ankimon.pyobj.database_manager", _src / "Ankimon" / "pyobj" / "database_manager.py")
+        global AnkimonDB
+        AnkimonDB = db_mod_fresh.AnkimonDB
+
+        utils_mod_fresh = force_load_module("Ankimon.utils", _src / "Ankimon" / "utils.py")
+
+        pokemon_obj_mod_fresh = force_load_module("Ankimon.pyobj.pokemon_obj", _src / "Ankimon" / "pyobj" / "pokemon_obj.py")
+        global PokemonObject
+        PokemonObject = pokemon_obj_mod_fresh.PokemonObject
+
+        # The shared service registry that give_held_item / remove_held_item / give_item read.
+        from Ankimon.services import services
+
+        # Create mock items.csv
+        headers = ["id", "identifier", "category_id", "cost", "fling_power", "fling_effect_id"]
+        rows = [
+            ["100", "lucky-egg", "1", "200", "", ""],
+        ]
+        with open(csv_file_path, "w", newline="", encoding="utf-8") as f:
+            writer = csv.writer(f)
+            writer.writerow(headers)
+            writer.writerows(rows)
+
+        with patch.object(db_mod_fresh, "user_path", tmp_path), \
+             patch.object(db_mod_fresh, "csv_file_items_cost", str(csv_file_path)), \
+             patch.object(utils_mod_fresh, "csv_file_items_cost", str(csv_file_path)):
+
+            db = AnkimonDB(MockLogger())
+            # Keep the global aqt mock consistent for any incidental mw.ankimon_db reader.
+            sys.modules["aqt"].mw.ankimon_db = db
+
+            # Route the seam at the shared registry. patch.object reverts on exit so
+            # the temp DB / main_pokemon never leak into the other Tier-1 tests. The
+            # real give_item / give_held_item now operate against this temp DB.
+            with patch.object(services, "db", db), \
+                 patch.object(services, "main_pokemon", None):
+                yield db
+    finally:
+        _restore_modules(snap)
+
+
+def test_held_item_lifecycle(temp_env):
+    db = temp_env
+
+    # 1. Give the player a lucky-egg in their bag
+    db.add_item("lucky-egg", 1)
+
+    # Verify it exists and quantity is 1
+    item = db.get_item("lucky-egg")
+    assert item is not None
+    assert item["quantity"] == 1
+
+    # 2. Create a Pokémon
+    pkm = PokemonObject(
+        name="Pikachu",
+        id=25,
+        shiny=False,
+        level=5,
+        ability="Static",
+        type=["Electric"],
+        gender="M",
+        growth_rate="medium",
+        captured_date=None,
+        tier="Normal",
+        individual_id="test-uuid",
+        held_item=None
+    )
+
+    # Save the Pokémon to database
+    db.save_pokemon(pkm.to_dict())
+
+    # Verify Pokémon in DB has no held item
+    db_pkm = db.get_pokemon("test-uuid")
+    assert db_pkm["held_item"] is None
+
+    # 3. Give the held item to Pokémon
+    pkm.give_held_item("lucky-egg")
+
+    # Check that item quantity decremented to 0 and got deleted from inventory
+    item_in_bag = db.get_item("lucky-egg")
+    assert item_in_bag is None  # Quant = 0 deletes it
+
+    # Check that Pokémon in DB holds the item
+    db_pkm = db.get_pokemon("test-uuid")
+    assert db_pkm["held_item"] == "lucky-egg"
+
+    # 4. Remove held item from Pokémon
+    pkm.remove_held_item()
+
+    # Check that item is back in bag with quantity 1
+    item_in_bag = db.get_item("lucky-egg")
+    assert item_in_bag is not None
+    assert item_in_bag["quantity"] == 1
+
+    # Check that Pokémon in DB no longer holds it
+    db_pkm = db.get_pokemon("test-uuid")
+    assert db_pkm["held_item"] is None
+
+
+def test_main_pokemon_singleton_sync(temp_env):
+    db = temp_env
+    from Ankimon.services import services
+
+    # Create the main Pokémon in the database and as an in-memory singleton
+    main_pkm = PokemonObject(
+        name="Charizard",
+        id=6,
+        shiny=False,
+        level=50,
+        ability="Blaze",
+        type=["Fire", "Flying"],
+        gender="M",
+        growth_rate="medium",
+        captured_date=None,
+        tier="Normal",
+        individual_id="main-uuid",
+        held_item=None
+    )
+
+    # Set as the global singleton on the service seam (reverted by the fixture's
+    # patch.object(services, "main_pokemon", None) on teardown).
+    services.main_pokemon = main_pkm
+
+    db.save_pokemon(main_pkm.to_dict())
+    db.add_item("lucky-egg", 1)
+
+    # We instantiate a temporary PokemonObject representing the main Pokémon (simulating UI action)
+    temp_pkm_obj = PokemonObject.from_dict(db.get_pokemon("main-uuid"))
+
+    # Give the item using the temporary object
+    temp_pkm_obj.give_held_item("lucky-egg")
+
+    # Verify that the database was updated
+    assert db.get_pokemon("main-uuid")["held_item"] == "lucky-egg"
+
+    # CRITICAL: Verify that the in-memory main_pokemon singleton was also updated!
+    assert services.main_pokemon.held_item == "lucky-egg"
+
+    # Remove the item using another temporary object (simulating UI remove action)
+    temp_pkm_obj2 = PokemonObject.from_dict(db.get_pokemon("main-uuid"))
+    temp_pkm_obj2.remove_held_item()
+
+    # Verify database was updated to None
+    assert db.get_pokemon("main-uuid")["held_item"] is None
+
+    # CRITICAL: Verify that the in-memory main_pokemon singleton was also updated to None!
+    assert services.main_pokemon.held_item is None
+
+
+def test_equipped_items_web_serialization_and_unequip(temp_env):
+    # This portion exercises AnkimonItemsWeb from ankimon_items_web/shop_obj.py —
+    # the web-shell HOST feature, which is NOT part of the F12 Items/Bag seam unit
+    # and is absent on this branch (src/Ankimon/ankimon_items_web/ does not exist on
+    # main yet). Skip just this portion so the rest of the file still validates the
+    # held-item give/remove lifecycle and main_pokemon singleton sync.
+    pytest.skip(
+        "AnkimonItemsWeb host (ankimon_items_web/shop_obj.py) absent in F12 unit; "
+        "web equipped-items serialize/unequip lands with the web-shell HOST leaf."
+    )


### PR DESCRIPTION
## What
Ports **F12** — the Items/Bag window web seam — onto the integration tip:

- `dispatch_use(item_name, item_type) → result-dict` seam method on `ItemWindow`: the entrypoint the web Items screen (`ItemsBridge.useItem` in the web-shell host) calls instead of driving the native Qt widget; returns a toast payload dict.
- `is_alive()` window-liveness guards on the give/use paths.
- Seam refit: 6 `mw.ankimon_db` sites in `item_window.py` → `services.db`; `mw.geometry()` stays direct (genuine Anki window-centering API).
- `tests/test_held_items.py` from exp (adapted to the seam): held-item give/remove, `main_pokemon.held_item` singleton sync, web equipped-items serialization/unequip. The host-dependent portion is `pytest.skip`'d with reason until the web-shell HOST PR merges.

## Edit-vs-edit reconciliation (the critical guard)
`item_window.py` was co-edited: main added the **trigger-2 held-item (trade) evolution branch** (`evolution_trigger_id == '2'` + `held_item_id` — Metal Coat / King's Rock / Deep Sea / Dragon Scale) and the `main_pokemon.held_item` singleton sync, which exp's reformatted copy lacked. This port keeps main's file as the base and layers exp's additions on top — the trigger-2 branch and singleton sync survive intact (verified by the adversarial reviewer against the merged hunks), and XP-share None-checks in the held-item give/remove paths are preserved.

## Verification
Two-tier gate on the branch tip (adversarially re-run by an independent verifier):
- compileall clean; ruff (`ci_ruff_check.toml`) = 10 pre-existing known-debt errors only (`item_window.py` ruff-clean).
- pytest Tier-1: **369 passed / 0 failed** / 55 skipped.
- harness/check.py 9/9 PASS.
- Qt: smoke + integrity 5 passed; probe_real_boot OK (`reviewer_did_answer_card` hooks == 3); probe_real_play OK.

Verifier observations recorded for the wave ledger (non-blocking): the `is_alive(pokemon_pc)` give-path guard force-constructs an offscreen PokemonPC via the lazy `__getattr__` factory rather than skipping (behavior-preserving; polish candidate), and `dispatch_use` gains automated coverage when the HOST PR lands its consumer test.

## Attribution
Originally implemented by @hakimh2 and @AIbrahimv2 on BRRRR_Experimental; credited via Co-authored-by trailers (`Hakimh2 <74561421+hakimh2@users.noreply.github.com>`, `AIbrahimv2 <66210743+AIbrahimv2@users.noreply.github.com>`). The broken `Your Name <you@example.com>` identity in the file history maps to Hakimh2.
