### PR TITLE
fix(ui): guard MovieSplashLabel show/hide against a torn-down QMovie

### DIFF
--- a/src/Ankimon/gui_entities.py
+++ b/src/Ankimon/gui_entities.py
@@ -46,10 +46,20 @@ class MovieSplashLabel(QLabel):
         self.movie.frameChanged.connect(self.repaint)
 
     def showEvent(self, event):
-        self.movie.start()
+        # During widget/interpreter teardown the QMovie's underlying C++ object can
+        # already be deleted when a show/hide event fires, which raises
+        # "wrapped C/C++ object of type QMovie has been deleted" and aborts on
+        # Anki shutdown. Guard both so a normal close is clean.
+        try:
+            self.movie.start()
+        except RuntimeError:
+            pass
 
     def hideEvent(self, event):
-        self.movie.stop()
+        try:
+            self.movie.stop()
+        except RuntimeError:
+            pass
 
 
 class UpdateNotificationWindow(QDialog):


### PR DESCRIPTION
## Problem

`MovieSplashLabel` (an animated-GIF `QLabel`) starts/stops its `QMovie` in `showEvent`/`hideEvent`. During widget/interpreter teardown the `QMovie`'s underlying C++ object can already be deleted when a hide event fires, so `self.movie.stop()` raises:

```
RuntimeError: wrapped C/C++ object of type QMovie has been deleted
```

which aborts the process (SIGABRT / exit 134) on an otherwise-normal Anki shutdown.

## Fix

Guard both `showEvent` and `hideEvent` with a `try/except RuntimeError`, so a deleted `QMovie` is a harmless no-op instead of a crash. One file; no behaviour change while the widget is alive.

## Verification

Surfaced by the Tier-2 harness `feature_check` (`harness/scenarios/feature_check.py`), which aborted at teardown:

- **Before:** exit **134**, `RuntimeError: ...QMovie... has been deleted` + core dump.
- **After:** exits normally — **zero** QMovie / abort / traceback lines in the run log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
