### PR TITLE
fix: rescale Battle Power and stop stat-inflating wild Pokemon EVs

### DIFF
--- a/src/Ankimon/business.py
+++ b/src/Ankimon/business.py
@@ -196,21 +196,33 @@ def type_compatibility_multiplier(attacker_types, defender_types) -> float:
 def calculate_present_power(
     cp: int,
     current_hp: int,
+    max_hp: int,
     compatibility_multiplier: float = 1.0,
     atk_stage: int = 0,
     spa_stage: int = 0,
 ) -> int:
-    """Present Power = CP × current HP × type multiplier × avg(atk, spa) stage.
+    """Present Power = CP × (current HP ÷ max HP) × type multiplier × avg(atk, spa) stage.
 
-    A live threat indicator: baseline power (CP), durability remaining
-    (current HP), type matchup, and in-battle attack-stage changes
-    (Swords Dance, Intimidate, etc.). Atk and Spa stages are averaged
-    to match the CP formula's averaging of physical and special. Drops
-    below neutral shrink BP; boosts grow it. Rounded down to an int.
+    A live threat indicator on the same scale as CP: at full HP with a
+    neutral matchup and no boosts, BP equals CP, so the two Pokemon's BP
+    readouts are directly comparable. Health is a *fraction* rather than
+    an absolute HP count — multiplying by raw HP double-counted stamina
+    (already inside CP) and blew BP up to a scale where the numbers meant
+    nothing. Atk and Spa stages are averaged to match the CP formula's
+    averaging of physical and special. Drops below neutral shrink BP;
+    boosts grow it. Rounded down to an int.
     """
     cp = max(int(cp if cp is not None else 0), 0)
     current_hp = max(int(current_hp if current_hp is not None else 0), 0)
+    max_hp = max(int(max_hp if max_hp is not None else 0), 0)
     compat = float(compatibility_multiplier if compatibility_multiplier is not None else 1.0)
+
+    if max_hp <= 0:
+        # Unknown max HP (stub/corrupt data): treat a living Pokemon as
+        # unhurt rather than zeroing its power.
+        hp_fraction = 1.0 if current_hp > 0 else 0.0
+    else:
+        hp_fraction = min(current_hp / max_hp, 1.0)
 
     def _stage_mult(stage) -> float:
         if stage is None:
@@ -222,7 +234,7 @@ def calculate_present_power(
         return float(val) if isinstance(val, (int, float)) else 1.0
 
     stage_factor = (_stage_mult(atk_stage) + _stage_mult(spa_stage)) / 2
-    return int(math.floor(cp * current_hp * compat * stage_factor))
+    return int(math.floor(cp * hp_fraction * compat * stage_factor))
 
 
 def format_compact_number(value) -> str:

--- a/src/Ankimon/functions/encounter_functions.py
+++ b/src/Ankimon/functions/encounter_functions.py
@@ -41,6 +41,7 @@ from ..utils import (
     limit_ev_yield,
     load_collected_pokemon_ids,
     play_effect_sound,
+    scale_ev_spread_to_level,
 )
 from ..business import calc_experience, calculate_cp_from_dict
 from ..const import gen_ids
@@ -1032,7 +1033,13 @@ def generate_random_pokemon(
         if numeric_abilities:
             ability = random.choice(list(numeric_abilities.values()))
 
-    ev = get_ev_spread(random.choice(["random", "pair", "defense", "uniform"]))
+    # Full competitive spreads gave every wild Pokemon up to 510 EVs from
+    # level 1, dwarfing the player's slowly-earned EVs; scale the budget to
+    # the wild Pokemon's level so its "training" matches its experience.
+    ev = scale_ev_spread_to_level(
+        get_ev_spread(random.choice(["random", "pair", "defense", "uniform"])),
+        wild_pokemon_lvl,
+    )
     stat_names = ["hp", "atk", "def", "spa", "spd", "spe"]
     iv = {stat: random.randint(0, 31) for stat in stat_names}
     nature = random.choice(ALL_NATURES)

--- a/src/Ankimon/pyobj/test_window.py
+++ b/src/Ankimon/pyobj/test_window.py
@@ -212,7 +212,9 @@ class TestWindow(QWidget):
     def _draw_cp_pp(self, painter):
         """Draw CP and Battle Power labels for both Pokemon.
 
-        Battle Power = CP * current_HP * type-matchup multiplier.
+        Battle Power = CP * (current_HP / max_HP) * type-matchup multiplier
+        * attack-stage factor — same scale as CP, so the two Pokemon's BP
+        values are directly comparable.
 
         The player box has an empty bottom-left column, so its two lines sit
         inside the box, sharing the HP numbers' font and baseline grid. The
@@ -256,6 +258,7 @@ class TestWindow(QWidget):
         enemy_bp = calculate_present_power(
             enemy_cp,
             getattr(self.enemy_pokemon, "hp", 0),
+            getattr(self.enemy_pokemon, "max_hp", 0),
             enemy_vs_main,
             enemy_stages.get("atk", 0),
             enemy_stages.get("spa", 0),
@@ -263,6 +266,7 @@ class TestWindow(QWidget):
         main_bp = calculate_present_power(
             main_cp,
             getattr(self.main_pokemon, "hp", 0),
+            getattr(self.main_pokemon, "max_hp", 0),
             main_vs_enemy,
             main_stages.get("atk", 0),
             main_stages.get("spa", 0),

--- a/src/Ankimon/utils.py
+++ b/src/Ankimon/utils.py
@@ -880,6 +880,29 @@ def get_ev_spread(mode: str = "random") -> dict[str, int]:
     raise ValueError(f"Received unknown value for 'mode': {mode}")
 
 
+def scale_ev_spread_to_level(ev: dict[str, int], level: int) -> dict[str, int]:
+    """Scale an EV spread down to a budget appropriate for ``level``.
+
+    ``get_ev_spread`` hands out full competitive budgets (up to 510 EVs),
+    which made every wild Pokemon stat-inflated relative to the player's,
+    whose Pokemon earns EVs a few points per defeat. A wild Pokemon has
+    only "trained" as long as its level implies, so its budget ramps
+    linearly with level — ``min(510, level × 5.1)`` — reaching the full
+    510 exactly at level 100. The spread's *shape* (which stats it
+    favours) is preserved; each stat stays within the per-stat 252 cap.
+    """
+    try:
+        level = int(level)
+    except (TypeError, ValueError):
+        level = 1
+    budget = min(510, max(0, round(level * 5.1)))
+    total = sum(max(0, int(v)) for v in ev.values())
+    if total <= budget:
+        return {k: min(252, max(0, int(v))) for k, v in ev.items()}
+    scale = budget / total
+    return {k: min(252, int(max(0, int(v)) * scale)) for k, v in ev.items()}
+
+
 def get_tier_by_id(pokemon_id: int) -> Optional[str]:
     """
     Determines the tier category of a Pokémon based on its ID.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -86,9 +86,17 @@ def restore_package_stubs():
                     sys.modules.pop("Ankimon.resources", None)
                 raise
 
-        # Also restore Ankimon.utils if it is a MagicMock
+        # Also restore Ankimon.utils if it is a MagicMock or a partial stub.
+        # The sentinel-attribute check mirrors the pokedex_path check above:
+        # some tests install a plain types.ModuleType stub carrying only the
+        # one function they fake (e.g. give_item), which would otherwise
+        # leak and break any later test that lazily imports real helpers.
         current_utils = sys.modules.get("Ankimon.utils")
-        if current_utils is None or isinstance(current_utils, MagicMock):
+        if (
+            current_utils is None
+            or isinstance(current_utils, MagicMock)
+            or not hasattr(current_utils, "get_ev_spread")
+        ):
             import importlib.util
 
             utils_spec = importlib.util.spec_from_file_location(

--- a/tests/encounter_weighting_simulations/test_encounter_simulation.py
+++ b/tests/encounter_weighting_simulations/test_encounter_simulation.py
@@ -188,6 +188,7 @@ collected_ids_mock = set(range(1, 11000))
 sys.modules["addon.utils"].limit_ev_yield = lambda *args: None
 sys.modules["addon.utils"].play_effect_sound = lambda *args: None
 sys.modules["addon.utils"].get_ev_spread = lambda *args: {}
+sys.modules["addon.utils"].scale_ev_spread_to_level = lambda ev, level: ev
 sys.modules["addon.utils"].is_alive = lambda *args: True
 sys.modules["addon.utils"].load_collected_pokemon_ids = lambda: collected_ids_mock
 

--- a/tests/test_cp_formula.py
+++ b/tests/test_cp_formula.py
@@ -146,40 +146,58 @@ class TestTypeCompatibilityMultiplier:
 
 
 class TestCalculatePresentPower:
-    def test_basic(self):
-        pp = calculate_present_power(100, 50, 1.0)
-        assert pp == 5000
+    def test_full_hp_neutral_equals_cp(self):
+        # BP is on the CP scale: full HP + neutral matchup → BP == CP
+        assert calculate_present_power(100, 50, 50, 1.0) == 100
+
+    def test_half_hp_halves_bp(self):
+        assert calculate_present_power(100, 25, 50, 1.0) == 50
 
     def test_with_multiplier(self):
-        pp = calculate_present_power(100, 50, 1.5)
-        assert pp == 7500
+        pp = calculate_present_power(100, 50, 50, 1.5)
+        assert pp == 150
 
     def test_zero_hp(self):
-        pp = calculate_present_power(100, 0, 1.5)
+        pp = calculate_present_power(100, 0, 50, 1.5)
         assert pp == 0
+
+    def test_negative_hp_clamps_to_zero(self):
+        # The current_hp clamp must run BEFORE the max_hp<=0 liveness check:
+        # a negative current_hp is dead, never "living = full health".
+        assert calculate_present_power(100, -5, 50, 1.0) == 0
+        assert calculate_present_power(100, -5, 0, 1.0) == 0
 
     def test_none_values(self):
-        pp = calculate_present_power(None, None, None)
+        pp = calculate_present_power(None, None, None, None)
         assert pp == 0
 
+    def test_unknown_max_hp_treats_living_as_unhurt(self):
+        # max_hp 0/None (stub data) → living Pokemon counts as full health
+        assert calculate_present_power(100, 50, 0, 1.0) == 100
+        assert calculate_present_power(100, 50, None, 1.0) == 100
+
+    def test_overheal_clamps_to_full(self):
+        # current_hp above max_hp must not push BP past CP
+        assert calculate_present_power(100, 80, 50, 1.0) == 100
+
     def test_atk_boost_increases_bp(self):
-        # +2 stage = 5/3, BP = 100 × 50 × 1 × 5/3 = 8333.33 → floor 8333
-        assert calculate_present_power(100, 50, 1.0, atk_stage=2, spa_stage=2) == 8333
+        # +2 stage = 5/3, BP = 100 × 1 × 1 × 5/3 = 166.66 → floor 166
+        assert calculate_present_power(100, 50, 50, 1.0, atk_stage=2, spa_stage=2) == 166
 
     def test_atk_drop_decreases_bp(self):
-        # -2 stage = 3/5 = 0.6, BP = 100 × 50 × 1 × 0.6 = 3000
-        assert calculate_present_power(100, 50, 1.0, atk_stage=-2, spa_stage=-2) == 3000
+        # -2 stage = 3/5 = 0.6, BP = 100 × 1 × 1 × 0.6 = 60
+        assert calculate_present_power(100, 50, 50, 1.0, atk_stage=-2, spa_stage=-2) == 60
 
     def test_mixed_atk_spa_stages_averaged(self):
-        # atk +2 (5/3), spa -2 (3/5), avg = 17/15, BP = 5000 × 17/15 = 5666.66 → floor 5666
-        assert calculate_present_power(100, 50, 1.0, atk_stage=2, spa_stage=-2) == 5666
+        # atk +2 (5/3), spa -2 (3/5), avg = 17/15, BP = 100 × 17/15 = 113.33 → floor 113
+        assert calculate_present_power(100, 50, 50, 1.0, atk_stage=2, spa_stage=-2) == 113
 
     def test_out_of_range_stage_neutral(self):
         # Stage 7 is invalid per get_multiplier_stats — should fall back to 1.0
-        assert calculate_present_power(100, 50, 1.0, atk_stage=7, spa_stage=7) == 5000
+        assert calculate_present_power(100, 50, 50, 1.0, atk_stage=7, spa_stage=7) == 100
 
     def test_none_stage_neutral(self):
-        assert calculate_present_power(100, 50, 1.0, atk_stage=None, spa_stage=None) == 5000
+        assert calculate_present_power(100, 50, 50, 1.0, atk_stage=None, spa_stage=None) == 100
 
 
 class TestCalculateCPFromDict:

--- a/tests/test_ev_spread_scaling.py
+++ b/tests/test_ev_spread_scaling.py
@@ -1,0 +1,107 @@
+"""Tier-1 contract for utils.scale_ev_spread_to_level (wild-Pokemon EV fairness).
+
+get_ev_spread hands out full competitive budgets (up to 510 EVs). Unscaled,
+every wild Pokemon spawned stat-inflated relative to the player's Pokemon,
+which earns EVs a few points per defeat — the root cause of enemy CP/BP
+readouts dwarfing the player's in the early game. The scaler caps a wild
+Pokemon's total EVs at min(510, level × 5.1) while preserving the spread's
+shape and the per-stat 252 cap.
+"""
+
+import pytest
+
+
+@pytest.fixture
+def ev_funcs():
+    # Imported lazily (repo convention): module-level Ankimon imports at
+    # collection time race with other test modules' resources stubs; the
+    # autouse conftest fixture restores the real modules around each test.
+    from Ankimon.utils import get_ev_spread, scale_ev_spread_to_level
+
+    return get_ev_spread, scale_ev_spread_to_level
+
+
+STATS = ["hp", "atk", "def", "spa", "spd", "spe"]
+
+
+def _total(ev):
+    return sum(ev.values())
+
+
+class TestScaleEvSpreadToLevel:
+    def test_low_level_shrinks_full_spread(self, ev_funcs):
+        _, scale_ev_spread_to_level = ev_funcs
+        ev = {"hp": 0, "atk": 252, "def": 0, "spa": 252, "spd": 4, "spe": 0}
+        scaled = scale_ev_spread_to_level(ev, 10)
+        assert _total(scaled) <= 51  # 10 × 5.1
+
+    def test_level_100_keeps_full_budget(self, ev_funcs):
+        _, scale_ev_spread_to_level = ev_funcs
+        ev = {"hp": 0, "atk": 252, "def": 0, "spa": 252, "spd": 4, "spe": 0}
+        scaled = scale_ev_spread_to_level(ev, 100)
+        assert scaled == ev  # 508 <= 510 budget → untouched
+
+    def test_shape_preserved(self, ev_funcs):
+        _, scale_ev_spread_to_level = ev_funcs
+        # A stat with 0 EVs stays 0; the favoured stats stay favoured.
+        ev = {"hp": 0, "atk": 252, "def": 0, "spa": 252, "spd": 4, "spe": 0}
+        scaled = scale_ev_spread_to_level(ev, 40)
+        assert scaled["hp"] == scaled["def"] == scaled["spe"] == 0
+        assert scaled["atk"] == scaled["spa"] > scaled["spd"]
+
+    def test_budget_grows_linearly_with_level(self, ev_funcs):
+        _, scale_ev_spread_to_level = ev_funcs
+        ev = {s: 85 for s in STATS}  # 510 total
+        totals = [_total(scale_ev_spread_to_level(ev, lvl)) for lvl in (10, 30, 60, 100)]
+        assert totals == sorted(totals)
+        assert totals[0] < totals[-1]
+
+    def test_per_stat_cap_respected(self, ev_funcs):
+        _, scale_ev_spread_to_level = ev_funcs
+        ev = {"hp": 252, "atk": 252, "def": 4, "spa": 0, "spd": 0, "spe": 0}
+        for lvl in (1, 25, 50, 75, 100):
+            scaled = scale_ev_spread_to_level(ev, lvl)
+            assert all(0 <= v <= 252 for v in scaled.values())
+
+    def test_small_spread_untouched(self, ev_funcs):
+        _, scale_ev_spread_to_level = ev_funcs
+        # A spread already under budget passes through unchanged.
+        ev = {"hp": 10, "atk": 20, "def": 0, "spa": 5, "spd": 0, "spe": 0}
+        assert scale_ev_spread_to_level(ev, 20) == ev
+
+    def test_garbage_level_falls_back_to_1(self, ev_funcs):
+        _, scale_ev_spread_to_level = ev_funcs
+        ev = {s: 85 for s in STATS}
+        scaled = scale_ev_spread_to_level(ev, "not-a-level")
+        assert _total(scaled) <= 5  # level 1 budget
+
+    def test_negative_values_clamped(self, ev_funcs):
+        _, scale_ev_spread_to_level = ev_funcs
+        ev = {"hp": -10, "atk": 600, "def": 0, "spa": 0, "spd": 0, "spe": 0}
+        scaled = scale_ev_spread_to_level(ev, 50)
+        assert scaled["hp"] == 0
+        assert 0 <= scaled["atk"] <= 252
+
+    def test_per_stat_cap_applies_under_budget_too(self, ev_funcs):
+        _, scale_ev_spread_to_level = ev_funcs
+        # One stat over 252 but total within budget must still be capped —
+        # the pass-through branch enforces the same invariant as scaling.
+        ev = {"hp": 0, "atk": 400, "def": 0, "spa": 0, "spd": 0, "spe": 0}
+        assert scale_ev_spread_to_level(ev, 100)["atk"] == 252
+
+    def test_empty_dict_no_division_error(self, ev_funcs):
+        _, scale_ev_spread_to_level = ev_funcs
+        # total=0 must short-circuit before budget/total division
+        assert scale_ev_spread_to_level({}, 10) == {}
+        assert scale_ev_spread_to_level({s: 0 for s in STATS}, 0) == {
+            s: 0 for s in STATS
+        }
+
+    @pytest.mark.parametrize("mode", ["random", "pair", "defense", "uniform"])
+    def test_every_generator_mode_lands_within_budget(self, ev_funcs, mode):
+        get_ev_spread, scale_ev_spread_to_level = ev_funcs
+        for lvl in (1, 12, 47, 100):
+            scaled = scale_ev_spread_to_level(get_ev_spread(mode), lvl)
+            assert _total(scaled) <= min(510, round(lvl * 5.1))
+            assert all(0 <= v <= 252 for v in scaled.values())
+            assert set(scaled) == set(STATS)


### PR DESCRIPTION
## Problem

BP (Battle Power) was effectively meaningless — enemy BP almost always dwarfed the player's, so the stat told you nothing. Two independent causes, both measured with the headless harness over 900 encounters:

1. **BP double-counted HP.** `calculate_present_power` multiplied CP by **absolute** current HP, producing million-scale numbers. Stamina is already inside CP, so HP was counted twice, and the magnitude made the number unreadable.
2. **Wild Pokémon were competitively EV-trained from level 1.** `generate_random_pokemon` gave every wild mon a full `get_ev_spread()` budget (~508 EVs) regardless of level, while the player's Pokémon earns EVs 1–3 at a time per defeat. At low levels this alone inflated enemy CP by ~40–45%.

Measured on `main`, an early-game player (L12, 0 EVs) saw **enemy BP higher in 88% of encounters** — median ratio 2.4×, p90 6.0×.

## Fix

**1. BP is now on the CP scale** (`business.calculate_present_power`):

```
BP = CP × (current_hp / max_hp) × type_multiplier × avg(atk, spa) stage factor
```

At full HP with a neutral matchup and no boosts, **BP == CP**, so the two Pokémon's readouts are directly comparable. BP now moves meaningfully within a battle: it shrinks as a Pokémon takes damage, and grows with stat boosts (Swords Dance) or a type advantage. Takes a new `max_hp` parameter; `max_hp <= 0` (stub/corrupt data) treats a living Pokémon as unhurt, and over-heal clamps to full.

**2. Wild EV budgets scale with level** (new `utils.scale_ev_spread_to_level`, applied in `generate_random_pokemon`):

```
budget = min(510, level × 5.1)
```

A wild Pokémon has only "trained" as long as its level implies. The spread's *shape* (which stats it favours) is preserved, and the per-stat 252 cap holds in both branches. A level-100 wild keeps today's full spread; a level-12 one no longer arrives competitively trained.

| Wild level | EVs (before → after) | CP (before → after) |
|---|---|---|
| 5 | 508 → 24 | 36 → 20 |
| 12 | 508 → 60 | 193 → 113 |
| 25 | 508 → 127 | 724 → 467 |
| 50 | 508 → 254 | 2,205 → 1,681 |
| 100 | 508 → 508 | 5,336 → 5,336 (unchanged) |

## Result

Same early-game simulation after the fix: enemy BP higher in **36% of encounters**, ratio centered on **1.0** for a median-strength Pokémon. A genuinely weak lead (low-level Pikachu) still correctly reads as outmatched — the stat now carries information instead of always saying the same thing. Mid/late game is unchanged in direction (the player still outscales, as before).

## Validation

- **Full pytest suite: 543 passed.** Updated `TestCalculatePresentPower` for the new formula; new `tests/test_ev_spread_scaling.py` (12 tests) pins the EV scaler's budget curve, shape preservation, per-stat cap, and garbage-input handling.
- **Tier-1 harness gate green** (9/9) and **Tier-2 offscreen render** of the real battle window: fainted enemy draws `BP 0`, healthy mon at full HP draws `BP == CP`.
- **In-battle behavior driven end-to-end**: enemy BP fell as it took damage across 6 cards; a +2/+2 boost raised main BP 2293 → 3822.
- **15-agent adversarial review** of the diff across correctness / game-balance / API-compat / test-quality. Confirmed findings were fixed and re-verified: a missing per-stat cap on the under-budget branch, a test-ordering hazard from a leaked module stub (hardened `tests/conftest.py`), and the new helper being unstubbed in the opt-in Monte Carlo sim. The review also confirmed **no downstream regressions** — caught Pokémon are unaffected because `save_caught_pokemon` zeroes EVs on capture anyway, and desktop + mobile encounters share the one generator.

## Notes for review

- `calculate_present_power` gained a **third positional parameter** (`max_hp`). Its only production caller is `pyobj/test_window.py`, updated here; grep confirms no other call sites in `src/`, `harness/`, or tests.
- The difficulty easing at low levels is the intended consequence of the EV fix, not a side effect — wild Pokémon were previously stronger than the game's own EV rules allow for their level.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

- [x] I consent to my email being public in the commit history