### PR TITLE
fix: StarterWindow reload-safety guard + captured_date timestamp (F52)

### DIFF
--- a/src/Ankimon/pyobj/starter_window.py
+++ b/src/Ankimon/pyobj/starter_window.py
@@ -34,7 +34,8 @@ from ..functions.badges_functions import check_for_badge, receive_badge
 from ..functions.battle_functions import calculate_hp
 from ..functions.pokedex_functions import get_base_experience, get_growth_rate, search_pokedex
 from ..functions.pokemon_functions import get_random_moves_for_pokemon, pick_random_gender
-from ..utils import load_custom_font, close_anki
+from ..services import services
+from ..utils import load_custom_font, close_anki, is_alive
 from ..resources import addon_dir, frontdefault
 from ..const import total_generations
 from .error_handler import show_warning_with_traceback
@@ -141,7 +142,7 @@ class StarterWindow(QWidget):
             current_hp=calculate_hp(int(base_stats["hp"]), level, ev, iv),
             growth_rate=growth_rate,
             individual_id=str(uuid.uuid4()),
-            captured_date=None,
+            captured_date=datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
             shiny=False,
             tier="Starter",
         )
@@ -158,8 +159,10 @@ class StarterWindow(QWidget):
 
         self.display_chosen_starter_pokemon(starter_name)
 
-        from ..singletons import pokemon_pc
-        pokemon_pc.refresh_pokemon_grid()
+        # Read services.pokemon_pc directly rather than importing pokemon_pc from
+        # singletons, which would force-construct a PC window the user never opened.
+        if is_alive(services.pokemon_pc):
+            services.pokemon_pc.refresh_pokemon_grid()
 
         close_anki()
 


### PR DESCRIPTION
## What
Ports **F52** — StarterWindow reload-safety guard + `captured_date` fix (`pyobj/starter_window.py`). Wraps `pokemon_pc.refresh_pokemon_grid()` in an `is_alive(services.pokemon_pc)` guard (same reload-safety pattern as the merged F12 fossil path — avoids the lazy-factory force-construction), and sets `captured_date` to a real timestamp instead of `None` (genuine bugfix).

## Verification
Small change (+is_alive guard, +real timestamp). Tier-1 **405 passed / 0 failed**; ruff 10; harness 9/9; Qt 5; boot 3 hooks; play OK. Verifier + Fable signed off. (Pre-existing `mw.ankimon_db` at line 151 untouched — out of scope.)

## Attribution
Originally implemented by @hakimh2 on BRRRR_Experimental; credited via Co-authored-by: Hakimh2.
