### PR TITLE
fix: sync main pokemon attacks on PC Box edit to resolve mobile preview discrepancy

### DIFF
--- a/src/Ankimon/pyobj/pc_box.py
+++ b/src/Ankimon/pyobj/pc_box.py
@@ -2233,9 +2233,10 @@ class PokemonPC(QDialog):
                     if top_r_layout is None:
                         return
 
-                    # Add new Move Manager
                     def _save_pokemon(data):
                         services.db.save_pokemon(data)
+                        if self.main_pokemon and self.main_pokemon.individual_id == data.get("individual_id"):
+                            self.main_pokemon.attacks = data.get("attacks", self.main_pokemon.attacks)
                         self.show_pokemon_details(pokemon)
 
                     # Retire the previous manager before building a new one.


### PR DESCRIPTION
### Description
This PR resolves an issue where the mobile/web review preview (simulation) outcome differs depending on whether the main Pokémon is explicitly configured as active or falls back automatically to active (when the active team is empty).

### Cause
When changing the moves of a companion inside the PC Box:
1. The updated moveset is written to the SQLite database via `services.db.save_pokemon(data)`.
2. However, the in-memory Python object representing the active main Pokémon (`services.game.main_pokemon` / `singletons.main_pokemon`) was not synchronized/updated.
3. In `load_active_team_clones` (which simulates battles to preview mobile reviews), if the main Pokémon is set as active, it is hydrated directly from the database (getting the **new** moveset). If the active team is empty, the preview falls back to `main_pokemon_fallback` which points to the in-memory object (getting the **old** moveset).
4. Because the simulation used two different movesets for the "same" Pokémon under these two states, the calculated number of battles differed.

### Solution
Synchronize the active `self.main_pokemon.attacks` in-memory attribute directly inside the `_save_pokemon(data)` callback in `pc_box.py` if the modified Pokémon matches the active `main_pokemon`'s `individual_id`. This keeps the runtime in-memory instance and database records in lockstep silently without requiring full re-selection, sounds, or popups.