### PR TITLE
Fix Team Deck View string boolean evaluation

### DIFF
--- a/src/Ankimon/gui_classes/overview_team.py
+++ b/src/Ankimon/gui_classes/overview_team.py
@@ -492,7 +492,11 @@ def register_overview_hooks() -> None:
     setattr(services, _HANDLER_RECORD, ())
 
     settings = services.settings
-    if settings is None or settings.get("gui.team_deck_view") is not True:
+    if settings is None:
+        return
+
+    team_deck_view = settings.get("gui.team_deck_view")
+    if not (team_deck_view is True or str(team_deck_view).lower() in ("true", "1")):
         return
 
     handlers = (


### PR DESCRIPTION
Fixes an issue where the Team Overview in the Deck Overview page fails to render if the user's settings store the configuration as a string `"true"` instead of a boolean `True`.

---
*PR created automatically by Jules for task [858402203341498389](https://jules.google.com/task/858402203341498389) started by @h0tp-ftw*