### PR TITLE
feat: CP/BP readout toggles for the native reviewer bottom bar

### DIFF
--- a/harness/fake_aqt.py
+++ b/harness/fake_aqt.py
@@ -281,7 +281,11 @@ def _make_fake_mw(app, user_path):
             super().__init__()
             self.app = app
             self.col = _Col()
-            self.reviewer = SimpleNamespace(web=_Web(), card=None, mw=self)
+            # bottom mirrors real Anki's mw.reviewer.bottom (the native bottom
+            # toolbar webview) — Ankimon paints the CP/BP readout into it.
+            self.reviewer = SimpleNamespace(
+                web=_Web(), bottom=SimpleNamespace(web=_Web()), card=None, mw=self
+            )
             self.taskman = _Taskman()
             self.addonManager = _AddonManager()
             self.pm = SimpleNamespace(name="headless", profileFolder=lambda: str(user_path),

--- a/harness/scenarios/feature_check.py
+++ b/harness/scenarios/feature_check.py
@@ -172,7 +172,52 @@ def check_update_channel(d, app, db, pc, pool):
             app.processEvents()
 
 
-CHECKS = [check_rename, check_make_favorite, check_catch_grows_collection, check_update_channel]
+def check_cp_bp_bottom_bar(d, app, db, pc, pool):
+    """The CP/BP readout in the NATIVE reviewer bottom bar
+    (gui.show_cp_in_reviewer / gui.show_bp_in_reviewer): each toggle alone shows
+    only its value, both together show both, and both off clears the readout."""
+    import json as _json
+    from aqt import mw
+
+    settings, reviewer = d.services.settings, d.services.reviewer
+    bottom = mw.reviewer.bottom.web
+
+    def paint(cp, bp):
+        settings.set("gui.show_cp_in_reviewer", cp)
+        settings.set("gui.show_bp_in_reviewer", bp)
+        bottom.last_js = None
+        # The show-question repaint path (card_hooks.on_reviewer_did_show_question).
+        reviewer.update_life_bar(mw.reviewer, None, None)
+        return bottom.last_js or ""
+
+    def payload(js):
+        # _BOTTOM_CP_BP_JS ends with `})(<json-encoded text>);` — recover the text.
+        start = js.rindex("})(") + 3
+        return _json.loads(js[start:js.rindex(")")])
+
+    main_cp = int(d.services.main_pokemon.cp)
+    try:
+        both = payload(paint(True, True))
+        cp_only = payload(paint(True, False))
+        bp_only = payload(paint(False, True))
+        off = payload(paint(False, False))     # also leaves the session's settings clean
+    except ValueError:
+        return ("cp_bp_bottom_bar (toggles + readout)", False,
+                "no CP/BP JS was eval'd into the bottom-bar webview")
+
+    ok = (
+        ("CP %s" % format(main_cp, ",")) in both and " BP " in (" " + both)
+        and both.startswith("Wild: ") and " | Main: " in both
+        and "CP " in cp_only and "BP " not in cp_only
+        and "BP " in bp_only and "CP " not in bp_only
+        and off == ""
+    )
+    return ("cp_bp_bottom_bar (toggles + readout)", ok,
+            "both=%r cp_only=%r bp_only=%r off=%r" % (both, cp_only, bp_only, off))
+
+
+CHECKS = [check_rename, check_make_favorite, check_catch_grows_collection, check_update_channel,
+          check_cp_bp_bottom_bar]
 
 
 def _boot():

--- a/src/Ankimon/config.json
+++ b/src/Ankimon/config.json
@@ -29,6 +29,8 @@
     "gui.reviewer_text_message_box": true,
     "gui.reviewer_text_message_box_time": 3,
     "gui.show_mainpkmn_in_reviewer": 1,
+    "gui.show_cp_in_reviewer": false,
+    "gui.show_bp_in_reviewer": false,
     "gui.hud_hidden_on_startup": false,
     "gui.team_deck_view": true,
     "gui.view_main_front": true,

--- a/src/Ankimon/config.md
+++ b/src/Ankimon/config.md
@@ -26,6 +26,11 @@ Main Pokemon in Reviewer:
 If `show_mainpkmn_in_reviewer` is set to 0, you will only see the wild Pokémon when reviewing cards. Setting it to 1 will display both your main Pokémon and the wild Pokémon in the reviewer, with the HP bar on the same height. If set to 2, you'll have a more "battle" look between your main Pokémon and the wild Pokémon.
 - `show_mainpkmn_in_reviewer` [0/1/2]
 
+CP and Battle Power in the Reviewer Bottom Bar:
+Show the Combat Power (CP) and/or the live Battle Power (BP = CP × current HP × type matchup) of the wild and your main Pokémon in the bottom bar of the Anki reviewer (next to the Edit button). Enable either one alone, or both together.
+- `show_cp_in_reviewer` [True/False]
+- `show_bp_in_reviewer` [True/False]
+
 Reviewer Text Message Box:
 Decide if you would like to see the colorful popup messages in the anki reviewer
 - `reviewer_text_message_box` [True/False]

--- a/src/Ankimon/lang/setting_description.json
+++ b/src/Ankimon/lang/setting_description.json
@@ -31,6 +31,8 @@
     "gui.reviewer_text_message_box": "Enable colorful pop-up messages in the reviewer.",
     "gui.reviewer_text_message_box_time": "Duration for message box display in seconds [1-5].",
     "gui.show_mainpkmn_in_reviewer": "Show main Pokémon in reviewer. [0: Hide, 1: Same level view, 2: Battle view]",
+    "gui.show_cp_in_reviewer": "Show the Combat Power (CP) of the wild and your main Pokémon in the bottom bar of the Anki reviewer. Enable together with BP to show both.",
+    "gui.show_bp_in_reviewer": "Show the live Battle Power (BP = CP × current HP × type matchup) of the wild and your main Pokémon in the bottom bar of the Anki reviewer. Enable together with CP to show both.",
     "gui.hud_hidden_on_startup": "Hide the Heads-Up Display (HUD) when the reviewer starts.",
     "gui.team_deck_view": "Enable a quick overview of your Pokémon team at the bottom of the deck overview.",
     "gui.view_main_front": "View front of main Pokémon in reviewer when GIFs are enabled. Set Disabled to show from the back.",

--- a/src/Ankimon/lang/setting_name.json
+++ b/src/Ankimon/lang/setting_name.json
@@ -34,6 +34,8 @@
     "gui.reviewer_text_message_box": "Show Text Message Box in Reviewer",
     "gui.reviewer_text_message_box_time": "Message Box Display Time",
     "gui.show_mainpkmn_in_reviewer": "Show Main Pokémon in Reviewer",
+    "gui.show_cp_in_reviewer": "Show CP in Reviewer Bottom Bar",
+    "gui.show_bp_in_reviewer": "Show Battle Power (BP) in Reviewer Bottom Bar",
     "gui.hud_hidden_on_startup": "Hide HUD on Reviewer Startup",
     "gui.team_deck_view": "Team Overview in Deck Overview",
     "gui.view_main_front": "View Main Pokémon Front",

--- a/src/Ankimon/pyobj/reviewer_obj.py
+++ b/src/Ankimon/pyobj/reviewer_obj.py
@@ -128,6 +128,90 @@ class Reviewer_Manager:
         except Exception:
             pass
 
+    # Injected into the NATIVE reviewer bottom bar (mw.reviewer.bottom.web),
+    # not the card webview: creates/updates a small span next to the Edit
+    # button, or removes it when the readout is empty (both toggles off).
+    # textContent (never innerHTML) so the payload stays plain text.
+    _BOTTOM_CP_BP_JS = """
+    (function(txt){
+        var el = document.getElementById('ankimon-cp-bp');
+        if (!txt) { if (el && el.parentNode) el.parentNode.removeChild(el); return; }
+        if (!el) {
+            var cell = document.querySelector('td.stat');
+            if (!cell) return;
+            el = document.createElement('span');
+            el.id = 'ankimon-cp-bp';
+            el.className = 'stattxt';
+            el.style.marginLeft = '8px';
+            el.style.whiteSpace = 'nowrap';
+            cell.appendChild(el);
+        }
+        el.textContent = txt;
+    })(%s);
+    """
+
+    def _cp_bp_display_text(self, show_cp, show_bp):
+        """Plain-text CP/BP readout for the bottom bar, wild side then main side.
+
+        Same math as the battle window's ``_draw_cp_pp``: CP is the Pokémon GO
+        style Combat Power, BP the live Present Power (CP × current HP × type
+        matchup × attack stages), each side computed against the other's types.
+        """
+        # Lazy import keeps this module loadable with ``Ankimon.business``
+        # absent (the reviewer_obj unit tests stub only reviewer_obj's own
+        # top-level imports).
+        from ..business import calculate_present_power, type_compatibility_multiplier
+
+        try:
+            translator = getattr(services, "translator", None)
+            cp_lbl = translator.translate("cp_label") if translator else "CP"
+            bp_lbl = translator.translate("bp_label") if translator else "BP"
+        except Exception:
+            cp_lbl, bp_lbl = "CP", "BP"
+
+        def side(pkmn, opponent):
+            try:
+                cp_val = int(pkmn.cp)
+            except (AttributeError, TypeError, ValueError):
+                cp_val = 0
+            parts = []
+            if show_cp:
+                parts.append(f"{cp_lbl} {cp_val:,}")
+            if show_bp:
+                stages = getattr(pkmn, "stat_stages", None) or {}
+                bp_val = calculate_present_power(
+                    cp_val,
+                    getattr(pkmn, "hp", 0),
+                    type_compatibility_multiplier(
+                        getattr(pkmn, "type", None), getattr(opponent, "type", None)
+                    ),
+                    stages.get("atk", 0),
+                    stages.get("spa", 0),
+                )
+                parts.append(f"{bp_lbl} {bp_val:,}")
+            return " · ".join(parts)
+
+        wild = side(self.enemy_pokemon, self.main_pokemon)
+        mine = side(self.main_pokemon, self.enemy_pokemon)
+        return f"Wild: {wild} | Main: {mine}"
+
+    def _update_bottom_cp_bp(self):
+        """Paint (or clear) the CP/BP readout in the native reviewer bottom bar.
+
+        Runs on every repaint entry (question shown / refresh_hud), so the BP
+        tracks live HP and stat stages. Silently a no-op when the reviewer or
+        its bottom webview isn't available (harness, dialogs outside review).
+        """
+        try:
+            show_cp = bool(self.settings.get("gui.show_cp_in_reviewer"))
+            show_bp = bool(self.settings.get("gui.show_bp_in_reviewer"))
+            text = ""
+            if show_cp or show_bp:
+                text = self._cp_bp_display_text(show_cp, show_bp)
+            mw.reviewer.bottom.web.eval(self._BOTTOM_CP_BP_JS % json.dumps(text))
+        except Exception:
+            pass
+
     def _resolve_addon_package(self):
         """Return the add-on package name for building /_addons/ media URLs."""
         try:
@@ -155,6 +239,11 @@ class Reviewer_Manager:
             return  # Hook from reviewer_did_answer_card
         if card is not None and not isinstance(card, int):
             return  # Hook received a Card object
+
+        # The CP/BP readout lives in the NATIVE bottom bar, not the HUD
+        # overlay — paint it before the HUD-off early-return and the repaint
+        # dedup below so it stays available (and clearable) in every HUD mode.
+        self._update_bottom_cp_bp()
 
         if int(self.settings.get("gui.show_mainpkmn_in_reviewer")) == 3:
             reviewer.web.eval("if(window.__ankimonHud) window.__ankimonHud.clear();")

--- a/src/Ankimon/pyobj/settings.py
+++ b/src/Ankimon/pyobj/settings.py
@@ -41,6 +41,8 @@ DEFAULT_CONFIG = {
     "gui.reviewer_text_message_box": True,
     "gui.reviewer_text_message_box_time": 3,
     "gui.show_mainpkmn_in_reviewer": 1,
+    "gui.show_cp_in_reviewer": False,
+    "gui.show_bp_in_reviewer": False,
     "gui.hud_hidden_on_startup": False,
     "gui.team_deck_view": True,
     "gui.view_main_front": True,

--- a/src/Ankimon/pyobj/settings_window.py
+++ b/src/Ankimon/pyobj/settings_window.py
@@ -367,6 +367,8 @@ class SettingsWindow(QMainWindow):
                     "Always Catch: Regional Form",
                     "Cards per Round",
                     "Show Main Pokémon in Reviewer",
+                    "Show CP in Reviewer Bottom Bar",
+                    "Show Battle Power (BP) in Reviewer Bottom Bar",
                     "Hide HUD on Reviewer Startup",
                     "Show Pokémon Buttons",
                     "Pop-Up on Defeat",
@@ -772,6 +774,16 @@ class SettingsWindow(QMainWindow):
                 setup_reviewer_ui(catch_key, defeat_key, pokemon_buttons)
         except Exception as e:
             print(f"Ankimon: Failed to refresh hotkeys: {e}")
+
+        # Repaint the reviewer so display toggles (CP/BP bottom-bar readout,
+        # HUD options) apply immediately instead of on the next card flip.
+        try:
+            from ..services import services
+
+            if services.reviewer is not None:
+                services.reviewer.refresh_hud()
+        except Exception as e:
+            print(f"Ankimon: Failed to refresh reviewer HUD: {e}")
 
         # The rest is for showing the confirmation message
         excluded_patterns = {


### PR DESCRIPTION
### Description

Adds two new settings that let you show your Pokémon's **CP** (Combat Power) and/or **BP** (live Battle Power) in the **native Anki reviewer's bottom bar** — the real toolbar next to the Edit button, *not* the Ankimon battle window.

- `gui.show_cp_in_reviewer` — **Show CP in Reviewer Bottom Bar** (default: off)
- `gui.show_bp_in_reviewer` — **Show Battle Power (BP) in Reviewer Bottom Bar** (default: off)

Both are independent toggles, so all four combinations work: **CP only**, **BP only**, **both together**, or **neither** (the readout is removed entirely). They live in Settings → Battle, right under "Show Main Pokémon in Reviewer".

The readout renders as, e.g.:

```
Wild: CP 81 · BP 2,349 | Main: CP 10 · BP 190
```

**Why:** CP/BP were previously only visible inside the Ankimon battle window, so you had to open it to judge a matchup. Many users keep that window closed while reviewing; this surfaces the same numbers where they're already looking.

**How it works**
- `reviewer_obj._update_bottom_cp_bp()` paints a `stattxt` span into `mw.reviewer.bottom.web` on every repaint entry (question shown / `refresh_hud`), so **BP tracks live HP and stat stages** during a battle.
- It runs *before* the HUD-off early-return and the repaint dedup, so it works in **every HUD mode** — including HUD hidden — and clears correctly when both toggles are off.
- The maths reuses the existing `calculate_present_power` / `type_compatibility_multiplier` from `business.py`, identical to the battle window's `_draw_cp_pp`, with each side evaluated against the other's types.
- The payload is written with `textContent` (never `innerHTML`), so Pokémon names/labels can't inject markup.
- Saving settings now calls `services.reviewer.refresh_hud()`, so the toggles apply **immediately** instead of on the next card flip.

### Related Issue
<!-- none -->

### Checklist
- [x] My code follows the code style and guidelines of this project.
- [x] I have run tests locally (`pytest tests/` and `pytest tests/test_addon_integrity.py`) and they all pass.
- [ ] **(Optional)** I have added/updated my entry in `.all-contributorsrc` at the root of the repository to specify my custom `"nickname"` and `"discord_id"` for release announcements and Discord pings.

---

### Validation

- **Tier-1 harness gate** (`python3 harness/check.py`): **9/9 green**.
- **Test suite**: **521 passed**, 62 skipped. `ruff` clean on all changed files.
- **Tier-2 acceptance test** — added `check_cp_bp_bottom_bar` to `harness/scenarios/feature_check.py`, which boots the real add-on and drives the real settings, asserting each combination end to end. It passes on every run:
  ```
  [PASS] cp_bp_bottom_bar (toggles + readout)
         both='Wild: CP 41 · BP 1,025 | Main: CP 10 · BP 190'
         cp_only='Wild: CP 41 | Main: CP 10'
         bp_only='Wild: BP 1,025 | Main: BP 190'
         off=''
  ```
- **Injected JavaScript** verified against a real DOM replica of Anki's bottom bar (JS extracted from the source file, so it can't drift): creates the span in `td.stat`, updates in place without duplicating per card, clears on empty payload, re-creates after clearing, survives Anki's per-card rewrite of the answer-button cell, doesn't throw when no `td.stat` exists, and does not allow HTML injection.

> Note on the harness: `feature_check`'s pre-existing `update_channel` and `rename` checks fail on this machine **on a clean `main` checkout too** (macOS offscreen-Qt flakiness / unrelated), so they're not regressions from this PR.

### Notes for the reviewer
- Both settings default to **off**, so existing users see no change until they opt in.
- `harness/fake_aqt.py` gained a `mw.reviewer.bottom.web` stub to mirror real Anki; this is dev-only and never ships in the `.ankiaddon`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
