### PR TITLE
fix(review): mobile-sync — double-processing, XP-share, ZeroDivision, DB race, XSS

### DIFF
--- a/src/Ankimon/ankimon_mobile_web/mobile.js
+++ b/src/Ankimon/ankimon_mobile_web/mobile.js
@@ -197,7 +197,7 @@ window.updateMobileEstimates = function(estimates) {
                 item.className = 'caught-pokemon-item';
                 const shinyIcon = pkmn.shiny ? '<span class="shiny-badge">✨</span> ' : '';
                 item.innerHTML = `
-                    <span class="caught-pokemon-name">${shinyIcon}${pkmn.name}</span>
+                    <span class="caught-pokemon-name">${shinyIcon}${escapeHtml(pkmn.name)}</span>
                     <span class="caught-pokemon-lvl">Lv.${pkmn.level}</span>
                 `;
                 caughtListEl.appendChild(item);
@@ -365,7 +365,7 @@ function fillPending(data) {
                 const shinyIcon = pkmn.shiny ? '<span class="shiny-badge">✨</span> ' : '';
 
                 item.innerHTML = `
-                    <span class="caught-pokemon-name">${shinyIcon}${pkmn.name}</span>
+                    <span class="caught-pokemon-name">${shinyIcon}${escapeHtml(pkmn.name)}</span>
                     <span class="caught-pokemon-lvl">Lv.${pkmn.level}</span>
                 `;
                 caughtListEl.appendChild(item);
@@ -587,7 +587,7 @@ function showSummaryModal(result) {
             const shiny = p.shiny ? '<span class="shiny-badge">✨</span> ' : '';
             const tier = (p.tier && p.tier !== 'Normal') ? `<span class="tier-badge">${p.tier}</span>` : '';
             item.innerHTML = `
-                <span class="caught-pokemon-name">${shiny}${p.name} ${tier}</span>
+                <span class="caught-pokemon-name">${shiny}${escapeHtml(p.name)} ${tier}</span>
                 <div style="display: flex; align-items: center; gap: 6px;">
                     <span class="caught-pokemon-lvl">Lv.${p.level}</span>
                     <span class="caught-pokemon-cp">CP ${p.cp || 10}</span>
@@ -740,7 +740,7 @@ function renderReplayBattle(result) {
     // Set initial narration
     const narrateEl = document.getElementById('narration-text');
     if (narrateEl) {
-        narrateEl.innerHTML = `<span class="narrate-encounter">Wild <strong>${result.enemy_name}</strong> appeared!</span>`;
+        narrateEl.innerHTML = `<span class="narrate-encounter">Wild <strong>${escapeHtml(result.enemy_name)}</strong> appeared!</span>`;
     }
 
     // Timeline sequence: animate turns list sequentially
@@ -758,7 +758,7 @@ function renderReplayBattle(result) {
                 if (defeatBtn) defeatBtn.disabled = false;
             }
             if (narrateEl) {
-                narrateEl.innerHTML = `Wild <strong>${result.enemy_name}</strong> is vulnerable! What will you do?`;
+                narrateEl.innerHTML = `Wild <strong>${escapeHtml(result.enemy_name)}</strong> is vulnerable! What will you do?`;
             }
             return;
         }
@@ -799,7 +799,7 @@ function renderReplayBattle(result) {
                 // 2. Enemy Attack
                 enemyCard.classList.add('attack-dash');
                 if (narrateEl) {
-                    narrateEl.innerHTML = `Wild <strong>${result.enemy_name}</strong> used <strong>${turn.enemy_attack}</strong>!`;
+                    narrateEl.innerHTML = `Wild <strong>${escapeHtml(result.enemy_name)}</strong> used <strong>${escapeHtml(turn.enemy_attack)}</strong>!`;
                 }
 
                 const tEnemyAttack = setTimeout(() => {
@@ -880,7 +880,7 @@ function animateResolution(outcome, xp_gained, remaining) {
 
     if (outcome === 'caught') {
         if (narrateEl) {
-            narrateEl.innerHTML = `You caught <strong>${result.enemy_name}</strong>! <span style="color: var(--accent-green)">Success!</span>`;
+            narrateEl.innerHTML = `You caught <strong>${escapeHtml(result.enemy_name)}</strong>! <span style="color: var(--accent-green)">Success!</span>`;
         }
         if (catchFlash) {
             catchFlash.classList.remove('hidden');
@@ -889,7 +889,7 @@ function animateResolution(outcome, xp_gained, remaining) {
         enemySprite.classList.add('caught-fade');
     } else {
         if (narrateEl) {
-            narrateEl.innerHTML = `<strong>${result.enemy_name}</strong> was defeated! <span style="color: var(--accent-blue)">+${xp_gained} XP</span>` +
+            narrateEl.innerHTML = `<strong>${escapeHtml(result.enemy_name)}</strong> was defeated! <span style="color: var(--accent-blue)">+${xp_gained} XP</span>` +
                 (result.cash_gained > 0 ? ` <span style="color: var(--accent-gold)">+${result.cash_gained}¥</span>` : '');
         }
         enemySprite.classList.add('fainted-fade');

--- a/src/Ankimon/card_hooks.py
+++ b/src/Ankimon/card_hooks.py
@@ -36,6 +36,20 @@ def answerCard_after(rev, card, ease):
         tooltip("Error in ColorConfirmation: Couldn't interpret ease")
     ankimon_tracker_obj.reset_card_timer()
 
+    # Mobile-review de-dupe (F29): this review was just turned into battle
+    # progress on desktop, so record its revlog id (and card id) to keep it out
+    # of the mobile queue. Without this the exclusion set is never populated and
+    # detect_mobile_reviews() re-queues every desktop review as a "mobile"
+    # review after the next sync, double-processing it (double XP / catches).
+    try:
+        from .functions.mobile_sync import record_desktop_review
+        revlog_id = rev.mw.col.db.scalar(
+            "SELECT MAX(id) FROM revlog WHERE cid = ?", card.id
+        )
+        record_desktop_review(revlog_id, card_id=card.id)
+    except Exception:
+        pass
+
 
 # Reload safety (F31): a second boot in the same session must not leave the
 # reviewer hooks registered twice, or every review would be double-counted.

--- a/src/Ankimon/functions/mobile_sync.py
+++ b/src/Ankimon/functions/mobile_sync.py
@@ -1801,9 +1801,31 @@ def commit_replay_outcome(choice: str, outcome_data: dict, db, settings_obj, tra
                     companion_id = outcome_data.get("companion_id", "")
                     if not companion_id and main_pokemon:
                         companion_id = getattr(main_pokemon, "individual_id", "")
-                    
-                    if companion_id and (total_xp > 0 or any(accumulated_evs.values())):
-                        _attribute_xp_and_evs_to_companion(companion_id, total_xp, accumulated_evs, settings_obj, db=db, logger=logger)
+
+                    # XP-Share (desktop parity): the manual replay-resolve path
+                    # must split the battling companion's XP 50/50 with the
+                    # configured trainer.xp_share target too, exactly like the
+                    # bulk-resolve commit block above and desktop
+                    # encounter_functions.kill_pokemon. Without this, XP-Share is
+                    # still 100% bypassed for every single-battle replay defeat
+                    # (total_xp here is the full, un-split battle XP built in the
+                    # replay prep). Runs on this QueryOp background thread under
+                    # _mobile_sync_lock via the mobile attribution path, so no
+                    # evo-window / tooltip Qt work happens here.
+                    xp_share_id = settings_obj.get("trainer.xp_share") if settings_obj else None
+                    grant_xp, share_half = (
+                        _xp_share_split(total_xp, companion_id, xp_share_id)
+                        if companion_id else (total_xp, 0)
+                    )
+
+                    if companion_id and (grant_xp > 0 or any(accumulated_evs.values())):
+                        _attribute_xp_and_evs_to_companion(companion_id, grant_xp, accumulated_evs, settings_obj, db=db, logger=logger)
+                    if companion_id and xp_share_id and share_half > 0:
+                        _attribute_xp_and_evs_to_companion(
+                            str(xp_share_id), share_half,
+                            {"hp": 0, "atk": 0, "def": 0, "spa": 0, "spd": 0, "spe": 0},
+                            settings_obj, battles_fought=0, db=db, logger=logger
+                        )
 
                 # 3. Mark resolved in DB
                 if review_ids:

--- a/src/Ankimon/functions/mobile_sync.py
+++ b/src/Ankimon/functions/mobile_sync.py
@@ -131,8 +131,29 @@ def _parse_cards_per_round(settings_obj) -> tuple[int, int]:
                         cards_per_round = 2
         except Exception:
             cards_per_round = 2
+    # Clamp to >= 1. The int-branch guard that both settings UIs apply
+    # (settings_window.py / settings_schema._coerce_cards_per_round: `1 if
+    # value == 0 else value`) only covers the plain-int case, so a range string
+    # whose average truncates to 0 (e.g. "0-0" / "0-1") would otherwise leak a
+    # cards_per_round of 0 here and later ZeroDivide (encounter_idx math,
+    # avg_reviews_per_encounter, seed_idx) at the mobile-sync entry point.
+    if not isinstance(cards_per_round, int) or cards_per_round < 1:
+        cards_per_round = 1
     cpr_split = cards_per_round
     return cards_per_round, cpr_split
+
+def _xp_share_split(earned_xp: int, earner_id, xp_share_id) -> tuple[int, int]:
+    """Split one companion's battle XP under trainer.xp_share.
+
+    Returns ``(xp_kept_by_earner, xp_for_share_target)`` mirroring the 50/50
+    split desktop ``encounter_functions.kill_pokemon`` applies. No share when
+    XP-Share is unset, points at the earner itself, or there is no positive XP;
+    the earner keeps the odd remainder so no XP is lost.
+    """
+    if not xp_share_id or earned_xp <= 0 or str(xp_share_id) == str(earner_id):
+        return earned_xp, 0
+    share_half = int(earned_xp * 0.5)
+    return earned_xp - share_half, share_half
 
 def _compute_initial_reviews(db, tracker, day_cutoff: int) -> int:
     """Computes the adjusted total review count for encounter seeding based on day_cutoff."""
@@ -299,13 +320,21 @@ def process_mobile_reviews_after_sync(col, ankimon_db, settings_obj, logger) -> 
 
         all_mobile = detect_mobile_reviews(col, watermark, desktop_ids)
 
-        # Apply cap — take the MOST RECENT N (highest revlog IDs)
+        # Apply cap — take the MOST RECENT N (highest revlog IDs). The dropped
+        # oldest reviews are permanently discarded (the watermark advances past
+        # them below), so this must NOT be silent: surface a user-visible
+        # warning, not just an info log line.
         if len(all_mobile) > MOBILE_QUEUE_CAP:
-            logger.log("info",
-                f"Mobile sync: {len(all_mobile)} reviews found. "
-                f"System cap is {MOBILE_QUEUE_CAP}. "
-                f"{len(all_mobile) - MOBILE_QUEUE_CAP} discarded."
+            discarded = len(all_mobile) - MOBILE_QUEUE_CAP
+            msg = (
+                f"Mobile sync: {len(all_mobile)} new reviews exceed the "
+                f"{MOBILE_QUEUE_CAP} system cap — the {discarded} oldest were "
+                f"discarded and will not become mobile battles."
             )
+            try:
+                logger.log_and_showinfo("warning", msg)
+            except Exception:
+                logger.log("warning", msg)
             all_mobile = all_mobile[-MOBILE_QUEUE_CAP:]  # list is ASC, so take tail
         else:
             logger.log("info", f"Mobile sync: {len(all_mobile)} reviews found.")
@@ -1151,6 +1180,12 @@ def _run_mobile_battles_impl(
     current_battle_cash = 0
     ci = int(settings_obj.get("trainer.cash_reward_interval", 5)) if settings_obj else 5
     ca = int(settings_obj.get("trainer.cash_reward_amount", 10)) if settings_obj else 10
+    # Seed the per-encounter cash counter from the SAME persisted carryover the
+    # final wallet credit uses (trainer.mobile_reviews_resolved_since_payout),
+    # so the sum of history entries' cash_gained matches trainer.cash actually
+    # credited below. Without this, cash payouts are counted from 0 each run and
+    # the Mobile Battle History screen misattributes where the cash came from.
+    payout_start = int(settings_obj.get("trainer.mobile_reviews_resolved_since_payout", 0)) if settings_obj else 0
 
     from .. import utils
     orig_load_ids = utils.load_collected_pokemon_ids
@@ -1200,7 +1235,7 @@ def _run_mobile_battles_impl(
                         pass
                 except Exception:
                     pass
-            if commit and ci > 0 and total_reviews_processed % ci == 0:
+            if commit and ci > 0 and (payout_start + total_reviews_processed) % ci == 0:
                 current_battle_cash += ca
             cards_battle_round += 1
             current_turn_reviews.append(review)
@@ -1471,16 +1506,29 @@ def _run_mobile_battles_impl(
                 if sk in companion_evs[cid]:
                     companion_evs[cid][sk] += v
 
+        # XP-Share (desktop parity): mirror encounter_functions.kill_pokemon —
+        # the battling companion keeps half of its battle XP and the configured
+        # trainer.xp_share target receives the other half. Without this the
+        # winning companion took 100% and the share target got nothing on every
+        # mobile-resolved battle. The share is applied through the same mobile
+        # attribution path used for teammates (below), so bulk-resolve UI
+        # suppression / thread serialisation still hold — the mobile path does
+        # not open the evolution window for companions, so we intentionally do
+        # not route through the desktop evo-triggering xp_share_gain_exp here.
+        xp_share_id = settings_obj.get("trainer.xp_share") if settings_obj else None
+        xp_share_pending = 0
         for cid, earned_xp in companion_xp.items():
             evs_gained = companion_evs.get(cid, {"hp": 0, "atk": 0, "def": 0, "spa": 0, "spd": 0, "spe": 0})
             battles_fought = companion_battle_count.get(cid, 0)
-            if earned_xp > 0 or any(evs_gained.values()) or battles_fought > 0:
+            grant_xp, share_half = _xp_share_split(earned_xp, cid, xp_share_id)
+            xp_share_pending += share_half
+            if grant_xp > 0 or any(evs_gained.values()) or battles_fought > 0:
                 if main_pokemon and cid == main_pokemon.individual_id:
                     class DummyEnemy:
                         def __init__(self, ev_yield): self.ev_yield = ev_yield
                     from ..services import services
                     save_main_pokemon_progress(
-                        main_pokemon, DummyEnemy(evs_gained), earned_xp,
+                        main_pokemon, DummyEnemy(evs_gained), grant_xp,
                         services.achievements, logger, get_evo_window()
                     )
                     # Apply additional battles fought to main_pokemon.pokemon_defeated
@@ -1495,7 +1543,15 @@ def _run_mobile_battles_impl(
                         except Exception:
                             pass
                 else:
-                    _attribute_xp_and_evs_to_companion(cid, earned_xp, evs_gained, settings_obj, battles_fought=battles_fought, db=db, logger=logger)
+                    _attribute_xp_and_evs_to_companion(cid, grant_xp, evs_gained, settings_obj, battles_fought=battles_fought, db=db, logger=logger)
+
+        # Grant the accumulated XP-Share half to the configured target Pokémon.
+        if xp_share_id and xp_share_pending > 0:
+            _attribute_xp_and_evs_to_companion(
+                str(xp_share_id), xp_share_pending,
+                {"hp": 0, "atk": 0, "def": 0, "spa": 0, "spd": 0, "spe": 0},
+                settings_obj, battles_fought=0, db=db, logger=logger
+            )
 
         total_trainer_xp = 0
         from ..pyobj.trainer_card import POKEMON_TIERS
@@ -1513,10 +1569,12 @@ def _run_mobile_battles_impl(
             trainer_card.total_xp = settings_obj.get("trainer.total_xp")
             trainer_card.check_level_up()
 
-        # Cash Reward
+        # Cash Reward — credited off the same carryover the per-encounter
+        # history counter (payout_start) was seeded from, so the wallet credit
+        # and the sum of history cash_gained agree.
         gained_cash = 0
         total_reviews_resolved = total_reviews_processed
-        current_counter = int(settings_obj.get("trainer.mobile_reviews_resolved_since_payout", 0)) if settings_obj else 0
+        current_counter = payout_start
         new_counter = current_counter + total_reviews_resolved
         
         ci = int(settings_obj.get("trainer.cash_reward_interval", 5)) if settings_obj else 5

--- a/src/Ankimon/pyobj/ankimon_sync.py
+++ b/src/Ankimon/pyobj/ankimon_sync.py
@@ -845,6 +845,11 @@ def read_ankimon_configs(settings_obj, media_sync_status: bool = False):
 # Global flag to track if automatic sync is enabled
 _automatic_sync_enabled = False
 
+# Reload safety (F31): the (hook, handler) pairs this module last registered,
+# stored on the services registry so they survive a re-execution of this module
+# (unlike a module-level flag) and can be removed before re-appending.
+_SYNC_HOOK_RECORD = "_ankimon_sync_hook_handlers"
+
 def setup_ankimon_sync_hooks(settings_obj, logger):
     """Set up hooks for automatic Ankimon data syncing - but disabled by default."""
     ankiweb_sync = settings_obj.get("misc.ankiweb_sync")
@@ -881,6 +886,8 @@ def setup_ankimon_sync_hooks(settings_obj, logger):
                     detect_mobile_reviews,
                     get_desktop_session_revlog_ids,
                     clear_desktop_session,
+                    _mobile_sync_lock,
+                    MOBILE_QUEUE_CAP,
                 )
                 from ..menu_buttons import update_mobile_badge
 
@@ -891,41 +898,71 @@ def setup_ankimon_sync_hooks(settings_obj, logger):
                 newly_queued_normal = 0
                 newly_queued_dev = 0
 
-                try:
-                    # 1. Queue to ankimon.db
-                    if db.db_path.name != "ankimon.db":
-                        db.switch_database("ankimon.db")
-                    watermark_normal = db.get_mobile_watermark()
-                    all_mobile_normal = detect_mobile_reviews(col, watermark_normal, desktop_ids)
-                    if all_mobile_normal:
-                        newly_queued_normal = db.queue_mobile_battles(all_mobile_normal)
-                        db.set_mobile_watermark(max(r["id"] for r in all_mobile_normal))
+                def _cap_mobile(reviews):
+                    # Bound each queueing pass to the same MOBILE_QUEUE_CAP the
+                    # startup pass (process_mobile_reviews_after_sync) applies, so
+                    # a huge backlog is handled consistently regardless of which
+                    # trigger fires first. Keep the newest N (list is ASC) and
+                    # warn — the dropped oldest are permanently discarded.
+                    if len(reviews) > MOBILE_QUEUE_CAP:
+                        discarded = len(reviews) - MOBILE_QUEUE_CAP
+                        msg = (
+                            f"Mobile sync: {len(reviews)} new reviews exceed the "
+                            f"{MOBILE_QUEUE_CAP} system cap — the {discarded} oldest "
+                            f"were discarded and will not become mobile battles."
+                        )
+                        try:
+                            logger.log_and_showinfo("warning", msg)
+                        except Exception:
+                            logger.log("warning", msg)
+                        return reviews[-MOBILE_QUEUE_CAP:]
+                    return reviews
 
-                    max_revlog_id = col.db.scalar("SELECT MAX(id) FROM revlog")
-                    if type(max_revlog_id).__name__ in ("MagicMock", "Mock"):
-                        max_revlog_id = None
-                    if isinstance(max_revlog_id, (int, float)):
-                        current_watermark = db.get_mobile_watermark()
-                        if max_revlog_id > current_watermark:
-                            db.set_mobile_watermark(max_revlog_id)
+                # Serialize the dual-DB switch/queue/restore dance against any
+                # in-flight background mobile-resolve (run_mobile_battles /
+                # commit_replay_outcome's do_db_work both hold _mobile_sync_lock).
+                # Without this, switch_database() mutates db.db_path mid-op and a
+                # background thread's next _get_connection() silently reopens
+                # against the wrong Ankimon DB file. The lock is released before
+                # the auto-resolve branch below (resolveAll reacquires it).
+                with _mobile_sync_lock:
+                    try:
+                        # 1. Queue to ankimon.db
+                        if db.db_path.name != "ankimon.db":
+                            db.switch_database("ankimon.db")
+                        watermark_normal = db.get_mobile_watermark()
+                        all_mobile_normal = detect_mobile_reviews(col, watermark_normal, desktop_ids)
+                        if all_mobile_normal:
+                            all_mobile_normal = _cap_mobile(all_mobile_normal)
+                            newly_queued_normal = db.queue_mobile_battles(all_mobile_normal)
+                            db.set_mobile_watermark(max(r["id"] for r in all_mobile_normal))
 
-                    # 2. Queue to ankimonDEV.db if present
-                    if dev_db_path.is_file():
-                        if db.db_path.name != "ankimonDEV.db":
-                            db.switch_database("ankimonDEV.db")
-                        watermark_dev = db.get_mobile_watermark()
-                        all_mobile_dev = detect_mobile_reviews(col, watermark_dev, desktop_ids)
-                        if all_mobile_dev:
-                            newly_queued_dev = db.queue_mobile_battles(all_mobile_dev)
-                            db.set_mobile_watermark(max(r["id"] for r in all_mobile_dev))
-
+                        max_revlog_id = col.db.scalar("SELECT MAX(id) FROM revlog")
+                        if type(max_revlog_id).__name__ in ("MagicMock", "Mock"):
+                            max_revlog_id = None
                         if isinstance(max_revlog_id, (int, float)):
                             current_watermark = db.get_mobile_watermark()
                             if max_revlog_id > current_watermark:
                                 db.set_mobile_watermark(max_revlog_id)
-                finally:
-                    if db.db_path.name != original_db_name:
-                        db.switch_database(original_db_name)
+
+                        # 2. Queue to ankimonDEV.db if present
+                        if dev_db_path.is_file():
+                            if db.db_path.name != "ankimonDEV.db":
+                                db.switch_database("ankimonDEV.db")
+                            watermark_dev = db.get_mobile_watermark()
+                            all_mobile_dev = detect_mobile_reviews(col, watermark_dev, desktop_ids)
+                            if all_mobile_dev:
+                                all_mobile_dev = _cap_mobile(all_mobile_dev)
+                                newly_queued_dev = db.queue_mobile_battles(all_mobile_dev)
+                                db.set_mobile_watermark(max(r["id"] for r in all_mobile_dev))
+
+                            if isinstance(max_revlog_id, (int, float)):
+                                current_watermark = db.get_mobile_watermark()
+                                if max_revlog_id > current_watermark:
+                                    db.set_mobile_watermark(max_revlog_id)
+                    finally:
+                        if db.db_path.name != original_db_name:
+                            db.switch_database(original_db_name)
 
                 # Clear desktop session to prevent indefinite exclusion-set accumulation
                 clear_desktop_session()
@@ -990,9 +1027,26 @@ def setup_ankimon_sync_hooks(settings_obj, logger):
         except Exception as e:
             logger.log("error", f"Failed to read files after sync: {str(e)}")
 
-    # Register hooks (but they won't auto-sync until enabled)
-    gui_hooks.sync_will_start.append(on_sync_will_start)
-    gui_hooks.sync_did_finish.append(on_sync_did_finish)
+    # Register hooks (but they won't auto-sync until enabled). Reload safety
+    # (F31 registry-anchored guard): a second boot in the same Anki session (the
+    # F26 branch self-updater reloading add-on code, or any re-run of
+    # register_profile_hooks) must not stack a second on_sync_did_finish — that
+    # would double the dual-DB queueing pass, double the tooltip, and in auto
+    # mode fire MobileBridge.resolveAll() twice per sync. Remove the previously
+    # recorded handlers first; gui_hooks' remove() tolerates already-absent
+    # callbacks, and the closures above are NEW objects each call, so only the
+    # stored originals can be found and removed.
+    from ..services import services
+    for hook, handler in getattr(services, _SYNC_HOOK_RECORD, ()):
+        hook.remove(handler)
+
+    _handlers = (
+        (gui_hooks.sync_will_start, on_sync_will_start),
+        (gui_hooks.sync_did_finish, on_sync_did_finish),
+    )
+    for hook, handler in _handlers:
+        hook.append(handler)
+    setattr(services, _SYNC_HOOK_RECORD, _handlers)
 
     logger.log("info", "Ankimon sync hooks registered (automatic sync disabled until manual sync)")
 

--- a/tests/test_mobile_auto_resolve.py
+++ b/tests/test_mobile_auto_resolve.py
@@ -173,3 +173,58 @@ def test_no_new_reviews_no_notify(wired):
     hook()
     assert db.get_pending_mobile_count() == 0
     assert not tooltip.called
+
+
+def test_setup_hooks_reload_safe(wired):
+    """A second setup in the same session removes the first handlers before
+    re-appending (F31), so on_sync_did_finish is never double-registered."""
+    db, build, tooltip, mock_bridge = wired
+    settings = _Settings({
+        "misc.ankiweb_sync": True, "mobile.enabled": True,
+        "mobile.resolution_mode": "manual",
+    })
+    sdf = MagicMock()
+    sws = MagicMock()
+    asy.gui_hooks.sync_did_finish = sdf
+    asy.gui_hooks.sync_will_start = sws
+    setattr(services, asy._SYNC_HOOK_RECORD, ())  # start from a clean record
+
+    asy.setup_ankimon_sync_hooks(settings, _Logger())
+    asy.setup_ankimon_sync_hooks(settings, _Logger())
+
+    # Two setups -> two appends, but the second removed the first's handler.
+    assert sdf.append.call_count == 2
+    assert sdf.remove.call_count == 1
+    first_handler = sdf.append.call_args_list[0][0][0]
+    assert sdf.remove.call_args[0][0] is first_handler
+
+
+def test_sync_did_finish_applies_queue_cap(wired, monkeypatch):
+    """on_sync_did_finish bounds each queueing pass by MOBILE_QUEUE_CAP the same
+    way the startup pass does: keep the newest N, discard the oldest."""
+    from Ankimon.functions import mobile_sync as ms
+    db, build, tooltip, mock_bridge = wired
+    monkeypatch.setattr(ms, "MOBILE_QUEUE_CAP", 2)
+    hook = build([1, 2, 3, 4], resolution_mode="manual")
+    hook()
+    assert db.get_pending_mobile_count() == 2
+    batch = db.get_next_pending_mobile_batch(limit=10)
+    assert sorted(r["revlog_id"] for r in batch) == [3, 4]
+
+
+def test_sync_did_finish_holds_lock_during_switch(wired, monkeypatch):
+    """The dual-DB switch/queue pass runs under _mobile_sync_lock so it cannot
+    interleave with an in-flight background mobile-resolve."""
+    from Ankimon.functions import mobile_sync as ms
+    db, build, tooltip, mock_bridge = wired
+    observed = {}
+    real_detect = ms.detect_mobile_reviews
+
+    def spy(col, watermark, ids):
+        observed["locked"] = ms._mobile_sync_lock.locked()
+        return real_detect(col, watermark, ids)
+
+    monkeypatch.setattr(ms, "detect_mobile_reviews", spy)
+    hook = build([1, 2, 3], resolution_mode="manual")
+    hook()
+    assert observed.get("locked") is True

--- a/tests/test_mobile_sync.py
+++ b/tests/test_mobile_sync.py
@@ -296,6 +296,13 @@ def test_process_applies_queue_cap(mobile_db, monkeypatch):
     (4, 4),
     ("3", 3),
     ("1-3", 2),
+    # cards_per_round must never be 0 — a range whose average truncates to 0
+    # (e.g. "0-0" / "0-1") or a plain 0/negative would ZeroDivide at the
+    # mobile-sync entry point; every branch clamps to >= 1.
+    ("0-0", 1),
+    ("0-1", 1),
+    (0, 1),
+    (-5, 1),
     (None, 2),
 ])
 def test_parse_cards_per_round(value, expected):
@@ -303,6 +310,57 @@ def test_parse_cards_per_round(value, expected):
     assert ms._parse_cards_per_round(settings)[0] == expected
 
 
+@pytest.mark.parametrize("earned,earner,share_id,expected", [
+    (100, "A", "B", (50, 50)),      # even split
+    (101, "A", "B", (51, 50)),      # earner keeps the odd remainder, no XP lost
+    (100, "A", "A", (100, 0)),      # can't share with yourself
+    (100, "A", None, (100, 0)),     # XP-Share not configured
+    (0, "A", "B", (0, 0)),          # nothing to split
+    (100, "A", "b", (50, 50)),      # distinct ids -> split applies
+])
+def test_xp_share_split(earned, earner, share_id, expected):
+    assert ms._xp_share_split(earned, earner, share_id) == expected
+
+
 def test_normalize_ev_yield_renames_keys():
     assert ms._normalize_ev_yield({"attack": 4, "speed": 2, "hp": 1}) == {"atk": 4, "spe": 2, "hp": 1}
     assert ms._normalize_ev_yield({}) == {}
+
+
+def test_answercard_after_records_desktop_review(monkeypatch):
+    """F29 de-dupe: answerCard_after must record the just-resolved review's
+    revlog id + card id into the mobile-sync exclusion set, so the next
+    detect pass does not re-queue it as a mobile battle (double XP/catches)."""
+    # card_hooks pulls the heavy singletons module (markdown/Qt) transitively;
+    # stub it with just the two names the module binds at import.
+    stub = types.ModuleType("Ankimon.singletons")
+    stub.ankimon_tracker_obj = MagicMock()
+    stub.reviewer_obj = MagicMock()
+    monkeypatch.setitem(sys.modules, "Ankimon.singletons", stub)
+    monkeypatch.delitem(sys.modules, "Ankimon.card_hooks", raising=False)
+
+    import Ankimon.card_hooks as ch
+
+    ms.clear_desktop_session()
+
+    class _Card:
+        id = 42
+
+    class _DB:
+        def scalar(self, _sql, cid):
+            return 9999 if cid == 42 else 0
+
+    class _Sched:
+        def answerButtons(self, _card):
+            return 4
+
+    rev = types.SimpleNamespace(
+        mw=types.SimpleNamespace(col=types.SimpleNamespace(db=_DB(), sched=_Sched()))
+    )
+
+    try:
+        ch.answerCard_after(rev, _Card(), ease=4)
+        ids = ms.get_desktop_session_revlog_ids()
+        assert 9999 in ids
+    finally:
+        ms.clear_desktop_session()

--- a/tests/test_mobile_sync.py
+++ b/tests/test_mobile_sync.py
@@ -322,6 +322,85 @@ def test_xp_share_split(earned, earner, share_id, expected):
     assert ms._xp_share_split(earned, earner, share_id) == expected
 
 
+def test_commit_replay_defeat_applies_xp_share(monkeypatch):
+    """XP-Share parity on the MANUAL replay-resolve path: commit_replay_outcome
+    ('defeat', ...) must split the battling companion's XP 50/50 with the
+    configured trainer.xp_share target, exactly like the bulk-resolve commit
+    block. Without the split this path grants the companion 100% and the
+    XP-Share target nothing (finding: mobile_sync commit_replay_outcome)."""
+    class _S:
+        def __init__(self, d): self._d = dict(d)
+        def get(self, k, default=None): return self._d.get(k, default)
+        def set(self, k, v): self._d[k] = v
+
+    # Spy on the attribution seam so we can see who got how much XP.
+    calls = []
+    monkeypatch.setattr(
+        ms, "_attribute_xp_and_evs_to_companion",
+        lambda cid, xp, evs, settings_obj, battles_fought=1, db=None, logger=None: calls.append((str(cid), xp)),
+    )
+    # Patch on the imported module object (not a dotted string path, which is
+    # import-order fragile across the full suite).
+    import Ankimon.business as _biz
+    monkeypatch.setattr(_biz, "calculate_cp_from_dict", lambda d: 10)
+
+    settings = _S({"trainer.xp_share": "TARGET"})
+    db = MagicMock()
+    db.get_pending_mobile_count.return_value = 0
+    enemy = MagicMock()
+    outcome_data = {
+        "enemy_pokemon": enemy,
+        "battle_xp": 100,
+        "total_xp": 100,
+        "accumulated_evs": {"hp": 0, "atk": 0, "def": 0, "spa": 0, "spd": 0, "spe": 0},
+        "total_trainer_xp": 0,
+        "gained_cash": 0,
+        "companion_id": "COMP",
+        "companion_name": "Comp",
+        "companion_level": 5,
+        "review_ids": [],
+        "companion_fainted": False,
+    }
+
+    res = ms.commit_replay_outcome("defeat", outcome_data, db, settings, None, None)
+    assert res.get("success") is True
+    # Companion keeps half; the XP-Share target receives the other half.
+    assert ("COMP", 50) in calls
+    assert ("TARGET", 50) in calls
+
+
+def test_commit_replay_defeat_no_share_when_unset(monkeypatch):
+    """With XP-Share unset the manual replay-defeat path grants the companion the
+    full battle XP and makes no second attribution call."""
+    class _S:
+        def __init__(self, d): self._d = dict(d)
+        def get(self, k, default=None): return self._d.get(k, default)
+        def set(self, k, v): self._d[k] = v
+
+    calls = []
+    monkeypatch.setattr(
+        ms, "_attribute_xp_and_evs_to_companion",
+        lambda cid, xp, evs, settings_obj, battles_fought=1, db=None, logger=None: calls.append((str(cid), xp)),
+    )
+    import Ankimon.business as _biz
+    monkeypatch.setattr(_biz, "calculate_cp_from_dict", lambda d: 10)
+
+    settings = _S({})  # no trainer.xp_share
+    db = MagicMock()
+    db.get_pending_mobile_count.return_value = 0
+    outcome_data = {
+        "enemy_pokemon": MagicMock(),
+        "battle_xp": 100, "total_xp": 100,
+        "accumulated_evs": {"hp": 0, "atk": 0, "def": 0, "spa": 0, "spd": 0, "spe": 0},
+        "total_trainer_xp": 0, "gained_cash": 0,
+        "companion_id": "COMP", "companion_name": "Comp", "companion_level": 5,
+        "review_ids": [], "companion_fainted": False,
+    }
+    res = ms.commit_replay_outcome("defeat", outcome_data, db, settings, None, None)
+    assert res.get("success") is True
+    assert calls == [("COMP", 100)]
+
+
 def test_normalize_ev_yield_renames_keys():
     assert ms._normalize_ev_yield({"attack": 4, "speed": 2, "hp": 1}) == {"atk": 4, "spe": 2, "hp": 1}
     assert ms._normalize_ev_yield({}) == {}


### PR DESCRIPTION
## What
Final-review fixes for the **mobile-sync subsystem** (from the Sonnet-5 max-effort review of the full integration diff). Addresses 9 findings (+6 regression tests):

- **HIGH — double-processing:** `record_desktop_review()` was never called, so every desktop-resolved review got re-queued as a mobile review after sync (double XP/catches). Now wired into `card_hooks.answerCard_after` (records the just-written revlog id, guarded).
- **HIGH — XP-Share bypassed on mobile:** mobile-resolved battles gave the winner full XP and the XP-Share companion nothing. Added `_xp_share_split()` (50/50, earner keeps odd remainder) applied in **both** the bulk/auto path and manual replay (`commit_replay_outcome`).
- **HIGH — ZeroDivisionError:** `_parse_cards_per_round` could return 0 for range strings like `'0-1'`. Clamped to ≥1 (covers the range-average branch the settings UI guard missed).
- **cross-thread DB race:** `on_sync_did_finish`'s dual-DB `switch_database` dance now runs under `_mobile_sync_lock`; hook registration made F31 registry-anchored (reload-safe).
- Cash-bookkeeping carryover fix; non-silent queue-cap warning; **mobile.js XSS** — escaped the remaining caught-name / `enemy_name` / `enemy_attack` innerHTML sinks.

Honestly **deferred** (need files outside this partition — recorded in NR-24): the desktop-side read-modify-write lock and the process-global `in_bulk_resolve` thread-scoping (both need `utils.py`/`encounter_functions.py`).

## Verification
Tier-1 **429 passed / 0 failed**; ruff 10 pre-existing; harness 9/9; Qt 5; probe_real_boot 3 hooks; probe_real_play OK. Opus fix → adversarial verify → Fable, all green.

## Attribution
Fixes to Hakimh2-authored mobile subsystem; Co-authored-by: Hakimh2.
