### PR TITLE
fix: require linking cord for plain trade evolutions

### DIFF
--- a/src/Ankimon/functions/pokedex_functions.py
+++ b/src/Ankimon/functions/pokedex_functions.py
@@ -864,13 +864,17 @@ def check_evolution_by_item(pokemon_id, item_id):
                             # apostrophes so pokedex.json display names (e.g.
                             # "King's Rock") match items.csv identifiers (e.g.
                             # "kings-rock"), which drop the apostrophe.
-                            required_item = (
-                                (target_data.get("evoItem") or "")
-                                .lower()
-                                .replace(" ", "")
-                                .replace("-", "")
-                                .replace("'", "")
-                            )
+                            # Plain trade evolutions require a Linking Cord in Ankimon.
+                            if target_data.get("evoType") == "trade" and not target_data.get("evoItem"):
+                                required_item = "linkingcord"
+                            else:
+                                required_item = (
+                                    (target_data.get("evoItem") or "")
+                                    .lower()
+                                    .replace(" ", "")
+                                    .replace("-", "")
+                                    .replace("'", "")
+                                )
                             normalized_item_name = (
                                 (item_name or "")
                                 .lower()
@@ -911,15 +915,18 @@ def check_evolution_by_item(pokemon_id, item_id):
                                             and sib_data.get("evoRegion").lower()
                                             == active_region.lower()
                                         ):
+                                            sib_req_item = sib_data.get("evoItem") or ""
+                                            target_req_item = target_data.get("evoItem") or ""
+                                            if sib_data.get("evoType") == "trade" and not sib_req_item:
+                                                sib_req_item = "linkingcord"
+                                            if target_data.get("evoType") == "trade" and not target_req_item:
+                                                target_req_item = "linkingcord"
+
                                             if (
                                                 sib_data.get("evoType")
                                                 == target_data.get("evoType")
-                                                and (
-                                                    sib_data.get("evoItem") or ""
-                                                ).lower()
-                                                == (
-                                                    target_data.get("evoItem") or ""
-                                                ).lower()
+                                                and sib_req_item.lower().replace(" ", "").replace("-", "").replace("'", "")
+                                                == target_req_item.lower().replace(" ", "").replace("-", "").replace("'", "")
                                             ):
                                                 has_matching_regional_sibling = True
                                                 break

--- a/tests/test_pokedex_evolution_bug.py
+++ b/tests/test_pokedex_evolution_bug.py
@@ -580,3 +580,50 @@ def test_check_evolution_for_pokemon_none_window_skips_cleanly(monkeypatch):
     # "no offer" without crashing or warning.
     assert _PF.check_evolution_for_pokemon("iid", 90401, 20, None) is None
     _PF.show_warning_with_traceback.assert_not_called()
+
+def test_plain_trade_evolutions_require_linking_cord(monkeypatch):
+    """
+    Plain trade evolutions (like Machoke -> Machamp) specify evoType="trade"
+    but no evoItem. These must inherently require a 'linkingcord' (item 2160)
+    rather than nothing. Held-item trades (like Onix -> Steelix) should still
+    require their respective evoItem (Metal Coat, item 210).
+    """
+    class DummyEvoWin:
+        pass
+
+    _install_synthetic_pokedex(
+        monkeypatch,
+        {
+            "machoke": {
+                "species_id": 67,
+                "actual_id": 67,
+                "evos": ["Machamp"],
+            },
+            "machamp": {
+                "species_id": 68,
+                "actual_id": 68,
+                "evoType": "trade"
+            },
+            "onix": {
+                "species_id": 95,
+                "actual_id": 95,
+                "evos": ["Steelix"]
+            },
+            "steelix": {
+                "species_id": 208,
+                "actual_id": 208,
+                "evoType": "trade",
+                "evoItem": "Metal Coat"
+            }
+        },
+    )
+
+    # linking cord
+    assert _PF.check_evolution_by_item(67, 2160) == 68
+    # machoke with metal coat should fail
+    assert _PF.check_evolution_by_item(67, 210) is None
+
+    # steelix requires metal coat
+    assert _PF.check_evolution_by_item(95, 210) == 208
+    # steelix with linking cord should fail
+    assert _PF.check_evolution_by_item(95, 2160) is None


### PR DESCRIPTION
Fixes a bug where plain trade-evolutions (like Machoke to Machamp, Haunter to Gengar) were unable to be evolved in Ankimon. The underlying data in `pokedex.json` specifies `"evoType": "trade"` but no item is attached, so the logic in `check_evolution_by_item` couldn't validate the condition. 

This patches the function to detect when a trade evolution lacks an item requirement and implicitly sets the required item to `"linkingcord"`, effectively matching it with the Linking Cord item in Ankimon's economy.

---
*PR created automatically by Jules for task [4865198703532034701](https://jules.google.com/task/4865198703532034701) started by @h0tp-ftw*