### PR TITLE
fix: inject Anki bridge script into isolated webviews to restore pycmd functionality

### DIFF
--- a/fix_ankidex.py
+++ b/fix_ankidex.py
@@ -1,0 +1,23 @@
+import re
+
+def insert_anki_bridge_injection(filepath):
+    with open(filepath, 'r') as f:
+        content = f.read()
+
+    if 'profile.scripts().insert(_bridge_script)' in content:
+        return
+
+    injection = """
+        try:
+            from aqt.webview import _bridge_script
+            if not self.profile.scripts().contains(_bridge_script):
+                self.profile.scripts().insert(_bridge_script)
+        except ImportError:
+            pass
+"""
+    new_content = content.replace("        self.profile = QWebEngineProfile()\n", "        self.profile = QWebEngineProfile()\n" + injection)
+
+    with open(filepath, 'w') as f:
+        f.write(new_content)
+
+insert_anki_bridge_injection('src/Ankimon/ankidex/ankidex_obj.py')

--- a/src/Ankimon/ankidex/ankidex_obj.py
+++ b/src/Ankimon/ankidex/ankidex_obj.py
@@ -43,6 +43,13 @@ class Ankidex(QDialog):
 
         from ..ankimon_items_web.shop_obj import SafeWebEnginePage
         self.profile = QWebEngineProfile()
+
+        try:
+            from aqt.webview import _bridge_script
+            if not self.profile.scripts().contains(_bridge_script):
+                self.profile.scripts().insert(_bridge_script)
+        except ImportError:
+            pass
         self.webview = QWebEngineView()
         self.webview.setPage(SafeWebEnginePage(self.profile, "ankidex_standalone", services.logger, self.webview))
 

--- a/src/Ankimon/ankimon_items_web/shop_obj.py
+++ b/src/Ankimon/ankimon_items_web/shop_obj.py
@@ -41,6 +41,13 @@ class SafeWebEnginePage(QWebEnginePage):
         self.screen_name = screen_name
         self.logger = logger
 
+        try:
+            from aqt.webview import _bridge_script
+            if not profile.scripts().contains(_bridge_script):
+                profile.scripts().insert(_bridge_script)
+        except ImportError:
+            pass
+
     def javaScriptConsoleMessage(self, level, message, line, source):
         """
         Forward JavaScript console messages to the configured logger with a severity level and screen identifier.


### PR DESCRIPTION
Fixes a bug where newly isolated `QWebEngineProfile` webviews were lacking the required `_bridge_script` needed to expose Anki's backend `pycmd` object to Javascript, causing `Cannot read properties of undefined (reading 'cmd')` errors on buttons like 'Save Changes' in Settings and Shop. Injected the `aqt.webview._bridge_script` into both `SafeWebEnginePage` (for all shell screens) and `Ankidex` (standalone view).

---
*PR created automatically by Jules for task [6926828009640487899](https://jules.google.com/task/6926828009640487899) started by @h0tp-ftw*