### PR TITLE
docs(changelog): add in-depth BRRRR_Experimental feature report to 2.1-E

### DIFF
--- a/assets/changelogs/2.1-E.md
+++ b/assets/changelogs/2.1-E.md
@@ -96,3 +96,270 @@ The bulk of this release is a massive body of work from the **BRRRR_Experimental
 - Fix `ValueError` unpacking return value from `read_github_file` [#489](https://github.com/h0tp-ftw/ankimon/pull/489) [@h0tp-ftw](https://github.com/h0tp-ftw) (h0tp)
 - refactor: aqt-free service registry to decouple addon logic from mw [#437](https://github.com/h0tp-ftw/ankimon/pull/437) [@h0tp-ftw](https://github.com/h0tp-ftw) (h0tp)
 
+
+***
+
+## 🔬 In depth — everything in this update
+
+A comprehensive breakdown of the features, systems, and improvements that landed in **2.1-E** from the BRRRR_Experimental line of work — from the unified web shell to Mega/Gmax encounters, mobile reviews, and the encounter overhaul.
+
+### 🌟 Quick Summary of Notable Features (For Players)
+
+Here is a quick look at what's new and improved:
+
+- **📱 Unified Web Shell**: A single, modern, unified window containing the **Item Shop/Bag**, the brand-new **Ankidex (Pokédex V2)**, a beautiful **Trainer Profile**, **Roster Management (Team Builder)**, and **Settings**. Swap between screens instantly without opening separate windows.
+- **⚖️ Balanced Battle Economy**: Continuously earn cash rewards as you review, toggle auto-catching per tier, and use custom wishlists.
+- **🌟 Mega, Gigantamax & Special Form Encounters**: Encounter and capture powerful **Mega Evolutions**, **Gigantamax forms**, and many other special forms (which are unavailable to be encountered in the main version) after discovering their base forms.
+- **🌎 Region Selection & Regional Forms**: Select an active region (like Kanto, Alola, Galar, etc.) to boost generation spawn odds and catch unique regional forms (e.g. Alolan Geodude, Galarian Darmanitan).
+- **🧬 Deep Evolution Depth**: Level-up evolutions now respect your selected active region and support move-based evolutions. Special forms have been accurately redistributed into their lore-correct Legendary/Mythical tiers.
+- **🔄 Fast Hotkeys**: Swap active team members instantly with the `9` key during card reviews.
+- **📱 Mobile Reviews Integration**: Review your flashcards on the go using AnkiMobile or AnkiWeb and resolve them as battles on your desktop. Support for Auto-Resolve (optimal team matchup selection) or Manual Replay (animated reviews).
+
+## 1. Performance & Memory Optimization
+
+The most significant architectural improvement in this update is the transition from high-latency file I/O and redundant database queries to an aggressive **in-memory caching system**. This results in nearly zero lag across the application.
+
+### Comprehensive Data Caching & Performance Polish
+
+- **File I/O Elimination**: `learnsets.json`, `pokedex.json`, and `next_lvl.csv` (experience tables) are now cached in memory to eliminate disk reads during move selection and level-up processing.
+- **CSV Memory Mapping**: Heavy CSV files (`pokemon.csv`, `stats.csv`, `pokemon_species.csv`, `evolution.csv`) are cached as dictionary structures.
+- **HUD Performance**: Implemented sprite caching in the reviewer to drastically speed up HUD rendering during battles.
+- **Fast ID Indexing**: A reverse index (`species_id` -> `pokemon_name`) is built at startup for $O(1)$ lookups.
+- **Shop TM Caching**: Cached the flattened TM pool on first call in `PokemonShopManager.get_tm_pool()` to avoid repetitive builds.
+
+### PC Box Query Optimization
+
+- **Results Caching**: The PC Box caches the results of the last filtered query. Navigating between boxes (paging) or selecting different Pokémon no longer triggers a new SQLite query unless the filter state changes.
+- **Filter State Tracking**: Balances performance with data accuracy by intelligently invalidating the cache only when necessary.
+
+### QStackedWidget Multi-View Shell (Instant Screen Swapping)
+
+- **Load Delay Elimination**: Replaced webpage-reloading delays with a persistent `QStackedWidget` in the `AnkimonItemsWeb` shell window, maintaining pre-loaded `QWebEngineView` instances for Items, Ankidex, Settings, Profile, and Team. This eliminates tab-loading white flashes and latency.
+- **Off-DOM Reconciliation & Scoped Repaints**: Unified Items grid leverages off-DOM `DocumentFragment` construction and atomic `replaceChildren` swaps to eliminate layout reflow flashes. CSS `contain: layout` is applied to the `.shop-grid` container to localize repaints.
+
+### Asynchronous & Thread-Safe Startup Sequence (Zero-Lag Boot)
+
+- **QueryOp Thread Offloading**: Offloaded all disk and CPU-intensive boot tasks (generating/validating database backups, verifying folder structures for sprites and assets, querying item statistics, and generating the first wild enemy Pokémon) to an asynchronous background thread using Anki's `QueryOp` to completely eliminate startup freeze/lag.
+- **Responsive UI Deferral**: Deferred Ankimon menu creation, profileLoaded database hooks, and singletons wiring until the background loading thread successfully completes.
+- **Robust Client Guards**: Placed thread guards on reviewer shortcuts, battle loops, and custom reviewer bottom bar layout to revert gracefully to safe fallbacks or native bars while loading.
+- **Thread-Safe DB Connection**: Configured SQLite connections with `check_same_thread=False` to securely permit read and write operations across background and main thread boundaries.
+
+---
+
+## 2. Major UI/UX Overhaul
+
+### Unified QWebEngineView Web Shell (`AnkimonItemsWeb`)
+
+The Item Shop, Item Bag, Settings, Trainer Card (Profile), and Pokémon Team windows have been completely moved out of their legacy, resource-heavy PyQt dialogs into a single, cohesive, HTML5/CSS3/JS-based unified web shell window.
+- **Drop-Down Screen Switcher**: A navigation bar with a drop-down selector allows users to jump instantly between Items, Ankidex, Team, Profile, and Settings within the same window.
+- **Loading & Flicker Polish**: Swapped generic loading white flashes for an elegant `#0d1117` background color default and skeleton card placeholder loaders in the Items grid and Ankidex during load events.
+- **Context Menu Suppression**: Disabled QtWebEngine browser-style right-click context menus (Inspect, Reload, Back/Forward) to keep the focus entirely on gameplay.
+- **Flicker-Free Transitions**: Off-DOM grid rebuilding and double-buffered updates eliminate flickering on item usage, purchases, or roster changes.
+
+### Ankidex (Pokédex V2)
+
+The legacy Pokédex system has been replaced with **Ankidex**, a high-performance, web-based implementation.
+- **Tech Stack**: HTML5, CSS3 (Glassmorphism), and Vanilla JavaScript integrated via QtWebEngine.
+- **Features**: Faster loading, improved search, aspect-ratio preservation for sprites, and support for regional/special forms.
+
+### Web Profile Screen
+
+A modern, responsive profile interface replacing the legacy trainer card:
+- Displays trainer levels, cash, cumulative XP, Pokédex count aligned to Ankidex, badge cases, and recent catches.
+- **Sprite Picker & Name Editing**: Supports selecting trainer sprites and editing trainer nicknames inline.
+
+### Web Team Screen
+
+A drag-and-drop team roster builder that:
+- Features filters (by type/search), customizable team rotation cycle limits, CP-based sorting, and XP Share toggles.
+- Displays animated sprites (synced with the Ankidex sprite toggle).
+- Provides real-time type coverage analysis (Strengths, Weaknesses, and Resistances).
+
+### In-Shell Pokémon Pickers
+
+Custom modal pickers inside the Bag and Mart to easily choose which Pokémon to apply evolution stones, held items, or move items to without spawning legacy PyQt bags.
+
+### PC Box (mini) Rework
+
+- **Persistent Details Panel**: Prevents UI flickering by reusing widgets and animating transitions.
+- **Fluid Animations**: Smooth fade-ins for headers, sliding bar animations for stats, and hover lift effects for slots.
+- **Friendship Bar Relocation**: Moved the Friendship bar from the top header to a dedicated animated row in the Stats tab (directly below XP) for a cleaner, unified UI.
+- **Manual Evolution Button**: Integrated a "Manual Evolution" button directly into the PC details panel, allowing users to evolve Pokémon instantly when readiness criteria are met. Ported from [scotej's PR #445](https://github.com/h0tp-ftw/ankimon/pull/445) and optimized for the current architecture.
+- **Maximized Window Stability**: Refactored the details panel to use a persistent `QStackedWidget`, fixing a legacy Qt layout issue where selecting a Pokémon while maximized would cause the window to restore/un-maximize.
+- **Nature Indicators**: Added Nature indicators (▲/▼) to stat labels to indicate the 10% boost or reduction from the Pokémon's Nature. (Also implemented nature randomization for captured Pokémon.)
+- **Advanced Sorting**: Added sorting by all individual stats (HP, Atk, Def, etc.), CP, IV Total, and EV Total.
+- **Move Manager Integration**: A new window to Manage Pokémon moves (`MoveManagerWidget`).
+
+### HUD Portal for Reviewer
+
+The reviewer interface received a "HUD Portal" upgrade for better injection and management of battle elements.
+
+---
+
+## 3. Advanced Battle & Collection Logic
+
+### Manual Evolution & Readiness
+
+- **Ported Evolution Logic**: Ported the comprehensive manual evolution system from [scotej's PR #445](https://github.com/h0tp-ftw/ankimon/pull/445).
+- **Evolution Hub**: The PC Box now acts as the primary hub for triggering evolutions that were previously rejected or missed during level-up.
+- **UI Refresh**: Implemented automatic cache invalidation and sprite refreshing to ensure evolved Pokémon are reflected instantly in the PC grid.
+- **Form-Aware Evolution**: Both auto-evolution (post-battle) and manual evolution (PC Box) now prioritize `pokedex.json` metadata over legacy CSVs. This fully supports evolution paths for regional forms (e.g., Alolan Geodude -> Alolan Graveler).
+- **Time-of-Day Enforcement**: Level-up evolutions now strictly respect time-of-day constraints (day/night) parsed from `pokedex.json` or CSVs. The PC Box displays dynamic status text (e.g., "waiting for Night") when the level is met but the time is wrong.
+- **Stone Evolution Consumption**: Dedicated stones are consumed upon manual evolution confirmation, updating the inventory and refreshing item displays.
+- **Move-Based Manual Evolution**: Supports manual evolutions that depend on learning specific moves (e.g., Koffing -> Galarian Weezing, Stantler -> Wyrdeer).
+- **Defeat-Based Evolution (minimumDefeated)**: Fully supports evolutions triggered by a minimum number of defeated opponents (e.g. Pawmo -> Pawmot, Rellor -> Rabsca, requiring 100 defeated enemies). Automatically evaluates defeat counts against `pokedex.json` thresholds, displays remaining defeats in the PC details view, shows grid status indicators correctly, and auto-prompts evolution upon victory battles.
+- **Region-Aware Level Evolution**: Level-up evolutions prefer regional targets (Galarian/Alolan) over base targets when `active_region` is set.
+
+### Rare & Level-Gated Encounters
+
+- **Mega & Gigantamax**: Restored and stabilized. These now require the user to have encountered the **base form** first, creating a more realistic progression.
+- **Starter Families**: Implemented as rare level-gated encounters with a strict prerequisite chain (e.g., you cannot encounter Charmeleon until you have caught Charmander).
+- **Legendary & Mythical Chains**: Gen I-III legendaries use their original `encounters.txt` prerequisite chains. Similar logic has been applied to Gen IV-IX legendaries and mythicals.
+- **Special Form Redistribution**: Relocated stat-shuffled special forms (0/negative BST boost like Dialga/Palkia/Giratina Origin, Tornadus/Thundurus/Landorus/Enamorus Therian, Urshifu Rapid Strike, Deoxys forms, Shaymin Sky, Meloetta, Keldeo) to Legendary/Mythical pools, enforcing base-form prerequisites. True battle boosts/forms (Kyogre/Groudon Primal, Eternatus Eternamax, Necrozma Dusk Mane/Dawn Wings/Ultra, Zacian/Zamazenta Crowned, Terapagos Terastal/Stellar, Hoopa Unbound, Magearna Original) remain in MEGA_AND_SPECIAL.
+- **Eternatus Eternamax Encounter & Learnset**: Supported Eternamax encounters and specific learnset retrieval.
+
+### Regional Forms & Region Selection
+
+- **Region Menu**: A new setting allows users to select a specific Pokémon region.
+- **Dynamic Odds**: Depending on the selected region, certain Pokémon generations are boosted with a higher chance of appearance.
+
+### Auto-Catching
+
+- **Settings Toggle**: Added a setting to automatically catch rare Pokémon regardless of whether "Automatic Battle" is enabled, ensuring valuable encounters aren't lost.
+
+### EV-yield Modifying Items
+
+- **Macho Brace**: Doubles the EV yield of defeated Pokémon.
+- **Power Items (Power Anklet, Power Band, etc.)**: Adds a flat +8 EVs to the yield for a specific stat.
+
+---
+
+## 4. Enhanced Trading System (Trade V2)
+
+The trade system has been modernized with protocol versioning and enhanced data transmission.
+
+- **Protocol Versioning (v02)**: Implemented a versioning system (sentinel `-200`) to ensure data integrity and prevent version mismatches.
+- **Nature Support**: Pokémon Natures are now transmitted in trade codes. Legacy codes automatically default to a "Serious" nature.
+- **Legacy Support**: Added a "Legacy Mode" to generate old-format codes, ensuring backward compatibility with older software versions.
+- **Canonicalization**: Improved verification logic to normalize trade codes and reduce manual entry errors.
+
+---
+
+## 5. Developer & Power-User Tools
+
+### Hidden Developer Mode Trigger
+
+Developer features are now dynamically enabled at runtime without modifying code. To activate developer mode, name your Anki Profile or Trainer in the settings to include a certain string (Ask BRRRRR if you wanna know haha).
+
+### Account & Database Switcher (Hidden Dev Feature)
+
+Toggle seamlessly between save profiles (different `.db` files) to test features without impacting main account progression. This menu action is visible only when Developer Mode is active.
+
+### Add-on Reloader & Hot-Reload Shortcut (Hidden Dev Feature)
+
+- **Reload Button**: A dedicated menu button for hot-reloading code. This eliminates the need to restart Anki for every code change, significantly accelerating development and testing. This menu action is visible only when Developer Mode is active.
+- **Global Hotkey `Ctrl+Shift+R`**: Triggers a fast reloader purger and restart action across the app.
+
+### Test Encounter Shortcut (Hidden Dev Feature)
+
+- **Hotkey `0`**: Triggers a new Pokémon encounter immediately during cards review. Only registered and active when Developer Mode is active.
+
+### Team Cycling & Roster Rotation
+
+- **Hotkey `9`**: Instantly swap between the top 3 team members during battle while clearing buffs/debuffs.
+- **Customizable Team Rotation Limits**: Team selection window supports customizable team rotation cycle limits and animated sprites (toggle synced with Ankidex).
+
+### Encounter Rate Simulator (Hidden Dev Feature)
+
+A premium, interactive web-based dashboard integrated directly into Ankimon's help menu under Developer Mode to let developers model and visualize wild Pokémon spawn weights.
+- **Dynamic Variable Sliders**: Allows real-time adjustments of all six simulation variables (Trainer Level, Dex Completion, Session Reviews Done, Daily Review Goal, Average Team CP, and Main Pokémon Level).
+- **Circular Progress Gauge**: Integrates a responsive SVG progress dial illustrating the resulting calculated Encounter Potential ($EP$) Mastery Index live.
+- **Interactive Exponential Rarity Curves**: Draws dynamic mathematical rarity lines on a `<canvas>` that automatically scale Y-axis visibility to zoom in on rare encounters, showing locks and active EP markers.
+- **Side-by-Side Matrix Table**: Compares current live overhaul vs legacy rates against simulated overhaul vs legacy rates under the active slider variables.
+- **Pity & Dry Spell Simulator**: Allows testing independent quadratic bad-luck protection during dry review spells (from 0 to 1000 reviews without spawn). Incorporates a custom-styled, crash-proof dropdown and active marker curve matching the selected tier's color theme.
+
+---
+
+## 6. Architectural & Data Improvements
+
+### Global Live Updates Sync
+
+- **Screen-Agnostic Push Architecture**: A lightweight JS/Python QWebChannel bridge (`singletons.notify_stats_changed()`) pushes changes in cash, experience, level, and caught Pokémon in real-time to active web pages. This avoids expensive manual reloads and updates components atomically.
+- **GUI Thread Execution**: Refreshes run asynchronously on the next event-loop turn via `QTimer.singleShot(0)` to prevent blocking gameplay execution or database commits.
+
+### Fixes & Fallbacks
+
+- **Generational Fallback**: A progressive move lookup system (Gen 9 → Gen 1) to handle incomplete data, specifically for newer additions like Ultra Beasts.
+- **Learnset Retrieval Upgrades**: Supported Relearn (`R`) and Special (`S`) moves to allow iconic moves like Behemoth Blade/Bash, Sunsteel Strike, Moongeistbeam to show in Move Manager. Programmatic exclusions (e.g., `DEOXYS_EXCLUSIONS`) prevent Deoxys forms from cross-learning each other's signature moves.
+- **3-Tier Suffix Fallbacks**: PokéAPI suffix-cleaning and 3-tier fallback to resolve form learnset errors (e.g., Galarian Darmanitan).
+- **Sprite Fallbacks**: Improved naming logic and back-sprite fallbacks for special forms to prevent "MissingNo" errors.
+- **Reward Balancing**: Configurable cash reward amounts and payout intervals. Unlike the `main` branch which pays a single flat 200¥ daily reward upon hitting the daily average, this update grants cash dynamically and continuously (defaulting to 40¥ every 10 reviews for new profiles to balance pacing). Fixed infinite cash reward exploits by correcting day cutoff calculation.
+- **Dynamic PC Box Stat Scaling**: Implemented a global square-root scaling formula for PC box stat bars to make visual stat differences look more balanced.
+- **Database-Specific Backups**: Implemented isolated backup and restore functionality for production (`ankimon.db`) and dev (`ankimonDEV.db`) files. Restores target only the active database to prevent cross-contamination of profiles, and manual backup triggers only clone the current active database.
+
+### Settings Upgrades
+
+- **Per-Tier Toggles**: Configured per-tier auto-catch toggles (Megas, Legendaries, etc.) and a regional forms toggle.
+- **Always-Catch Wishlist Suggestions**: Implemented a premium always-catch wishlist suggestions popup. Added Pikachu and Eevee to default wishlist settings.
+- **Friendship & Time Evolution**: Removed the Friendship & Time Evolution setting toggle and always enabled it to match standard expectations.
+
+### Massive Data Update
+
+- **Updated `pokedex.json`**: Enhanced with additional metadata and actual IDs for special variants.
+
+---
+
+## 7. Automatic Update Notifications & Snooze System
+
+A modern startup check and installation system designed specifically to keep users on the experimental branch up-to-date with remote changes.
+
+- **Startup Delta Checks**: Queries the GitHub API in a silent background thread at startup to compare local and remote commits on the `BRRRR_Experimental` branch.
+- **Sandbox & Offline Resiliency**: Bypasses fragile synchronous network connectivity pre-checks, ensuring branch update checks run completely asynchronously in the background. This prevents startup blocking and ensures prompts trigger even in restricted packaged sandboxes like `AnkiTEST`.
+- **Unconditional User Data Protection**: The installer unconditionally protects all files under `user_files/` (such as SQLite `.db`, `.db-shm`, `.db-wal` databases, local backups, and custom downloaded sprites) and critical root files (`HelpInfos.html`, `updateinfos.md`, `meta.json`). This guarantees updates never corrupt or delete user progress.
+- **Premium 3-Tab Update Dialog Interface**: The manual "Check for Updates" menu option has been redesigned into a highly responsive, multi-tabbed dashboard:
+  - **Tab 1: BRRRR_Experimental Branch** (opened by default): Displays the active branch name, currently installed commit SHA, author/committer date (fetched dynamically via GitHub API), the local last-update installation timestamp, real-time sync status, a weekly snooze checkbox, and a scrollable commit feed of what's new. Includes a primary update button for one-click asynchronous branch updates.
+  - **Tab 2: Releases**: Provides a fast dropdown list and direct release installer for public experimental releases.
+  - **Tab 3: Developer**: Allows power users to lazy-load and install directly from other branches, tags, or specific open Pull Requests asynchronously.
+- **Safe Installation Logging**: Fixed state persistence to record the actual current time in `installed_at` upon successful update, instead of keeping the old cached file modification date.
+- **Weekly Snooze Option**: A checkbox allows users to snooze update checks and prompts for exactly 1 week.
+- **Locked-Files Bypass Safety**: Gracefully bypasses Windows permission locks on static assets (such as loaded `.ttf` fonts like `Early GameBoy.ttf`) by displaying a non-fatal warning and successfully installing code updates.
+- **Git Clone & Development-Safe In-App Updates**: Redesigned the update applicator to be fully safe on git clones by using `git pull --ff-only` asynchronously in a background thread if the directory is a git repository, prompting a warning about overwriting code on manual Pull Request installations, and filtering out legacy release tags prior to version v2.0.
+
+> **Note:** 2.1-E ships the newer **user-selectable update channel** (Stable / Experimental / Main) on top of the above — pick which releases you track right from the update dialog.
+
+---
+
+## 8. Mobile Reviews Integration (AnkiMobile / AnkiWeb)
+
+Play Ankimon on the go! You can now review cards on your phone (using AnkiMobile or AnkiWeb) and sync them back to your computer to resolve them as Pokémon battles.
+
+### Core Gameplay Features
+
+- **Sync and Fight**: Reviews done on mobile devices are captured during Anki syncs. When you return to your desktop, a dedicated **Mobile Reviews** tab inside your web shell will show you how many pending battles are waiting for you.
+- **Roster Selection & Companion Toggles**: All your team members can participate as companions on mobile reviews. If you want a specific Pokémon in your team but don't want it to fight mobile battles, simply click its sprite in the Team tab to make it **inactive** (it will appear darkened).
+- **Auto-Resolve (Matchup Optimization)**: Don't want to play through dozens of battles manually? Choose **Auto-Resolve**! The game will simulate the battles in the background and automatically select the best companion from your active mobile roster for each battle based on move types, power, and speed to finish the fight as quickly as possible.
+- **Manual Replay Mode**: Want to see the action? Choose **Manual Replay** to play through your synced mobile battles one by one with full combat animations. You can even manually override the active companion before starting each battle to try different strategies or train specific Pokémon.
+- **Battle History Logs**: A dedicated **Battle History** panel in the Mobile tab lets you review your recently resolved mobile battles (capped at 500 records). It displays the opponent details, your chosen companion, the battle outcome (caught, defeated, fled, etc.), and all the rewards (XP and cash) you earned.
+- **Continuous Payouts**: Cash and experience rewards earned during mobile review resolution are distributed continuously as you resolve them, keeping your progress synced and rewarding.
+- **Deterministic Encounter Sequence**: The sequence of wild Pokémon you fight is determined solely by your review queue and is fully consistent — the same enemies appear in the same order whether you auto-resolve or manually replay, and regardless of which team members are active.
+- **Non-Blocking UI**: All heavy work (battle simulation, database writes, XP attribution) runs off the main thread. The UI stays fully responsive during estimate calculation, manual replay loading, and catch/defeat commits.
+
+---
+
+## 9. Comprehensive Encounter Systems Overhaul (Opt-in)
+
+A major mathematical and architectural redesign of the wild spawn economy to curb rare spawn inflation and establish a robust, progression-driven economy. It is fully backwards-compatible with the legacy system and kept **inactive by default** for baseline stability (developer toggle `USE_OVERHAUL_ENCOUNTER_SYSTEM`).
+
+- **Unified Mastery Index ($EP$):** Replaces basic progress ratios with a dynamic 100-point progression scale incorporating:
+  - **Trainer Level ($T_{norm}$ - 25%):** Normalized to a Trainer Level Cap (default: `50.0`).
+  - **Pokedex Completion ($D_{norm}$ - 25%):** True completion ratio with robust form-to-base ID resolution.
+  - **Session Progress ($S_{norm}$ - 25%):** Completed reviews relative to the daily average review goal.
+  - **Core Team Power ($C_{norm}$ - 25%):** Average CP of the top 6 active team members scaled to a Core Team CP Cap (default: `16000.0`).
+- **Exponential Rarity Scaling ("Soft Landing"):** Rarity weights scale exponentially with EP, limiting endgame rare spawns to a healthy **12.3% aggregate cap** (down from ~35% hyper-inflation in the legacy economy).
+- **Player Level-Lock Enforcement:** Enforces strict main Pokémon level thresholds for advanced tiers (Starters require Level 80+, Megas Level 60+, Legendaries Level 50+, and Ultra Beasts Level 30+).
+- **Independent Pity System (Decoupled Bad-Luck Protection):** Persistent dry-spell review trackers are stored globally in SQLite `user_data`. Spawning a rare Pokémon resets its specific counter to `0` while incrementing others. Trackers apply quadratic scaling to shield players from prolonged dry spells.
+- **Developer Config Block:** Balancing coefficients, weights, caps, level thresholds, and pity boundaries are parameterized and centralized at the top of the overhaul section in `encounter_functions.py` for quick tuning.
+
+---
+
+_Built on **BRRRR_Experimental** by [@hakimh2](https://github.com/hakimh2) (Brrrrrrr), [@AIbrahimv2](https://github.com/AIbrahimv2) (Krow), [@jupiterslegacy](https://github.com/jupiterslegacy), and [@scotej](https://github.com/scotej) (Scoot) — ported to main by [@h0tp-ftw](https://github.com/h0tp-ftw) (h0tp). Thank you for the hundreds of hours. 💖_


### PR DESCRIPTION
Adds a comprehensive **In depth** feature section to `assets/changelogs/2.1-E.md` and the GitHub release notes (web shell, encounters, evolutions, Trade V2, mobile reviews, dev tools, encounter overhaul). Kept below the Full-Changelog marker so the **Discord** changelog stays intro-only. Reframed as shipped; dev-only Key Files table dropped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)