### PR TITLE
feat: dual-database (Normal/Dev) backup system (F27)

### DIFF
--- a/src/Ankimon/pyobj/backup_files.py
+++ b/src/Ankimon/pyobj/backup_files.py
@@ -4,13 +4,22 @@ from datetime import datetime
 import json
 from aqt.utils import showInfo
 from aqt import mw
+from ..services import services
 from ..resources import mypokemon_path, mainpokemon_path, itembag_path, badgebag_path, user_path_credentials, backup_root, user_path
 # Define backup directory and files to back up
 backup_folders = [os.path.join(backup_root, f"backup_{i}") for i in range(1, 4)]
-files_to_backup = [mypokemon_path, mainpokemon_path, itembag_path, badgebag_path, user_path_credentials, user_path / "ankimon.db"]  # Adjust as needed
+files_to_backup = [mypokemon_path, mainpokemon_path, itembag_path, badgebag_path, user_path_credentials, user_path / "ankimon.db", user_path / "ankimonDEV.db"]  # Adjust as needed
 
 def create_backup_folder(folder_path):
     """Creates a backup folder and places a timestamped text file inside."""
+    # Checkpoint the active database first so WAL frames are flushed to the
+    # main DB file before the single-file copy below.
+    if services.db is not None:
+        try:
+            services.db.execute("PRAGMA wal_checkpoint(TRUNCATE);")
+        except Exception:
+            pass
+
     os.makedirs(folder_path, exist_ok=True)
 
     # Create a timestamp file

--- a/src/Ankimon/pyobj/backup_manager.py
+++ b/src/Ankimon/pyobj/backup_manager.py
@@ -7,9 +7,9 @@ import datetime
 from pathlib import Path
 from typing import List, Dict, Any, Optional
 
-from aqt import mw
 from aqt.utils import showInfo, showWarning, askUser
 
+from ..services import services
 from ..utils import close_anki
 from ..resources import user_path, addon_dir
 
@@ -19,6 +19,7 @@ class BackupManager:
     _OBFUSCATION_KEY = "H0tP-!s-N0t-4-C@tG!rL_v2"
     FILES_TO_BACKUP = [
         "ankimon.db",
+        "ankimonDEV.db",
         # config.obf removed - now stored in ankimon.db
     ]
     MAX_BACKUPS = 5
@@ -37,7 +38,7 @@ class BackupManager:
         try:
             new_separator = "---DATA_START---"
             old_separator = "\n---"
-            
+
             if new_separator in obfuscated_str:
                 parts = obfuscated_str.split(new_separator)
                 obfuscated_data = parts[1]
@@ -58,30 +59,67 @@ class BackupManager:
             return None
 
     def get_backups(self) -> List[Dict[str, Any]]:
-        """Returns a list of available backups with their summary stats."""
+        """Returns a list of available backups with their summary stats.
+
+        Only backups that contain the database for the *currently active* mode
+        (normal ``ankimon.db`` vs developer ``ankimonDEV.db``) are shown, and the
+        per-DB stats section for the active mode is merged onto the root of the
+        summary so the dialog can read them without knowing about dual-DB.
+        """
         backups = []
+        active_db = services.db.db_path.name
         for backup_dir in sorted(self.backups_path.iterdir(), reverse=True):
             if backup_dir.is_dir():
+                # Only show a backup if it contains the database for the active mode.
+                if not (backup_dir / active_db).exists():
+                    continue
                 summary_path = backup_dir / "summary.json"
                 if summary_path.exists():
                     with open(summary_path, 'r', encoding='utf-8') as f:
                         try:
                             summary = json.load(f)
+                            # Shape the summary to match what the UI expects for the active DB.
+                            stats_key = "dev_stats" if active_db == "ankimonDEV.db" else "normal_stats"
+                            db_stats = summary.get(stats_key, {})
+
+                            # Merge DB-specific stats into the root summary object for the UI.
+                            summary.update(db_stats)
                             summary['path'] = str(backup_dir)
                             backups.append(summary)
                         except json.JSONDecodeError:
                             self.logger.log("error", f"Could not read summary for backup: {backup_dir.name}")
+                elif active_db == "ankimon.db":
+                    # Fallback for older backups without summary.json.
+                    summary = {
+                        "date": backup_dir.name.replace("backup_", "").replace("_", " "),
+                        "path": str(backup_dir),
+                    }
+                    backups.append(summary)
         return backups
 
     def create_backup(self, manual=False):
         """Creates a new backup."""
         timestamp = datetime.datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
         backup_dir = self.backups_path / f"backup_{timestamp}"
-        
+
         try:
+            # Checkpoint the active database first to flush all WAL changes to disk,
+            # so the single-file copy below captures the latest committed state.
+            if services.db is not None:
+                try:
+                    services.db.execute("PRAGMA wal_checkpoint(TRUNCATE);")
+                    self.logger.log("info", "Checkpoint database before backup.")
+                except Exception as e:
+                    self.logger.log("error", f"Failed to checkpoint database before backup: {e}")
+
             backup_dir.mkdir()
-            
-            for filename in self.FILES_TO_BACKUP:
+
+            # For manual backups, only back up the currently active database.
+            files_to_copy = self.FILES_TO_BACKUP
+            if manual and services.db is not None:
+                files_to_copy = [services.db.db_path.name]
+
+            for filename in files_to_copy:
                 source_path = self.user_files_path / filename
                 if source_path.exists():
                     shutil.copy2(source_path, backup_dir / filename)
@@ -90,7 +128,7 @@ class BackupManager:
             summary['manual'] = manual
             with open(backup_dir / "summary.json", 'w', encoding='utf-8') as f:
                 json.dump(summary, f, indent=4)
-            
+
             if manual:
                 showInfo("Manual backup created successfully.")
             self.logger.log("info", f"Created backup: {backup_dir.name}")
@@ -99,128 +137,193 @@ class BackupManager:
             self.logger.log("error", f"Failed to create backup: {e}")
             if manual:
                 showWarning(f"Failed to create backup: {e}")
-        
+
         self.cleanup_backups()
 
-    def _generate_summary(self, backup_dir: Path) -> Dict[str, Any]:
-        """Generates a summary for a backup."""
-        summary = {
-            "date": backup_dir.name.replace("backup_", "").replace("_", " "),
+    def _get_db_file_stats(self, db_file_path: Path) -> Dict[str, Any]:
+        """Reads summary stats directly from one Ankimon SQLite backup file.
+
+        Used to build the per-database (normal / dev) sections of a backup
+        summary. Reads the backup file's OWN data (not the live database) so the
+        summary reflects that backup's historical state.
+        """
+        stats = {
             "main_pokemon_name": "N/A",
             "main_pokemon_level": "N/A",
             "pokemon_count": 0,
             "trainer_name": "N/A",
             "trainer_cash": 0,
-            "trainer_level": 0,
+            "trainer_level": 1,
             "item_count": 0,
         }
+        if not db_file_path.exists():
+            return stats
 
-        # Prefer stats from the backup's OWN ankimon.db (not the live mw.ankimon_db),
-        # so the summary reflects this backup's historical state rather than the
-        # current database.
-        db_path = backup_dir / "ankimon.db"
-        if db_path.exists():
-            import sqlite3
-            import json
-            from contextlib import closing
+        import sqlite3
+        import json
+        from contextlib import closing
+        try:
+            with closing(sqlite3.connect(str(db_file_path))) as conn:
+                conn.row_factory = sqlite3.Row
+                cursor = conn.cursor()
+
+                cursor.execute("SELECT COUNT(*) AS count FROM captured_pokemon")
+                stats["pokemon_count"] = cursor.fetchone()["count"]
+
+                cursor.execute("SELECT COUNT(*) AS count FROM items")
+                stats["item_count"] = cursor.fetchone()["count"]
+
+                cursor.execute("SELECT data FROM captured_pokemon WHERE is_main = 1 LIMIT 1")
+                main_row = cursor.fetchone()
+                if main_row:
+                    main_data = json.loads(main_row["data"])
+                    stats["main_pokemon_name"] = main_data.get("name", "N/A")
+                    stats["main_pokemon_level"] = main_data.get("level", "N/A")
+
+                # Trainer info lives in the `config` table as flat dotted
+                # key/value rows (e.g. key='trainer.name', value='Ash'). Guard
+                # on the table existing so an older backup can't abort the counts.
+                cursor.execute(
+                    "SELECT name FROM sqlite_master WHERE type='table' AND name='config'"
+                )
+                if cursor.fetchone():
+                    def _cfg(key):
+                        cursor.execute("SELECT value FROM config WHERE key = ?", (key,))
+                        r = cursor.fetchone()
+                        return r["value"] if r else None
+
+                    name = _cfg("trainer.name")
+                    if name is not None:
+                        stats["trainer_name"] = name
+                    for cfg_key, sum_key in (
+                        ("trainer.cash", "trainer_cash"),
+                        ("trainer.level", "trainer_level"),
+                    ):
+                        raw = _cfg(cfg_key)
+                        if raw is not None:
+                            try:
+                                stats[sum_key] = int(raw)
+                            except (ValueError, TypeError):
+                                pass
+        except Exception as e:
+            self.logger.log("error", f"Failed to read stats from {db_file_path.name}: {e}")
+        return stats
+
+    def _generate_summary(self, backup_dir: Path) -> Dict[str, Any]:
+        """Generates a summary for a backup, with per-database (normal/dev) stats."""
+        active_db_name = (
+            services.db.db_path.name if services.db is not None else "ankimon.db"
+        )
+
+        # Read stats from the database files stored inside this backup directory.
+        normal_stats = self._get_db_file_stats(backup_dir / "ankimon.db")
+        dev_stats = self._get_db_file_stats(backup_dir / "ankimonDEV.db")
+
+        normal_exists = (backup_dir / "ankimon.db").exists()
+        dev_exists = (backup_dir / "ankimonDEV.db").exists()
+
+        # If the backup folder has no DB files yet (e.g. a freshly-created dummy
+        # in tests, or a summary generated for the live session), fall back to
+        # the active database connection's current live state.
+        db = services.db
+        if not normal_exists and not dev_exists and db is not None:
             try:
-                with closing(sqlite3.connect(str(db_path))) as conn:
-                    conn.row_factory = sqlite3.Row
-                    cursor = conn.cursor()
+                stats = db.get_stats()
+                live_stats = {
+                    "pokemon_count": stats.get("pokemon", 0),
+                    "item_count": stats.get("items", 0),
+                    "main_pokemon_name": "N/A",
+                    "main_pokemon_level": "N/A",
+                    "trainer_name": db.get_config_value("trainer.name", "N/A"),
+                    "trainer_cash": db.get_config_value("trainer.cash", 0),
+                    "trainer_level": db.get_config_value("trainer.level", 1),
+                }
+                main_pokemon = db.get_main_pokemon()
+                if main_pokemon:
+                    live_stats["main_pokemon_name"] = main_pokemon.get("name", "N/A")
+                    live_stats["main_pokemon_level"] = main_pokemon.get("level", "N/A")
 
-                    cursor.execute("SELECT COUNT(*) AS count FROM captured_pokemon")
-                    summary["pokemon_count"] = cursor.fetchone()["count"]
-
-                    cursor.execute("SELECT COUNT(*) AS count FROM items")
-                    summary["item_count"] = cursor.fetchone()["count"]
-
-                    cursor.execute("SELECT data FROM captured_pokemon WHERE is_main = 1 LIMIT 1")
-                    main_row = cursor.fetchone()
-                    if main_row:
-                        main_data = json.loads(main_row["data"])
-                        summary["main_pokemon_name"] = main_data.get("name", "N/A")
-                        summary["main_pokemon_level"] = main_data.get("level", "N/A")
-
-                    # Trainer info lives in the `config` table as flat dotted
-                    # key/value rows (e.g. key='trainer.name', value='Ash'). Guard
-                    # on the table existing so an older backup can't abort the counts.
-                    cursor.execute(
-                        "SELECT name FROM sqlite_master WHERE type='table' AND name='config'"
-                    )
-                    if cursor.fetchone():
-                        def _cfg(key):
-                            cursor.execute("SELECT value FROM config WHERE key = ?", (key,))
-                            r = cursor.fetchone()
-                            return r["value"] if r else None
-
-                        name = _cfg("trainer.name")
-                        if name is not None:
-                            summary["trainer_name"] = name
-                        for cfg_key, sum_key in (
-                            ("trainer.cash", "trainer_cash"),
-                            ("trainer.level", "trainer_level"),
-                        ):
-                            raw = _cfg(cfg_key)
-                            if raw is not None:
-                                try:
-                                    summary[sum_key] = int(raw)
-                                except (ValueError, TypeError):
-                                    pass
-
-                    return summary
+                if active_db_name == "ankimonDEV.db":
+                    dev_stats = live_stats
+                else:
+                    normal_stats = live_stats
             except Exception as e:
                 self.logger.log("error", f"Failed to get DB stats for backup summary: {e}")
 
-        # Fallback to legacy JSON for older backups or migration period
-        # (Remaining legacy code omitted for brevity but I will keep it in the replacement)
-        
-        # Read mainpokemon.json for main Pokémon info
-        mainpokemon_path = backup_dir / "mainpokemon.json"
-        if mainpokemon_path.exists():
-            with open(mainpokemon_path, 'r', encoding='utf-8') as f:
-                try:
-                    mainpokemon_data = json.load(f)
-                    if mainpokemon_data:
-                        summary["main_pokemon_name"] = mainpokemon_data[0].get("name", "N/A")
-                        summary["main_pokemon_level"] = mainpokemon_data[0].get("level", "N/A")
-                except (json.JSONDecodeError, IndexError):
-                    pass
+        summary = {
+            "date": backup_dir.name.replace("backup_", "").replace("_", " "),
+            "normal_stats": normal_stats,
+            "dev_stats": dev_stats,
+        }
 
-        # Read mypokemon.json for total Pokémon count
-        mypokemon_path = backup_dir / "mypokemon.json"
-        if mypokemon_path.exists():
-            with open(mypokemon_path, 'r', encoding='utf-8') as f:
-                try:
-                    mypokemon_data = json.load(f)
-                    summary["pokemon_count"] = len(mypokemon_data)
-                except json.JSONDecodeError:
-                    pass
+        # Merge the active DB's stats onto the root of the summary for backwards
+        # compatibility with the UI (and the tests).
+        stats_key = "dev_stats" if active_db_name == "ankimonDEV.db" else "normal_stats"
+        summary.update(summary.get(stats_key, {}))
 
-        # Read items.json for total item count
-        items_path = backup_dir / "items.json"
-        if items_path.exists():
-            with open(items_path, 'r', encoding='utf-8') as f:
-                try:
-                    items_data = json.load(f)
-                    summary["item_count"] = sum(item.get('quantity', 0) for item in items_data)
-                except json.JSONDecodeError:
-                    pass
+        # Fallback to legacy JSON for older backups or migration period, only when
+        # there are no DB files in the backup and no live database to read from.
+        if not normal_exists and not dev_exists and db is None:
+            legacy_stats = {
+                "main_pokemon_name": "N/A",
+                "main_pokemon_level": "N/A",
+                "pokemon_count": 0,
+                "trainer_name": "N/A",
+                "trainer_cash": 0,
+                "trainer_level": 1,
+                "item_count": 0,
+            }
 
-        # Read config.obf for trainer info
-        config_path = backup_dir / "config.obf"
-        if config_path.exists():
-            with open(config_path, 'r', encoding='utf-8') as f:
-                obfuscated_data = f.read()
-            config_data = self._deobfuscate_data(obfuscated_data)
-            if config_data:
-                summary["trainer_name"] = config_data.get("trainer.name", "N/A")
-                summary["trainer_cash"] = config_data.get("trainer.cash", 0)
-                summary["trainer_level"] = config_data.get("trainer.level", 1)
-        
+            # Read mainpokemon.json for main Pokémon info
+            mainpokemon_path = backup_dir / "mainpokemon.json"
+            if mainpokemon_path.exists():
+                with open(mainpokemon_path, 'r', encoding='utf-8') as f:
+                    try:
+                        mainpokemon_data = json.load(f)
+                        if mainpokemon_data:
+                            legacy_stats["main_pokemon_name"] = mainpokemon_data[0].get("name", "N/A")
+                            legacy_stats["main_pokemon_level"] = mainpokemon_data[0].get("level", "N/A")
+                    except (json.JSONDecodeError, IndexError):
+                        pass
+
+            # Read mypokemon.json for total Pokémon count
+            mypokemon_path = backup_dir / "mypokemon.json"
+            if mypokemon_path.exists():
+                with open(mypokemon_path, 'r', encoding='utf-8') as f:
+                    try:
+                        mypokemon_data = json.load(f)
+                        legacy_stats["pokemon_count"] = len(mypokemon_data)
+                    except json.JSONDecodeError:
+                        pass
+
+            # Read items.json for total item count
+            items_path = backup_dir / "items.json"
+            if items_path.exists():
+                with open(items_path, 'r', encoding='utf-8') as f:
+                    try:
+                        items_data = json.load(f)
+                        legacy_stats["item_count"] = sum(item.get('quantity', 0) for item in items_data)
+                    except json.JSONDecodeError:
+                        pass
+
+            # Read config.obf for trainer info (legacy backups predate the DB config table)
+            config_path = backup_dir / "config.obf"
+            if config_path.exists():
+                with open(config_path, 'r', encoding='utf-8') as f:
+                    obfuscated_data = f.read()
+                config_data = self._deobfuscate_data(obfuscated_data)
+                if config_data:
+                    legacy_stats["trainer_name"] = config_data.get("trainer.name", "N/A")
+                    legacy_stats["trainer_cash"] = config_data.get("trainer.cash", 0)
+                    legacy_stats["trainer_level"] = config_data.get("trainer.level", 1)
+
+            summary["normal_stats"] = legacy_stats
+            summary.update(legacy_stats)
+
         return summary
 
     def restore_backup(self, backup_path_str: str):
-        """Restores a selected backup."""
+        """Restores a selected backup (only the currently active database)."""
         backup_path = Path(backup_path_str)
         if not backup_path.is_dir():
             showWarning("Selected backup path does not exist.")
@@ -232,15 +335,15 @@ class BackupManager:
             return
 
         try:
-            for filename in self.FILES_TO_BACKUP:
-                backup_file = backup_path / filename
-                if backup_file.exists():
-                    shutil.copy2(backup_file, self.user_files_path / filename)
-                else:
-                    # If a file doesn't exist in backup, it should be removed from user_files
-                    user_file = self.user_files_path / filename
-                    if user_file.exists():
-                        os.remove(user_file)
+            active_db = services.db.db_path.name
+            backup_file = backup_path / active_db
+            if backup_file.exists():
+                shutil.copy2(backup_file, self.user_files_path / active_db)
+            else:
+                showWarning(
+                    f"The selected backup does not contain a backup for the active database ({active_db})."
+                )
+                return
 
             showInfo("Backup restored successfully. Anki will now close. Please restart Anki to see the changes.")
             close_anki()
@@ -267,7 +370,7 @@ class BackupManager:
         """Deletes old backups based on retention policy."""
         # Get only directories and sort them by modification time
         backups = sorted([p for p in self.backups_path.iterdir() if p.is_dir()], key=os.path.getmtime)
-        
+
         backups_to_keep = []
         for backup_dir in backups:
             backup_time = datetime.datetime.fromtimestamp(os.path.getmtime(backup_dir))

--- a/src/Ankimon/pyobj/backup_manager.py
+++ b/src/Ankimon/pyobj/backup_manager.py
@@ -67,6 +67,11 @@ class BackupManager:
         summary so the dialog can read them without knowing about dual-DB.
         """
         backups = []
+        # If the database service isn't initialized yet (e.g. early boot or a
+        # headless environment), there is no active mode to filter on — return an
+        # empty list rather than crashing on ``None.db_path``.
+        if services.db is None:
+            return backups
         active_db = services.db.db_path.name
         for backup_dir in sorted(self.backups_path.iterdir(), reverse=True):
             if backup_dir.is_dir():
@@ -173,12 +178,19 @@ class BackupManager:
                 cursor.execute("SELECT COUNT(*) AS count FROM items")
                 stats["item_count"] = cursor.fetchone()["count"]
 
-                cursor.execute("SELECT data FROM captured_pokemon WHERE is_main = 1 LIMIT 1")
-                main_row = cursor.fetchone()
-                if main_row:
-                    main_data = json.loads(main_row["data"])
-                    stats["main_pokemon_name"] = main_data.get("name", "N/A")
-                    stats["main_pokemon_level"] = main_data.get("level", "N/A")
+                # Older backup files predate the ``is_main`` migration
+                # (database_manager adds this column on upgrade), so reading such
+                # a raw file directly can raise "no such column: is_main". Guard
+                # it so the trainer/config read below still runs.
+                try:
+                    cursor.execute("SELECT data FROM captured_pokemon WHERE is_main = 1 LIMIT 1")
+                    main_row = cursor.fetchone()
+                    if main_row:
+                        main_data = json.loads(main_row["data"])
+                        stats["main_pokemon_name"] = main_data.get("name", "N/A")
+                        stats["main_pokemon_level"] = main_data.get("level", "N/A")
+                except sqlite3.OperationalError:
+                    pass
 
                 # Trainer info lives in the `config` table as flat dotted
                 # key/value rows (e.g. key='trainer.name', value='Ash'). Guard
@@ -335,6 +347,12 @@ class BackupManager:
             return
 
         try:
+            # Without an initialized database service we cannot tell which mode
+            # (normal vs dev) is active, so refuse the destructive restore rather
+            # than guessing or crashing on ``None.db_path``.
+            if services.db is None:
+                showWarning("The Ankimon database is not initialized yet; cannot restore a backup.")
+                return
             active_db = services.db.db_path.name
             backup_file = backup_path / active_db
             if backup_file.exists():

--- a/tests/test_backup_manager.py
+++ b/tests/test_backup_manager.py
@@ -1,0 +1,222 @@
+import os
+import sys
+import json
+import sqlite3
+import pytest
+import importlib.util
+from pathlib import Path
+from unittest.mock import MagicMock, patch, PropertyMock
+import types
+
+# 1. SETUP CLEAN MOCKS BEFORE ANY IMPORTS
+_src = Path(__file__).parent.parent / "src"
+
+def setup_mocks():
+    # Mock aqt/anki namespaces
+    for name in [
+        "aqt", "aqt.qt", "aqt.utils", "aqt.gui_hooks", "aqt.operations",
+        "aqt.reviewer", "aqt.webview", "aqt.main", "aqt.operations.QueryOp",
+        "anki", "anki.hooks", "anki.collection", "anki.models", "anki.notes", "anki.template", "anki.buildinfo"
+    ]:
+        if name not in sys.modules:
+            sys.modules[name] = MagicMock()
+
+    # Stub parent packages so relative imports resolve without loading __init__.py
+    if "Ankimon" not in sys.modules:
+        _mod = types.ModuleType("Ankimon")
+        _mod.__path__ = [str(_src / "Ankimon")]
+        _mod.__package__ = "Ankimon"
+        sys.modules["Ankimon"] = _mod
+    else:
+        _mod = sys.modules["Ankimon"]
+        if not hasattr(_mod, "__path__") or not _mod.__path__:
+            _mod.__path__ = [str(_src / "Ankimon")]
+
+    # Load the REAL resources module (not a /tmp mock). This module also runs at
+    # collection time; leaving a /tmp-path mock in sys.modules would poison other
+    # modules that bind resource paths at import (e.g. business.py caches
+    # ``effectiveness_chart_file_path``), breaking unrelated tests like
+    # test_cp_formula. The fixture patches ``user_path`` per test for filesystem
+    # isolation, so we do not need a mock here.
+    _existing_res = sys.modules.get("Ankimon.resources")
+    if (
+        _existing_res is None
+        or isinstance(_existing_res, MagicMock)
+        or not hasattr(_existing_res, "effectiveness_chart_file_path")
+    ):
+        _res_spec = importlib.util.spec_from_file_location(
+            "Ankimon.resources", _src / "Ankimon" / "resources.py"
+        )
+        _resources = importlib.util.module_from_spec(_res_spec)
+        sys.modules["Ankimon.resources"] = _resources
+        _res_spec.loader.exec_module(_resources)
+
+    if "Ankimon.singletons" not in sys.modules:
+        sys.modules["Ankimon.singletons"] = MagicMock()
+    if "Ankimon.utils" not in sys.modules:
+        sys.modules["Ankimon.utils"] = MagicMock()
+
+    if "Ankimon.pyobj" not in sys.modules:
+        _pyobj = types.ModuleType("Ankimon.pyobj")
+        _pyobj.__path__ = [str(_src / "Ankimon" / "pyobj")]
+        _pyobj.__package__ = "Ankimon.pyobj"
+        sys.modules["Ankimon.pyobj"] = _pyobj
+    else:
+        _pyobj = sys.modules["Ankimon.pyobj"]
+        if not hasattr(_pyobj, "__path__") or not _pyobj.__path__:
+            _pyobj.__path__ = [str(_src / "Ankimon" / "pyobj")]
+
+setup_mocks()
+
+# Dynamically load modules to avoid importing __init__.py directly
+def load_module(name, relative_path):
+    spec = importlib.util.spec_from_file_location(name, _src / relative_path)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+_db_mod = load_module("Ankimon.pyobj.database_manager", "Ankimon/pyobj/database_manager.py")
+_bm_mod = load_module("Ankimon.pyobj.backup_manager", "Ankimon/pyobj/backup_manager.py")
+
+from Ankimon.pyobj.database_manager import AnkimonDB
+from Ankimon.pyobj.backup_manager import BackupManager
+# The seam registry backup_manager reads its database from (replaces mw.ankimon_db).
+from Ankimon.services import services
+
+class MockLogger:
+    def log(self, level, msg): pass
+
+@pytest.fixture
+def mock_env(tmp_path):
+    # Create temp user path and backup path structure
+    user_files_dir = tmp_path / "user_files"
+    user_files_dir.mkdir()
+    addon_dir = tmp_path / "Ankimon"
+    addon_dir.mkdir()
+
+    # Mock resources within database_manager and backup_manager namespaces
+    with patch.object(_db_mod, "user_path", user_files_dir), \
+         patch.object(_bm_mod, "user_path", user_files_dir), \
+         patch.object(_bm_mod, "addon_dir", addon_dir):
+
+        # Instantiate test database manager
+        db = AnkimonDB(MockLogger())
+
+        # Set config settings in the database config table
+        db.set_config_value("trainer.name", "Red")
+        db.set_config_value("trainer.cash", 5000)
+        db.set_config_value("trainer.level", 12)
+
+        # Instantiate test backup manager
+        settings_mock = MagicMock()
+        settings_mock.get.side_effect = lambda k, default=None: {
+            "misc.developer_mode": False
+        }.get(k, default)
+
+        bm = BackupManager(MockLogger(), settings_mock)
+
+        # Point the service registry's db at our test database. On main the seam
+        # replaces exp's direct mw.ankimon_db access, so backup_manager reads
+        # services.db instead of a mocked mw.
+        with patch.object(services, "db", db):
+            yield bm, db, user_files_dir, addon_dir
+
+def test_backup_summary_trainer_info(mock_env):
+    bm, db, user_files_dir, addon_dir = mock_env
+
+    # 1. Create a dummy backup directory (no DB files -> live fallback path)
+    backup_dir = bm.backups_path / "backup_2026-05-31_23-00-00"
+    backup_dir.mkdir(parents=True, exist_ok=True)
+
+    # 2. Run generate_summary
+    summary = bm._generate_summary(backup_dir)
+
+    # 3. Assertions: check that trainer fields are loaded correctly from config (not user_data)
+    assert summary["trainer_name"] == "Red"
+    assert summary["trainer_cash"] == 5000
+    assert summary["trainer_level"] == 12
+
+
+def _seed_db(db_path, name, cash, level=7):
+    """Create a real Ankimon SQLite file with trainer config values."""
+    seeded = AnkimonDB(MockLogger(), db_path=db_path)
+    seeded.set_config_value("trainer.name", name)
+    seeded.set_config_value("trainer.cash", cash)
+    seeded.set_config_value("trainer.level", level)
+    seeded.close()
+
+
+def test_dual_db_summary(mock_env):
+    bm, db, user_files_dir, addon_dir = mock_env
+
+    # A backup directory that actually contains BOTH database files.
+    backup_dir = bm.backups_path / "backup_2026-06-01_10-00-00"
+    backup_dir.mkdir(parents=True, exist_ok=True)
+    _seed_db(backup_dir / "ankimon.db", "Blue", 999)
+    _seed_db(backup_dir / "ankimonDEV.db", "DevGuy", 111)
+
+    summary = bm._generate_summary(backup_dir)
+
+    # Per-database sections are read from each backed-up DB file.
+    assert summary["normal_stats"]["trainer_name"] == "Blue"
+    assert summary["normal_stats"]["trainer_cash"] == 999
+    assert summary["dev_stats"]["trainer_name"] == "DevGuy"
+    assert summary["dev_stats"]["trainer_cash"] == 111
+
+    # Active DB is ankimon.db (services.db.db_path.name) -> root mirrors normal_stats.
+    assert summary["trainer_name"] == "Blue"
+    assert summary["trainer_cash"] == 999
+
+
+def test_get_backups_active_db_filtering(mock_env):
+    bm, db, user_files_dir, addon_dir = mock_env
+
+    # Backup A: a normal-mode backup (contains ankimon.db).
+    a = bm.backups_path / "backup_2026-06-03_08-00-00"
+    a.mkdir(parents=True, exist_ok=True)
+    (a / "ankimon.db").write_bytes(b"x")
+    with open(a / "summary.json", "w", encoding="utf-8") as f:
+        json.dump({
+            "date": "2026-06-03 08-00-00",
+            "normal_stats": {"trainer_name": "Norm"},
+            "dev_stats": {"trainer_name": "Dev"},
+        }, f)
+
+    # Backup B: a dev-only backup (contains ankimonDEV.db, NOT ankimon.db).
+    b = bm.backups_path / "backup_2026-06-03_09-00-00"
+    b.mkdir(parents=True, exist_ok=True)
+    (b / "ankimonDEV.db").write_bytes(b"x")
+    with open(b / "summary.json", "w", encoding="utf-8") as f:
+        json.dump({
+            "date": "2026-06-03 09-00-00",
+            "normal_stats": {"trainer_name": "Norm2"},
+            "dev_stats": {"trainer_name": "Dev2"},
+        }, f)
+
+    # Active DB is ankimon.db -> only the normal backup is listed.
+    backups = bm.get_backups()
+    names = {Path(bk["path"]).name for bk in backups}
+    assert "backup_2026-06-03_08-00-00" in names
+    assert "backup_2026-06-03_09-00-00" not in names
+
+    a_entry = next(bk for bk in backups if Path(bk["path"]).name == "backup_2026-06-03_08-00-00")
+    # The active DB's stats section is merged onto the root for the UI.
+    assert a_entry["trainer_name"] == "Norm"
+
+
+def test_restore_only_active_db(mock_env):
+    bm, db, user_files_dir, addon_dir = mock_env
+
+    backup_dir = bm.backups_path / "backup_2026-06-02_09-00-00"
+    backup_dir.mkdir(parents=True, exist_ok=True)
+    (backup_dir / "ankimon.db").write_bytes(b"NORMAL_DB_CONTENT")
+    (backup_dir / "ankimonDEV.db").write_bytes(b"DEV_DB_CONTENT")
+
+    # Active DB is ankimon.db -> only that file is restored; the dev DB is untouched.
+    bm.restore_backup(str(backup_dir))
+
+    restored = user_files_dir / "ankimon.db"
+    assert restored.exists()
+    assert restored.read_bytes() == b"NORMAL_DB_CONTENT"
+    assert not (user_files_dir / "ankimonDEV.db").exists()


### PR DESCRIPTION
## What
Ports **F27** — the dual-database (Normal / Dev-Mode) backup system (`pyobj/backup_manager.py` + `backup_files.py`). Adds `ankimonDEV.db` to the backup set; per-DB `normal_stats`/`dev_stats` summaries via a generalized `_get_db_file_stats`; active-DB filtering in `get_backups`/`restore_backup`; a `PRAGMA wal_checkpoint(TRUNCATE)` before backup/folder-create.

## Seam (edit-vs-edit, layered onto main)
`mw.ankimon_db → services.db` throughout (`db_path.name`, `execute`, `get_stats`, `get_main_pokemon`, `get_config_value`). exp's `get_user_data → get_config_value` switch kept (matches main's config-table model). `_get_db_file_stats` reuses main's guarded "read the backup's own DB" logic (closing() ctx, sqlite_master guard, int coercion). +4 new Tier-1 tests (seam-patched).

## Guards
- **`config.obf` NOT resurrected** in `FILES_TO_BACKUP` — main intentionally removed it (now in `ankimon.db`); kept the removal, only added `ankimonDEV.db`.
- Preserved main's summary edits, `set_config_value` upsert, `reset_db`, `rate_this` migration.

## Verification
Tier-1 **409 passed / 0 failed**; ruff 10; harness 9/9; Qt 5; boot 3 hooks; play OK. Verifier + Fable signed off. (Non-blocking follow-up: `get_backups`/`restore_backup` deref `services.db.db_path` without a None-guard — safe post-boot; noted for polish.)

## Attribution
Originally implemented by @hakimh2 on BRRRR_Experimental; credited via Co-authored-by: Hakimh2.
