### PR TITLE
fix(review): battle/evolution regressions + learnset S-code move leak

### DIFF
--- a/src/Ankimon/battle_loop.py
+++ b/src/Ankimon/battle_loop.py
@@ -17,7 +17,13 @@ from .functions.battle_functions import (
     process_battle_data,
 )
 from .functions.drawing_utils import tooltipWithColour
-from .utils import safe_get_random_move, play_effect_sound, play_sound, is_alive
+from .utils import (
+    safe_get_random_move,
+    play_effect_sound,
+    play_sound,
+    is_alive,
+    random_item,
+)
 from .functions.ankimon_hooks_to_poke_engine import simulate_battle_with_poke_engine
 from .pyobj.error_handler import show_warning_with_traceback
 
@@ -104,14 +110,24 @@ def on_review_card(*args):
         s.item_receive_value -= 1
         if s.item_receive_value <= 0:
             s.item_receive_value = random.randint(3, 385)
-            # Liveness guard (F24): the seam window may have been closed (its C++
-            # object deleted) since boot; resolve it fresh from the registry and
-            # only paint while it is still alive.
+            # Reward the item every time this trigger fires (main granted it
+            # unconditionally). display_item() both rolls+grants the reward (via
+            # random_item -> give_item) AND paints the popup; the grant is the
+            # actual reward, the QDialog is only the visual. Liveness guard (F24):
+            # the seam window may have been closed (its C++ object deleted) since
+            # boot. When it's dead we still roll+grant the reward directly via
+            # random_item() so it is never silently dropped — only the popup is
+            # skipped.
             item_window = services.test_window
             if is_alive(item_window):
                 try:
                     item_window.display_item()
                 except RuntimeError:
+                    pass
+            else:
+                try:
+                    random_item()
+                except Exception:
                     pass
             if not check_for_badge(achievements, 6):
                 receive_badge(6, achievements)
@@ -215,11 +231,13 @@ def on_review_card(*args):
             )
 
             if true_dmg_from_enemy_move < 0:
-                true_dmg_from_enemy_move = 0
+                # abs() must be taken BEFORE zeroing, or the heal tooltip always
+                # shows +0 instead of the recovered magnitude.
                 heals_to_user += abs(true_dmg_from_enemy_move)
+                true_dmg_from_enemy_move = 0
             if true_dmg_from_user_move < 0:
-                true_dmg_from_user_move = 0
                 heals_to_opponent += abs(true_dmg_from_user_move)
+                true_dmg_from_user_move = 0
 
             main_pokemon.hp = s.new_state.user.active.hp
             main_pokemon.current_hp = s.new_state.user.active.hp

--- a/src/Ankimon/functions/encounter_functions.py
+++ b/src/Ankimon/functions/encounter_functions.py
@@ -552,30 +552,6 @@ def clear_encounter_cache():
     }
 
 
-def get_random_pokemon_in_tier(tier):
-    if tier == "Normal":
-        id_data = encounter_data.NORMAL
-    elif tier == "Baby":
-        id_data = encounter_data.BABY
-    elif tier == "Ultra":
-        id_data = encounter_data.ULTRA
-    elif tier == "Legendary":
-        id_data = encounter_data.LEGENDARY
-    elif tier == "Mythical":
-        id_data = encounter_data.MYTHICAL
-    elif tier == "Mega":
-        id_data = encounter_data.MEGA
-    elif tier == "Gmax":
-        id_data = encounter_data.GMAX
-    elif tier == "Starter":
-        # id_data = encounter_data.STARTERS   #Uncomment to activate starters
-        id_data = []
-    else:
-        return 1
-
-    return random.choice(id_data) if id_data else 1
-
-
 def _player_owns_base_form(actual_id: int, collected_ids: set) -> bool:
     """Return True if the player owns the base species of this Mega/Gmax form."""
     name = search_pokedex_by_id(actual_id)
@@ -633,28 +609,6 @@ def get_tier(total_reviews, trainer_level=1, event_modifier=None):
 
     choice = random.choices(tiers, probabilities, k=1)
     return choice[0]
-
-
-def choose_random_pkmn_from_tier():
-    """
-    Runs a tier-selection and a subsequent ID-selection function to pick a random Pokemon from a given randomly picked Tier.
-    The tier is a weighted probability selection, based on total_reviews and trainer_level.
-    Pokemon ID is picked randomly from within that tier.
-
-    Returns:
-        id (int): Pokedex ID for generated Pokemon
-        tier (str): Rarity tier for generated Pokemon (normal/ultra/legendary etc.)
-    """
-    total_reviews = ankimon_tracker_obj.get_total_reviews()
-    trainer_level = trainer_card.level
-    try:
-        tier = get_tier(total_reviews, trainer_level)
-        id = get_random_pokemon_in_tier(tier)
-        services.logger.game_log(f"Selected tier: {tier}, Resulting Pokemon ID: {id}")
-        return id, tier
-    except Exception as e:
-        services.logger.log("error", f"Error in choose_random_pkmn_from_tier: {str(e)}")
-        show_warning_with_traceback(exception=e, message="Error occurred")
 
 
 def check_min_generate_level(name):
@@ -757,30 +711,6 @@ def check_id_ok(id_num: Union[int, list[int]]):
             return gen_config[generation - 1]
 
     return False
-
-
-def get_regional_substitute(species_id: int, region: str = None) -> "int | None":
-    """
-    Returns a regional form actual_id for the given species and region, or None.
-    If region is None, returns any valid regional variant from any region.
-    """
-    eligible = []
-    lookup = _get_regional_form_lookup().get(species_id, {})
-
-    if region:
-        options = lookup.get(region, [])
-        for v in options:
-            if check_id_ok(v):
-                eligible.append(v)
-    else:
-        for reg_variants in lookup.values():
-            for v in reg_variants:
-                if check_id_ok(v):
-                    eligible.append(v)
-
-    if eligible:
-        return random.choice(eligible)
-    return None
 
 
 def get_boosted_gens_for_region(region: str) -> list[int]:
@@ -1501,7 +1431,13 @@ def save_main_pokemon_progress(
         # MAX_FRIENDSHIP; the raw number above it is what keeps growing.
         main_pokemon.friendship += random.randint(5, 9)
         mainpkmndata["friendship"] = main_pokemon.friendship
-        if not evolution_prompted:
+        # Skip the friendship-evolution offer when the evo window is dead/None
+        # (F31 lazy singletons can leave services.evo_window None):
+        # check_friendship_evolution_for_pokemon calls evo_window.ask_pokemon_evo(...)
+        # unguarded, and an AttributeError here would abort save_main_pokemon_progress
+        # before the final ankimon_db.save_main_pokemon(...) below — silently
+        # discarding this defeat's level/xp/EV/friendship persistence.
+        if not evolution_prompted and evo_window is not None:
             friendship_evo_id = check_friendship_evolution_for_pokemon(
                 main_pokemon.individual_id,
                 main_pokemon.id,
@@ -1603,14 +1539,22 @@ def kill_pokemon(
     # Handle XP share logic
     xp_share_individual_id = settings_obj.get("trainer.xp_share")
     if xp_share_individual_id:
-        exp = xp_share_gain_exp(
-            logger,
-            settings_obj,
-            evo_window,
-            main_pokemon.id,
-            exp,
-            xp_share_individual_id,
-        )
+        try:
+            exp = xp_share_gain_exp(
+                logger,
+                settings_obj,
+                evo_window,
+                main_pokemon.id,
+                exp,
+                xp_share_individual_id,
+            )
+        except Exception as e:
+            # xp_share_gain_exp's evolution check calls evo_window.ask_pokemon_evo(...)
+            # unguarded; a dead/None window (F31 lazy singletons) can raise here.
+            # Never let the XP-share side quest abort the main Pokemon's own
+            # progress persistence below — fall back to the standard 50% share.
+            services.logger.log("error", f"XP-share evolution check failed: {e}")
+            exp = int(exp * 0.5)
 
     msg = ""
 

--- a/src/Ankimon/functions/learnset_retrieval.py
+++ b/src/Ankimon/functions/learnset_retrieval.py
@@ -205,7 +205,12 @@ def _get_learnset_moves(pokemon_name, pokemon_level, generation=9):
                 if not learn_code or learn_code[0] != target_generation:
                     continue
 
-                # Parse method: L (level-up), R (relearn), S (special/event level)
+                # Parse method: L (level-up) and R (relearn) are the only
+                # level-based sources. Every other code (M/E/T/V/D and S) is
+                # ignored. In particular 'S' encodes an event-distribution INDEX
+                # (e.g. Mewtwo "9S8", Charizard "9S11"), NOT a character level, so
+                # parsing its trailing digits as a learn level leaks event-only
+                # moves (Psystrike, Flare Blitz) into ordinary low-level movesets.
                 method = learn_code[1] if len(learn_code) > 1 else ""
                 if method == "L":
                     try:
@@ -214,11 +219,6 @@ def _get_learnset_moves(pokemon_name, pokemon_level, generation=9):
                         continue
                 elif method == "R":
                     learn_level = 1  # Relearn moves can be learned at any level >= 1
-                elif method == "S":
-                    try:
-                        learn_level = int(learn_code[2:])
-                    except ValueError:
-                        continue
                 else:
                     continue
 

--- a/src/Ankimon/functions/pokedex_functions.py
+++ b/src/Ankimon/functions/pokedex_functions.py
@@ -777,15 +777,19 @@ def return_identifier_for_item_id(item_id):
     return None
 
 
-def check_evolution_by_item(pokemon_id, item_id, file_path=poke_evo_path):
+def check_evolution_by_item(pokemon_id, item_id):
     """
     Check if a Pokémon evolves using a specific item.
 
     Region-aware and driven exclusively by pokedex.json form data: a candidate
-    evolution qualifies when its ``evoType`` is ``"useItem"`` and its ``evoItem``
-    matches the supplied item. Regional forms (``evoRegion``) are preferred when
-    the active region matches; a plain form is suppressed only when a matching
-    regional sibling exists for the current region.
+    evolution qualifies when its ``evoType`` is ``"useItem"`` **or** ``"trade"``
+    and its ``evoItem`` matches the supplied item. ``trade`` is accepted because
+    Ankimon has no trading, so the 16 trade-with-held-item species (Onix->Steelix
+    via Metal Coat, Poliwhirl->Politoed via King's Rock, Seadra->Kingdra via
+    Dragon Scale, ...) are evolved by applying the held item directly. Regional
+    forms (``evoRegion``) are preferred when the active region matches; a plain
+    form is suppressed only when a matching regional sibling exists for the
+    current region.
 
     Args:
         pokemon_id (int): The ID of the (pre-evolution) Pokémon.
@@ -822,7 +826,10 @@ def check_evolution_by_item(pokemon_id, item_id, file_path=poke_evo_path):
                             normalized_target
                         ) or pokedex_data.get(target_evo_name.lower())
 
-                        if target_data and target_data.get("evoType") == "useItem":
+                        if target_data and target_data.get("evoType") in (
+                            "useItem",
+                            "trade",
+                        ):
                             # Normalize both sides by stripping spaces, hyphens and
                             # apostrophes so pokedex.json display names (e.g.
                             # "King's Rock") match items.csv identifiers (e.g.
@@ -1003,6 +1010,14 @@ def check_evolution_for_pokemon(
     if getattr(utils, "in_bulk_resolve", False) or evolution_rejected or everstone:
         return None
 
+    # A dead/never-built evolution window (F31 lazy singletons can leave
+    # services.evo_window None) means there's nowhere to prompt the offer; skip
+    # it so the caller's defeat-persistence path is never aborted by an
+    # AttributeError from evo_window.ask_pokemon_evo(...). The offer re-fires on
+    # the next defeat once a live window exists.
+    if evo_window is None:
+        return None
+
     try:
         current_time = get_time_of_day()
 
@@ -1085,8 +1100,12 @@ def check_evolution_for_pokemon(
                                 ):
                                     knows_move = True
                             else:
-                                # Fallback when the moveset is unavailable (e.g. tests).
-                                knows_move = True
+                                # Fail closed when the moveset can't be fetched:
+                                # a move-gated evolution must never fire on
+                                # unconfirmed data (mirrors friendship_evolution.py's
+                                # conservative levelMove handling). knows_move stays
+                                # False so the evolution simply doesn't trigger.
+                                knows_move = False
 
                             if knows_move:
                                 is_level_evo = True

--- a/tests/test_encounter_functions.py
+++ b/tests/test_encounter_functions.py
@@ -345,3 +345,106 @@ def test_meets_prerequisites_fusion_and_normal():
     assert ef._meets_prerequisites(1024, {1008}) is True
     assert ef._meets_prerequisites(1024, {1007, 1008}) is True
     assert ef._meets_prerequisites(1024, set()) is False
+
+
+def test_save_main_pokemon_progress_persists_when_evo_window_none():
+    """A friendship-evo-ready main Pokemon defeated while the evo window is
+    dead/None (F31 lazy singletons) must still persist its level/xp/EV/friendship.
+
+    check_friendship_evolution_for_pokemon calls ``evo_window.ask_pokemon_evo(...)``
+    unguarded; without the call-site guard, the resulting AttributeError aborts
+    save_main_pokemon_progress before its final ankimon_db.save_main_pokemon(...),
+    silently discarding the defeat's progress. The guard must skip the offer (not
+    invoke the checker) when the window is None so the save always runs.
+    """
+    import types
+
+    names = (
+        "settings_obj",
+        "translator",
+        "services",
+        "ankimon_db",
+        "find_experience_for_level",
+        "limit_ev_yield",
+        "check_friendship_evolution_for_pokemon",
+        "check_evolution_for_pokemon",
+    )
+    orig = {n: getattr(ef, n) for n in names}
+    try:
+        main_data = {
+            "name": "Pikachu",
+            "attacks": ["Tackle"],
+            "ev": {"hp": 0, "atk": 0, "def": 0, "spa": 0, "spd": 0, "spe": 0},
+            "held_item": None,
+            "pokemon_defeated": 0,
+            "stats": {},
+            "level": 50,
+            "xp": 0,
+            "friendship": 300,
+        }
+
+        settings = mock.MagicMock()
+        settings.get = lambda k, d=None: {
+            "misc.remove_level_cap": False,
+            "gui.pop_up_dialog_message_on_defeat": False,
+        }.get(k, d)
+        ef.settings_obj = settings
+
+        ef.translator = mock.MagicMock()
+        ef.translator.translate = lambda *a, **k: "msg"
+
+        ef.services = mock.MagicMock()
+        ef.services.db.get_main_pokemon.return_value = main_data
+        ef.ankimon_db = mock.MagicMock()
+
+        # Never level up (keeps the friendship path the only evolution branch).
+        ef.find_experience_for_level = lambda *a, **k: 10**9
+        ef.limit_ev_yield = lambda have, add: {
+            "hp": 0,
+            "attack": 0,
+            "defense": 0,
+            "special-attack": 0,
+            "special-defense": 0,
+            "speed": 0,
+        }
+        # Simulate the real UNGUARDED crash: reaching this with a None window
+        # raises exactly as evo_window.ask_pokemon_evo(...) would.
+        ef.check_friendship_evolution_for_pokemon = mock.MagicMock(
+            side_effect=AttributeError(
+                "'NoneType' object has no attribute 'ask_pokemon_evo'"
+            )
+        )
+        ef.check_evolution_for_pokemon = mock.MagicMock(return_value=None)
+
+        main = types.SimpleNamespace(
+            name="Pikachu",
+            growth_rate="medium",
+            level=50,
+            xp=0,
+            individual_id="iid",
+            id=25,
+            everstone=False,
+            friendship=300,
+            stats={},
+            ev={"hp": 0, "atk": 0, "def": 0, "spa": 0, "spd": 0, "spe": 0},
+            hp=100,
+            held_item=None,
+            pokemon_defeated=0,
+            tier="Normal",
+            is_favorite=False,
+            evolution_rejected=False,
+            invalidate_cp_cache=lambda: None,
+        )
+        enemy = types.SimpleNamespace(ev_yield={})
+
+        # evo_window=None must NOT abort the save.
+        result = ef.save_main_pokemon_progress(
+            main, enemy, 5, {}, mock.MagicMock(), None
+        )
+
+        ef.ankimon_db.save_main_pokemon.assert_called_once()  # persistence intact
+        ef.check_friendship_evolution_for_pokemon.assert_not_called()  # offer skipped
+        assert result == 50
+    finally:
+        for n, v in orig.items():
+            setattr(ef, n, v)

--- a/tests/test_learnset_retrieval.py
+++ b/tests/test_learnset_retrieval.py
@@ -103,6 +103,21 @@ FAKE_LEARNSET = {
             "zapcannon": ["9L61"],
         }
     },
+    # Event 'S' codes carry a distribution INDEX, not a level (mirrors the real
+    # learnsets.json). Mewtwo "9S8" / Charizard "9S11" must NOT leak Psystrike /
+    # Flare Blitz into ordinary low-level movesets — only the real "9L" applies.
+    "mewtwo": {
+        "learnset": {
+            "confusion": ["9L1"],
+            "psystrike": ["9L72", "9S8"],
+        }
+    },
+    "charizard": {
+        "learnset": {
+            "ember": ["9L1"],
+            "flareblitz": ["9L62", "9S11"],
+        }
+    },
 }
 
 _FAKE_JSON = json.dumps(FAKE_LEARNSET)
@@ -207,6 +222,30 @@ class TestGetLevelupMove:
     def test_no_match_returns_empty_list(self):
         result = get_levelup_move_for_pokemon("slowpoke", 13, 9)
         assert result == []
+
+
+class TestEventSCodesExcluded:
+    """'S' method codes encode an event-distribution index, not a level, so they
+    must never contribute a level-up move (regression for the S-code fix)."""
+
+    def test_scode_not_leaked_below_real_level(self):
+        # "9S8" must NOT be read as level 8 — Psystrike's only legit source here
+        # is "9L72", so it is absent everywhere below level 72.
+        assert "psystrike" not in _get_learnset_moves("mewtwo", 8, 9)
+        assert "psystrike" not in _get_learnset_moves("mewtwo", 71, 9)
+
+    def test_real_level_entry_still_applies(self):
+        # The genuine "9L72" entry is unaffected by dropping the S branch.
+        assert _get_learnset_moves("mewtwo", 72, 9).get("psystrike") == 72
+
+    def test_charizard_flareblitz_scode_excluded(self):
+        # "9S11" must not leak Flare Blitz at level 11; "9L62" still grants it.
+        assert "flareblitz" not in _get_learnset_moves("charizard", 11, 9)
+        assert _get_learnset_moves("charizard", 62, 9).get("flareblitz") == 62
+
+    def test_scode_absent_from_public_move_pools(self):
+        # get_all_pokemon_moves feeds wild/starter movesets; no S-code leakage.
+        assert "psystrike" not in get_all_pokemon_moves("mewtwo", 8, 9)
 
 
 class TestLearnsetMismatches:

--- a/tests/test_pokedex_evolution_bug.py
+++ b/tests/test_pokedex_evolution_bug.py
@@ -479,3 +479,104 @@ def test_move_based_evolution_none_move_safe(monkeypatch):
     win2 = _EvoWin()
     assert _PF.check_evolution_for_pokemon("iid-2", 90101, 20, win2) is None
     assert win2.called is None
+
+
+def test_check_evolution_by_item_trade_species_real_data(monkeypatch):
+    """Trade-with-held-item species (``evoType == "trade"``) are evolvable by
+    applying the held item directly — Ankimon has no trading. Exercised against
+    the REAL pokedex.json + items.csv (not a synthetic ``useItem`` fixture), so
+    a regression that only accepts ``useItem`` fails here."""
+    monkeypatch.setattr(_PF.services, "settings", None, raising=False)  # No Region
+    # (pre_evo_id, item_id) -> evolved_id, all from the real bundled data:
+    #   Onix 95      + Metal Coat 210   -> Steelix 208
+    #   Scyther 123  + Metal Coat 210   -> Scizor 212
+    #   Seadra 117   + Dragon Scale 212 -> Kingdra 230
+    #   Poliwhirl 61 + King's Rock 198  -> Politoed 186
+    #   Slowpoke 79  + King's Rock 198  -> Slowking 199
+    assert _PF.check_evolution_by_item(95, 210) == 208
+    assert _PF.check_evolution_by_item(123, 210) == 212
+    assert _PF.check_evolution_by_item(117, 212) == 230
+    assert _PF.check_evolution_by_item(61, 198) == 186
+    assert _PF.check_evolution_by_item(79, 198) == 199
+    # Wrong item must not trigger: Onix needs Metal Coat, not King's Rock.
+    assert _PF.check_evolution_by_item(95, 198) is None
+
+
+def test_move_based_evolution_fails_closed_when_data_unavailable(monkeypatch):
+    """A ``levelMove`` evolution must NOT fire when the moveset can't be
+    confirmed (DB record lacks ``attacks`` or ``get_pokemon`` raises) — it fails
+    closed, mirroring friendship_evolution.py, instead of the old fail-open
+    default that could evolve on unconfirmed data (Gemini :1087)."""
+    monkeypatch.setattr(_PF.services, "settings", None, raising=False)
+    _install_synthetic_pokedex(
+        monkeypatch,
+        {
+            "movemon": {
+                "species_id": 90301,
+                "actual_id": 90301,
+                "evos": ["MoveKing"],
+            },
+            "moveking": {
+                "species_id": 90302,
+                "actual_id": 90302,
+                "evoType": "levelMove",
+                "evoMove": "Psyshield Bash",
+            },
+        },
+    )
+
+    class _EvoWin:
+        def __init__(self):
+            self.called = None
+
+        def ask_pokemon_evo(self, individual_id, pokemon_id, evo_id):
+            self.called = (individual_id, pokemon_id, evo_id)
+
+    # DB record without an "attacks" key -> move unconfirmed -> no evolution.
+    class _DBNoAttacks:
+        def get_pokemon(self, individual_id):
+            return {"level": 20}
+
+    monkeypatch.setattr(_PF.services, "db", _DBNoAttacks(), raising=False)
+    win = _EvoWin()
+    assert _PF.check_evolution_for_pokemon("iid", 90301, 20, win) is None
+    assert win.called is None
+
+    # DB unavailable (raises) -> also fails closed, no crash.
+    class _DBRaises:
+        def get_pokemon(self, individual_id):
+            raise RuntimeError("db down")
+
+    monkeypatch.setattr(_PF.services, "db", _DBRaises(), raising=False)
+    win2 = _EvoWin()
+    assert _PF.check_evolution_for_pokemon("iid", 90301, 20, win2) is None
+    assert win2.called is None
+
+
+def test_check_evolution_for_pokemon_none_window_skips_cleanly(monkeypatch):
+    """A ``None`` evo_window (F31 lazy singletons can leave services.evo_window
+    None) must skip the offer and return None WITHOUT reaching
+    ``evo_window.ask_pokemon_evo(...)`` — so the caller's defeat-persistence path
+    is never aborted by an AttributeError (the old broad-except only turned that
+    crash into a scary warning dialog)."""
+    monkeypatch.setattr(_PF.services, "settings", None, raising=False)
+    _install_synthetic_pokedex(
+        monkeypatch,
+        {
+            "levelmon": {
+                "species_id": 90401,
+                "actual_id": 90401,
+                "evos": ["LevelKing"],
+            },
+            "levelking": {
+                "species_id": 90402,
+                "actual_id": 90402,
+                "evoLevel": 16,
+            },
+        },
+    )
+    _PF.show_warning_with_traceback.reset_mock()
+    # Level 20 >= evoLevel 16 would normally prompt; a None window degrades to
+    # "no offer" without crashing or warning.
+    assert _PF.check_evolution_for_pokemon("iid", 90401, 20, None) is None
+    _PF.show_warning_with_traceback.assert_not_called()


### PR DESCRIPTION
## What
Final-review fixes for **battle-loop + evolution + learnset** — two integration regressions and one real bug (+8 regression tests):

- **HIGH regression — silent data loss:** `battle_loop` passes `evo_window=None` when the window is dead, but `check_evolution_for_pokemon` / `check_friendship_evolution_for_pokemon` called `evo_window.ask_pokemon_evo()` unguarded → `AttributeError` aborted `save_main_pokemon_progress`, discarding a defeat's level/XP/EV/friendship persistence. Now None-guarded so persistence + post-battle cleanup always run.
- **HIGH regression — 16 species unevolvable:** `check_evolution_by_item` had narrowed to `evoType=='useItem'`, dropping the trade-with-held-item path (Steelix/Scizor/Kingdra/Politoed/Slowking/…). Restored, with a regression test using **real** `pokedex.json` data (the prior test used a synthetic fixture, so it never caught this).
- **HIGH bug — event moves leaking:** the learnset **S-code** (`'9S55'`) suffix is an event-distribution *index*, not a level, so moves like Psystrike@lv8 / Flare Blitz@lv11 leaked into wild/starter movesets. Excluded S-codes from the level-up pool; added an S-code test.

## Verification
Tier-1 **421 passed / 0 failed**; ruff 10; harness 9/9; Qt 5; boot 3 hooks; play OK. Caching layer + `services.ui.warn` seam preserved.

## Attribution
Co-authored-by: Hakimh2.
