### PR TITLE
feat: battle_loop reviewer-hook liveness guards on the service seam (F24)

### DIFF
--- a/harness/fakes.py
+++ b/harness/fakes.py
@@ -26,6 +26,14 @@ class _RecordingFake:
 
     _target = "window"
 
+    def objectName(self) -> str:
+        # Liveness probe: production code guards window access with
+        # ``utils.is_alive``, which calls ``objectName()`` to detect a deleted
+        # C++ object. A live fake must answer truthfully *without* recording a
+        # ``ui`` event (the probe is infrastructure, not a game action), so the
+        # observable stream stays clean on every guarded touch.
+        return self._target
+
     def __getattr__(self, name):
         def _record(*args, **kwargs):
             events.emit("ui", target=self._target, method=name)

--- a/src/Ankimon/battle_loop.py
+++ b/src/Ankimon/battle_loop.py
@@ -17,7 +17,7 @@ from .functions.battle_functions import (
     process_battle_data,
 )
 from .functions.drawing_utils import tooltipWithColour
-from .utils import safe_get_random_move, play_effect_sound, play_sound
+from .utils import safe_get_random_move, play_effect_sound, play_sound, is_alive
 from .functions.ankimon_hooks_to_poke_engine import simulate_battle_with_poke_engine
 from .pyobj.error_handler import show_warning_with_traceback
 
@@ -73,6 +73,12 @@ def _get_cards_per_round() -> int:
 
 
 def on_review_card(*args):
+    # Startup-readiness gate: a review that arrives before the async boot has
+    # finished cannot be battled. Instead of reading exp's raw
+    # ``mw.ankimon_startup_finished`` here, the gate is applied one level up on
+    # the seam — ``__init__``'s ``_on_review_card_gated`` forwards to this
+    # function only once ``services.startup_finished`` is True (F32) — so this
+    # body always runs against a fully-booted registry.
     global _state
     s = _state
 
@@ -98,7 +104,15 @@ def on_review_card(*args):
         s.item_receive_value -= 1
         if s.item_receive_value <= 0:
             s.item_receive_value = random.randint(3, 385)
-            test_window.display_item()
+            # Liveness guard (F24): the seam window may have been closed (its C++
+            # object deleted) since boot; resolve it fresh from the registry and
+            # only paint while it is still alive.
+            item_window = services.test_window
+            if is_alive(item_window):
+                try:
+                    item_window.display_item()
+                except RuntimeError:
+                    pass
             if not check_for_badge(achievements, 6):
                 receive_badge(6, achievements)
 
@@ -280,13 +294,25 @@ def on_review_card(*args):
 
             if enemy_pokemon.hp < 1:
                 enemy_pokemon.hp = 0
-                test_window.display_battle()
+                # Liveness guards (F24): resolve both windows fresh from the
+                # registry and only touch/pass them while their C++ objects are
+                # alive. A dead window becomes None so the faint handler's own
+                # None-checks (new_pokemon / display paths) take over instead of
+                # raising "wrapped C/C++ object deleted".
+                faint_window = services.test_window
+                live_faint_window = faint_window if is_alive(faint_window) else None
+                if live_faint_window is not None:
+                    try:
+                        live_faint_window.display_battle()
+                    except RuntimeError:
+                        live_faint_window = None
+                evo = services.evo_window
                 handle_enemy_faint(
                     main_pokemon,
                     enemy_pokemon,
                     s.collected_pokemon_ids,
-                    test_window,
-                    evo_window,
+                    live_faint_window,
+                    evo if is_alive(evo) else None,
                     reviewer_obj,
                     logger,
                     achievements,
@@ -297,15 +323,27 @@ def on_review_card(*args):
             play_sound(enemy_pokemon.id, settings_obj)
 
         if main_pokemon.hp < 1:
+            # Liveness guard (F24): hand the faint handler a live window or None
+            # (new_pokemon already None-checks before painting).
+            main_faint_window = services.test_window
             handle_main_pokemon_faint(
-                main_pokemon, enemy_pokemon, test_window, reviewer_obj, translator
+                main_pokemon,
+                enemy_pokemon,
+                main_faint_window if is_alive(main_faint_window) else None,
+                reviewer_obj,
+                translator,
             )
             s.mutator_full_reset = 1
 
         reviewer_obj.refresh_hud()
-        if test_window is not None:
-            if enemy_pokemon.hp > 0:
-                test_window.display_battle()
+        # Liveness guard (F24): is_alive replaces the bare None-check so a
+        # deleted-but-non-None widget can't raise on the end-of-turn repaint.
+        final_window = services.test_window
+        if is_alive(final_window) and enemy_pokemon.hp > 0:
+            try:
+                final_window.display_battle()
+            except RuntimeError:
+                pass
     except Exception as e:
         show_warning_with_traceback(
             exception=e, message="An error occurred in reviewer:"

--- a/tests/test_headless_harness.py
+++ b/tests/test_headless_harness.py
@@ -121,6 +121,12 @@ def test_battle_loop_survives_dead_windows():
     result = _subrun(
         "from collections import Counter\n"
         "from harness.driver import Driver\n"
+        # Deterministic RNG in the child: enemy faints are stochastic
+        # (~1-2 per 60 'good' answers), so an unseeded run can produce zero
+        # faints and flake the gate. seed(0) is verified to exercise the
+        # faint-guard path with zero error events.
+        "import random\n"
+        "random.seed(0)\n"
         "class _DeadWindow:\n"
         "    # Simulates a Qt window whose underlying C++ object was deleted.\n"
         "    def objectName(self):\n"

--- a/tests/test_headless_harness.py
+++ b/tests/test_headless_harness.py
@@ -108,8 +108,52 @@ def test_auto_battle_mode_cycles():
     assert "error" not in result
 
 
+def test_battle_loop_survives_dead_windows():
+    """F24: on_review_card's is_alive guards must skip a deleted (dead) window
+    instead of raising 'wrapped C/C++ object of type X has been deleted'.
+
+    We swap the live test_window/evo_window for a stand-in whose every attribute
+    access (including the ``objectName`` liveness probe) raises RuntimeError —
+    exactly what a Qt widget does once its C++ half is destroyed. The battle loop
+    must keep running: real battle/faint/encounter events, zero error events.
+    Auto-catch mode (1) is used so the faint path never routes through the
+    evo_window level-up branch, isolating this to the battle_loop guards."""
+    result = _subrun(
+        "from collections import Counter\n"
+        "from harness.driver import Driver\n"
+        "class _DeadWindow:\n"
+        "    # Simulates a Qt window whose underlying C++ object was deleted.\n"
+        "    def objectName(self):\n"
+        "        raise RuntimeError('wrapped C/C++ object of type TestWindow has been deleted')\n"
+        "    def __getattr__(self, name):\n"
+        "        raise RuntimeError('wrapped C/C++ object of type TestWindow has been deleted')\n"
+        "d = Driver(settings_overrides={'battle.cards_per_round': 1, 'battle.automatic_battle': 1})\n"
+        "d.services.test_window = _DeadWindow()\n"
+        "d.services.evo_window = _DeadWindow()\n"
+        "events = []\n"
+        "for _ in range(60):\n"
+        "    events += d.answer('good')\n"
+        "kinds = Counter(e['type'] for e in events)\n"
+        "errs = [e for e in events if e['type'] == 'error']\n"
+        "print(%r + json.dumps({\n"
+        "    'has_battle': kinds.get('battle', 0) > 0,\n"
+        "    'has_faint': kinds.get('faint', 0) > 0,\n"
+        "    'has_encounter': kinds.get('encounter', 0) > 0,\n"
+        "    'errors': kinds.get('error', 0),\n"
+        "    'first_error': (errs[0].get('exception') if errs else None),\n"
+        "}))" % _MARKER
+    )
+    assert result["has_battle"], "no battle turns with dead windows"
+    assert result["has_faint"], "enemy never fainted (faint guard path not exercised)"
+    assert result["has_encounter"], "auto-catch never spawned a new encounter"
+    assert result["errors"] == 0, (
+        "dead-window touch raised instead of being guarded: %s" % result["first_error"]
+    )
+
+
 if __name__ == "__main__":
     test_play_session_runs_without_errors()
     test_state_snapshot_and_single_answer()
     test_auto_battle_mode_cycles()
+    test_battle_loop_survives_dead_windows()
     print("headless harness tests: OK")


### PR DESCRIPTION
## What
Ports **F24** — the genuinely-useful guards from exp's `battle_loop.py` glue — onto the integration tip, cherry-picked onto main's seam version (edit-vs-edit collision; exp's direct-`mw` file was **not** taken wholesale):

- `is_alive()` window-liveness guards on every `test_window`/`evo_window` touch in `on_review_card`: item-drop `display_item()`, pre-faint `display_battle()`, the windows passed to `handle_enemy_faint`/`handle_main_pokemon_faint`, and the end-of-turn repaint (with `try/except RuntimeError` for the deleted-C++-object race). Dead windows degrade to `None` — an already-handled path.
- Liveness reads resolve **fresh from the registry** (`services.test_window` / `services.evo_window`) instead of the module-global snapshots, so a window recreated after teardown is seen.
- Startup-readiness: exp's raw `mw.ankimon_startup_finished` gate is **not** duplicated — it is already expressed on the seam by F32's `_on_review_card_gated` wrapper (documented in-function).

## Deferred per the inventory row
Cash-reward-interval hunks, `mobile_sync.record_desktop_review`, and `singletons.notify_stats_changed` are left out entirely — they belong to their owning Wave-4/5 leaves. XP-share None-checks in the `handle_enemy_faint → kill_pokemon → xp_share_gain_exp` path are preserved untouched.

## Harness finding (fixed at the fake)
Tier-1's `Driver.answer()` drives the real `on_review_card` against recording fakes whose `__getattr__` records every attribute access as a `'ui'` event — so `is_alive()`'s `objectName()` probe would have polluted the observable event stream on the hot answer path. Fixed by giving `_RecordingFake` a quiet `objectName()` (consistent with the real infra `FakeEvoWindow` already exposes); the gate confirms no golden depended on those events.

New regression test `test_battle_loop_survives_dead_windows`: drives `on_review_card` with a stand-in whose every attribute access raises `RuntimeError` (simulating a deleted QObject) and asserts battle/faint/encounter events with **zero** error events. Mutation-verified — removing the final `display_battle` guard makes it fail with 60 "wrapped C/C++ object deleted" error events.

## Verification
Two-tier gate on the branch tip (adversarially re-run by an independent verifier):
- compileall clean; ruff (`ci_ruff_check.toml`) = 10 pre-existing known-debt errors only.
- pytest Tier-1: **368 passed / 0 failed** / 54 skipped (367 baseline + 1 new).
- harness/check.py 9/9 PASS.
- Qt: smoke + integrity 5 passed; probe_real_boot OK (`reviewer_did_answer_card` hooks == 3, no duplicate registration); probe_real_play OK.
- Verifier confirmed: only `mw.` token left in `battle_loop.py` is a comment; no domain `mw.*` leaked; no deferred hunks leaked.

## Attribution
Originally implemented by @hakimh2 on BRRRR_Experimental (commits `180bcf29d`/`302c3761d`); credited via Co-authored-by trailer (`Hakimh2 <74561421+hakimh2@users.noreply.github.com>`).
