### PR TITLE
Fix: Preserve `pokemon_defeated` stat across restarts for monthly challenge pokemon

### DIFF
--- a/src/Ankimon/functions/update_main_pokemon.py
+++ b/src/Ankimon/functions/update_main_pokemon.py
@@ -28,6 +28,7 @@ MAIN_POKEMON_DEFAULT = {
     "tier": "Normal",
     "shiny": False,
     "captured_date": "2000-01-01 00:00:00",
+    "pokemon_defeated": 0,
 }
 
 

--- a/src/Ankimon/pyobj/pokemon_obj.py
+++ b/src/Ankimon/pyobj/pokemon_obj.py
@@ -267,8 +267,9 @@ class PokemonObject:
         for key, value in kwargs.items():
             if key in self._READONLY_ATTRS:
                 continue
-            if hasattr(self, key):
-                setattr(self, key, value)
+            # We assign all attributes directly, as some valid attributes (e.g. pokemon_defeated)
+            # may not exist if instantiated via MAIN_POKEMON_DEFAULT
+            setattr(self, key, value)
         # Derived caches — recompute from the (possibly updated)
         # base_stats/level/iv/ev so they don't go stale.
         self.max_hp = self.calculate_max_hp()


### PR DESCRIPTION
Fixes an issue where the `pokemon_defeated` counter for Monthly Challenge Pokémon gets stuck and resets to 0 upon restarting the application.

---
*PR created automatically by Jules for task [12249459410554851687](https://jules.google.com/task/12249459410554851687) started by @h0tp-ftw*