### PR TITLE
feat(reloader): developer hot-reload, adapted to the service-seam architecture

### DIFF
--- a/src/Ankimon/__init__.py
+++ b/src/Ankimon/__init__.py
@@ -268,6 +268,27 @@ def start_asynchronous_startup():
             settings_obj.get("controls.pokemon_buttons"),
         )
 
+        # 5b. Developer hot-reload shortcut (Ctrl+Shift+R -> restart_ankimon).
+        #     Wired here (startup-complete, main thread) rather than at module
+        #     scope so mw is fully up. Reload-safe: the QShortcut handle is
+        #     recorded on the services registry and deleted by
+        #     reloader.teardown_ankimon before this callback re-runs on a reload,
+        #     so a reload never stacks a second Ctrl+Shift+R binding. The
+        #     dedicated QShortcut (not the menu action) owns the accelerator to
+        #     avoid an "ambiguous shortcut overload" with the menu entry.
+        from PyQt6.QtGui import QKeySequence, QShortcut
+        from .reloader import restart_ankimon
+
+        for _stale_sc in getattr(services, "_reload_shortcuts", ()) or ():
+            try:
+                _stale_sc.setEnabled(False)
+                _stale_sc.deleteLater()
+            except Exception:
+                pass
+        _reload_shortcut = QShortcut(QKeySequence("Ctrl+Shift+R"), mw)
+        _reload_shortcut.activated.connect(restart_ankimon)
+        services._reload_shortcuts = [_reload_shortcut]
+
         # 6. Boot finished: open the review gate and signal observers.
         setattr(services, _STARTUP_FINISHED_ATTR, True)
         events.emit("startup_finished")

--- a/src/Ankimon/menu_buttons.py
+++ b/src/Ankimon/menu_buttons.py
@@ -339,6 +339,17 @@ def create_menu_actions(
     switch_account_action.triggered.connect(swap_ankimon_account)
     mw.pokemenu.addAction(switch_account_action)
 
+    # Restart Ankimon — developer hot-reload (teardown + in-place re-import of
+    # the add-on). The Ctrl+Shift+R accelerator is owned by a dedicated QShortcut
+    # wired at startup (see __init__.py); this menu entry deliberately sets no
+    # shortcut of its own to avoid an "ambiguous shortcut overload" with it.
+    from .reloader import restart_ankimon
+
+    restart_ankimon_action = QAction("Restart Ankimon", mw)
+    restart_ankimon_action.setMenuRole(QAction.MenuRole.NoRole)
+    restart_ankimon_action.triggered.connect(restart_ankimon)
+    mw.pokemenu.addAction(restart_ankimon_action)
+
     # Encounter Rate Simulator (developer tool). Cache the dialog on mw (like the
     # file's other game/dev windows) before showing it: the dialog is parentless
     # and embeds a QWebEngineView, so if the only reference lived in the lambda it
@@ -376,6 +387,7 @@ def create_menu_actions(
     def update_dev_actions_visibility():
         is_dev = is_dev_mode()
         switch_account_action.setVisible(is_dev)
+        restart_ankimon_action.setVisible(is_dev)
         simulator_action.setVisible(is_dev)
         # Hide the Debug submenu and disable the tracker hotkey unless Developer
         # Mode is on. setEnabled(False) is what actually suppresses the

--- a/src/Ankimon/pyobj/database_manager.py
+++ b/src/Ankimon/pyobj/database_manager.py
@@ -1480,11 +1480,18 @@ class AnkimonDB:
 _db_instance: Optional[AnkimonDB] = None
 
 
-def get_db(logger=None) -> AnkimonDB:
-    """Gets the singleton database instance."""
+def get_db(logger=None, db_path=None) -> AnkimonDB:
+    """Gets the singleton database instance.
+
+    ``db_path`` lets a caller build the singleton against a specific database
+    file (multi-profile / hot-reload account preservation); when omitted the
+    default ``ankimon.db`` under ``user_path`` is used. It is only honoured when
+    the singleton does not yet exist — call :func:`reset_db` first to rebuild
+    against a different path.
+    """
     global _db_instance
     if _db_instance is None:
-        _db_instance = AnkimonDB(logger)
+        _db_instance = AnkimonDB(logger, db_path=db_path)
     return _db_instance
 
 

--- a/src/Ankimon/reloader.py
+++ b/src/Ankimon/reloader.py
@@ -1,0 +1,228 @@
+"""
+reloader.py — developer hot-reload for the Ankimon add-on.
+
+Ctrl+Shift+R (and the developer-only "Restart Ankimon" menu entry) call
+:func:`restart_ankimon`, which tears the add-on down and re-imports it in place
+so code edits take effect without restarting Anki.
+
+Seam-aware teardown
+-------------------
+Ankimon's live state lives in the ``services`` registry (:mod:`Ankimon.services`),
+not on ``mw``. So unlike a naive "delete every submodule" reload, this one
+**preserves ``<addon>.services``** across the purge: the registry singleton keeps
+the database, settings, tracker, Pokemon and trainer card, which is what lets
+``singletons`` re-execute down its ``_core_is_populated()``-is-True branch (reuse
+the core, rebind module globals) instead of rebuilding — and is what preserves
+the active database file (e.g. ``ankimonDEV.db``) across a reload.
+
+Every hook-registering module already records its handlers on that surviving
+registry and removes the previous record before re-appending on re-import, so
+re-registration is self-deduplicating. Teardown's remaining job is therefore to:
+
+* remove the add-on's ``gui_hooks`` handlers (belt-and-suspenders, and the only
+  way the *unrecorded* ``webview_will_set_content`` handler gets cleared),
+* restore the pristine ``Reviewer`` methods that ``reviewer_ui`` wraps (the
+  ``Reviewer._ankimon_orig_*`` contract),
+* delete the ``Ctrl+Shift+R`` ``QShortcut`` objects (the one UI handle with no
+  self-dedup),
+* close and delete every add-on Qt widget / QWebEngine web shell, and null the
+  registry's UI slots (windows + reviewer manager) so ``singletons`` rebuilds
+  them — while leaving the core *data* services untouched,
+* drop the cached DB singleton (``database_manager.reset_db``), and finally
+* purge the add-on's own submodules from ``sys.modules`` (keeping ``services``
+  and any native extension modules) so the re-import loads fresh code.
+
+Headless-import contract (integrity test): Qt classes are imported directly from
+``PyQt6`` (not the possibly-mocked ``aqt.qt``), aqt-only symbols are imported
+lazily inside the functions, and nothing constructs a Qt object at import time.
+"""
+
+import importlib
+import sys
+import traceback
+
+from PyQt6.QtWidgets import QApplication, QWidget
+from aqt import gui_hooks, mw
+
+
+def restart_ankimon():
+    """Tear the add-on down and re-import it in place (developer hot-reload)."""
+    from aqt.utils import tooltip
+
+    addon_package = __name__.split(".")[0]
+    try:
+        teardown_ankimon(addon_package)
+        importlib.import_module(addon_package)
+        tooltip("Ankimon reloaded.")
+    except Exception as exc:  # surface any reload failure to the developer
+        message = f"Ankimon reload failed: {exc}\n{traceback.format_exc()}"
+        print(message)
+        try:
+            tooltip("Ankimon reload failed — see console.")
+        except Exception:
+            pass
+
+
+def _handler_belongs_to_addon(handler, addon_package):
+    """True if a gui_hooks callback was defined inside this add-on."""
+    module = getattr(handler, "__module__", "") or ""
+    # Bound methods proxy __module__ to __func__; be explicit for robustness.
+    if not module and hasattr(handler, "__func__"):
+        module = getattr(handler.__func__, "__module__", "") or ""
+    return module == addon_package or module.startswith(addon_package + ".")
+
+
+def _remove_addon_gui_hooks(addon_package):
+    """Remove every ``gui_hooks`` handler that belongs to this add-on.
+
+    Anki's generated hooks expose their callback list as ``_hooks``; the headless
+    fake hooks *are* lists. Handle both. ``remove()`` tolerates already-absent
+    callbacks on both, so this stays safe even though each module also removes
+    its own recorded handlers on re-import.
+    """
+    for attr_name in dir(gui_hooks):
+        attr = getattr(gui_hooks, attr_name, None)
+        inner = getattr(attr, "_hooks", None)
+        if isinstance(inner, list):
+            handlers = list(inner)
+        elif isinstance(attr, list):
+            handlers = list(attr)
+        else:
+            continue
+        for handler in handlers:
+            if not _handler_belongs_to_addon(handler, addon_package):
+                continue
+            try:
+                attr.remove(handler)
+            except Exception:
+                pass
+
+
+def _restore_reviewer_wraps():
+    """Undo ``reviewer_ui``'s Reviewer method wrapping (the _ankimon_orig_* contract)."""
+    from aqt.reviewer import Reviewer
+
+    for method in ("_shortcutKeys", "_linkHandler", "_bottomHTML"):
+        orig_attr = "_ankimon_orig_" + method
+        if hasattr(Reviewer, orig_attr):
+            setattr(Reviewer, method, getattr(Reviewer, orig_attr))
+            delattr(Reviewer, orig_attr)
+
+
+def _delete_reload_shortcuts(services):
+    """Delete the Ctrl+Shift+R QShortcut objects recorded on the registry."""
+    for shortcut in list(getattr(services, "_reload_shortcuts", ()) or ()):
+        try:
+            shortcut.setEnabled(False)
+            shortcut.deleteLater()
+        except Exception:
+            pass
+    services._reload_shortcuts = []
+
+
+def _close_widget(obj):
+    if obj is None:
+        return
+    try:
+        if hasattr(obj, "close"):
+            obj.close()
+    except Exception:
+        pass
+    try:
+        if isinstance(obj, QWidget):
+            obj.deleteLater()
+    except Exception:
+        pass
+
+
+def _teardown_windows(addon_package, services):
+    """Close/delete the add-on's Qt windows and null the registry UI slots."""
+    # Remove the add-on menu from the menubar (rebuilt by create_menu_actions).
+    pokemenu = getattr(mw, "pokemenu", None)
+    if pokemenu is not None:
+        try:
+            mw.form.menubar.removeAction(pokemenu.menuAction())
+        except Exception:
+            pass
+
+    # Close + delete the registry-held windows, then null the slots so the
+    # singletons factories rebuild them. (Their is_alive() checks would rebuild
+    # a dead one anyway, but nulling avoids ever handing out a deleted C++ object.)
+    for slot in ("test_window", "evo_window", "pokemon_pc"):
+        _close_widget(getattr(services, slot, None))
+        setattr(services, slot, None)
+    # The reviewer manager is not a widget; its gui_hooks were just removed, so
+    # null it and let singletons rebuild it (re-registering its hooks).
+    services.reviewer = None
+
+    # Catch every other add-on widget (item/settings windows, QWebEngine web
+    # shells, Ankidex SPA, encounter-simulator dialog, …) by module ownership.
+    for widget in QApplication.allWidgets():
+        cls_module = getattr(widget.__class__, "__module__", "") or ""
+        if cls_module == addon_package or cls_module.startswith(addon_package + "."):
+            _close_widget(widget)
+
+    # Drop dangling UI references parked on mw so the re-import rebuilds them.
+    for attr in ("pokemenu", "settings_ankimon", "_encounter_simulator_dialog"):
+        if hasattr(mw, attr):
+            try:
+                delattr(mw, attr)
+            except Exception:
+                pass
+
+
+def _purge_addon_modules(addon_package):
+    """Drop the add-on's submodules from ``sys.modules`` so the re-import is fresh.
+
+    Preserves two things:
+
+    * ``<addon>.services`` — the live registry singleton that holds the reused
+      core state. Keeping it is what makes ``singletons`` re-execute its reuse
+      branch and is what preserves the active DB file across the reload.
+    * Any already-loaded native extension modules — re-initialising a compiled
+      (C/Rust) extension a second time can crash the interpreter.
+    """
+    services_module = addon_package + ".services"
+    for name in list(sys.modules):
+        if name != addon_package and not name.startswith(addon_package + "."):
+            continue
+        if name == services_module:
+            continue
+        module = sys.modules.get(name)
+        origin = ""
+        spec = getattr(module, "__spec__", None)
+        if spec is not None and getattr(spec, "origin", None):
+            origin = spec.origin
+        elif getattr(module, "__file__", None):
+            origin = module.__file__
+        if origin.endswith((".so", ".pyd", ".dylib")):
+            continue
+        del sys.modules[name]
+
+
+def teardown_ankimon(addon_package):
+    """Undo everything the add-on installed, then purge its modules.
+
+    Preserves the ``services`` registry's core data objects (db / settings /
+    tracker / pokemon / trainer card) so the re-import reuses them — which is
+    what preserves the active database file across the reload.
+    """
+    from .services import services
+
+    _remove_addon_gui_hooks(addon_package)
+    _restore_reviewer_wraps()
+    _delete_reload_shortcuts(services)
+    _teardown_windows(addon_package, services)
+
+    # Drop the cached DB singleton (closes its connection). The registry still
+    # holds the same AnkimonDB instance with its db_path intact, so the reused
+    # core reopens the SAME file (e.g. ankimonDEV.db) lazily on next access.
+    try:
+        from .pyobj.database_manager import reset_db
+
+        reset_db()
+    except Exception:
+        pass
+
+    # Fresh code on re-import (services + native extensions preserved).
+    _purge_addon_modules(addon_package)

--- a/tests/test_addon_integrity.py
+++ b/tests/test_addon_integrity.py
@@ -17,9 +17,10 @@ iterating a MagicMock __path__ generates objects indefinitely.
 
 The explicit MODULES_TO_CHECK list is reconciled against main's actual module
 set: it includes main's service-seam / scaffolding modules (core, services,
-events, ui_port, gui_presenter, boot_async, webshell.*) and omits Stage-B leaf
-modules that have not landed on this branch yet (e.g. pyobj.move_picker,
-pyobj.encounter_simulator_dialog, ankidex.ankidex_obj, reloader).
+events, ui_port, gui_presenter, boot_async, webshell.*) and the developer
+hot-reload module (reloader), and omits Stage-B leaf modules that have not
+landed on this branch yet (e.g. pyobj.move_picker,
+pyobj.encounter_simulator_dialog, ankidex.ankidex_obj).
 """
 
 import os
@@ -122,6 +123,7 @@ MODULES_TO_CHECK = [
     "Ankimon.menu_buttons",
     "Ankimon.move_names",
     "Ankimon.profile_hooks",
+    "Ankimon.reloader",
     "Ankimon.resources",
     "Ankimon.reviewer_ui",
     "Ankimon.startup",


### PR DESCRIPTION
## What

Ports the developer hot-reload feature (`reloader.py`) from `BRRRR_Experimental` into this branch. **Ctrl+Shift+R** and a developer-only **"Restart Ankimon"** menu entry tear the add-on down and re-import it in place, so code edits take effect without restarting Anki.

## Why the port isn't a straight copy

The exp original hung its reload-safe singletons on Anki's `mw` (which survives a `sys.modules` purge) and then purged **every** add-on submodule. On this branch the equivalent live state lives in the **`services` registry** instead. So the reload strategy is re-architected:

- `teardown_ankimon()` **preserves `<addon>.services`** across the purge (plus any native extension module — re-initialising a compiled module can crash the interpreter).
- Each hook-registering module already self-deduplicates on re-import via its services-anchored handler record, so re-registration is safe.
- Because the surviving registry still holds `services.db` with its `db_path` intact, `singletons` re-executes down its `_core_is_populated()`-True branch (reuse core + rebind globals). **The active database file — e.g. `ankimonDEV.db` — is preserved across the reload**, and the PC Box + every other component keep reading it.

## Changes

- **`reloader.py`** (new) — `teardown_ankimon()`:
  - removes the add-on's `gui_hooks` handlers (targets Anki's `_hooks` list, with a fake-hook list fallback; also the only path that clears the *unrecorded* `webview_will_set_content` handler),
  - restores the pristine `Reviewer` methods wrapped by `reviewer_ui` (the `Reviewer._ankimon_orig_*` contract),
  - deletes the Ctrl+Shift+R `QShortcut` objects (recorded on `services`),
  - closes/deletes every add-on Qt widget + QWebEngine web shell and nulls the registry UI slots (windows + reviewer manager) so `singletons` rebuilds them, leaving the core *data* services untouched,
  - drops the cached DB singleton via `database_manager.reset_db()`, then
  - purges the add-on's own submodules from `sys.modules` **last**.
- **`__init__.py`** — Ctrl+Shift+R `QShortcut` created in the startup-complete callback (main thread, `mw` fully up), recorded on `services._reload_shortcuts` so a reload never stacks a second binding. The QShortcut owns the accelerator so the menu entry can omit it (avoids an ambiguous-shortcut overload).
- **`menu_buttons.py`** — "Restart Ankimon" action in the developer-only section, gated by the existing `update_dev_actions_visibility()` / `is_dev_mode()`.
- **`database_manager.py`** — `get_db()` gains a `db_path` arg to build the singleton against a specific file; `reset_db()` (already present) is now called from teardown.
- **`tests/test_addon_integrity.py`** — `Ankimon.reloader` added to `MODULES_TO_CHECK`. It imports `QWidget`/`QApplication` directly from `PyQt6.QtWidgets` (not the possibly-mocked `aqt.qt`), keeps aqt-only symbols lazy, and constructs no Qt object at import time.

## Verification

- Tier-1 harness (`python3 harness/check.py`): **9/9 green**
- Integrity test: **green** (now covering `reloader`)
- CI ruff (`PLE`,`UP018`): **clean**
- The module purge (services + native-ext preservation), `gui_hooks` ownership/removal, and double-remove tolerance were verified against the **real installed `aqt`**.

The one thing not exercisable headlessly is the full teardown→re-import round-trip inside a live Anki (no Tier-2 env), but each teardown step's logic is individually verified and re-import safety is guaranteed by the per-module `services`-anchored dedup records the branch already ships.

Original `reloader.py` authored by @hakimh2 on `BRRRR_Experimental`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)