### PR TITLE
fix(mobile): stop auto-resolve KeyError crash and reduce resolve/replay UI lag

### DIFF
--- a/src/Ankimon/ankimon_items_web/shop_obj.py
+++ b/src/Ankimon/ankimon_items_web/shop_obj.py
@@ -583,6 +583,7 @@ class MobileBridge(QObject):
         self._bulk_paused = False
         self._bulk_stopped = False
         self._bulk_refreshed = False
+        self._bulk_last_yield = 0.0  # GIL-yield throttle clock (Bug 2)
 
         # Read the scheduler's day cutoff on the main GUI thread — mw.col.sched
         # must not be touched from the worker thread. Matches resolveAll /
@@ -602,11 +603,26 @@ class MobileBridge(QObject):
                         self._bulk_progress["processed"] = status
                         if total is not None:
                             self._bulk_progress["total"] = total
-                    
+
                     import time
+                    # GIL yield / rate limit (Bug 2). The per-review battle
+                    # simulation is CPU-bound pure Python that holds the GIL; on a
+                    # plain worker thread it starves the Qt GUI thread, so the
+                    # progress bar froze then jumped and Pause/Stop registered late.
+                    # Sleeping briefly hands the GIL to the GUI thread so it can
+                    # repaint and process clicks. Time-gated (~3ms handed over per
+                    # ~20ms of work => ~13% slower, smooth UI) rather than per call,
+                    # so throughput barely drops. Only the background bulk-resolve
+                    # passes a progress_callback, so the synchronous post-sync
+                    # auto-resolve path is unaffected.
+                    now = time.monotonic()
+                    if now - getattr(self, "_bulk_last_yield", 0.0) >= 0.02:
+                        time.sleep(0.003)
+                        self._bulk_last_yield = time.monotonic()
+
                     while getattr(self, "_bulk_paused", False) and not getattr(self, "_bulk_stopped", False):
                         time.sleep(0.1)
-                    
+
                     if getattr(self, "_bulk_stopped", False):
                         return False
                     return True

--- a/src/Ankimon/functions/ankimon_hooks_to_poke_engine.py
+++ b/src/Ankimon/functions/ankimon_hooks_to_poke_engine.py
@@ -62,6 +62,107 @@ if not getattr(
     )
 
 
+# --- Non-canonical form-id tolerance for engine pokedex lookups ---------------
+# Ankimon battles Mega/Gmax/regional forms (actual_id >= 10000, e.g. "golurkmega",
+# "darkraimega" — Golurk/Darkrai have no real Mega) whose normalized id is NOT a
+# Smogon pokedex key. The vendored engine's weight-based moves (Heavy Slam / Heat
+# Crash / Low Kick / Grass Knot) index ``pokedex[pokemon.id][WEIGHT]`` directly, so
+# such a form raised ``KeyError``. That error is caught, but the handler
+# (show_warning_with_traceback) then builds a Qt dialog — and mobile bulk
+# auto-resolve runs on a worker thread, where constructing a QWidget is a C++-level
+# abort ("force-close" after ~230 reviews, once a Mega/Gmax battler is drawn).
+#
+# The engine is a git submodule (its edits are lost on ``git submodule update``),
+# so instead of patching it we install a form-tolerant *view* of its pokedex on the
+# modules that do id-keyed lookups. A missing form id resolves to the longest base
+# species key it starts with (``golurkmega`` -> ``golurk``); canonical ids pass
+# through unchanged, so battle behaviour for known Pokemon is identical. Applied
+# once and idempotent under the reload-safe-singletons module reload (it always
+# wraps the raw data-module dict, never a previously installed view).
+from ..poke_engine.data import pokedex as _engine_pokedex
+
+_pokedex_key_cache = {}
+
+
+def resolve_pokedex_key(name):
+    """Return an engine-pokedex key for ``name`` (itself if canonical, else the
+    longest base-species key it starts with), or ``None`` if nothing matches."""
+    if name in _engine_pokedex:
+        return name
+    if name in _pokedex_key_cache:
+        return _pokedex_key_cache[name]
+    best = None
+    for key in _engine_pokedex:
+        if name.startswith(key) and (best is None or len(key) > len(best)):
+            best = key
+    _pokedex_key_cache[name] = best
+    return best
+
+
+class _FormTolerantPokedex:
+    """Read-through view of the engine pokedex that resolves non-canonical form
+    ids to their base species so id-keyed lookups (notably weight-based moves)
+    never KeyError. Every other mapping operation delegates to the real pokedex."""
+
+    __slots__ = ("_base",)
+    # Only ever returned for a totally unresolvable id (no base-species prefix
+    # exists) — eff. impossible for real data, since base species are always
+    # present; a neutral weight keeps weight-based moves functional regardless.
+    _FALLBACK = {constants.WEIGHT: 100.0}
+
+    def __init__(self, base):
+        self._base = base
+
+    def __getitem__(self, key):
+        base = self._base
+        if key in base:
+            return base[key]
+        resolved = resolve_pokedex_key(key)
+        return base[resolved] if resolved is not None else self._FALLBACK
+
+    def __contains__(self, key):
+        return key in self._base
+
+    def __iter__(self):
+        return iter(self._base)
+
+    def __len__(self):
+        return len(self._base)
+
+    def get(self, key, default=None):
+        return self._base.get(key, default)
+
+    def keys(self):
+        return self._base.keys()
+
+    def values(self):
+        return self._base.values()
+
+    def items(self):
+        return self._base.items()
+
+
+def _install_form_tolerant_pokedex():
+    # Patch the modules whose lookups are keyed by a live battler's id/name. The
+    # weight moves in modify_move are the confirmed crash; damage_calculator's
+    # (terastallize-gated) STAB lookup is guarded defensively too. Always wraps the
+    # raw dict so a module reload can't nest views.
+    from ..poke_engine.special_effects.moves import modify_move
+    from ..poke_engine import damage_calculator
+
+    view = _FormTolerantPokedex(_engine_pokedex)
+    modify_move.pokedex = view
+    damage_calculator.pokedex = view
+
+
+try:
+    _install_form_tolerant_pokedex()
+except Exception:
+    # Never let a hardening patch break battle import; the raw engine still works
+    # for every canonical Pokemon, which is the overwhelming majority.
+    pass
+
+
 def reset_stat_boosts(pokemon: Pokemon) -> Pokemon:
     """
     Resets all stat boosts of a given Pokemon to zero.

--- a/src/Ankimon/functions/mobile_sync.py
+++ b/src/Ankimon/functions/mobile_sync.py
@@ -1248,10 +1248,29 @@ def _run_mobile_battles_impl(
         reviews_to_process = reviews_list
         extra_reviews = []
 
+    # GIL yield for background preview sims (Bug 4). The mobile tab's estimates
+    # (getMobileStatus.run_sim -> simulate_pending_mobile_battles) and the manual
+    # replay "next" preview both run this CPU-bound loop on a QueryOp background
+    # thread with NO progress_callback; the pure-Python engine work holds the GIL
+    # and starves the Qt GUI, making the tab and replay transitions feel sluggish.
+    # Hand the GIL to the GUI periodically. Gated so it only fires on a real
+    # background thread (never the synchronous post-sync auto-resolve, which runs
+    # on the GUI thread) and only when nobody else is already throttling via a
+    # progress_callback (the bulk-resolve worker does its own yield). is_main_thread
+    # returns True headless, so the Tier-1 harness / tests are unaffected.
+    from ..utils import is_main_thread
+    _yield_bg = (progress_callback is None) and (not is_main_thread())
+    _last_yield = time.monotonic()
+
     try:
         for review in reviews_to_process:
             temp_tracker.total_reviews += 1
             total_reviews_processed += 1
+            if _yield_bg:
+                _now = time.monotonic()
+                if _now - _last_yield >= 0.02:
+                    time.sleep(0.003)
+                    _last_yield = time.monotonic()
             if progress_callback:
                 try:
                     cb_res = progress_callback({

--- a/src/Ankimon/pyobj/error_handler.py
+++ b/src/Ankimon/pyobj/error_handler.py
@@ -280,6 +280,19 @@ def show_warning_with_traceback(
     if not _HAVE_QT:
         return
 
+    # Constructing a QWidget/QDialog off the Qt GUI thread is a hard Qt violation
+    # that aborts the process at the C++ level (a "force-close", not a catchable
+    # Python error). Background workers — notably mobile bulk auto-resolve
+    # (ShopObj.startBulkResolve's bg_resolve thread) — funnel simulation
+    # exceptions here, so when we are not on the GUI thread we stop after the
+    # log + error-event above (the durable record) rather than building a dialog.
+    try:
+        from ..utils import is_main_thread
+        if not is_main_thread():
+            return
+    except Exception:
+        pass
+
     try:
         from aqt import mw as _mw
     except Exception:


### PR DESCRIPTION
Fixes three Mobile Review defects, all Ankimon-side (the `poke_engine` submodule is untouched). Rebased on the current `integration/brrr-into-main-debugging` tip.

## Bug 1 — auto-resolve C++ force-close (KeyError on Mega/Gmax forms)
Weight-based moves (Heavy Slam / Heat Crash / Low Kick / Grass Knot) index `pokedex[pokemon.id][WEIGHT]`. Ankimon's non-canonical Mega/Gmax/regional forms (`actual_id >= 10000`, e.g. `golurkmega`, `darkraimega`) aren't keys in the engine pokedex → `KeyError`. The error is caught, but the handler then builds a `QDialog().exec()` — and bulk auto-resolve runs on a worker thread, where constructing a QWidget aborts the process at the C++ level (the "force-close" after ~230 reviews once a Mega/Gmax battler is drawn).

**Fix:** install a form-tolerant *view* of the engine pokedex (`golurkmega` → `golurk` at lookup; canonical ids pass through unchanged) via monkeypatch in `ankimon_hooks_to_poke_engine.py`, matching the existing `get_instructions_from_damage` wrap. Also harden `show_warning_with_traceback` to skip the Qt dialog when off the GUI thread, so *any* background-thread exception logs instead of crashing Anki.

## Bug 2 — progress bar freeze/jump + late Pause/Stop
Profiling showed the bulk resolve is CPU-bound pure-Python engine simulation (~12 ms/review) on a worker thread — it already runs in one deferred-commit transaction, so it is not I/O-bound. The worker holds the GIL and starves the Qt GUI, so the progress bar freezes then jumps and Pause/Stop register late.

**Fix:** a time-gated GIL yield in the bulk-resolve `progress_cb` (background path only; the synchronous post-sync auto-resolve passes no callback and is untouched).

## Bug 4 — mobile tab / manual replay lag
The `getMobileStatus` estimates sim and the replay preview run the same CPU-bound loop on background QueryOp threads, causing the same GIL starvation.

**Fix:** a GIL yield in the per-review loop that activates only for background preview sims (`progress_callback is None and not is_main_thread()`) — never on the GUI-thread synchronous path or in tests.

## Not included: sync-refresh staleness
The Mobile tab not updating its count after "Sync & Refresh" was **already fixed on this base** by `6706b906` (`singletons.notify_stats_changed()`), so it is intentionally excluded here.

## Verification
- Mobile suites 45/45.
- Bug 1: weight resolution confirmed (`golurkmega` → `golurk` = 330 kg, `darkraimega` → `darkrai` = 50.5 kg); canonical entries returned unchanged (identity check); raw engine still reproduces the KeyError with the fix removed (proves it's load-bearing).
- `ruff check --select PLE,UP018` clean.

## Note for maintainer (unrelated to this PR)
`6706b906` added `from ..singletons import notify_stats_changed` inside `battle_loop.on_review_card`. Under the Tier-1 headless harness that import triggers `ankimon_shop`'s module-load `daily_item_list()` → the sprite-download agreement dialog → a QWidget with no QApplication → abort. Harmless in real Anki (sprites + QApplication present), but it makes the Tier-1 harness abort on the battle path. Flagging in case you rely on that harness for CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
