### PR TITLE
Fix: Add team cycle hotkey back to settings

### DIFF
--- a/src/Ankimon/__init__.py
+++ b/src/Ankimon/__init__.py
@@ -266,6 +266,7 @@ def start_asynchronous_startup():
             settings_obj.get("controls.catch_key"),
             settings_obj.get("controls.defeat_key"),
             settings_obj.get("controls.pokemon_buttons"),
+            settings_obj.get("controls.team_cycle_key"),
         )
 
         # 5b. Developer hot-reload shortcut (Ctrl+Shift+R -> restart_ankimon).

--- a/tests/test_async_startup_boot.py
+++ b/tests/test_async_startup_boot.py
@@ -895,7 +895,7 @@ def test_reviewer_ui_called_with_base_three_arg_signature(boot_env):
     boot_env.exec_init()
 
     setup = _first(boot_env, "setup_reviewer_ui")
-    assert setup[1] == ("6", "5", True)
+    assert setup[1] == ("6", "5", True, None)
     assert setup[2] == {}
 
 


### PR DESCRIPTION
The Web UI settings was missing the new `Key for Team Cycling` hotkey setting that was recently introduced. It looks like it was correctly integrated into the legacy python UI, but was missed in the Web UI schema. 

I've also updated `__init__.py` to call `setup_reviewer_ui` with the new argument `team_cycle_key` (instead of using the kwargs default) so it doesn't fail tests or behave inconsistently. Tests were also updated to expect the new signature.

---
*PR created automatically by Jules for task [15866305706101961811](https://jules.google.com/task/15866305706101961811) started by @h0tp-ftw*