### PR TITLE
fix: handle boolean strings in discord rich presence hook registration

### DIFF
--- a/src/Ankimon/discord_integration.py
+++ b/src/Ankimon/discord_integration.py
@@ -8,14 +8,22 @@ LARGE_IMAGE_URL = "https://raw.githubusercontent.com/Unlucky-Life/ankimon/refs/h
 
 
 def setup_discord_hooks():
-    if settings_obj.get("misc.discord_rich_presence") != True:
-        return
+    def is_discord_enabled():
+        val = settings_obj.get("misc.discord_rich_presence")
+        return str(val).lower() in ("true", "1") or val is True
 
-    mw.ankimon_presence = DiscordPresence(
-        CLIENT_ID, LARGE_IMAGE_URL, ankimon_tracker_obj, logger, settings_obj
-    )
+    if is_discord_enabled():
+        mw.ankimon_presence = DiscordPresence(
+            CLIENT_ID, LARGE_IMAGE_URL, ankimon_tracker_obj, logger, settings_obj
+        )
 
     def on_reviewer_initialized(rev, card, ease):
+        if not is_discord_enabled():
+            if hasattr(mw, "ankimon_presence") and mw.ankimon_presence and mw.ankimon_presence.loop is True:
+                mw.ankimon_presence.loop = False
+                mw.ankimon_presence.stop()
+            return
+
         if not hasattr(mw, "ankimon_presence") or not mw.ankimon_presence:
             mw.ankimon_presence = DiscordPresence(
                 CLIENT_ID, LARGE_IMAGE_URL, ankimon_tracker_obj, logger, settings_obj
@@ -25,9 +33,14 @@ def setup_discord_hooks():
             mw.ankimon_presence.start()
 
     def on_reviewer_will_end(*args):
-        mw.ankimon_presence.loop = False
-        mw.ankimon_presence.stop_presence()
+        if hasattr(mw, "ankimon_presence") and mw.ankimon_presence:
+            mw.ankimon_presence.loop = False
+            mw.ankimon_presence.stop_presence()
+
+    def on_sync_did_finish(*args):
+        if hasattr(mw, "ankimon_presence") and mw.ankimon_presence:
+            mw.ankimon_presence.stop()
 
     gui_hooks.reviewer_did_answer_card.append(on_reviewer_initialized)
     gui_hooks.reviewer_will_end.append(on_reviewer_will_end)
-    gui_hooks.sync_did_finish.append(mw.ankimon_presence.stop)
+    gui_hooks.sync_did_finish.append(on_sync_did_finish)


### PR DESCRIPTION
Addresses an issue where Discord Rich Presence failed to initialize because Ankimon's config values returned from the database often appear as strings (`"true"`) rather than native boolean objects (`True`).

This also re-engineers the hook registration sequence so hooks append fully at start-up, but the callbacks process the logic checking the status, which enables users to turn the feature on or off in the GUI without having to restart Anki entirely for the hooks to latch on.

---
*PR created automatically by Jules for task [17936504165156294924](https://jules.google.com/task/17936504165156294924) started by @h0tp-ftw*