### PR TITLE
docs(changelog): credit BRRRR_Experimental features in the 2.1-E changelog

### DIFF
--- a/assets/changelogs/2.1-E-discord.md
+++ b/assets/changelogs/2.1-E-discord.md
@@ -2,7 +2,7 @@
 
 A huge thank you to <@430066577262510080>, @Copilot, <@445586026451173377>, <@418451430270042133>, @jupiterslegacy, <@720180197403525120> for their contributions to this update! <3
 
-This release includes 23 merged pull requests with 2 enhancements and 2 bug fixes!
+This release includes 23 pull requests merged directly on main — **plus a huge batch of features and fixes ported from the BRRRR_Experimental branch** (listed below). It's easily our biggest update yet!
 
 We have a huge number of new features from the contributors above working on the "BRRRR_Experimental" branch. Expect a ton of new stuff in this update! Thanks to the contributors for hundreds of hours of work into coding, implementing and merging these features.
 

--- a/assets/changelogs/2.1-E.md
+++ b/assets/changelogs/2.1-E.md
@@ -2,7 +2,7 @@
 
 A huge thank you to [@AIbrahimv2](https://github.com/AIbrahimv2) (Krow), [@Copilot](https://github.com/Copilot), [@h0tp-ftw](https://github.com/h0tp-ftw) (h0tp), [@hakimh2](https://github.com/hakimh2) (Brrrrrrr), [@jupiterslegacy](https://github.com/jupiterslegacy), [@scotej](https://github.com/scotej) (Scoot) for their contributions to this update! <3
 
-This release includes 23 merged pull requests with 2 enhancements and 2 bug fixes!
+This release includes 23 pull requests merged directly on main — **plus a huge batch of features and fixes ported from the BRRRR_Experimental branch** (listed below). It's easily our biggest update yet!
 
 We have a huge number of new features from the contributors above working on the "BRRRR_Experimental" branch. Expect a ton of new stuff in this update! Thanks to the contributors for hundreds of hours of work into coding, implementing and merging these features.
 
@@ -18,6 +18,52 @@ Want to stay updated or get involved? Join our server for the latest updates on 
 ### 🚨 Critical Changes!
 
 - [MAJOR] Integrate BRRRR_Experimental feature set onto main (service-seam re-fit) [#582](https://github.com/h0tp-ftw/ankimon/pull/582) [@h0tp-ftw](https://github.com/h0tp-ftw) (h0tp)
+
+### 🌈 From BRRRR_Experimental — the big one!
+
+The bulk of this release is a massive body of work from the **BRRRR_Experimental** branch — dozens of new systems, features, and fixes built by [@hakimh2](https://github.com/hakimh2) (Brrrrrrr), [@AIbrahimv2](https://github.com/AIbrahimv2) (Krow), [@jupiterslegacy](https://github.com/jupiterslegacy), and [@scotej](https://github.com/scotej) (Scoot), then ported onto main by [@h0tp-ftw](https://github.com/h0tp-ftw) (h0tp). Hundreds of hours of work — here's what landed:
+
+**✨ New systems & features**
+
+- Encounter Overhaul — 8 encounter tiers, Megas & Gmax, regional forms, catch-chains, and EP-mastery CP scaling [#551](https://github.com/h0tp-ftw/ankimon/pull/551) [@hakimh2](https://github.com/hakimh2) (Brrrrrrr), [@AIbrahimv2](https://github.com/AIbrahimv2) (Krow)
+- Evolution overhaul — region, time, location & item-stone evolutions, plus an evolution-ready badge [#556](https://github.com/h0tp-ftw/ankimon/pull/556) [@hakimh2](https://github.com/hakimh2) (Brrrrrrr)
+- Region-aware & move-based evolutions with Pokédex form data [#554](https://github.com/h0tp-ftw/ankimon/pull/554) [@hakimh2](https://github.com/hakimh2) (Brrrrrrr)
+- Ankidex — a brand-new Pokédex V2 in its own window [#566](https://github.com/h0tp-ftw/ankimon/pull/566) [@AIbrahimv2](https://github.com/AIbrahimv2) (Krow), [@hakimh2](https://github.com/hakimh2) (Brrrrrrr)
+- New web-based Shop, Settings, Profile & Team screens [#561](https://github.com/h0tp-ftw/ankimon/pull/561) [@AIbrahimv2](https://github.com/AIbrahimv2) (Krow), [@hakimh2](https://github.com/hakimh2) (Brrrrrrr)
+- PC Box rework — move manager, evolution-readiness badge, remembered window position [#557](https://github.com/h0tp-ftw/ankimon/pull/557) [@AIbrahimv2](https://github.com/AIbrahimv2) (Krow), [@hakimh2](https://github.com/hakimh2) (Brrrrrrr)
+- Trade V2 — versioned trade codes, natures, legacy mode, and mega forms [#573](https://github.com/h0tp-ftw/ankimon/pull/573) [@hakimh2](https://github.com/hakimh2) (Brrrrrrr)
+- Mobile & Web Reviews — review from your phone or browser, with a sync engine and companion AI [#567](https://github.com/h0tp-ftw/ankimon/pull/567) [@hakimh2](https://github.com/hakimh2) (Brrrrrrr)
+- Redesigned Pokémon details window — nature chart, animated stat bars, remember-attack [#550](https://github.com/h0tp-ftw/ankimon/pull/550) [@hakimh2](https://github.com/hakimh2) (Brrrrrrr)
+- Encounter simulator — preview encounter rates in a dedicated window [#558](https://github.com/h0tp-ftw/ankimon/pull/558) [@hakimh2](https://github.com/hakimh2) (Brrrrrrr)
+- Dual-database (Normal / Dev) backup system [#572](https://github.com/h0tp-ftw/ankimon/pull/572) [@hakimh2](https://github.com/hakimh2) (Brrrrrrr)
+- Team deck-overview grid backed by the Ankimon database [#571](https://github.com/h0tp-ftw/ankimon/pull/571) [@hakimh2](https://github.com/hakimh2) (Brrrrrrr)
+- In-app branch self-updater — 3-tab dialog with snooze and safe apply [#548](https://github.com/h0tp-ftw/ankimon/pull/548) [@hakimh2](https://github.com/hakimh2) (Brrrrrrr)
+- Reviewer HUD rewrite with team-cycle hotkeys [#555](https://github.com/h0tp-ftw/ankimon/pull/555) [@hakimh2](https://github.com/hakimh2) (Brrrrrrr)
+- Live-refreshing Trainer Card [#574](https://github.com/h0tp-ftw/ankimon/pull/574) [@AIbrahimv2](https://github.com/AIbrahimv2) (Krow), [@hakimh2](https://github.com/hakimh2) (Brrrrrrr)
+- Web-based Items / Bag with in-shell item use [#563](https://github.com/h0tp-ftw/ankimon/pull/563) [@AIbrahimv2](https://github.com/AIbrahimv2) (Krow), [@hakimh2](https://github.com/hakimh2) (Brrrrrrr)
+- Shared move-picker dialog [#538](https://github.com/h0tp-ftw/ankimon/pull/538) [@hakimh2](https://github.com/hakimh2) (Brrrrrrr)
+- Live language switching without a restart [#535](https://github.com/h0tp-ftw/ankimon/pull/535) [@hakimh2](https://github.com/hakimh2) (Brrrrrrr)
+- Encounter display rewrite — persistent layout, Mega/Gmax names [#559](https://github.com/h0tp-ftw/ankimon/pull/559) [@hakimh2](https://github.com/hakimh2) (Brrrrrrr)
+- Mega & Gmax sprite resolution [#542](https://github.com/h0tp-ftw/ankimon/pull/542) [@hakimh2](https://github.com/hakimh2) (Brrrrrrr)
+- Learnset improvements — level / TM / tutor moves, Deoxys & Eternamax, generation fallbacks [#539](https://github.com/h0tp-ftw/ankimon/pull/539) [@hakimh2](https://github.com/hakimh2) (Brrrrrrr)
+- Full translations for evolution / friendship / badge text and the nature chart [#541](https://github.com/h0tp-ftw/ankimon/pull/541) [@hakimh2](https://github.com/hakimh2) (Brrrrrrr)
+- Pokémon-GO-style CP / economy tuning [#546](https://github.com/h0tp-ftw/ankimon/pull/546) [@hakimh2](https://github.com/hakimh2) (Brrrrrrr)
+- Fossil tiers, name persistence & Pokémon display helpers [#543](https://github.com/h0tp-ftw/ankimon/pull/543) [@hakimh2](https://github.com/hakimh2) (Brrrrrrr)
+- Asynchronous, thread-safe startup [#553](https://github.com/h0tp-ftw/ankimon/pull/553) [@hakimh2](https://github.com/hakimh2) (Brrrrrrr), [@jupiterslegacy](https://github.com/jupiterslegacy)
+
+**🐛 Stability & fixes**
+
+- Review-based damage multiplier at the engine level [#540](https://github.com/h0tp-ftw/ankimon/pull/540) [@hakimh2](https://github.com/hakimh2) (Brrrrrrr)
+- Language-agnostic review counting + faint guard [#536](https://github.com/h0tp-ftw/ankimon/pull/536) [@hakimh2](https://github.com/hakimh2) (Brrrrrrr)
+- Mobile-sync hardening — double-processing, XP-share, divide-by-zero, DB races, XSS [#576](https://github.com/h0tp-ftw/ankimon/pull/576) [@hakimh2](https://github.com/hakimh2) (Brrrrrrr)
+- Battle & evolution regression fixes + learnset move-leak [#577](https://github.com/h0tp-ftw/ankimon/pull/577) [@hakimh2](https://github.com/hakimh2) (Brrrrrrr)
+- Deck-Browser nickname XSS and stat-bar crash fixes [#578](https://github.com/h0tp-ftw/ankimon/pull/578) [@hakimh2](https://github.com/hakimh2) (Brrrrrrr)
+- Web-shell thread-safety & cache-invalidation fixes [#579](https://github.com/h0tp-ftw/ankimon/pull/579) [@hakimh2](https://github.com/hakimh2) (Brrrrrrr)
+- SQLite busy-timeout + dev-mode helper [#580](https://github.com/h0tp-ftw/ankimon/pull/580) [@hakimh2](https://github.com/hakimh2) (Brrrrrrr)
+- StarterWindow reload-safety + capture timestamp [#575](https://github.com/h0tp-ftw/ankimon/pull/575) [@hakimh2](https://github.com/hakimh2) (Brrrrrrr)
+- Mobile-review detection for default users + file-sync hardening [#586](https://github.com/h0tp-ftw/ankimon/pull/586) [@scotej](https://github.com/scotej) (Scoot)
+- Fixed a mobile auto-resolve crash and reduced review / replay lag [#589](https://github.com/h0tp-ftw/ankimon/pull/589) [@scotej](https://github.com/scotej) (Scoot)
+- Mobile reviews stability — schema/init, history dedupe, resolve regressions [#493](https://github.com/h0tp-ftw/ankimon/pull/493), [#494](https://github.com/h0tp-ftw/ankimon/pull/494), [#502](https://github.com/h0tp-ftw/ankimon/pull/502), [#505](https://github.com/h0tp-ftw/ankimon/pull/505) [@h0tp-ftw](https://github.com/h0tp-ftw) (h0tp)
 
 ### ✨ Features & Improvements!
 


### PR DESCRIPTION
Adds a **From BRRRR_Experimental** section to `assets/changelogs/2.1-E.md` listing ~34 of the ~48 feature/fix PRs that landed via umbrella #582 and never got a line-item. Each is credited to its original author(s) — @hakimh2, @AIbrahimv2, @jupiterslegacy, @scotej — taken from the commit co-author trailers, with @h0tp-ftw as integrator. Discord changelog regenerated. (The published GitHub release notes are updated to match separately.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)