### PR TITLE
feat: team deck-overview grid backed by AnkimonDB + reload-safe hook registration (F19)

### DIFF
--- a/src/Ankimon/__init__.py
+++ b/src/Ankimon/__init__.py
@@ -66,9 +66,12 @@ from .events import events
 # once menu_buttons stops building its own translator.
 mw.translator = translator
 
-# Importing overview_team registers its deck-browser/overview hooks exactly
-# once, at module scope, gated by the gui.team_deck_view setting.
-from .gui_classes import overview_team
+# Deck-browser / deck-overview team grid (F19). Registration is gated on the
+# gui.team_deck_view setting and reload-safe (F31 registry-anchored record on
+# services), so an add-on reload swaps the handlers instead of stacking them.
+from .gui_classes.overview_team import register_overview_hooks
+
+register_overview_hooks()
 
 # --- Startup readiness flag (F32 async boot) ---
 # Expressed on the services registry (not mw): reviews that arrive before the

--- a/src/Ankimon/gui_classes/overview_team.py
+++ b/src/Ankimon/gui_classes/overview_team.py
@@ -356,7 +356,10 @@ def load_pokemon_team() -> list[dict[str, Any]]:
 
         # Final fallback: return every Pokémon from mypokemon.json.
         with open(mypokemon_path, "r", encoding="utf-8") as fh:
-            return json.load(fh)[:_MAX_TEAM_SIZE]
+            all_pokemon = json.load(fh)
+        if isinstance(all_pokemon, list):
+            return [p for p in all_pokemon if isinstance(p, dict)][:_MAX_TEAM_SIZE]
+        return []
     except (OSError, json.JSONDecodeError, TypeError):
         # I/O / parse / non-list-slice errors during the final fallback.
         return []

--- a/src/Ankimon/gui_classes/overview_team.py
+++ b/src/Ankimon/gui_classes/overview_team.py
@@ -6,16 +6,20 @@ Deck Overview pages via ``gui_hooks``.
 
 Key public components:
 
-* :func:`load_pokemon_team` — reads ``team.json`` / ``mypokemon.json`` and
-  returns an ordered list of Pokémon dictionaries.
+* :func:`load_pokemon_team` — reads from AnkimonDB via the ``services.db``
+  seam and falls back to ``team.json`` / ``mypokemon.json``, returning an
+  ordered list of Pokémon dictionaries.
 * :func:`deck_browser_will_render` — hook callback that prepends the grid
   to the Deck Browser stats area.
 * :func:`on_overview_will_render_content` — hook callback that prepends the
   grid to the Deck Overview table area.
+* :func:`register_overview_hooks` — registers the two hook callbacks above.
 
-Hook registration is performed at **import time** and is gated behind the
-``gui.team_deck_view`` user setting.  Toggling the setting therefore requires
-an Anki restart to take effect.
+Hook registration is performed by :func:`register_overview_hooks`, invoked
+once from the add-on's composition root (``__init__.py``) and gated behind the
+``gui.team_deck_view`` user setting.  The (hook, handler) record lives on the
+``services`` registry, so an add-on reload swaps the handlers rather than
+stacking a duplicate set (F31 reload-safety).
 
 Note:
     Sprites are embedded as base64 data-URIs so the generated HTML is fully
@@ -28,11 +32,12 @@ import json
 import os
 from typing import Any
 
-from aqt import gui_hooks, mw
+from aqt import gui_hooks
 
 from ..business import calculate_cp_from_dict
 from ..functions.sprite_functions import get_sprite_path
 from ..resources import mypokemon_path, icon_path as pokeball_path, team_pokemon_path
+from ..services import services
 from ..utils import png_to_base64
 
 # ---------------------------------------------------------------------------
@@ -215,9 +220,11 @@ def _build_card_html(pokemon: dict[str, Any], id_prefix: str) -> str:
     Returns:
         An HTML string representing one ``.poke-item`` element.
     """
+    from ..functions.pokedex_functions import format_lore_name
+
     name = pokemon.get("name", "Unknown")
     nickname = pokemon.get("nickname", "")
-    display_name = nickname or name
+    display_name = nickname or format_lore_name(name)
     level = pokemon.get("level", 1)
     gender = pokemon.get("gender", "M")
     current_hp = pokemon.get("current_hp", 0)
@@ -232,6 +239,7 @@ def _build_card_html(pokemon: dict[str, Any], id_prefix: str) -> str:
         pokemon.get("id", 132),
         pokemon.get("shiny", False),
         gender,
+        pokemon.get("name"),
     )
     sprite_src = png_to_base64(sprite_path)
 
@@ -267,58 +275,93 @@ def load_pokemon_team() -> list[dict[str, Any]]:
 
     Resolution order:
 
-    1. If ``team.json`` exists, read the ordered ``individual_id`` values,
-       resolve each against ``mypokemon.json``, and return the matching
-       Pokémon in team order (skipping any unresolved entries).
-    2. If ``team.json`` is absent **or** resolution yields an empty list,
-       fall back to the full contents of ``mypokemon.json``.
-    3. On any I/O or parse error, return an empty list (never raises).
+    1. Priority: query AnkimonDB (SQLite) through the ``services.db`` seam.
+       Active team entries are resolved by ``individual_id``; when the team is
+       empty the first available Pokémon in the collection are used instead.
+       A DB error falls through to the legacy JSON path rather than raising.
+    2. Legacy fallback: if ``team.json`` exists, read the ordered
+       ``individual_id`` values, resolve each against ``mypokemon.json``, and
+       return the matching Pokémon in team order (skipping unresolved entries).
+    3. Final fallback: return the full contents of ``mypokemon.json``.
+    4. On any DB, I/O, or parse error, return an empty list (never raises).
 
     Returns:
-        Ordered list of Pokémon dictionaries (`list[dict[str, Any]]`).
-        May be empty when no data files exist or parsing fails.
+        Ordered list of Pokémon dictionaries (`list[dict[str, Any]]`), capped
+        at :data:`_MAX_TEAM_SIZE`.  May be empty when no data exists or parsing
+        fails.
     """
     try:
+        # Priority: AnkimonDB (SQLite) through the services.db seam. Any DB
+        # hiccup is swallowed here so it can never crash the Deck Browser —
+        # execution then falls through to the legacy JSON path below.
+        db = services.db
+        if db is not None:
+            try:
+                team_stub = db.get_team()
+                if team_stub:
+                    team: list[dict[str, Any]] = []
+                    for entry in team_stub:
+                        ind_id = (
+                            entry.get("individual_id")
+                            if isinstance(entry, dict)
+                            else None
+                        )
+                        if ind_id:
+                            pokemon = db.get_pokemon(ind_id)
+                            if pokemon:
+                                team.append(pokemon)
+                    if team:
+                        return team[:_MAX_TEAM_SIZE]
+
+                all_pokemon = db.get_all_pokemon()
+                if all_pokemon:
+                    return all_pokemon[:_MAX_TEAM_SIZE]
+            except Exception as e:
+                print(f"Ankimon Team Overview - DB Error: {e}")
+
+        # Legacy JSON fallback: resolve team.json order against mypokemon.json.
         if os.path.exists(team_pokemon_path):
             try:
                 with open(team_pokemon_path, "r", encoding="utf-8") as fh:
                     team_entries = json.load(fh)
+                if not isinstance(team_entries, list):
+                    team_entries = []
             except (json.JSONDecodeError, OSError):
                 team_entries = []
 
             individual_ids = [
                 entry.get("individual_id")
                 for entry in team_entries
-                if entry.get("individual_id") is not None
+                if isinstance(entry, dict) and entry.get("individual_id") is not None
             ]
 
             try:
                 with open(mypokemon_path, "r", encoding="utf-8") as fh:
                     all_pokemon = json.load(fh)
+                if not isinstance(all_pokemon, list):
+                    all_pokemon = []
             except (json.JSONDecodeError, OSError):
                 all_pokemon = []
 
             pokemon_by_id = {
                 p.get("individual_id"): p
                 for p in all_pokemon
-                if p.get("individual_id") is not None
+                if isinstance(p, dict) and p.get("individual_id") is not None
             }
             ordered = [
                 pokemon_by_id[ind] for ind in individual_ids if ind in pokemon_by_id
             ]
             if ordered:
-                return ordered
+                return ordered[:_MAX_TEAM_SIZE]
 
-        # Fallback: return every Pokémon from mypokemon.json.
+        # Final fallback: return every Pokémon from mypokemon.json.
         with open(mypokemon_path, "r", encoding="utf-8") as fh:
-            return json.load(fh)
-    except (OSError, json.JSONDecodeError):
-        # Fallback for I/O or parse errors during the final fallback attempt.
+            return json.load(fh)[:_MAX_TEAM_SIZE]
+    except (OSError, json.JSONDecodeError, TypeError):
+        # I/O / parse / non-list-slice errors during the final fallback.
         return []
     except Exception as e:
         # Unexpected errors are logged but not allowed to crash Anki's UI.
-        # mw.progress has no chrome_logger attribute — the previous call
-        # would raise AttributeError and mask the original exception.
         print(f"Ankimon Team Overview Error: {e}")
         return []
 
@@ -384,9 +427,41 @@ def on_overview_will_render_content(overview: Any, content: Any) -> None:
 
 
 # ---------------------------------------------------------------------------
-# Hook registration (runs at import time, gated by user setting)
+# Hook registration (reload-safe, gated by user setting)
 # ---------------------------------------------------------------------------
 
-if mw.settings_obj.get("gui.team_deck_view") is True:
-    gui_hooks.deck_browser_will_render_content.append(deck_browser_will_render)
-    gui_hooks.overview_will_render_content.append(on_overview_will_render_content)
+# Reload safety (F31): the (hook, handler) record lives on the services
+# registry — which, unlike a module-level flag, survives a re-execution of this
+# module (an add-on reload). It stores the exact handler objects appended, so a
+# second boot removes those originals before appending the reloaded module's
+# functions, swapping the registration instead of stacking a duplicate set.
+_HANDLER_RECORD = "_overview_team_hook_handlers"
+
+
+def register_overview_hooks() -> None:
+    """Register the Deck Browser / Deck Overview team-grid hooks.
+
+    Called once from the add-on's composition root (``__init__.py``). Gated on
+    the ``gui.team_deck_view`` setting and reload-safe via the services-anchored
+    ``_HANDLER_RECORD`` (see the module docstring). When the setting is off, any
+    previously registered handlers are still removed (so toggling off then
+    reloading clears the grid) but nothing new is appended.
+    """
+    # Drop any prior registration first. No-op on a first boot (no record); on a
+    # re-boot the stored pairs are removed so the appends below cannot
+    # double-register. gui_hooks' remove() tolerates already-absent callbacks.
+    for hook, handler in getattr(services, _HANDLER_RECORD, ()):
+        hook.remove(handler)
+    setattr(services, _HANDLER_RECORD, ())
+
+    settings = services.settings
+    if settings is None or settings.get("gui.team_deck_view") is not True:
+        return
+
+    handlers = (
+        (gui_hooks.deck_browser_will_render_content, deck_browser_will_render),
+        (gui_hooks.overview_will_render_content, on_overview_will_render_content),
+    )
+    for hook, handler in handlers:
+        hook.append(handler)
+    setattr(services, _HANDLER_RECORD, handlers)

--- a/tests/test_async_startup_boot.py
+++ b/tests/test_async_startup_boot.py
@@ -721,7 +721,8 @@ def boot_env(monkeypatch):
             "Ankimon.events", events=SimpleNamespace(emit=rec("events.emit"))
         ),
         "Ankimon.gui_classes.overview_team": _stub_module(
-            "Ankimon.gui_classes.overview_team"
+            "Ankimon.gui_classes.overview_team",
+            register_overview_hooks=rec("register_overview_hooks"),
         ),
         "Ankimon.card_hooks": _stub_module(
             "Ankimon.card_hooks",
@@ -776,7 +777,8 @@ def boot_env(monkeypatch):
         ),
     )
 
-    # `from .gui_classes import overview_team` resolves via the parent module.
+    # `from .gui_classes.overview_team import register_overview_hooks` resolves
+    # the submodule (stubbed above) via this parent package.
     gui_classes_pkg = _stub_module("Ankimon.gui_classes")
     gui_classes_pkg.overview_team = stubs["Ankimon.gui_classes.overview_team"]
     monkeypatch.setitem(sys.modules, "Ankimon.gui_classes", gui_classes_pkg)

--- a/tests/test_overview_team_reload_safe.py
+++ b/tests/test_overview_team_reload_safe.py
@@ -1,0 +1,183 @@
+"""Reload-safety contract for ``gui_classes/overview_team.py`` (F19).
+
+The team-overview grid used to register its Deck Browser / Deck Overview hooks
+at **import time**, gated by ``mw.settings_obj.get("gui.team_deck_view")``. That
+is an unguarded side-effect: a second execution of the module (an add-on reload
+in the same Anki session) would append the handlers a *second* time, so every
+Deck Browser render would inject the grid twice.
+
+The port moves registration into :func:`register_overview_hooks`, following the
+F31 registry-anchored guard idiom already used by ``card_hooks.py``: the exact
+``(hook, handler)`` pairs are recorded on the ``services`` registry (which
+survives a module re-exec), and each call removes the previously stored pairs
+before appending. A reload therefore *swaps* the handlers instead of stacking a
+duplicate set. Registration is gated on ``gui.team_deck_view`` and read through
+``services.settings`` rather than ``mw``.
+
+These tests exec the real module against a ``gui_hooks`` stub (plain lists, so
+an unmatched ``remove()`` would fail loudly) and a fresh, real ``services``
+registry — no Anki/Qt runtime required (Tier-1).
+"""
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+from types import SimpleNamespace
+
+_src = Path(__file__).parent.parent / "src"
+
+
+def _stub_module(name, **attrs):
+    mod = types.ModuleType(name)
+    for key, value in attrs.items():
+        setattr(mod, key, value)
+    return mod
+
+
+def _fresh_hooks():
+    """gui_hooks stub: plain lists, so an unmatched remove() would fail loudly."""
+    return SimpleNamespace(
+        deck_browser_will_render_content=[],
+        overview_will_render_content=[],
+    )
+
+
+def _counts(hooks):
+    return (
+        len(hooks.deck_browser_will_render_content),
+        len(hooks.overview_will_render_content),
+    )
+
+
+def _fresh_services(monkeypatch):
+    """Exec a fresh, REAL services registry (isolated from other tests)."""
+    spec = importlib.util.spec_from_file_location(
+        "Ankimon.services", _src / "Ankimon" / "services.py"
+    )
+    mod = importlib.util.module_from_spec(spec)
+    monkeypatch.setitem(sys.modules, "Ankimon.services", mod)
+    spec.loader.exec_module(mod)
+    return mod.services
+
+
+def _exec_overview_team(monkeypatch, hooks):
+    """Exec the real overview_team.py against a gui_hooks stub. Each call returns
+    a FRESH module object (fresh handler functions) — exactly what an add-on
+    reload produces — while ``Ankimon.services`` is left to the caller.
+
+    The module's leaf dependencies are stubbed so the import stays isolated and
+    Qt-free; only ``gui_hooks`` (via the aqt stub) and ``services`` are real
+    to the registration path under test.
+    """
+    monkeypatch.setitem(sys.modules, "aqt", _stub_module("aqt", gui_hooks=hooks))
+    monkeypatch.setitem(
+        sys.modules,
+        "Ankimon.business",
+        _stub_module("Ankimon.business", calculate_cp_from_dict=lambda p: 0),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "Ankimon.functions.sprite_functions",
+        _stub_module(
+            "Ankimon.functions.sprite_functions", get_sprite_path=lambda *a, **k: ""
+        ),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "Ankimon.resources",
+        _stub_module(
+            "Ankimon.resources",
+            mypokemon_path="mypokemon.json",
+            icon_path="pokeball.png",
+            team_pokemon_path="team.json",
+        ),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "Ankimon.utils",
+        _stub_module("Ankimon.utils", png_to_base64=lambda *a, **k: ""),
+    )
+
+    # Parent package so the dotted exec + relative imports resolve.
+    gui_classes_pkg = _stub_module("Ankimon.gui_classes")
+    gui_classes_pkg.__path__ = [str(_src / "Ankimon" / "gui_classes")]
+    monkeypatch.setitem(sys.modules, "Ankimon.gui_classes", gui_classes_pkg)
+
+    spec = importlib.util.spec_from_file_location(
+        "Ankimon.gui_classes.overview_team",
+        _src / "Ankimon" / "gui_classes" / "overview_team.py",
+    )
+    mod = importlib.util.module_from_spec(spec)
+    monkeypatch.setitem(sys.modules, "Ankimon.gui_classes.overview_team", mod)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _settings(value):
+    return SimpleNamespace(get=lambda key, default=None: value)
+
+
+def test_register_overview_hooks_is_idempotent(monkeypatch):
+    services = _fresh_services(monkeypatch)
+    services.settings = _settings(True)
+    hooks = _fresh_hooks()
+    mod = _exec_overview_team(monkeypatch, hooks)
+
+    mod.register_overview_hooks()
+    assert _counts(hooks) == (1, 1)
+
+    mod.register_overview_hooks()
+    assert _counts(hooks) == (1, 1), "second registration must not stack handlers"
+
+
+def test_register_overview_hooks_survives_module_reexec(monkeypatch):
+    """The F31 failure this guards: re-executing overview_team (an add-on
+    reload) creates NEW handler function objects, so a module-level flag would
+    reset and remove()-by-identity would miss the old handlers. The
+    registry-stored record must swap the handlers instead of stacking."""
+    services = _fresh_services(monkeypatch)
+    services.settings = _settings(True)
+    hooks = _fresh_hooks()
+
+    mod1 = _exec_overview_team(monkeypatch, hooks)
+    mod1.register_overview_hooks()
+    assert _counts(hooks) == (1, 1)
+
+    # Reload: fresh module + functions, same gui_hooks, surviving registry.
+    mod2 = _exec_overview_team(monkeypatch, hooks)
+    assert mod2.deck_browser_will_render is not mod1.deck_browser_will_render
+    mod2.register_overview_hooks()
+
+    assert _counts(hooks) == (1, 1), "reload must not stack handlers"
+    # The live handlers are the reloaded module's, not the stale first set.
+    assert hooks.deck_browser_will_render_content == [mod2.deck_browser_will_render]
+    assert hooks.overview_will_render_content == [mod2.on_overview_will_render_content]
+
+
+def test_register_overview_hooks_gated_off_clears_prior(monkeypatch):
+    """Toggling the setting off then re-registering (e.g. a reload) must remove
+    the previously registered handlers and append nothing new."""
+    services = _fresh_services(monkeypatch)
+    services.settings = _settings(True)
+    hooks = _fresh_hooks()
+    mod = _exec_overview_team(monkeypatch, hooks)
+
+    mod.register_overview_hooks()
+    assert _counts(hooks) == (1, 1)
+
+    services.settings = _settings(False)
+    mod.register_overview_hooks()
+    assert _counts(hooks) == (0, 0)
+
+
+def test_register_overview_hooks_no_settings_is_safe(monkeypatch):
+    """A missing settings service must not crash registration (defensive
+    None-guard); nothing is appended."""
+    services = _fresh_services(monkeypatch)
+    services.settings = None
+    hooks = _fresh_hooks()
+    mod = _exec_overview_team(monkeypatch, hooks)
+
+    mod.register_overview_hooks()  # must not raise
+    assert _counts(hooks) == (0, 0)


### PR DESCRIPTION
## What
Ports **F19** — the Team Deck-Overview grid backed by AnkimonDB (`gui_classes/overview_team.py`). `load_pokemon_team` now prefers `services.db` (`get_team`/`get_pokemon`/`get_all_pokemon`) with the legacy `team.json`/`mypokemon.json` JSON as fallback; the grid renders on the Deck Browser via `gui_hooks`.

## Seam + reload-safety
- `mw.ankimon_db → services.db`; `mw.settings_obj.get('gui.team_deck_view') → services.settings` (None-guarded); dropped the now-unused `mw` import (`gui_hooks` kept direct). `get_sprite_path` passes the name positional arg (main's sprite seam).
- **Import-time hook registration made reload-safe:** the old module-level `gui_hooks.deck_browser_will_render_content.append(...)` (double-registration on reload) is replaced by `register_overview_hooks()` called from `__init__.py` after `services` is populated, using the F31 registry-anchored remove-before-append guard (toggling the setting off + reload also clears the grid).

## Guards
Defensive `isinstance`/None fallbacks for legacy JSON (non-list/malformed entries coerced safely so the grid never crashes the Deck Browser); DB path wrapped in try/except that falls through to JSON; `_MAX_TEAM_SIZE` cap on every return path. +4 new Tier-1 reload-safety tests.

## Verification
compileall clean; ruff 10 pre-existing; Tier-1 **409 passed / 0 failed**; harness 9/9; Qt 5; probe_real_boot 3 hooks; probe_real_play OK. Adversarial verifier + Fable both signed off.

## Attribution
Originally implemented by @hakimh2 on BRRRR_Experimental; credited via Co-authored-by: Hakimh2.
