### PR TITLE
fix(changelog): stop crediting the Copilot AI agent as a contributor

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -220,17 +220,6 @@
       "discord_id": "478553780854718465"
     },
     {
-      "login": "Copilot",
-      "name": "Copilot",
-      "avatar_url": "https://github.com/Copilot.png",
-      "profile": "https://github.com/Copilot",
-      "contributions": [
-        "code"
-      ],
-      "nickname": "PENDING_REVIEW",
-      "discord_id": "PENDING_REVIEW"
-    },
-    {
       "login": "jupiterslegacy",
       "name": "jupiterslegacy",
       "avatar_url": "https://github.com/jupiterslegacy.png",

--- a/README.md
+++ b/README.md
@@ -37,9 +37,6 @@
       <td align="center" valign="top" width="20%"><a href="https://github.com/scotej"><img src="https://github.com/scotej.png?s=80" width="80px;" alt="scotej"/><br /><sub><b>scotej</b></sub></a><br /><a href="https://github.com/h0tp-ftw/ankimon/commits?author=scotej" title="Code">💻</a></td>
       <td align="center" valign="top" width="20%"><a href="https://github.com/maciej-baruch"><img src="https://github.com/maciej-baruch.png?s=80" width="80px;" alt="maciej-baruch"/><br /><sub><b>maciej-baruch</b></sub></a><br /><a href="https://github.com/h0tp-ftw/ankimon/commits?author=maciej-baruch" title="Code">💻</a></td>
       <td align="center" valign="top" width="20%"><a href="https://github.com/mathieulabs"><img src="https://github.com/mathieulabs.png?s=80" width="80px;" alt="mathieulabs"/><br /><sub><b>mathieulabs</b></sub></a><br /><a href="https://github.com/h0tp-ftw/ankimon/commits?author=mathieulabs" title="Code">💻</a></td>
-      <td align="center" valign="top" width="20%"><a href="https://github.com/Copilot"><img src="https://github.com/Copilot.png?s=80" width="80px;" alt="Copilot"/><br /><sub><b>Copilot</b></sub></a><br /><a href="https://github.com/h0tp-ftw/ankimon/commits?author=Copilot" title="Code">💻</a></td>
-    </tr>
-    <tr>
       <td align="center" valign="top" width="20%"><a href="https://github.com/jupiterslegacy"><img src="https://github.com/jupiterslegacy.png?s=80" width="80px;" alt="jupiterslegacy"/><br /><sub><b>jupiterslegacy</b></sub></a><br /><a href="https://github.com/h0tp-ftw/ankimon/commits?author=jupiterslegacy" title="Code">💻</a></td>
     </tr>
   </tbody>

--- a/assets/changelogs/2.1-E-discord.md
+++ b/assets/changelogs/2.1-E-discord.md
@@ -1,6 +1,6 @@
 ## 🌟 Ankimon v2.1-E 🌟
 
-A huge thank you to <@430066577262510080>, @Copilot, <@445586026451173377>, <@418451430270042133>, @jupiterslegacy, <@720180197403525120> for their contributions to this update! <3
+A huge thank you to <@430066577262510080>, <@445586026451173377>, <@418451430270042133>, @jupiterslegacy, <@720180197403525120> for their contributions to this update! <3
 
 This release includes 23 pull requests merged directly on main — **plus a huge batch of features and fixes ported from the BRRRR_Experimental branch** (listed below). It's easily our biggest update yet!
 

--- a/assets/changelogs/2.1-E.md
+++ b/assets/changelogs/2.1-E.md
@@ -1,6 +1,6 @@
 ## 🌟 Ankimon v2.1-E 🌟
 
-A huge thank you to [@AIbrahimv2](https://github.com/AIbrahimv2) (Krow), [@Copilot](https://github.com/Copilot), [@h0tp-ftw](https://github.com/h0tp-ftw) (h0tp), [@hakimh2](https://github.com/hakimh2) (Brrrrrrr), [@jupiterslegacy](https://github.com/jupiterslegacy), [@scotej](https://github.com/scotej) (Scoot) for their contributions to this update! <3
+A huge thank you to [@AIbrahimv2](https://github.com/AIbrahimv2) (Krow), [@h0tp-ftw](https://github.com/h0tp-ftw) (h0tp), [@hakimh2](https://github.com/hakimh2) (Brrrrrrr), [@jupiterslegacy](https://github.com/jupiterslegacy), [@scotej](https://github.com/scotej) (Scoot) for their contributions to this update! <3
 
 This release includes 23 pull requests merged directly on main — **plus a huge batch of features and fixes ported from the BRRRR_Experimental branch** (listed below). It's easily our biggest update yet!
 
@@ -72,7 +72,6 @@ The bulk of this release is a massive body of work from the **BRRRR_Experimental
 
 ### 🐛 Bug Fixes & Stability!
 
-- fix(ci): fix failing GitHub Pages 'build' job (Liquid syntax error in porting guide) [#593](https://github.com/h0tp-ftw/ankimon/pull/593) [@Copilot](https://github.com/Copilot)
 - fix: resolve addon package prefix dynamically & use services registry in leaderboard [#527](https://github.com/h0tp-ftw/ankimon/pull/527) [@h0tp-ftw](https://github.com/h0tp-ftw) (h0tp)
 
 ### 🔧 Other Changes!

--- a/scripts/prepare_release.py
+++ b/scripts/prepare_release.py
@@ -18,6 +18,21 @@ PENDING_PROFILE = "PENDING_REVIEW"
 # tools, never human contributors, so they're excluded from acknowledgement.
 _BOT_EMAIL_MARKERS = ("[bot]", "github-actions", "noreply@anthropic.com")
 
+# Login-based bot / AI-agent detection (complements the email markers above).
+# Covers any "*[bot]" account plus AI coding agents like GitHub Copilot, which
+# open PRs / author commits under a plain login (no "[bot]" suffix) yet are not
+# human contributors to acknowledge or add to the contributors table.
+_BOT_LOGINS = frozenset({"copilot", "copilot-swe-agent", "dependabot", "jules-invoke"})
+
+
+def _is_bot_login(login: str) -> bool:
+    """True for bot / AI-agent GitHub logins that must never be credited."""
+    if not login:
+        return True
+    lo = login.lower()
+    return lo.endswith("[bot]") or lo in _BOT_LOGINS
+
+
 # GitHub "noreply" commit emails encode the account login directly:
 #   12345+login@users.noreply.github.com  (modern, id-prefixed)
 #   login@users.noreply.github.com        (legacy)
@@ -105,7 +120,7 @@ def fetch_prs_since_tag(repo: str, previous_tag: str) -> List[Dict]:
             # Filter out automated release PRs
             author = pr.get("user", {}).get("login", "")
             title = pr.get("title", "")
-            if author == "github-actions[bot]" or author == "jules-invoke[bot]" or "bump version" in title.lower() or "release v" in title.lower():
+            if _is_bot_login(author) or "bump version" in title.lower() or "release v" in title.lower():
                 continue
                 
             pull_requests.append(pr)
@@ -211,7 +226,7 @@ def update_contributors(logins):
     new_found = False
     
     for login in sorted(logins):
-        if not login or login.lower() in existing or login.lower().endswith("[bot]"):
+        if not login or login.lower() in existing or _is_bot_login(login):
             continue
         print(f"Adding new contributor: {login}")
         data["contributors"].append({


### PR DESCRIPTION
The Copilot AI coding agent (PR #593) was credited in the 2.1-E changelog, README contributors table, and `.all-contributorsrc` — it evaded the bot filter (which only matched `[bot]`-suffixed logins). Removes it everywhere and hardens `prepare_release.py` with a login-based `_is_bot_login` check (copilot / copilot-swe-agent / dependabot / `*[bot]`) so it won't recur. Claude was already excluded via the anthropic noreply marker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)