### PR TITLE
fix(battle-ui): fit the CP/BP display into the battle window's pixel-art boxes

### DIFF
--- a/src/Ankimon/business.py
+++ b/src/Ankimon/business.py
@@ -225,6 +225,35 @@ def calculate_present_power(
     return int(math.floor(cp * current_hp * compat * stage_factor))
 
 
+def format_compact_number(value) -> str:
+    """Format a stat for the battle window's fixed-width pixel-art boxes.
+
+    Values under 10,000 keep the full thousands-separated form ("2,564");
+    anything larger is compacted to a bounded width ("54.1K", "367K",
+    "4.3M" — at most ~5 glyphs) so Battle Power — a product of CP × HP
+    that routinely reaches 6-7 digits — can never overflow its box.
+    Non-numeric or negative input renders as "0".
+    """
+    try:
+        n = int(value)
+    except (TypeError, ValueError, OverflowError):  # OverflowError: float inf
+        n = 0
+    n = max(n, 0)
+    if n < 10_000:
+        return f"{n:,}"
+    for divisor, suffix in ((10**9, "B"), (10**6, "M"), (10**3, "K")):
+        scaled = n / divisor
+        # Enter this tier once the next-smaller tier's display would round
+        # past three digits: 999,400 stays "999K", 999,500 becomes "1M".
+        if scaled < 0.9995:
+            continue
+        text = f"{scaled:.1f}" if scaled < 99.95 else f"{scaled:.0f}"
+        if text.endswith(".0"):
+            text = text[:-2]
+        return text + suffix
+    return f"{n:,}"  # unreachable for n >= 10,000, defensive fallback
+
+
 def cp_breakdown_tooltip(pokemon_dict: dict) -> str:
     """Human-readable CP breakdown for Qt tooltips.
 

--- a/src/Ankimon/pyobj/test_window.py
+++ b/src/Ankimon/pyobj/test_window.py
@@ -17,7 +17,7 @@ from aqt.qt import (
 
 from aqt.utils import showWarning
 
-from PyQt6.QtGui import QIcon, QColor, QPainterPath
+from PyQt6.QtGui import QIcon, QColor, QFontMetrics, QPainterPath
 
 from PyQt6.QtWidgets import (
     QDialog,
@@ -48,7 +48,11 @@ from ..pyobj.translator import Translator
 
 from .error_handler import show_warning_with_traceback
 
-from ..business import calculate_present_power, type_compatibility_multiplier
+from ..business import (
+    calculate_present_power,
+    format_compact_number,
+    type_compatibility_multiplier,
+)
 
 from ..resources import (
     pkmnimgfolder,
@@ -184,14 +188,52 @@ class TestWindow(QWidget):
             self.first_start = True
             self.pkmn_window = True
 
+    # Palette of the info boxes baked into the battle-scene backgrounds —
+    # the CP/BP tag must be drawn in exactly these colors to blend in.
+    _BOX_FILL = QColor(240, 240, 208)
+    _BOX_INK = QColor(31, 31, 39)
+
+    def _draw_info_tag(self, painter, x, y, w, h):
+        """A small pixel-art plaque matching the baked-in info boxes.
+
+        Ink border with 2px stepped (chunky, not smooth) corners and a cream
+        fill — the same language as the background boxes, so the tag reads as
+        part of the scene art.
+        """
+        painter.save()
+        painter.setPen(Qt.PenStyle.NoPen)
+        painter.setBrush(self._BOX_INK)
+        painter.drawRect(x + 2, y, w - 4, h)
+        painter.drawRect(x, y + 2, w, h - 4)
+        painter.setBrush(self._BOX_FILL)
+        painter.drawRect(x + 3, y + 3, w - 6, h - 6)
+        painter.restore()
+
     def _draw_cp_pp(self, painter):
         """Draw CP and Battle Power labels for both Pokemon.
 
         Battle Power = CP * current_HP * type-matchup multiplier.
+
+        The player box has an empty bottom-left column, so its two lines sit
+        inside the box, sharing the HP numbers' font and baseline grid. The
+        enemy box has no free interior space, so its values go on a slim tag
+        fused to the box's bottom border (see _draw_info_tag). Values are
+        compacted ("367K") so they can never overflow either box.
         """
-        cp_font = load_custom_font(18, int(self.settings_obj.get("misc.language")))
+        lang = int(self.settings_obj.get("misc.language"))
+        # The player lines live on the box's baked 11px baseline grid (HP bar
+        # bottom y=216, baselines y=227/238, box interior floor y=240). The
+        # language fonts differ in height at the same size — shrink until the
+        # ascent fits the pitch (Early GameBoy fits at 18, PKMN Western at 16).
+        size = 18
+        cp_font = load_custom_font(size, lang)
+        metrics = QFontMetrics(cp_font)
+        while size > 10 and metrics.ascent() > 10:
+            size -= 2
+            cp_font = load_custom_font(size, lang)
+            metrics = QFontMetrics(cp_font)
         painter.setFont(cp_font)
-        painter.setPen(QColor(31, 31, 39))
+        painter.setPen(self._BOX_INK)
         try:
             enemy_cp = int(self.enemy_pokemon.cp)
         except (AttributeError, TypeError, ValueError):
@@ -228,10 +270,25 @@ class TestWindow(QWidget):
 
         cp_lbl = self.translator.translate("cp_label")
         bp_lbl = self.translator.translate("bp_label")
-        painter.drawText(48, 104, f"{cp_lbl} {enemy_cp:,}")
-        painter.drawText(48, 118, f"{bp_lbl} {enemy_bp:,}")
-        painter.drawText(326, 216, f"{cp_lbl} {main_cp:,}")
-        painter.drawText(326, 230, f"{bp_lbl} {main_bp:,}")
+        enemy_cp_text = f"{cp_lbl} {format_compact_number(enemy_cp)}"
+        enemy_bp_text = f"{bp_lbl} {format_compact_number(enemy_bp)}"
+
+        # Enemy: slim one-line tag hanging under the box. Its top border
+        # (y=92..94) lands exactly on the box's bottom border, so the two
+        # fuse; width follows the measured text so any language/value fits.
+        gap = 14
+        cp_w = metrics.horizontalAdvance(enemy_cp_text)
+        bp_w = metrics.horizontalAdvance(enemy_bp_text)
+        tag_x, tag_y, pad = 39, 92, 7
+        tag_w = cp_w + gap + bp_w + 2 * pad
+        self._draw_info_tag(painter, tag_x, tag_y, tag_w, 20)
+        painter.drawText(tag_x + pad, tag_y + 13, enemy_cp_text)
+        painter.drawText(tag_x + pad + cp_w + gap, tag_y + 13, enemy_bp_text)
+
+        # Player: the box's bottom-left column is empty — two lines there,
+        # the lower one sharing its baseline with the HP numbers row.
+        painter.drawText(326, 227, f"{cp_lbl} {format_compact_number(main_cp)}")
+        painter.drawText(326, 238, f"{bp_lbl} {format_compact_number(main_bp)}")
 
     def _get_display_name(self, pokemon):
         """Helper to safely get localized or pretty name for normal and special forms."""

--- a/tests/test_cp_formula.py
+++ b/tests/test_cp_formula.py
@@ -31,6 +31,7 @@ from Ankimon.business import (
     calculate_cpm,
     calculate_pokemon_go_cp,
     calculate_present_power,
+    format_compact_number,
     pokemon_go_raw_stats,
     type_compatibility_multiplier,
     calculate_cp_from_dict,
@@ -302,3 +303,40 @@ class TestCPBreakdownTooltip:
     def test_handles_missing_level(self):
         tip = cp_breakdown_tooltip({"base_stats": self.BASE})
         assert "CP at Level 100" in tip
+
+
+class TestFormatCompactNumber:
+    """format_compact_number keeps battle-window CP/BP inside their boxes."""
+
+    def test_small_values_keep_thousands_separator(self):
+        assert format_compact_number(0) == "0"
+        assert format_compact_number(10) == "10"
+        assert format_compact_number(2564) == "2,564"
+        assert format_compact_number(9999) == "9,999"
+
+    def test_thousands_compact(self):
+        assert format_compact_number(10_000) == "10K"
+        assert format_compact_number(54_120) == "54.1K"
+        assert format_compact_number(301_344) == "301K"
+        assert format_compact_number(366_652) == "367K"
+        assert format_compact_number(999_400) == "999K"
+
+    def test_millions_compact(self):
+        assert format_compact_number(1_000_000) == "1M"
+        assert format_compact_number(4_323_910) == "4.3M"
+        assert format_compact_number(43_000_000) == "43M"
+
+    def test_tier_boundary_promotes_instead_of_1000K(self):
+        assert format_compact_number(999_500) == "1M"
+        assert format_compact_number(999_950) == "1M"
+        assert format_compact_number(999_500_000) == "1B"
+
+    def test_garbage_and_negatives_render_zero(self):
+        assert format_compact_number(None) == "0"
+        assert format_compact_number("junk") == "0"
+        assert format_compact_number(-5) == "0"
+        assert format_compact_number(float("inf")) == "0"
+        assert format_compact_number(float("nan")) == "0"
+
+    def test_float_input_truncates_like_int(self):
+        assert format_compact_number(2564.9) == "2,564"


### PR DESCRIPTION
## Summary

The battle window drew CP and Battle Power as raw 7-digit text at positions outside the baked-in info boxes: the enemy's values floated over the grass below its box, and the player's CP was sliced through by the pixel-art HP bar label.

- **Player box** — the two lines now sit in the empty bottom-left column, sharing the HP numbers' baseline grid, with the font auto-shrunk per language until its ascent fits the row pitch (Early GameBoy keeps its size; the taller PKMN Western steps down one size).
- **Enemy box** — values move onto a slim tag fused to the box's bottom border, drawn in the background art's exact palette (cream fill, ink border, 2px stepped corners), with its width following the measured text so any language or value fits.
- **New `business.format_compact_number`** — keeps values bounded: under 10,000 stays `2,564`; larger compacts to `54.1K` / `367K` / `4.3M`, with display-precision tier promotion (`999,400` → `999K`, `999,500` → `1M`).

Battle Power is a product of CP × current HP × type multiplier, so it routinely reaches 6–7 digits — compaction is what guarantees it can never overflow its box.

## Verification

- `pytest tests/test_cp_formula.py` → **45 passed**, including the 6 new `TestFormatCompactNumber` cases (tier boundaries, `NaN`/`inf`/`None`/negative input, float truncation).
- CI's gating lint, `ruff check --config ci_ruff_check.toml`, passes on all three changed files.
- `Qt` and `QFontMetrics` confirmed bound in `test_window.py` (no star-import), and both changed sources byte-compile.
- Originally verified offscreen via the Tier-2 harness across both battle views, EN and JP fonts, huge BP (4.3M), tiny CP, long names, and low HP; no error events.

## Notes for review

- `ruff format --check` reports `business.py` and `test_cp_formula.py` as unformatted — this is **pre-existing on `main`** (both files report identically without this patch applied) and that check is not gating. No formatting regression is introduced.
- `test_window.py` has no test coverage in CI, so the drawing changes rest on the harness verification above rather than on automated tests.

Draft: opening for review of the coordinate/pixel choices before marking ready.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
