### PR TITLE
fix: main pokemon sync/pcbox updates, mobile watermark, and pokedex_id boot crash

### DIFF
--- a/src/Ankimon/pyobj/database_manager.py
+++ b/src/Ankimon/pyobj/database_manager.py
@@ -1256,7 +1256,7 @@ class AnkimonDB:
         elif self.is_migrated():
             import time
             now_ms = int(time.time() * 1000)
-            self.set_mobile_watermark(now_ms)
+            self.set_mobile_watermark(now_ms, force=True)
             return now_ms
         return 0
 

--- a/src/Ankimon/pyobj/database_manager.py
+++ b/src/Ankimon/pyobj/database_manager.py
@@ -1251,7 +1251,14 @@ class AnkimonDB:
         row = self.execute(
             "SELECT value FROM metadata WHERE key = 'mobile_revlog_watermark'"
         ).fetchone()
-        return int(row[0]) if row else 0
+        if row:
+            return int(row[0])
+        elif self.is_migrated():
+            import time
+            now_ms = int(time.time() * 1000)
+            self.set_mobile_watermark(now_ms)
+            return now_ms
+        return 0
 
     def set_mobile_watermark(self, watermark_ms: int, *, force: bool = False) -> None:
         # Monotonic by default: the watermark must never move backwards. A

--- a/src/Ankimon/pyobj/database_manager.py
+++ b/src/Ankimon/pyobj/database_manager.py
@@ -1253,7 +1253,10 @@ class AnkimonDB:
         ).fetchone()
         if row:
             return int(row[0])
-        elif self.is_migrated():
+        if self.is_migrated():
+            # ``force=True`` is load-bearing, not an optimisation: the
+            # force=False path of ``set_mobile_watermark`` calls back into
+            # this getter to clamp monotonically, which would recurse forever.
             import time
             now_ms = int(time.time() * 1000)
             self.set_mobile_watermark(now_ms, force=True)

--- a/src/Ankimon/pyobj/pc_box.py
+++ b/src/Ankimon/pyobj/pc_box.py
@@ -2233,9 +2233,10 @@ class PokemonPC(QDialog):
                     if top_r_layout is None:
                         return
 
-                    # Add new Move Manager
                     def _save_pokemon(data):
                         services.db.save_pokemon(data)
+                        if self.main_pokemon and self.main_pokemon.individual_id == data.get("individual_id"):
+                            self.main_pokemon.attacks = data.get("attacks", self.main_pokemon.attacks)
                         self.show_pokemon_details(pokemon)
 
                     # Retire the previous manager before building a new one.

--- a/src/Ankimon/pyobj/pc_box.py
+++ b/src/Ankimon/pyobj/pc_box.py
@@ -2233,10 +2233,17 @@ class PokemonPC(QDialog):
                     if top_r_layout is None:
                         return
 
+                    # Add new Move Manager
                     def _save_pokemon(data):
                         services.db.save_pokemon(data)
-                        if self.main_pokemon and self.main_pokemon.individual_id == data.get("individual_id"):
-                            self.main_pokemon.attacks = data.get("attacks", self.main_pokemon.attacks)
+                        # Keep the live main-pokemon singleton in step with a
+                        # moveset edit, mirroring give_held_item/remove_held_item.
+                        main_pkmn = services.main_pokemon
+                        if (
+                            main_pkmn is not None
+                            and getattr(main_pkmn, "individual_id", None) == data.get("individual_id")
+                        ):
+                            main_pkmn.attacks = data.get("attacks", main_pkmn.attacks)
                         self.show_pokemon_details(pokemon)
 
                     # Retire the previous manager before building a new one.

--- a/src/Ankimon/pyobj/pokemon_obj.py
+++ b/src/Ankimon/pyobj/pokemon_obj.py
@@ -405,7 +405,7 @@ class PokemonObject:
     # would succeed, but the splatted value is almost certainly stale
     # relative to the new ``level``/``base_stats``, so we skip it and
     # recompute it ourselves below.
-    _READONLY_ATTRS = frozenset({"cp", "stats", "max_hp"})
+    _READONLY_ATTRS = frozenset({"cp", "stats", "max_hp", "pokedex_id", "display_name", "generation"})
 
     def update_stats(self, **kwargs):
         """Update the attributes of the Pokémon object with keyword arguments."""

--- a/src/Ankimon/pyobj/pokemon_obj.py
+++ b/src/Ankimon/pyobj/pokemon_obj.py
@@ -404,8 +404,13 @@ class PokemonObject:
     # `except Exception`). ``max_hp`` is a plain cache field — setattr
     # would succeed, but the splatted value is almost certainly stale
     # relative to the new ``level``/``base_stats``, so we skip it and
-    # recompute it ourselves below.
-    _READONLY_ATTRS = frozenset({"cp", "stats", "max_hp", "pokedex_id", "display_name", "generation"})
+    # recompute it ourselves below. ``pokedex_id`` / ``display_name`` /
+    # ``generation`` are likewise getter-only derived properties (resolved
+    # from ``self.id``), so a splatted value is redundant at best and raises
+    # AttributeError at worst.
+    _READONLY_ATTRS = frozenset(
+        {"cp", "stats", "max_hp", "pokedex_id", "display_name", "generation"}
+    )
 
     def update_stats(self, **kwargs):
         """Update the attributes of the Pokémon object with keyword arguments."""

--- a/src/Ankimon/pyobj/update_manager.py
+++ b/src/Ankimon/pyobj/update_manager.py
@@ -68,6 +68,12 @@ def is_git_clone() -> bool:
     clobbered). So the destructive updater is hidden for clones; a safe
     ``git pull --ff-only`` is offered instead (see ``git_pull_ff_only``).
     """
+    try:
+        from ..utils import is_dev_mode
+        if is_dev_mode():
+            return False
+    except Exception:
+        pass
     return _git_repo_root() is not None
 
 

--- a/tests/test_update_manager.py
+++ b/tests/test_update_manager.py
@@ -105,11 +105,11 @@ def test_is_git_clone_false_in_dev_mode(tmp_path, monkeypatch):
     monkeypatch.setattr(um, "addon_dir", addon)
 
     # When not in dev mode, it returns True because it has a .git folder
-    with patch("Ankimon.utils.is_dev_mode", return_value=False, create=True):
+    with patch("Ankimon.utils.is_dev_mode", return_value=False):
         assert um.is_git_clone() is True
 
     # When in dev mode, it returns False even with a .git folder
-    with patch("Ankimon.utils.is_dev_mode", return_value=True, create=True):
+    with patch("Ankimon.utils.is_dev_mode", return_value=True):
         assert um.is_git_clone() is False
 
 

--- a/tests/test_update_manager.py
+++ b/tests/test_update_manager.py
@@ -97,6 +97,22 @@ def test_is_git_clone_true_when_addon_dir_is_repo(tmp_path, monkeypatch):
     assert um.is_git_clone() is True
 
 
+def test_is_git_clone_false_in_dev_mode(tmp_path, monkeypatch):
+    from unittest.mock import patch
+    addon = tmp_path / "ankimon"
+    addon.mkdir()
+    (addon / ".git").mkdir()
+    monkeypatch.setattr(um, "addon_dir", addon)
+
+    # When not in dev mode, it returns True because it has a .git folder
+    with patch("Ankimon.utils.is_dev_mode", return_value=False, create=True):
+        assert um.is_git_clone() is True
+
+    # When in dev mode, it returns False even with a .git folder
+    with patch("Ankimon.utils.is_dev_mode", return_value=True, create=True):
+        assert um.is_git_clone() is False
+
+
 def test_is_git_clone_false_for_plain_install(tmp_path, monkeypatch):
     addon = tmp_path / "addons21" / "ankimon"
     addon.mkdir(parents=True)


### PR DESCRIPTION
This PR consolidates four critical bug fixes that were implemented and verified on the `BRRRR_Experimental` branch:

### 1. Fix PC Box Moveset Update Mismatch
* **Issue:** When a user changed a Pokémon's moveset in the PC Box, the active team moveset cache in memory (`services.trainer_card` / `services.main_pokemon`) was not updated. The mobile companion synced the new moves, but the local desktop UI/battles still used the stale cached moves.
* **Fix:** Added an update check to automatically refresh/rehydrate the active main Pokémon moveset cache in memory immediately when moves are modified in the PC Box.

### 2. Fix 10,000 Historical Review Battle Spam (Mobile Sync)
* **Issue:** First-time installers and upgrading users upgrading from 2.0 lacked the `mobile_revlog_watermark` key in `ankimon.db`. When syncing, the database overwrite wiped any local startup watermark initialization. In subsequent syncs, the watermark was read as `0`, scanning the user's entire historical `revlog` table (e.g., 498k reviews) and triggering the 10,000 battle cap warning.
* **Fix:** Modified `get_mobile_watermark()` in `database_manager.py` to automatically initialize the watermark to the current time in milliseconds if it is missing in a migrated database. This avoids querying Anki's sqlite database for `MAX(id)` (preventing database locks) and safely ignores all historical reviews.

### 3. Fix Boot Crash via Pokedex ID AttributeError
* **Issue:** An `AttributeError` was triggered on boot when trying to write to read-only properties (such as `pokedex_id`) during the hydration/instantiation of Pokémon objects.
* **Fix:** Handled the property assignments correctly to prevent writing to read-only fields on instantiation.

### 4. Bypass Git Clone Safety Guard in Update Manager When in Dev Mode
* **Issue:** When running in developer mode (using a `_dev` or `dev_` profile/trainer name), developers would be blocked by the `is_git_clone()` safety check, which is intended to prevent users' dev clones from being clobbered by automatic in-place updates.
* **Fix:** Modified `is_git_clone()` to check if the user is in developer mode via the existing `is_dev_mode()` helper. If so, it returns `False`, allowing the update manager actions. Added unit tests to cover this logic.

All tests (pytest and harness Tier-1 checks) pass successfully.