### PR TITLE
feat: SQLite Hardening & Interactive Self-Healing Database Diagnostics

### DIFF
--- a/src/Ankimon/menu_buttons.py
+++ b/src/Ankimon/menu_buttons.py
@@ -387,8 +387,16 @@ def create_menu_actions(
     tracker_window_action.setMenuRole(QAction.MenuRole.NoRole)
     tracker_window_action.triggered.connect(ankimon_tracker_window.toggle_window)
     tracker_window_action.setShortcut(QKeySequence("Ctrl+Shift+K"))
+    
+    # Database Diagnostics (Verify & Repair)
+    from .pyobj.db_diagnostics import trigger_database_diagnostics
+    diagnostics_action = QAction("Verify and Repair Database", mw)
+    diagnostics_action.setMenuRole(QAction.MenuRole.NoRole)
+    diagnostics_action.triggered.connect(trigger_database_diagnostics)
+    
     if debug is True:
         debug_menu.addAction(tracker_window_action)
+        debug_menu.addAction(diagnostics_action)
 
     # Re-evaluate the developer-only entries each time the menu opens, so
     # toggling Developer Mode takes effect without rebuilding the menu.
@@ -402,8 +410,9 @@ def create_menu_actions(
         # Ctrl+Shift+K shortcut — an invisible-but-enabled QAction can still fire.
         tracker_window_action.setVisible(is_dev)
         tracker_window_action.setEnabled(is_dev)
+        diagnostics_action.setVisible(True)
         if debug is True:
-            debug_menu.menuAction().setVisible(is_dev)
+            debug_menu.menuAction().setVisible(True)
         # Keep the Ctrl+Shift+R hot-reload accelerator in lockstep with the menu
         # action (registered in __init__.on_startup_complete). Guard on liveness:
         # the shortcut list may be absent before startup-complete or hold a dead

--- a/src/Ankimon/pyobj/ankimon_sync.py
+++ b/src/Ankimon/pyobj/ankimon_sync.py
@@ -752,12 +752,36 @@ class AnkimonDataSync:
         pre-replace inode can be orphaned. Pre-existing to this change and narrow
         (opt-in file-sync overlapping a live resolve); left documented rather than
         pulling the multi-profile connection model into a hardening pass."""
+        import gc
+        import time
         source_file.parent.mkdir(parents=True, exist_ok=True)
         tmp = source_file.with_name(source_file.name + ".synctmp")
         try:
             shutil.copy2(media_file, tmp)
+            
+            # Close connection registry completely to release all OS locks
+            try:
+                from ..singletons import services
+                if services.db:
+                    services.db.close()
+            except Exception:
+                pass
             self._close_live_db_connection(source_file)
-            os.replace(tmp, source_file)
+            
+            # Force collection of connection handles
+            gc.collect()
+            
+            # Retry loop to allow OS file lock release on Windows
+            for attempt in range(3):
+                try:
+                    os.replace(tmp, source_file)
+                    break
+                except PermissionError as e:
+                    if attempt == 2:
+                        raise e
+                    time.sleep(0.1)
+                    gc.collect()
+
             for sidecar in ("-wal", "-shm"):
                 stale = source_file.with_name(source_file.name + sidecar)
                 try:

--- a/src/Ankimon/pyobj/ankimon_sync.py
+++ b/src/Ankimon/pyobj/ankimon_sync.py
@@ -1,9 +1,10 @@
-# ankimon_sync.py - Improved Ankimon data sync system with subfolder approach
 import base64
 import filecmp
+import gc
 import json
 import os
 import shutil
+import time
 from pathlib import Path
 from typing import Dict, List, Any
 
@@ -752,8 +753,6 @@ class AnkimonDataSync:
         pre-replace inode can be orphaned. Pre-existing to this change and narrow
         (opt-in file-sync overlapping a live resolve); left documented rather than
         pulling the multi-profile connection model into a hardening pass."""
-        import gc
-        import time
         source_file.parent.mkdir(parents=True, exist_ok=True)
         tmp = source_file.with_name(source_file.name + ".synctmp")
         try:
@@ -761,7 +760,7 @@ class AnkimonDataSync:
             
             # Close connection registry completely to release all OS locks
             try:
-                from ..singletons import services
+                from ..services import services
                 if services.db:
                     services.db.close()
             except Exception:
@@ -776,9 +775,9 @@ class AnkimonDataSync:
                 try:
                     os.replace(tmp, source_file)
                     break
-                except PermissionError as e:
+                except PermissionError:
                     if attempt == 2:
-                        raise e
+                        raise
                     time.sleep(0.1)
                     gc.collect()
 

--- a/src/Ankimon/pyobj/database_manager.py
+++ b/src/Ankimon/pyobj/database_manager.py
@@ -192,7 +192,7 @@ class AnkimonDB:
                 conn.execute("PRAGMA temp_store=MEMORY;")
             except Exception as e:
                 self._log("warning", f"Failed to set WAL PRAGMAs: {e}")
-        wrapper = ConnectionWrapper(conn)
+        wrapper = ConnectionWrapper(conn, self)
         with self._conn_lock:
             self._all_connections.append(weakref.ref(wrapper))
         return wrapper
@@ -284,15 +284,23 @@ class AnkimonDB:
                     
             # Dump current database safely
             src_conn = sqlite3.connect(str(db_file))
-            lines = list(src_conn.iterdump())
-            src_conn.close()
+            try:
+                lines = list(src_conn.iterdump())
+            finally:
+                src_conn.close()
             
-            # Modify schema to disable primary key constraint during insert and use INSERT OR REPLACE
+            # Modify schema to define generated columns as physical columns initially,
+            # which allows SQL dump inserts (which contain all values) to succeed.
+            # We also disable the unique constraint.
             modified_sql = []
             for line in lines:
                 if "CREATE TABLE captured_pokemon" in line:
-                    line = line.replace("individual_id TEXT PRIMARY KEY", "individual_id TEXT")
-                if line.startswith("INSERT INTO "):
+                    line = """CREATE TABLE captured_pokemon (
+                        individual_id TEXT,
+                        is_main INTEGER DEFAULT 0,
+                        data TEXT NOT NULL
+                    );"""
+                elif line.startswith("INSERT INTO "):
                     line = line.replace("INSERT INTO ", "INSERT OR REPLACE INTO ", 1)
                 modified_sql.append(line)
             full_sql = "\n".join(modified_sql)
@@ -352,6 +360,12 @@ class AnkimonDB:
                 SELECT individual_id, is_main, data FROM captured_pokemon_old
             """)
             cursor.execute("DROP TABLE captured_pokemon_old")
+            
+            # Recreate secondary indexes
+            cursor.execute("CREATE INDEX IF NOT EXISTS idx_pokemon_name ON captured_pokemon(name)")
+            cursor.execute("CREATE INDEX IF NOT EXISTS idx_pokemon_pokedex_id ON captured_pokemon(pokedex_id)")
+            cursor.execute("CREATE INDEX IF NOT EXISTS idx_pokemon_shiny ON captured_pokemon(shiny)")
+            cursor.execute("CREATE INDEX IF NOT EXISTS idx_pokemon_level ON captured_pokemon(level)")
             
             # Rebuild index and verify
             cursor.execute("REINDEX")
@@ -420,8 +434,16 @@ class AnkimonDB:
                     tmp_db.unlink()
         except Exception as e:
             self._log("error", f"Self-healing database repair failed: {e}")
+            raise e
         finally:
             self._is_repairing = False
+            # Clean up the temporary database file if it was left behind due to a crash/exception
+            try:
+                tmp_db_path = self.db_path.with_name(self.db_path.name + ".tmp")
+                if tmp_db_path.exists():
+                    tmp_db_path.unlink()
+            except Exception:
+                pass
 
     def switch_database(self, db_filename: str):
         """Close current connections and reopen against a different profile DB file.

--- a/src/Ankimon/pyobj/database_manager.py
+++ b/src/Ankimon/pyobj/database_manager.py
@@ -323,6 +323,15 @@ class AnkimonDB:
             
             cursor = dest_conn.cursor()
             
+            # Propagate is_main flag to all duplicates of the main Pokémon so the highest-progress survivor inherits it
+            cursor.execute("""
+                UPDATE captured_pokemon 
+                SET is_main = 1 
+                WHERE individual_id IN (
+                    SELECT individual_id FROM captured_pokemon WHERE is_main = 1
+                )
+            """)
+
             # Prune duplicate captured_pokemon rows by highest Level and XP
             cursor.execute("""
                 DELETE FROM captured_pokemon 

--- a/src/Ankimon/pyobj/database_manager.py
+++ b/src/Ankimon/pyobj/database_manager.py
@@ -10,6 +10,8 @@ import sqlite3
 import threading
 import uuid
 import weakref
+import gc
+import time
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Union
 
@@ -36,13 +38,17 @@ class ConnectionWrapper:
         self._db_mgr = db_mgr
 
     def commit(self):
+        # NOTE: Direct raw cursor execution (conn.cursor().execute(...)) bypasses wrapper-level auto-healing.
         if not self._disable_commit:
             try:
                 self._conn.commit()
             except sqlite3.DatabaseError as e:
                 if self._db_mgr and ("malformed" in str(e).lower() or "disk image" in str(e).lower()) and not self._db_mgr._is_repairing:
                     self._db_mgr.repair_database()
-                raise e
+                    self._conn = self._db_mgr._get_connection()._conn
+                    self._conn.commit()
+                    return
+                raise
 
     def rollback(self):
         self._conn.rollback()
@@ -51,23 +57,26 @@ class ConnectionWrapper:
         self._conn.close()
 
     def execute(self, *args, **kwargs):
+        # NOTE: Direct raw cursor execution (conn.cursor().execute(...)) bypasses wrapper-level auto-healing.
         try:
             return self._conn.execute(*args, **kwargs)
         except sqlite3.DatabaseError as e:
             if self._db_mgr and ("malformed" in str(e).lower() or "disk image" in str(e).lower()) and not self._db_mgr._is_repairing:
                 self._db_mgr.repair_database()
-                # Re-get the connection and execute
-                return self._db_mgr._get_connection()._conn.execute(*args, **kwargs)
-            raise e
+                self._conn = self._db_mgr._get_connection()._conn
+                return self._conn.execute(*args, **kwargs)
+            raise
 
     def executemany(self, *args, **kwargs):
+        # NOTE: Direct raw cursor execution (conn.cursor().execute(...)) bypasses wrapper-level auto-healing.
         try:
             return self._conn.executemany(*args, **kwargs)
         except sqlite3.DatabaseError as e:
             if self._db_mgr and ("malformed" in str(e).lower() or "disk image" in str(e).lower()) and not self._db_mgr._is_repairing:
                 self._db_mgr.repair_database()
-                return self._db_mgr._get_connection()._conn.executemany(*args, **kwargs)
-            raise e
+                self._conn = self._db_mgr._get_connection()._conn
+                return self._conn.executemany(*args, **kwargs)
+            raise
 
     def cursor(self, *args, **kwargs):
         return self._conn.cursor(*args, **kwargs)
@@ -385,8 +394,6 @@ class AnkimonDB:
                         backup_db.unlink()
                     except Exception:
                         pass
-                import gc
-                import time
                 try:
                     for attempt in range(3):
                         try:
@@ -395,6 +402,7 @@ class AnkimonDB:
                         except Exception as e:
                             if attempt == 2:
                                 self._log("warning", f"Failed to backup corrupt database: {e}")
+                                break
                             time.sleep(0.1)
                             gc.collect()
                 except Exception:
@@ -406,9 +414,9 @@ class AnkimonDB:
                         try:
                             tmp_db.replace(db_file)
                             break
-                        except Exception as e:
+                        except Exception:
                             if attempt == 2:
-                                raise e
+                                raise
                             time.sleep(0.1)
                             gc.collect()
                     for sidecar in ("-wal", "-shm"):
@@ -434,7 +442,7 @@ class AnkimonDB:
                     tmp_db.unlink()
         except Exception as e:
             self._log("error", f"Self-healing database repair failed: {e}")
-            raise e
+            raise
         finally:
             self._is_repairing = False
             # Clean up the temporary database file if it was left behind due to a crash/exception

--- a/src/Ankimon/pyobj/database_manager.py
+++ b/src/Ankimon/pyobj/database_manager.py
@@ -9,6 +9,7 @@ import json
 import sqlite3
 import threading
 import uuid
+import weakref
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Union
 
@@ -29,13 +30,19 @@ class ConnectionWrapper:
     """Wraps a sqlite3.Connection, proxying everything, with a re-entrant
     ``with conn:`` transaction and an opt-out commit flag (used by bulk paths)."""
 
-    def __init__(self, conn):
+    def __init__(self, conn, db_mgr=None):
         self._conn = conn
         self._disable_commit = False
+        self._db_mgr = db_mgr
 
     def commit(self):
         if not self._disable_commit:
-            self._conn.commit()
+            try:
+                self._conn.commit()
+            except sqlite3.DatabaseError as e:
+                if self._db_mgr and ("malformed" in str(e).lower() or "disk image" in str(e).lower()) and not self._db_mgr._is_repairing:
+                    self._db_mgr.repair_database()
+                raise e
 
     def rollback(self):
         self._conn.rollback()
@@ -44,10 +51,23 @@ class ConnectionWrapper:
         self._conn.close()
 
     def execute(self, *args, **kwargs):
-        return self._conn.execute(*args, **kwargs)
+        try:
+            return self._conn.execute(*args, **kwargs)
+        except sqlite3.DatabaseError as e:
+            if self._db_mgr and ("malformed" in str(e).lower() or "disk image" in str(e).lower()) and not self._db_mgr._is_repairing:
+                self._db_mgr.repair_database()
+                # Re-get the connection and execute
+                return self._db_mgr._get_connection()._conn.execute(*args, **kwargs)
+            raise e
 
     def executemany(self, *args, **kwargs):
-        return self._conn.executemany(*args, **kwargs)
+        try:
+            return self._conn.executemany(*args, **kwargs)
+        except sqlite3.DatabaseError as e:
+            if self._db_mgr and ("malformed" in str(e).lower() or "disk image" in str(e).lower()) and not self._db_mgr._is_repairing:
+                self._db_mgr.repair_database()
+                return self._db_mgr._get_connection()._conn.executemany(*args, **kwargs)
+            raise e
 
     def cursor(self, *args, **kwargs):
         return self._conn.cursor(*args, **kwargs)
@@ -135,6 +155,9 @@ class AnkimonDB:
         self._wal = wal
         self._connection: Optional[ConnectionWrapper] = None       # GUI-thread connection
         self._local_conn = threading.local()                       # per-background-thread
+        self._all_connections = []
+        self._conn_lock = threading.Lock()
+        self._is_repairing = False
         # When non-None, mark_mobile_battle_resolved defers the mirror-DB sync
         # (which commits on a separate connection, escaping any outer transaction)
         # and collects the revlog ids here to be flushed after the caller's bulk
@@ -169,7 +192,10 @@ class AnkimonDB:
                 conn.execute("PRAGMA temp_store=MEMORY;")
             except Exception as e:
                 self._log("warning", f"Failed to set WAL PRAGMAs: {e}")
-        return ConnectionWrapper(conn)
+        wrapper = ConnectionWrapper(conn)
+        with self._conn_lock:
+            self._all_connections.append(weakref.ref(wrapper))
+        return wrapper
 
     def _log(self, level: str, message: str):
         """Helper for logging."""
@@ -200,7 +226,7 @@ class AnkimonDB:
                 local.conn = self._prepare_connection(conn)
                 local.db_path = self.db_path
             elif not isinstance(local.conn, ConnectionWrapper):
-                local.conn = ConnectionWrapper(local.conn)
+                local.conn = ConnectionWrapper(local.conn, self)
                 local.db_path = self.db_path
             return local.conn
 
@@ -208,23 +234,194 @@ class AnkimonDB:
             conn = sqlite3.connect(str(self.db_path), check_same_thread=False)
             self._connection = self._prepare_connection(conn)
         elif not isinstance(self._connection, ConnectionWrapper):
-            self._connection = ConnectionWrapper(self._connection)
+            self._connection = ConnectionWrapper(self._connection, self)
         return self._connection
 
     def close(self):
-        """Closes the GUI-thread connection and this thread's background connection."""
-        if self._connection:
+        """Closes all database connections across all threads."""
+        with self._conn_lock:
+            if self._connection:
+                try:
+                    self._connection.close()
+                except Exception:
+                    pass
+                self._connection = None
+            
+            for conn_ref in self._all_connections:
+                conn = conn_ref()
+                if conn is not None:
+                    try:
+                        conn.close()
+                    except Exception:
+                        pass
+            self._all_connections.clear()
+            
+            if hasattr(self, "_local_conn"):
+                try:
+                    if getattr(self._local_conn, "conn", None) is not None:
+                        self._local_conn.conn.close()
+                except Exception:
+                    pass
+                self._local_conn.conn = None
+
+    def repair_database(self):
+        """Repair a corrupted/malformed database out-of-place."""
+        if self._is_repairing:
+            return
+        self._is_repairing = True
+        self._log("warning", "SQLite database corruption detected! Initiating out-of-place self-healing repair...")
+        
+        try:
+            db_file = self.db_path
+            tmp_db = db_file.with_name(db_file.name + ".tmp")
+            backup_db = db_file.with_name(db_file.name + ".corrupt_backup")
+            
+            if tmp_db.exists():
+                try:
+                    tmp_db.unlink()
+                except Exception:
+                    pass
+                    
+            # Dump current database safely
+            src_conn = sqlite3.connect(str(db_file))
+            lines = list(src_conn.iterdump())
+            src_conn.close()
+            
+            # Modify schema to disable primary key constraint during insert and use INSERT OR REPLACE
+            modified_sql = []
+            for line in lines:
+                if "CREATE TABLE captured_pokemon" in line:
+                    line = line.replace("individual_id TEXT PRIMARY KEY", "individual_id TEXT")
+                if line.startswith("INSERT INTO "):
+                    line = line.replace("INSERT INTO ", "INSERT OR REPLACE INTO ", 1)
+                modified_sql.append(line)
+            full_sql = "\n".join(modified_sql)
+            
+            # Write to temporary file
+            dest_conn = sqlite3.connect(str(tmp_db))
+            dest_conn.executescript(full_sql)
+            
+            cursor = dest_conn.cursor()
+            
+            # Prune duplicate captured_pokemon rows by highest Level and XP
+            cursor.execute("""
+                DELETE FROM captured_pokemon 
+                WHERE rowid NOT IN (
+                    SELECT rowid FROM (
+                        SELECT rowid, ROW_NUMBER() OVER (
+                            PARTITION BY individual_id 
+                            ORDER BY 
+                                CAST(json_extract(data, '$.level') AS INTEGER) DESC, 
+                                CAST(json_extract(data, '$.xp') AS INTEGER) DESC
+                        ) as rn 
+                        FROM captured_pokemon
+                    ) WHERE rn = 1
+                )
+            """)
+            
+            # Clean duplicate keys in pending_mobile_battles if table exists
             try:
-                self._connection.close()
+                cursor.execute("SELECT name FROM sqlite_master WHERE type='table' AND name='pending_mobile_battles'")
+                if cursor.fetchone():
+                    cursor.execute("""
+                        DELETE FROM pending_mobile_battles 
+                        WHERE rowid NOT IN (
+                            SELECT MIN(rowid) 
+                            FROM pending_mobile_battles 
+                            GROUP BY id
+                        )
+                    """)
             except Exception:
                 pass
-            self._connection = None
-        if hasattr(self, "_local_conn") and getattr(self._local_conn, "conn", None):
-            try:
-                self._local_conn.conn.close()
-            except Exception:
-                pass
-            self._local_conn.conn = None
+                
+            # Restore unique PRIMARY KEY table definition
+            cursor.execute("ALTER TABLE captured_pokemon RENAME TO captured_pokemon_old")
+            cursor.execute("""
+                CREATE TABLE captured_pokemon (
+                    individual_id TEXT PRIMARY KEY,
+                    is_main INTEGER DEFAULT 0,
+                    data TEXT NOT NULL,
+                    name TEXT GENERATED ALWAYS AS (json_extract(data, '$.name')) VIRTUAL,
+                    pokedex_id INTEGER GENERATED ALWAYS AS (json_extract(data, '$.id')) VIRTUAL,
+                    shiny BOOLEAN GENERATED ALWAYS AS (json_extract(data, '$.shiny')) VIRTUAL,
+                    level INTEGER GENERATED ALWAYS AS (json_extract(data, '$.level')) VIRTUAL
+                )
+            """)
+            cursor.execute("""
+                INSERT INTO captured_pokemon (individual_id, is_main, data)
+                SELECT individual_id, is_main, data FROM captured_pokemon_old
+            """)
+            cursor.execute("DROP TABLE captured_pokemon_old")
+            
+            # Rebuild index and verify
+            cursor.execute("REINDEX")
+            cursor.execute("PRAGMA integrity_check")
+            check_result = cursor.fetchone()[0]
+            
+            if check_result == "ok":
+                dest_conn.commit()
+                dest_conn.close()
+                
+                # Close all connections completely to drop locks
+                self.close()
+                
+                # Clean up existing corrupted backup
+                if backup_db.exists():
+                    try:
+                        backup_db.unlink()
+                    except Exception:
+                        pass
+                import gc
+                import time
+                try:
+                    for attempt in range(3):
+                        try:
+                            db_file.replace(backup_db)
+                            break
+                        except Exception as e:
+                            if attempt == 2:
+                                self._log("warning", f"Failed to backup corrupt database: {e}")
+                            time.sleep(0.1)
+                            gc.collect()
+                except Exception:
+                    pass
+                    
+                # Swap in repaired file and clean WAL/SHM sidecars
+                try:
+                    for attempt in range(3):
+                        try:
+                            tmp_db.replace(db_file)
+                            break
+                        except Exception as e:
+                            if attempt == 2:
+                                raise e
+                            time.sleep(0.1)
+                            gc.collect()
+                    for sidecar in ("-wal", "-shm"):
+                        sidecar_file = db_file.with_name(db_file.name + sidecar)
+                        try:
+                            if sidecar_file.exists():
+                                sidecar_file.unlink()
+                        except Exception:
+                            pass
+                    self._log("info", "SQLite self-healing completed successfully! Database index repaired.")
+                except Exception as e:
+                    self._log("error", f"Failed to swap repaired database: {e}")
+                    if backup_db.exists() and not db_file.exists():
+                        try:
+                            backup_db.replace(db_file)
+                        except Exception:
+                            pass
+            else:
+                dest_conn.rollback()
+                dest_conn.close()
+                self._log("error", f"Integrity check on repaired DB failed: {check_result}")
+                if tmp_db.exists():
+                    tmp_db.unlink()
+        except Exception as e:
+            self._log("error", f"Self-healing database repair failed: {e}")
+        finally:
+            self._is_repairing = False
 
     def switch_database(self, db_filename: str):
         """Close current connections and reopen against a different profile DB file.
@@ -571,10 +768,20 @@ class AnkimonDB:
     def execute(self, query: str, parameters: tuple = ()) -> sqlite3.Cursor:
         """Executes a custom SQL query and returns the cursor. 
         Useful for caller-specific fast-path queries without cluttering the manager."""
-        conn = self._get_connection()
-        cursor = conn.cursor()
-        cursor.execute(query, parameters)
-        return cursor
+        try:
+            conn = self._get_connection()
+            cursor = conn.cursor()
+            cursor.execute(query, parameters)
+            return cursor
+        except sqlite3.DatabaseError as e:
+            if ("malformed" in str(e).lower() or "disk image" in str(e).lower()) and not self._is_repairing:
+                self.repair_database()
+                # Retry once after repair
+                conn = self._get_connection()
+                cursor = conn.cursor()
+                cursor.execute(query, parameters)
+                return cursor
+            raise e
 
     def get_pokemons_by_individual_ids(self, ids: List[str]) -> List[Dict[str, Any]]:
         """Retrieves multiple pokemon by their individual_ids."""

--- a/src/Ankimon/pyobj/database_manager.py
+++ b/src/Ankimon/pyobj/database_manager.py
@@ -303,6 +303,9 @@ class AnkimonDB:
             # We also disable the unique constraint.
             modified_sql = []
             for line in lines:
+                if line.startswith("CREATE INDEX") or line.startswith("CREATE UNIQUE INDEX"):
+                    if "captured_pokemon" in line:
+                        continue
                 if "CREATE TABLE captured_pokemon" in line:
                     line = """CREATE TABLE captured_pokemon (
                         individual_id TEXT,

--- a/src/Ankimon/pyobj/db_diagnostics.py
+++ b/src/Ankimon/pyobj/db_diagnostics.py
@@ -11,7 +11,7 @@ def trigger_database_diagnostics():
         )
         return
 
-    from ..singletons import services
+    from ..services import services
     db = services.db
     if not db:
         showWarning("Database connection is not available.")

--- a/src/Ankimon/pyobj/db_diagnostics.py
+++ b/src/Ankimon/pyobj/db_diagnostics.py
@@ -1,0 +1,110 @@
+import sqlite3
+from aqt import mw
+from aqt.utils import showInfo, showWarning, askUser
+
+def trigger_database_diagnostics():
+    # 1. Safety Guard: Block if cards are being reviewed
+    if getattr(mw.reviewer, "card", None) is not None:
+        showWarning(
+            "Diagnostics Unavailable\n\n"
+            "Please finish or exit your current card review session before running database diagnostics to avoid database locks."
+        )
+        return
+
+    from ..singletons import services
+    db = services.db
+    if not db:
+        showWarning("Database connection is not available.")
+        return
+
+    # Phase 1: Read-only Diagnostics
+    try:
+        conn = db._get_connection()
+        cursor = conn.cursor()
+        cursor.execute("PRAGMA integrity_check")
+        integrity_result = cursor.fetchone()[0]
+        is_corrupt = (integrity_result != "ok")
+
+        cursor.execute("""
+            SELECT COUNT(*) FROM (
+                SELECT individual_id FROM captured_pokemon 
+                GROUP BY individual_id HAVING COUNT(*) > 1
+            )
+        """)
+        duplicate_count = cursor.fetchone()[0]
+
+    except Exception as e:
+        showWarning(f"Failed to run diagnostics: {e}")
+        return
+
+    # Scenario A: Database is completely healthy
+    if not is_corrupt and duplicate_count == 0:
+        showInfo(
+            "Database Integrity: Healthy\n\n"
+            "No index corruption or duplicate Pokemon records were detected. Your database is fully healthy!"
+        )
+        return
+
+    # Scenario B: Issues found, prompt to repair
+    issue_desc = ""
+    if duplicate_count > 0:
+        issue_desc += f"• {duplicate_count} duplicate Pokemon sharing unique IDs\n"
+    if is_corrupt:
+        issue_desc += f"• Database index pages are malformed/corrupted (integrity status: {integrity_result})\n"
+
+    msg = (
+        "Issues Detected in Database\n\n"
+        f"We found the following issues in your database:\n{issue_desc}\n"
+        "Would you like to repair your database now? This will rebuild indexes and merge duplicates "
+        "by keeping the copy with the highest level/XP progress."
+    )
+
+    if not askUser(msg):
+        return
+
+    # Phase 2: Execute Repair
+    try:
+        db.repair_database()
+        
+        # Verify the repair succeeded
+        conn = db._get_connection()
+        cursor = conn.cursor()
+        cursor.execute("PRAGMA integrity_check")
+        check_res = cursor.fetchone()[0]
+        
+        cursor.execute("""
+            SELECT COUNT(*) FROM (
+                SELECT individual_id FROM captured_pokemon 
+                GROUP BY individual_id HAVING COUNT(*) > 1
+            )
+        """)
+        new_dup_count = cursor.fetchone()[0]
+        
+        if check_res == "ok" and new_dup_count == 0:
+            showInfo(
+                "Repair Successful\n\n"
+                "Database has been successfully recovered and re-indexed. Duplicates have been pruned.\n\n"
+                "Anki will now reload your profile to apply changes."
+            )
+            # Reload profile to safely reinitialize connections (handles both old and new Anki versions)
+            def reload_profile_callback():
+                mw.loadProfile()
+                
+            try:
+                mw.unloadProfile(reload_profile_callback)
+            except TypeError:
+                mw.unloadProfile()
+                mw.loadProfile()
+        else:
+            showWarning(
+                "Repair Completed with Warnings\n\n"
+                f"The repair script finished but some issues might remain. (Integrity check: {check_res}, duplicates: {new_dup_count})"
+            )
+    except PermissionError:
+        showWarning(
+            "Repair Failed: File Locked\n\n"
+            "Could not write the repaired database because the file is locked by another program (e.g. OneDrive, Dropbox, or antivirus).\n\n"
+            "Please temporarily pause file sync/scanners and try again."
+        )
+    except Exception as e:
+        showWarning(f"Repair process encountered an error: {e}")

--- a/src/Ankimon/pyobj/migration_dialog.py
+++ b/src/Ankimon/pyobj/migration_dialog.py
@@ -152,12 +152,15 @@ class MigrationDialog(QDialog):
                         pokemon_list = json.load(f)
                     
                     total = len(pokemon_list)
+                    seen_ids = set()
                     for i, pokemon in enumerate(pokemon_list):
                         if self.cancelled: break
                         if not isinstance(pokemon, dict):
                             continue
-                        if not pokemon.get("individual_id"):
+                        ind_id = pokemon.get("individual_id")
+                        if not ind_id or ind_id in seen_ids:
                             pokemon["individual_id"] = str(uuid.uuid4())
+                        seen_ids.add(pokemon["individual_id"])
                         if self.db.save_pokemon(pokemon):
                             stats["pokemon"] += 1
                         if total > 0 and (i % 20 == 0 or i == total - 1):

--- a/src/Ankimon/pyobj/migration_dialog.py
+++ b/src/Ankimon/pyobj/migration_dialog.py
@@ -137,6 +137,7 @@ class MigrationDialog(QDialog):
         self.start_button.setText("Migrating...")
         stats = {"pokemon": 0, "main": 0, "items": 0, "badges": 0, 
                  "team": 0, "history": 0, "userdata": 0}
+        remapped_ids = {}
         
         try:
             # Check if Phase 1 is already done
@@ -159,11 +160,13 @@ class MigrationDialog(QDialog):
                             continue
                         ind_id = pokemon.get("individual_id")
                         if not ind_id or ind_id in seen_ids:
+                            new_uuid = str(uuid.uuid4())
                             if ind_id:
                                 self.log_area.append(
                                     f"  ⚠ Duplicate individual_id {ind_id}; assigned a new UUID (kept both copies)"
                                 )
-                            pokemon["individual_id"] = str(uuid.uuid4())
+                                remapped_ids.setdefault(ind_id, []).append(new_uuid)
+                            pokemon["individual_id"] = new_uuid
                         seen_ids.add(pokemon["individual_id"])
                         if self.db.save_pokemon(pokemon):
                             stats["pokemon"] += 1
@@ -287,7 +290,10 @@ class MigrationDialog(QDialog):
                 valid_team_list = []
                 for member in team_list:
                     if isinstance(member, dict):
-                        if not member.get("individual_id"):
+                        old_id = member.get("individual_id")
+                        if old_id and old_id in remapped_ids and remapped_ids[old_id]:
+                            member["individual_id"] = remapped_ids[old_id].pop(0)
+                        elif not old_id:
                             match_key = (
                                 str(member.get("name", "")).lower(),
                                 str(member.get("level", "")),

--- a/src/Ankimon/pyobj/migration_dialog.py
+++ b/src/Ankimon/pyobj/migration_dialog.py
@@ -159,6 +159,10 @@ class MigrationDialog(QDialog):
                             continue
                         ind_id = pokemon.get("individual_id")
                         if not ind_id or ind_id in seen_ids:
+                            if ind_id:
+                                self.log_area.append(
+                                    f"  ⚠ Duplicate individual_id {ind_id}; assigned a new UUID (kept both copies)"
+                                )
                             pokemon["individual_id"] = str(uuid.uuid4())
                         seen_ids.add(pokemon["individual_id"])
                         if self.db.save_pokemon(pokemon):

--- a/tests/test_database_manager.py
+++ b/tests/test_database_manager.py
@@ -201,3 +201,59 @@ def test_busy_timeout_set_on_background_thread_connection(temp_env):
         conn = db._get_connection()  # dedicated per-thread connection
         got = conn.execute("PRAGMA busy_timeout;").fetchone()[0]
     assert got == AnkimonDB._BUSY_TIMEOUT_MS
+
+
+def test_database_corruption_self_healing(temp_env):
+    """Verify that repair_database() successfully prunes duplicates (keeping the one
+    with the highest progress) and recovers the unique PRIMARY KEY index constraint."""
+    db, _ = temp_env
+    # Save base pokemon
+    pk1 = {"individual_id": "duplicate-uuid", "name": "archen", "id": 566, "level": 5, "xp": 100}
+    db.save_pokemon(pk1)
+    
+    # Close connections so we can bypass constraints with a custom raw connection
+    db.close()
+    
+    raw_conn = sqlite3.connect(str(db.db_path))
+    cursor = raw_conn.cursor()
+    
+    # Temporarily drop constraint by renaming and copying to a non-constrained table
+    cursor.execute("ALTER TABLE captured_pokemon RENAME TO captured_pokemon_old")
+    cursor.execute("""
+        CREATE TABLE captured_pokemon (
+            individual_id TEXT,
+            is_main INTEGER DEFAULT 0,
+            data TEXT NOT NULL
+        )
+    """)
+    cursor.execute("INSERT INTO captured_pokemon (individual_id, is_main, data) SELECT individual_id, is_main, data FROM captured_pokemon_old")
+    cursor.execute("DROP TABLE captured_pokemon_old")
+    
+    # Insert a duplicate with a higher level (Level 34)
+    pk2 = {"individual_id": "duplicate-uuid", "name": "archen", "id": 566, "level": 34, "xp": 1000}
+    cursor.execute("INSERT INTO captured_pokemon (individual_id, is_main, data) VALUES (?, 0, ?)", 
+                   ("duplicate-uuid", json.dumps(pk2)))
+                   
+    # Insert another duplicate with intermediate level (Level 30)
+    pk3 = {"individual_id": "duplicate-uuid", "name": "archen", "id": 566, "level": 30, "xp": 500}
+    cursor.execute("INSERT INTO captured_pokemon (individual_id, is_main, data) VALUES (?, 0, ?)", 
+                   ("duplicate-uuid", json.dumps(pk3)))
+    
+    raw_conn.commit()
+    raw_conn.close()
+    
+    # Trigger repair
+    db.repair_database()
+    
+    # Reopen and check: only the highest level (Level 34) should survive, constraint must be restored
+    conn = db._get_connection()
+    cursor = conn.cursor()
+    cursor.execute("SELECT data FROM captured_pokemon WHERE individual_id = 'duplicate-uuid'")
+    rows = cursor.fetchall()
+    assert len(rows) == 1
+    saved_pk = json.loads(rows[0][0])
+    assert saved_pk["level"] == 34
+    
+    # Confirm unique constraint is back by verifying that inserting a duplicate now raises IntegrityError
+    with pytest.raises(sqlite3.IntegrityError):
+        cursor.execute("INSERT INTO captured_pokemon (individual_id, is_main, data) VALUES ('duplicate-uuid', 0, '{}')")

--- a/tests/test_database_manager.py
+++ b/tests/test_database_manager.py
@@ -210,6 +210,7 @@ def test_database_corruption_self_healing(temp_env):
     # Save base pokemon
     pk1 = {"individual_id": "duplicate-uuid", "name": "archen", "id": 566, "level": 5, "xp": 100}
     db.save_pokemon(pk1)
+    db.set_main_pokemon("duplicate-uuid")
     
     # Close connections so we can bypass constraints with a custom raw connection
     db.close()
@@ -252,11 +253,13 @@ def test_database_corruption_self_healing(temp_env):
     # Reopen and check: only the highest level (Level 34) should survive, constraint must be restored
     conn = db._get_connection()
     cursor = conn.cursor()
-    cursor.execute("SELECT data FROM captured_pokemon WHERE individual_id = 'duplicate-uuid'")
+    cursor.execute("SELECT is_main, data FROM captured_pokemon WHERE individual_id = 'duplicate-uuid'")
     rows = cursor.fetchall()
     assert len(rows) == 1
-    saved_pk = json.loads(rows[0][0])
+    is_main, data = rows[0]
+    saved_pk = json.loads(data)
     assert saved_pk["level"] == 34
+    assert is_main == 1
     
     # Confirm unique constraint is back by verifying that inserting a duplicate now raises IntegrityError
     with pytest.raises(sqlite3.IntegrityError):

--- a/tests/test_database_manager.py
+++ b/tests/test_database_manager.py
@@ -223,7 +223,11 @@ def test_database_corruption_self_healing(temp_env):
         CREATE TABLE captured_pokemon (
             individual_id TEXT,
             is_main INTEGER DEFAULT 0,
-            data TEXT NOT NULL
+            data TEXT NOT NULL,
+            name TEXT GENERATED ALWAYS AS (json_extract(data, '$.name')) VIRTUAL,
+            pokedex_id INTEGER GENERATED ALWAYS AS (json_extract(data, '$.id')) VIRTUAL,
+            shiny BOOLEAN GENERATED ALWAYS AS (json_extract(data, '$.shiny')) VIRTUAL,
+            level INTEGER GENERATED ALWAYS AS (json_extract(data, '$.level')) VIRTUAL
         )
     """)
     cursor.execute("INSERT INTO captured_pokemon (individual_id, is_main, data) SELECT individual_id, is_main, data FROM captured_pokemon_old")

--- a/tests/test_migration_dialog.py
+++ b/tests/test_migration_dialog.py
@@ -1,0 +1,90 @@
+import json
+import uuid
+import pytest
+from unittest.mock import MagicMock, patch
+from pathlib import Path
+from PyQt6.QtWidgets import QApplication
+
+# Ensure QApplication is initialized for QDialog subclasses in tests
+@pytest.fixture(scope="session")
+def qapp():
+    app = QApplication.instance()
+    if not app:
+        app = QApplication([])
+    return app
+
+def test_migration_dialog_remaps_duplicate_team_ids(qapp, tmp_path):
+    import sys
+    for m in list(sys.modules.keys()):
+        if m.startswith("PyQt6") or "migration_dialog" in m:
+            sys.modules.pop(m, None)
+    from Ankimon.pyobj.migration_dialog import MigrationDialog
+
+    # 1. Create a corrupt/duplicate collection JSON
+    dup_uuid = str(uuid.uuid4())
+    mypokemon_data = [
+        {"individual_id": dup_uuid, "name": "Pikachu", "level": 10, "species_id": 25},
+        {"individual_id": dup_uuid, "name": "Charmander", "level": 15, "species_id": 4},  # Duplicate individual_id!
+    ]
+    mypokemon_path = tmp_path / "mypokemon.json"
+    mypokemon_path.write_text(json.dumps(mypokemon_data))
+
+    # 2. Create team JSON referencing the duplicate ID
+    team_data = [
+        {"individual_id": dup_uuid, "name": "Charmander", "level": 15, "species_id": 4}
+    ]
+    team_path = tmp_path / "team.json"
+    team_path.write_text(json.dumps(team_data))
+
+    # Mock database
+    mock_db = MagicMock()
+    mock_db.is_migrated_phase1.return_value = False
+    mock_db.save_pokemon.return_value = True
+    
+    # When save_team is called, we capture the list saved to the DB
+    saved_team = []
+    def mock_save_team(team_list):
+        saved_team.extend(team_list)
+        return True
+    mock_db.save_team.side_effect = mock_save_team
+
+    # We mock get_all_pokemon to return what was supposedly saved in phase 1
+    # since Step 5 does: all_captured = self.db.get_all_pokemon()
+    saved_pokemon = []
+    def mock_save_pokemon(pokemon):
+        saved_pokemon.append(pokemon)
+        return True
+    mock_db.save_pokemon.side_effect = mock_save_pokemon
+    mock_db.get_all_pokemon.side_effect = lambda: saved_pokemon
+
+    # Initialize the dialog
+    dialog = MigrationDialog(
+        mock_db,
+        mypokemon_path=mypokemon_path,
+        mainpokemon_path=tmp_path / "mainpokemon.json",
+        items_path=tmp_path / "items.json",
+        badges_path=tmp_path / "badges.json",
+        team_path=team_path,
+        history_path=tmp_path / "history.json",
+        data_path=tmp_path / "data.json",
+        rate_path=tmp_path / "rate.json"
+    )
+
+    # Run migration step
+    with patch("PyQt6.QtWidgets.QApplication.processEvents"):
+        dialog._run_migration()
+
+    # Verify that the two migrated pokemon have distinct IDs
+    if len(saved_pokemon) != 2:
+        print("MIGRATION LOGS:")
+        print(dialog.log_area.toPlainText())
+    assert len(saved_pokemon) == 2
+    id1 = saved_pokemon[0]["individual_id"]
+    id2 = saved_pokemon[1]["individual_id"]
+    assert id1 != id2
+    assert id1 == dup_uuid or id2 == dup_uuid
+    new_uuid = id1 if id2 == dup_uuid else id2
+
+    # Verify that the team member's ID was updated to the new UUID
+    assert len(saved_team) == 1
+    assert saved_team[0]["individual_id"] == new_uuid

--- a/tests/test_scaffolding_smoke.py
+++ b/tests/test_scaffolding_smoke.py
@@ -35,9 +35,17 @@ def _scaffolding_env_guard():
     import types
     from pathlib import Path
 
+    # Clear any mocked PyQt6 modules from other tests to restore the real ones
+    for m in list(sys.modules.keys()):
+        if m.startswith("PyQt6") or "webshell" in m:
+            sys.modules.pop(m, None)
+
+    # Force load of actual PyQt6 modules so sys.modules.get works for _is_main_thread checks
+    import PyQt6.QtCore
+    import PyQt6.QtWidgets
     from PyQt6.QtWidgets import QDialog
 
-    if not isinstance(QDialog, type):  # PyQt6 was mocked by another test in this run
+    if not isinstance(QDialog, type) or "MagicMock" in str(QDialog):  # PyQt6 was mocked by another test in this run
         pytest.skip(
             "real PyQt6 not active (mocked by another test); "
             "run tests/test_scaffolding_smoke.py standalone"

--- a/tests/test_scaffolding_smoke.py
+++ b/tests/test_scaffolding_smoke.py
@@ -35,35 +35,50 @@ def _scaffolding_env_guard():
     import types
     from pathlib import Path
 
-    # Clear any mocked PyQt6 modules from other tests to restore the real ones
+    # Snapshot existing state to restore on teardown
+    sys_modules_snapshot = {}
     for m in list(sys.modules.keys()):
-        if m.startswith("PyQt6") or "webshell" in m:
-            sys.modules.pop(m, None)
+        if m.startswith("PyQt6") or "webshell" in m or m == "Ankimon" or m.startswith("Ankimon."):
+            sys_modules_snapshot[m] = sys.modules.get(m)
 
-    # Force load of actual PyQt6 modules so sys.modules.get works for _is_main_thread checks
-    import PyQt6.QtCore
-    import PyQt6.QtWidgets
-    from PyQt6.QtWidgets import QDialog
+    try:
+        # Clear any mocked PyQt6 modules from other tests to restore the real ones
+        for m in list(sys_modules_snapshot.keys()):
+            if m.startswith("PyQt6") or "webshell" in m:
+                sys.modules.pop(m, None)
 
-    if not isinstance(QDialog, type) or "MagicMock" in str(QDialog):  # PyQt6 was mocked by another test in this run
-        pytest.skip(
-            "real PyQt6 not active (mocked by another test); "
-            "run tests/test_scaffolding_smoke.py standalone"
-        )
+        # Force load of actual PyQt6 modules so sys.modules.get works for _is_main_thread checks
+        import PyQt6.QtCore
+        import PyQt6.QtWidgets
+        from PyQt6.QtWidgets import QDialog
 
-    # A prior test may have rebound Ankimon as a non-package; restore a real one.
-    src = Path(__file__).parent.parent / "src"
-    if str(src) not in sys.path:
-        sys.path.insert(0, str(src))
-    ank = sys.modules.get("Ankimon")
-    if ank is None or not getattr(ank, "__path__", None):
-        pkg = types.ModuleType("Ankimon")
-        pkg.__path__ = [str(src / "Ankimon")]
-        pkg.__package__ = "Ankimon"
-        sys.modules["Ankimon"] = pkg
-        for stale in [m for m in sys.modules if m.startswith("Ankimon.")]:
-            del sys.modules[stale]
-    yield
+        if not isinstance(QDialog, type) or "MagicMock" in str(QDialog):  # PyQt6 was mocked by another test in this run
+            pytest.skip(
+                "real PyQt6 not active (mocked by another test); "
+                "run tests/test_scaffolding_smoke.py standalone"
+            )
+
+        # A prior test may have rebound Ankimon as a non-package; restore a real one.
+        src = Path(__file__).parent.parent / "src"
+        if str(src) not in sys.path:
+            sys.path.insert(0, str(src))
+        ank = sys.modules.get("Ankimon")
+        if ank is None or not getattr(ank, "__path__", None):
+            pkg = types.ModuleType("Ankimon")
+            pkg.__path__ = [str(src / "Ankimon")]
+            pkg.__package__ = "Ankimon"
+            sys.modules["Ankimon"] = pkg
+            for stale in [m for m in sys.modules if m.startswith("Ankimon.")]:
+                del sys.modules[stale]
+        yield
+    finally:
+        # Restore sys.modules completely
+        for m in list(sys.modules.keys()):
+            if m.startswith("PyQt6") or "webshell" in m or m == "Ankimon" or m.startswith("Ankimon."):
+                sys.modules.pop(m, None)
+        for m, val in sys_modules_snapshot.items():
+            if val is not None:
+                sys.modules[m] = val
 
 
 # --- (a) web-shell host mounts a stub screen -------------------------------

--- a/tests/test_update_channels.py
+++ b/tests/test_update_channels.py
@@ -111,13 +111,13 @@ def _fake_services(stored):
 
 
 def test_get_update_channel_returns_stored_valid_value():
-    with patch("Ankimon.pyobj.update_manager.read_update_state", return_value=None):
+    with patch.object(um, "read_update_state", return_value=None):
         with patch.dict(sys.modules, {"Ankimon.services": _fake_services("main")}):
             assert um.get_update_channel() == um.CHANNEL_MAIN
 
 
 def test_get_update_channel_defaults_stable_for_plain_build():
-    with patch("Ankimon.pyobj.update_manager.read_update_state", return_value=None):
+    with patch.object(um, "read_update_state", return_value=None):
         with patch.dict(sys.modules, {"Ankimon.services": _fake_services(None)}):
             with patch("Ankimon.resources.IS_EXPERIMENTAL_BUILD", False):
                 assert um.get_update_channel() == um.CHANNEL_STABLE
@@ -125,7 +125,7 @@ def test_get_update_channel_defaults_stable_for_plain_build():
 
 def test_get_update_channel_defaults_experimental_for_e_build():
     # unrecognized stored value also falls back to the build-derived default
-    with patch("Ankimon.pyobj.update_manager.read_update_state", return_value=None):
+    with patch.object(um, "read_update_state", return_value=None):
         with patch.dict(sys.modules, {"Ankimon.services": _fake_services("garbage")}):
             with patch("Ankimon.resources.IS_EXPERIMENTAL_BUILD", True):
                 assert um.get_update_channel() == um.CHANNEL_EXPERIMENTAL


### PR DESCRIPTION
## Overview
This PR introduces robust database hardening, synchronization protection on Windows, automatic self-healing for corrupted indexes, and an interactive diagnostics menu utility to prevent and repair database errors.

## The Case We Encountered (Archen Level Discrepancy & Vanished Fossils)
During testing, we diagnosed a bug where a user reported that all fossil Pokémon suddenly \"vanished\" after evolving Archen:
1. **The Cause (Index Corruption):** A database index (`sqlite_autoindex_captured_pokemon_1`) became corrupted, which bypassed SQLite's `PRIMARY KEY` unique constraint. This allowed duplicate Pokémon rows with identical `individual_id` fields to be written directly to the database.
2. **Selective Updates:** During evolution or level up, SQLite queries `WHERE individual_id = ?`. Since the index was corrupted, only one of the duplicate rows was found and updated (e.g. Archen rowid `1819` at **Level 34**), leaving the older duplicate row (rowid `1815` at **Level 5**) stuck at its initial level.
3. **The \"Vanish\" Illusion:** In WAL/sync mode, writing to a corrupted index triggers a fatal `sqlite3.DatabaseError: database disk image is malformed`. This crashed the database reads, causing the GUI to fail to load any cards and make all Pokémon appear to have vanished from the PC Box.

---

## Implemented Fixes

### 1. Active Connection Registry & Thread-Safe Closure
* **File:** `database_manager.py`
* **Fix:** Introduced a thread-safe connection registry list (`self._all_connections` guarded by a lock) storing connections as **weak references** (`weakref.ref`). This resolves `PermissionError [WinError 5]` on Windows during sync/replacements by ensuring that all background/GUI threads' database handles are closed before swapping files.

### 2. Out-of-Place Self-Healing Repair
* **File:** `database_manager.py`
* **Fix:** Added a `repair_database()` routine that executes when a `DatabaseError` containing `malformed` or `disk image` is thrown:
  * Rebuilds the database **out-of-place** using a SQL dump to a temporary file (`.db.tmp`) to ensure that interrupted repairs do not damage the original file.
  * Uses `INSERT OR REPLACE` during restore to resolve duplicate key violations on all tables (like `pending_mobile_battles`).
  * Prunes duplicate Pokémon rows by progress (keeping the copy with the highest level/XP) before restoring the `PRIMARY KEY` constraint.
  * Rebuilds all indexes (`REINDEX;`) and runs `PRAGMA integrity_check` before swapping.
  * Integrates a file-replacement retry loop and explicit garbage collection (`gc.collect()`) to handle transient OS locks.

### 3. Verify & Repair Database Diagnostics Menu
* **Files:** `db_diagnostics.py`, `menu_buttons.py`
* **Fix:** Added a user-triggered **Verify and Repair Database** option under the Debug submenu (visible to all users). It runs read-only integrity and duplicate scans, prompts the user if issues are detected, triggers self-healing, and automatically reloads the active profile on success. Includes robust warnings if the reviewer is currently active or if file locking prevents writing.

### 4. Defensive JSON Migration
* **File:** `migration_dialog.py`
* **Fix:** Added a seen-ID tracking set during JSON migration to dynamically assign new UUIDs to duplicate legacy records, preventing duplicates from entering SQLite in the first place.

### 5. Automated Tests
* **File:** `test_database_manager.py`
* **Fix:** Added unit tests verifying duplicate pruning and index recovery on corruption. All 9 Tier-1 harness checks are fully green.