### PR TITLE
feat: Mobile & Web Reviews sync subsystem — engine, screens, sync hook, bootstrap (F14/F15/F29/F20b)

### DIFF
--- a/src/Ankimon/ankimon_mobile_web/history.html
+++ b/src/Ankimon/ankimon_mobile_web/history.html
@@ -1,0 +1,126 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Ankimon — Battle History</title>
+  <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700;800;900&family=JetBrains+Mono:wght@500;700&display=swap" rel="stylesheet">
+
+  <link rel="stylesheet" href="../ankimon_items_web/shop.css">
+  <link rel="stylesheet" href="../ankimon_items_web/nav-switcher.css">
+  <link rel="stylesheet" href="mobile.css">
+</head>
+<body class="dark-mode shell-mode">
+  <div class="app-container">
+    <!-- Sidebar -->
+    <aside class="sidebar">
+      <div class="sidebar-header">
+        <div id="nav-switcher" class="nav-switcher">
+          <button id="nav-trigger" class="nav-trigger" type="button" aria-haspopup="true" aria-expanded="false">
+            <img src="../user_files/sprites/items/elixir.png" class="app-logo icon-item-sprite" alt="">
+            <h1>MOBILE</h1>
+            <span class="nav-chevron">▾</span>
+          </button>
+          <div id="nav-menu" class="nav-menu hidden" role="menu">
+            <button class="nav-menu-item" role="menuitem" data-screen="items">
+              <span class="nav-menu-icon"><img src="../user_files/sprites/items/max-potion.png" class="icon-item-sprite" alt=""></span>
+              <div class="nav-menu-text">
+                <span class="nav-menu-title">Items</span>
+                <span class="nav-menu-desc">Your inventory and today's Mart</span>
+              </div>
+            </button>
+            <button class="nav-menu-item" role="menuitem" data-screen="ankidex">
+              <span class="nav-menu-icon"><img src="../user_files/sprites/items/poke-ball.png" alt=""></span>
+              <div class="nav-menu-text">
+                <span class="nav-menu-title">Ankidex</span>
+                <span class="nav-menu-desc">Browse caught Pokémon</span>
+              </div>
+            </button>
+            <button class="nav-menu-item" role="menuitem" data-screen="team">
+              <span class="nav-menu-icon"><img src="../user_files/sprites/items/great-ball.png" class="icon-item-sprite" alt=""></span>
+              <div class="nav-menu-text">
+                <span class="nav-menu-title">Team</span>
+                <span class="nav-menu-desc">Your active 6 Pokémon</span>
+              </div>
+            </button>
+            <button class="nav-menu-item" role="menuitem" data-screen="profile">
+              <span class="nav-menu-icon"><img src="../user_files/sprites/items/water-gem.png" class="icon-item-sprite" alt=""></span>
+              <div class="nav-menu-text">
+                <span class="nav-menu-title">Profile</span>
+                <span class="nav-menu-desc">Card, badges &amp; avatar</span>
+              </div>
+            </button>
+            <button class="nav-menu-item" role="menuitem" data-screen="settings">
+              <span class="nav-menu-icon"><img src="../user_files/sprites/items/x-speed.png" class="icon-item-sprite" alt=""></span>
+              <div class="nav-menu-text">
+                <span class="nav-menu-title">Settings</span>
+                <span class="nav-menu-desc">Configure Ankimon</span>
+              </div>
+            </button>
+            <button class="nav-menu-item active" role="menuitem" data-screen="mobile">
+              <span class="nav-menu-icon"><img src="../user_files/sprites/items/elixir.png" class="icon-item-sprite" alt=""></span>
+              <div class="nav-menu-text">
+                <span class="nav-menu-title">Mobile & Web Reviews</span>
+                <span class="nav-menu-desc">Pending mobile/web battles</span>
+              </div>
+            </button>
+          </div>
+        </div>
+      </div>
+      <!-- Mode list or status inside sidebar -->
+      <nav class="sidebar-nav">
+        <div class="nav-group">
+          <label>Navigation</label>
+          <button class="nav-item" onclick="goToMobileReviews()">
+            <span class="nav-icon" style="color: var(--accent-blue)">●</span>Mobile & Web Reviews
+          </button>
+          <button class="nav-item active" onclick="goToHistory()">
+            <span class="nav-icon" style="color: var(--accent-gold)">●</span>Battle History
+          </button>
+        </div>
+      </nav>
+    </aside>
+
+    <!-- Main Content Area -->
+    <main class="main-content">
+      <!-- Persistent Header Top Bar -->
+      <header class="top-bar">
+        <div class="top-bar-titles">
+          <h2>Battle History</h2>
+          <span class="top-bar-sub">Logs and outcomes of resolved mobile reviews</span>
+        </div>
+        <div class="top-actions">
+          <button class="btn btn-secondary btn-clear-history" onclick="clearHistory()">
+            Clear History
+          </button>
+        </div>
+      </header>
+
+      <!-- Scrollable content area -->
+      <div class="content-scroll">
+        <div id="loading" class="loading-state">
+          <div class="spinner-box">
+            <div class="spinner"></div>
+          </div>
+          <span>Loading battle history...</span>
+        </div>
+
+        <div id="app" class="history-app-container">
+          <div id="history-empty" class="history-empty-state">
+            No recent battle records.
+          </div>
+          <div id="history-list" class="history-list scrollable-history-list hidden" style="max-height: none;">
+            <!-- Dynamically populated -->
+          </div>
+        </div>
+      </div>
+    </main>
+  </div>
+
+  <div id="toast" class="toast"></div>
+
+  <script src="qrc:///qtwebchannel/qwebchannel.js"></script>
+  <script src="../ankimon_items_web/nav-switcher.js"></script>
+  <script src="history.js"></script>
+</body>
+</html>

--- a/src/Ankimon/ankimon_mobile_web/history.js
+++ b/src/Ankimon/ankimon_mobile_web/history.js
@@ -1,0 +1,236 @@
+function showConfirm(message, onConfirm, onCancel = null) {
+    const overlay = document.createElement('div');
+    overlay.className = 'modal-overlay';
+    overlay.style.zIndex = '1000';
+
+    const modal = document.createElement('div');
+    modal.className = 'modal';
+    modal.style.maxWidth = '400px';
+
+    const head = document.createElement('div');
+    head.className = 'modal-head';
+    const title = document.createElement('h3');
+    title.textContent = 'Confirmation';
+    head.appendChild(title);
+
+    const body = document.createElement('div');
+    body.className = 'modal-body';
+    body.style.padding = '18px';
+    body.style.fontSize = '0.95rem';
+    body.style.lineHeight = '1.4';
+    body.style.color = 'var(--text-main)';
+    body.textContent = message;
+
+    const foot = document.createElement('div');
+    foot.className = 'modal-foot';
+    foot.style.gap = '10px';
+
+    const cancelBtn = document.createElement('button');
+    cancelBtn.className = 'btn btn-secondary';
+    cancelBtn.textContent = 'Cancel';
+    cancelBtn.onclick = function() {
+        document.body.removeChild(overlay);
+        if (onCancel) onCancel();
+    };
+
+    const confirmBtn = document.createElement('button');
+    confirmBtn.className = 'btn btn-primary';
+    confirmBtn.textContent = 'Confirm';
+    confirmBtn.onclick = function() {
+        document.body.removeChild(overlay);
+        onConfirm();
+    };
+
+    foot.appendChild(cancelBtn);
+    foot.appendChild(confirmBtn);
+
+    modal.appendChild(head);
+    modal.appendChild(body);
+    modal.appendChild(foot);
+    overlay.appendChild(modal);
+
+    document.body.appendChild(overlay);
+}
+
+function showAlert(message, onOk = null) {
+    const overlay = document.createElement('div');
+    overlay.className = 'modal-overlay';
+    overlay.style.zIndex = '1000';
+
+    const modal = document.createElement('div');
+    modal.className = 'modal';
+    modal.style.maxWidth = '400px';
+
+    const head = document.createElement('div');
+    head.className = 'modal-head';
+    const title = document.createElement('h3');
+    title.textContent = 'Notification';
+    head.appendChild(title);
+
+    const body = document.createElement('div');
+    body.className = 'modal-body';
+    body.style.padding = '18px';
+    body.style.fontSize = '0.95rem';
+    body.style.lineHeight = '1.4';
+    body.style.color = 'var(--text-main)';
+    body.textContent = message;
+
+    const foot = document.createElement('div');
+    foot.className = 'modal-foot';
+
+    const okBtn = document.createElement('button');
+    okBtn.className = 'btn btn-primary';
+    okBtn.textContent = 'OK';
+    okBtn.onclick = function() {
+        document.body.removeChild(overlay);
+        if (onOk) onOk();
+    };
+
+    foot.appendChild(okBtn);
+
+    modal.appendChild(head);
+    modal.appendChild(body);
+    modal.appendChild(foot);
+    overlay.appendChild(modal);
+
+    document.body.appendChild(overlay);
+}
+
+let mobileBridge = null;
+let nav = null;
+
+
+new QWebChannel(qt.webChannelTransport, function(channel) {
+    mobileBridge = channel.objects.mobile;
+    nav = channel.objects && channel.objects.nav;
+    window.nav = nav;
+    loadHistory();
+    if (window.wireNavSwitcher) {
+        window.wireNavSwitcher(nav);
+    }
+});
+
+function goToMobileReviews() {
+    if (nav && typeof nav.openMobile === 'function') {
+        nav.openMobile();
+    }
+}
+
+function goToHistory() {
+    // Already on History tab
+}
+
+function loadHistory() {
+    if (!mobileBridge || typeof mobileBridge.getMobileHistory !== 'function') return;
+    mobileBridge.getMobileHistory(function(historyList) {
+        initializeHistory(historyList);
+    });
+}
+
+window.initializeHistory = function(historyList) {
+    const loadingEl = document.getElementById('loading');
+    if (loadingEl) {
+        loadingEl.style.display = 'none';
+    }
+    renderHistory(historyList);
+};
+
+window.liveRefreshHistory = function(historyList) {
+    renderHistory(historyList);
+};
+
+function renderHistory(historyList) {
+    const emptyEl = document.getElementById('history-empty');
+    const listEl = document.getElementById('history-list');
+    
+    if (!historyList || historyList.length === 0) {
+        if (emptyEl) emptyEl.classList.remove('hidden');
+        if (listEl) listEl.classList.add('hidden');
+        return;
+    }
+    
+    if (emptyEl) emptyEl.classList.add('hidden');
+    if (listEl) listEl.classList.remove('hidden');
+    
+    listEl.innerHTML = '';
+    
+    historyList.forEach(entry => {
+        const item = document.createElement('div');
+        item.className = `history-item outcome-${entry.outcome}`;
+        
+        let outcomeBadge = '';
+        if (entry.outcome === 'caught') {
+            outcomeBadge = '<span class="outcome-badge badge-caught">CAUGHT</span>';
+        } else if (entry.outcome === 'defeated') {
+            outcomeBadge = '<span class="outcome-badge badge-defeated">DEFEATED</span>';
+        } else if (entry.outcome === 'lost') {
+            outcomeBadge = '<span class="outcome-badge badge-lost">LOST</span>';
+        } else if (entry.outcome === 'escaped') {
+            outcomeBadge = '<span class="outcome-badge badge-escaped">ESCAPED</span>';
+        }
+        
+        const shinyTag = entry.enemy_shiny ? '✨ ' : '';
+        const vsDetails = `Your <strong>${entry.companion_name || 'Companion'}</strong> (Lv.${entry.companion_level || 5}) vs wild <strong>${shinyTag}${entry.enemy_name || '???'}</strong> (Lv.${entry.enemy_level || 5})`;
+        
+        let rewards = [];
+        if (entry.xp_gained > 0) {
+            rewards.push(`<span class="reward-val reward-xp">+${entry.xp_gained} XP</span>`);
+        }
+        if (entry.trainer_xp_gained > 0) {
+            rewards.push(`<span class="reward-val reward-txp">+${entry.trainer_xp_gained} Trainer XP</span>`);
+        }
+        if (entry.cash_gained > 0) {
+            rewards.push(`<span class="reward-val reward-cash">+${entry.cash_gained}¥</span>`);
+        }
+        
+        const rewardsSection = rewards.length > 0 
+            ? `<div class="history-item-rewards">${rewards.join(' ')}</div>`
+            : '';
+            
+        item.innerHTML = `
+            <div class="history-item-main">
+                <div class="history-item-left">
+                    ${outcomeBadge}
+                    <span class="history-item-details">${vsDetails}</span>
+                </div>
+                <span class="history-item-time">${formatTime(entry.timestamp)}</span>
+            </div>
+            ${rewardsSection}
+        `;
+        
+        listEl.appendChild(item);
+    });
+}
+
+function clearHistory() {
+    if (!mobileBridge || typeof mobileBridge.clearMobileHistory !== 'function') return;
+    showConfirm("Are you sure you want to clear your mobile battle history?", function() {
+        mobileBridge.clearMobileHistory(function(success) {
+            if (success) {
+                loadHistory();
+            } else {
+                showAlert("Failed to clear mobile history.");
+            }
+        });
+    });
+}
+
+function formatTime(timestamp) {
+    if (!timestamp) return '';
+    try {
+        const date = new Date(timestamp);
+        const now = new Date();
+        
+        const diffMs = now - date;
+        const diffMins = Math.floor(diffMs / (1000 * 60));
+        const diffHours = Math.floor(diffMs / (1000 * 60 * 60));
+        
+        if (diffMins < 1) return 'Just now';
+        if (diffMins < 60) return `${diffMins}m ago`;
+        if (diffHours < 24) return `${diffHours}h ago`;
+        
+        return date.toLocaleDateString(undefined, { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' });
+    } catch (e) {
+        return '';
+    }
+}

--- a/src/Ankimon/ankimon_mobile_web/history.js
+++ b/src/Ankimon/ankimon_mobile_web/history.js
@@ -1,3 +1,11 @@
+// Escape HTML metacharacters before interpolating user-controlled strings
+// (Pokemon nicknames) into innerHTML — prevents stored-XSS from malicious names.
+function escapeHtml(value) {
+    return String(value == null ? '' : value).replace(/[&<>"']/g, function (c) {
+        return { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c];
+    });
+}
+
 function showConfirm(message, onConfirm, onCancel = null) {
     const overlay = document.createElement('div');
     overlay.className = 'modal-overlay';
@@ -170,7 +178,9 @@ function renderHistory(historyList) {
         }
         
         const shinyTag = entry.enemy_shiny ? '✨ ' : '';
-        const vsDetails = `Your <strong>${entry.companion_name || 'Companion'}</strong> (Lv.${entry.companion_level || 5}) vs wild <strong>${shinyTag}${entry.enemy_name || '???'}</strong> (Lv.${entry.enemy_level || 5})`;
+        const companionName = escapeHtml(entry.companion_name || 'Companion');
+        const enemyName = escapeHtml(entry.enemy_name || '???');
+        const vsDetails = `Your <strong>${companionName}</strong> (Lv.${entry.companion_level || 5}) vs wild <strong>${shinyTag}${enemyName}</strong> (Lv.${entry.enemy_level || 5})`;
         
         let rewards = [];
         if (entry.xp_gained > 0) {

--- a/src/Ankimon/ankimon_mobile_web/mobile.css
+++ b/src/Ankimon/ankimon_mobile_web/mobile.css
@@ -1,0 +1,1487 @@
+/* Specific stylesheet for Mobile reviews cards inside the main content area */
+
+:root {
+  --border: var(--border-main, #30363d);
+  --surface: var(--bg-card, #161b22);
+  --bg: var(--bg-dark, #0d1117);
+  --text: var(--text-main, #c9d1d9);
+  --text-muted: #8b949e;
+  --accent-orange: #ff9f43; /* Custom HSL orange for Hard badge */
+}
+
+body {
+  font-family: 'Outfit', sans-serif;
+  background: var(--bg);
+  color: var(--text);
+}
+
+/* Scrollable Layout Structure */
+.content-scroll {
+  flex: 1;
+  overflow-y: auto;
+  padding: 24px;
+  height: calc(100vh - 70px);
+}
+
+.state-container {
+  display: none;
+  max-width: 960px;
+  margin: 0 auto;
+}
+
+.state-container.active {
+  display: block;
+  animation: fade-in 0.3s ease-out;
+}
+
+@keyframes fade-in {
+  from { opacity: 0; transform: translateY(5px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+/* Persistent Header Subtitle */
+.top-bar-titles {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.top-bar-sub {
+  font-size: 0.8rem;
+  color: var(--text-muted);
+}
+
+.top-actions {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+}
+
+.btn-refresh {
+  width: auto !important;
+  padding: 6px 14px !important;
+  font-size: 0.8rem !important;
+  height: 34px;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  border-radius: 8px;
+}
+
+.spin-icon {
+  display: inline-block;
+  font-size: 0.95rem;
+}
+
+@keyframes spin {
+  from { transform: rotate(0deg); }
+  to { transform: rotate(360deg); }
+}
+
+.spinning {
+  animation: spin 0.8s linear infinite;
+}
+
+.badge-count {
+  background: var(--border);
+  color: var(--text-bright, #ffffff);
+  padding: 6px 14px;
+  border-radius: 20px;
+  font-size: 13px;
+  font-weight: 700;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  font-family: 'JetBrains Mono', monospace;
+}
+
+.badge-count.hidden {
+  display: none;
+}
+
+/* Loading State */
+.loading-state {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 100px 24px;
+  gap: 16px;
+  color: var(--text-muted);
+  font-size: 14px;
+}
+
+.spinner-box {
+  width: 40px;
+  height: 40px;
+}
+
+.spinner {
+  width: 40px;
+  height: 40px;
+  border: 3px solid rgba(88, 166, 255, 0.1);
+  border-top: 3px solid var(--accent-blue);
+  border-radius: 50%;
+  animation: spin 0.8s linear infinite;
+}
+
+/* Empty State */
+.empty-content {
+  text-align: center;
+  padding: 80px 24px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.25);
+}
+
+.pokeball-icon-container {
+  display: flex;
+  justify-content: center;
+  margin-bottom: 24px;
+}
+
+.pokeball-icon {
+  width: 96px;
+  height: 96px;
+  animation: float-pokeball 3s ease-in-out infinite;
+}
+
+@keyframes float-pokeball {
+  0%, 100% { transform: translateY(0); }
+  50% { transform: translateY(-10px); }
+}
+
+.empty-content h2 {
+  font-size: 22px;
+  font-weight: 700;
+  margin-bottom: 12px;
+  color: var(--text-bright, #ffffff);
+}
+
+.empty-content p {
+  color: var(--text-muted);
+  font-size: 14px;
+  max-width: 420px;
+  margin: 0 auto;
+  line-height: 1.6;
+}
+
+/* Pending State Layout */
+.pending-layout {
+  display: grid;
+  grid-template-columns: 1.2fr 1fr;
+  gap: 24px;
+}
+
+@media (max-width: 800px) {
+  .pending-layout {
+    grid-template-columns: 1fr;
+  }
+}
+
+.card {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  padding: 24px;
+  margin-bottom: 24px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+}
+
+.card h3 {
+  font-size: 16px;
+  font-weight: 700;
+  margin-bottom: 18px;
+  color: var(--text-bright, #ffffff);
+  border-bottom: 1px solid var(--border);
+  padding-bottom: 10px;
+  letter-spacing: -0.2px;
+}
+
+/* Breakdown Grid */
+.breakdown-grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 12px;
+}
+
+@media (max-width: 600px) {
+  .breakdown-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+.breakdown-item {
+  border-radius: 12px;
+  padding: 14px 10px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  transition: transform var(--transition-fast, 0.15s), border-color var(--transition-fast, 0.15s), box-shadow var(--transition-fast, 0.15s);
+  cursor: default;
+}
+
+.breakdown-item:hover {
+  transform: translateY(-2px);
+}
+
+.breakdown-label {
+  font-size: 0.7rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.breakdown-val {
+  font-size: 1.4rem;
+  font-weight: 800;
+  font-family: 'JetBrains Mono', monospace;
+}
+
+/* HSL Status Colors */
+.breakdown-again {
+  background: hsla(359, 100%, 68%, 0.08);
+  border: 1px solid hsla(359, 100%, 68%, 0.2);
+}
+.breakdown-again:hover {
+  border-color: hsla(359, 100%, 68%, 0.45);
+  box-shadow: 0 4px 16px hsla(359, 100%, 68%, 0.15);
+}
+.breakdown-again .breakdown-label, .breakdown-again .breakdown-val { color: #ff6b6b; }
+
+.breakdown-hard {
+  background: hsla(35, 100%, 55%, 0.08);
+  border: 1px solid hsla(35, 100%, 55%, 0.2);
+}
+.breakdown-hard:hover {
+  border-color: hsla(35, 100%, 55%, 0.45);
+  box-shadow: 0 4px 16px hsla(35, 100%, 55%, 0.15);
+}
+.breakdown-hard .breakdown-label, .breakdown-hard .breakdown-val { color: var(--accent-orange); }
+
+.breakdown-good {
+  background: hsla(210, 100%, 65%, 0.08);
+  border: 1px solid hsla(210, 100%, 65%, 0.2);
+}
+.breakdown-good:hover {
+  border-color: hsla(210, 100%, 65%, 0.45);
+  box-shadow: 0 4px 16px hsla(210, 100%, 65%, 0.15);
+}
+.breakdown-good .breakdown-label, .breakdown-good .breakdown-val { color: var(--accent-blue); }
+
+.breakdown-easy {
+  background: hsla(120, 100%, 45%, 0.08);
+  border: 1px solid hsla(120, 100%, 45%, 0.2);
+}
+.breakdown-easy:hover {
+  border-color: hsla(120, 100%, 45%, 0.45);
+  box-shadow: 0 4px 16px hsla(120, 100%, 45%, 0.15);
+}
+.breakdown-easy .breakdown-label, .breakdown-easy .breakdown-val { color: var(--accent-green); }
+
+/* Estimates */
+.estimates-intro {
+  font-size: 13px;
+  color: var(--text-muted);
+  margin-bottom: 14px;
+}
+
+.estimates-grid {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  margin-bottom: 18px;
+}
+
+.estimate-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 8px 0;
+  border-bottom: 1px dashed var(--border);
+}
+
+.est-label {
+  font-size: 14px;
+  color: var(--text);
+}
+
+.est-val {
+  font-size: 15px;
+  font-weight: 700;
+  color: var(--accent-green);
+  font-family: 'JetBrains Mono', monospace;
+}
+
+#est-xp { color: var(--accent-blue); }
+#est-cash { color: var(--accent-gold); }
+
+.estimates-footer {
+  display: flex;
+  justify-content: space-between;
+  font-size: 12px;
+  color: var(--text-muted);
+  background: rgba(0, 0, 0, 0.2);
+  padding: 10px 14px;
+  border-radius: 8px;
+  border: 1px solid var(--border);
+}
+
+.status-val {
+  color: var(--text-bright, #ffffff);
+  font-weight: 700;
+}
+
+/* Companion Box & Details */
+.companion-box {
+  display: flex;
+  align-items: center;
+  gap: 18px;
+  background: rgba(0, 0, 0, 0.2);
+  padding: 16px;
+  border-radius: 12px;
+  border: 1px solid var(--border);
+  position: relative;
+  overflow: hidden;
+}
+
+.companion-sprite-wrap {
+  width: 68px;
+  height: 68px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: radial-gradient(circle, rgba(88, 166, 255, 0.12) 0%, transparent 70%);
+  border-radius: 10px;
+  border: 1px solid rgba(88, 166, 255, 0.2);
+  overflow: hidden;
+}
+
+#companion-sprite {
+  max-width: 60px;
+  max-height: 60px;
+  object-fit: contain;
+  image-rendering: pixelated;
+}
+
+.companion-details h4 {
+  font-size: 16px;
+  font-weight: 700;
+  color: var(--text-bright, #ffffff);
+}
+
+.companion-details p {
+  font-size: 12px;
+  color: var(--text-muted);
+  margin-top: 4px;
+}
+
+.btn {
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  padding: 9px 16px;
+  font-size: 0.85rem;
+  font-weight: 700;
+  border-radius: 9px;
+  border: 1px solid var(--border);
+  background: var(--surface);
+  color: var(--text);
+  cursor: pointer;
+  transition: background 0.15s ease, border-color 0.15s ease, color 0.15s ease;
+  font-family: inherit;
+}
+
+.btn:active {
+  transform: scale(0.98);
+}
+
+.btn-primary {
+  background: var(--accent-blue);
+  color: #06111f;
+  border-color: var(--accent-blue);
+}
+.btn-primary:hover {
+  filter: brightness(1.08);
+  background: var(--accent-blue);
+}
+
+.btn-warning {
+  background: var(--accent-gold);
+  color: #0d1117;
+  border-color: var(--accent-gold);
+}
+.btn-warning:hover {
+  filter: brightness(1.08);
+  background: var(--accent-gold);
+}
+
+.btn-danger {
+  background: transparent;
+  color: var(--accent-red);
+  border-color: rgba(248, 81, 73, 0.4);
+}
+.btn-danger:hover {
+  background: rgba(248, 81, 73, 0.12);
+  color: var(--accent-red);
+  border-color: var(--accent-red);
+}
+
+.btn-secondary {
+  background: var(--surface);
+  color: var(--text);
+  border-color: var(--border);
+}
+.btn-secondary:hover {
+  background: var(--bg-card-hover, #21262d);
+  color: var(--text-bright);
+}
+
+/* Captures Preview List */
+.caught-list-container {
+  margin-top: 18px;
+  border-top: 1px solid var(--border);
+  padding-top: 14px;
+}
+
+.caught-list-container h4 {
+  font-size: 13px;
+  font-weight: 700;
+  color: var(--text-muted);
+  margin-bottom: 10px;
+}
+
+.caught-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  max-height: 140px;
+  overflow-y: auto;
+  padding-right: 6px;
+}
+
+/* Custom scrollbar for caught list */
+.caught-list::-webkit-scrollbar {
+  width: 5px;
+}
+.caught-list::-webkit-scrollbar-track {
+  background: rgba(0, 0, 0, 0.15);
+  border-radius: 99px;
+}
+.caught-list::-webkit-scrollbar-thumb {
+  background: var(--border);
+  border-radius: 99px;
+}
+
+.caught-pokemon-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-size: 13px;
+  background: rgba(0, 0, 0, 0.15);
+  padding: 8px 12px;
+  border-radius: 8px;
+  border: 1px solid var(--border);
+  transition: border-color var(--transition-fast, 0.15s);
+}
+.caught-pokemon-item:hover {
+  border-color: var(--accent-blue);
+}
+
+.caught-pokemon-name {
+  font-weight: 700;
+  color: var(--text-bright, #ffffff);
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.caught-pokemon-lvl {
+  font-size: 10px;
+  font-weight: 700;
+  color: var(--text-muted);
+  background: var(--border);
+  padding: 2px 8px;
+  border-radius: 20px;
+  font-family: 'JetBrains Mono', monospace;
+}
+
+.shiny-badge {
+  color: var(--accent-gold);
+  text-shadow: 0 0 6px rgba(210, 153, 34, 0.4);
+}
+
+.truncation-note {
+  font-size: 12px;
+  color: var(--accent-gold);
+  padding: 8px 12px;
+  background: rgba(210, 153, 34, 0.06);
+  border: 1px solid rgba(210, 153, 34, 0.15);
+  border-radius: 8px;
+  margin-top: 10px;
+  line-height: 1.4;
+}
+
+/* State 3: Summary screen */
+.summary-grid {
+  display: grid;
+  grid-template-columns: 1fr 1.2fr;
+  gap: 24px;
+}
+
+@media (max-width: 640px) {
+  .summary-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+.summary-stats {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.summary-stat {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 10px 0;
+  border-bottom: 1px dashed var(--border);
+}
+
+.stat-label {
+  font-size: 14px;
+  color: var(--text-muted);
+}
+
+.stat-val {
+  font-size: 16px;
+  font-weight: 800;
+  color: var(--text-bright, #ffffff);
+}
+
+.stat-val.accent-green { color: var(--accent-green); }
+.stat-val.accent-gold  { color: var(--accent-gold); }
+
+.tier-badge {
+  font-size: 9px;
+  font-weight: 800;
+  color: var(--accent-gold);
+  background: rgba(210, 153, 34, 0.08);
+  border: 1px solid rgba(210, 153, 34, 0.25);
+  padding: 2px 6px;
+  border-radius: 20px;
+  margin-left: 6px;
+  text-transform: uppercase;
+}
+
+/* ===== State 4: Replay (Visual Battle Stage) ===== */
+.in-replay .top-bar {
+  display: none;
+}
+
+.replay-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  border-bottom: 1px solid var(--border);
+  padding-bottom: 16px;
+  margin-bottom: 24px;
+}
+
+.replay-header h2 {
+  font-size: 20px;
+  font-weight: 800;
+  color: var(--text-bright, #ffffff);
+}
+
+.battle-counter {
+  font-size: 14px;
+  font-weight: 500;
+  color: var(--text-muted);
+  margin-left: 8px;
+}
+
+.btn-sm {
+  padding: 6px 14px !important;
+  font-size: 13px !important;
+  height: auto !important;
+  width: auto !important;
+  border-radius: 8px;
+}
+
+.replay-team-selector-container {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-bottom: 16px;
+  background: var(--bg-card);
+  padding: 12px;
+  border-radius: 12px;
+  border: 1px solid var(--border-main);
+}
+.replay-team-selector-container .selector-label {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text-muted);
+}
+.replay-team-selector {
+  display: flex;
+  gap: 12px;
+  overflow-x: auto;
+  padding-bottom: 4px;
+}
+.replay-member-card {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 6px;
+  border-radius: 8px;
+  border: 2px solid transparent;
+  background: rgba(255, 255, 255, 0.03);
+  cursor: pointer;
+  min-width: 64px;
+  transition: all 0.2s ease;
+  position: relative;
+}
+.replay-member-card:hover {
+  background: rgba(255, 255, 255, 0.08);
+}
+.replay-member-card.active-selected {
+  border-color: var(--accent-blue);
+  background: rgba(56, 139, 253, 0.1);
+}
+.replay-member-card.fainted {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+.replay-member-card.inactive {
+  opacity: 0.6;
+  cursor: pointer;
+}
+.replay-member-sprite-wrap {
+  width: 48px;
+  height: 48px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.replay-member-sprite {
+  max-width: 100%;
+  max-height: 100%;
+  object-fit: contain;
+}
+.replay-member-name {
+  font-size: 11px;
+  font-weight: 700;
+  color: var(--text-bright, #ffffff);
+  margin-top: 4px;
+  text-align: center;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  width: 100%;
+}
+
+.battle-scene {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 24px;
+  padding: 32px 24px;
+  background: var(--bg-darker);
+  border: 1px solid var(--border-main);
+  border-radius: 16px;
+  margin-bottom: 24px;
+  min-height: 280px;
+  position: relative;
+  overflow: hidden;
+}
+
+.battle-side {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  flex: 1;
+  max-width: 250px;
+  transition: transform 0.15s cubic-bezier(0.175, 0.885, 0.32, 1.275), opacity 0.15s ease;
+  z-index: 2;
+  will-change: transform, opacity;
+}
+
+.replay-card {
+  width: 100%;
+  background: linear-gradient(135deg, rgba(22, 27, 34, 0.95), rgba(8, 10, 12, 0.95));
+  border: 1px solid var(--border-main);
+  border-radius: 16px;
+  padding: 18px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.4);
+  position: relative;
+}
+
+/* Staggered card slide-in animations */
+.enemy-side {
+  opacity: 0;
+  transform: translateX(80px);
+}
+.enemy-side.slide-in {
+  opacity: 1;
+  transform: translateX(0);
+}
+
+.player-side {
+  opacity: 0;
+  transform: translateX(-80px);
+}
+.player-side.slide-in {
+  opacity: 1;
+  transform: translateX(0);
+}
+
+/* Battle Move Interactions */
+.player-side.attack-dash {
+  transform: translateX(10px);
+  z-index: 10;
+}
+.enemy-side.attack-dash {
+  transform: translateX(-10px);
+  z-index: 10;
+}
+
+.enemy-side.damaged, .player-side.damaged {
+  animation: damaged-wobble 0.1s ease-in-out;
+}
+
+@keyframes damaged-wobble {
+  0%, 100% { transform: translateX(0); }
+  30%, 70% { transform: translateX(-3px); }
+  50% { transform: translateX(3px); }
+}
+
+.battle-info-bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  font-size: 13px;
+  font-weight: 700;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+  padding-bottom: 8px;
+}
+
+.pkmn-name {
+  color: var(--text-bright, #ffffff);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 120px;
+}
+
+.pkmn-level {
+  color: var(--text-muted);
+  font-size: 11px;
+  font-family: 'JetBrains Mono', monospace;
+}
+
+.tier-badge-inline {
+  font-size: 9px;
+  font-weight: 800;
+  color: var(--accent-gold);
+  background: rgba(210, 153, 34, 0.08);
+  border: 1px solid rgba(210, 153, 34, 0.25);
+  padding: 1px 6px;
+  border-radius: 10px;
+}
+
+.sprite-stage {
+  position: relative;
+  width: 100px;
+  height: 100px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.battle-sprite {
+  max-width: 90px;
+  max-height: 90px;
+  object-fit: contain;
+  image-rendering: pixelated;
+  transition: transform 0.3s ease;
+}
+
+.enemy-battle-sprite {
+  /* No floating animation for GIF sprites */
+}
+
+.player-battle-sprite {
+  transform: scaleX(-1); /* face the enemy */
+}
+
+/* Fading States */
+.caught-fade {
+  animation: caught-shrink 0.25s cubic-bezier(0.6, -0.28, 0.735, 0.045) forwards;
+}
+
+@keyframes caught-shrink {
+  0% { transform: scale(1); }
+  45% { transform: scale(1.15) translateY(-8px); }
+  100% { transform: scale(0) translateY(30px); opacity: 0; }
+}
+
+.fainted-fade {
+  animation: fainted-sink 0.25s ease-in forwards;
+}
+
+@keyframes fainted-sink {
+  0% { transform: translateY(0); opacity: 1; }
+  100% { transform: translateY(40px); opacity: 0; }
+}
+
+/* Catch flash overlay */
+.catch-flash {
+  position: absolute;
+  inset: 0;
+  border-radius: 50%;
+  background: radial-gradient(circle, rgba(255,220,50,0.95) 0%, rgba(255,150,0,0.4) 50%, transparent 70%);
+  z-index: 5;
+  animation: catch-burst 0.3s ease-out forwards;
+}
+
+.catch-flash.hidden {
+  display: none;
+}
+
+@keyframes catch-burst {
+  0%   { opacity: 1; transform: scale(0.1); }
+  60%  { opacity: 0.8; transform: scale(1.3); }
+  100% { opacity: 0; transform: scale(1.6); }
+}
+
+/* HP Bars */
+.hp-bar-wrap {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 4px;
+}
+
+.hp-bar-label {
+  font-size: 10px;
+  font-weight: 800;
+  color: var(--text-muted);
+  width: 16px;
+  font-family: 'JetBrains Mono', monospace;
+}
+
+.hp-bar-track {
+  flex: 1;
+  height: 8px;
+  background: rgba(0, 0, 0, 0.35);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  overflow: hidden;
+  position: relative;
+}
+
+.hp-bar-fill {
+  height: 100%;
+  border-radius: 6px;
+  background: linear-gradient(90deg, #3fb950, #56d364);
+  transition: width 0.6s cubic-bezier(0.4, 0, 0.2, 1);
+  box-shadow: inset 0 1px 1px rgba(255,255,255,0.2);
+}
+
+.battle-scene .hp-bar-fill {
+  transition: width 0.1s ease-out;
+}
+
+.hp-bar-fill.hp-green {
+  background: linear-gradient(90deg, #3fb950, #56d364);
+}
+.hp-bar-fill.hp-yellow {
+  background: linear-gradient(90deg, #d29922, #e3b341);
+}
+.hp-bar-fill.hp-red {
+  background: linear-gradient(90deg, #f85149, #ff7b72);
+}
+.hp-bar-fill.hp-blue {
+  background: linear-gradient(90deg, #58a6ff, #79c0ff);
+}
+
+.hp-bar-fill.player-hp {
+  background: linear-gradient(90deg, #58a6ff, #79c0ff);
+}
+
+/* VS Divider */
+.vs-divider {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 48px;
+  z-index: 3;
+}
+
+.vs-text {
+  font-size: 22px;
+  font-weight: 900;
+  color: var(--accent-red);
+  text-shadow: 0 0 15px rgba(248,81,73,0.6);
+  font-style: italic;
+}
+
+/* Narration box */
+.narration-box {
+  background: rgba(0, 0, 0, 0.2);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 16px 20px;
+  margin-bottom: 20px;
+  min-height: 72px;
+  display: flex;
+  align-items: center;
+}
+
+.narration-text {
+  font-size: 14px;
+  line-height: 1.5;
+  color: var(--text-bright, #ffffff);
+  width: 100%;
+}
+
+.narrate-encounter {
+  color: var(--text-muted);
+}
+
+/* Review ease indicator */
+/* Replay controls */
+.replay-controls {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.replay-controls .btn {
+  width: auto;
+  min-width: 140px;
+}
+
+/* Roster picker modal & filter styles */
+.modal-overlay {
+  position: fixed; inset: 0;
+  background: rgba(1, 4, 9, 0.72);
+  display: flex; align-items: center; justify-content: center;
+  z-index: 500;
+}
+.modal-overlay.hidden { display: none; }
+.modal {
+  width: min(560px, 92vw);
+  max-height: 80vh;
+  background: var(--bg-card);
+  border: 1px solid var(--border-main);
+  border-radius: 16px;
+  display: flex; flex-direction: column;
+  overflow: hidden;
+}
+.modal-head {
+  padding: 16px 18px;
+  border-bottom: 1px solid var(--border-main);
+  display: flex; align-items: center; gap: 10px;
+}
+.modal-head h3 { flex: 1; font-size: 1rem; color: var(--text-bright); }
+.icon-btn {
+  background: transparent; border: none; color: var(--text-muted);
+  font-size: 1.3rem; cursor: pointer; line-height: 1;
+}
+.icon-btn:hover { color: var(--text-bright); }
+
+/* Toast */
+.toast {
+  position: fixed;
+  bottom: 24px;
+  left: 50%;
+  transform: translateX(-50%) translateY(20px);
+  background: rgba(22, 27, 34, 0.95);
+  border: 1px solid var(--border-main);
+  color: var(--text-main);
+  padding: 12px 24px;
+  border-radius: 12px;
+  font-size: 14px;
+  font-weight: 600;
+  z-index: 1000;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.2s, transform 0.2s;
+  box-shadow: 0 8px 24px rgba(0,0,0,0.5);
+}
+.toast.show {
+  opacity: 1;
+  transform: translateX(-50%) translateY(0);
+}
+.toast.success {
+  border-color: rgba(63, 185, 80, 0.4);
+  background: rgba(13, 20, 15, 0.95);
+  color: #58a6ff;
+}
+.toast.error {
+  border-color: rgba(248, 81, 73, 0.4);
+  background: rgba(26, 14, 14, 0.95);
+  color: #ff6b6b;
+}
+
+.btn-success {
+  background: transparent;
+  color: var(--accent-green);
+  border-color: rgba(57, 211, 83, 0.4);
+}
+.btn-success:hover {
+  background: rgba(57, 211, 83, 0.12);
+  color: var(--accent-green);
+  border-color: var(--accent-green);
+}
+
+.replay-choice-box {
+  display: flex;
+  gap: 12px;
+}
+
+/* Summary Modal styling */
+.summary-modal-content {
+  width: min(600px, 94vw);
+  background: var(--bg-card);
+  border: 1px solid var(--border-main);
+  border-radius: 16px;
+  box-shadow: 0 16px 48px rgba(0, 0, 0, 0.6);
+}
+
+.modal-body {
+  padding: 20px;
+  overflow-y: auto;
+}
+
+.summary-stats-banner {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 10px;
+  margin-bottom: 20px;
+}
+
+.summary-stat-box {
+  background: rgba(0, 0, 0, 0.22);
+  border: 1px solid var(--border-main);
+  border-radius: 10px;
+  padding: 12px 6px;
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.stat-box-label {
+  font-size: 11px;
+  color: var(--text-muted);
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.stat-box-val {
+  font-size: 16px;
+  font-weight: 800;
+  color: var(--text-bright);
+}
+
+.modal-caught-section {
+  margin-top: 10px;
+}
+
+.modal-caught-section h4 {
+  margin: 0 0 10px 0;
+  font-size: 14px;
+  color: var(--text-bright);
+  font-weight: 600;
+}
+
+.scrollable-caught-list {
+  max-height: 240px;
+  overflow-y: auto;
+  padding-right: 4px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.modal-foot {
+  padding: 16px 20px;
+  border-top: 1px solid var(--border-main);
+  display: flex;
+  justify-content: flex-end;
+}
+
+/* CP Pill Badge */
+.caught-pokemon-cp {
+  font-size: 10px;
+  font-weight: 800;
+  color: var(--accent-gold);
+  background: rgba(212, 175, 55, 0.15);
+  border: 1px solid rgba(212, 175, 55, 0.35);
+  padding: 2px 8px;
+  border-radius: 20px;
+  margin-left: 6px;
+  letter-spacing: 0.3px;
+  font-family: 'JetBrains Mono', monospace;
+}
+
+/* Team grid for multi-companion reviews */
+.team-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 10px;
+  margin-top: 10px;
+}
+
+.team-card {
+  background: rgba(0, 0, 0, 0.22);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 10px 6px;
+  text-align: center;
+  cursor: pointer;
+  transition: transform 0.2s, border-color 0.2s, opacity 0.2s;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  position: relative;
+}
+
+.team-card:hover {
+  transform: translateY(-2px);
+  border-color: var(--accent-blue);
+}
+
+.team-sprite-wrap {
+  width: 54px;
+  height: 54px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-bottom: 4px;
+}
+
+.team-sprite {
+  max-width: 100%;
+  max-height: 100%;
+  image-rendering: pixelated;
+}
+
+.team-name {
+  font-size: 11px;
+  font-weight: 700;
+  color: var(--text-bright, #ffffff);
+  margin-bottom: 2px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  width: 100%;
+}
+
+.team-level {
+  font-size: 10px;
+  color: var(--text-muted);
+  font-family: 'JetBrains Mono', monospace;
+}
+
+.team-card.inactive {
+  opacity: 0.4;
+}
+
+.team-inactive-badge {
+  font-size: 9px;
+  color: #ff4d4d;
+  font-weight: 700;
+  margin-top: 2px;
+}
+
+/* History Section CSS */
+.card-history {
+  margin-top: 24px;
+}
+
+.card-header-history {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  border-bottom: 1px solid var(--border);
+  padding-bottom: 10px;
+  margin-bottom: 18px;
+}
+
+.card-header-history h3 {
+  margin-bottom: 0;
+  border-bottom: none;
+  padding-bottom: 0;
+}
+
+.btn-clear-history {
+  padding: 4px 10px !important;
+  font-size: 0.75rem !important;
+  height: 28px;
+  border-radius: 6px;
+  cursor: pointer;
+}
+
+.history-empty-state {
+  color: var(--text-muted);
+  font-size: 0.9rem;
+  text-align: center;
+  padding: 30px 10px;
+  background: rgba(255, 255, 255, 0.02);
+  border-radius: 8px;
+  border: 1px dashed var(--border);
+}
+
+.scrollable-history-list {
+  max-height: 300px;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding-right: 4px;
+}
+
+.history-item {
+  background: rgba(255, 255, 255, 0.02);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 12px 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  transition: background-color 0.2s ease;
+}
+
+.history-item:hover {
+  background: rgba(255, 255, 255, 0.04);
+}
+
+.history-item-main {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  width: 100%;
+}
+
+.history-item-left {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.outcome-badge {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 10px;
+  font-weight: 700;
+  padding: 2px 8px;
+  border-radius: 4px;
+  letter-spacing: 0.5px;
+}
+
+.badge-caught {
+  background: rgba(57, 255, 20, 0.1);
+  color: #39ff14;
+  border: 1px solid rgba(57, 255, 20, 0.2);
+}
+
+.badge-defeated {
+  background: rgba(88, 166, 255, 0.1);
+  color: var(--accent-blue, #58a6ff);
+  border: 1px solid rgba(88, 166, 255, 0.2);
+}
+
+.badge-lost {
+  background: rgba(255, 77, 77, 0.1);
+  color: #ff4d4d;
+  border: 1px solid rgba(255, 77, 77, 0.2);
+}
+
+.badge-escaped {
+  background: rgba(240, 196, 25, 0.1);
+  color: var(--accent-gold, #f0c419);
+  border: 1px solid rgba(240, 196, 25, 0.2);
+}
+
+.history-item-details {
+  font-size: 0.9rem;
+  color: var(--text);
+}
+
+.history-item-time {
+  font-size: 0.8rem;
+  color: var(--text-muted);
+}
+
+.history-item-rewards {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  padding-left: 76px;
+}
+
+.reward-val {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 11px;
+  font-weight: 500;
+  padding: 1px 6px;
+  border-radius: 3px;
+}
+
+.reward-xp {
+  background: rgba(57, 255, 20, 0.05);
+  color: #39ff14;
+}
+
+.reward-txp {
+  background: rgba(255, 255, 255, 0.05);
+  color: #ffffff;
+}
+
+.reward-cash {
+  background: rgba(240, 196, 25, 0.05);
+  color: var(--accent-gold, #f0c419);
+}
+
+@media (max-width: 600px) {
+  .history-item-main {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 6px;
+  }
+  .history-item-time {
+    align-self: flex-end;
+  }
+  .history-item-rewards {
+    padding-left: 0;
+  }
+}
+
+/* Estimates loader overlay */
+.estimates-loader-overlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(22, 27, 34, 0.85);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  z-index: 10;
+  border-radius: 16px;
+  color: var(--text-muted);
+  font-size: 13px;
+  font-weight: 500;
+  transition: opacity 0.2s ease;
+}
+
+.estimates-loader-overlay.hidden {
+  display: none !important;
+}
+
+.pokeball-spinner {
+  width: 44px;
+  height: 44px;
+  animation: spin 1s linear infinite;
+}
+
+/* Info indicator and tooltip styles */
+.info-indicator {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  margin-left: 4px;
+  color: var(--text-muted);
+  cursor: help;
+  font-size: 13px;
+  position: relative;
+  transition: color 0.2s;
+}
+
+.info-indicator:hover {
+  color: var(--text-bright, #ffffff);
+}
+
+.info-indicator::before {
+  content: attr(data-tooltip);
+  position: absolute;
+  bottom: 125%;
+  left: 50%;
+  transform: translateX(-50%) scale(0.95);
+  background: var(--surface, #161b22);
+  color: var(--text, #c9d1d9);
+  padding: 8px 12px;
+  border-radius: 6px;
+  border: 1px solid var(--border, #30363d);
+  font-size: 11px;
+  white-space: normal;
+  width: 180px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.5);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.15s ease, transform 0.15s ease;
+  z-index: 100;
+  text-align: center;
+  font-weight: normal;
+  line-height: 1.4;
+}
+
+.info-indicator::after {
+  content: "";
+  position: absolute;
+  bottom: 110%;
+  left: 50%;
+  transform: translateX(-50%);
+  border-width: 5px;
+  border-style: solid;
+  border-color: var(--border, #30363d) transparent transparent transparent;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.15s ease;
+  z-index: 100;
+}
+
+.info-indicator:hover::before {
+  opacity: 1;
+  transform: translateX(-50%) scale(1);
+}
+
+.info-indicator:hover::after {
+  opacity: 1;
+}
+
+/* Align rightmost tooltip to avoid overflow */
+.info-indicator.tooltip-right::before {
+  left: auto;
+  right: -10px;
+  transform: scale(0.95);
+}
+
+.info-indicator.tooltip-right:hover::before {
+  transform: scale(1);
+}
+
+.info-indicator.tooltip-right::after {
+  left: auto;
+  right: 2px;
+  transform: none;
+}
+
+
+
+

--- a/src/Ankimon/ankimon_mobile_web/mobile.html
+++ b/src/Ankimon/ankimon_mobile_web/mobile.html
@@ -1,0 +1,378 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Ankimon — Mobile Battles</title>
+  <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700;800;900&family=JetBrains+Mono:wght@500;700&display=swap" rel="stylesheet">
+
+  <link rel="stylesheet" href="../ankimon_items_web/shop.css">
+  <link rel="stylesheet" href="../ankimon_items_web/nav-switcher.css">
+  <link rel="stylesheet" href="mobile.css">
+</head>
+<body class="dark-mode shell-mode">
+  <div class="app-container">
+    <!-- Sidebar -->
+    <aside class="sidebar">
+      <div class="sidebar-header">
+        <div id="nav-switcher" class="nav-switcher">
+          <button id="nav-trigger" class="nav-trigger" type="button" aria-haspopup="true" aria-expanded="false">
+            <img src="../user_files/sprites/items/elixir.png" class="app-logo icon-item-sprite" alt="">
+            <h1>MOBILE</h1>
+            <span class="nav-chevron">▾</span>
+          </button>
+          <div id="nav-menu" class="nav-menu hidden" role="menu">
+            <button class="nav-menu-item" role="menuitem" data-screen="items">
+              <span class="nav-menu-icon"><img src="../user_files/sprites/items/max-potion.png" class="icon-item-sprite" alt=""></span>
+              <div class="nav-menu-text">
+                <span class="nav-menu-title">Items</span>
+                <span class="nav-menu-desc">Your inventory and today's Mart</span>
+              </div>
+            </button>
+            <button class="nav-menu-item" role="menuitem" data-screen="ankidex">
+              <span class="nav-menu-icon"><img src="../user_files/sprites/items/poke-ball.png" alt=""></span>
+              <div class="nav-menu-text">
+                <span class="nav-menu-title">Ankidex</span>
+                <span class="nav-menu-desc">Browse caught Pokémon</span>
+              </div>
+            </button>
+            <button class="nav-menu-item" role="menuitem" data-screen="team">
+              <span class="nav-menu-icon"><img src="../user_files/sprites/items/great-ball.png" class="icon-item-sprite" alt=""></span>
+              <div class="nav-menu-text">
+                <span class="nav-menu-title">Team</span>
+                <span class="nav-menu-desc">Your active 6 Pokémon</span>
+              </div>
+            </button>
+            <button class="nav-menu-item" role="menuitem" data-screen="profile">
+              <span class="nav-menu-icon"><img src="../user_files/sprites/items/water-gem.png" class="icon-item-sprite" alt=""></span>
+              <div class="nav-menu-text">
+                <span class="nav-menu-title">Profile</span>
+                <span class="nav-menu-desc">Card, badges &amp; avatar</span>
+              </div>
+            </button>
+            <button class="nav-menu-item" role="menuitem" data-screen="settings">
+              <span class="nav-menu-icon"><img src="../user_files/sprites/items/x-speed.png" class="icon-item-sprite" alt=""></span>
+              <div class="nav-menu-text">
+                <span class="nav-menu-title">Settings</span>
+                <span class="nav-menu-desc">Configure Ankimon</span>
+              </div>
+            </button>
+            <button class="nav-menu-item active" role="menuitem" data-screen="mobile">
+              <span class="nav-menu-icon"><img src="../user_files/sprites/items/elixir.png" class="icon-item-sprite" alt=""></span>
+              <div class="nav-menu-text">
+                <span class="nav-menu-title">Mobile & Web Reviews</span>
+                <span class="nav-menu-desc">Pending mobile/web battles</span>
+              </div>
+            </button>
+          </div>
+        </div>
+      </div>
+      <!-- Mode list or status inside sidebar -->
+      <nav class="sidebar-nav">
+        <div class="nav-group">
+          <label>Navigation</label>
+          <button class="nav-item active" onclick="goToMobileReviews()">
+            <span class="nav-icon" style="color: var(--accent-blue)">●</span>Mobile & Web Reviews
+          </button>
+          <button class="nav-item" onclick="goToHistory()">
+            <span class="nav-icon" style="color: var(--accent-gold)">●</span>Battle History
+          </button>
+        </div>
+      </nav>
+    </aside>
+
+    <!-- Main Content Area -->
+    <main class="main-content">
+      <!-- Persistent Header Top Bar -->
+      <header class="top-bar">
+        <div class="top-bar-titles">
+          <h2>Mobile &amp; Web Battles</h2>
+          <span class="top-bar-sub">Resolve card reviews performed on your mobile or web device</span>
+        </div>
+        <div class="top-actions">
+          <span id="top-count-display" class="badge-count hidden">0 / 10000</span>
+          <button class="btn btn-secondary btn-refresh" onclick="refreshStatus()">
+            <span class="spin-icon">↻</span> Sync &amp; Refresh
+          </button>
+        </div>
+      </header>
+
+      <!-- Scrollable content area -->
+      <div class="content-scroll">
+        <div id="loading" class="loading-state">
+          <div class="spinner-box">
+            <div class="spinner"></div>
+          </div>
+          <span>Syncing reviews and loading battles...</span>
+        </div>
+
+        <div id="app">
+          <!-- State 1: Empty -->
+          <div id="state-empty" class="state-container">
+            <div class="empty-content">
+              <div class="pokeball-icon-container">
+                <svg class="pokeball-icon" viewBox="0 0 100 100">
+                  <circle cx="50" cy="50" r="48" fill="none" stroke="var(--border-main)" stroke-width="4"/>
+                  <path d="M2 50 H98" stroke="var(--border-main)" stroke-width="4"/>
+                  <circle cx="50" cy="50" r="15" fill="var(--bg-card)" stroke="var(--border-main)" stroke-width="4"/>
+                  <circle cx="50" cy="50" r="7" fill="none" stroke="var(--border-main)" stroke-width="2"/>
+                </svg>
+              </div>
+              <h2>No battles pending</h2>
+              <p>Review cards on mobile or web, sync your collection, and your pending battles will appear here.</p>
+            </div>
+          </div>
+
+          <!-- State 2: Pending -->
+          <div id="state-pending" class="state-container">
+            <div class="pending-layout">
+              <!-- Left Column: Breakdown & Estimates -->
+              <div class="info-column">
+                <div class="card card-breakdown">
+                  <h3>Review Breakdown</h3>
+                  <div class="breakdown-grid">
+                    <div class="breakdown-item breakdown-again">
+                      <span class="breakdown-label">Again</span>
+                      <span id="ease-again" class="breakdown-val ease-again">0</span>
+                    </div>
+                    <div class="breakdown-item breakdown-hard">
+                      <span class="breakdown-label">Hard</span>
+                      <span id="ease-hard" class="breakdown-val ease-hard">0</span>
+                    </div>
+                    <div class="breakdown-item breakdown-good">
+                      <span class="breakdown-label">Good</span>
+                      <span id="ease-good" class="breakdown-val ease-good">0</span>
+                    </div>
+                    <div class="breakdown-item breakdown-easy">
+                      <span class="breakdown-label">Easy</span>
+                      <span id="ease-easy" class="breakdown-val ease-easy">0</span>
+                    </div>
+                  </div>
+                </div>
+
+                <div class="card card-estimates" style="position: relative;">
+                  <div id="estimates-loader" class="estimates-loader-overlay hidden">
+                    <img class="pokeball-spinner" src="../user_files/sprites/items/poke-ball.png" alt="Loading">
+                    <span>Calculating estimates...</span>
+                  </div>
+                  <h3>Auto-Resolve Preview</h3>
+                  <p class="estimates-intro">Outcomes based on current settings:</p>
+                  <div class="estimates-grid">
+                    <div class="estimate-item">
+                      <span class="est-label">Total XP Gained</span>
+                      <span id="est-xp" class="est-val">+0</span>
+                    </div>
+                    <div class="estimate-item">
+                      <span class="est-label">Total Encounters</span>
+                      <span id="est-encounters" class="est-val">0</span>
+                    </div>
+                    <div class="estimate-item">
+                      <span class="est-label">Total Catches</span>
+                      <span id="est-catches" class="est-val">0</span>
+                    </div>
+                    <div class="estimate-item">
+                      <span class="est-label">Est. Cash Reward</span>
+                      <span id="est-cash" class="est-val">+0</span>
+                    </div>
+                  </div>
+                  <div class="estimates-footer">
+                    <div style="display: flex; align-items: center; gap: 4px;">
+                      Auto-Battle: <span id="auto-battle-status" class="status-val">OFF</span>
+                      <span class="info-indicator" data-tooltip="This shows your current automated battle setting. You can change this behavior in the Settings tab.">ⓘ</span>
+                    </div>
+                    <div style="display: flex; align-items: center; gap: 4px;">
+                      Rare Catch: <span id="rare-catch-status" class="status-val">OFF</span>
+                      <span class="info-indicator tooltip-right" data-tooltip="This shows if you have configured any auto-catch settings. You can change this behavior in the Settings tab.">ⓘ</span>
+                    </div>
+                  </div>
+                  <div id="caught-list-container" class="caught-list-container">
+                    <h4>Captures Preview:</h4>
+                    <div id="caught-list" class="caught-list">
+                      <!-- Caught pokemon items will be dynamically inserted here -->
+                    </div>
+                  </div>
+                </div>
+              </div>
+
+              <!-- Right Column: Active Pokemon Preview & Action buttons -->
+              <div class="action-column">
+                <div class="card card-team-grid">
+                  <h3>Battle Team</h3>
+                  <div class="team-grid" id="team-grid">
+                    <!-- Team members populated dynamically -->
+                  </div>
+                </div>
+
+                <div class="actions-box">
+                  <button class="btn btn-primary btn-block" onclick="startReplay()">Start Replay</button>
+                  <button class="btn btn-warning btn-block" onclick="resolveAll()">Auto-Resolve All</button>
+                  <button class="btn btn-danger btn-block" onclick="dismissAll()">Dismiss All</button>
+                </div>
+              </div>
+            </div>
+          </div>
+
+
+
+          <!-- State 4: Replay (single-battle animated view) -->
+          <div id="state-replay" class="state-container">
+            <div class="replay-header">
+              <h2>Mobile/Web Battle <span id="replay-battle-counter" class="battle-counter"></span></h2>
+              <button class="btn btn-secondary btn-sm" onclick="pauseReplay()">Pause &amp; Save</button>
+            </div>
+
+
+            <!-- Compact Team Selector for Replay Override -->
+            <div id="replay-team-selector-container" class="replay-team-selector-container">
+              <span class="selector-label">Select Active Attacker:</span>
+              <div id="replay-team-selector" class="replay-team-selector"></div>
+            </div>
+
+            <div class="battle-scene">
+              <!-- Player side -->
+              <div class="battle-side player-side">
+                <div class="replay-card">
+                  <div class="battle-info-bar">
+                    <span id="replay-player-name" class="pkmn-name"></span>
+                    <span id="replay-player-level" class="pkmn-level"></span>
+                  </div>
+                  <div class="sprite-stage player-sprite-stage">
+                    <img id="replay-player-sprite" src="" alt="Companion" class="battle-sprite player-battle-sprite"
+                         onerror="if (this.src.indexOf('_gif') !== -1) { this.src = this.src.replace('_gif', '').replace('.gif', '.png'); } else { this.onerror=null; this.src='../user_files/sprites/front_default/0.png'; }">
+                  </div>
+                  <div class="hp-bar-wrap">
+                    <span class="hp-bar-label">HP</span>
+                    <div class="hp-bar-track">
+                      <div id="replay-player-hp" class="hp-bar-fill player-hp"></div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+
+              <!-- VS divider -->
+              <div class="vs-divider">
+                <span class="vs-text">VS</span>
+              </div>
+
+              <!-- Enemy side -->
+              <div class="battle-side enemy-side">
+                <div class="replay-card">
+                  <div class="battle-info-bar">
+                    <span id="replay-enemy-name" class="pkmn-name"></span>
+                    <span id="replay-enemy-level" class="pkmn-level"></span>
+                    <span id="replay-enemy-tier" class="tier-badge-inline"></span>
+                  </div>
+                  <div class="sprite-stage enemy-sprite-stage">
+                    <img id="replay-enemy-sprite" src="" alt="Enemy" class="battle-sprite enemy-battle-sprite"
+                         onerror="if (this.src.indexOf('_gif') !== -1) { this.src = this.src.replace('_gif', '').replace('.gif', '.png'); } else { this.onerror=null; this.src='../user_files/sprites/front_default/0.png'; }">
+                    <div id="replay-catch-flash" class="catch-flash hidden"></div>
+                  </div>
+                  <div class="hp-bar-wrap">
+                    <span class="hp-bar-label">HP</span>
+                    <div class="hp-bar-track">
+                      <div id="replay-enemy-hp" class="hp-bar-fill"></div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            <!-- Narration box -->
+            <div class="narration-box">
+              <div id="narration-text" class="narration-text"></div>
+            </div>
+
+            <!-- Action controls -->
+            <div class="replay-controls">
+              <div id="replay-choice-controls" class="replay-choice-box hidden">
+                <button id="replay-catch-btn" class="btn btn-success" onclick="chooseOutcome('catch')">
+                  Catch
+                </button>
+                <button id="replay-defeat-btn" class="btn btn-danger" onclick="chooseOutcome('defeat')">
+                  Defeat
+                </button>
+              </div>
+              <button id="replay-next-btn" class="btn btn-primary hidden" onclick="nextReplayBattle()">
+                Next Battle
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </main>
+  </div>
+
+  <!-- Auto-Resolve Summary Modal -->
+  <div id="summary-modal" class="modal-overlay hidden">
+    <div class="modal summary-modal-content">
+      <div class="modal-head">
+        <h3>Auto-Resolve Results</h3>
+        <button class="icon-btn" onclick="closeSummaryModal()">&times;</button>
+      </div>
+
+      <div class="modal-body">
+        <div class="summary-stats-banner">
+          <div class="summary-stat-box">
+            <span class="stat-box-label">Companion XP</span>
+            <span id="modal-summary-xp" class="stat-box-val accent-green">+0</span>
+          </div>
+          <div class="summary-stat-box">
+            <span class="stat-box-label">Cash Earned</span>
+            <span id="modal-summary-cash" class="stat-box-val accent-gold">+0¥</span>
+          </div>
+          <div class="summary-stat-box">
+            <span class="stat-box-label">Encounters</span>
+            <span id="modal-summary-encounters" class="stat-box-val accent-blue">0</span>
+          </div>
+          <div class="summary-stat-box">
+            <span class="stat-box-label">Trainer XP</span>
+            <span id="modal-summary-trainer-xp" class="stat-box-val">+0</span>
+          </div>
+        </div>
+        
+        <div class="modal-caught-section">
+          <h4>Caught Pokémon (<span id="modal-summary-catches">0</span>)</h4>
+          <div id="modal-summary-caught-list" class="caught-list scrollable-caught-list">
+            <!-- Dynamically populated -->
+          </div>
+        </div>
+      </div>
+      <div class="modal-foot">
+        <button class="btn btn-primary btn-block" onclick="closeSummaryModal()">Done</button>
+      </div>
+    </div>
+  </div>
+  <!-- Auto-Resolve Progress Modal -->
+  <div id="resolve-progress-modal" class="modal-overlay hidden">
+    <div class="modal" style="max-width: 400px; max-height: auto;">
+      <div class="modal-head">
+        <h3>Auto-Resolving Battles</h3>
+      </div>
+      <div class="modal-body" style="padding: 24px 20px; display: flex; flex-direction: column; gap: 15px; align-items: center;">
+        <div id="resolve-progress-text" style="font-size: 0.95rem; color: var(--text-main); text-align: center; font-weight: 500;">
+          Processed reviews: 0 / 0 (0%)
+        </div>
+        <div id="resolve-progress-encounters" style="font-size: 0.85rem; color: var(--text-muted); text-align: center;">
+          Encounters resolved: 0
+        </div>
+        <div style="width: 100%; height: 10px; background: rgba(255,255,255,0.08); border-radius: 5px; overflow: hidden; border: 1px solid var(--border-main);">
+          <div id="resolve-progress-bar-fill" style="width: 0%; height: 100%; background: var(--accent-green); transition: width 0.1s ease; border-radius: 5px;"></div>
+        </div>
+        <div style="font-size: 0.82rem; color: #ff5555; text-align: center; font-weight: 600; margin-top: 5px; line-height: 1.3;">
+          ⚠️ WARNING: Do not review cards on desktop while auto-resolve is active or you risk losing your progress!
+        </div>
+        <div style="display: flex; gap: 10px; width: 100%; margin-top: 10px;">
+          <button id="resolve-pause-btn" class="btn btn-warning" style="flex: 1;" onclick="togglePauseResolve()">Pause</button>
+          <button class="btn btn-danger" style="flex: 1;" onclick="stopResolve()">Stop</button>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div id="toast" class="toast"></div>
+
+  <script src="qrc:///qtwebchannel/qwebchannel.js"></script>
+  <script src="../ankimon_items_web/nav-switcher.js"></script>
+  <script src="mobile.js"></script>
+</body>
+</html>

--- a/src/Ankimon/ankimon_mobile_web/mobile.js
+++ b/src/Ankimon/ankimon_mobile_web/mobile.js
@@ -768,7 +768,7 @@ function renderReplayBattle(result) {
         // 1. Player Attack
         playerCard.classList.add('attack-dash');
         if (narrateEl) {
-            narrateEl.innerHTML = `<strong>${result.companion_name}</strong> used <strong>${turn.user_attack}</strong>!`;
+            narrateEl.innerHTML = `<strong>${escapeHtml(result.companion_name)}</strong> used <strong>${escapeHtml(turn.user_attack)}</strong>!`;
         }
 
         const tPlayer = setTimeout(() => {
@@ -952,12 +952,13 @@ function renderReplayTeamSelector(activeCompanionId) {
                 card.classList.add('inactive');
             }
 
+            const memberName = escapeHtml(member.name);
             card.innerHTML = `
                 <div class="replay-member-sprite-wrap">
-                    <img class="replay-member-sprite" src="${member.sprite_path}" alt="${member.name}"
+                    <img class="replay-member-sprite" src="${escapeHtml(member.sprite_path)}" alt="${memberName}"
                          onerror="if (this.src.indexOf('_gif') !== -1) { this.src = this.src.replace('_gif', '').replace('.gif', '.png'); } else { this.onerror=null; this.src='../user_files/sprites/front_default/0.png'; }">
                 </div>
-                <div class="replay-member-name">${member.name}</div>
+                <div class="replay-member-name">${memberName}</div>
             `;
 
             card.onclick = function() {

--- a/src/Ankimon/ankimon_mobile_web/mobile.js
+++ b/src/Ankimon/ankimon_mobile_web/mobile.js
@@ -1,0 +1,1019 @@
+// State machine: "loading" → "empty" | "pending"
+
+function showConfirm(message, onConfirm, onCancel = null) {
+    const overlay = document.createElement('div');
+    overlay.className = 'modal-overlay';
+    overlay.style.zIndex = '1000';
+
+    const modal = document.createElement('div');
+    modal.className = 'modal';
+    modal.style.maxWidth = '400px';
+
+    const head = document.createElement('div');
+    head.className = 'modal-head';
+    const title = document.createElement('h3');
+    title.textContent = 'Confirmation';
+    head.appendChild(title);
+
+    const body = document.createElement('div');
+    body.className = 'modal-body';
+    body.style.padding = '18px';
+    body.style.fontSize = '0.95rem';
+    body.style.lineHeight = '1.4';
+    body.style.color = 'var(--text-main)';
+    body.innerHTML = message;
+
+    const foot = document.createElement('div');
+    foot.className = 'modal-foot';
+    foot.style.gap = '10px';
+
+    const cancelBtn = document.createElement('button');
+    cancelBtn.className = 'btn btn-secondary';
+    cancelBtn.textContent = 'Cancel';
+    cancelBtn.onclick = function() {
+        document.body.removeChild(overlay);
+        if (onCancel) onCancel();
+    };
+
+    const confirmBtn = document.createElement('button');
+    confirmBtn.className = 'btn btn-primary';
+    confirmBtn.textContent = 'Confirm';
+    confirmBtn.onclick = function() {
+        document.body.removeChild(overlay);
+        onConfirm();
+    };
+
+    foot.appendChild(cancelBtn);
+    foot.appendChild(confirmBtn);
+
+    modal.appendChild(head);
+    modal.appendChild(body);
+    modal.appendChild(foot);
+    overlay.appendChild(modal);
+
+    document.body.appendChild(overlay);
+}
+
+function showAlert(message, onOk = null) {
+    const overlay = document.createElement('div');
+    overlay.className = 'modal-overlay';
+    overlay.style.zIndex = '1000';
+
+    const modal = document.createElement('div');
+    modal.className = 'modal';
+    modal.style.maxWidth = '400px';
+
+    const head = document.createElement('div');
+    head.className = 'modal-head';
+    const title = document.createElement('h3');
+    title.textContent = 'Notification';
+    head.appendChild(title);
+
+    const body = document.createElement('div');
+    body.className = 'modal-body';
+    body.style.padding = '18px';
+    body.style.fontSize = '0.95rem';
+    body.style.lineHeight = '1.4';
+    body.style.color = 'var(--text-main)';
+    body.textContent = message;
+
+    const foot = document.createElement('div');
+    foot.className = 'modal-foot';
+
+    const okBtn = document.createElement('button');
+    okBtn.className = 'btn btn-primary';
+    okBtn.textContent = 'OK';
+    okBtn.onclick = function() {
+        document.body.removeChild(overlay);
+        if (onOk) onOk();
+    };
+
+    foot.appendChild(okBtn);
+
+    modal.appendChild(head);
+    modal.appendChild(body);
+    modal.appendChild(foot);
+    overlay.appendChild(modal);
+
+    document.body.appendChild(overlay);
+}
+
+
+let mobileBridge = null;
+let nav = null;
+let _currentMobileStatus = null;
+let _replayCompanionOverride = null;
+
+new QWebChannel(qt.webChannelTransport, function(channel) {
+    window.parentChannel = channel; // Expose to iframe picker
+    mobileBridge = channel.objects.mobile;
+    nav = channel.objects && channel.objects.nav;
+    window.nav = nav;
+    loadStatus();
+    if (window.wireNavSwitcher) {
+        window.wireNavSwitcher(nav);
+    }
+});
+
+function loadStatus() {
+    if (!mobileBridge) return;
+    mobileBridge.getMobileStatus(function(status) {
+        render(status);
+    });
+}
+
+function refreshStatus() {
+    const icons = document.querySelectorAll('.spin-icon');
+    icons.forEach(icon => icon.classList.add('spinning'));
+    if (!mobileBridge) {
+        setTimeout(() => icons.forEach(icon => icon.classList.remove('spinning')), 500);
+        return;
+    }
+    mobileBridge.triggerAnkiSync(function(res) {
+        mobileBridge.getMobileStatus(function(status) {
+            render(status);
+            setTimeout(() => icons.forEach(icon => icon.classList.remove('spinning')), 600);
+        });
+    });
+}
+
+window.initializeMobile = function(status) {
+    render(status);
+};
+
+window.liveRefreshMobile = function(status) {
+    render(status);
+};
+
+window.updateMobileEstimates = function(estimates) {
+    if (_currentMobileStatus) {
+        _currentMobileStatus.estimates = estimates;
+        _currentMobileStatus.estimates_loading = false;
+        _currentMobileStatus.battle_count = estimates.encounters;
+        
+        // Update top badge count display with correct battle count
+        const countDisplay = document.getElementById('top-count-display');
+        if (countDisplay && _currentMobileStatus.pending_count > 0) {
+            countDisplay.textContent = `${_currentMobileStatus.pending_count} / ${_currentMobileStatus.cap || 10000}`;
+            countDisplay.classList.remove('hidden');
+        }
+    }
+
+    const estXp = document.getElementById('est-xp');
+    if (estXp) estXp.textContent = `+${estimates.xp || 0}`;
+    const estEncounters = document.getElementById('est-encounters');
+    if (estEncounters) estEncounters.textContent = estimates.encounters || 0;
+    const estCatches = document.getElementById('est-catches');
+    if (estCatches) estCatches.textContent = estimates.catches || 0;
+    const estCashEl = document.getElementById('est-cash');
+    if (estCashEl) {
+        estCashEl.textContent = `+${estimates.cash || 0}`;
+    }
+
+    const caughtListContainer = document.getElementById('caught-list-container');
+    const caughtListEl = document.getElementById('caught-list');
+
+    if (caughtListEl) {
+        caughtListEl.innerHTML = '';
+        if (caughtListContainer) {
+            const existingNote = caughtListContainer.querySelector('.truncation-note');
+            if (existingNote) {
+                existingNote.remove();
+            }
+        }
+        const caughtList = estimates.caught_list || [];
+        if (caughtList.length > 0) {
+            if (caughtListContainer) caughtListContainer.style.display = 'block';
+            caughtList.forEach(pkmn => {
+                const item = document.createElement('div');
+                item.className = 'caught-pokemon-item';
+                const shinyIcon = pkmn.shiny ? '<span class="shiny-badge">✨</span> ' : '';
+                item.innerHTML = `
+                    <span class="caught-pokemon-name">${shinyIcon}${pkmn.name}</span>
+                    <span class="caught-pokemon-lvl">Lv.${pkmn.level}</span>
+                `;
+                caughtListEl.appendChild(item);
+            });
+        } else {
+            if (caughtListContainer) caughtListContainer.style.display = 'block';
+            caughtListEl.innerHTML = `
+                <div style="font-size: 12px; color: var(--text-muted); font-style: italic; padding: 4px 0;">
+                    No Pokémon will be caught.
+                </div>
+            `;
+        }
+
+        if (estimates.is_truncated && caughtListContainer) {
+            const noteEl = document.createElement('div');
+            noteEl.className = 'truncation-note';
+            noteEl.innerHTML = `
+  ⚠ Preview shows first ${estimates.simulated_reviews} of ${estimates.total_reviews} reviews.
+  XP and encounter counts include estimates for the remainder.
+            `.trim();
+            caughtListContainer.appendChild(noteEl);
+        }
+    }
+
+    const loaderEl = document.getElementById('estimates-loader');
+    if (loaderEl) {
+        loaderEl.classList.add('hidden');
+    }
+};
+
+window.onResolveNextReady = function(result) {
+    if (!_replayRunning) return;
+    if (result.done) {
+        _replayRunning = false;
+        loadStatus();
+        return;
+    }
+    if (result.error) {
+        _replayRunning = false;
+        showAlert('Replay error: ' + result.error);
+        loadStatus();
+        return;
+    }
+    renderReplayBattle(result);
+};
+
+
+function render(status) {
+    _currentMobileStatus = status;
+    const loadingEl = document.getElementById('loading');
+    if (loadingEl) {
+        loadingEl.style.display = 'none';
+    }
+
+    const countDisplay = document.getElementById('top-count-display');
+    if (countDisplay) {
+        if (status.pending_count > 0) {
+            countDisplay.textContent = `${status.pending_count} / ${status.cap || 10000}`;
+            countDisplay.classList.remove('hidden');
+        } else {
+            countDisplay.classList.add('hidden');
+        }
+    }
+
+    if (status.error) {
+        document.getElementById('app').innerHTML =
+            `<p style="color:var(--accent-red); text-align:center; padding: 40px;">Error loading status: ${status.error}</p>`;
+        return;
+    }
+
+    if (_replayRunning) {
+        return;
+    }
+
+    if (status.pending_count === 0) {
+        showState('empty');
+    } else {
+        showState('pending', status);
+    }
+}
+
+function showState(name, data) {
+    document.querySelectorAll('#state-empty, #state-pending, #state-summary, #state-replay')
+            .forEach(el => el.classList.remove('active'));
+    const el = document.getElementById(`state-${name}`);
+    if (el) {
+        el.classList.add('active');
+        if (name === 'pending' && data) fillPending(data);
+    }
+    
+    // Toggle in-replay class on body for conditional styling
+    document.body.classList.toggle('in-replay', name === 'replay');
+}
+
+function fillPending(data) {
+    // Count / cap
+    const countEl = document.getElementById('count-display') || document.getElementById('top-count-display');
+    if (countEl) {
+        countEl.textContent = `${data.pending_count} / ${data.cap}`;
+    }
+
+    // Ease breakdown
+    const eb = data.ease_breakdown || {};
+    const easeAgain = document.getElementById('ease-again');
+    if (easeAgain) easeAgain.textContent = eb["1"] || 0;
+    const easeHard = document.getElementById('ease-hard');
+    if (easeHard) easeHard.textContent = eb["2"] || 0;
+    const easeGood = document.getElementById('ease-good');
+    if (easeGood) easeGood.textContent = eb["3"] || 0;
+    const easeEasy = document.getElementById('ease-easy');
+    if (easeEasy) easeEasy.textContent = eb["4"] || 0;
+
+    // Show/hide estimates loader
+    const loaderEl = document.getElementById('estimates-loader');
+    if (loaderEl) {
+        if (data.estimates_loading) {
+            loaderEl.classList.remove('hidden');
+        } else {
+            loaderEl.classList.add('hidden');
+        }
+    }
+
+    // Auto-resolve preview
+    const est = data.estimates || {};
+    const estXp = document.getElementById('est-xp');
+    if (estXp) estXp.textContent = `+${est.xp || 0}`;
+    const estEncounters = document.getElementById('est-encounters');
+    if (estEncounters) estEncounters.textContent = est.encounters || 0;
+    const estCatches = document.getElementById('est-catches');
+    if (estCatches) estCatches.textContent = est.catches || 0;
+    const estCashEl = document.getElementById('est-cash');
+    if (estCashEl) {
+        estCashEl.textContent = `+${est.cash || 0}`;
+    }
+
+    const autoBattleStatus = document.getElementById('auto-battle-status');
+    if (autoBattleStatus) {
+        autoBattleStatus.textContent = data.auto_battle_mode || 'OFF';
+    }
+
+    const rareCatchEl = document.getElementById('rare-catch-status');
+    if (rareCatchEl) {
+        rareCatchEl.textContent = data.rare_catch_active ? 'ON' : 'OFF';
+    }
+
+    // Populate caught list
+    const caughtListContainer = document.getElementById('caught-list-container');
+    const caughtListEl = document.getElementById('caught-list');
+
+    if (caughtListEl) {
+        caughtListEl.innerHTML = '';
+        if (caughtListContainer) {
+            const existingNote = caughtListContainer.querySelector('.truncation-note');
+            if (existingNote) {
+                existingNote.remove();
+            }
+        }
+        const caughtList = est.caught_list || [];
+        if (caughtList.length > 0) {
+            if (caughtListContainer) caughtListContainer.style.display = 'block';
+            caughtList.forEach(pkmn => {
+                const item = document.createElement('div');
+                item.className = 'caught-pokemon-item';
+
+                const shinyIcon = pkmn.shiny ? '<span class="shiny-badge">✨</span> ' : '';
+
+                item.innerHTML = `
+                    <span class="caught-pokemon-name">${shinyIcon}${pkmn.name}</span>
+                    <span class="caught-pokemon-lvl">Lv.${pkmn.level}</span>
+                `;
+                caughtListEl.appendChild(item);
+            });
+        } else {
+            if (caughtListContainer) caughtListContainer.style.display = 'block';
+            caughtListEl.innerHTML = `
+                <div style="font-size: 12px; color: var(--text-muted); font-style: italic; padding: 4px 0;">
+                    No Pokémon will be caught.
+                </div>
+            `;
+        }
+
+        if (est.is_truncated && caughtListContainer) {
+            const noteEl = document.createElement('div');
+            noteEl.className = 'truncation-note';
+            noteEl.innerHTML = `
+  ⚠ Preview shows first ${est.simulated_reviews} of ${est.total_reviews} reviews.
+  XP and encounter counts include estimates for the remainder.
+            `.trim();
+            caughtListContainer.appendChild(noteEl);
+        }
+    }
+
+
+
+    // Render Team Grid
+    const teamGrid = document.getElementById('team-grid');
+    if (teamGrid && data.team_status && data.team_status.team) {
+        teamGrid.innerHTML = '';
+        data.team_status.team.forEach(member => {
+            const card = document.createElement('div');
+            card.className = 'team-card' + (member.inactive ? ' inactive' : '');
+            card.setAttribute('data-id', member.individual_id);
+            card.onclick = function() {
+                toggleMobileCompanion(member.individual_id);
+            };
+
+            card.innerHTML = `
+                <div class="team-sprite-wrap">
+                    <img class="team-sprite" src="${member.sprite_path}" alt="${member.name}"
+                         onerror="if (this.src.indexOf('_gif') !== -1) { this.src = this.src.replace('_gif', '').replace('.gif', '.png'); } else { this.onerror=null; this.src='../user_files/sprites/front_default/0.png'; }">
+                </div>
+                <div class="team-name">${member.name}</div>
+                <div class="team-level">Lv.${member.level}</div>
+            `;
+            teamGrid.appendChild(card);
+        });
+    }
+}
+
+function toggleMobileCompanion(individualId) {
+    if (!mobileBridge) return;
+
+    // Optimistic UI: toggle the active/inactive state immediately for instant feedback
+    const cards = document.querySelectorAll('.team-card');
+    cards.forEach(card => {
+        if (card.getAttribute('data-id') === individualId) {
+            card.classList.toggle('inactive');
+        }
+    });
+
+    // Show the loader immediately
+    const loaderEl = document.getElementById('estimates-loader');
+    if (loaderEl) {
+        loaderEl.classList.remove('hidden');
+    }
+
+    mobileBridge.toggleMobileCompanion(individualId, function(res) {
+        if (res.success) {
+            loadStatus();
+        } else {
+            showAlert('Error toggling companion: ' + res.error);
+        }
+    });
+}
+
+
+
+function dismissAll() {
+    if (!mobileBridge) return;
+    showConfirm('Dismiss all pending battles? This cannot be undone.', function() {
+        mobileBridge.dismissAll(function(result) {
+            if (result.success) {
+                loadStatus();  // Re-render (will show State 1)
+            } else {
+                showAlert('Error: ' + result.error);
+            }
+        });
+    });
+}
+
+function resolveAll() {
+    if (!mobileBridge) return;
+    showConfirm('Resolve all pending battles? This will apply catches and XP to your active companion.<br/><br/><strong style="color: #ff5555; display: block; text-align: center;">⚠️ WARNING: Do not review cards on desktop while auto-resolve is active or you risk losing your progress!</strong>', function() {
+        const totalReviews = _currentMobileStatus ? _currentMobileStatus.pending_count : 0;
+        runChunkedResolve(totalReviews);
+    });
+}
+
+let _isResolvePaused = false;
+
+function togglePauseResolve() {
+    if (!mobileBridge) return;
+    const btn = document.getElementById('resolve-pause-btn');
+    if (_isResolvePaused) {
+        mobileBridge.resumeBulkResolve(function() {
+            _isResolvePaused = false;
+            if (btn) btn.textContent = 'Pause';
+            const headEl = document.querySelector('#resolve-progress-modal h3');
+            if (headEl) headEl.textContent = 'Auto-Resolving Battles';
+        });
+    } else {
+        mobileBridge.pauseBulkResolve(function() {
+            _isResolvePaused = true;
+            if (btn) btn.textContent = 'Resume';
+            const headEl = document.querySelector('#resolve-progress-modal h3');
+            if (headEl) headEl.textContent = 'Auto-Resolve Paused';
+        });
+    }
+}
+
+function stopResolve() {
+    if (!mobileBridge) return;
+    showConfirm('Stop auto-resolving? Any reviews processed so far will be saved.', function() {
+        mobileBridge.stopBulkResolve(function() {
+            // Background thread will exit, poller will pick up the completion.
+        });
+    });
+}
+
+function runChunkedResolve(totalReviews) {
+    if (totalReviews <= 0) return;
+    if (!mobileBridge) return;
+
+    _isResolvePaused = false;
+    const btn = document.getElementById('resolve-pause-btn');
+    if (btn) btn.textContent = 'Pause';
+    const headEl = document.querySelector('#resolve-progress-modal h3');
+    if (headEl) headEl.textContent = 'Auto-Resolving Battles';
+
+    const progressModal = document.getElementById('resolve-progress-modal');
+    const textEl = document.getElementById('resolve-progress-text');
+    const encountersEl = document.getElementById('resolve-progress-encounters');
+    const barEl = document.getElementById('resolve-progress-bar-fill');
+
+    if (progressModal) {
+        progressModal.classList.remove('hidden');
+    }
+    
+    function updateProgress(proc, total, encs) {
+        if (textEl) {
+            textEl.textContent = `Processed reviews: ${proc} / ${total} (${Math.round(proc * 100 / (total || 1))}%);`;
+        }
+        if (encountersEl) {
+            encountersEl.textContent = `Encounters resolved: ${encs}`;
+        }
+        if (barEl) {
+            barEl.style.width = `${Math.min(100, Math.round(proc * 100 / (total || 1)))}%`;
+        }
+    }
+
+    updateProgress(0, totalReviews, 0);
+
+    // Start background thread execution
+    mobileBridge.startBulkResolve(function() {
+        // Poll for progress updates
+        let poller = setInterval(function() {
+            mobileBridge.getBulkResolveProgress(function(progress) {
+                updateProgress(progress.processed, progress.total, progress.resolved);
+
+                // Update pause state dynamically
+                const btnVal = document.getElementById('resolve-pause-btn');
+                const headVal = document.querySelector('#resolve-progress-modal h3');
+                if (progress.paused) {
+                    _isResolvePaused = true;
+                    if (btnVal) btnVal.textContent = 'Resume';
+                    if (headVal) headVal.textContent = 'Auto-Resolve Paused';
+                } else {
+                    _isResolvePaused = false;
+                    if (btnVal) btnVal.textContent = 'Pause';
+                    if (headVal) headVal.textContent = 'Auto-Resolving Battles';
+                }
+
+                if (progress.done) {
+                    clearInterval(poller);
+                    if (progressModal) progressModal.classList.add('hidden');
+                    if (progress.error) {
+                        showAlert("Error in bulk resolve:\n" + progress.error);
+                    } else {
+                        showSummaryModal(progress);
+                    }
+                    loadStatus();
+                }
+            });
+        }, 150);
+    });
+}
+
+function showSummaryModal(result) {
+    // Fill summary data in modal
+    document.getElementById('modal-summary-xp').textContent = `+${result.xp_gained || 0}`;
+    document.getElementById('modal-summary-encounters').textContent = result.resolved || 0;
+    document.getElementById('modal-summary-catches').textContent = result.catches || 0;
+    document.getElementById('modal-summary-cash').textContent = `+${result.cash_gained || 0}¥`;
+    document.getElementById('modal-summary-trainer-xp').textContent = `+${result.trainer_xp_gained || 0}`;
+
+    // Populate caught list
+    const listEl = document.getElementById('modal-summary-caught-list');
+    listEl.innerHTML = '';
+    const caught = result.caught_list || [];
+    if (caught.length === 0) {
+        listEl.innerHTML = '<div style="color:var(--text-muted); font-size: 13px; text-align: center; padding: 12px 0;">No Pokémon caught.</div>';
+    } else {
+        caught.forEach(p => {
+            const item = document.createElement('div');
+            item.className = 'caught-pokemon-item';
+            const shiny = p.shiny ? '<span class="shiny-badge">✨</span> ' : '';
+            const tier = (p.tier && p.tier !== 'Normal') ? `<span class="tier-badge">${p.tier}</span>` : '';
+            item.innerHTML = `
+                <span class="caught-pokemon-name">${shiny}${p.name} ${tier}</span>
+                <div style="display: flex; align-items: center; gap: 6px;">
+                    <span class="caught-pokemon-lvl">Lv.${p.level}</span>
+                    <span class="caught-pokemon-cp">CP ${p.cp || 10}</span>
+                </div>
+            `;
+            listEl.appendChild(item);
+        });
+    }
+
+    // Show modal overlay
+    const modal = document.getElementById('summary-modal');
+    if (modal) {
+        modal.classList.remove('hidden');
+    }
+}
+
+function closeSummaryModal() {
+    const modal = document.getElementById('summary-modal');
+    if (modal) {
+        modal.classList.add('hidden');
+    }
+    loadStatus();  // Re-render: will show State 1 (no more pending battles)
+}
+
+// ===== Replay State =====
+
+let _replayRunning = false;
+let _replayTotal = 0;
+let _replayResolved = 0;
+let _currentReplayResult = null;
+let _replayTimeouts = [];
+
+function clearReplayTimeouts() {
+    _replayTimeouts.forEach(clearTimeout);
+    _replayTimeouts = [];
+}
+
+function startReplay() {
+    _replayCompanionOverride = null;
+    if (!mobileBridge) return;
+    _replayRunning = true;
+    clearReplayTimeouts();
+    // Get total count from current pending status before starting
+    mobileBridge.getMobileStatus(function(status) {
+        _replayTotal = status.battle_count || 0;
+        _replayResolved = 0;
+        showState('replay');
+        updateReplayCounter();
+        // Kick off the first battle
+        loadNextBattle();
+    });
+}
+
+function loadNextBattle() {
+    if (!mobileBridge || !_replayRunning) return;
+    // Disable button while loading
+    const btn = document.getElementById('replay-next-btn');
+    if (btn) { btn.disabled = true; btn.textContent = 'Resolving…'; }
+
+    const companionOverrideId = _replayCompanionOverride || "";
+    _replayCompanionOverride = null;
+
+    mobileBridge.resolveNext(companionOverrideId, function(result) {
+        if (result && result.loading) {
+            return;
+        }
+        if (result.done) {
+            // All done — show summary equivalent
+            _replayRunning = false;
+            loadStatus();  // will show State 1 (empty)
+            return;
+        }
+        if (result.error) {
+            _replayRunning = false;
+            showAlert('Replay error: ' + result.error);
+            loadStatus();
+            return;
+        }
+        renderReplayBattle(result);
+    });
+}
+
+function renderReplayBattle(result) {
+    _currentReplayResult = result;
+    clearReplayTimeouts();
+
+    // Hide controls initially during animation sequence
+    const nextBtn = document.getElementById('replay-next-btn');
+    if (nextBtn) { nextBtn.classList.add('hidden'); nextBtn.disabled = true; }
+    const choiceBox = document.getElementById('replay-choice-controls');
+    if (choiceBox) { choiceBox.classList.add('hidden'); }
+
+    // Update counter
+    updateReplayCounter();
+
+    // Reset HP bars and colors
+    const enemyHpBar = document.getElementById('replay-enemy-hp');
+    const playerHpBar = document.getElementById('replay-player-hp');
+    if (enemyHpBar) {
+        enemyHpBar.style.width = '100%';
+        enemyHpBar.className = 'hp-bar-fill hp-green';
+    }
+    if (playerHpBar) {
+        playerHpBar.style.width = '100%';
+        playerHpBar.className = 'hp-bar-fill player-hp hp-blue';
+    }
+
+    // Reset sprites and names
+    const enemySprite = document.getElementById('replay-enemy-sprite');
+    enemySprite.src = result.enemy_sprite || `../user_files/sprites/front_default/${result.enemy_id}.png`;
+    enemySprite.className = 'battle-sprite enemy-battle-sprite'; // remove caught/fainted fade classes
+
+    const playerSprite = document.getElementById('replay-player-sprite');
+    if (playerSprite && result.companion_sprite) {
+        playerSprite.src = result.companion_sprite;
+    }
+
+    document.getElementById('replay-enemy-name').textContent = result.enemy_name || '???';
+    document.getElementById('replay-enemy-level').textContent = `Lv.${result.enemy_level}`;
+    document.getElementById('replay-player-name').textContent = result.companion_name || 'Companion';
+    document.getElementById('replay-player-level').textContent = `Lv.${result.companion_level}`;
+
+    // Render the compact selector
+    renderReplayTeamSelector(result.companion_id);
+
+    // Tier badge
+    const tierEl = document.getElementById('replay-enemy-tier');
+    if (tierEl) {
+        tierEl.textContent = (result.enemy_tier && result.enemy_tier !== 'Normal') ? result.enemy_tier : '';
+        tierEl.style.display = (result.enemy_tier && result.enemy_tier !== 'Normal') ? 'inline' : 'none';
+    }
+
+    // Reset cards entry animations
+    const enemyCard = document.querySelector('.enemy-side');
+    const playerCard = document.querySelector('.player-side');
+    enemyCard.classList.remove('slide-in', 'damaged');
+    playerCard.classList.remove('slide-in', 'attack-dash');
+
+    // Trigger slide-in entry path animations
+    void enemyCard.offsetWidth; // Reflow to restart animations
+    enemyCard.classList.add('slide-in');
+    playerCard.classList.add('slide-in');
+
+    // Setup catch flash
+    const catchFlash = document.getElementById('replay-catch-flash');
+    if (catchFlash) {
+        catchFlash.classList.add('hidden');
+    }
+
+    // Set initial narration
+    const narrateEl = document.getElementById('narration-text');
+    if (narrateEl) {
+        narrateEl.innerHTML = `<span class="narrate-encounter">Wild <strong>${result.enemy_name}</strong> appeared!</span>`;
+    }
+
+    // Timeline sequence: animate turns list sequentially
+    const turns = result.turns || [];
+
+    function animateTurn(idx) {
+        if (!_replayRunning) return;
+        if (idx >= turns.length) {
+            // Battle finished, show choice controls
+            if (choiceBox) {
+                choiceBox.classList.remove('hidden');
+                const catchBtn = document.getElementById('replay-catch-btn');
+                const defeatBtn = document.getElementById('replay-defeat-btn');
+                if (catchBtn) catchBtn.disabled = false;
+                if (defeatBtn) defeatBtn.disabled = false;
+            }
+            if (narrateEl) {
+                narrateEl.innerHTML = `Wild <strong>${result.enemy_name}</strong> is vulnerable! What will you do?`;
+            }
+            return;
+        }
+
+        const turn = turns[idx];
+        
+        // 1. Player Attack
+        playerCard.classList.add('attack-dash');
+        if (narrateEl) {
+            narrateEl.innerHTML = `<strong>${result.companion_name}</strong> used <strong>${turn.user_attack}</strong>!`;
+        }
+
+        const tPlayer = setTimeout(() => {
+            playerCard.classList.remove('attack-dash');
+            
+            // Shake enemy and deplete enemy HP
+            enemyCard.classList.add('damaged');
+            if (enemyHpBar) {
+                enemyHpBar.style.width = `${turn.enemy_hp_pct}%`;
+                if (turn.enemy_hp_pct < 20) {
+                    enemyHpBar.className = 'hp-bar-fill hp-red';
+                } else if (turn.enemy_hp_pct < 50) {
+                    enemyHpBar.className = 'hp-bar-fill hp-yellow';
+                } else {
+                    enemyHpBar.className = 'hp-bar-fill hp-green';
+                }
+            }
+
+            const tEnemyHurt = setTimeout(() => {
+                enemyCard.classList.remove('damaged');
+
+                // If enemy fainted, skip enemy turn and finish battle
+                if (turn.enemy_hp_pct <= 0) {
+                    animateTurn(idx + 1);
+                    return;
+                }
+
+                // 2. Enemy Attack
+                enemyCard.classList.add('attack-dash');
+                if (narrateEl) {
+                    narrateEl.innerHTML = `Wild <strong>${result.enemy_name}</strong> used <strong>${turn.enemy_attack}</strong>!`;
+                }
+
+                const tEnemyAttack = setTimeout(() => {
+                    enemyCard.classList.remove('attack-dash');
+                    playerCard.classList.add('damaged');
+
+                    if (playerHpBar) {
+                        playerHpBar.style.width = `${turn.comp_hp_pct}%`;
+                        if (turn.comp_hp_pct < 20) {
+                            playerHpBar.className = 'hp-bar-fill player-hp hp-red';
+                        } else if (turn.comp_hp_pct < 50) {
+                            playerHpBar.className = 'hp-bar-fill player-hp hp-yellow';
+                        } else {
+                            playerHpBar.className = 'hp-bar-fill player-hp hp-blue';
+                        }
+                    }
+
+                    const tPlayerHurt = setTimeout(() => {
+                        playerCard.classList.remove('damaged');
+                        animateTurn(idx + 1);
+                    }, 240);
+                    _replayTimeouts.push(tPlayerHurt);
+
+                }, 240);
+                _replayTimeouts.push(tEnemyAttack);
+
+            }, 240);
+            _replayTimeouts.push(tEnemyHurt);
+
+        }, 240);
+        _replayTimeouts.push(tPlayer);
+    }
+
+    const tStart = setTimeout(() => {
+        animateTurn(0);
+    }, 100);
+    _replayTimeouts.push(tStart);
+
+}
+
+function chooseOutcome(choice) {
+    if (!mobileBridge || !_replayRunning || !_currentReplayResult) return;
+
+    const catchBtn = document.getElementById('replay-catch-btn');
+    const defeatBtn = document.getElementById('replay-defeat-btn');
+    if (catchBtn) catchBtn.disabled = true;
+    if (defeatBtn) defeatBtn.disabled = true;
+
+    mobileBridge.commitReplayOutcome(choice, function(res) {
+        if (res.error) {
+            showAlert("Outcome error: " + res.error);
+            if (catchBtn) catchBtn.disabled = false;
+            if (defeatBtn) defeatBtn.disabled = false;
+            return;
+        }
+
+        const choiceBox = document.getElementById('replay-choice-controls');
+        if (choiceBox) {
+            choiceBox.classList.add('hidden');
+        }
+
+        _replayResolved++;
+        if (res && res.success && typeof res.cash_gained !== 'undefined') {
+            _currentReplayResult.cash_gained = res.cash_gained;
+        }
+        animateResolution(res.outcome, res.xp_gained, res.remaining);
+    });
+}
+
+function animateResolution(outcome, xp_gained, remaining) {
+    if (!_replayRunning || !_currentReplayResult) return;
+
+    const result = _currentReplayResult;
+    const enemySprite = document.getElementById('replay-enemy-sprite');
+    const catchFlash = document.getElementById('replay-catch-flash');
+    const narrateEl = document.getElementById('narration-text');
+    const nextBtn = document.getElementById('replay-next-btn');
+
+    if (outcome === 'caught') {
+        if (narrateEl) {
+            narrateEl.innerHTML = `You caught <strong>${result.enemy_name}</strong>! <span style="color: var(--accent-green)">Success!</span>`;
+        }
+        if (catchFlash) {
+            catchFlash.classList.remove('hidden');
+            setTimeout(() => catchFlash.classList.add('hidden'), 300);
+        }
+        enemySprite.classList.add('caught-fade');
+    } else {
+        if (narrateEl) {
+            narrateEl.innerHTML = `<strong>${result.enemy_name}</strong> was defeated! <span style="color: var(--accent-blue)">+${xp_gained} XP</span>` +
+                (result.cash_gained > 0 ? ` <span style="color: var(--accent-gold)">+${result.cash_gained}¥</span>` : '');
+        }
+        enemySprite.classList.add('fainted-fade');
+    }
+
+    if (nextBtn) {
+        nextBtn.classList.remove('hidden');
+        if (remaining === 0) {
+            nextBtn.textContent = 'Finish ✓';
+            nextBtn.onclick = function() { _replayRunning = false; loadStatus(); };
+        } else {
+            nextBtn.textContent = 'Next Battle ▶';
+            nextBtn.onclick = nextReplayBattle;
+        }
+        nextBtn.disabled = false;
+    }
+}
+
+function nextReplayBattle() {
+    loadNextBattle();
+}
+
+function pauseReplay() {
+    _replayRunning = false;
+    clearReplayTimeouts();
+    // Return to pending state (or empty if all resolved)
+    loadStatus();
+}
+
+function updateReplayCounter() {
+    const el = document.getElementById('replay-battle-counter');
+    if (el && _currentReplayResult) {
+        const cpr = (_currentMobileStatus && _currentMobileStatus.cards_per_round) || 2;
+        const totalReviews = (_currentMobileStatus && _currentMobileStatus.pending_count_at_start) || (_replayTotal * cpr);
+        const resolvedReviews = _replayResolved * cpr;
+        const remainingReviews = Math.max(0, totalReviews - resolvedReviews);
+        
+        el.textContent = `(${remainingReviews} reviews remaining)`;
+    }
+}
+
+function renderReplayTeamSelector(activeCompanionId) {
+    const container = document.getElementById('replay-team-selector');
+    if (!container) return;
+
+    if (!_currentMobileStatus || !_currentMobileStatus.team_status || !_currentMobileStatus.team_status.team) {
+        container.innerHTML = '';
+        return;
+    }
+
+    const team = _currentMobileStatus.team_status.team;
+    
+    // Only build team selector DOM cards once
+    if (container.children.length === 0) {
+        team.forEach(member => {
+            const card = document.createElement('div');
+            card.className = 'replay-member-card';
+            card.dataset.individualId = member.individual_id;
+            if (member.inactive) {
+                card.classList.add('inactive');
+            }
+
+            card.innerHTML = `
+                <div class="replay-member-sprite-wrap">
+                    <img class="replay-member-sprite" src="${member.sprite_path}" alt="${member.name}"
+                         onerror="if (this.src.indexOf('_gif') !== -1) { this.src = this.src.replace('_gif', '').replace('.gif', '.png'); } else { this.onerror=null; this.src='../user_files/sprites/front_default/0.png'; }">
+                </div>
+                <div class="replay-member-name">${member.name}</div>
+            `;
+
+            card.onclick = function() {
+                if (card.classList.contains('active-selected')) return;
+
+                // Re-simulate with new companion
+                _replayCompanionOverride = member.individual_id;
+                mobileBridge.resolveNext(member.individual_id, function(result) {
+                    if (result && result.loading) {
+                        return;
+                    }
+                    if (result.error) {
+                        showAlert('Replay error: ' + result.error);
+                        return;
+                    }
+                    renderReplayBattle(result);
+                });
+            };
+
+            container.appendChild(card);
+        });
+    }
+
+    // Update active selections dynamically to avoid complete DOM re-creations
+    const cards = container.querySelectorAll('.replay-member-card');
+    cards.forEach(card => {
+        const indId = card.dataset.individualId;
+        const isSelected = _replayCompanionOverride
+            ? (_replayCompanionOverride === indId)
+            : (activeCompanionId === indId);
+
+        if (isSelected) {
+            card.classList.add('active-selected');
+        } else {
+            card.classList.remove('active-selected');
+        }
+    });
+}
+
+function formatTime(timestamp) {
+    if (!timestamp) return "";
+    const ts = Number(timestamp);
+    if (isNaN(ts) || ts <= 0) return "";
+    const diffMs = Date.now() - ts;
+    const diffSecs = Math.floor(diffMs / 1000);
+    const diffMins = Math.floor(diffSecs / 60);
+    const diffHours = Math.floor(diffMins / 60);
+    
+    if (diffSecs < 60) return "Just now";
+    if (diffMins < 60) return `${diffMins}m ago`;
+    if (diffHours < 24) return `${diffHours}h ago`;
+    
+    const d = new Date(ts);
+    return d.toLocaleDateString(undefined, { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' });
+}
+
+function goToMobileReviews() {
+    // Already on Mobile Reviews tab
+}
+
+function goToHistory() {
+    if (nav && typeof nav.openHistory === 'function') {
+        nav.openHistory();
+    }
+}
+
+
+

--- a/src/Ankimon/ankimon_mobile_web/mobile.js
+++ b/src/Ankimon/ankimon_mobile_web/mobile.js
@@ -1,5 +1,13 @@
 // State machine: "loading" → "empty" | "pending"
 
+// Escape HTML metacharacters before interpolating user-controlled strings
+// (Pokemon nicknames) into innerHTML — prevents stored-XSS from malicious names.
+function escapeHtml(value) {
+    return String(value == null ? '' : value).replace(/[&<>"']/g, function (c) {
+        return { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c];
+    });
+}
+
 function showConfirm(message, onConfirm, onCancel = null) {
     const overlay = document.createElement('div');
     overlay.className = 'modal-overlay';
@@ -396,12 +404,13 @@ function fillPending(data) {
                 toggleMobileCompanion(member.individual_id);
             };
 
+            const memberName = escapeHtml(member.name);
             card.innerHTML = `
                 <div class="team-sprite-wrap">
-                    <img class="team-sprite" src="${member.sprite_path}" alt="${member.name}"
+                    <img class="team-sprite" src="${escapeHtml(member.sprite_path)}" alt="${memberName}"
                          onerror="if (this.src.indexOf('_gif') !== -1) { this.src = this.src.replace('_gif', '').replace('.gif', '.png'); } else { this.onerror=null; this.src='../user_files/sprites/front_default/0.png'; }">
                 </div>
-                <div class="team-name">${member.name}</div>
+                <div class="team-name">${memberName}</div>
                 <div class="team-level">Lv.${member.level}</div>
             `;
             teamGrid.appendChild(card);

--- a/src/Ankimon/functions/mobile_sync.py
+++ b/src/Ankimon/functions/mobile_sync.py
@@ -1,0 +1,2089 @@
+from __future__ import annotations
+import random
+import math
+import uuid
+import copy
+import json
+import time
+from datetime import datetime
+import threading
+
+_mobile_sync_lock = threading.Lock()
+
+_desktop_session_revlog_ids: set[int] = set()
+_desktop_session_card_ids: set[int] = set()
+MOBILE_QUEUE_CAP = 10_000
+
+def record_desktop_review(revlog_id: int, card_id: int = None) -> None:
+    """Record a revlog.id that Ankimon handled on desktop this inter-sync interval."""
+    if revlog_id:
+        _desktop_session_revlog_ids.add(revlog_id)
+        # Also durably advance the watermark so a restart mid-session can't re-expose this review
+        try:
+            from ..services import services
+            db = services.db
+            current = db.get_mobile_watermark()
+            if revlog_id > current:
+                db.set_mobile_watermark(revlog_id)
+        except Exception:
+            pass
+    if card_id is not None:
+        _desktop_session_card_ids.add(card_id)
+
+def get_desktop_session_revlog_ids(col=None) -> frozenset[int]:
+    ids = set(_desktop_session_revlog_ids)
+    if col and _desktop_session_card_ids:
+        try:
+            placeholders = ",".join("?" for _ in _desktop_session_card_ids)
+            rows = col.db.list(
+                f"SELECT id FROM revlog WHERE cid IN ({placeholders})",
+                *list(_desktop_session_card_ids)
+            )
+            for r_id in rows:
+                ids.add(r_id)
+        except Exception:
+            pass
+    return frozenset(ids)
+
+def clear_desktop_session() -> None:
+    _desktop_session_revlog_ids.clear()
+    _desktop_session_card_ids.clear()
+
+class TempTracker:
+    def __init__(self, total_reviews: int):
+        self.total_reviews = total_reviews
+        self.pokemon_encounter = 0
+        self.cards_battle_round = 0
+
+    def get_total_reviews(self) -> int:
+        return self.total_reviews
+
+def _get_team_max_level(team_clones: list, db, settings_obj, main_pokemon) -> int:
+    import os
+    """Get the maximum level of any companion in the team, including inactive ones.
+    
+    This ensures that activating or deactivating a companion does not shift the
+    encounter generation level (and thus the seed/pool of valid wild species).
+    """
+    levels = []
+    for c in team_clones:
+        lvl = getattr(c, "level", None)
+        if lvl is not None and isinstance(lvl, (int, float)):
+            levels.append(int(lvl))
+            
+    inactive = settings_obj.get("mobile.inactive_companions", []) if settings_obj else []
+    if inactive and db is not None:
+        is_mock = type(db).__name__ in ("MagicMock", "Mock", "NonCallableMagicMock")
+        use_fallback = is_mock or "PYTEST_CURRENT_TEST" in os.environ
+        if not use_fallback:
+            try:
+                placeholders = ",".join("?" for _ in inactive)
+                cursor = db.execute(
+                    f"SELECT data FROM captured_pokemon WHERE individual_id IN ({placeholders})",
+                    inactive
+                )
+                for row in cursor.fetchall():
+                    data = db._deobfuscate(row["data"])
+                    if data:
+                        lvl = data.get("level")
+                        if lvl is not None:
+                            levels.append(int(lvl))
+            except Exception:
+                use_fallback = True
+        
+        if use_fallback or not levels:
+            for ind_id in inactive:
+                try:
+                    pdata = db.get_pokemon_by_individual_id(ind_id) if hasattr(db, "get_pokemon_by_individual_id") else db.get_pokemon(ind_id)
+                    if pdata:
+                        lvl = pdata.get("level")
+                        if lvl is not None:
+                            levels.append(int(lvl))
+                except Exception:
+                    pass
+                
+    if levels:
+        return max(levels)
+        
+    if main_pokemon:
+        lvl = getattr(main_pokemon, "level", 5)
+        if isinstance(lvl, (int, float)):
+            return int(lvl)
+            
+    return 5
+
+def _parse_cards_per_round(settings_obj) -> tuple[int, int]:
+    """Reads settings_obj.get('battle.cards_per_round', 2) and returns (cards_per_round, cpr_split)."""
+    cards_per_round = 2
+    if settings_obj:
+        try:
+            cpr = settings_obj.get("battle.cards_per_round", 2)
+            if isinstance(cpr, int):
+                cards_per_round = cpr
+            elif isinstance(cpr, str):
+                if "-" in cpr:
+                    parts = cpr.split("-")
+                    cards_per_round = int(sum(map(int, parts)) / len(parts))
+                else:
+                    try:
+                        cards_per_round = int(cpr)
+                    except ValueError:
+                        cards_per_round = 2
+        except Exception:
+            cards_per_round = 2
+    cpr_split = cards_per_round
+    return cards_per_round, cpr_split
+
+def _compute_initial_reviews(db, tracker, day_cutoff: int) -> int:
+    """Computes the adjusted total review count for encounter seeding based on day_cutoff."""
+    initial_reviews = tracker.get_total_reviews() if tracker else 0
+    try:
+        if db:
+            cutoff_ms = (day_cutoff - 86400) * 1000
+            
+            # Subtract all mobile reviews done today (both resolved and unresolved)
+            # to get today's desktop-only baseline.
+            cursor = db.execute(
+                "SELECT COUNT(*) FROM pending_mobile_battles WHERE revlog_id >= ?",
+                (cutoff_ms,)
+            )
+            row = cursor.fetchone()
+            mobile_reviews_today = row[0] if row else 0
+            
+            initial_reviews = max(0, initial_reviews - mobile_reviews_today)
+    except Exception:
+        pass
+    return initial_reviews
+
+def _generate_encounter(level: int, tracker, collected_ids=None, settings_obj=None, pokedex_cache=None) -> dict | None:
+    """Generates a random wild Pokémon encounter."""
+    from .encounter_functions import generate_random_pokemon
+    from .. import utils
+
+    if collected_ids is None:
+        try:
+            collected_ids = set(utils.load_collected_pokemon_ids())
+        except Exception:
+            collected_ids = set()
+
+    orig_load_ids = utils.load_collected_pokemon_ids
+    utils.load_collected_pokemon_ids = lambda: collected_ids
+    try:
+        try:
+            res = generate_random_pokemon(level, tracker, collected_ids=collected_ids)
+        except TypeError:
+            res = generate_random_pokemon(level, tracker)
+        pkmn_name, pkmn_id, pkmn_lvl, ability, pkmn_type, base_stats, \
+        enemy_attacks, base_exp, growth_rate, ev, iv, gender, \
+        battle_status, battle_stats, pkmn_tier, ev_yield, pkmn_shiny, nature = res
+    except Exception:
+        pkmn_name = "Pikachu"
+        pkmn_id = 25
+        pkmn_lvl = level
+        ability = "Run Away"
+        pkmn_type = ["Electric"]
+        base_stats = {"hp": 35, "atk": 55, "def": 40, "spa": 50, "spd": 50, "spe": 90}
+        enemy_attacks = ["Thunderbolt"]
+        base_exp = 112
+        growth_rate = "Medium"
+        ev = {"hp": 0, "atk": 0, "def": 0, "spa": 0, "spd": 0, "spe": 0}
+        iv = {"hp": 15, "atk": 15, "def": 15, "spa": 15, "spd": 15, "spe": 15}
+        gender = "M"
+        battle_status = "Fighting"
+        battle_stats = {}
+        pkmn_tier = "Normal"
+        ev_yield = {"speed": 2}
+        pkmn_shiny = False
+        nature = "serious"
+    finally:
+        utils.load_collected_pokemon_ids = orig_load_ids
+
+    return {
+        "name": pkmn_name,
+        "id": pkmn_id,
+        "level": pkmn_lvl,
+        "ability": ability,
+        "type": pkmn_type,
+        "base_stats": base_stats,
+        "attacks": enemy_attacks,
+        "base_experience": base_exp,
+        "growth_rate": growth_rate,
+        "ev": ev,
+        "iv": iv,
+        "gender": gender,
+        "battle_status": battle_status,
+        "battle_stats": battle_stats,
+        "tier": pkmn_tier,
+        "ev_yield": ev_yield,
+        "shiny": pkmn_shiny,
+        "nature": nature
+    }
+
+def _normalize_ev_yield(raw: dict) -> dict:
+    """Renames EV keys and returns the normalized dict."""
+    if not raw:
+        return {}
+    mapping = {
+        "attack": "atk",
+        "defense": "def",
+        "special-attack": "spa",
+        "special-defense": "spd",
+        "speed": "spe"
+    }
+    return {mapping.get(k.lower(), k.lower()): v for k, v in raw.items()}
+
+def _heal_to_full(p) -> None:
+    """Restore a companion clone to full HP and clear its battle bonuses.
+
+    Run after every resolved encounter so each encounter begins with the
+    companion at full health — exactly the way manual replay behaves (it reloads
+    the team fresh on every call). Without this heal, damage carries across
+    encounters, so battle length (and therefore the encounter count and the seed
+    of every subsequent encounter) starts to depend on how many companions are
+    active and on the odd/even fainting-revival cycle, and the preview /
+    auto-resolve / manual-replay sequences drift apart.
+    """
+    if p is None:
+        return
+    max_hp_val = getattr(p, "max_hp", 100)
+    if isinstance(max_hp_val, (int, float)):
+        p.hp = max_hp_val
+        if hasattr(p, "current_hp"):
+            p.current_hp = max_hp_val
+    try:
+        p.reset_bonuses()
+    except Exception:
+        pass
+
+def detect_mobile_reviews(col, watermark_ms: int, desktop_revlog_ids: frozenset[int]) -> list[dict]:
+    """
+    Returns revlog rows that are:
+    - Newer than watermark_ms
+    - type IN (0, 1, 2, 3) — learn, review, relearn, cram (matches desktop Ankimon behavior)
+    - NOT in desktop_revlog_ids (i.e., NOT already handled by Ankimon on desktop)
+    """
+    rows = col.db.all(
+        """
+        SELECT id, cid, ease, time, type
+        FROM revlog
+        WHERE id > ?
+          AND type IN (0, 1, 2, 3)
+        ORDER BY id ASC
+        """,
+        watermark_ms
+    )
+    return [
+        {"id": r[0], "cid": r[1], "ease": r[2], "time": r[3], "type": r[4]}
+        for r in rows
+        if r[0] not in desktop_revlog_ids
+    ]
+
+
+def process_mobile_reviews_after_sync(col, ankimon_db, settings_obj, logger) -> int:
+    """
+    Full post-sync pipeline:
+    1. Read watermark from DB
+    2. Diff revlog against session set
+    3. Apply system cap (MOBILE_QUEUE_CAP)
+    4. Queue new mobile battles (INSERT OR IGNORE)
+    5. Advance watermark to max(revlog.id) right now
+    6. Clear session set
+    Returns count of newly queued battles.
+    """
+    if not settings_obj.get("mobile.enabled", True):
+        return 0
+
+    try:
+        watermark = ankimon_db.get_mobile_watermark()
+        desktop_ids = get_desktop_session_revlog_ids()
+
+        all_mobile = detect_mobile_reviews(col, watermark, desktop_ids)
+
+        # Apply cap — take the MOST RECENT N (highest revlog IDs)
+        if len(all_mobile) > MOBILE_QUEUE_CAP:
+            logger.log("info",
+                f"Mobile sync: {len(all_mobile)} reviews found. "
+                f"System cap is {MOBILE_QUEUE_CAP}. "
+                f"{len(all_mobile) - MOBILE_QUEUE_CAP} discarded."
+            )
+            all_mobile = all_mobile[-MOBILE_QUEUE_CAP:]  # list is ASC, so take tail
+        else:
+            logger.log("info", f"Mobile sync: {len(all_mobile)} reviews found.")
+
+        newly_queued = ankimon_db.queue_mobile_battles(all_mobile)
+
+        # Advance watermark to max revlog.id in the collection right now
+        new_watermark = col.db.scalar("SELECT MAX(id) FROM revlog") or watermark
+        ankimon_db.set_mobile_watermark(new_watermark)
+
+        # Clear session set — next inter-sync interval starts fresh
+        clear_desktop_session()
+
+        return newly_queued
+
+    except Exception as e:
+        logger.log("error", f"Mobile sync error: {e}")
+        return 0
+
+def load_active_team_clones(ankimon_db, settings_obj, main_pokemon_fallback) -> list:
+    """
+    Load the current team from DB, filter out inactive companions, and return
+    a list of deep-cloned PokemonObject instances healed to full HP.
+
+    Returns a non-empty list. Falls back to [clone(main_pokemon_fallback)] if:
+    - The team table is empty
+    - None of the team members can be hydrated into PokemonObjects
+    - All team members are in the inactive list
+    """
+    from ..pyobj.pokemon_obj import PokemonObject
+
+    clones = []
+    if ankimon_db is not None:
+        try:
+            team_rows = ankimon_db.get_team()
+            inactive = set(settings_obj.get("mobile.inactive_companions", [])) if settings_obj else set()
+            active_ids = [t.get("individual_id") for t in team_rows if t.get("individual_id") and t.get("individual_id") not in inactive]
+            if active_ids:
+                is_mock = type(ankimon_db).__name__ in ("MagicMock", "Mock", "NonCallableMagicMock")
+                if is_mock:
+                    for ind_id in active_ids:
+                        if hasattr(ankimon_db, "get_pokemon_by_individual_id"):
+                            data = ankimon_db.get_pokemon_by_individual_id(ind_id)
+                        else:
+                            data = ankimon_db.get_pokemon(ind_id)
+                        if data:
+                            try:
+                                pkmn = PokemonObject(**data)
+                                clones.append(pkmn)
+                            except Exception:
+                                pass
+                else:
+                    placeholders = ",".join("?" for _ in active_ids)
+                    cursor = ankimon_db.execute(
+                        f"SELECT data FROM captured_pokemon WHERE individual_id IN ({placeholders})",
+                        active_ids
+                    )
+                    id_to_data = {}
+                    for row in cursor.fetchall():
+                        data = ankimon_db._deobfuscate(row["data"])
+                        if data and "individual_id" in data:
+                            id_to_data[data["individual_id"]] = data
+
+                    for ind_id in active_ids:
+                        data = id_to_data.get(ind_id)
+                        if data:
+                            try:
+                                pkmn = PokemonObject(**data)
+                                clones.append(pkmn)
+                            except Exception as e:
+                                try:
+                                    from ..services import services
+                                    if services.logger:
+                                        services.logger.log("warning", f"load_active_team_clones: skipping {ind_id}: {e}")
+                                except Exception:
+                                    pass
+        except Exception:
+            pass
+
+    def make_safe_clone(p):
+        p_clone = copy.copy(p)
+        if hasattr(p, "stats") and isinstance(p.stats, dict):
+            try:
+                p_clone.stats = copy.deepcopy(p.stats)
+            except AttributeError:
+                if hasattr(p_clone, "__dict__"):
+                    p_clone.__dict__["stats"] = copy.deepcopy(p.stats)
+        if hasattr(p, "base_stats") and isinstance(p.base_stats, dict):
+            p_clone.base_stats = copy.deepcopy(p.base_stats)
+        if hasattr(p, "ev") and isinstance(p.ev, dict):
+            p_clone.ev = copy.deepcopy(p.ev)
+        if hasattr(p, "iv") and isinstance(p.iv, dict):
+            p_clone.iv = copy.deepcopy(p.iv)
+        if hasattr(p, "attacks") and isinstance(p.attacks, list):
+            p_clone.attacks = copy.deepcopy(p.attacks)
+        if hasattr(p, "stat_stages") and isinstance(p.stat_stages, dict):
+            p_clone.stat_stages = copy.deepcopy(p.stat_stages)
+        if hasattr(p, "volatile_status") and isinstance(p.volatile_status, (set, list)):
+            p_clone.volatile_status = set(p.volatile_status)
+        return p_clone
+
+    def heal_clone(p):
+        p_clone = make_safe_clone(p)
+            
+        max_hp_val = getattr(p_clone, "max_hp", 100)
+        if isinstance(max_hp_val, (int, float)):
+            p_clone.hp = max_hp_val
+            if hasattr(p_clone, "current_hp"):
+                p_clone.current_hp = max_hp_val
+            if hasattr(p_clone, "reset_bonuses"):
+                try:
+                    p_clone.reset_bonuses()
+                except Exception:
+                    pass
+        return p_clone
+
+    if not clones and main_pokemon_fallback is not None:
+        fb = main_pokemon_fallback
+        fb_copy = make_safe_clone(fb)
+        clones = [fb_copy]
+
+    return [heal_clone(c) for c in clones]
+
+
+def select_best_companion(team_clones: list, enemy_pokemon) -> object:
+    """
+    Pick the team member with the highest estimated damage output against this enemy.
+
+    Per move: Base Power * Stat (Atk or Sp.Atk by category) * type effectiveness vs
+    the enemy * STAB. EDO (Estimated Damage Output) is the average of those move
+    scores. The final score is EDO * Speed -- HP is intentionally excluded so a
+    low-HP-but-strong companion isn't passed over. Ties break on Speed, then level.
+    Fainted members are skipped; if the whole team has fainted they are revived first.
+    """
+    from ..business import _load_type_chart
+    from .pokedex_functions import _load_moves_cache
+
+    if not team_clones:
+        return None
+
+    try:
+        moves_data = _load_moves_cache() or {}
+    except Exception:
+        moves_data = {}
+
+    def get_real_move_effectiveness(move_type: str, defender_types: list[str]) -> float:
+        chart = _load_type_chart()
+        if not chart:
+            from ..business import type_compatibility_multiplier
+            return type_compatibility_multiplier([move_type], defender_types)
+        if not move_type or not defender_types:
+            return 1.0
+        mult = 1.0
+        atk_row = chart.get(move_type.capitalize())
+        if not atk_row:
+            return 1.0
+        for dfn in defender_types:
+            val = atk_row.get(dfn.capitalize())
+            if val is not None:
+                mult *= float(val)
+        return mult
+
+    def get_hp_safe(c):
+        val = getattr(c, "hp", 100)
+        return float(val) if isinstance(val, (int, float)) else 100.0
+
+    def get_max_hp_safe(c):
+        val = getattr(c, "max_hp", None) or getattr(c, "hp", 100)
+        return float(val) if isinstance(val, (int, float)) else 100.0
+
+    # Revive all if the whole team has fainted
+    all_fainted = all(get_hp_safe(c) <= 0 for c in team_clones)
+    if all_fainted:
+        for c in team_clones:
+            max_hp = get_max_hp_safe(c)
+            c.hp = max_hp
+            if hasattr(c, "current_hp"):
+                c.current_hp = max_hp
+            if hasattr(c, "reset_bonuses"):
+                try:
+                    c.reset_bonuses()
+                except Exception:
+                    pass
+
+    enemy_type = getattr(enemy_pokemon, "type", ["Normal"])
+
+    best_clone = None
+    best_score = -1.0
+
+    for c in team_clones:
+        hp = get_hp_safe(c)
+        if hp <= 0:
+            continue  # Skip fainted
+
+        stats = getattr(c, "stats", {}) or {}
+        atk = float(stats.get("atk", 10) or 10)
+        spa = float(stats.get("spa", 10) or 10)
+        spe = float(stats.get("spe", 10) or 10)
+
+        c_type = getattr(c, "type", ["Normal"])
+
+        # Retrieve moves
+        moves = getattr(c, "attacks", None)
+        if not moves and hasattr(c, "to_dict"):
+            try:
+                moves = c.to_dict().get("attacks", [])
+            except Exception:
+                moves = []
+        if not moves:
+            moves = getattr(c, "moves", [])
+        if not moves:
+            moves = ["Tackle"]
+
+        move_scores = []
+        for move_name in moves:
+            if not move_name or not isinstance(move_name, str):
+                continue
+            
+            # Retrieve move details from cache
+            move = moves_data.get(move_name.lower())
+            if not move:
+                move = moves_data.get(move_name.replace(" ", "").lower())
+            if not move:
+                move = moves_data.get(move_name.replace("-", "").lower())
+            if not move:
+                move = moves_data.get("tackle") or {}
+
+            bp = float(move.get("basePower", 0) or 0)
+            category = move.get("category", "Physical")
+            move_type = move.get("type", "Normal")
+
+            if category == "Status" or bp == 0:
+                move_scores.append(0.0)
+                continue
+
+            stat_val = spa if category == "Special" else atk
+
+            # Move type compatibility against the enemy (multiplied for dual types, real multipliers)
+            move_type_mult = get_real_move_effectiveness(move_type, enemy_type)
+
+            # STAB (1.5x if move matches companion's type)
+            stab = 1.5 if move_type in c_type else 1.0
+
+            move_scores.append(bp * stat_val * move_type_mult * stab)
+
+        # Average EDO culmination across all active moves
+        if move_scores:
+            culminated_edo = sum(move_scores) / len(move_scores)
+        else:
+            culminated_edo = max(atk, spa) * 40.0
+
+        # Final score is EDO (tie breaks on Speed, then level)
+        score = culminated_edo
+
+        if score > best_score:
+            best_score = score
+            best_clone = c
+        elif score == best_score and best_clone is not None:
+            # Tie breaker: prefer higher speed, then higher level
+            c_spe = float(stats.get("spe", 10) or 10)
+            bc_stats = getattr(best_clone, "stats", {}) or {}
+            bc_spe = float(bc_stats.get("spe", 10) or 10)
+            if c_spe > bc_spe:
+                best_clone = c
+            elif c_spe == bc_spe:
+                if getattr(c, "level", 0) > getattr(best_clone, "level", 0):
+                    best_clone = c
+
+    if best_clone is None:
+        best_clone = team_clones[0]
+
+    return best_clone
+
+
+def _compute_encounter_idx(all_reviews: list[dict], db, settings_obj, tracker, trainer_card, main_pokemon, commit: bool = True) -> int:
+    if not all_reviews:
+        return 0
+
+    if db is not None:
+        try:
+            # Try to get the cached count
+            cursor = db.execute("SELECT value FROM metadata WHERE key = 'mobile_resolved_encounters_count'")
+            row = cursor.fetchone()
+            if row is not None:
+                return int(row[0])
+            
+            # If missing, calculate starting index using resolved reviews (never use pruned history)
+            cursor = db.execute("SELECT COUNT(*) FROM pending_mobile_battles WHERE resolved = 1")
+            resolved_reviews = cursor.fetchone()[0]
+            cards_per_round, _ = _parse_cards_per_round(settings_obj)
+            approx_count = resolved_reviews // cards_per_round
+            
+            if commit:
+                conn = db._get_connection()
+                with conn:
+                    conn.execute(
+                        "INSERT OR REPLACE INTO metadata (key, value) VALUES ('mobile_resolved_encounters_count', ?)",
+                        (str(approx_count),)
+                    )
+            return approx_count
+        except Exception:
+            pass
+
+    # If DB is None or lookup fails, we fall back to approximating using all_reviews
+    cards_per_round, _ = _parse_cards_per_round(settings_obj)
+    resolved_count = sum(1 for r in all_reviews if r.get("resolved") == 1)
+    return resolved_count // cards_per_round
+
+
+def run_mobile_battles(
+    reviews: list[dict] = None,
+    *,
+    commit: bool,
+    db,
+    settings_obj,
+    tracker,
+    trainer_card,
+    main_pokemon=None,
+    companion_override_id=None,
+    logger=None,
+    day_cutoff=0,
+    limit=None,
+    mode="all",
+    progress_callback=None
+) -> dict:
+    with _mobile_sync_lock:
+        return _run_mobile_battles_impl(
+            reviews=reviews,
+            commit=commit,
+            db=db,
+            settings_obj=settings_obj,
+            tracker=tracker,
+            trainer_card=trainer_card,
+            main_pokemon=main_pokemon,
+            companion_override_id=companion_override_id,
+            logger=logger,
+            day_cutoff=day_cutoff,
+            limit=limit,
+            mode=mode,
+            progress_callback=progress_callback
+        )
+
+
+def _run_mobile_battles_impl(
+    reviews: list[dict] = None,
+    *,
+    commit: bool,
+    db,
+    settings_obj,
+    tracker,
+    trainer_card,
+    main_pokemon=None,
+    companion_override_id=None,
+    logger=None,
+    day_cutoff=0,
+    limit=None,
+    mode="all",
+    progress_callback=None
+) -> dict:
+    """
+    Unified engine for:
+    - Dry-run simulation of pending mobile battles (commit=False, mode="all")
+    - Real auto-resolve of pending mobile battles (commit=True, mode="all")
+    - Turn-by-turn manual battle simulation (commit=True/False, mode="next")
+    """
+    from aqt import mw
+    if day_cutoff == 0:
+        day_cutoff = mw.col.sched.day_cutoff if (mw and mw.col) else 0
+
+    # Load all reviews from DB to construct a stable sequence for deterministic seeding
+    all_reviews = []
+    if db is not None:
+        try:
+            if hasattr(db, "execute") and callable(db.execute):
+                all_rows = db.execute(
+                    """SELECT id, revlog_id, card_id, ease, review_time, review_type, queued_at, resolved
+                       FROM pending_mobile_battles
+                       ORDER BY id ASC"""
+                ).fetchall()
+                all_reviews = [
+                    {
+                        "id": r[0],
+                        "revlog_id": r[1],
+                        "card_id": r[2],
+                        "ease": r[3],
+                        "review_time": r[4],
+                        "review_type": r[5],
+                        "queued_at": r[6],
+                        "resolved": r[7],
+                    }
+                    for r in all_rows
+                ]
+        except Exception:
+            pass
+
+    if not all_reviews and reviews is not None:
+        all_reviews = list(reviews)
+
+    if mode == "next":
+        # Dedicated manual replay simulation block
+        unresolved_rows = db.execute(
+            """SELECT id, revlog_id, card_id, ease, review_time, review_type, queued_at
+               FROM pending_mobile_battles
+               WHERE resolved = 0
+               ORDER BY id ASC"""
+        ).fetchall()
+        if not unresolved_rows:
+            return {"done": True}
+
+        all_unresolved = [
+            {
+                "id": r[0],
+                "revlog_id": r[1],
+                "card_id": r[2],
+                "ease": r[3],
+                "review_time": r[4],
+                "review_type": r[5],
+                "queued_at": r[6],
+            }
+            for r in unresolved_rows
+        ]
+
+        # We will simulate turn-by-turn until enemy or companion faints
+        from ..utils import load_collected_pokemon_ids
+        collected_ids = set(load_collected_pokemon_ids())
+        team_clones = load_active_team_clones(db, settings_obj, main_pokemon)
+        stable_max_level = _get_team_max_level(team_clones, db, settings_obj, main_pokemon)
+        
+        # Calculate active_max_level (max level of active team clones only)
+        active_levels = []
+        for c in team_clones:
+            lvl = getattr(c, "level", None)
+            if lvl is not None and isinstance(lvl, (int, float)):
+                active_levels.append(int(lvl))
+        if active_levels:
+            active_max_level = max(active_levels)
+        elif main_pokemon:
+            active_max_level = int(getattr(main_pokemon, "level", 5))
+        else:
+            active_max_level = 5
+
+        from ..pyobj.pokemon_obj import PokemonObject
+        from ..business import calc_experience
+        from .ankimon_hooks_to_poke_engine import simulate_battle_with_poke_engine
+
+        cards_per_round, _ = _parse_cards_per_round(settings_obj)
+
+        # Initial seed of the encounter using stable index
+        first_review = all_unresolved[0]
+        resolved_count = sum(1 for r in all_reviews if r.get("resolved") == 1)
+        encounter_idx = _compute_encounter_idx(all_reviews, db, settings_obj, tracker, trainer_card, main_pokemon, commit=commit)
+        if all_reviews:
+            seed_idx = min(len(all_reviews) - 1, (encounter_idx + 1) * cards_per_round - 1)
+            seed_review = all_reviews[seed_idx]
+            enc_seed = seed_review.get("revlog_id") or seed_review.get("id") or 42
+        else:
+            enc_seed = 42
+        random.seed(enc_seed)
+
+        initial_reviews = _compute_initial_reviews(
+            db,
+            tracker,
+            day_cutoff
+        )
+        cards_in_encounter = seed_idx + 1
+        temp_tracker = TempTracker(initial_reviews + cards_in_encounter)
+
+        enc_data = _generate_encounter(stable_max_level, temp_tracker, collected_ids, settings_obj, None)
+        adjusted_level = max(1, active_max_level + (enc_data["level"] - stable_max_level))
+        current_enemy_pokemon = PokemonObject(
+            type=enc_data["type"], name=enc_data["name"], id=enc_data["id"], shiny=enc_data["shiny"],
+            level=adjusted_level, ability=enc_data["ability"], gender=enc_data["gender"], growth_rate=enc_data["growth_rate"],
+            captured_date=None, tier=enc_data["tier"], individual_id=str(uuid.uuid4()),
+            base_stats=enc_data["base_stats"], attacks=enc_data["attacks"], base_experience=enc_data["base_experience"],
+            ev=enc_data["ev"], iv=enc_data["iv"], battle_status=enc_data["battle_status"], ev_yield=enc_data["ev_yield"], nature=enc_data["nature"]
+        )
+
+        selected_override = None
+        if companion_override_id:
+            for tc in team_clones:
+                if getattr(tc, "individual_id", None) == companion_override_id:
+                    if getattr(tc, "hp", 0) <= 0:
+                        max_hp_val = getattr(tc, "max_hp", 100)
+                        tc.hp = max_hp_val
+                        if hasattr(tc, "current_hp"):
+                            tc.current_hp = max_hp_val
+                    selected_override = tc
+                    break
+            if selected_override is None:
+                try:
+                    if hasattr(db, "get_pokemon_by_individual_id"):
+                        data = db.get_pokemon_by_individual_id(companion_override_id)
+                    else:
+                        data = db.get_pokemon(companion_override_id)
+                    if data:
+                        from ..pyobj.pokemon_obj import PokemonObject
+                        pkmn = PokemonObject(**data)
+                        max_hp_val = getattr(pkmn, "max_hp", 100)
+                        if isinstance(max_hp_val, (int, float)):
+                            pkmn.hp = max_hp_val
+                            if hasattr(pkmn, "current_hp"):
+                                pkmn.current_hp = max_hp_val
+                        if hasattr(pkmn, "reset_bonuses"):
+                            try:
+                                pkmn.reset_bonuses()
+                            except Exception:
+                                pass
+                        selected_override = pkmn
+                except Exception:
+                    pass
+        if selected_override is not None:
+            main_pokemon_clone = selected_override
+        else:
+            main_pokemon_clone = select_best_companion(team_clones, current_enemy_pokemon)
+
+        mutator_full_reset = 1
+        engine_state = None
+        
+        reviews_list = []
+        turns_log = []
+        accumulated_evs = {"hp": 0, "atk": 0, "def": 0, "spa": 0, "spd": 0, "spe": 0}
+
+        # Read multiplier/boosts settings
+        xp_multiplier = 1.0
+        choose_moves_penalty = 1.0
+        if settings_obj:
+            xp_multiplier = settings_obj.get("battle.xp_multiplier", 1.0)
+            if settings_obj.get("controls.allow_to_choose_moves", False):
+                choose_moves_penalty = 0.5
+        lucky_egg_boost = 1.0
+        if main_pokemon_clone and getattr(main_pokemon_clone, "held_item", None) == "lucky-egg":
+            lucky_egg_boost = 1.5
+
+        chunk_idx = 0
+        while chunk_idx < len(all_unresolved):
+            chunk = all_unresolved[chunk_idx : chunk_idx + cards_per_round]
+            reviews_list.extend(chunk)
+            chunk_idx += cards_per_round
+
+            companion_max_hp = getattr(main_pokemon_clone, "max_hp", 100)
+            enemy_max_hp = getattr(current_enemy_pokemon, "max_hp", 100)
+
+            # Select moves
+            main_attacks = getattr(main_pokemon_clone, "attacks", None)
+            if isinstance(main_attacks, (list, tuple)) and len(main_attacks) > 0:
+                user_attack = random.choice(main_attacks)
+            else:
+                user_attack = "splash"
+
+            enemy_attacks_list = getattr(current_enemy_pokemon, "attacks", None)
+            if isinstance(enemy_attacks_list, (list, tuple)) and len(enemy_attacks_list) > 0:
+                enemy_attack = random.choice(enemy_attacks_list)
+            else:
+                enemy_attack = "splash"
+
+            points_map = {1: 0, 2: 5, 3: 10, 4: 20}
+            total_points = sum(points_map.get(r.get("ease") or 3, 10) for r in chunk)
+            max_points = 10.0 * len(chunk)
+            turn_multiplier = total_points / max_points if max_points > 0 else 1.0
+
+            orig_multiplier = 1.0
+            has_tracker = tracker and hasattr(tracker, "multiplier")
+            if has_tracker:
+                orig_multiplier = tracker.multiplier
+                tracker.multiplier = turn_multiplier
+
+            try:
+                results = simulate_battle_with_poke_engine(
+                    main_pokemon_clone, current_enemy_pokemon, user_attack, enemy_attack,
+                    mutator_full_reset, engine_state
+                )
+                engine_state, mutator_full_reset = results[1], results[4]
+            except Exception:
+                current_enemy_pokemon.hp = 0
+            finally:
+                if has_tracker: tracker.multiplier = orig_multiplier
+
+            comp_hp_val = getattr(main_pokemon_clone, "hp", 0)
+            enemy_hp_val = getattr(current_enemy_pokemon, "hp", 0)
+            comp_hp_after = max(0, comp_hp_val)
+            enemy_hp_after = max(0, enemy_hp_val)
+
+            turns_log.append({
+                "user_attack": user_attack.title(),
+                "enemy_attack": enemy_attack.title(),
+                "comp_hp_pct": int((comp_hp_after * 100) / companion_max_hp),
+                "enemy_hp_pct": int((enemy_hp_after * 100) / enemy_max_hp),
+            })
+
+            if comp_hp_after <= 0 or enemy_hp_after <= 0:
+                break
+
+        # Calculate rewards
+        battle_xp = 0
+        total_trainer_xp = 0
+        gained_cash = 0
+        if enemy_hp_after <= 0:
+            exp = calc_experience(current_enemy_pokemon.base_experience, current_enemy_pokemon.level)
+            try:
+                exp = max(1, math.ceil(exp * choose_moves_penalty * lucky_egg_boost * xp_multiplier))
+            except TypeError:
+                exp = 100
+            battle_xp = exp
+
+            from ..pyobj.trainer_card import POKEMON_TIERS
+            txp = POKEMON_TIERS.get(current_enemy_pokemon.tier.lower(), 10)
+            allow_to_choose_move = settings_obj.get("controls.allow_to_choose_moves") if settings_obj else False
+            if allow_to_choose_move: txp *= 0.5
+            total_trainer_xp = int(txp)
+
+            if current_enemy_pokemon.ev_yield:
+                for sk, v in _normalize_ev_yield(current_enemy_pokemon.ev_yield).items():
+                    if sk in accumulated_evs: accumulated_evs[sk] += v
+
+            gained_cash = 0
+
+        from .sprite_functions import get_relative_sprite_path
+        last_result_data = {
+            "done": False,
+            "enemy_name": current_enemy_pokemon.display_name,
+            "enemy_id": current_enemy_pokemon.id,
+            "enemy_level": current_enemy_pokemon.level,
+            "enemy_shiny": current_enemy_pokemon.shiny,
+            "enemy_tier": current_enemy_pokemon.tier,
+            "enemy_sprite": get_relative_sprite_path(
+                current_enemy_pokemon.id,
+                current_enemy_pokemon.shiny,
+                getattr(current_enemy_pokemon, "gender", "N") or "N",
+                current_enemy_pokemon.name,
+                "gif"
+            ),
+            "ease": first_review.get("ease", 3),
+            "companion_name": main_pokemon_clone.display_name if main_pokemon_clone else "Companion",
+            "companion_level": main_pokemon_clone.level if main_pokemon_clone else 5,
+            "companion_sprite": get_relative_sprite_path(main_pokemon_clone.id, main_pokemon_clone.shiny, (getattr(main_pokemon_clone, "gender", "N") or "N"), main_pokemon_clone.name, "gif") if main_pokemon_clone else "",
+            "companion_id": getattr(main_pokemon_clone, "individual_id", ""),
+            "xp_gained": battle_xp,
+            "turns": turns_log,
+        }
+
+        # Return state to commit later
+        current_pending_outcome = {
+            "enemy_pokemon": current_enemy_pokemon,
+            "battle_xp": battle_xp,
+            "total_xp": battle_xp,
+            "accumulated_evs": accumulated_evs,
+            "total_trainer_xp": total_trainer_xp,
+            "companion_id": getattr(main_pokemon_clone, "individual_id", ""),
+            "companion_name": getattr(main_pokemon_clone, "display_name", "Companion"),
+            "companion_level": getattr(main_pokemon_clone, "level", 5),
+            "review_ids": [r["id"] for r in reviews_list],
+            "companion_fainted": (comp_hp_after <= 0),
+            "gained_cash": gained_cash,
+        }
+
+        pending_total_at_start = len(all_unresolved)
+        remaining_reviews = pending_total_at_start - len(reviews_list)
+        last_result_data.update({
+            "remaining": remaining_reviews,
+            "cash_gained": gained_cash,
+            "trainer_xp_gained": total_trainer_xp,
+        })
+
+        # Re-calculate battle_number properly:
+        resolved_count = db.execute("SELECT COUNT(*) FROM pending_mobile_battles WHERE resolved=1").fetchone()[0]
+        # Total encounters
+        total_resolved_encounters = _compute_encounter_idx(all_reviews, db, settings_obj, tracker, trainer_card, main_pokemon, commit=commit)
+        last_result_data["battle_number"] = total_resolved_encounters
+        # Total encounters overall
+        total_all_count = db.execute("SELECT COUNT(*) FROM pending_mobile_battles").fetchone()[0]
+        last_result_data["total_battles"] = math.ceil(total_all_count / cards_per_round)
+
+        return {
+            "result": last_result_data,
+            "current_pending_outcome": current_pending_outcome
+        }
+
+    # Otherwise, mode == "all"
+    if reviews is None:
+        if limit is not None:
+            reviews_rows = db.execute(
+                """SELECT id, revlog_id, card_id, ease, review_time, review_type, queued_at
+                   FROM pending_mobile_battles
+                   WHERE resolved = 0
+                   ORDER BY id ASC
+                   LIMIT ?""",
+                (limit,)
+            ).fetchall()
+        else:
+            reviews_rows = db.execute(
+                """SELECT id, revlog_id, card_id, ease, review_time, review_type, queued_at
+                   FROM pending_mobile_battles
+                   WHERE resolved = 0
+                   ORDER BY id ASC"""
+            ).fetchall()
+
+        if not reviews_rows:
+            if commit:
+                return {"success": True, "resolved": 0, "message": "No pending battles.", "done": True}
+            else:
+                return {
+                    "xp": 0, "encounters": 0, "caught": [], "defeated": [],
+                    "catches_count": 0, "is_truncated": False, "simulated_reviews": 0,
+                    "total_reviews": 0, "cash": 0
+                }
+
+        reviews_list = [
+            {
+                "id": r[0],
+                "revlog_id": r[1],
+                "card_id": r[2],
+                "ease": r[3],
+                "review_time": r[4],
+                "review_type": r[5],
+                "queued_at": r[6],
+            }
+            for r in reviews_rows
+        ]
+    else:
+        reviews_list = list(reviews)
+
+    if not reviews_list:
+        if commit:
+            return {"success": True, "resolved": 0, "message": "No pending battles.", "done": True}
+        else:
+            return {
+                "xp": 0, "encounters": 0, "caught": [], "defeated": [],
+                "catches_count": 0, "is_truncated": False, "simulated_reviews": 0,
+                "total_reviews": 0, "cash": 0
+            }
+
+
+
+    state = random.getstate()
+
+    cards_per_round, _ = _parse_cards_per_round(settings_obj)
+
+    # Unified deterministic seed for the first encounter using the stable index
+    resolved_count = sum(1 for r in all_reviews if r.get("resolved") == 1)
+    encounter_idx = _compute_encounter_idx(all_reviews, db, settings_obj, tracker, trainer_card, main_pokemon, commit=commit)
+    if all_reviews:
+        seed_idx = min(len(all_reviews) - 1, (encounter_idx + 1) * cards_per_round - 1)
+        seed_review = all_reviews[seed_idx]
+        enc_seed = seed_review.get("revlog_id") or seed_review.get("id") or 42
+    else:
+        enc_seed = 42
+    random.seed(enc_seed)
+
+    auto_battle_setting = 3
+    if settings_obj:
+        try:
+            auto_battle_setting = int(settings_obj.get("battle.automatic_battle", 3))
+        except Exception: pass
+    if auto_battle_setting == 0: auto_battle_setting = 3
+
+    wishlist = []
+    auto_catch_legendary = True
+    auto_catch_mythical = True
+    auto_catch_ultra = True
+    auto_catch_starter = True
+    auto_catch_mega = True
+    auto_catch_gmax = True
+    auto_catch_regional = True
+    xp_multiplier = 1.0
+    choose_moves_penalty = 1.0
+
+    if settings_obj:
+        wishlist = settings_obj.get("battle.auto_catch_wishlist", [])
+        auto_catch_legendary = settings_obj.get("battle.auto_catch_legendary", True)
+        auto_catch_mythical = settings_obj.get("battle.auto_catch_mythical", True)
+        auto_catch_ultra = settings_obj.get("battle.auto_catch_ultra", True)
+        auto_catch_starter = settings_obj.get("battle.auto_catch_starter", True)
+        auto_catch_mega = settings_obj.get("battle.auto_catch_mega", True)
+        auto_catch_gmax = settings_obj.get("battle.auto_catch_gmax", True)
+        auto_catch_regional = settings_obj.get("battle.auto_catch_regional", True)
+        xp_multiplier = settings_obj.get("battle.xp_multiplier", 1.0)
+        if settings_obj.get("controls.allow_to_choose_moves", False):
+            choose_moves_penalty = 0.5
+
+    lucky_egg_boost = 1.0
+    if main_pokemon and getattr(main_pokemon, "held_item", None) == "lucky-egg":
+        lucky_egg_boost = 1.5
+
+    from ..utils import load_collected_pokemon_ids
+    collected_ids = set(load_collected_pokemon_ids())
+
+    from .encounter_functions import (
+        generate_random_pokemon,
+        save_caught_pokemon,
+        save_main_pokemon_progress
+    )
+    from .encounter_data import MEGA, GMAX, REGIONAL_FORM_REGION
+    from ..business import calc_experience, calculate_cp_from_dict
+    from ..pyobj.pokemon_obj import PokemonObject
+    from ..singletons import get_evo_window
+
+    initial_reviews = _compute_initial_reviews(
+        db,
+        tracker,
+        day_cutoff
+    )
+    temp_tracker = TempTracker(initial_reviews + resolved_count)
+    team_clones = load_active_team_clones(db, settings_obj, main_pokemon)
+    main_pokemon_clone = team_clones[0] if team_clones else None
+    stable_max_level = _get_team_max_level(team_clones, db, settings_obj, main_pokemon)
+    
+    # Calculate active_max_level (max level of active team clones only)
+    active_levels = []
+    for c in team_clones:
+        lvl = getattr(c, "level", None)
+        if lvl is not None and isinstance(lvl, (int, float)):
+            active_levels.append(int(lvl))
+    if active_levels:
+        active_max_level = max(active_levels)
+    elif main_pokemon:
+        active_max_level = int(getattr(main_pokemon, "level", 5))
+    else:
+        active_max_level = 5
+
+    total_xp = 0
+    total_trainer_xp = 0
+    caught_count = 0
+    caught_pokemon_list = []
+    cards_battle_round = 0
+    accumulated_evs = {"hp": 0, "atk": 0, "def": 0, "spa": 0, "spd": 0, "spe": 0}
+    defeated_encounters = []
+    current_turn_reviews = []
+    total_reviews_processed = 0
+    current_battle_cash = 0
+    ci = int(settings_obj.get("trainer.cash_reward_interval", 5)) if settings_obj else 5
+    ca = int(settings_obj.get("trainer.cash_reward_amount", 10)) if settings_obj else 10
+
+    from .. import utils
+    orig_load_ids = utils.load_collected_pokemon_ids
+    utils.load_collected_pokemon_ids = lambda: collected_ids
+
+    current_enemy_pokemon = None
+    mutator_full_reset = 1
+    engine_state = None
+    from .ankimon_hooks_to_poke_engine import simulate_battle_with_poke_engine
+
+    history_entries_to_add = []
+    encounters_fought = 0
+    reviews_spent_for_resolved = 0
+    resolved_encounters = 0
+    current_encounter_reviews = 0
+
+    caught_pokemon = []
+    defeated_pokemon = []
+    if not commit:
+        reviews_to_process = reviews_list[:100]
+        extra_reviews = reviews_list[100:]
+    else:
+        reviews_to_process = reviews_list
+        extra_reviews = []
+
+    try:
+        for review in reviews_to_process:
+            temp_tracker.total_reviews += 1
+            total_reviews_processed += 1
+            if progress_callback:
+                try:
+                    cb_res = progress_callback({
+                        "processed": total_reviews_processed,
+                        "total": len(reviews_to_process),
+                        "resolved": resolved_encounters,
+                        "catches": caught_count,
+                        "xp_gained": total_xp
+                    })
+                    if cb_res is False:
+                        break
+                except TypeError:
+                    try:
+                        cb_res = progress_callback(total_reviews_processed, len(reviews_to_process))
+                        if cb_res is False:
+                            break
+                    except Exception:
+                        pass
+                except Exception:
+                    pass
+            if commit and ci > 0 and total_reviews_processed % ci == 0:
+                current_battle_cash += ca
+            cards_battle_round += 1
+            current_turn_reviews.append(review)
+            
+            if current_enemy_pokemon is not None:
+                current_encounter_reviews += 1
+
+            if cards_battle_round >= cards_per_round or review == reviews_to_process[-1]:
+                cards_battle_round = 0
+
+                if current_enemy_pokemon is None:
+                    encounters_fought += 1
+                    current_encounter_reviews = len(current_turn_reviews)
+                    
+                    # Stable seeding based on encounter index
+                    if all_reviews:
+                        seed_idx = min(len(all_reviews) - 1, (encounter_idx + 1) * cards_per_round - 1)
+                        seed_review = all_reviews[seed_idx]
+                        enc_seed = seed_review.get("revlog_id") or seed_review.get("id") or 42
+                    else:
+                        enc_seed = 42
+                    random.seed(enc_seed)
+                    encounter_idx += 1
+                    
+                    enc_data = _generate_encounter(stable_max_level, temp_tracker, collected_ids, settings_obj, None)
+                    adjusted_level = max(1, active_max_level + (enc_data["level"] - stable_max_level))
+                    current_enemy_pokemon = PokemonObject(
+                        type=enc_data["type"], name=enc_data["name"], id=enc_data["id"], shiny=enc_data["shiny"],
+                        level=adjusted_level, ability=enc_data["ability"], gender=enc_data["gender"], growth_rate=enc_data["growth_rate"],
+                        captured_date=None, tier=enc_data["tier"], individual_id=str(uuid.uuid4()),
+                        base_stats=enc_data["base_stats"], attacks=enc_data["attacks"], base_experience=enc_data["base_experience"],
+                        ev=enc_data["ev"], iv=enc_data["iv"], battle_status=enc_data["battle_status"], ev_yield=enc_data["ev_yield"], nature=enc_data["nature"]
+                    )
+                    main_pokemon_clone = select_best_companion(team_clones, current_enemy_pokemon)
+                    mutator_full_reset = 1
+                    engine_state = None
+
+                # Turn simulation
+                main_attacks = getattr(main_pokemon_clone, "attacks", None)
+                if isinstance(main_attacks, (list, tuple)) and len(main_attacks) > 0:
+                    user_attack = random.choice(main_attacks)
+                else:
+                    user_attack = "splash"
+
+                enemy_attacks_list = getattr(current_enemy_pokemon, "attacks", None)
+                if isinstance(enemy_attacks_list, (list, tuple)) and len(enemy_attacks_list) > 0:
+                    enemy_attack = random.choice(enemy_attacks_list)
+                else:
+                    enemy_attack = "splash"
+
+                points_map = {1: 0, 2: 5, 3: 10, 4: 20}
+                total_points = sum(points_map.get(r.get("ease") or 3, 10) for r in current_turn_reviews)
+                max_points = 10.0 * len(current_turn_reviews)
+                turn_multiplier = total_points / max_points if max_points > 0 else 1.0
+
+                orig_multiplier = 1.0
+                has_tracker = tracker and hasattr(tracker, "multiplier")
+                if has_tracker:
+                    orig_multiplier = tracker.multiplier
+                    tracker.multiplier = turn_multiplier
+
+                try:
+                    results = simulate_battle_with_poke_engine(
+                        main_pokemon_clone, current_enemy_pokemon, user_attack, enemy_attack,
+                        mutator_full_reset, engine_state
+                    )
+                    engine_state, mutator_full_reset = results[1], results[4]
+                except Exception:
+                    current_enemy_pokemon.hp = 0
+                finally:
+                    if has_tracker: tracker.multiplier = orig_multiplier
+                    current_turn_reviews = []
+
+                enemy_hp = getattr(current_enemy_pokemon, "hp", 100)
+                companion_hp = getattr(main_pokemon_clone, "hp", 100)
+
+                if isinstance(enemy_hp, (int, float)) and enemy_hp <= 0:
+                    is_mega = current_enemy_pokemon.id in MEGA
+                    is_gmax = current_enemy_pokemon.id in GMAX
+                    is_regional = current_enemy_pokemon.id in REGIONAL_FORM_REGION
+                    should_catch_always = (
+                        (current_enemy_pokemon.tier == "Legendary" and auto_catch_legendary)
+                        or (current_enemy_pokemon.tier == "Mythical" and auto_catch_mythical)
+                        or (current_enemy_pokemon.tier == "Ultra" and auto_catch_ultra)
+                        or (current_enemy_pokemon.tier == "Starter" and auto_catch_starter)
+                        or (is_mega and auto_catch_mega)
+                        or (is_gmax and auto_catch_gmax)
+                        or (is_regional and auto_catch_regional)
+                        or (current_enemy_pokemon.id in wishlist)
+                    )
+
+                    caught = False
+                    if auto_battle_setting == 1: caught = True
+                    elif auto_battle_setting == 2: caught = (current_enemy_pokemon.shiny or should_catch_always)
+                    elif auto_battle_setting == 3:
+                        caught = (current_enemy_pokemon.id not in collected_ids or current_enemy_pokemon.shiny or should_catch_always)
+                    
+                    if caught:
+                        collected_ids.add(current_enemy_pokemon.id)
+
+                    enemy_dict = current_enemy_pokemon.to_dict()
+                    enemy_dict.update({
+                        "ev": {"hp": 0, "atk": 0, "def": 0, "spa": 0, "spd": 0, "spe": 0},
+                    })
+                    cp_val = calculate_cp_from_dict(enemy_dict)
+
+                    pkmn_info = {
+                        "name": str(current_enemy_pokemon.display_name),
+                        "id": int(current_enemy_pokemon.id),
+                        "level": int(current_enemy_pokemon.level),
+                        "shiny": bool(current_enemy_pokemon.shiny),
+                        "tier": str(current_enemy_pokemon.tier),
+                        "xp": 0,
+                        "cp": cp_val
+                    }
+
+                    if caught:
+                        if commit:
+                            from ..services import services
+                            capture_time = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+                            current_enemy_pokemon.captured_date = capture_time
+                            save_caught_pokemon(current_enemy_pokemon, nickname=None, achievements=services.achievements)
+                            try:
+                                from ..reviewer_ui import _collected_pokemon_ids
+                                if isinstance(_collected_pokemon_ids, set): _collected_pokemon_ids.add(current_enemy_pokemon.id)
+                            except Exception: pass
+                            caught_pokemon_list.append(pkmn_info)
+                            caught_count += 1  # else resolveAll/the UI report "0 caught"
+                            last_outcome = "caught"
+                        else:
+                            caught_pokemon.append(pkmn_info)
+                    else:
+                        exp = calc_experience(current_enemy_pokemon.base_experience, current_enemy_pokemon.level)
+                        try:
+                            exp = max(1, math.ceil(exp * choose_moves_penalty * lucky_egg_boost * xp_multiplier))
+                        except TypeError:
+                            exp = 100
+                        battle_xp = exp
+                        pkmn_info["xp"] = exp
+
+                        if commit:
+                            total_xp += exp
+                            defeated_encounters.append({"tier": current_enemy_pokemon.tier})
+                            if current_enemy_pokemon.ev_yield:
+                                for sk, v in _normalize_ev_yield(current_enemy_pokemon.ev_yield).items():
+                                    if sk in accumulated_evs: accumulated_evs[sk] += v
+                            last_outcome = "defeated"
+                        else:
+                            total_xp += exp
+                            defeated_pokemon.append(pkmn_info)
+
+                    if commit:
+                        # Insert history for caught or defeated
+                        try:
+                            from ..pyobj.trainer_card import POKEMON_TIERS
+                            txp = POKEMON_TIERS.get(current_enemy_pokemon.tier.lower(), 10)
+                            allow_to_choose_move = settings_obj.get("controls.allow_to_choose_moves") if settings_obj else False
+                            if allow_to_choose_move: txp *= 0.5
+                            txp = int(txp) if last_outcome == "defeated" else 0
+                            history_entries_to_add.append({
+                                "timestamp": int(time.time() * 1000),
+                                "enemy_id": current_enemy_pokemon.id,
+                                "enemy_name": current_enemy_pokemon.display_name,
+                                "enemy_level": current_enemy_pokemon.level,
+                                "enemy_shiny": current_enemy_pokemon.shiny,
+                                "companion_name": main_pokemon_clone.display_name if main_pokemon_clone else None,
+                                "companion_level": main_pokemon_clone.level if main_pokemon_clone else None,
+                                "companion_id": main_pokemon_clone.individual_id if main_pokemon_clone else None,
+                                "ev_yield": current_enemy_pokemon.ev_yield.copy() if (last_outcome == "defeated" and current_enemy_pokemon and getattr(current_enemy_pokemon, "ev_yield", None)) else {},
+                                "outcome": last_outcome,
+                                "xp_gained": battle_xp if last_outcome == "defeated" else 0,
+                                "trainer_xp_gained": txp,
+                                "cash_gained": current_battle_cash,
+                            })
+                        except Exception as ex:
+                            if logger:
+                                logger.log("error", f"Failed to record auto-resolve history: {ex}")
+                        current_battle_cash = 0
+
+                    reviews_spent_for_resolved += current_encounter_reviews
+                    resolved_encounters += 1
+                    current_enemy_pokemon = None
+                    for c in team_clones:
+                        _heal_to_full(c)
+
+                elif isinstance(companion_hp, (int, float)) and companion_hp <= 0:
+                    if commit:
+                        # Insert history for loss
+                        try:
+                            history_entries_to_add.append({
+                                "timestamp": int(time.time() * 1000),
+                                "enemy_id": current_enemy_pokemon.id,
+                                "enemy_name": current_enemy_pokemon.display_name,
+                                "enemy_level": current_enemy_pokemon.level,
+                                "enemy_shiny": current_enemy_pokemon.shiny,
+                                "companion_name": main_pokemon_clone.display_name if main_pokemon_clone else None,
+                                "companion_level": main_pokemon_clone.level if main_pokemon_clone else None,
+                                "companion_id": main_pokemon_clone.individual_id if main_pokemon_clone else None,
+                                "outcome": "lost",
+                                "xp_gained": 0,
+                                "trainer_xp_gained": 0,
+                                "cash_gained": current_battle_cash,
+                            })
+                        except Exception as ex:
+                            if logger:
+                                logger.log("error", f"Failed to record auto-resolve loss history: {ex}")
+                        current_battle_cash = 0
+
+                    reviews_spent_for_resolved += current_encounter_reviews
+                    resolved_encounters += 1
+                    current_enemy_pokemon = None
+                    for c in team_clones:
+                        _heal_to_full(c)
+        
+        if commit and current_enemy_pokemon is not None:
+            # Insert history for escaped / unfinished battle
+            try:
+                history_entries_to_add.append({
+                    "timestamp": int(time.time() * 1000),
+                    "enemy_id": current_enemy_pokemon.id,
+                    "enemy_name": current_enemy_pokemon.display_name,
+                    "enemy_level": current_enemy_pokemon.level,
+                    "enemy_shiny": current_enemy_pokemon.shiny,
+                    "companion_name": main_pokemon_clone.display_name if main_pokemon_clone else None,
+                    "companion_level": main_pokemon_clone.level if main_pokemon_clone else None,
+                    "companion_id": main_pokemon_clone.individual_id if main_pokemon_clone else None,
+                    "outcome": "escaped",
+                    "xp_gained": 0,
+                    "trainer_xp_gained": 0,
+                    "cash_gained": current_battle_cash,
+                })
+            except Exception as ex:
+                if logger:
+                    logger.log("error", f"Failed to record auto-resolve escape history: {ex}")
+    finally:
+        utils.load_collected_pokemon_ids = orig_load_ids
+
+    if commit:
+        if history_entries_to_add:
+            try:
+                if hasattr(db, "add_mobile_history_entries_batch"):
+                    db.add_mobile_history_entries_batch(history_entries_to_add)
+                else:
+                    for entry in history_entries_to_add:
+                        db.add_mobile_history_entry(entry)
+            except Exception as ex:
+                if logger:
+                    logger.log("error", f"Failed to record batch auto-resolve history: {ex}")
+        random.setstate(state)
+
+        companion_xp = {}
+        companion_evs = {}
+        companion_battle_count = {}
+        for entry in history_entries_to_add:
+            cid = entry.get("companion_id")
+            if not cid:
+                continue
+            xp_g = entry.get("xp_gained", 0)
+            companion_xp[cid] = companion_xp.get(cid, 0) + xp_g
+            
+            if entry.get("outcome") in ("defeated", "caught"):
+                companion_battle_count[cid] = companion_battle_count.get(cid, 0) + 1
+            
+            if cid not in companion_evs:
+                companion_evs[cid] = {"hp": 0, "atk": 0, "def": 0, "spa": 0, "spd": 0, "spe": 0}
+            ev_yield = entry.get("ev_yield", {})
+            for sk, v in _normalize_ev_yield(ev_yield).items():
+                if sk in companion_evs[cid]:
+                    companion_evs[cid][sk] += v
+
+        for cid, earned_xp in companion_xp.items():
+            evs_gained = companion_evs.get(cid, {"hp": 0, "atk": 0, "def": 0, "spa": 0, "spd": 0, "spe": 0})
+            battles_fought = companion_battle_count.get(cid, 0)
+            if earned_xp > 0 or any(evs_gained.values()) or battles_fought > 0:
+                if main_pokemon and cid == main_pokemon.individual_id:
+                    class DummyEnemy:
+                        def __init__(self, ev_yield): self.ev_yield = ev_yield
+                    from ..services import services
+                    save_main_pokemon_progress(
+                        main_pokemon, DummyEnemy(evs_gained), earned_xp,
+                        services.achievements, logger, get_evo_window()
+                    )
+                    # Apply additional battles fought to main_pokemon.pokemon_defeated
+                    if battles_fought > 1:
+                        extra = battles_fought - 1
+                        main_pokemon.pokemon_defeated += extra
+                        try:
+                            mp_data = db.get_main_pokemon()
+                            if mp_data:
+                                mp_data["pokemon_defeated"] = main_pokemon.pokemon_defeated
+                                db.save_main_pokemon(mp_data)
+                        except Exception:
+                            pass
+                else:
+                    _attribute_xp_and_evs_to_companion(cid, earned_xp, evs_gained, settings_obj, battles_fought=battles_fought, db=db, logger=logger)
+
+        total_trainer_xp = 0
+        from ..pyobj.trainer_card import POKEMON_TIERS
+        allow_to_choose_move = settings_obj.get("controls.allow_to_choose_moves") if settings_obj else False
+        for enc in defeated_encounters:
+            txp = POKEMON_TIERS.get(enc.get("tier", "normal").lower(), 10)
+            if allow_to_choose_move: txp *= 0.5
+            total_trainer_xp += txp
+
+        if total_trainer_xp > 0 and trainer_card:
+            new_txp = int(settings_obj.get("trainer.xp", 0) + total_trainer_xp)
+            settings_obj.set("trainer.xp", new_txp)
+            settings_obj.set("trainer.total_xp", int(settings_obj.get("trainer.total_xp", 0) + total_trainer_xp))
+            trainer_card.xp = new_txp
+            trainer_card.total_xp = settings_obj.get("trainer.total_xp")
+            trainer_card.check_level_up()
+
+        # Cash Reward
+        gained_cash = 0
+        total_reviews_resolved = total_reviews_processed
+        current_counter = int(settings_obj.get("trainer.mobile_reviews_resolved_since_payout", 0)) if settings_obj else 0
+        new_counter = current_counter + total_reviews_resolved
+        
+        ci = int(settings_obj.get("trainer.cash_reward_interval", 5)) if settings_obj else 5
+        ca = int(settings_obj.get("trainer.cash_reward_amount", 10)) if settings_obj else 10
+        
+        gained_cash = (new_counter // ci) * ca
+        remaining_counter = new_counter % ci
+        if settings_obj:
+            settings_obj.set("trainer.mobile_reviews_resolved_since_payout", remaining_counter)
+            settings_obj.set("trainer.cash", int(settings_obj.get("trainer.cash", 0) + gained_cash))
+        if trainer_card and settings_obj:
+            trainer_card.cash = settings_obj.get("trainer.cash")
+
+        # Mark resolved
+        res_ids = [r["id"] for r in reviews_list[:total_reviews_processed]]
+        for rid in res_ids:
+            db.mark_mobile_battle_resolved(rid)
+
+        if encounters_fought > 0:
+            try:
+                cursor = db.execute("SELECT value FROM metadata WHERE key = 'mobile_resolved_encounters_count'")
+                row = cursor.fetchone()
+                if row is not None:
+                    new_count = int(row[0]) + encounters_fought
+                else:
+                    cursor = db.execute("SELECT COUNT(*) FROM pending_mobile_battles WHERE resolved = 1")
+                    resolved_reviews = cursor.fetchone()[0]
+                    cards_per_round, _ = _parse_cards_per_round(settings_obj)
+                    new_count = resolved_reviews // cards_per_round
+                
+                with db._get_connection():
+                    db._get_connection().execute(
+                        "INSERT OR REPLACE INTO metadata (key, value) VALUES ('mobile_resolved_encounters_count', ?)",
+                        (str(new_count),)
+                    )
+            except Exception:
+                pass
+
+        remaining = db.get_pending_mobile_count()
+        from ..menu_buttons import update_mobile_badge
+        update_mobile_badge(remaining)
+
+        try:
+            from ..events import events
+            events.emit("stats_changed")
+        except Exception: pass
+        return {
+            "success": True, "resolved": encounters_fought, "xp_gained": total_xp,
+            "catches": caught_count, "cash_gained": gained_cash,
+            "trainer_xp_gained": total_trainer_xp, "caught_list": caught_pokemon_list,
+            "reviews_processed": total_reviews_processed,
+        }
+    else:
+        # Estimate extrapolation
+        avg_reviews_per_encounter = cards_per_round
+        if resolved_encounters > 0:
+            avg_reviews_per_encounter = reviews_spent_for_resolved / resolved_encounters
+
+        extra_caught_count = 0
+        if extra_reviews:
+            extra_reviews_count = len(extra_reviews)
+            extra_encounters = int(extra_reviews_count / avg_reviews_per_encounter)
+
+            if extra_encounters > 0:
+                encounters_count = resolved_encounters + extra_encounters
+                
+                # Estimate defeated and caught ratio from simulated pool
+                defeated_ratio = 0.8
+                caught_ratio = 0.2
+                total_encs = len(caught_pokemon) + len(defeated_pokemon)
+                if total_encs > 0:
+                    defeated_ratio = len(defeated_pokemon) / total_encs
+                    caught_ratio = len(caught_pokemon) / total_encs
+
+                extra_defeated = extra_encounters * defeated_ratio
+                extra_caught_count = int(extra_encounters * caught_ratio)
+
+                est_exp = calc_experience(130, active_max_level)
+                try:
+                    est_exp = max(1, math.ceil(est_exp * choose_moves_penalty * lucky_egg_boost * xp_multiplier))
+                except TypeError:
+                    est_exp = 100
+                total_xp += int(extra_defeated * est_exp)
+            else:
+                encounters_count = resolved_encounters
+        else:
+            encounters_count = resolved_encounters
+
+        # Estimate trainer cash reward based on settings
+        cash_interval = int(settings_obj.get("trainer.cash_reward_interval", 5)) if settings_obj else 5
+        cash_amount = int(settings_obj.get("trainer.cash_reward_amount", 10)) if settings_obj else 10
+        total_reviews_count = len(reviews_list)
+        cash_gained = (total_reviews_count // cash_interval) * cash_amount
+
+        # Restore random state
+        random.setstate(state)
+
+        return {
+            "xp": total_xp,
+            "encounters": encounters_count,
+            "caught": caught_pokemon,
+            "defeated": defeated_pokemon,
+            "catches_count": len(caught_pokemon) + extra_caught_count,
+            "is_truncated": len(extra_reviews) > 0,  # True if >100 reviews, extrapolated
+            "simulated_reviews": len(reviews_to_process),
+            "total_reviews": len(reviews_list),
+            "cash": cash_gained
+        }
+
+
+def estimate_pending_battles(pending_reviews: list[dict], main_pokemon, settings_obj, trainer_card, ankimon_tracker_obj, ankimon_db=None) -> dict:
+    return run_mobile_battles(
+        reviews=pending_reviews,
+        commit=False,
+        db=ankimon_db,
+        settings_obj=settings_obj,
+        tracker=ankimon_tracker_obj,
+        trainer_card=trainer_card,
+        main_pokemon=main_pokemon
+    )
+
+
+# Alias for backwards compatibility
+simulate_pending_mobile_battles = estimate_pending_battles
+
+
+def resolve_all(db, settings_obj, tracker, trainer_card, main_pokemon, logger=None, day_cutoff=0, limit=None, progress_callback=None) -> dict:
+    return _resolve_internal(
+        mode="all",
+        companion_id="",
+        limit=limit,
+        db=db,
+        settings_obj=settings_obj,
+        tracker=tracker,
+        trainer_card=trainer_card,
+        main_pokemon=main_pokemon,
+        logger=logger,
+        day_cutoff=day_cutoff,
+        progress_callback=progress_callback
+    )
+
+
+def resolve_next(companion_id: str, db, settings_obj, tracker, trainer_card, main_pokemon, logger=None, day_cutoff=0) -> dict:
+    return _resolve_internal(
+        mode="next",
+        companion_id=companion_id,
+        limit=None,
+        db=db,
+        settings_obj=settings_obj,
+        tracker=tracker,
+        trainer_card=trainer_card,
+        main_pokemon=main_pokemon,
+        logger=logger,
+        day_cutoff=day_cutoff
+    )
+
+
+def commit_replay_outcome(choice: str, outcome_data: dict, db, settings_obj, trainer_card, main_pokemon, achievements_dict=None, logger=None) -> dict:
+    try:
+        if not outcome_data:
+            return {"success": False, "error": "No pending battle to resolve."}
+
+        enemy_pokemon = outcome_data["enemy_pokemon"]
+        battle_xp = outcome_data["battle_xp"]
+        total_xp = outcome_data["total_xp"]
+        accumulated_evs = outcome_data["accumulated_evs"]
+        total_trainer_xp = outcome_data["total_trainer_xp"]
+        gained_cash = outcome_data.get("gained_cash", 0)
+
+        now_ms = int(time.time() * 1000)
+        review_ids = outcome_data.get("review_ids", [])
+
+        # 1. Pre-calculate values for immediate return
+        gained_cash = 0
+        remaining_counter = 0
+        if review_ids and settings_obj:
+            total_reviews_resolved = len(review_ids)
+            current_counter = int(settings_obj.get("trainer.mobile_reviews_resolved_since_payout", 0))
+            new_counter = current_counter + total_reviews_resolved
+            
+            ci = int(settings_obj.get("trainer.cash_reward_interval", 5))
+            ca = int(settings_obj.get("trainer.cash_reward_amount", 10))
+            
+            gained_cash = (new_counter // ci) * ca
+            remaining_counter = new_counter % ci
+
+        # Calculate CP for the return value
+        from ..business import calculate_cp_from_dict
+        enemy_dict = enemy_pokemon.to_dict()
+        enemy_dict.update({
+            "ev": {"hp": 0, "atk": 0, "def": 0, "spa": 0, "spd": 0, "spe": 0},
+        })
+        cp_val = calculate_cp_from_dict(enemy_dict)
+
+        # Pre-calculate remaining count
+        current_pending = db.get_pending_mobile_count()
+        remaining = max(0, current_pending - len(review_ids))
+
+        # We will split the DB operations (heavy) and the GUI updates.
+        # Run DB operations in the background thread:
+        def do_db_work(col):
+            nonlocal battle_xp
+            # Set in_bulk_resolve to avoid tooltips/dialogs in background thread
+            from .. import utils
+            orig_in_bulk = getattr(utils, "in_bulk_resolve", False)
+            utils.in_bulk_resolve = True
+
+            try:
+                # 1. Catch logic
+                if choice == "catch":
+                    from .encounter_functions import save_caught_pokemon
+                    capture_time = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+                    enemy_pokemon.captured_date = capture_time
+                    save_caught_pokemon(enemy_pokemon, nickname=None, achievements=achievements_dict)
+                    battle_xp = 0
+                
+                # 2. Defeat logic
+                elif choice == "defeat":
+                    companion_id = outcome_data.get("companion_id", "")
+                    if not companion_id and main_pokemon:
+                        companion_id = getattr(main_pokemon, "individual_id", "")
+                    
+                    if companion_id and (total_xp > 0 or any(accumulated_evs.values())):
+                        _attribute_xp_and_evs_to_companion(companion_id, total_xp, accumulated_evs, settings_obj, db=db, logger=logger)
+
+                # 3. Mark resolved in DB
+                if review_ids:
+                    placeholders = ",".join("?" for _ in review_ids)
+                    try:
+                        cursor = db.execute(
+                            f"SELECT revlog_id FROM pending_mobile_battles WHERE id IN ({placeholders})",
+                            list(review_ids)
+                        )
+                        revlog_ids = [r[0] for r in cursor.fetchall() if r[0]]
+                    except Exception:
+                        revlog_ids = []
+
+                    with db._get_connection():
+                        db._get_connection().execute(
+                            f"UPDATE pending_mobile_battles SET resolved=1, resolved_at=? WHERE id IN ({placeholders})",
+                            [now_ms] + list(review_ids)
+                        )
+                    
+                    if revlog_ids:
+                        db.sync_resolutions_to_other_db(revlog_ids, now_ms)
+
+                    try:
+                        cursor = db.execute("SELECT value FROM metadata WHERE key = 'mobile_resolved_encounters_count'")
+                        row = cursor.fetchone()
+                        if row is not None:
+                            new_count_meta = int(row[0]) + 1
+                        else:
+                            cursor = db.execute("SELECT COUNT(*) FROM pending_mobile_battles WHERE resolved = 1")
+                            resolved_reviews = cursor.fetchone()[0]
+                            cards_per_round, _ = _parse_cards_per_round(settings_obj)
+                            new_count_meta = resolved_reviews // cards_per_round
+                        
+                        with db._get_connection():
+                            db._get_connection().execute(
+                                "INSERT OR REPLACE INTO metadata (key, value) VALUES ('mobile_resolved_encounters_count', ?)",
+                                (str(new_count_meta),)
+                            )
+                    except Exception:
+                        pass
+
+                # 4. Save to mobile history
+                try:
+                    comp_name = outcome_data.get("companion_name")
+                    comp_level = outcome_data.get("companion_level")
+                    if not comp_name:
+                        comp_name = "Companion"
+                        comp_level = 5
+                        active_comp = None
+                        if choice == "defeat" and main_pokemon:
+                            active_comp = main_pokemon
+                        
+                        if active_comp:
+                            comp_name = getattr(active_comp, "display_name", "Companion")
+                            comp_level = getattr(active_comp, "level", 5)
+
+                    outcome_val = "caught" if choice == "catch" else "defeated"
+                    if outcome_data.get("companion_fainted", False):
+                        outcome_val = "lost"
+
+                    db.add_mobile_history_entry({
+                        "timestamp": now_ms,
+                        "enemy_id": enemy_pokemon.id,
+                        "enemy_name": enemy_pokemon.display_name,
+                        "enemy_level": enemy_pokemon.level,
+                        "enemy_shiny": enemy_pokemon.shiny,
+                        "companion_name": comp_name,
+                        "companion_level": comp_level,
+                        "outcome": outcome_val,
+                        "xp_gained": battle_xp if outcome_val == "defeated" else 0,
+                        "trainer_xp_gained": total_trainer_xp if outcome_val == "defeated" else 0,
+                        "cash_gained": gained_cash,
+                    })
+                except Exception as ex:
+                    if logger:
+                        logger.log("error", f"Failed to record manual mobile battle history: {ex}")
+
+            finally:
+                utils.in_bulk_resolve = orig_in_bulk
+
+        def on_db_work_done(dummy_res):
+            try:
+                # Update mobile reviews payout counter settings
+                if review_ids and settings_obj:
+                    settings_obj.set("trainer.mobile_reviews_resolved_since_payout", remaining_counter)
+                    if gained_cash > 0:
+                        settings_obj.set("trainer.cash", int(settings_obj.get("trainer.cash", 0) + gained_cash))
+                        if trainer_card:
+                            trainer_card.cash = settings_obj.get("trainer.cash")
+
+                if choice == "catch":
+                    try:
+                        from ..reviewer_ui import _collected_pokemon_ids
+                        if isinstance(_collected_pokemon_ids, set):
+                            _collected_pokemon_ids.add(enemy_pokemon.id)
+                    except Exception: pass
+                elif choice == "defeat":
+                    if total_trainer_xp > 0 and trainer_card:
+                        new_txp = int(settings_obj.get("trainer.xp", 0) + total_trainer_xp)
+                        settings_obj.set("trainer.xp", new_txp)
+                        settings_obj.set("trainer.total_xp", int(settings_obj.get("trainer.total_xp", 0) + total_trainer_xp))
+                        trainer_card.xp = new_txp
+                        trainer_card.total_xp = settings_obj.get("trainer.total_xp")
+                        trainer_card.check_level_up()
+
+                # Update mobile badge
+                remaining_real = db.get_pending_mobile_count()
+                try:
+                    from ..menu_buttons import update_mobile_badge
+                    update_mobile_badge(remaining_real)
+                except Exception: pass
+
+                # Trigger sync notification to refresh UI
+                try:
+                    from ..events import events
+                    events.emit("stats_changed")
+                except Exception: pass
+            except Exception as e:
+                if logger:
+                    logger.log("error", f"on_db_work_done in commit_replay_outcome failed: {e}")
+
+        # 3. Schedule or execute work
+        import os
+        if "PYTEST_CURRENT_TEST" in os.environ:
+            do_db_work(None)
+            on_db_work_done(None)
+        else:
+            from aqt.operations import QueryOp
+            from aqt import mw
+            QueryOp(
+                parent=mw,
+                op=do_db_work,
+                success=on_db_work_done
+            ).without_collection().run_in_background()
+
+        return {"success": True, "outcome": "caught" if choice == "catch" else "defeated", "xp_gained": battle_xp, "cp": cp_val, "remaining": remaining, "cash_gained": gained_cash}
+    except Exception as e:
+        return {"success": False, "error": str(e)}
+
+
+def _resolve_internal(mode="all", companion_id="", limit=None, db=None, settings_obj=None, tracker=None, trainer_card=None, main_pokemon=None, logger=None, day_cutoff=0, progress_callback=None) -> dict:
+    conn = db._get_connection()
+    
+    use_transaction = (mode == "all")
+    if use_transaction:
+        conn._disable_commit = True
+        from .. import utils
+        utils.in_bulk_resolve = True
+
+    try:
+        if use_transaction:
+            with conn:
+                result = run_mobile_battles(
+                    reviews=None,
+                    commit=True,
+                    db=db,
+                    settings_obj=settings_obj,
+                    tracker=tracker,
+                    trainer_card=trainer_card,
+                    main_pokemon=main_pokemon,
+                    companion_override_id=companion_id,
+                    logger=logger,
+                    day_cutoff=day_cutoff,
+                    limit=limit,
+                    mode=mode,
+                    progress_callback=progress_callback
+                )
+        else:
+            result = run_mobile_battles(
+                reviews=None,
+                commit=True,
+                db=db,
+                settings_obj=settings_obj,
+                tracker=tracker,
+                trainer_card=trainer_card,
+                main_pokemon=main_pokemon,
+                companion_override_id=companion_id,
+                logger=logger,
+                day_cutoff=day_cutoff,
+                limit=limit,
+                mode=mode,
+                progress_callback=progress_callback
+            )
+        return result
+    finally:
+        if use_transaction:
+            conn._disable_commit = False
+            # Reset the bulk-resolve flag. If this is dropped, in_bulk_resolve
+            # stays True for the rest of the session and silently suppresses
+            # level-up tooltips, evolution prompts and learn-move dialogs in
+            # normal desktop play (encounter_functions / pokedex_functions gate
+            # those on `not in_bulk_resolve`).
+            from .. import utils
+            utils.in_bulk_resolve = False
+
+
+def _attribute_xp_and_evs_to_companion(companion_id: str, xp_gained: int, ev_yield_gained: dict, settings_obj, battles_fought=1, db=None, logger=None) -> None:
+    if xp_gained <= 0 and not any(ev_yield_gained.values()) and battles_fought <= 0:
+        return
+
+    if db is None:
+        from ..services import services
+        db = services.db
+    pkmndata = None
+    if companion_id:
+        try:
+            pkmndata = db.get_pokemon_by_individual_id(companion_id) if hasattr(db, "get_pokemon_by_individual_id") else db.get_pokemon(companion_id)
+        except Exception:
+            pass
+
+    if not pkmndata:
+        return
+
+    from .pokemon_functions import find_experience_for_level, get_levelup_move_for_pokemon
+    from .drawing_utils import tooltipWithColour
+    from ..pyobj.pokemon_obj import PokemonObject
+    from .. import utils
+
+    growth_rate = pkmndata.get("growth_rate", "medium-fast")
+    level = int(pkmndata.get("level", 1))
+    xp = int(pkmndata.get("xp", 0))
+    remove_cap = settings_obj.get("misc.remove_level_cap") if settings_obj else False
+
+    experience_req = int(find_experience_for_level(growth_rate, level, remove_cap))
+    if remove_cap:
+        xp += xp_gained
+        level_cap = None
+    elif level != 100:
+        xp += xp_gained
+        level_cap = 100
+    else:
+        level_cap = 100
+
+    from ..services import services
+    main_pokemon_singleton = services.main_pokemon
+    is_active = (main_pokemon_singleton is not None and getattr(main_pokemon_singleton, "individual_id", None) == companion_id)
+    in_bulk = getattr(utils, "in_bulk_resolve", False)
+    
+    color = "#6A4DAC"
+
+    # level-ups
+    while int(find_experience_for_level(growth_rate, level, remove_cap)) < xp and (level_cap is None or level < level_cap):
+        level += 1
+        msg = f"Your {pkmndata.get('name', 'Pokemon')} is now level {level} !"
+        
+        if is_active and not in_bulk:
+            try:
+                if services.logger:
+                    services.logger.game_log(f"Level Up: {msg}")
+                tooltipWithColour(msg, color)
+                if settings_obj and settings_obj.get("gui.pop_up_dialog_message_on_defeat") is True:
+                    if services.logger:
+                        services.logger.log_and_showinfo("info", f"{msg}")
+            except Exception:
+                pass
+                
+        xp = int(max(0, xp - int(experience_req)))
+        experience_req = int(find_experience_for_level(growth_rate, level, remove_cap))
+        
+        # level-up moves
+        name_lower = pkmndata.get("name", "").lower()
+        new_attacks = get_levelup_move_for_pokemon(name_lower, level)
+        if new_attacks:
+            attacks = pkmndata.get("attacks", [])
+            if isinstance(attacks, str):
+                try:
+                    attacks = json.loads(attacks)
+                except Exception:
+                    attacks = []
+            
+            for new_attack in new_attacks:
+                if len(attacks) < 4 and new_attack not in attacks:
+                    attacks.append(new_attack)
+                    if is_active and not in_bulk:
+                        msg_learn = f"{pkmndata.get('name', '').capitalize()} learned {new_attack}!"
+                        tooltipWithColour(msg_learn, color)
+                elif new_attack not in attacks:
+                    if is_active and not in_bulk:
+                        from ..pyobj.attack_dialog import AttackDialog
+                        from PyQt6.QtWidgets import QDialog
+                        dialog = AttackDialog(attacks, new_attack)
+                        if dialog.exec() == QDialog.DialogCode.Accepted:
+                            selected_attack = dialog.selected_attack
+                            if selected_attack in attacks:
+                                idx = attacks.index(selected_attack)
+                                attacks[idx] = new_attack
+            pkmndata["attacks"] = attacks
+
+    pkmndata["level"] = level
+    pkmndata["xp"] = xp
+    
+    # EV Updates
+    if "ev" not in pkmndata or not isinstance(pkmndata["ev"], dict):
+        pkmndata["ev"] = {"hp": 0, "atk": 0, "def": 0, "spa": 0, "spd": 0, "spe": 0}
+    else:
+        pkmndata["ev"] = _normalize_ev_yield(pkmndata["ev"])
+        
+    normalized_yield = {
+        "hp": ev_yield_gained.get("hp", 0),
+        "attack": ev_yield_gained.get("attack", 0) + ev_yield_gained.get("atk", 0),
+        "defense": ev_yield_gained.get("defense", 0) + ev_yield_gained.get("def", 0),
+        "special-attack": ev_yield_gained.get("special-attack", 0) + ev_yield_gained.get("spa", 0),
+        "special-defense": ev_yield_gained.get("special-defense", 0) + ev_yield_gained.get("spd", 0),
+        "speed": ev_yield_gained.get("speed", 0) + ev_yield_gained.get("spe", 0),
+    }
+    
+    held_item = pkmndata.get("held_item", None)
+    if held_item == "macho-brace":
+        for stat in normalized_yield:
+            normalized_yield[stat] *= 2
+    else:
+        power_item_mapping = {
+            "power-weight": "hp",
+            "power-bracer": "attack",
+            "power-belt": "defense",
+            "power-lens": "special-attack",
+            "power-band": "special-defense",
+            "power-anklet": "speed",
+        }
+        if held_item in power_item_mapping:
+            stat_to_boost = power_item_mapping[held_item]
+            normalized_yield[stat_to_boost] += 8
+
+    ev_yield = utils.limit_ev_yield(pkmndata["ev"], normalized_yield)
+    pkmndata["ev"]["hp"] += ev_yield["hp"]
+    pkmndata["ev"]["atk"] += ev_yield["attack"]
+    pkmndata["ev"]["def"] += ev_yield["defense"]
+    pkmndata["ev"]["spa"] += ev_yield["special-attack"]
+    pkmndata["ev"]["spd"] += ev_yield["special-defense"]
+    pkmndata["ev"]["spe"] += ev_yield["speed"]
+
+    # Recompute stats
+    pkmndata["stats"] = {
+        k: PokemonObject.calc_stat(k, val, level, pkmndata["iv"][k], pkmndata["ev"][k], pkmndata.get("nature", "serious"))
+        for k, val in pkmndata["base_stats"].items()
+        if k in ("hp", "atk", "def", "spa", "spd", "spe")
+    }
+    pkmndata["current_hp"] = pkmndata["stats"].get("hp", 15)
+    
+    friendship = int(pkmndata.get("friendship", 0))
+    friendship += random.randint(5, 9)
+    pkmndata["friendship"] = min(255, friendship)
+    
+    pkmndata["pokemon_defeated"] = int(pkmndata.get("pokemon_defeated", 0)) + battles_fought
+
+    # Call db.save_pokemon(updated_entry)
+    db.save_pokemon(pkmndata)
+
+    # 4. If active, also update the in-memory singleton
+    if is_active:
+        mp = main_pokemon_singleton
+        mp.xp = pkmndata["xp"]
+        mp.level = pkmndata["level"]
+        mp.ev = pkmndata["ev"].copy()
+        mp.friendship = pkmndata["friendship"]
+        mp.pokemon_defeated = pkmndata["pokemon_defeated"]
+        if "attacks" in pkmndata:
+            mp.attacks = list(pkmndata["attacks"])
+        mp.invalidate_cp_cache()
+

--- a/src/Ankimon/functions/mobile_sync.py
+++ b/src/Ankimon/functions/mobile_sync.py
@@ -1110,6 +1110,20 @@ def _run_mobile_battles_impl(
     temp_tracker = TempTracker(initial_reviews + resolved_count)
     team_clones = load_active_team_clones(db, settings_obj, main_pokemon)
     main_pokemon_clone = team_clones[0] if team_clones else None
+    if not main_pokemon_clone:
+        # No active companion and no main-Pokemon fallback: without a battler the
+        # engine would call simulate_battle_with_poke_engine(None, ...), which
+        # raises and is swallowed into enemy.hp = 0 while companion hp defaults to
+        # 100 (getattr(None, "hp", 100)) -> the player auto-wins/catches every
+        # review for free. Bail out with a benign empty result instead.
+        if commit:
+            return {"success": False, "error": "No active companion or main Pokémon available to battle."}
+        else:
+            return {
+                "xp": 0, "encounters": 0, "caught": [], "defeated": [],
+                "catches_count": 0, "is_truncated": False, "simulated_reviews": 0,
+                "total_reviews": 0, "cash": 0
+            }
     stable_max_level = _get_team_max_level(team_clones, db, settings_obj, main_pokemon)
     
     # Calculate active_max_level (max level of active team clones only)
@@ -1710,6 +1724,11 @@ def commit_replay_outcome(choice: str, outcome_data: dict, db, settings_obj, tra
             orig_in_bulk = getattr(utils, "in_bulk_resolve", False)
             utils.in_bulk_resolve = True
 
+            # Serialize against run_mobile_battles (auto-resolve): both mutate the
+            # pending_mobile_battles queue and companion rows, and this body runs
+            # in a QueryOp background thread. Sharing _mobile_sync_lock guarantees
+            # a concurrent auto-resolve can't double-resolve reviews or race writes.
+            _mobile_sync_lock.acquire()
             try:
                 # 1. Catch logic
                 if choice == "catch":
@@ -1806,6 +1825,7 @@ def commit_replay_outcome(choice: str, outcome_data: dict, db, settings_obj, tra
 
             finally:
                 utils.in_bulk_resolve = orig_in_bulk
+                _mobile_sync_lock.release()
 
         def on_db_work_done(dummy_res):
             try:

--- a/src/Ankimon/menu_buttons.py
+++ b/src/Ankimon/menu_buttons.py
@@ -318,3 +318,31 @@ def create_menu_actions(
     help_menu.addAction(downloader_action)
 
     mw.form.menubar.addMenu(mw.pokemenu)
+
+
+# The "Mobile and Web Reviews" menu action is created by the later menu rewrite
+# (F36). Until it exists this stays None, and update_mobile_badge() is a safe
+# no-op — so the mobile sync/bootstrap paths can call it unconditionally now.
+_mobile_battles_action = None
+
+
+def update_mobile_badge(count: int) -> None:
+    """Reflect the pending mobile-battle count on the Mobile & Web Reviews entry.
+
+    Guarded no-op: returns immediately off the main thread or before the mobile
+    menu action has been built (F36). Never raises — a badge update must never
+    crash the sync hook or profile bootstrap that calls it.
+    """
+    try:
+        from .utils import is_main_thread
+        if not is_main_thread():
+            return
+        action = globals().get("_mobile_battles_action")
+        if action is None:
+            return
+        if count and count > 0:
+            action.setText(f"({count}) Mobile and Web Reviews")
+        else:
+            action.setText("Mobile and Web Reviews")
+    except Exception:
+        pass  # Never let a badge update crash anything

--- a/src/Ankimon/profile_hooks.py
+++ b/src/Ankimon/profile_hooks.py
@@ -37,6 +37,45 @@ def _on_profile_close():
 
 def _on_profile_did_open(online_connectivity):
     def handler():
+        # Mobile-review sync bootstrap (F20 deferred half): initialise the revlog
+        # watermark on first run, clear the desktop session set for a fresh
+        # inter-sync interval, run a startup detection pass to catch reviews pulled
+        # in by the startup sync, and restore the pending-count badge. Guarded so a
+        # missing DB / collection is a benign no-op.
+        try:
+            db = services.db
+            col = services.col if services.col is not None else mw.col
+            if db is not None and col is not None:
+                from .functions.mobile_sync import clear_desktop_session
+                from .menu_buttons import update_mobile_badge
+
+                watermark = db.get_mobile_watermark()
+                if watermark == 0:
+                    # First-ever run — set watermark to NOW so no retroactive battles
+                    initial_watermark = col.db.scalar("SELECT MAX(id) FROM revlog") or 0
+                    db.set_mobile_watermark(initial_watermark or 0)
+                # Always clear session set on profile open (fresh inter-sync interval)
+                clear_desktop_session()
+
+                # Run detection immediately to catch reviews pulled in by startup sync
+                if settings_obj.get("mobile.enabled", True):
+                    try:
+                        from .functions.mobile_sync import process_mobile_reviews_after_sync
+                        process_mobile_reviews_after_sync(
+                            col=col,
+                            ankimon_db=db,
+                            settings_obj=settings_obj,
+                            logger=logger,
+                        )
+                    except Exception as sync_err:
+                        logger.log("error", f"Failed to run startup mobile reviews sync: {sync_err}")
+
+                # Restore badge — show pending count from previous session
+                pending = db.get_pending_mobile_count()
+                update_mobile_badge(pending)
+        except Exception as e:
+            logger.log("error", f"Failed to initialize mobile watermark: {e}")
+
         try:
             show_tip_of_the_day()
         except Exception as e:

--- a/src/Ankimon/pyobj/ankimon_sync.py
+++ b/src/Ankimon/pyobj/ankimon_sync.py
@@ -868,7 +868,116 @@ def setup_ankimon_sync_hooks(settings_obj, logger):
             logger.log("error", f"Failed to prepare files for sync: {str(e)}")
 
     def on_sync_did_finish():
-        """Called after sync finishes - only auto-read if enabled."""
+        """Called after sync finishes."""
+        # === Mobile-review sync engine (F29): dual-DB detection + queueing ===
+        # Runs regardless of the AnkiWeb-config auto-sync toggle below — mobile
+        # review detection is independent of Ankimon-config file syncing.
+        try:
+            from ..services import services
+            db = services.db
+            col = services.col if services.col is not None else mw.col
+            if db is not None and col is not None and settings_obj.get("mobile.enabled", True):
+                from ..functions.mobile_sync import (
+                    detect_mobile_reviews,
+                    get_desktop_session_revlog_ids,
+                    clear_desktop_session,
+                )
+                from ..menu_buttons import update_mobile_badge
+
+                dev_db_path = user_path / "ankimonDEV.db"
+                original_db_name = db.db_path.name
+                desktop_ids = get_desktop_session_revlog_ids(col)
+
+                newly_queued_normal = 0
+                newly_queued_dev = 0
+
+                try:
+                    # 1. Queue to ankimon.db
+                    if db.db_path.name != "ankimon.db":
+                        db.switch_database("ankimon.db")
+                    watermark_normal = db.get_mobile_watermark()
+                    all_mobile_normal = detect_mobile_reviews(col, watermark_normal, desktop_ids)
+                    if all_mobile_normal:
+                        newly_queued_normal = db.queue_mobile_battles(all_mobile_normal)
+                        db.set_mobile_watermark(max(r["id"] for r in all_mobile_normal))
+
+                    max_revlog_id = col.db.scalar("SELECT MAX(id) FROM revlog")
+                    if type(max_revlog_id).__name__ in ("MagicMock", "Mock"):
+                        max_revlog_id = None
+                    if isinstance(max_revlog_id, (int, float)):
+                        current_watermark = db.get_mobile_watermark()
+                        if max_revlog_id > current_watermark:
+                            db.set_mobile_watermark(max_revlog_id)
+
+                    # 2. Queue to ankimonDEV.db if present
+                    if dev_db_path.is_file():
+                        if db.db_path.name != "ankimonDEV.db":
+                            db.switch_database("ankimonDEV.db")
+                        watermark_dev = db.get_mobile_watermark()
+                        all_mobile_dev = detect_mobile_reviews(col, watermark_dev, desktop_ids)
+                        if all_mobile_dev:
+                            newly_queued_dev = db.queue_mobile_battles(all_mobile_dev)
+                            db.set_mobile_watermark(max(r["id"] for r in all_mobile_dev))
+
+                        if isinstance(max_revlog_id, (int, float)):
+                            current_watermark = db.get_mobile_watermark()
+                            if max_revlog_id > current_watermark:
+                                db.set_mobile_watermark(max_revlog_id)
+                finally:
+                    if db.db_path.name != original_db_name:
+                        db.switch_database(original_db_name)
+
+                # Clear desktop session to prevent indefinite exclusion-set accumulation
+                clear_desktop_session()
+
+                # Always update the badge with the TOTAL pending count of the active DB
+                total_pending = db.get_pending_mobile_count()
+                update_mobile_badge(total_pending)
+
+                msg_parts = []
+                if newly_queued_normal > 0:
+                    msg_parts.append(f"{newly_queued_normal} in Normal")
+                if newly_queued_dev > 0:
+                    msg_parts.append(f"{newly_queued_dev} in Dev")
+
+                if msg_parts:
+                    resolution_mode = settings_obj.get("mobile.resolution_mode", "manual")
+
+                    if resolution_mode == "auto":
+                        try:
+                            from ..ankimon_items_web.shop_obj import MobileBridge
+                            bridge = MobileBridge(mw)
+                            result = bridge.resolveAll()
+                            if result.get("success"):
+                                xp_gained = result.get("xp_gained", 0)
+                                cash_gained = result.get("cash_gained", 0)
+                                caught_list = result.get("caught_list", [])
+                                resolved = result.get("resolved", 0)
+                                caught_names = [p["name"] for p in caught_list]
+                                caught_str = f" Caught: {', '.join(caught_names)}." if caught_names else ""
+                                tooltip(f"⚔ Auto-resolved {resolved} mobile/web reviews! +{xp_gained} XP, +{cash_gained}¥.{caught_str}")
+                                logger.log("info", f"Auto-resolved {resolved} mobile/web reviews on active DB. +{xp_gained} XP, +{cash_gained}¥.{caught_str}")
+                            else:
+                                error_msg = result.get("error", "Unknown error")
+                                tooltip(f"⚠ Auto-resolve failed: {error_msg}. Please resolve manually.")
+                                logger.log("error", f"Auto-resolve failed: {error_msg}")
+                        except Exception as ex:
+                            tooltip(f"⚠ Auto-resolve error: {ex}. Please resolve manually.")
+                            logger.log("error", f"Auto-resolve error: {ex}")
+                    else:
+                        tooltip(f"⚔ Mobile/web reviews synced: {', '.join(msg_parts)}! Open Ankimon → Mobile & Web Reviews to resolve.")
+                        logger.log("info", f"Mobile/web reviews synced: {', '.join(msg_parts)}. Total active pending: {total_pending}.")
+                logger.log("info", f"Mobile dual-queue complete. Active DB restored to: {db.db_path.name}")
+                try:
+                    from ..events import events
+                    events.emit("stats_changed")
+                except Exception:
+                    pass
+        except Exception as e:
+            logger.log("error", f"Mobile review detection failed: {e}")
+        # === END mobile-review sync engine ===
+
+        # Only auto-read Ankimon configs if automatic sync is enabled
         if not _automatic_sync_enabled:
             logger.log("info", "Anki sync finished - automatic Ankimon sync disabled (awaiting manual sync)")
             return

--- a/src/Ankimon/pyobj/database_manager.py
+++ b/src/Ankimon/pyobj/database_manager.py
@@ -1170,6 +1170,216 @@ class AnkimonDB:
         row = cursor.fetchone()
         return row is not None and row["value"] == "true"
 
+    # --- Mobile Sync Operations ---
+    # Deferred F25 leaf accessors for the mobile-review sync engine (F14/F29).
+    # The pending_mobile_battles + mobile_battle_history tables already ship in
+    # the base schema (empty/idempotent); these methods are the leaf's read/write
+    # surface and were held back until the mobile engine landed.
+
+    def get_mobile_watermark(self) -> int:
+        """Return stored watermark (ms). Returns 0 if not set (first-ever run)."""
+        row = self.execute(
+            "SELECT value FROM metadata WHERE key = 'mobile_revlog_watermark'"
+        ).fetchone()
+        return int(row[0]) if row else 0
+
+    def set_mobile_watermark(self, watermark_ms: int) -> None:
+        with self._get_connection():
+            self._get_connection().execute(
+                "INSERT OR REPLACE INTO metadata (key, value) VALUES ('mobile_revlog_watermark', ?)",
+                (str(watermark_ms),)
+            )
+
+    def queue_mobile_battles(self, reviews: list[dict]) -> int:
+        """Insert mobile reviews into pending queue. Returns count inserted (skips duplicates)."""
+        import time
+        now = int(time.time() * 1000)
+        inserted = 0
+        conn = self._get_connection()
+        with conn:
+            for r in reviews:
+                cursor = conn.execute(
+                    """INSERT OR IGNORE INTO pending_mobile_battles
+                       (revlog_id, card_id, ease, review_time, review_type, queued_at)
+                       VALUES (?, ?, ?, ?, ?, ?)""",
+                    (r["id"], r["cid"], r["ease"], r["time"], r["type"], now)
+                )
+                inserted += cursor.rowcount
+        return inserted
+
+    def get_pending_mobile_count(self) -> int:
+        return self.execute(
+            "SELECT COUNT(*) FROM pending_mobile_battles WHERE resolved = 0"
+        ).fetchone()[0]
+
+    def get_next_pending_mobile_batch(self, limit: int = 1) -> list[dict]:
+        """Return next N unresolved battles, oldest-first (lowest revlog_id first)."""
+        rows = self.execute(
+            """SELECT id, revlog_id, card_id, ease, review_time, review_type
+               FROM pending_mobile_battles
+               WHERE resolved = 0
+               ORDER BY revlog_id ASC
+               LIMIT ?""",
+            (limit,)
+        ).fetchall()
+        keys = ["queue_id", "revlog_id", "card_id", "ease", "review_time", "review_type"]
+        return [dict(zip(keys, r)) for r in rows]
+
+    def mark_mobile_battle_resolved(self, queue_id: int) -> None:
+        import time
+        now = int(time.time() * 1000)
+        cursor = self.execute("SELECT revlog_id FROM pending_mobile_battles WHERE id = ?", (queue_id,))
+        row = cursor.fetchone()
+        revlog_id = row[0] if row else None
+
+        with self._get_connection():
+            self._get_connection().execute(
+                "UPDATE pending_mobile_battles SET resolved=1, resolved_at=? WHERE id=?",
+                (now, queue_id)
+            )
+
+        if revlog_id:
+            self.sync_resolutions_to_other_db([revlog_id], now)
+
+    def add_mobile_history_entry(self, entry: Dict[str, Any]) -> bool:
+        """Saves a single mobile battle outcome to history."""
+        return self.add_mobile_history_entries_batch([entry])
+
+    def add_mobile_history_entries_batch(self, entries: List[Dict[str, Any]]) -> bool:
+        """Saves a batch of mobile battle outcomes to history in a single transaction."""
+        if not entries:
+            return True
+
+        def _clean_val(v, default):
+            if v is None:
+                return default
+            return v
+
+        try:
+            conn = self._get_connection()
+            with conn:
+                conn.executemany(
+                    """INSERT INTO mobile_battle_history (
+                        timestamp, enemy_id, enemy_name, enemy_level, enemy_shiny,
+                        companion_name, companion_level, outcome, xp_gained,
+                        trainer_xp_gained, cash_gained
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                    [
+                        (
+                            _clean_val(entry.get("timestamp"), 0),
+                            _clean_val(entry.get("enemy_id"), 0),
+                            str(_clean_val(entry.get("enemy_name"), "")),
+                            _clean_val(entry.get("enemy_level"), 0),
+                            1 if entry.get("enemy_shiny") else 0,
+                            str(_clean_val(entry.get("companion_name"), "")),
+                            _clean_val(entry.get("companion_level"), 0),
+                            str(_clean_val(entry.get("outcome"), "")),
+                            _clean_val(entry.get("xp_gained"), 0),
+                            _clean_val(entry.get("trainer_xp_gained"), 0),
+                            _clean_val(entry.get("cash_gained"), 0),
+                        )
+                        for entry in entries
+                    ]
+                )
+                conn.execute(
+                    """DELETE FROM mobile_battle_history
+                       WHERE id NOT IN (
+                           SELECT id FROM mobile_battle_history
+                           ORDER BY timestamp DESC, id DESC
+                           LIMIT 500
+                       )"""
+                )
+            return True
+        except Exception as e:
+            self._log("error", f"Failed to batch add mobile history entries: {e}")
+            return False
+
+    def get_mobile_history(self, limit: int = 500) -> List[Dict[str, Any]]:
+        """Retrieves recent mobile battle history entries, newest first."""
+        try:
+            rows = self.execute(
+                """SELECT id, timestamp, enemy_id, enemy_name, enemy_level, enemy_shiny,
+                          companion_name, companion_level, outcome, xp_gained,
+                          trainer_xp_gained, cash_gained
+                   FROM mobile_battle_history
+                   ORDER BY timestamp DESC, id DESC
+                   LIMIT ?""",
+                (limit,)
+            ).fetchall()
+            keys = [
+                "id", "timestamp", "enemy_id", "enemy_name", "enemy_level", "enemy_shiny",
+                "companion_name", "companion_level", "outcome", "xp_gained",
+                "trainer_xp_gained", "cash_gained"
+            ]
+            result = []
+            for r in rows:
+                item = dict(zip(keys, r))
+                item["enemy_shiny"] = bool(item["enemy_shiny"])
+                result.append(item)
+            return result
+        except Exception as e:
+            self._log("error", f"Failed to get mobile history: {e}")
+            return []
+
+    def clear_mobile_history(self) -> bool:
+        """Clears all entries from the mobile battle history."""
+        try:
+            conn = self._get_connection()
+            with conn:
+                conn.execute("DELETE FROM mobile_battle_history")
+            return True
+        except Exception as e:
+            self._log("error", f"Failed to clear mobile history: {e}")
+            return False
+
+    def sync_resolutions_to_other_db(self, revlog_ids: list[int], resolved_at: int) -> None:
+        """
+        If the other database exists (normal vs dev), sync the resolved status of the given
+        revlog_ids to it directly.
+        """
+        if not revlog_ids:
+            return
+
+        current_name = self.db_path.name
+        if current_name == "ankimon.db":
+            other_name = "ankimonDEV.db"
+        elif current_name == "ankimonDEV.db":
+            other_name = "ankimon.db"
+        else:
+            return
+
+        other_path = user_path / other_name
+        if not other_path.is_file():
+            return
+
+        try:
+            import sqlite3
+            conn = sqlite3.connect(str(other_path), timeout=5.0)
+            try:
+                conn.execute("""
+                    CREATE TABLE IF NOT EXISTS pending_mobile_battles (
+                        id            INTEGER PRIMARY KEY AUTOINCREMENT,
+                        revlog_id     INTEGER UNIQUE NOT NULL,
+                        card_id       INTEGER NOT NULL,
+                        ease          INTEGER NOT NULL,
+                        review_time   INTEGER NOT NULL,
+                        review_type   INTEGER NOT NULL,
+                        queued_at     INTEGER NOT NULL,
+                        resolved      INTEGER NOT NULL DEFAULT 0,
+                        resolved_at   INTEGER
+                    )
+                """)
+                placeholders = ",".join("?" for _ in revlog_ids)
+                conn.execute(
+                    f"UPDATE pending_mobile_battles SET resolved=1, resolved_at=? WHERE revlog_id IN ({placeholders})",
+                    [resolved_at] + list(revlog_ids)
+                )
+                conn.commit()
+            finally:
+                conn.close()
+        except Exception as e:
+            self._log("error", f"Failed to sync resolutions to {other_name}: {e}")
+
 
 # Singleton instance for use throughout the addon
 _db_instance: Optional[AnkimonDB] = None

--- a/tests/test_mobile_auto_resolve.py
+++ b/tests/test_mobile_auto_resolve.py
@@ -1,0 +1,175 @@
+"""Tier-1 seam tests for the post-sync mobile detection hook (F29).
+
+Drives ``setup_ankimon_sync_hooks`` -> ``on_sync_did_finish`` end to end with a
+faked Anki/Qt runtime, a real ``AnkimonDB`` behind ``services.db``, and a fake
+collection behind ``services.col``. Verifies the dual-DB detection/queue path,
+watermark advance, and the auto-vs-manual resolution routing (the auto branch
+reaches ``MobileBridge`` via the web-shell seam).
+"""
+
+import os
+import sys
+import types
+import tempfile
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+_SRC = Path(__file__).resolve().parent.parent / "src"
+
+for _name in (
+    "aqt", "aqt.qt", "aqt.utils", "aqt.gui_hooks", "aqt.operations",
+    "aqt.theme", "aqt.sound", "aqt.webview", "aqt.main",
+    "anki", "anki.hooks", "anki.collection", "anki.utils",
+    "PyQt6", "PyQt6.QtGui", "PyQt6.QtWidgets", "PyQt6.QtCore",
+    "PyQt6.QtWebChannel", "PyQt6.QtWebEngineWidgets",
+):
+    sys.modules.setdefault(_name, MagicMock())
+
+for _pkg in ("Ankimon", "Ankimon.functions", "Ankimon.pyobj", "Ankimon.ankimon_items_web"):
+    _existing = sys.modules.get(_pkg)
+    if _existing is None or not hasattr(_existing, "__path__"):
+        _mod = types.ModuleType(_pkg)
+        _mod.__path__ = [str(_SRC / _pkg.replace(".", "/"))]
+        _mod.__package__ = _pkg
+        sys.modules[_pkg] = _mod
+
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+_USER_DIR = Path(tempfile.mkdtemp(prefix="ankimon_autoresolve_ut_"))
+os.environ.setdefault("ANKIMON_USER_PATH", str(_USER_DIR))
+
+from Ankimon.services import services  # noqa: E402
+from Ankimon.pyobj.database_manager import AnkimonDB  # noqa: E402
+from Ankimon.pyobj import ankimon_sync as asy  # noqa: E402
+
+
+class _Logger:
+    def log(self, *a, **k): pass
+    def game_log(self, *a, **k): pass
+    def log_and_showinfo(self, *a, **k): pass
+
+
+class _Settings:
+    def __init__(self, d=None):
+        self.d = dict(d or {})
+
+    def get(self, key, default=None):
+        return self.d.get(key, default)
+
+    def set(self, key, value):
+        self.d[key] = value
+
+
+class _FakeCol:
+    """Stand-in for mw.col carrying the revlog rows the detector reads."""
+
+    def __init__(self, review_ids):
+        rows = [(rid, 1000 + rid, 3, 10000, 1) for rid in review_ids]
+        maxid = max(review_ids, default=0)
+
+        class _DB:
+            def all(self, _q, watermark):
+                return [r for r in rows if r[0] > watermark]
+
+            def scalar(self, _q):
+                return maxid
+
+            def list(self, _q, *cids):
+                return []
+
+        self.db = _DB()
+
+
+@pytest.fixture
+def wired(tmp_path, monkeypatch):
+    """AnkimonDB + fake col on the seam, a captured sync-finish hook, stub deps."""
+    db = AnkimonDB(_Logger(), db_path=str(tmp_path / "ankimon.db"))
+    prev_db, prev_col = services.db, services.col
+    services.db = db
+
+    # Route the module-level user_path (dev-db probe) at this test's scratch dir.
+    monkeypatch.setattr(asy, "user_path", tmp_path, raising=False)
+
+    # Stub the sibling leaves the hook lazily imports so the heavy real modules
+    # (menu_buttons pulls in markdown/Qt) stay out of the Qt-free Tier-1 venv.
+    badge = types.ModuleType("Ankimon.menu_buttons")
+    badge.update_mobile_badge = lambda *a, **k: None
+    monkeypatch.setitem(sys.modules, "Ankimon.menu_buttons", badge)
+
+    mock_bridge = MagicMock()
+    mock_bridge.resolveAll.return_value = {
+        "success": True, "resolved": 3, "xp_gained": 100, "cash_gained": 50,
+        "caught_list": [{"name": "Pikachu"}],
+    }
+    shop_stub = types.ModuleType("Ankimon.ankimon_items_web.shop_obj")
+    shop_stub.MobileBridge = lambda *a, **k: mock_bridge
+    monkeypatch.setitem(sys.modules, "Ankimon.ankimon_items_web.shop_obj", shop_stub)
+
+    tooltip = MagicMock()
+    monkeypatch.setattr(asy, "tooltip", tooltip, raising=False)
+
+    def build(review_ids, resolution_mode="manual", mobile_enabled=True):
+        services.col = _FakeCol(review_ids)
+        settings = _Settings({
+            "misc.ankiweb_sync": True,
+            "mobile.enabled": mobile_enabled,
+            "mobile.resolution_mode": resolution_mode,
+        })
+        # Capture through ankimon_sync's OWN gui_hooks reference: another test
+        # module may have swapped sys.modules["aqt"] for a fresh MagicMock, so a
+        # local ``from aqt import gui_hooks`` could resolve to a different object
+        # than the one setup_ankimon_sync_hooks appends to.
+        asy.gui_hooks.sync_did_finish = MagicMock()
+        asy.setup_ankimon_sync_hooks(settings, _Logger())
+        return asy.gui_hooks.sync_did_finish.append.call_args[0][0]
+
+    try:
+        yield db, build, tooltip, mock_bridge
+    finally:
+        services.db, services.col = prev_db, prev_col
+
+
+def test_manual_mode_queues_and_notifies(wired):
+    db, build, tooltip, mock_bridge = wired
+    hook = build([1, 2, 3, 4, 5], resolution_mode="manual")
+    hook()
+    # Reviews were queued into the real DB and the watermark advanced.
+    assert db.get_pending_mobile_count() == 5
+    assert db.get_mobile_watermark() == 5
+    # Manual mode does not auto-resolve.
+    assert not mock_bridge.resolveAll.called
+    tooltip.assert_called_with(
+        "⚔ Mobile/web reviews synced: 5 in Normal! Open Ankimon → Mobile & Web Reviews to resolve."
+    )
+
+
+def test_auto_mode_resolves_via_bridge(wired):
+    db, build, tooltip, mock_bridge = wired
+    hook = build([1, 2, 3], resolution_mode="auto")
+    hook()
+    assert mock_bridge.resolveAll.called
+    tooltip.assert_called_with(
+        "⚔ Auto-resolved 3 mobile/web reviews! +100 XP, +50¥. Caught: Pikachu."
+    )
+
+
+def test_disabled_skips_detection(wired):
+    db, build, tooltip, mock_bridge = wired
+    hook = build([1, 2, 3], resolution_mode="auto", mobile_enabled=False)
+    hook()
+    assert db.get_pending_mobile_count() == 0
+    assert not mock_bridge.resolveAll.called
+    assert not tooltip.called
+
+
+def test_no_new_reviews_no_notify(wired):
+    db, build, tooltip, mock_bridge = wired
+    # Watermark already at the max revlog id -> nothing new to queue.
+    db.set_mobile_watermark(3)
+    hook = build([1, 2, 3], resolution_mode="manual")
+    hook()
+    assert db.get_pending_mobile_count() == 0
+    assert not tooltip.called

--- a/tests/test_mobile_replay.py
+++ b/tests/test_mobile_replay.py
@@ -1,0 +1,138 @@
+"""Tier-1 seam tests for single-battle mobile resolution (F14 replay path).
+
+Covers the DB-backed dequeue semantics behind ``MobileBridge.resolveNext`` and
+the engine's ``resolve_next`` empty-queue contract, all through the service seam
+and without a real Anki/Qt runtime.
+"""
+
+import os
+import sys
+import time
+import types
+import tempfile
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+_SRC = Path(__file__).resolve().parent.parent / "src"
+
+for _name in (
+    "aqt", "aqt.qt", "aqt.utils", "aqt.gui_hooks", "aqt.operations",
+    "aqt.theme", "aqt.sound", "aqt.webview", "aqt.main",
+    "anki", "anki.hooks", "anki.collection", "anki.utils",
+    "PyQt6", "PyQt6.QtGui", "PyQt6.QtWidgets", "PyQt6.QtCore",
+    "PyQt6.QtWebChannel", "PyQt6.QtWebEngineWidgets",
+):
+    sys.modules.setdefault(_name, MagicMock())
+
+for _pkg in ("Ankimon", "Ankimon.functions", "Ankimon.pyobj", "Ankimon.ankimon_items_web"):
+    _existing = sys.modules.get(_pkg)
+    if _existing is None or not hasattr(_existing, "__path__"):
+        _mod = types.ModuleType(_pkg)
+        _mod.__path__ = [str(_SRC / _pkg.replace(".", "/"))]
+        _mod.__package__ = _pkg
+        sys.modules[_pkg] = _mod
+
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+_USER_DIR = Path(tempfile.mkdtemp(prefix="ankimon_replay_ut_"))
+os.environ.setdefault("ANKIMON_USER_PATH", str(_USER_DIR))
+
+from Ankimon.services import services  # noqa: E402
+from Ankimon.functions import mobile_sync as ms  # noqa: E402
+from Ankimon.pyobj.database_manager import AnkimonDB  # noqa: E402
+
+
+class _Logger:
+    def log(self, *a, **k): pass
+    def game_log(self, *a, **k): pass
+    def log_and_showinfo(self, *a, **k): pass
+
+
+class _Settings:
+    def __init__(self, d=None):
+        self.d = dict(d or {})
+
+    def get(self, key, default=None):
+        return self.d.get(key, default)
+
+    def set(self, key, value):
+        self.d[key] = value
+
+
+@pytest.fixture
+def mobile_db(tmp_path):
+    db = AnkimonDB(_Logger(), db_path=str(tmp_path / "ankimon.db"))
+    prev_db, prev_col = services.db, services.col
+    services.db = db
+    services.col = None
+    ms.clear_desktop_session()
+    try:
+        yield db
+    finally:
+        ms.clear_desktop_session()
+        services.db, services.col = prev_db, prev_col
+        try:
+            db.close()
+        except Exception:
+            pass
+
+
+def _seed(db, n):
+    now = int(time.time() * 1000)
+    db.queue_mobile_battles([
+        {"id": now + i, "cid": 1000 + i, "ease": 3, "time": 5000, "type": 1}
+        for i in range(n)
+    ])
+
+
+def test_resolve_next_marks_one_batch_resolved(mobile_db):
+    """A single dequeue-of-two resolves exactly two reviews, leaving the rest."""
+    db = mobile_db
+    _seed(db, 6)  # cards_per_round default 2 -> 3 encounters
+    batch = db.get_next_pending_mobile_batch(limit=2)
+    assert len(batch) == 2
+    for row in batch:
+        db.mark_mobile_battle_resolved(row["queue_id"])
+    assert db.get_pending_mobile_count() == 4
+
+
+def test_pending_count_decrements_each_resolve(mobile_db):
+    db = mobile_db
+    _seed(db, 4)
+    for _ in range(2):
+        batch = db.get_next_pending_mobile_batch(limit=2)
+        if not batch:
+            break
+        for row in batch:
+            db.mark_mobile_battle_resolved(row["queue_id"])
+    assert db.get_pending_mobile_count() == 0
+
+
+def test_resolved_flag_persists_and_batch_skips_resolved(mobile_db):
+    db = mobile_db
+    _seed(db, 3)
+    first = db.get_next_pending_mobile_batch(limit=1)[0]
+    db.mark_mobile_battle_resolved(first["queue_id"])
+    # a resolved row is never handed out again
+    remaining = db.get_next_pending_mobile_batch(limit=10)
+    assert first["revlog_id"] not in [r["revlog_id"] for r in remaining]
+    assert len(remaining) == 2
+
+
+def test_resolve_next_returns_done_when_empty(mobile_db):
+    """The engine's public resolve_next contract: empty queue -> {'done': True}."""
+    db = mobile_db
+    result = ms.resolve_next(
+        companion_id="",
+        db=db,
+        settings_obj=_Settings({"battle.cards_per_round": 2}),
+        tracker=None,
+        trainer_card=None,
+        main_pokemon=None,
+        logger=_Logger(),
+        day_cutoff=1,  # non-zero so the mw.col scheduler lookup is skipped
+    )
+    assert result == {"done": True}

--- a/tests/test_mobile_sync.py
+++ b/tests/test_mobile_sync.py
@@ -1,0 +1,308 @@
+"""Tier-1 seam tests for the Mobile & Web Reviews sync engine (F14/F25/F29).
+
+These exercise the mobile-review backend through the service seam (``services``
++ ``events``) rather than exp's direct ``aqt.mw.*`` access:
+
+* the deferred ``AnkimonDB`` mobile accessors (watermark / queue / history /
+  cross-DB resolution sync);
+* the desktop-session bookkeeping + revlog detection + post-sync queueing
+  pipeline;
+* the pure helpers (``_parse_cards_per_round`` / ``_normalize_ev_yield``);
+* ``menu_buttons.update_mobile_badge`` as a guarded no-op before F36 builds the
+  menu action.
+
+The engine imports are stdlib-only at module load, so this runs Qt-free in the
+Tier-1 venv; ``aqt`` / ``anki`` / ``PyQt6`` are stubbed so any lazy import of a
+sibling module resolves without a real Anki/Qt runtime.
+"""
+
+import os
+import sys
+import types
+import tempfile
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+# --- Tier-1 bootstrap: real addon modules, faked Anki/Qt runtime ------------
+_SRC = Path(__file__).resolve().parent.parent / "src"
+
+for _name in (
+    "aqt", "aqt.qt", "aqt.utils", "aqt.gui_hooks", "aqt.operations",
+    "aqt.theme", "aqt.sound", "aqt.webview", "aqt.main",
+    "anki", "anki.hooks", "anki.collection", "anki.utils",
+    "PyQt6", "PyQt6.QtGui", "PyQt6.QtWidgets", "PyQt6.QtCore",
+    "PyQt6.QtWebChannel", "PyQt6.QtWebEngineWidgets",
+):
+    sys.modules.setdefault(_name, MagicMock())
+
+for _pkg in ("Ankimon", "Ankimon.functions", "Ankimon.pyobj", "Ankimon.ankimon_items_web"):
+    _existing = sys.modules.get(_pkg)
+    if _existing is None or not hasattr(_existing, "__path__"):
+        _mod = types.ModuleType(_pkg)
+        _mod.__path__ = [str(_SRC / _pkg.replace(".", "/"))]
+        _mod.__package__ = _pkg
+        sys.modules[_pkg] = _mod
+
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+# Point the DB layer's user_path at a scratch dir before it is imported.
+_USER_DIR = Path(tempfile.mkdtemp(prefix="ankimon_mobile_ut_"))
+os.environ.setdefault("ANKIMON_USER_PATH", str(_USER_DIR))
+
+from Ankimon.services import services  # noqa: E402
+from Ankimon.functions import mobile_sync as ms  # noqa: E402
+from Ankimon.pyobj.database_manager import AnkimonDB  # noqa: E402
+
+
+class _Logger:
+    def log(self, *a, **k): pass
+    def game_log(self, *a, **k): pass
+    def log_and_showinfo(self, *a, **k): pass
+
+
+class _Settings:
+    def __init__(self, d=None):
+        self.d = dict(d or {})
+
+    def get(self, key, default=None):
+        return self.d.get(key, default)
+
+    def set(self, key, value):
+        self.d[key] = value
+
+
+@pytest.fixture
+def mobile_db(tmp_path):
+    """Fresh AnkimonDB wired into the service seam; state reset afterwards."""
+    db = AnkimonDB(_Logger(), db_path=str(tmp_path / "ankimon.db"))
+    prev_db, prev_col = services.db, services.col
+    services.db = db
+    services.col = None
+    ms.clear_desktop_session()
+    try:
+        yield db, tmp_path
+    finally:
+        ms.clear_desktop_session()
+        services.db, services.col = prev_db, prev_col
+        try:
+            db.close()
+        except Exception:
+            pass
+
+
+# --- DB mobile accessors ----------------------------------------------------
+
+def test_watermark_get_set_defaults_to_zero(mobile_db):
+    db, _ = mobile_db
+    assert db.get_mobile_watermark() == 0
+    db.set_mobile_watermark(123456)
+    assert db.get_mobile_watermark() == 123456
+
+
+def test_queue_dedup_and_pending_count(mobile_db):
+    db, _ = mobile_db
+    reviews = [
+        {"id": 101, "cid": 1001, "ease": 3, "time": 15000, "type": 1},
+        {"id": 102, "cid": 1002, "ease": 2, "time": 20000, "type": 2},
+    ]
+    assert db.queue_mobile_battles(reviews) == 2
+    assert db.get_pending_mobile_count() == 2
+    # revlog_id is UNIQUE -> a re-queue of the same ids inserts nothing.
+    assert db.queue_mobile_battles(reviews) == 0
+    assert db.get_pending_mobile_count() == 2
+
+
+def test_next_batch_ordering_and_mark_resolved(mobile_db):
+    db, _ = mobile_db
+    db.queue_mobile_battles([
+        {"id": 205, "cid": 1, "ease": 3, "time": 1, "type": 1},
+        {"id": 101, "cid": 2, "ease": 3, "time": 1, "type": 1},
+    ])
+    # oldest-first == lowest revlog_id first
+    batch = db.get_next_pending_mobile_batch(limit=1)
+    assert len(batch) == 1
+    assert batch[0]["revlog_id"] == 101
+
+    db.mark_mobile_battle_resolved(batch[0]["queue_id"])
+    assert db.get_pending_mobile_count() == 1
+    remaining = db.get_next_pending_mobile_batch(limit=10)
+    assert [r["revlog_id"] for r in remaining] == [205]
+
+
+def test_get_next_batch_empty(mobile_db):
+    db, _ = mobile_db
+    assert db.get_next_pending_mobile_batch(limit=5) == []
+
+
+# --- Cross-DB resolution sync ----------------------------------------------
+
+def test_cross_db_resolution_sync(mobile_db, monkeypatch):
+    db, tmp_path = mobile_db
+    # Route the "other DB" lookup at this test's scratch dir. Patch the module
+    # globals the method actually reads (another test may have loaded a second
+    # copy of database_manager into sys.modules, so patch via the class method).
+    monkeypatch.setitem(
+        AnkimonDB.sync_resolutions_to_other_db.__globals__, "user_path", tmp_path
+    )
+
+    other = tmp_path / "ankimonDEV.db"
+    import sqlite3
+    conn = sqlite3.connect(str(other))
+    conn.execute(
+        """CREATE TABLE pending_mobile_battles (
+               id INTEGER PRIMARY KEY AUTOINCREMENT,
+               revlog_id INTEGER UNIQUE NOT NULL, card_id INTEGER NOT NULL,
+               ease INTEGER NOT NULL, review_time INTEGER NOT NULL,
+               review_type INTEGER NOT NULL, queued_at INTEGER NOT NULL,
+               resolved INTEGER NOT NULL DEFAULT 0, resolved_at INTEGER)"""
+    )
+    conn.execute(
+        "INSERT INTO pending_mobile_battles (revlog_id, card_id, ease, review_time, review_type, queued_at) "
+        "VALUES (777, 1, 3, 1, 1, 1)"
+    )
+    conn.commit()
+    conn.close()
+
+    db.sync_resolutions_to_other_db([777], resolved_at=999)
+
+    conn = sqlite3.connect(str(other))
+    row = conn.execute("SELECT resolved, resolved_at FROM pending_mobile_battles WHERE revlog_id=777").fetchone()
+    conn.close()
+    assert row == (1, 999)
+
+
+# --- History table ----------------------------------------------------------
+
+def test_history_add_get_clear_and_none_safety(mobile_db):
+    db, _ = mobile_db
+    assert db.get_mobile_history() == []
+    # companion_* None and a missing xp_gained must not crash the insert.
+    ok = db.add_mobile_history_entry({
+        "timestamp": 10, "enemy_id": 25, "enemy_name": "Pikachu",
+        "enemy_level": 5, "enemy_shiny": True, "companion_name": None,
+        "companion_level": None, "outcome": "caught",
+    })
+    assert ok is True
+    hist = db.get_mobile_history()
+    assert len(hist) == 1
+    assert hist[0]["enemy_name"] == "Pikachu"
+    assert hist[0]["enemy_shiny"] is True
+    assert hist[0]["xp_gained"] == 0
+    assert db.clear_mobile_history() is True
+    assert db.get_mobile_history() == []
+
+
+def test_history_trims_to_500(mobile_db):
+    db, _ = mobile_db
+    entries = [
+        {"timestamp": i, "enemy_id": i, "enemy_name": f"e{i}", "enemy_level": 1,
+         "enemy_shiny": False, "outcome": "defeated", "xp_gained": 1}
+        for i in range(520)
+    ]
+    assert db.add_mobile_history_entries_batch(entries) is True
+    hist = db.get_mobile_history(limit=1000)
+    assert len(hist) == 500
+    # Newest kept, oldest trimmed.
+    assert hist[0]["timestamp"] == 519
+    assert min(h["timestamp"] for h in hist) == 20
+
+
+# --- Desktop-session bookkeeping + watermark ------------------------------
+
+def test_record_desktop_review_tracks_session_and_advances_watermark(mobile_db):
+    db, _ = mobile_db
+    db.set_mobile_watermark(1000)
+    ms.record_desktop_review(500)          # below watermark -> no advance
+    ms.record_desktop_review(1500)         # above watermark -> durable advance
+    assert ms.get_desktop_session_revlog_ids() == frozenset({500, 1500})
+    assert db.get_mobile_watermark() == 1500
+    ms.clear_desktop_session()
+    assert ms.get_desktop_session_revlog_ids() == frozenset()
+
+
+def test_get_desktop_session_resolves_card_ids_via_col(mobile_db):
+    db, _ = mobile_db
+    ms.record_desktop_review(0, card_id=42)   # revlog_id falsy -> only card recorded
+
+    class _Col:
+        class db:
+            @staticmethod
+            def list(q, *cids):
+                return [9001] if 42 in cids else []
+
+    ids = ms.get_desktop_session_revlog_ids(_Col())
+    assert 9001 in ids
+
+
+# --- detect / process pipeline ---------------------------------------------
+
+class _FakeCol:
+    """Minimal stand-in for mw.col with just the revlog queries the engine uses."""
+
+    def __init__(self, rows):
+        self._rows = rows  # list of (id, cid, ease, time, type)
+        outer = self
+
+        class _DB:
+            def all(self, _q, watermark):
+                return [r for r in outer._rows if r[0] > watermark]
+
+            def scalar(self, _q):
+                return max((r[0] for r in outer._rows), default=0)
+
+        self.db = _DB()
+
+
+def test_detect_mobile_reviews_filters_watermark_and_session():
+    col = _FakeCol([(10, 1, 3, 100, 1), (20, 2, 2, 200, 1), (30, 3, 4, 300, 0)])
+    result = ms.detect_mobile_reviews(col, watermark_ms=5, desktop_revlog_ids=frozenset({20}))
+    # > watermark AND not in the desktop session set.
+    assert [r["id"] for r in result] == [10, 30]
+
+
+def test_process_mobile_reviews_queues_and_advances_watermark(mobile_db):
+    db, _ = mobile_db
+    col = _FakeCol([(11, 1, 3, 100, 1), (22, 2, 2, 200, 1), (33, 3, 4, 300, 0)])
+    queued = ms.process_mobile_reviews_after_sync(col, db, _Settings({"mobile.enabled": True}), _Logger())
+    assert queued == 3
+    assert db.get_pending_mobile_count() == 3
+    assert db.get_mobile_watermark() == 33
+
+
+def test_process_respects_mobile_disabled(mobile_db):
+    db, _ = mobile_db
+    col = _FakeCol([(11, 1, 3, 100, 1)])
+    assert ms.process_mobile_reviews_after_sync(col, db, _Settings({"mobile.enabled": False}), _Logger()) == 0
+    assert db.get_pending_mobile_count() == 0
+
+
+def test_process_applies_queue_cap(mobile_db, monkeypatch):
+    db, _ = mobile_db
+    monkeypatch.setattr(ms, "MOBILE_QUEUE_CAP", 2)
+    col = _FakeCol([(1, 1, 3, 1, 1), (2, 2, 3, 1, 1), (3, 3, 3, 1, 1)])
+    queued = ms.process_mobile_reviews_after_sync(col, db, _Settings({"mobile.enabled": True}), _Logger())
+    # cap keeps the most recent 2 (highest ids).
+    assert queued == 2
+    batch = db.get_next_pending_mobile_batch(limit=10)
+    assert sorted(r["revlog_id"] for r in batch) == [2, 3]
+
+
+# --- Pure helpers -----------------------------------------------------------
+
+@pytest.mark.parametrize("value,expected", [
+    (4, 4),
+    ("3", 3),
+    ("1-3", 2),
+    (None, 2),
+])
+def test_parse_cards_per_round(value, expected):
+    settings = _Settings({"battle.cards_per_round": value}) if value is not None else None
+    assert ms._parse_cards_per_round(settings)[0] == expected
+
+
+def test_normalize_ev_yield_renames_keys():
+    assert ms._normalize_ev_yield({"attack": 4, "speed": 2, "hp": 1}) == {"atk": 4, "spe": 2, "hp": 1}
+    assert ms._normalize_ev_yield({}) == {}


### PR DESCRIPTION
## What
Ports the **Mobile & Web Reviews subsystem** — the integration's largest single feature — onto the tip. Reviews done on AnkiMobile/AnkiWeb (where the add-on can't run) are detected after sync, queued, and replayed into battles on desktop: XP/EV attribution, companion healing, evolutions, level-ups, catches. Bundles four inventory rows into one coherent subsystem, decomposed into 6 commits:

- **F25 (db accessors)** — `pyobj/database_manager.py`: adds the deferred mobile accessor methods (`get/set_mobile_watermark`, `queue_mobile_battles`, `get_pending_mobile_count`, `get_next_pending_mobile_batch`, `mark_mobile_battle_resolved`, `add_mobile_history`, `sync_resolutions_to_other_db`) on top of the already-present `pending_mobile_battles`/`mobile_battle_history` tables. Main's `set_config_value`/`reset_db`/`rate_this` untouched.
- **F14 (engine)** — `functions/mobile_sync.py` (~2087 lines): the offline-review resolution engine.
- **F15 (screens)** — `ankimon_mobile_web/{mobile,history}.{html,js,css}`: the web-shell Mobile & History screens (reuse the host's nav/shop CSS).
- **F29 (sync hook)** — `pyobj/ankimon_sync.py`: dual-DB mobile detection/queue block inside `on_sync_did_finish`.
- **F20b (bootstrap)** — `profile_hooks.py`: the mobile watermark/session/badge bootstrap (the half intentionally deferred out of #562).
- **F14 (badge)** — `menu_buttons.py`: a guarded `update_mobile_badge` (safe no-op until the menu is built by F36).

## Seam re-fit
`mw.ankimon_db → services.db`, `mw.achievements_dict → services.achievements`, `mw.main_pokemon → services.main_pokemon`, `mw.logger → services.logger`. `QueryOp(parent=mw)` (async commit) and the guarded `mw.col.sched.day_cutoff` fallback stay direct (genuine Anki APIs). The engine's background-thread work touches only disk/DB/CPU and commits via `QueryOp` — thread-safety preserved. `shop_obj.py` is **not modified**: the host's `MobileBridge` lazy-imports `mobile_sync` and now resolves the real engine instead of its benign fallback.

## Guards preserved (per inventory rows)
- Main's dual-DB stat region in `ankimon_sync.py` (`get_db_stats`, ImprovedPokemonDataSync) preserved — the mobile block is additive.
- XP-share None-checks (`xp_share_gain_exp` / trade-away) carried intact; encounter level-cap NameError guard (#402) via the ported `encounter_functions` callees; EV-yield None/limit hardening via `utils.limit_ev_yield` + `_normalize_ev_yield`.
- `update_mobile_badge` no-ops safely without the pokemenu; F20 cache-clear hook and main's connectivity/monthly/changelog structure untouched.

## Verification
Two-tier gate on the branch tip (adversarial verifier **and** Fable final check):
- compileall clean; ruff (`ci_ruff_check.toml`) = 10 pre-existing known-debt errors only.
- pytest Tier-1: **402 passed / 0 failed** / 55 skipped (+26 new mobile tests: sync, replay, auto-resolve).
- harness 9/9; Qt smoke+integrity 5 passed; probe_real_boot OK (reviewer hooks == 3 — the `sync_did_finish` hook registers without perturbing the reviewer hooks); probe_real_play OK.

## Attribution
Originally implemented by @hakimh2 on BRRRR_Experimental; credited via Co-authored-by trailer. The broken `Your Name <you@example.com>` identity maps to Hakimh2.
