### PR TITLE
fix(review): SQLite busy_timeout + is_dev_mode helper + core mediums

### DIFF
--- a/src/Ankimon/ankidex/ankidex_data.py
+++ b/src/Ankimon/ankidex/ankidex_data.py
@@ -1,0 +1,192 @@
+"""Widget-free Ankidex payload builder (extracted from ``ankidex_obj.Ankidex``).
+
+Keeps the collection-data query out of the Qt dialog so the same logic can be
+unit-tested without constructing a ``QWebEngineView`` (and reused by other hosts
+without spinning up a hidden window). The Qt-bound ``Ankidex`` window delegates
+here; the heavy ``encounter_functions`` import is done lazily so this module
+stays cheap to import and easy to stub in tests.
+"""
+
+from ..functions import encounter_data
+
+
+# Tiers the live wild-encounter roll draws from (encounter_functions.
+# get_all_pokemon_in_tier). "Starter" is included on purpose: that function
+# returns [] for it (starters come only from the one-time starter picker), so
+# gating through it keeps Ankidex's "Available" badge in lockstep with the roll.
+_ENCOUNTER_TIERS = (
+    "Normal",
+    "Baby",
+    "Ultra",
+    "Legendary",
+    "Mythical",
+    "Mega",
+    "Gmax",
+    "Starter",
+)
+
+
+def build_encounterable_ids(settings):
+    """Return the set of Pokemon the live wild-encounter roll can actually produce.
+
+    Built from the SAME source the roll uses — ``get_all_pokemon_in_tier()`` per
+    tier, each candidate gated by ``check_id_ok()`` (the roll's generation-toggle
+    / regional-form check) — instead of unioning the raw ``encounter_data`` tier
+    lists. Reading the raw lists marked species "Available" that can never spawn:
+    every Starter (``get_all_pokemon_in_tier('Starter')`` is ``[]``) and, by
+    default, every generation whose ``misc.genN`` toggle is off (Gen 9 defaults
+    off), e.g. Koraidon / Miraidon / Terapagos.
+    """
+    from ..functions.encounter_functions import (
+        check_id_ok,
+        get_all_pokemon_in_tier,
+    )
+
+    ids = set()
+    for tier in _ENCOUNTER_TIERS:
+        for pid in get_all_pokemon_in_tier(tier):
+            if check_id_ok(pid):
+                ids.add(pid)
+
+    # Explicit exclusions: never spawnable regardless of tier / generation.
+    for uid in getattr(encounter_data, "UNAVAILABLE", []):
+        ids.discard(uid)
+
+    # Regional forms for the active region — same generation gate as the roll.
+    active_region = settings.get("misc.active_region") if settings else None
+    regional = getattr(encounter_data, "REGIONAL_FORMS", {})
+    if active_region and active_region in regional:
+        for pid in regional[active_region]:
+            if check_id_ok(pid):
+                ids.add(pid)
+
+    return ids
+
+
+def _empty_payload():
+    """Empty-but-valid payload so the SPA still renders when the DB is absent."""
+    return {
+        "owned": [],
+        "shinies": [],
+        "seen": [],
+        "encounterable": [],
+        "prerequisites": {},
+        "prefs": {
+            "viewMode": "grid",
+            "sortMode": "id-asc",
+            "spriteMode": "static",
+        },
+        "regional_data": {"boosts": {}, "forms": {}},
+        "evolutionNote": "",
+    }
+
+
+def _prefs(settings):
+    """Read the Ankidex view prefs, falling back to the legacy pokedex_v2 keys."""
+    if not settings:
+        return {"viewMode": "grid", "sortMode": "id-asc", "spriteMode": "static"}
+    return {
+        "viewMode": settings.get(
+            "ankidex.viewMode", settings.get("pokedex_v2.viewMode", "grid")
+        ),
+        "sortMode": settings.get(
+            "ankidex.sortMode", settings.get("pokedex_v2.sortMode", "id-asc")
+        ),
+        "spriteMode": settings.get(
+            "ankidex.spriteMode", settings.get("pokedex_v2.spriteMode", "static")
+        ),
+    }
+
+
+def get_ankidex_data(db, settings, tracker=None):
+    """Fetch comprehensive collection data for the Ankidex SPA (widget-free).
+
+    ``db`` / ``settings`` are the services-resolved singletons (passed in so this
+    stays testable and reusable); ``tracker`` is optional (its
+    ``get_ids_in_collection()`` side effect is preserved when present).
+    """
+    if not db:
+        # Reload-safe: between a profile swap and the next populate() the registry
+        # can be unpopulated (db is None). Serve an empty-but-valid payload so the
+        # SPA still renders instead of raising AttributeError on db.execute(...).
+        return _empty_payload()
+
+    if tracker is not None:
+        tracker.get_ids_in_collection()
+
+    # 1. Shiny owned
+    cursor = db.execute(
+        "SELECT DISTINCT pokedex_id FROM captured_pokemon WHERE shiny = 1 AND pokedex_id IS NOT NULL"
+    )
+    shiny_owned_ids = [row[0] for row in cursor.fetchall()]
+
+    # 2. Caught status — currently owned
+    cursor = db.execute(
+        "SELECT pokedex_id FROM captured_pokemon WHERE pokedex_id IS NOT NULL"
+    )
+    caught_ids = {row[0] for row in cursor.fetchall()}
+
+    # Released Pokemon (from history)
+    cursor = db.execute(
+        "SELECT DISTINCT json_extract(data, '$.id') FROM pokemon_history"
+    )
+    for row in cursor.fetchall():
+        if row[0]:
+            caught_ids.add(int(row[0]))
+
+    # Explicitly recorded caught Pokemon (e.g. from evolutions or prior captures)
+    if hasattr(db, "get_caught_ids"):
+        try:
+            caught_ids.update(db.get_caught_ids())
+        except Exception:
+            pass
+
+    # 3. Seen status (encountered but not caught)
+    seen_ids = set()
+    if hasattr(db, "get_seen_ids"):
+        seen_ids.update(db.get_seen_ids())
+    else:
+        seen_data = db.get_user_data("pokedex_seen", [])
+        if isinstance(seen_data, list):
+            seen_ids.update(set(seen_data))
+    seen_ids = seen_ids - caught_ids
+
+    # 4. Encounterable IDs — gated to exactly what the live roll can produce.
+    encounterable_ids = build_encounterable_ids(settings)
+
+    # 5. Prerequisites
+    prereqs = {}
+    for k, v in encounter_data.PREREQUISITES.items():
+        if isinstance(v, set):
+            prereqs[str(k)] = list(v)
+        elif isinstance(v, tuple) and len(v) == 2:
+            # Handle ("OR", {1007, 1008})
+            op, items = v
+            prereqs[str(k)] = [op, list(items) if isinstance(items, set) else items]
+        else:
+            prereqs[str(k)] = v
+
+    return {
+        "owned": list(caught_ids),
+        "shinies": shiny_owned_ids,
+        "seen": list(seen_ids),
+        "encounterable": list(encounterable_ids),
+        "prerequisites": prereqs,
+        "prefs": _prefs(settings),
+        "regional_data": {
+            "boosts": {
+                "kanto": [1],
+                "johto": [2],
+                "hoenn": [3],
+                "sinnoh": [4],
+                "unova": [5],
+                "kalos": [6],
+                "alola": [7],
+                "galar": [8],
+                "paldea": [9],
+                "hisui": [4, 8],
+            },
+            "forms": encounter_data.REGIONAL_FORM_REGION,
+        },
+        "evolutionNote": "Evolutions in Ankimon can trigger via Level, Friendship, Evolution Stones/Items, Time of Day, or knowing specific Moves.",
+    }

--- a/src/Ankimon/ankidex/ankidex_obj.py
+++ b/src/Ankimon/ankidex/ankidex_obj.py
@@ -3,7 +3,6 @@ import json
 from aqt import QDialog, QVBoxLayout, QWebEngineView
 from aqt.qt import Qt, QUrl, QFrame
 from ..services import services
-from ..functions import encounter_data
 
 
 class Ankidex(QDialog):
@@ -48,180 +47,15 @@ class Ankidex(QDialog):
         self.load_initial_html()
 
     def get_ankidex_data(self):
-        """Fetches comprehensive collection data for Ankidex."""
-        db = services.db
-        settings = services.settings
-        if not db:
-            # Reload-safe: between a profile swap and the next populate() the
-            # registry can be unpopulated (services.db is None). Serve an
-            # empty-but-valid payload so the SPA still renders instead of
-            # raising AttributeError on db.execute(...).
-            return {
-                "owned": [],
-                "shinies": [],
-                "seen": [],
-                "encounterable": [],
-                "prerequisites": {},
-                "stats": {
-                    "caughtCount": 0,
-                    "releasedCount": 0,
-                    "defeatedCount": 0,
-                },
-                "prefs": {
-                    "viewMode": "grid",
-                    "sortMode": "id-asc",
-                    "spriteMode": "static",
-                },
-                "regional_data": {"boosts": {}, "forms": {}},
-                "evolutionNote": "",
-            }
-        self.ankimon_tracker.get_ids_in_collection()
+        """Fetch comprehensive collection data for Ankidex.
 
-        # 1. Shiny Owned
-        cursor = db.execute(
-            "SELECT DISTINCT pokedex_id FROM captured_pokemon WHERE shiny = 1 AND pokedex_id IS NOT NULL"
-        )
-        shiny_owned_ids = [row[0] for row in cursor.fetchall()]
+        Delegates to the widget-free ``ankidex_data`` builder so the query logic
+        does not depend on this QDialog and can be unit-tested / reused without a
+        hidden QWebEngineView.
+        """
+        from .ankidex_data import get_ankidex_data
 
-        # 1. Caught Status (Currently in collection OR released)
-        # Currently owned
-        cursor = db.execute(
-            "SELECT pokedex_id FROM captured_pokemon WHERE pokedex_id IS NOT NULL"
-        )
-        caught_ids = {row[0] for row in cursor.fetchall()}
-
-        # Released Pokémon (from history)
-        cursor = db.execute(
-            "SELECT DISTINCT json_extract(data, '$.id') FROM pokemon_history"
-        )
-        for row in cursor.fetchall():
-            if row[0]:
-                caught_ids.add(int(row[0]))
-
-        # Explicitly recorded caught Pokémon (e.g. from evolutions or prior captures)
-        if hasattr(db, "get_caught_ids"):
-            try:
-                caught_ids.update(db.get_caught_ids())
-            except Exception:
-                pass
-
-        # 2. Seen Status (Encountered but not caught)
-        seen_ids = set()
-        if hasattr(db, "get_seen_ids"):
-            seen_ids.update(db.get_seen_ids())
-        else:
-            seen_data = db.get_user_data("pokedex_seen", [])
-            if isinstance(seen_data, list):
-                seen_ids.update(set(seen_data))
-
-        # Remove caught IDs from seen IDs to keep them strictly separate
-        seen_ids = seen_ids - caught_ids
-
-        # 3. Stats Summary
-        total_caught_count = db.get_pokemon_count()
-        cursor = db.execute(
-            "SELECT SUM(CAST(json_extract(data, '$.pokemon_defeated') AS INTEGER)) FROM captured_pokemon"
-        )
-        defeated_caught = cursor.fetchone()[0] or 0
-
-        cursor = db.execute(
-            "SELECT COUNT(*), SUM(CAST(json_extract(data, '$.pokemon_defeated') AS INTEGER)) FROM pokemon_history"
-        )
-        row = cursor.fetchone()
-        released_count = row[0] or 0
-        defeated_released = row[1] or 0
-
-        defeated_total = defeated_caught + defeated_released
-
-        # 4. Encounterable IDs
-        encounterable_ids = set()
-        # Positive lists
-        for list_name in [
-            "LEGENDARY",
-            "MYTHICAL",
-            "BABY",
-            "ULTRA",
-            "NORMAL",
-            "STARTERS",
-            "MEGA",
-            "GMAX",
-        ]:
-            l = getattr(encounter_data, list_name, [])
-            encounterable_ids.update(l)
-
-        # Explicit exclusions
-        unavail = getattr(encounter_data, "UNAVAILABLE", [])
-        for uid in unavail:
-            if uid in encounterable_ids:
-                encounterable_ids.remove(uid)
-
-        # Add encounterable regional form IDs for the active region
-        from ..functions.encounter_data import REGIONAL_FORMS
-
-        active_region = settings.get("misc.active_region") if settings else None
-        if active_region and active_region in REGIONAL_FORMS:
-            encounterable_ids.update(REGIONAL_FORMS[active_region])
-
-        # 5. Prerequisites
-        prereqs = {}
-        for k, v in encounter_data.PREREQUISITES.items():
-            if isinstance(v, set):
-                prereqs[str(k)] = list(v)
-            elif isinstance(v, tuple) and len(v) == 2:
-                # Handle ("OR", {1007, 1008})
-                op, items = v
-                prereqs[str(k)] = [op, list(items) if isinstance(items, set) else items]
-            else:
-                prereqs[str(k)] = v
-
-        return {
-            "owned": list(caught_ids),
-            "shinies": shiny_owned_ids,
-            "seen": list(seen_ids),
-            "encounterable": list(encounterable_ids),
-            "prerequisites": prereqs,
-            "stats": {
-                "caughtCount": total_caught_count,
-                "releasedCount": released_count,
-                "defeatedCount": defeated_total,
-            },
-            "prefs": {
-                "viewMode": settings.get(
-                    "ankidex.viewMode",
-                    settings.get("pokedex_v2.viewMode", "grid"),
-                )
-                if settings
-                else "grid",
-                "sortMode": settings.get(
-                    "ankidex.sortMode",
-                    settings.get("pokedex_v2.sortMode", "id-asc"),
-                )
-                if settings
-                else "id-asc",
-                "spriteMode": settings.get(
-                    "ankidex.spriteMode",
-                    settings.get("pokedex_v2.spriteMode", "static"),
-                )
-                if settings
-                else "static",
-            },
-            "regional_data": {
-                "boosts": {
-                    "kanto": [1],
-                    "johto": [2],
-                    "hoenn": [3],
-                    "sinnoh": [4],
-                    "unova": [5],
-                    "kalos": [6],
-                    "alola": [7],
-                    "galar": [8],
-                    "paldea": [9],
-                    "hisui": [4, 8],
-                },
-                "forms": encounter_data.REGIONAL_FORM_REGION,
-            },
-            "evolutionNote": "Evolutions in Ankimon can trigger via Level, Friendship, Evolution Stones/Items, Time of Day, or knowing specific Moves.",
-        }
+        return get_ankidex_data(services.db, services.settings, self.ankimon_tracker)
 
     def load_initial_html(self):
         file_path = os.path.join(self.addon_dir, "ankidex", "ankidex.html").replace(

--- a/src/Ankimon/menu_buttons.py
+++ b/src/Ankimon/menu_buttons.py
@@ -35,14 +35,10 @@ from .gui_entities import (
     Version_Dialog,
 )
 
-# is_dev_mode lands with the thread-reload-and-misc-utils unit; until then fall
-# back to a disabled dev mode so the developer-only menu entries stay hidden.
-try:
-    from .utils import is_dev_mode
-except ImportError:  # pragma: no cover - dev helper not landed yet
-
-    def is_dev_mode():
-        return False
+# Developer-mode gate (reads misc.developer_mode via the settings seam). Hides
+# the developer-only menu entries (Switch Account / Encounter Rate Simulator)
+# unless the user has turned Developer Mode on.
+from .utils import is_dev_mode, is_alive
 
 
 debug = True
@@ -325,14 +321,25 @@ def create_menu_actions(
     switch_account_action.triggered.connect(swap_ankimon_account)
     mw.pokemenu.addAction(switch_account_action)
 
-    # Encounter Rate Simulator (developer tool).
+    # Encounter Rate Simulator (developer tool). Cache the dialog on mw (like the
+    # file's other game/dev windows) before showing it: the dialog is parentless
+    # and embeds a QWebEngineView, so if the only reference lived in the lambda it
+    # would be dropped the moment the lambda returned and SIP would delete the
+    # underlying C++ widget — the window would vanish or crash on open. Keeping a
+    # Python reference on mw (rebuilt when its C++ object dies) keeps it alive.
     from .pyobj.encounter_simulator_dialog import EncounterSimulatorDialog
+
+    def _open_encounter_simulator():
+        if not is_alive(getattr(mw, "_encounter_simulator_dialog", None)):
+            mw._encounter_simulator_dialog = EncounterSimulatorDialog(addon_dir)
+        dlg = mw._encounter_simulator_dialog
+        dlg.show()
+        dlg.raise_()
+        dlg.activateWindow()
 
     simulator_action = QAction("Encounter Rate Simulator", mw)
     simulator_action.setMenuRole(QAction.MenuRole.NoRole)
-    simulator_action.triggered.connect(
-        lambda: EncounterSimulatorDialog(addon_dir).show()
-    )
+    simulator_action.triggered.connect(_open_encounter_simulator)
     help_menu.addAction(simulator_action)
 
     # Re-evaluate the developer-only entries each time the menu opens, so
@@ -396,6 +403,19 @@ def create_menu_actions(
     mobile_battles_action.triggered.connect(lambda: _open_shell_at("mobile"))
     game_menu.addAction(mobile_battles_action)
     _mobile_battles_action = mobile_battles_action
+
+    # Restore the previous-session pending count now that the action exists. The
+    # profile_did_open bootstrap calls update_mobile_badge() as it restores the
+    # badge, but on a cold boot that fires (10ms Qt timer) before this menu is
+    # built by the background-boot success callback — so its update was a no-op
+    # and the count was dropped. Re-applying here makes the restore ordering-
+    # independent: the badge is correct the instant the action is created.
+    try:
+        from .services import services
+
+        update_mobile_badge(services.db.get_pending_mobile_count())
+    except Exception:
+        pass
 
     file_check_action = QAction(mw.translator.translate("ankimon_file_checker_button"), mw)
     file_check_action.setMenuRole(QAction.MenuRole.NoRole)

--- a/src/Ankimon/pyobj/database_manager.py
+++ b/src/Ankimon/pyobj/database_manager.py
@@ -105,6 +105,10 @@ class AnkimonDB:
     
     DB_FILENAME = "ankimon.db"
 
+    # Every connection (GUI + per-background-thread) waits this long for a
+    # write lock before sqlite raises "database is locked". See _prepare_connection.
+    _BUSY_TIMEOUT_MS = 30000
+
     def __init__(self, logger=None, db_path: Optional[Union[str, Path]] = None,
                  *, wal: bool = False):
         self.logger = logger
@@ -123,8 +127,23 @@ class AnkimonDB:
         self._setup_database()
 
     def _prepare_connection(self, conn):
-        """Apply row factory and (only when opted in) WAL-family PRAGMAs, then wrap."""
+        """Apply row factory, a generous busy-timeout, and (only when opted in)
+        WAL-family PRAGMAs, then wrap."""
         conn.row_factory = sqlite3.Row  # Access columns by name
+        # Busy-timeout on EVERY connection (GUI + per-background-thread), regardless
+        # of journal mode. mobile-sync's bulk "Resolve All" runs on a background
+        # thread and holds one long write transaction (conn._disable_commit while it
+        # batches every companion), so a concurrent GUI-thread write — a live
+        # review's save_pokemon / set_config_value — can find the DB write-locked.
+        # Without a busy-timeout sqlite3 raises "database is locked" immediately;
+        # with one it waits for the bulk transaction to commit instead of erroring.
+        # 30s comfortably covers a full bulk resolve (Python's connect() default is
+        # only 5s). This is the robust, single-file-safe alternative to enabling WAL
+        # here (which would need a checkpoint-before-copy backup fix, NR-05).
+        try:
+            conn.execute(f"PRAGMA busy_timeout={self._BUSY_TIMEOUT_MS};")
+        except Exception as e:
+            self._log("warning", f"Failed to set busy_timeout: {e}")
         if self._wal:
             try:
                 mode = conn.execute("PRAGMA journal_mode;").fetchone()[0]

--- a/src/Ankimon/reviewer_ui.py
+++ b/src/Ankimon/reviewer_ui.py
@@ -21,12 +21,9 @@ from .functions.encounter_functions import (
 )
 from .texts import _bottomHTML_template, button_style
 
-try:
-    from .utils import is_dev_mode
-except ImportError:  # dev helper not landed yet (thread-reload-and-misc-utils unit)
-
-    def is_dev_mode():
-        return False
+# Developer-mode gate (reads misc.developer_mode via the settings seam). Guards
+# the dev-only test-encounter hotkey ('0'); default-off so it stays hidden.
+from .utils import is_dev_mode
 
 
 _collected_pokemon_ids = set()

--- a/src/Ankimon/singletons.py
+++ b/src/Ankimon/singletons.py
@@ -411,8 +411,15 @@ def swap_ankimon_account():
         # Reload configuration in place.
         services.settings.load_config()
 
-        # Update the main Pokémon in place.
-        update_main_pokemon(services.main_pokemon)
+        # Update the main Pokémon. update_main_pokemon() mutates the passed-in
+        # object in place ONLY when the now-active DB already has a saved main;
+        # for a DB with none yet (e.g. the first switch to ankimonDEV.db) it
+        # returns a fresh, unrelated PokemonObject. Discarding that would leave
+        # the live singleton — shared by test_window / battle_loop / pokemon_pc —
+        # still showing the previous account's Pokemon, so apply it back.
+        new_main, _ = update_main_pokemon(services.main_pokemon)
+        if new_main is not None and new_main is not services.main_pokemon:
+            services.main_pokemon.update_stats(**new_main.to_dict())
 
         # Refresh trainer-card data from the now-active account.
         services.trainer_card.refresh()

--- a/src/Ankimon/texts.py
+++ b/src/Ankimon/texts.py
@@ -9,6 +9,7 @@ _bottomHTML_template = """
         <td align=center valign=top class=stat>
         <button title="%(DefeatKey)s" onclick="pycmd('defeat');">Defeat Pokemon</button>
         <button title="%(CatchKey)s" onclick="pycmd('catch');">Catch Pokemon</button>
+        <button title="%(TeamCycleKey)s" onclick="pycmd('team_cycle');">Cycle Team</button>
         </td>
         <td align=end valign=top class=stat>
         <button title="%(morekey)s" onclick="pycmd('more');">%(more)s %(downArrow)s</button>

--- a/src/Ankimon/utils.py
+++ b/src/Ankimon/utils.py
@@ -1016,3 +1016,19 @@ def is_alive(obj) -> bool:
         return True
     except (RuntimeError, AttributeError):
         return False
+
+
+def is_dev_mode() -> bool:
+    """True when the user has enabled Developer Mode (``misc.developer_mode``).
+
+    Single source of truth for the developer-only surface: the menu entries
+    ``Switch Account (DEV/Normal)`` / ``Encounter Rate Simulator`` and the
+    reviewer test hotkey ('0'). Reads through the settings seam and never raises
+    — a missing settings service or key leaves the dev tools hidden (default
+    False), so importers can drop their local ImportError fallbacks now that the
+    helper has landed.
+    """
+    try:
+        return bool(services.settings.get("misc.developer_mode", False))
+    except Exception:
+        return False

--- a/tests/test_ankidex_encounterable.py
+++ b/tests/test_ankidex_encounterable.py
@@ -1,0 +1,117 @@
+"""Tier-1 contract for the Ankidex 'Available' badge source (ankidex_data).
+
+build_encounterable_ids() must mark a species 'Available' only when the live
+wild-encounter roll can actually produce it — i.e. it must gate every candidate
+through encounter_functions.get_all_pokemon_in_tier() + check_id_ok(), NOT union
+the raw encounter_data tier lists. The regression this pins:
+
+* Starters never appear (get_all_pokemon_in_tier('Starter') is [] — starters
+  come only from the one-time starter picker).
+* Generation-disabled species (e.g. Gen 9 legendaries when misc.gen9 is off)
+  never appear, because check_id_ok() rejects them.
+* UNAVAILABLE ids and generation-disabled regional forms never appear.
+
+Qt-free: ankidex_data.py imports no Qt; encounter_functions / encounter_data are
+stubbed so the test controls the gate and never touches the real 1000-line data.
+"""
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+_src = Path(__file__).parent.parent / "src"
+
+# Simulated live-roll pool. Starter is empty on purpose (matches the real
+# get_all_pokemon_in_tier('Starter') == []).
+_TIER_POOL = {
+    "Normal": [1, 4, 7],
+    "Baby": [172],
+    "Ultra": [793],
+    "Legendary": [1007, 888],  # 1007 = Gen 9 (disabled below), 888 = Gen 8
+    "Mythical": [1024],        # Gen 9 (disabled)
+    "Mega": [],
+    "Gmax": [],
+    "Starter": [],             # never wild-spawnable
+}
+
+# Ids the generation toggle rejects (stand-in for misc.gen9 == False, plus a
+# disabled regional form).
+_DISABLED = {1007, 1024, 10101}
+
+
+def _fake_get_all_pokemon_in_tier(tier):
+    return _TIER_POOL.get(tier, [])
+
+
+def _fake_check_id_ok(pid):
+    return pid not in _DISABLED
+
+
+class _Settings:
+    def __init__(self, region=None):
+        self._region = region
+
+    def get(self, key, default=None):
+        if key == "misc.active_region":
+            return self._region
+        return default
+
+
+@pytest.fixture
+def ankidex_data(monkeypatch):
+    # Stub encounter_data (top-level import) and encounter_functions (lazy import
+    # inside build_encounterable_ids) so the gate is fully under test control.
+    ed = types.ModuleType("Ankimon.functions.encounter_data")
+    ed.UNAVAILABLE = [4]  # Normal-tier id that is explicitly excluded
+    ed.REGIONAL_FORMS = {"alola": [10100, 10101]}
+    ed.PREREQUISITES = {}
+    ed.REGIONAL_FORM_REGION = {}
+    monkeypatch.setitem(sys.modules, "Ankimon.functions.encounter_data", ed)
+
+    ef = types.ModuleType("Ankimon.functions.encounter_functions")
+    ef.check_id_ok = _fake_check_id_ok
+    ef.get_all_pokemon_in_tier = _fake_get_all_pokemon_in_tier
+    monkeypatch.setitem(sys.modules, "Ankimon.functions.encounter_functions", ef)
+
+    spec = importlib.util.spec_from_file_location(
+        "Ankimon.ankidex.ankidex_data", _src / "Ankimon" / "ankidex" / "ankidex_data.py"
+    )
+    mod = importlib.util.module_from_spec(spec)
+    monkeypatch.setitem(sys.modules, "Ankimon.ankidex.ankidex_data", mod)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_encounterable_excludes_generation_disabled_legendaries(ankidex_data):
+    ids = ankidex_data.build_encounterable_ids(_Settings())
+    # The exact reported bug: a Gen-9-disabled legendary/mythical shown Available.
+    assert 1007 not in ids
+    assert 1024 not in ids
+    # A gen-enabled legendary from the same tier list still shows.
+    assert 888 in ids
+
+
+def test_encounterable_excludes_starters(ankidex_data):
+    ids = ankidex_data.build_encounterable_ids(_Settings())
+    # Starter tier yields [] — no starter can leak in as wild-Available.
+    assert ids == {1, 7, 172, 793, 888}
+
+
+def test_encounterable_applies_unavailable_exclusion(ankidex_data):
+    ids = ankidex_data.build_encounterable_ids(_Settings())
+    assert 4 not in ids  # in UNAVAILABLE
+
+
+def test_encounterable_regional_forms_are_generation_gated(ankidex_data):
+    ids = ankidex_data.build_encounterable_ids(_Settings(region="alola"))
+    assert 10100 in ids       # enabled regional form for the active region
+    assert 10101 not in ids   # disabled regional form must not appear
+
+
+def test_stats_key_removed_from_empty_payload(ankidex_data):
+    # The dead 'stats' block (2 aggregate SQL queries nothing in the UI read) is
+    # gone from the payload shape.
+    assert "stats" not in ankidex_data._empty_payload()

--- a/tests/test_database_manager.py
+++ b/tests/test_database_manager.py
@@ -174,6 +174,30 @@ def test_get_item_returns_empty_dict_extras(temp_env):
     conn = db._get_connection()
     conn.execute("INSERT INTO items (id, item_name, quantity, data) VALUES (999, 'null-item', 1, NULL)")
     conn.commit()
-    
+
     item = db.get_item("null-item")
     assert item["extra_data"] == {} # Should be {} not None
+
+
+def test_busy_timeout_set_on_gui_connection(temp_env):
+    """Concurrency guard: every connection must carry the generous busy-timeout
+    so a GUI-thread write does not immediately raise 'database is locked' while
+    mobile-sync's bulk 'Resolve All' holds its long background write transaction.
+    Without the fix the connect() default (5000ms) would be in effect."""
+    db, _ = temp_env
+    conn = db._get_connection()
+    got = conn.execute("PRAGMA busy_timeout;").fetchone()[0]
+    assert got == AnkimonDB._BUSY_TIMEOUT_MS
+    assert got >= 30000
+
+
+def test_busy_timeout_set_on_background_thread_connection(temp_env):
+    """The per-background-thread connection (used by the bulk mobile resolve) must
+    get the same busy-timeout as the GUI connection — it is the one that races.
+    Force the off-GUI-thread branch of _get_connection() so the dedicated
+    per-thread connection is what gets probed."""
+    db, _ = temp_env
+    with patch.object(_db_mod, "_is_main_thread", return_value=False):
+        conn = db._get_connection()  # dedicated per-thread connection
+        got = conn.execute("PRAGMA busy_timeout;").fetchone()[0]
+    assert got == AnkimonDB._BUSY_TIMEOUT_MS

--- a/tests/test_is_dev_mode.py
+++ b/tests/test_is_dev_mode.py
@@ -1,0 +1,59 @@
+"""Tier-1 contract for utils.is_dev_mode() (the developer-mode gate).
+
+The helper is the single source of truth behind the developer-only menu entries
+(Switch Account / Encounter Rate Simulator) and the reviewer test hotkey. It must
+read misc.developer_mode through the settings seam and default to False (dev
+tools hidden) when settings are missing or the read raises.
+
+Qt-free: uses the real Ankimon.utils (conftest keeps it real) and swaps only
+services.settings, so nothing Qt is constructed. The import is done inside the
+fixture — after conftest's autouse restore has re-established the Ankimon package
+with its __path__ (other test modules clobber that stub at their import time).
+"""
+
+import pytest
+
+
+@pytest.fixture
+def dev(monkeypatch):
+    import Ankimon.utils as utils_mod
+    from Ankimon.utils import is_dev_mode
+
+    store = {}
+
+    class _Settings:
+        def get(self, key, default=None):
+            return store.get(key, default)
+
+    monkeypatch.setattr(utils_mod.services, "settings", _Settings())
+    return is_dev_mode, store
+
+
+def test_dev_mode_true_when_flag_enabled(dev):
+    is_dev_mode, store = dev
+    store["misc.developer_mode"] = True
+    assert is_dev_mode() is True
+
+
+def test_dev_mode_false_when_flag_disabled(dev):
+    is_dev_mode, store = dev
+    store["misc.developer_mode"] = False
+    assert is_dev_mode() is False
+
+
+def test_dev_mode_defaults_false_when_key_absent(dev):
+    is_dev_mode, _ = dev
+    # Nothing set — the helper must default to hidden dev tools.
+    assert is_dev_mode() is False
+
+
+def test_dev_mode_false_and_no_raise_when_settings_broken(monkeypatch):
+    import Ankimon.utils as utils_mod
+    from Ankimon.utils import is_dev_mode
+
+    class _Broken:
+        def get(self, *a, **k):
+            raise RuntimeError("settings not ready")
+
+    monkeypatch.setattr(utils_mod.services, "settings", _Broken())
+    assert is_dev_mode() is False

--- a/tests/test_reviewer_team_cycle_button.py
+++ b/tests/test_reviewer_team_cycle_button.py
@@ -1,0 +1,37 @@
+"""Tier-1 contract for the reviewer bottom-bar 'Cycle Team' button (F34).
+
+reviewer_ui._linkHandler_wrap already routes pycmd('team_cycle') to the team
+cycler and _bottomHTML_wrap computes a TeamCycleKey tooltip, but until a button
+actually emits pycmd('team_cycle') that branch/tooltip are unreachable (team
+cycling only worked via the '9' hotkey). This pins that the bottom-bar template
+carries the click entry point, matching the Catch/Defeat buttons.
+
+texts.py is pure string constants; load it directly so the test is independent
+of the shared Ankimon package-stub state other test modules leave behind.
+"""
+
+import importlib.util
+from pathlib import Path
+
+_texts_path = Path(__file__).parent.parent / "src" / "Ankimon" / "texts.py"
+_spec = importlib.util.spec_from_file_location("_ankimon_texts_under_test", _texts_path)
+_texts = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_texts)
+
+_bottomHTML_template = _texts._bottomHTML_template
+
+
+def test_team_cycle_button_wired_into_bottom_bar():
+    assert "pycmd('team_cycle')" in _bottomHTML_template
+
+
+def test_team_cycle_button_uses_the_tooltip_key():
+    # The TeamCycleKey placeholder must be referenced so _bottomHTML_wrap's
+    # computed tooltip value actually reaches the rendered button.
+    assert "%(TeamCycleKey)s" in _bottomHTML_template
+
+
+def test_catch_and_defeat_buttons_still_present():
+    # Guard: adding the third button must not disturb the existing two.
+    assert "pycmd('catch')" in _bottomHTML_template
+    assert "pycmd('defeat')" in _bottomHTML_template

--- a/tests/test_swap_account_main_pokemon.py
+++ b/tests/test_swap_account_main_pokemon.py
@@ -1,0 +1,211 @@
+"""Tier-1 contract for singletons.swap_ankimon_account()'s main-Pokemon refresh.
+
+update_main_pokemon() mutates the passed-in object IN PLACE only when the newly
+active DB already has a saved main Pokemon; when it does not (e.g. the first
+switch to ankimonDEV.db) it RETURNS a fresh, unrelated PokemonObject. The bug:
+swap_ankimon_account() used to discard that return, so the live main_pokemon
+singleton (shared by test_window / battle_loop / pokemon_pc) kept showing the
+previous account's Pokemon after the swap.
+
+The fix captures the return and, when it is a different object, copies its stats
+onto the live singleton. These tests pin both branches:
+
+* different object returned  -> live singleton.update_stats(**new.to_dict())
+* same object returned       -> no update_stats (already mutated in place)
+
+House pattern (mirrors tests/test_ankidex_singleton.py): stub aqt + the heavy
+sibling modules, exec the REAL singletons module, drive swap_ankimon_account().
+"""
+
+import importlib.util
+import sys
+import types
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+_src = __import__("pathlib").Path(__file__).parent.parent / "src"
+
+
+def _stub_module(name, **attrs):
+    mod = types.ModuleType(name)
+    for key, value in attrs.items():
+        setattr(mod, key, value)
+    return mod
+
+
+def _fresh_services(monkeypatch):
+    spec = importlib.util.spec_from_file_location(
+        "Ankimon.services", _src / "Ankimon" / "services.py"
+    )
+    mod = importlib.util.module_from_spec(spec)
+    monkeypatch.setitem(sys.modules, "Ankimon.services", mod)
+    spec.loader.exec_module(mod)
+    return mod.services
+
+
+class _FakeReviewerManager:
+    def __init__(self, *a, **k):
+        pass
+
+
+class _FakeShopManager:
+    def __init__(self, *a, **k):
+        pass
+
+
+@pytest.fixture
+def swap_env(monkeypatch):
+    """A fully-stubbed singletons module plus captured swap-dependency spies."""
+    mw = SimpleNamespace()
+    monkeypatch.setitem(sys.modules, "aqt", _stub_module("aqt", mw=mw))
+    monkeypatch.setitem(
+        sys.modules, "aqt.utils", _stub_module("aqt.utils", tooltip=MagicMock())
+    )
+
+    def is_alive(obj):
+        if obj is None:
+            return False
+        try:
+            obj.objectName()
+            return True
+        except (RuntimeError, AttributeError):
+            return False
+
+    monkeypatch.setitem(
+        sys.modules, "Ankimon.utils", _stub_module("Ankimon.utils", is_alive=is_alive)
+    )
+
+    services = _fresh_services(monkeypatch)
+
+    # A real (identity-stable) main-Pokemon spy so we can assert update_stats.
+    main_pokemon = MagicMock(name="live_main_pokemon")
+    main_pokemon.objectName.side_effect = AttributeError  # not a Qt window
+
+    def build_core():
+        objs = {
+            "logger": MagicMock(),
+            "db": MagicMock(name="db"),
+            "settings": MagicMock(name="settings"),
+            "translator": MagicMock(),
+            "tracker": MagicMock(name="tracker"),
+            "main_pokemon": main_pokemon,
+            "enemy_pokemon": MagicMock(),
+            "trainer_card": MagicMock(),
+            "achievements": {"1": False},
+        }
+        services.populate(**objs)
+        return SimpleNamespace(
+            logger=objs["logger"],
+            ankimon_db=objs["db"],
+            settings_obj=objs["settings"],
+            translator=objs["translator"],
+            main_pokemon=objs["main_pokemon"],
+            mainpokemon_empty=False,
+            enemy_pokemon=objs["enemy_pokemon"],
+            trainer_card=objs["trainer_card"],
+            ankimon_tracker_obj=objs["tracker"],
+            achievements=objs["achievements"],
+        )
+
+    monkeypatch.setitem(
+        sys.modules,
+        "Ankimon.core",
+        _stub_module(
+            "Ankimon.core", build_core=build_core, bind_runtime_globals=lambda: None
+        ),
+    )
+
+    class QtPresenter:
+        pass
+
+    monkeypatch.setitem(
+        sys.modules,
+        "Ankimon.gui_presenter",
+        _stub_module("Ankimon.gui_presenter", QtPresenter=QtPresenter),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "Ankimon.pyobj.ankimon_shop",
+        _stub_module("Ankimon.pyobj.ankimon_shop", PokemonShopManager=_FakeShopManager),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "Ankimon.pyobj.reviewer_obj",
+        _stub_module("Ankimon.pyobj.reviewer_obj", Reviewer_Manager=_FakeReviewerManager),
+    )
+
+    # --- swap_ankimon_account()'s function-local imports -------------------
+    update_main_pokemon = MagicMock(name="update_main_pokemon")
+    monkeypatch.setitem(
+        sys.modules,
+        "Ankimon.functions.update_main_pokemon",
+        _stub_module(
+            "Ankimon.functions.update_main_pokemon",
+            update_main_pokemon=update_main_pokemon,
+        ),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "Ankimon.functions.encounter_functions",
+        _stub_module(
+            "Ankimon.functions.encounter_functions",
+            new_pokemon=MagicMock(),
+            clear_encounter_cache=MagicMock(),
+        ),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "Ankimon.reviewer_ui",
+        _stub_module("Ankimon.reviewer_ui", set_collected_ids=MagicMock()),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "Ankimon.battle_loop",
+        _stub_module("Ankimon.battle_loop", init_battle_state=MagicMock()),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "Ankimon.menu_buttons",
+        _stub_module("Ankimon.menu_buttons", update_mobile_badge=MagicMock()),
+    )
+
+    sys.modules.pop("Ankimon.singletons", None)
+    spec = importlib.util.spec_from_file_location(
+        "Ankimon.singletons", _src / "Ankimon" / "singletons.py"
+    )
+    singletons = importlib.util.module_from_spec(spec)
+    sys.modules["Ankimon.singletons"] = singletons
+    spec.loader.exec_module(singletons)
+
+    yield SimpleNamespace(
+        singletons=singletons,
+        services=services,
+        main_pokemon=main_pokemon,
+        update_main_pokemon=update_main_pokemon,
+    )
+
+    sys.modules.pop("Ankimon.singletons", None)
+
+
+def test_swap_applies_fresh_main_pokemon_to_live_singleton(swap_env):
+    """No saved main in the target DB -> a fresh object is returned; its stats
+    must be copied onto the live singleton (else it shows the old account)."""
+    fresh = SimpleNamespace(to_dict=lambda: {"name": "Ditto", "level": 5})
+    swap_env.update_main_pokemon.return_value = (fresh, True)
+
+    swap_env.singletons.swap_ankimon_account()
+
+    swap_env.update_main_pokemon.assert_called_once_with(swap_env.main_pokemon)
+    swap_env.main_pokemon.update_stats.assert_called_once_with(name="Ditto", level=5)
+
+
+def test_swap_does_not_double_apply_when_mutated_in_place(swap_env):
+    """Target DB has a saved main -> update_main_pokemon mutates the SAME object
+    in place and returns it; swap must NOT redundantly call update_stats."""
+    swap_env.update_main_pokemon.return_value = (swap_env.main_pokemon, False)
+
+    swap_env.singletons.swap_ankimon_account()
+
+    swap_env.main_pokemon.update_stats.assert_not_called()


### PR DESCRIPTION
## What
Final-review fixes for **db/core/menu** (+6 tests): added a 30s SQLite `busy_timeout` so the mobile bulk-resolve background writes don't hit lock errors against the (intentionally non-WAL, per NR-05) DB; added the missing `is_dev_mode()` helper to `utils` and wired the scattered `return False` fallbacks to it (so F36's dev submenu is no longer permanently inert); plus singletons / menu_buttons / reviewer_ui / ankidex mediums.

WAL itself honestly **deferred** (NR-05 single-file persistence guard) with `busy_timeout` as the mitigation. NR-24 records the residuals.

## Verification
Tier-1 **429 passed / 0 failed**; ruff 10; harness 9/9; Qt 5; boot 3 hooks; play OK.

## Attribution
Co-authored-by: Hakimh2.
