### PR TITLE
docs: Add detailed notes for tier 2 fuzzing issues

### DIFF
--- a/tier2_fuzzing_notes/fix1_requests.md
+++ b/tier2_fuzzing_notes/fix1_requests.md
@@ -1,0 +1,10 @@
+# Issue 1: Missing requests module during fuzzing
+
+## Description
+During headless fuzzing, the `requests` module was throwing a `ModuleNotFoundError` in several test suites, primarily crashing test collections and stopping tests from running properly. The headless fuzz script `harness/scenarios/fuzz.py` and the main `conftest.py` use it directly or via some imports inside Ankimon.
+
+## Root Cause
+`requests` is imported in `utils.py` and `error_handler.py`, and when running fuzzing tests under a sterile environment or via pytest, the library was not available because it wasn't strictly enforced or installed in the CI container environment or test runner context.
+
+## Proposed Fix
+Make sure that `requests` is properly listed as a test or runtime dependency and ensure `pip install requests` is executed before running fuzzing/tests in CI/CD or the testing documentation. (In this session, `requests` was simply installed via pip).

--- a/tier2_fuzzing_notes/fix2_adjacentAlly.md
+++ b/tier2_fuzzing_notes/fix2_adjacentAlly.md
@@ -1,0 +1,28 @@
+# Issue 2: Invalid affected_side 'adjacentAlly' in instruction generator
+
+## Description
+When running the battle engine simulation with random moves and setups, `AssertionError: error event during answer: ... 'Invalid affected_side: adjacentAlly'` or similar crashes occurred. The engine logs showed it couldn't resolve the string 'adjacentAlly'.
+
+## Root Cause
+In `src/Ankimon/poke_engine/instruction_generator.py`, the constant list `same_side_strings` didn't include `'adjacentAlly'` and `opposing_side_strings` didn't include `'adjacentFoe'`, which are standard move targets used by the underlying showdown move JSONs. When an instruction resolved to this affected side, it hit the `logger.critical("Invalid affected_side: {}".format(affected_side))` path, returning empty or failing.
+
+## Proposed Fix
+Update `same_side_strings` in `instruction_generator.py` to include `'adjacentAlly'` and update `opposing_side_strings` to include `'adjacentFoe'`.
+
+```python
+same_side_strings = [
+    constants.SELF,
+    constants.ALLY_SIDE,
+    'adjacentAlly'
+]
+
+opposing_side_strings = [
+    constants.NORMAL,
+    constants.OPPONENT,
+    constants.FOESIDE,
+    constants.ALL_ADJACENT_FOES,
+    constants.ALL_ADJACENT,
+    constants.ALL,
+    'adjacentFoe',
+]
+```

--- a/tier2_fuzzing_notes/fix3_keyerror.md
+++ b/tier2_fuzzing_notes/fix3_keyerror.md
@@ -1,0 +1,25 @@
+# Issue 3: KeyError crashes for random invalid move strings in poke_engine
+
+## Description
+The fuzzer naturally generates bogus move strings like `'zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz'` and `'hyperbeam!!!'` or even `''`. When the Ankimon hooks passed these bogus strings into the `poke_engine` (such as in `objects.py` or `find_state_instructions.py`), it resulted in `KeyError` crashes because the code blindly accessed the `all_move_json` dictionary.
+
+## Root Cause
+In `src/Ankimon/poke_engine/objects.py` inside `calculate_burn_multiplier`, it iterates through a pokemon's moves and checks:
+`all_move_json[m[constants.ID]][constants.CATEGORY] == constants.PHYSICAL`
+If the move is invalid or empty, this throws a `KeyError`.
+
+Similarly, in `src/Ankimon/poke_engine/find_state_instructions.py` inside `lookup_move`:
+`return all_move_json[move_name.lower()]`
+This throws a `KeyError` if the move isn't found.
+
+## Proposed Fix
+Use `.get()` checks and `.get(constants.CATEGORY)` checks instead of direct indexing.
+For `objects.py`:
+```python
+burn_multiplier = len([m for m in self.moves if m.get(constants.ID) in all_move_json and all_move_json[m[constants.ID]].get(constants.CATEGORY) == constants.PHYSICAL])
+```
+
+For `find_state_instructions.py`:
+```python
+return all_move_json.get(move_name.lower(), all_move_json.get("splash"))
+```

--- a/tier2_fuzzing_notes/fix4_cash.md
+++ b/tier2_fuzzing_notes/fix4_cash.md
@@ -1,0 +1,27 @@
+# Issue 4: Type coercion crashes for trainer.cash string values
+
+## Description
+The fuzzer occasionally injects invalid types like a string `"x"` or a negative integer `-5` into `trainer.cash`. When this happens, a `TypeError` occurs later in the invariants check or battle math: `'>=' not supported between instances of 'str' and 'int'`. Additionally, there was a failure where `negative cash: -5` failed an assertion.
+
+## Root Cause
+In `src/Ankimon/pyobj/settings.py`, the `_apply_type_coercion` function was coercing specific values to `int`, but it was skipping `trainer.cash`. Also, the coercion logic was throwing a warning on `ValueError` but leaving the invalid string value intact in the `config` dictionary, breaking assumptions downstream. Finally, `trainer.cash` was not bounds-checked to prevent negative values.
+
+## Proposed Fix
+Add `trainer.cash` to `keys_to_coerce_to_int` in `_apply_type_coercion` and strengthen the coercion loop to actively default to `0` if an invalid string or type is provided, and clamp negative cash to `0`.
+
+```python
+                try:
+                    config[key] = int(config[key])
+                    if config[key] < 0 and key == "trainer.cash":
+                        config[key] = 0
+                except (ValueError, TypeError):
+                    print(
+                        f"Ankimon: Warning: Could not convert '{config[key]}' for key '{key}' to int."
+                    )
+                    # If it's a completely invalid type like string 'x', coerce to a sensible default
+                    if key == "trainer.cash":
+                        config[key] = 0
+                    elif isinstance(config[key], str):
+                        # Ensure we don't leave invalid strings in keys that expect integers
+                        config[key] = 0
+```

--- a/tier2_fuzzing_notes/fix5_hp.md
+++ b/tier2_fuzzing_notes/fix5_hp.md
@@ -1,0 +1,31 @@
+# Issue 5: HP values going out of bounds or resolving to strings
+
+## Description
+The fuzzer caused `AssertionError: enemy HP out of range: 318/23` or similar crashes where HP would end up negative or higher than the maximum HP.
+
+## Root Cause
+In `src/Ankimon/functions/ankimon_hooks_to_poke_engine.py`, the changes from the poke-engine state back to Ankimon's `PokemonObject` were done with simple assignments:
+```python
+main_pokemon.hp = state.user.active.hp
+enemy_pokemon.hp = state.opponent.active.hp
+```
+There were no clamps to ensure HP stayed within `0` and `max_hp`. Additionally, there were cases where HP could become a `NoneType` or a string during fuzzing due to bad setups, causing issues.
+
+## Proposed Fix
+Clamp the HP using `max(0, min(current_hp, max_hp))` and ensure the values are integers.
+
+```python
+        user_hp = state.user.active.hp if state.user.active.hp is not None else 0
+        opponent_hp = state.opponent.active.hp if state.opponent.active.hp is not None else 0
+
+        main_pokemon_max_hp = main_pokemon.max_hp if main_pokemon.max_hp is not None else 0
+        main_pokemon.hp = max(0, min(int(user_hp), int(main_pokemon_max_hp)))
+        main_pokemon.current_hp = main_pokemon.hp
+
+        enemy_max_hp = enemy_pokemon.max_hp if enemy_pokemon.max_hp is not None else 0
+        if int(enemy_max_hp) == 0:
+            enemy_pokemon.hp = max(0, int(opponent_hp))
+        else:
+            enemy_pokemon.hp = max(0, min(int(opponent_hp), int(enemy_max_hp)))
+        enemy_pokemon.current_hp = enemy_pokemon.hp
+```

--- a/tier2_fuzzing_notes/fix6_fuzz_script.md
+++ b/tier2_fuzzing_notes/fix6_fuzz_script.md
@@ -1,0 +1,10 @@
+# Issue 6: Fuzz script environment issues
+
+## Description
+The fuzz script (`harness/scenarios/fuzz.py`) occasionally threw warnings or hit bugs itself rather than Ankimon's code, or was relying on implicit assumptions about `PYTHONPATH`.
+
+## Root Cause
+Fuzzing script did not inject `requests` properly, or have an automatic `PYTHONPATH` resolution for external testing if run in isolation outside of `pytest` or Anki.
+
+## Proposed Fix
+Provide a robust runner shell script or document that `PYTHONPATH=src` and `pip install requests` must be used to run the fuzz tests successfully.


### PR DESCRIPTION
Added detailed markdown notes for all issues discovered during tier 2 fuzzing in `tier2_fuzzing_notes/`. Each file describes the issue, root cause, and proposed fix without modifying actual source code as requested.

---
*PR created automatically by Jules for task [11318426289522941619](https://jules.google.com/task/11318426289522941619) started by @h0tp-ftw*