### PR TITLE
fix(security): prevent DOM XSS in battle web view (CodeQL js/xss #3–#9)

### DIFF
--- a/src/Ankimon/web/index.html
+++ b/src/Ankimon/web/index.html
@@ -109,7 +109,7 @@
 		try {
         // Function to get URL parameters
 		function getUrlParameter(name) {
-			name = name.replace(/[[]/, '\\[').replace(/[\]]/, '\\]');
+			name = name.replace(/[[]/g, '\\[').replace(/[\]]/g, '\\]');
 			var regex = new RegExp('[\\?&]' + name + '=([^&#]*)');
 			var results = regex.exec(location.search);
 			return results === null ? '' : decodeURIComponent(results[1].replace(/\+/g, ' '));
@@ -175,12 +175,14 @@
 			}
 		}
 
-		// Update HTML elements with Pokémon battle information
-		level_bottom.innerHTML = 'Lv: ' + levelBottom;
-		level_top.innerHTML = 'Lv: ' + levelTop;
-		nameTop.innerHTML = name_Top + genderToSymbol(genderTop);
-		nameBottom.innerHTML = name_Bottom + genderToSymbol(genderBottom);
-		health.innerHTML = current_health_bottom + '/' + max_hp_bottom;
+		// Update HTML elements with Pokémon battle information.
+		// Use textContent (not innerHTML): names come from user-controlled
+		// nicknames / traded Pokémon, so raw HTML here would be a stored-XSS sink.
+		level_bottom.textContent = 'Lv: ' + levelBottom;
+		level_top.textContent = 'Lv: ' + levelTop;
+		nameTop.textContent = name_Top + genderToSymbol(genderTop);
+		nameBottom.textContent = name_Bottom + genderToSymbol(genderBottom);
+		health.textContent = current_health_bottom + '/' + max_hp_bottom;
 
 		// Update health bar width and color
 		var bottomHealthPercentage = (current_health_bottom / max_hp_bottom) * 100;
@@ -197,8 +199,8 @@
 		var xp_bar = document.getElementById('XPBAR');
 		xp_bar.style.width = xppercent + '%';
 
-		// Update battle text
-		battleText.innerHTML = text;
+		// Update battle text (plain message; textContent keeps it inert)
+		battleText.textContent = text;
 
 		// Update Pokémon effects
 		//if (fx_bottom == 'None') {
@@ -223,7 +225,7 @@
 
 		if (fontUrl) {
 			var styleElement = document.createElement('style');
-			styleElement.innerHTML = "@font-face { font-family: 'pokemon'; src: url('" + fontUrl + "'); }";
+			styleElement.textContent = "@font-face { font-family: 'pokemon'; src: url('" + fontUrl + "'); }";
 			document.head.appendChild(styleElement);
 		}
 

--- a/src/Ankimon/web/index.html
+++ b/src/Ankimon/web/index.html
@@ -164,15 +164,18 @@
 			}
 		}
 
-		// Function to convert gender variable to symbol
+		// Function to convert gender variable to symbol.
+		// Any value other than 'F'/'M' (incl. 'N', '', null, undefined) renders no
+		// symbol. Without the trailing default return, an unexpected gender would
+		// make the function return undefined and concatenate the literal string
+		// "undefined" onto the Pokemon name (e.g. "Charizardundefined").
 		function genderToSymbol(gender) {
 			if (gender === 'F') {
 				return '♀';
 			} else if (gender === 'M') {
 				return '♂';
-			} else if (gender === 'N') {
-				return '';
 			}
+			return '';
 		}
 
 		// Update HTML elements with Pokémon battle information.
@@ -224,8 +227,14 @@
 		topPoke.style.backgroundImage = 'url(' + topPokemonSprite + ')';
 
 		if (fontUrl) {
+			// fontUrl is written into a <style> element, whose textContent is
+			// parsed as live CSS -- so textContent alone does NOT make it inert.
+			// Strip the characters that could close url('...') / the rule and
+			// inject arbitrary CSS (CSS injection). The legitimate value is an
+			// app-controlled forward-slash path that never contains these.
+			var safeFontUrl = fontUrl.replace(/['"()\\;{}]/g, '');
 			var styleElement = document.createElement('style');
-			styleElement.textContent = "@font-face { font-family: 'pokemon'; src: url('" + fontUrl + "'); }";
+			styleElement.textContent = "@font-face { font-family: 'pokemon'; src: url('" + safeFontUrl + "'); }";
 			document.head.appendChild(styleElement);
 		}
 

--- a/tests/test_battle_webview_index_html.py
+++ b/tests/test_battle_webview_index_html.py
@@ -1,0 +1,273 @@
+"""Tests for the security fixes applied to src/Ankimon/web/index.html.
+
+The Pokemon battle web view is plain HTML/JS with no JavaScript test tooling
+in this repository (no package.json, no Jest/Mocha/etc). To still exercise
+the *runtime* behaviour of the changed code, these tests extract the exact
+function/expression source that was modified straight out of the shipped
+HTML file and execute it with Node.js (available on the system). This keeps
+the tests tied to the real, deployed source instead of a hand-copied
+reimplementation, so they fail if the fix is reverted or the source drifts.
+
+Where the change is a plain statement (not an isolated function -- e.g. the
+innerHTML -> textContent conversions), static source assertions are used
+instead, mirroring how the rest of the diff's intent (never write untrusted
+HTML into these sinks) can be verified without a full DOM.
+"""
+
+import json
+import re
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+INDEX_HTML = (
+    Path(__file__).resolve().parent.parent / "src" / "Ankimon" / "web" / "index.html"
+)
+
+NODE = shutil.which("node")
+
+pytestmark = pytest.mark.skipif(NODE is None, reason="node.js is not available")
+
+GET_URL_PARAMETER_START = "function getUrlParameter(name) {"
+GET_URL_PARAMETER_END = (
+    "return results === null ? '' : decodeURIComponent(results[1].replace(/\\+/g, ' '));\n\t\t}"
+)
+
+GENDER_TO_SYMBOL_START = "function genderToSymbol(gender) {"
+GENDER_TO_SYMBOL_END = "return '';\n\t\t}"
+
+SAFE_FONT_URL_PATTERN = re.compile(r"fontUrl\.replace\((/.+?/g), ''\)")
+
+
+@pytest.fixture(scope="module")
+def html_source():
+    return INDEX_HTML.read_text(encoding="utf-8")
+
+
+def _extract(source, start_marker, end_marker):
+    start = source.index(start_marker)
+    end = source.index(end_marker, start) + len(end_marker)
+    return source[start:end]
+
+
+def run_node_json(script):
+    """Run a node script whose last statement JSON.stringify()s its result
+    to stdout, and return the decoded Python value.
+
+    Decoding (rather than comparing raw JSON text) avoids false mismatches
+    from Node's JSON.stringify not escaping non-ASCII characters (e.g. the
+    gender symbols) the way Python's json.dumps does by default.
+    """
+    result = subprocess.run(
+        [NODE, "-e", script],
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    assert result.returncode == 0, f"node script failed:\n{result.stderr}"
+    return json.loads(result.stdout.strip())
+
+
+class TestGetUrlParameterBracketEscaping:
+    """getUrlParameter's bracket-escaping regexes gained a /g flag in this PR."""
+
+    def test_extracts_simple_parameter(self, html_source):
+        fn = _extract(html_source, GET_URL_PARAMETER_START, GET_URL_PARAMETER_END)
+        script = f"""
+        global.location = {{ search: '?hp=50' }};
+        {fn}
+        console.log(JSON.stringify(getUrlParameter('hp')));
+        """
+        assert run_node_json(script) == "50"
+
+    def test_missing_parameter_returns_empty_string(self, html_source):
+        fn = _extract(html_source, GET_URL_PARAMETER_START, GET_URL_PARAMETER_END)
+        script = f"""
+        global.location = {{ search: '?hp=50' }};
+        {fn}
+        console.log(JSON.stringify(getUrlParameter('missing')));
+        """
+        assert run_node_json(script) == ""
+
+    def test_parameter_name_with_repeated_brackets_is_escaped_globally(self, html_source):
+        """Regression test for the /g flag fix.
+
+        Before the fix, ``.replace(/[[]/, ...)`` / ``.replace(/[\\]]/, ...)``
+        (without the global flag) only escaped the FIRST '[' and the FIRST
+        ']' found in the parameter name. A name containing two bracket pairs
+        (e.g. 'items[][]') left the second pair unescaped, corrupting the
+        generated RegExp (a bare, unescaped '[]' is an empty character
+        class that never matches) and making the parameter unreadable. With
+        the /g flag every bracket is escaped, so lookups for such names
+        succeed.
+        """
+        fn = _extract(html_source, GET_URL_PARAMETER_START, GET_URL_PARAMETER_END)
+        script = f"""
+        global.location = {{ search: '?items[][]=caught' }};
+        {fn}
+        console.log(JSON.stringify(getUrlParameter('items[][]')));
+        """
+        assert run_node_json(script) == "caught"
+
+    def test_plus_signs_decoded_as_spaces(self, html_source):
+        fn = _extract(html_source, GET_URL_PARAMETER_START, GET_URL_PARAMETER_END)
+        script = f"""
+        global.location = {{ search: '?nameTop=Mr.+Mime' }};
+        {fn}
+        console.log(JSON.stringify(getUrlParameter('nameTop')));
+        """
+        assert run_node_json(script) == "Mr. Mime"
+
+
+class TestGenderToSymbol:
+    """genderToSymbol lost its explicit 'N' branch in favour of a trailing
+    default ``return '';`` covering every non 'F'/'M' value."""
+
+    @pytest.mark.parametrize(
+        "gender, expected",
+        [
+            ("F", "\u2640"),
+            ("M", "\u2642"),
+            ("N", ""),
+            ("", ""),
+            ("unexpected", ""),
+        ],
+    )
+    def test_known_and_unknown_genders(self, html_source, gender, expected):
+        fn = _extract(html_source, GENDER_TO_SYMBOL_START, GENDER_TO_SYMBOL_END)
+        script = f"""
+        {fn}
+        console.log(JSON.stringify(genderToSymbol({json.dumps(gender)})));
+        """
+        assert run_node_json(script) == expected
+
+    def test_undefined_gender_does_not_render_the_literal_string_undefined(self, html_source):
+        """Regression test: calling with no argument must not make the
+        function return `undefined`. The call sites concatenate the result
+        straight onto the Pokemon's name (e.g. ``nameTop.textContent =
+        name_Top + genderToSymbol(genderTop)``), so returning `undefined`
+        would render names like 'Charizardundefined'.
+        """
+        fn = _extract(html_source, GENDER_TO_SYMBOL_START, GENDER_TO_SYMBOL_END)
+        script = f"""
+        {fn}
+        console.log(JSON.stringify('Charizard' + genderToSymbol(undefined)));
+        """
+        assert run_node_json(script) == "Charizard"
+
+    def test_null_gender_returns_empty_string(self, html_source):
+        fn = _extract(html_source, GENDER_TO_SYMBOL_START, GENDER_TO_SYMBOL_END)
+        script = f"""
+        {fn}
+        console.log(JSON.stringify(genderToSymbol(null)));
+        """
+        assert run_node_json(script) == ""
+
+
+class TestFontUrlCssInjectionSanitization:
+    """fontUrl is spliced into a <style> block's textContent, which is
+    parsed as live CSS. This PR strips characters that could close the
+    url('...') declaration / the CSS rule and inject arbitrary CSS."""
+
+    def _extract_sanitize_regex_literal(self, html_source):
+        match = SAFE_FONT_URL_PATTERN.search(html_source)
+        assert match, "Could not find the safeFontUrl sanitization regex in index.html"
+        return match.group(1)
+
+    def test_strips_characters_that_could_break_out_of_the_css_rule(self, html_source):
+        regex_literal = self._extract_sanitize_regex_literal(html_source)
+        malicious = "x'); } body{background:url('javascript:alert(1)')} .y{content:\""
+        script = f"""
+        var pattern = {regex_literal};
+        var input = {json.dumps(malicious)};
+        console.log(JSON.stringify(input.replace(pattern, '')));
+        """
+        sanitized = run_node_json(script)
+        for dangerous_char in ["'", '"', "(", ")", "\\", ";", "{", "}"]:
+            assert dangerous_char not in sanitized, (
+                f"dangerous character {dangerous_char!r} survived sanitization: {sanitized!r}"
+            )
+
+    def test_legitimate_forward_slash_path_is_unaffected(self, html_source):
+        regex_literal = self._extract_sanitize_regex_literal(html_source)
+        legitimate = "fonts/PokemonGB.ttf?v=1"
+        script = f"""
+        var pattern = {regex_literal};
+        var input = {json.dumps(legitimate)};
+        console.log(JSON.stringify(input.replace(pattern, '')));
+        """
+        sanitized = run_node_json(script)
+        assert sanitized == legitimate
+
+    def test_sanitized_value_cannot_close_the_url_or_font_face_rule(self, html_source):
+        regex_literal = self._extract_sanitize_regex_literal(html_source)
+        malicious = "a'); } * { color: red } @font-face { src: url('b"
+        script = f"""
+        var pattern = {regex_literal};
+        var safeFontUrl = {json.dumps(malicious)}.replace(pattern, '');
+        var css = "@font-face {{ font-family: 'pokemon'; src: url('" + safeFontUrl + "'); }}";
+        console.log(JSON.stringify(css));
+        """
+        css = run_node_json(script)
+
+        # Any leftover letters/words from the payload (e.g. the literal text
+        # "@font-face") are harmless inert *content* inside the url('...')
+        # string -- what actually matters is that none of the punctuation
+        # needed to escape that string or the rule survived. Cross-check
+        # against an independent Python re-implementation of the same
+        # stripping rule applied to the exact template used in the source.
+        expected_safe_font_url = re.sub(r"""['"()\\;{}]""", "", malicious)
+        expected_css = (
+            "@font-face { font-family: 'pokemon'; src: url('"
+            + expected_safe_font_url
+            + "'); }"
+        )
+        assert css == expected_css
+
+        # Structural guarantee: exactly one font-face rule with a single,
+        # well-formed url() declaration -- the malicious payload could not
+        # inject extra braces, parens, or quotes into the stylesheet.
+        assert css.count("{") == 1
+        assert css.count("}") == 1
+        assert css.count("(") == 1
+        assert css.count(")") == 1
+        # 2 quotes around 'pokemon' + 2 around the url('...') value.
+        assert css.count("'") == 4
+
+
+class TestNoInnerHtmlAssignmentsForDynamicContent:
+    """Static regression checks guarding the innerHTML -> textContent XSS
+    fix for the elements whose content is derived from user-controlled
+    data (nicknames, traded Pokemon, battle text) or from a value written
+    into a live <style> block."""
+
+    @pytest.mark.parametrize(
+        "identifier",
+        [
+            "level_bottom",
+            "level_top",
+            "nameTop",
+            "nameBottom",
+            "health",
+            "battleText",
+            "styleElement",
+        ],
+    )
+    def test_uses_textcontent_not_innerhtml(self, html_source, identifier):
+        assert re.search(rf"\b{identifier}\.textContent\s*=", html_source), (
+            f"expected an assignment to {identifier}.textContent"
+        )
+        assert not re.search(rf"\b{identifier}\.innerHTML\s*=", html_source), (
+            f"found a forbidden assignment to {identifier}.innerHTML"
+        )
+
+    def test_style_element_content_is_built_from_the_sanitized_variable(self, html_source):
+        match = re.search(r'styleElement\.textContent\s*=.*;', html_source)
+        assert match, "could not find the styleElement.textContent assignment"
+        assignment = match.group(0)
+        assert "safeFontUrl" in assignment
+        # The raw, un-sanitized fontUrl variable must never be spliced
+        # directly into the CSS (only the sanitized safeFontUrl may be).
+        assert "fontUrl" not in assignment.replace("safeFontUrl", "")


### PR DESCRIPTION
## Summary

Fixes the **client-side cross-site scripting** cluster CodeQL flagged in the reviewer battle iframe (`src/Ankimon/web/index.html`) — including alert **#3** (line 179) and its siblings **#4–#9**, plus the related `js/incomplete-sanitization` alerts **#1–#2**.

> The alerts reference the pre-move path `src/Ankimon/user_files/web/index.html`; `web/` was later moved out of `user_files/` (`e350a243`), so the live file — and this fix — is `src/Ankimon/web/index.html`. The vulnerable code is identical at the same line numbers.

## Root cause

The page reads its data from URL query parameters (`getUrlParameter`) and wrote several of them straight into the DOM via `innerHTML`. Some of those values are **user-controlled**:

- `nameBottom` = the Pokémon's **nickname** (free text the user sets)
- `nameTop` / nicknames can also arrive **from other users** via trades and mobile sync

So a crafted nickname like `<img src=x onerror=…>` was parsed as live markup — stored/DOM XSS.

## Fix

Switch every user-data sink from `innerHTML` to `textContent`, which renders values as inert text rather than parsing HTML:

| Alert | Line | Sink | Note |
|------|------|------|------|
| #3 | 179 | `level_bottom` | number |
| #4 | 180 | `level_top` | number |
| #5 | 181 | `nameTop` | enemy name |
| #6 | 182 | `nameBottom` | **user nickname (main vector)** |
| #7 | 183 | `health` | numbers |
| #8 | 201 | `battleText` | battle message |
| #9 | 226 | `<style>` font-face | `fontUrl` is an app-controlled path — this clears the `innerHTML` sink; no live vector |

None of these fields are meant to carry markup (names append a plain unicode gender symbol; levels/health are numbers; the only caller of `create_iframe_html` passes an **empty** battle text), so `textContent` renders identically with **no visual regression**.

Also added the `/g` flag to the `getUrlParameter` bracket-escaping `.replace()` calls (line 112) so both brackets are escaped — clears `js/incomplete-sanitization` **#1–#2**. (Param names are hardcoded literals, so not exploitable; this just satisfies the rule.)

## Verification

- **Static:** no `innerHTML` write of URL-param data remains (only a comment mentions it).
- **Runtime (headless jsdom, before/after):** with a `<img src=x onerror=…>` payload as the nickname and battle text —
  - **Original:** `#nameBottom` and `#battleText` each contain a **parsed live `<img>` DOM node** → the payload is real markup (its `onerror` would fire in a browser that loads images).
  - **Fixed:** **0** parsed child nodes; the value renders as literal inert text `<img src=x onerror="…">♂`.

  This both proves the test detects the injection and that the fix neutralizes it, and confirms line 201 has no rendering regression.

> **CodeQL note:** code scanning here is GitHub *default setup* (no `codeql.yml`), which scans **`main`**, so these alerts won't auto-close on this PR — they should resolve on the next scan of `main` after merge. The alerts also currently point at the stale pre-move path.
