### PR TITLE
fix: skip read-only properties in PokemonObject update_stats

### DIFF
--- a/src/Ankimon/pyobj/pokemon_obj.py
+++ b/src/Ankimon/pyobj/pokemon_obj.py
@@ -405,7 +405,7 @@ class PokemonObject:
     # would succeed, but the splatted value is almost certainly stale
     # relative to the new ``level``/``base_stats``, so we skip it and
     # recompute it ourselves below.
-    _READONLY_ATTRS = frozenset({"cp", "stats", "max_hp"})
+    _READONLY_ATTRS = frozenset({"cp", "stats", "max_hp", "pokedex_id", "display_name", "generation"})
 
     def update_stats(self, **kwargs):
         """Update the attributes of the Pokémon object with keyword arguments."""


### PR DESCRIPTION
When parsing Pokemon dictionaries with properties like `pokedex_id`, the `update_stats` method attempts to overwrite them using `setattr`. Since these properties lack setters, it throws an `AttributeError` which bubbles up and prevents Anki from starting.

This fix explicitly adds these keys to the `_READONLY_ATTRS` ignore list.

---
*PR created automatically by Jules for task [17657895961596033828](https://jules.google.com/task/17657895961596033828) started by @h0tp-ftw*