### PR TITLE
feat: implement shiny charm functionality to increase shiny encounter rate

### DIFF
--- a/src/Ankimon/functions/pokemon_functions.py
+++ b/src/Ankimon/functions/pokemon_functions.py
@@ -133,8 +133,24 @@ def find_experience_for_level(group_growth_rate, level, remove_levelcap=True):
 def shiny_chance():
     # Shiny Pokémon probability (1 in 4096 chance)
     SHINY_PROBABILITY = 4096
-    shiny = random.randint(1, SHINY_PROBABILITY) == 1
-    return shiny
+    db = services.db
+
+    rolls = 1
+    if db:
+        shiny_charm = db.get_item("shiny-charm")
+        if shiny_charm:
+            try:
+                quantity = shiny_charm["quantity"]
+            except (KeyError, TypeError, IndexError):
+                quantity = 0
+            if quantity > 0:
+                rolls = 3
+
+    for _ in range(rolls):
+        if random.randint(1, SHINY_PROBABILITY) == 1:
+            return True
+
+    return False
 
 # unused, archived
 # must fix missing fields if used

--- a/src/Ankimon/functions/pokemon_functions.py
+++ b/src/Ankimon/functions/pokemon_functions.py
@@ -143,7 +143,8 @@ def shiny_chance():
                 quantity = shiny_charm["quantity"]
             except (KeyError, TypeError, IndexError):
                 quantity = 0
-            if quantity > 0:
+            # Ensure quantity is actually an int before comparing with > 0, to support mocks
+            if isinstance(quantity, int) and quantity > 0:
                 rolls = 3
 
     for _ in range(rolls):


### PR DESCRIPTION
This PR implements functionality for the `shiny-charm` item.
When a user has at least one Shiny Charm in their inventory, their odds of encountering a Shiny Pokémon are increased from 1/4096 to 3/4096, which matches the behavior introduced in modern Pokémon games.

---
*PR created automatically by Jules for task [6055843886061598956](https://jules.google.com/task/6055843886061598956) started by @h0tp-ftw*