### PR TITLE
feat(move): move leaderboard credentials to settings

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -229,7 +229,7 @@
       ],
       "nickname": "PENDING_REVIEW",
       "discord_id": "PENDING_REVIEW"
-    }
+    },
     {
       "login": "Nut2026",
       "name": "Nut2026",

--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -230,6 +230,17 @@
       "nickname": "PENDING_REVIEW",
       "discord_id": "PENDING_REVIEW"
     }
+    {
+      "login": "Nut2026",
+      "name": "Nut2026",
+      "avatar_url": "https://github.com/Nut2026.png",
+      "profile": "https://github.com/Nut2026",
+      "contributions": [
+        "code"
+      ],
+      "nickname": "Nuz",
+      "discord_id": "1317008280911876109"
+    }
   ],
   "contributorsPerLine": 5
 }

--- a/src/Ankimon/__init__.py
+++ b/src/Ankimon/__init__.py
@@ -67,16 +67,15 @@ from .pyobj.ankimon_leaderboard import migrate_credentials_from_db
 # once menu_buttons stops building its own translator.
 mw.translator = translator
 
+# ============================================================
 # Migrate leaderboard credentials from database to settings
 # This runs once when Anki starts up
-def _migrate_on_startup():
-    try:
-        migrate_credentials_from_db()
-        print("Ankimon: Leaderboard credentials migration checked")
-    except Exception as e:
-        print(f"Ankimon: Error during leaderboard credentials migration: {e}")
-
-events.on("startup_finished", _migrate_on_startup)
+# ============================================================
+try:
+    migrate_credentials_from_db()
+    print("Ankimon: Leaderboard credentials migration checked")
+except Exception as e:
+    print(f"Ankimon: Error during leaderboard credentials migration: {e}")
 
 # Deck-browser / deck-overview team grid (F19). Registration is gated on the
 # gui.team_deck_view setting and reload-safe (F31 registry-anchored record on

--- a/src/Ankimon/__init__.py
+++ b/src/Ankimon/__init__.py
@@ -56,6 +56,7 @@ from .pyobj.error_handler import show_warning_with_traceback
 from .pyobj.backup_manager import BackupManager
 from .services import services
 from .events import events
+from .pyobj.ankimon_leaderboard import migrate_credentials_from_db
 
 # singletons.py already populated the service registry and mirrored these onto
 # mw (see services.py), so the previous mw.settings_ankimon/logger/settings_obj
@@ -65,6 +66,14 @@ from .events import events
 # instance to keep mw.translator identical to services.translator. Remove this
 # once menu_buttons stops building its own translator.
 mw.translator = translator
+
+# Migrate leaderboard credentials from database to settings
+# This runs once when Anki starts up
+try:
+    migrate_credentials_from_db()
+    print("Ankimon: Leaderboard credentials migration checked")
+except Exception as e:
+    print(f"Ankimon: Error during leaderboard credentials migration: {e}")
 
 # Deck-browser / deck-overview team grid (F19). Registration is gated on the
 # gui.team_deck_view setting and reload-safe (F31 registry-anchored record on

--- a/src/Ankimon/__init__.py
+++ b/src/Ankimon/__init__.py
@@ -69,11 +69,14 @@ mw.translator = translator
 
 # Migrate leaderboard credentials from database to settings
 # This runs once when Anki starts up
-try:
-    migrate_credentials_from_db()
-    print("Ankimon: Leaderboard credentials migration checked")
-except Exception as e:
-    print(f"Ankimon: Error during leaderboard credentials migration: {e}")
+def _migrate_on_startup():
+    try:
+        migrate_credentials_from_db()
+        print("Ankimon: Leaderboard credentials migration checked")
+    except Exception as e:
+        print(f"Ankimon: Error during leaderboard credentials migration: {e}")
+
+events.on("startup_finished", _migrate_on_startup)
 
 # Deck-browser / deck-overview team grid (F19). Registration is gated on the
 # gui.team_deck_view setting and reload-safe (F31 registry-anchored record on

--- a/src/Ankimon/__init__.py
+++ b/src/Ankimon/__init__.py
@@ -68,14 +68,10 @@ from .pyobj.ankimon_leaderboard import migrate_credentials_from_db
 mw.translator = translator
 
 # ============================================================
-# Migrate leaderboard credentials from database to settings
-# This runs once when Anki starts up
+# REMOVED: Module-level migration call
+# migrate_credentials_from_db() now runs in on_startup_complete
+# where services.db is guaranteed to be initialized.
 # ============================================================
-try:
-    migrate_credentials_from_db()
-    print("Ankimon: Leaderboard credentials migration checked")
-except Exception as e:
-    print(f"Ankimon: Error during leaderboard credentials migration: {e}")
 
 # Deck-browser / deck-overview team grid (F19). Registration is gated on the
 # gui.team_deck_view setting and reload-safe (F31 registry-anchored record on
@@ -211,6 +207,16 @@ def start_asynchronous_startup():
         #    for the module-level consumers registered above).
         collected_pokemon_ids.update(results["collected_pokemon_ids"])
         init_battle_state(collected_pokemon_ids)
+
+        # ============================================================
+        # LEADERBOARD CREDENTIALS MIGRATION
+        # Now runs here where services.db is guaranteed to be initialized
+        # ============================================================
+        try:
+            migrate_credentials_from_db()
+            print("Ankimon: Leaderboard credentials migration checked")
+        except Exception as e:
+            print(f"Ankimon: Error during leaderboard credentials migration: {e}")
 
         # 3. Reviewer UI: collected IDs + shortcut/button wiring. Imported
         #    here (not at module scope) because reviewer_ui pulls lazy F31

--- a/src/Ankimon/ankimon_items_web/settings.css
+++ b/src/Ankimon/ankimon_items_web/settings.css
@@ -859,3 +859,39 @@
     border-color: rgba(255, 255, 255, 0.08);
     cursor: not-allowed;
 }
+
+/* ============================================================
+   Validation error styles
+   ============================================================ */
+.setting-row.validation-error .setting-input {
+    border-color: var(--accent-red, #f85149);
+    box-shadow: 0 0 0 3px rgba(248, 81, 73, 0.15);
+    animation: error-shake 0.4s ease;
+}
+
+.setting-row.validation-error .setting-label {
+    color: var(--accent-red, #f85149);
+}
+
+.setting-row.validation-error .setting-input:focus {
+    border-color: var(--accent-red, #f85149);
+    box-shadow: 0 0 0 3px rgba(248, 81, 73, 0.25);
+}
+
+.setting-row.validation-error .setting-description {
+    color: var(--accent-red, #f85149);
+    opacity: 0.8;
+}
+
+.setting-input.validation-error {
+    border-color: var(--accent-red, #f85149) !important;
+    box-shadow: 0 0 0 3px rgba(248, 81, 73, 0.15) !important;
+}
+
+@keyframes error-shake {
+    0%, 100% { transform: translateX(0); }
+    20% { transform: translateX(-6px); }
+    40% { transform: translateX(6px); }
+    60% { transform: translateX(-4px); }
+    80% { transform: translateX(4px); }
+}

--- a/src/Ankimon/ankimon_items_web/settings.css
+++ b/src/Ankimon/ankimon_items_web/settings.css
@@ -823,3 +823,39 @@
 .setting-description a[target="_blank"]:hover::after {
     opacity: 1;
 }
+
+/* ============================================================
+   Disabled setting rows (for leaderboard toggle)
+   ============================================================ */
+.setting-row.disabled {
+    opacity: 0.5;
+    pointer-events: none;
+    transition: opacity 0.2s ease;
+}
+
+.setting-row.disabled .setting-input {
+    background: var(--bg-darker);
+    border-color: rgba(255, 255, 255, 0.08);
+    color: var(--text-muted);
+    cursor: not-allowed;
+}
+
+.setting-row.disabled .setting-label {
+    color: var(--text-muted);
+}
+
+.setting-row.disabled .setting-description {
+    color: var(--text-muted);
+    opacity: 0.6;
+}
+
+.setting-row.disabled .setting-input[type="password"] {
+    background: var(--bg-darker);
+    border-color: rgba(255, 255, 255, 0.08);
+    color: var(--text-muted);
+}
+
+.setting-row.disabled .setting-input:hover {
+    border-color: rgba(255, 255, 255, 0.08);
+    cursor: not-allowed;
+}

--- a/src/Ankimon/ankimon_items_web/settings.css
+++ b/src/Ankimon/ankimon_items_web/settings.css
@@ -753,3 +753,73 @@
     to { transform: translateY(0); opacity: 1; }
 }
 
+/* ============================================================
+   Password input field styling
+   ============================================================ */
+.setting-input[type="password"] {
+    font-family: 'JetBrains Mono', monospace;
+    letter-spacing: 2px;
+}
+
+.setting-input[type="password"]::placeholder {
+    letter-spacing: 0px;
+    font-family: 'Outfit', sans-serif;
+}
+
+/* Leaderboard section specific styling */
+.setting-row[data-key="leaderboard.api_key"] .setting-description {
+    color: var(--text-muted);
+}
+
+.setting-row[data-key="leaderboard.api_key"] .setting-control {
+    position: relative;
+}
+
+/* Optional: add a small lock icon indicator for password fields */
+.setting-row[data-key="leaderboard.api_key"] .setting-label::before {
+    content: '🔒 ';
+    font-size: 0.85rem;
+}
+
+/* ============================================================
+   Settings description links
+   ============================================================ */
+.setting-description a {
+    color: var(--text-muted-light, #c8ced6);  /* Lighter grey */
+    text-decoration: underline;
+    text-underline-offset: 2px;
+    text-decoration-color: rgba(200, 206, 214, 0.25);
+    transition: color 0.15s ease, text-decoration-color 0.15s ease;
+}
+
+.setting-description a:hover {
+    color: var(--text-bright, #e8edf5);  /* Lighter on hover, not darker */
+    text-decoration-color: rgba(200, 206, 214, 0.5);
+}
+
+.setting-description a:visited {
+    color: var(--text-muted-light, #c8ced6);  /* Same as regular */
+}
+
+/* Light mode support */
+:root:not(.dark-mode) .setting-description a {
+    color: #8a94a6;  /* Lighter grey for light mode */
+    text-decoration-color: rgba(138, 148, 166, 0.3);
+}
+
+:root:not(.dark-mode) .setting-description a:hover {
+    color: #6b7a8f;  /* Slightly lighter on hover (still readable) */
+    text-decoration-color: rgba(138, 148, 166, 0.6);
+}
+
+/* External link indicator */
+.setting-description a[target="_blank"]::after {
+    content: ' ↗';
+    font-size: 0.75em;
+    opacity: 0.5;
+    transition: opacity 0.15s ease;
+}
+
+.setting-description a[target="_blank"]:hover::after {
+    opacity: 1;
+}

--- a/src/Ankimon/ankimon_items_web/settings.css
+++ b/src/Ankimon/ankimon_items_web/settings.css
@@ -320,6 +320,13 @@
     border-radius: 8px;
     padding: 3px;
     gap: 2px;
+    flex-shrink: 0;
+}
+
+.setting-toggle-wrapper {
+    display: flex;
+    align-items: center;
+    gap: 12px;
     width: 100%;
 }
 
@@ -350,6 +357,129 @@
 .setting-toggle-option.active.off {
     background: var(--bg-card-hover);
     color: var(--text-muted);
+}
+
+/* --- Leaderboard status indicator --- */
+.leaderboard-status {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 4px 8px;
+    border-left: 1px solid var(--border-main);
+    flex-shrink: 0;
+}
+
+.status-dot {
+    display: inline-block;
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+    flex-shrink: 0;
+    transition: background-color 0.3s ease, box-shadow 0.3s ease;
+}
+
+/* --- Grey: Not connected (static, no animation) --- */
+.status-dot-grey {
+    background-color: #6b7280;
+    box-shadow: 0 0 4px rgba(107, 114, 128, 0.3);
+}
+
+/* --- Orange: Syncing paused (slow pulse) --- */
+.status-dot-orange {
+    background-color: #f59e0b;
+    box-shadow: 0 0 4px rgba(245, 158, 11, 0.4);
+    animation: pulse-orange 2s ease-in-out infinite;
+}
+
+@keyframes pulse-orange {
+    0%, 100% {
+        box-shadow: 0 0 4px rgba(245, 158, 11, 0.4);
+        transform: scale(1);
+    }
+    50% {
+        box-shadow: 0 0 12px rgba(245, 158, 11, 0.7), 0 0 20px rgba(245, 158, 11, 0.3);
+        transform: scale(1.2);
+    }
+}
+
+/* --- Green: Syncing live (fast pulse with glow) --- */
+.status-dot-green {
+    background-color: #22c55e;
+    box-shadow: 0 0 4px rgba(34, 197, 94, 0.4);
+    animation: pulse-green 1.5s ease-in-out infinite;
+}
+
+@keyframes pulse-green {
+    0%, 100% {
+        box-shadow: 0 0 4px rgba(34, 197, 94, 0.4);
+        transform: scale(1);
+    }
+    50% {
+        box-shadow: 0 0 14px rgba(34, 197, 94, 0.8), 0 0 24px rgba(34, 197, 94, 0.3);
+        transform: scale(1.25);
+    }
+}
+
+.status-text {
+    font-size: 0.78rem;
+    font-weight: 500;
+    color: var(--text-muted, #b0b8c4);
+    white-space: nowrap;
+}
+
+/* Status text color matching dot */
+.status-dot-orange ~ .status-text {
+    color: #f59e0b;
+}
+
+.status-dot-green ~ .status-text {
+    color: #22c55e;
+}
+
+.status-dot-grey ~ .status-text {
+    color: var(--text-muted, #6b7280);
+}
+
+/* Light mode support */
+:root:not(.dark-mode) .status-dot-grey {
+    background-color: #9ca3af;
+}
+
+:root:not(.dark-mode) .status-dot-orange {
+    background-color: #d97706;
+}
+
+:root:not(.dark-mode) .status-dot-green {
+    background-color: #16a34a;
+}
+
+:root:not(.dark-mode) .status-dot-orange ~ .status-text {
+    color: #d97706;
+}
+
+:root:not(.dark-mode) .status-dot-green ~ .status-text {
+    color: #16a34a;
+}
+
+:root:not(.dark-mode) .status-dot-grey ~ .status-text {
+    color: #6b7280;
+}
+
+/* Responsive: stack on narrow widths */
+@media (max-width: 600px) {
+    .setting-toggle-wrapper {
+        flex-wrap: wrap;
+        gap: 8px;
+    }
+    
+    .leaderboard-status {
+        border-left: none;
+        padding-left: 0;
+        padding-top: 4px;
+        border-top: 1px solid var(--border-main);
+        width: 100%;
+        justify-content: flex-start;
+    }
 }
 
 /* --- Validation hint --- */

--- a/src/Ankimon/ankimon_items_web/settings.js
+++ b/src/Ankimon/ankimon_items_web/settings.js
@@ -36,6 +36,35 @@
         renderAll();
     };
 
+    // ---------- Link handling ----------
+    function setupDescriptionLinks() {
+        document.querySelectorAll('.setting-description a').forEach(function(link) {
+            // Remove old listener to prevent duplicates
+            if (link._clickHandler) {
+                link.removeEventListener('click', link._clickHandler);
+            }
+            
+            link._clickHandler = function(e) {
+                e.preventDefault();
+                e.stopPropagation();
+                const url = this.getAttribute('href');
+                if (!url) return;
+                
+                // Try to use bridge if available
+                if (bridge && typeof bridge.openUrl === 'function') {
+                    bridge.openUrl(url);
+                } else if (bridge && typeof bridge.openLink === 'function') {
+                    bridge.openLink(url);
+                } else {
+                    // Fallback: open in new tab/window
+                    window.open(url, '_blank');
+                }
+            };
+            
+            link.addEventListener('click', link._clickHandler);
+        });
+    }
+
     // ---------- Rendering ----------
     function renderAll() {
         renderGroupJumps();
@@ -120,6 +149,9 @@
             frag.appendChild(groupEl);
         });
         root.replaceChildren(frag);
+        
+        // Setup description links after content is rendered
+        setupDescriptionLinks();
     }
 
     function buildSettingRow(setting) {
@@ -173,9 +205,25 @@
                 return buildChipGroup(setting);
             case 'wishlist':
                 return buildWishlistControl(setting);
+            case 'password':
+                return buildPasswordInput(setting);
             default:
                 return buildTextInput(setting);
         }
+    }
+
+    function buildPasswordInput(setting) {
+        const input = document.createElement('input');
+        input.type = 'password';
+        input.className = 'setting-input';
+        input.value = currentValue(setting) ?? '';
+        input.placeholder = 'Enter your API key';
+        input.addEventListener('input', () => {
+            setEdit(setting.key, input.value);
+            updateDirtyUI();
+            markRowDirty(setting.key);
+        });
+        return input;
     }
 
     function buildWishlistControl(setting) {

--- a/src/Ankimon/ankimon_items_web/settings.js
+++ b/src/Ankimon/ankimon_items_web/settings.js
@@ -99,6 +99,16 @@
         updateLeaderboardFields();
     }
 
+    // ---------- Validation helpers ----------
+    function clearValidationErrors() {
+        document.querySelectorAll('.validation-error').forEach(el => {
+            el.classList.remove('validation-error');
+        });
+        document.querySelectorAll('.setting-input.validation-error').forEach(el => {
+            el.classList.remove('validation-error');
+        });
+    }
+
     // ---------- Rendering ----------
     function renderAll() {
         renderGroupJumps();
@@ -259,6 +269,8 @@
             setEdit(setting.key, input.value);
             updateDirtyUI();
             markRowDirty(setting.key);
+            // Clear validation error when user types
+            clearValidationErrors();
         });
         return input;
     }
@@ -669,6 +681,8 @@
             }
             updateDirtyUI();
             markRowDirty(setting.key);
+            // Clear validation error when user types
+            clearValidationErrors();
         });
         return input;
     }
@@ -682,6 +696,8 @@
             setEdit(setting.key, input.value);
             updateDirtyUI();
             markRowDirty(setting.key);
+            // Clear validation error when user types
+            clearValidationErrors();
         });
         return input;
     }
@@ -795,6 +811,61 @@
         // callers like the unsaved-changes guard can chain navigation.
         const done = typeof onDone === 'function' ? onDone : null;
         if (!bridge) { if (done) done(); return; }
+        
+        // ============================================================
+        // LEADERBOARD VALIDATION
+        // ============================================================
+        const toggleRow = document.querySelector('.setting-row[data-key="misc.leaderboard"]');
+        if (toggleRow) {
+            const isEnabled = toggleRow.querySelector('.setting-toggle-option.active')?.textContent === 'Enabled';
+            
+            if (isEnabled) {
+                const usernameRow = document.querySelector('.setting-row[data-key="leaderboard.username"]');
+                const apiKeyRow = document.querySelector('.setting-row[data-key="leaderboard.api_key"]');
+                
+                let username = '';
+                let apiKey = '';
+                
+                if (usernameRow) {
+                    const input = usernameRow.querySelector('.setting-input');
+                    if (input) username = input.value.trim();
+                }
+                
+                if (apiKeyRow) {
+                    const input = apiKeyRow.querySelector('.setting-input');
+                    if (input) apiKey = input.value.trim();
+                }
+                
+                if (!username || !apiKey) {
+                    const missing = [];
+                    if (!username) missing.push('• Username');
+                    if (!apiKey) missing.push('• API Key');
+                    
+                    const msg = '⚠️ Leaderboard Sync is enabled but the following fields are empty:\n\n' + 
+                               missing.join('\n') + 
+                               '\n\nPlease fill in all fields before saving.';
+                    showToast(msg, true);
+                    
+                    if (!username && usernameRow) {
+                        usernameRow.classList.add('validation-error');
+                        const input = usernameRow.querySelector('.setting-input');
+                        if (input) input.classList.add('validation-error');
+                    }
+                    if (!apiKey && apiKeyRow) {
+                        apiKeyRow.classList.add('validation-error');
+                        const input = apiKeyRow.querySelector('.setting-input');
+                        if (input) input.classList.add('validation-error');
+                    }
+                    
+                    if (done) done();
+                    return;
+                }
+            }
+        }
+        // ============================================================
+        // END LEADERBOARD VALIDATION
+        // ============================================================
+        
         const payload = {...state.edits};
         if (Object.keys(payload).length === 0) { if (done) done(); return; }
         // Stringify so the bridge sees a stable `str` parameter — see the

--- a/src/Ankimon/ankimon_items_web/settings.js
+++ b/src/Ankimon/ankimon_items_web/settings.js
@@ -1045,8 +1045,8 @@
                 if (!apiKey) missing.push('• API Key');
                 
                 const msg = '⚠️ Leaderboard Sync is enabled but the following fields are empty:\n\n' + 
-                           missing.join('\n') + 
-                           '\n\nPlease fill in all fields before saving.';
+                        missing.join('\n') + 
+                        '\n\nPlease fill in all fields before saving.';
                 showToast(msg, true);
                 
                 if (!username && usernameRow) {
@@ -1060,8 +1060,12 @@
                     if (input) input.classList.add('validation-error');
                 }
                 
-                if (done) done();
-                return;
+                // ============================================================
+                // FIXED: Do NOT call done() here - user must stay on the page
+                // to fix validation errors before navigating away.
+                // ============================================================
+                // Removed: if (done) done();
+                return;  // Stay on the page and abort save
             }
         }
         // ============================================================

--- a/src/Ankimon/ankimon_items_web/settings.js
+++ b/src/Ankimon/ankimon_items_web/settings.js
@@ -70,9 +70,6 @@
         const toggleRow = document.querySelector('.setting-row[data-key="misc.leaderboard"]');
         if (!toggleRow) return;
         
-        const toggleButtons = toggleRow.querySelectorAll('.setting-toggle-option');
-        if (!toggleButtons.length) return;
-        
         const usernameRow = document.querySelector('.setting-row[data-key="leaderboard.username"]');
         const apiKeyRow = document.querySelector('.setting-row[data-key="leaderboard.api_key"]');
         
@@ -89,13 +86,8 @@
             });
         }
         
-        toggleButtons.forEach(btn => {
-            btn.addEventListener('click', function() {
-                setTimeout(updateLeaderboardFields, 10);
-            });
-        });
-        
-        // Initial state
+        // No redundant click listeners needed!
+        // The toggle's click handler already calls renderAll() → setupLeaderboardToggle() → updateLeaderboardFields()
         updateLeaderboardFields();
     }
 
@@ -815,51 +807,49 @@
         // ============================================================
         // LEADERBOARD VALIDATION
         // ============================================================
-        const toggleRow = document.querySelector('.setting-row[data-key="misc.leaderboard"]');
-        if (toggleRow) {
-            const isEnabled = toggleRow.querySelector('.setting-toggle-option.active')?.textContent === 'Enabled';
+        const setting = findSetting('misc.leaderboard');
+        const isEnabled = setting ? currentValue(setting) : false;
+        
+        if (isEnabled) {
+            const usernameRow = document.querySelector('.setting-row[data-key="leaderboard.username"]');
+            const apiKeyRow = document.querySelector('.setting-row[data-key="leaderboard.api_key"]');
             
-            if (isEnabled) {
-                const usernameRow = document.querySelector('.setting-row[data-key="leaderboard.username"]');
-                const apiKeyRow = document.querySelector('.setting-row[data-key="leaderboard.api_key"]');
+            let username = '';
+            let apiKey = '';
+            
+            if (usernameRow) {
+                const input = usernameRow.querySelector('.setting-input');
+                if (input) username = input.value.trim();
+            }
+            
+            if (apiKeyRow) {
+                const input = apiKeyRow.querySelector('.setting-input');
+                if (input) apiKey = input.value.trim();
+            }
+            
+            if (!username || !apiKey) {
+                const missing = [];
+                if (!username) missing.push('• Username');
+                if (!apiKey) missing.push('• API Key');
                 
-                let username = '';
-                let apiKey = '';
+                const msg = '⚠️ Leaderboard Sync is enabled but the following fields are empty:\n\n' + 
+                           missing.join('\n') + 
+                           '\n\nPlease fill in all fields before saving.';
+                showToast(msg, true);
                 
-                if (usernameRow) {
+                if (!username && usernameRow) {
+                    usernameRow.classList.add('validation-error');
                     const input = usernameRow.querySelector('.setting-input');
-                    if (input) username = input.value.trim();
+                    if (input) input.classList.add('validation-error');
                 }
-                
-                if (apiKeyRow) {
+                if (!apiKey && apiKeyRow) {
+                    apiKeyRow.classList.add('validation-error');
                     const input = apiKeyRow.querySelector('.setting-input');
-                    if (input) apiKey = input.value.trim();
+                    if (input) input.classList.add('validation-error');
                 }
                 
-                if (!username || !apiKey) {
-                    const missing = [];
-                    if (!username) missing.push('• Username');
-                    if (!apiKey) missing.push('• API Key');
-                    
-                    const msg = '⚠️ Leaderboard Sync is enabled but the following fields are empty:\n\n' + 
-                               missing.join('\n') + 
-                               '\n\nPlease fill in all fields before saving.';
-                    showToast(msg, true);
-                    
-                    if (!username && usernameRow) {
-                        usernameRow.classList.add('validation-error');
-                        const input = usernameRow.querySelector('.setting-input');
-                        if (input) input.classList.add('validation-error');
-                    }
-                    if (!apiKey && apiKeyRow) {
-                        apiKeyRow.classList.add('validation-error');
-                        const input = apiKeyRow.querySelector('.setting-input');
-                        if (input) input.classList.add('validation-error');
-                    }
-                    
-                    if (done) done();
-                    return;
-                }
+                if (done) done();
+                return;
             }
         }
         // ============================================================

--- a/src/Ankimon/ankimon_items_web/settings.js
+++ b/src/Ankimon/ankimon_items_web/settings.js
@@ -107,8 +107,15 @@
         const usernameRow = document.querySelector('.setting-row[data-key="leaderboard.username"]');
         const apiKeyRow = document.querySelector('.setting-row[data-key="leaderboard.api_key"]');
         
+        // Use the setting value directly instead of DOM text content
+        // This is robust against translation/i18n changes
+        const setting = findSetting('misc.leaderboard');
+        const isEnabled = setting ? currentValue(setting) : false;
+        
         function updateLeaderboardFields() {
-            const isEnabled = toggleRow.querySelector('.setting-toggle-option.active')?.textContent === 'Enabled';
+            // Re-query the setting value each time to ensure fresh state
+            const setting = findSetting('misc.leaderboard');
+            const isEnabled = setting ? currentValue(setting) : false;
             
             [usernameRow, apiKeyRow].forEach(row => {
                 if (!row) return;
@@ -1021,21 +1028,16 @@
         const isEnabled = setting ? currentValue(setting) : false;
         
         if (isEnabled) {
+            // Use currentValue() to get values from settings state
+            // This is robust and independent of DOM structure
+            const usernameSetting = findSetting('leaderboard.username');
+            const apiKeySetting = findSetting('leaderboard.api_key');
+            const username = usernameSetting ? (currentValue(usernameSetting) || '').trim() : '';
+            const apiKey = apiKeySetting ? (currentValue(apiKeySetting) || '').trim() : '';
+            
+            // Still need DOM references for highlighting validation errors
             const usernameRow = document.querySelector('.setting-row[data-key="leaderboard.username"]');
             const apiKeyRow = document.querySelector('.setting-row[data-key="leaderboard.api_key"]');
-            
-            let username = '';
-            let apiKey = '';
-            
-            if (usernameRow) {
-                const input = usernameRow.querySelector('.setting-input');
-                if (input) username = input.value.trim();
-            }
-            
-            if (apiKeyRow) {
-                const input = apiKeyRow.querySelector('.setting-input');
-                if (input) apiKey = input.value.trim();
-            }
             
             if (!username || !apiKey) {
                 const missing = [];

--- a/src/Ankimon/ankimon_items_web/settings.js
+++ b/src/Ankimon/ankimon_items_web/settings.js
@@ -15,6 +15,16 @@
     let nav = null;
     let unsavedGuardOpen = false;
 
+    /**
+     * Initializes the QWebChannel connection to the Python backend.
+     * 
+     * Establishes communication with the settings bridge object exposed
+     * by the Python side. Falls back to standalone mode if the Qt
+     * WebChannel transport is unavailable.
+     * 
+     * @param {Function} cb - Callback function invoked with the bridge object
+     *                         or null if initialization fails.
+     */
     function initChannel(cb) {
         if (typeof qt === 'undefined' || !qt.webChannelTransport) {
             console.warn('qt.webChannelTransport unavailable — standalone mode');
@@ -30,6 +40,15 @@
         });
     }
 
+    /**
+     * Entry point for the Python backend to initialize the settings UI.
+     * 
+     * Receives the settings data payload, resets any pending edits, and
+     * triggers a full UI re-render.
+     * 
+     * @param {Object} data - The settings data containing groups, settings,
+     *                        and current values from the Python backend.
+     */
     window.initializeSettings = function (data) {
         state.data = data || {groups: []};
         state.edits = {};  // fresh data resets dirty state
@@ -37,6 +56,13 @@
     };
 
     // ---------- Link handling ----------
+    /**
+     * Sets up click handlers for all anchor tags within setting descriptions.
+     * 
+     * Intercepts link clicks to prevent default browser navigation and instead
+     * routes them through the Qt bridge for opening in the system's default
+     * browser. Falls back to window.open if the bridge is unavailable.
+     */
     function setupDescriptionLinks() {
         document.querySelectorAll('.setting-description a').forEach(function(link) {
             // Remove old listener to prevent duplicates
@@ -66,6 +92,14 @@
     }
 
     // ---------- Leaderboard toggle handling ----------
+    /**
+     * Manages the enabling/disabling of leaderboard credential fields.
+     * 
+     * When the "Enable Leaderboard Sync" toggle is toggled, this function
+     * enables or disables the Username and API Key input fields accordingly.
+     * The toggle's built-in click handler already triggers a full re-render,
+     * so no additional event listeners are needed.
+     */
     function setupLeaderboardToggle() {
         const toggleRow = document.querySelector('.setting-row[data-key="misc.leaderboard"]');
         if (!toggleRow) return;
@@ -92,6 +126,13 @@
     }
 
     // ---------- Validation helpers ----------
+    /**
+     * Removes validation error styling from all form elements.
+     * 
+     * Clears the 'validation-error' class from both setting rows and
+     * individual input elements. Typically called when the user begins
+     * typing in a previously invalid field.
+     */
     function clearValidationErrors() {
         document.querySelectorAll('.validation-error').forEach(el => {
             el.classList.remove('validation-error');
@@ -102,6 +143,13 @@
     }
 
     // ---------- Rendering ----------
+    /**
+     * Renders the entire settings UI from scratch.
+     * 
+     * Orchestrates the full rendering pipeline including sidebar navigation,
+     * settings content, search filtering, dirty state indicators, and
+     * scroll position tracking.
+     */
     function renderAll() {
         renderGroupJumps();
         renderContent();
@@ -113,6 +161,12 @@
         updateActiveSection();
     }
 
+    /**
+     * Renders the sidebar navigation with group section links.
+     * 
+     * Creates clickable jump links for each settings group, displaying
+     * the group name and the count of settings within it.
+     */
     function renderGroupJumps() {
         const container = document.getElementById('group-jumps');
         // Build into a fragment then swap atomically to avoid a brief
@@ -135,12 +189,25 @@
         container.replaceChildren(frag);
     }
 
+    /**
+     * Counts the total number of settings within a group including subgroups.
+     * 
+     * @param {Object} group - The settings group object.
+     * @returns {number} The total count of settings in the group.
+     */
     function countSettings(group) {
         let n = (group.settings || []).length;
         (group.subgroups || []).forEach((s) => { n += (s.settings || []).length; });
         return n;
     }
 
+    /**
+     * Renders the main settings content area.
+     * 
+     * Builds the complete settings tree from the data payload, including
+     * all groups, subgroups, and individual setting rows. After rendering,
+     * sets up link handlers and leaderboard toggle behavior.
+     */
     function renderContent() {
         const root = document.getElementById('settings-content');
         // Build the whole settings tree into a fragment off-DOM, then swap
@@ -193,6 +260,15 @@
         setupLeaderboardToggle();
     }
 
+    /**
+     * Builds a single setting row DOM element.
+     * 
+     * Creates the DOM structure for an individual setting, including its
+     * label, description (if any), and the appropriate input control.
+     * 
+     * @param {Object} setting - The setting configuration object.
+     * @returns {HTMLElement} The constructed setting row element.
+     */
     function buildSettingRow(setting) {
         const row = document.createElement('div');
         row.className = 'setting-row';
@@ -231,6 +307,15 @@
         return row;
     }
 
+    /**
+     * Builds the appropriate input control for a setting based on its type.
+     * 
+     * Routes to the appropriate builder function based on the setting's
+     * declared type (boolean, select, int, float, chips, wishlist, password).
+     * 
+     * @param {Object} setting - The setting configuration object.
+     * @returns {HTMLElement} The constructed input control element.
+     */
     function buildControl(setting) {
         switch (setting.type) {
             case 'boolean':
@@ -251,6 +336,15 @@
         }
     }
 
+    /**
+     * Builds a password input field for sensitive credential settings.
+     * 
+     * Creates a masked input field with placeholder text and change tracking.
+     * Clears validation errors when the user begins typing.
+     * 
+     * @param {Object} setting - The setting configuration object.
+     * @returns {HTMLElement} The password input element.
+     */
     function buildPasswordInput(setting) {
         const input = document.createElement('input');
         input.type = 'password';
@@ -267,6 +361,16 @@
         return input;
     }
 
+    /**
+     * Builds a wishlist control for managing catch wishlist Pokémon.
+     * 
+     * Creates a searchable input with dropdown suggestions and chip-based
+     * display of currently selected Pokémon. Supports adding/removing
+     * Pokémon via search or modal selection.
+     * 
+     * @param {Object} setting - The setting configuration object.
+     * @returns {HTMLElement} The wishlist control container.
+     */
     function buildWishlistControl(setting) {
         if (setting.names) {
             state._wishlistNames = state._wishlistNames || {};
@@ -579,6 +683,16 @@
         return wrap;
     }
 
+    /**
+     * Builds a chip group for multi-select boolean toggles.
+     * 
+     * Creates a group of toggle buttons where each chip represents a
+     * boolean setting. Active chips are visually highlighted and tracked
+     * in the edit state.
+     * 
+     * @param {Object} setting - The setting configuration object.
+     * @returns {HTMLElement} The chip group container.
+     */
     function buildChipGroup(setting) {
         const wrap = document.createElement('div');
         wrap.className = 'setting-chips';
@@ -609,6 +723,11 @@
         return wrap;
     }
 
+    /**
+     * Marks a chip row as dirty if any of its chips have pending edits.
+     * 
+     * @param {string} rowKey - The data-key attribute of the row to check.
+     */
     function markChipRowDirty(rowKey) {
         const row = document.querySelector(`.setting-row[data-key="${cssEscape(rowKey)}"]`);
         if (!row) return;
@@ -617,6 +736,16 @@
         row.classList.toggle('dirty', anyDirty);
     }
 
+    /**
+     * Builds a boolean toggle control with Enabled/Disabled buttons.
+     * 
+     * Creates a segmented control with two buttons (Enabled/Disabled)
+     * that act as a binary toggle. Clicking either button updates the
+     * setting value and triggers a full re-render.
+     * 
+     * @param {Object} setting - The setting configuration object.
+     * @returns {HTMLElement} The toggle control container.
+     */
     function buildToggle(setting) {
         const wrap = document.createElement('div');
         wrap.className = 'setting-toggle';
@@ -636,6 +765,12 @@
         return wrap;
     }
 
+    /**
+     * Builds a select dropdown for enumerated settings.
+     * 
+     * @param {Object} setting - The setting configuration object.
+     * @returns {HTMLElement} The select element.
+     */
     function buildSelect(setting) {
         const sel = document.createElement('select');
         sel.className = 'setting-select';
@@ -655,6 +790,15 @@
         return sel;
     }
 
+    /**
+     * Builds a numeric input with support for hyphenated ranges.
+     * 
+     * Allows numeric values and special range syntax (e.g., "1-3") for
+     * settings like cards_per_round.
+     * 
+     * @param {Object} setting - The setting configuration object.
+     * @returns {HTMLElement} The numeric input element.
+     */
     function buildNumberInput(setting) {
         const input = document.createElement('input');
         input.type = 'text';  // text so range strings like "1-3" work too
@@ -679,6 +823,12 @@
         return input;
     }
 
+    /**
+     * Builds a standard text input for string settings.
+     * 
+     * @param {Object} setting - The setting configuration object.
+     * @returns {HTMLElement} The text input element.
+     */
     function buildTextInput(setting) {
         const input = document.createElement('input');
         input.type = 'text';
@@ -694,6 +844,12 @@
         return input;
     }
 
+    /**
+     * Gets the current value of a setting, checking pending edits first.
+     * 
+     * @param {Object} setting - The setting configuration object.
+     * @returns {*} The current value from edits or the original value.
+     */
     function currentValue(setting) {
         if (Object.prototype.hasOwnProperty.call(state.edits, setting.key)) {
             return state.edits[setting.key];
@@ -702,6 +858,15 @@
     }
 
     // ---------- Edit tracking ----------
+    /**
+     * Sets a pending edit for a setting key.
+     * 
+     * Updates the edits state, tracking changes before they are saved.
+     * If the new value equals the original, the edit is removed.
+     * 
+     * @param {string} key - The setting key.
+     * @param {*} value - The new value.
+     */
     function setEdit(key, value) {
         const original = findSetting(key);
         if (!original) return;
@@ -712,6 +877,15 @@
         }
     }
 
+    /**
+     * Finds a setting definition by its key.
+     * 
+     * Searches through all groups and subgroups for a setting with the
+     * matching key.
+     * 
+     * @param {string} key - The setting key to find.
+     * @returns {Object|null} The setting object or null if not found.
+     */
     function findSetting(key) {
         for (const g of (state.data.groups || [])) {
             for (const s of (g.settings || [])) {
@@ -726,12 +900,27 @@
         return null;
     }
 
+    /**
+     * Performs a deep equality comparison between two values.
+     * 
+     * Uses JSON serialization for reliable deep comparison of objects
+     * and arrays.
+     * 
+     * @param {*} a - First value to compare.
+     * @param {*} b - Second value to compare.
+     * @returns {boolean} True if the values are deeply equal.
+     */
     function deepEqual(a, b) {
         if (a === b) return true;
         if (typeof a !== typeof b) return false;
         return JSON.stringify(a) === JSON.stringify(b);
     }
 
+    /**
+     * Marks a specific setting row as dirty (has unsaved changes).
+     * 
+     * @param {string} key - The setting key to mark dirty.
+     */
     function markRowDirty(key) {
         document.querySelectorAll('.setting-row').forEach((row) => {
             if (row.dataset.key !== key) return;
@@ -740,6 +929,12 @@
         });
     }
 
+    /**
+     * Updates the UI elements that display dirty state status.
+     * 
+     * Updates the save button state, dirty pill count, and status text
+     * based on the number of pending edits.
+     */
     function updateDirtyUI() {
         const n = Object.keys(state.edits).length;
         const dirty = n > 0;
@@ -774,6 +969,12 @@
     }
 
     // ---------- Search ----------
+    /**
+     * Filters settings based on the current search query.
+     * 
+     * Hides groups, subgroups, and individual rows that don't match the
+     * search term. Shows the empty state message when no matches are found.
+     */
     function applySearchFilter() {
         const q = state.search;
         const empty = document.getElementById('settings-empty');
@@ -798,6 +999,15 @@
     }
 
     // ---------- Save ----------
+    /**
+     * Saves all pending setting edits to the Python backend.
+     * 
+     * Performs validation on leaderboard settings before saving.
+     * If leaderboard sync is enabled, ensures username and API key
+     * are both filled. Shows validation errors if fields are missing.
+     * 
+     * @param {Function} onDone - Optional callback invoked after save completion.
+     */
     function onSave(onDone) {
         // onDone (optional) fires only after a successful save/no-op, so
         // callers like the unsaved-changes guard can chain navigation.
@@ -889,6 +1099,15 @@
         return true;
     }
 
+    /**
+     * Displays a modal dialog for unsaved changes when navigating away.
+     * 
+     * Shows a confirmation dialog with options to stay, discard changes,
+     * or save and leave.
+     * 
+     * @param {Function} proceed - Callback to continue navigation after
+     *                             the user makes a choice.
+     */
     function showUnsavedGuardModal(proceed) {
         if (unsavedGuardOpen) return;
         unsavedGuardOpen = true;
@@ -967,6 +1186,9 @@
         document.body.appendChild(backdrop);
     }
 
+    /**
+     * Discards all pending edits and resets the UI.
+     */
     function onDiscard() {
         if (Object.keys(state.edits).length === 0) return;
         state.edits = {};
@@ -974,6 +1196,12 @@
         showToast('Changes discarded');
     }
 
+    /**
+     * Displays a toast notification with optional error styling.
+     * 
+     * @param {string} message - The message to display.
+     * @param {boolean} isError - Whether the message is an error.
+     */
     function showToast(message, isError) {
         if (!message) return;
         const toast = document.getElementById('toast');
@@ -1002,6 +1230,14 @@
     let suppressSpyUntil = 0;
     const READING_LINE_PX = 80;
 
+    /**
+     * Updates the active button in the sidebar navigation.
+     * 
+     * Highlights the group jump button corresponding to the currently
+     * visible settings group.
+     * 
+     * @param {string} label - The label of the active group.
+     */
     function setActiveButton(label) {
         if (label === state.activeGroup) return;
         state.activeGroup = label;
@@ -1010,6 +1246,14 @@
         });
     }
 
+    /**
+     * Scrolls the settings content to a specific group section.
+     * 
+     * Smoothly scrolls to the target group, highlights it with a flash
+     * animation, and updates the active sidebar button.
+     * 
+     * @param {string} label - The label of the group to scroll to.
+     */
     function scrollToGroup(label) {
         const el = document.querySelector(`.settings-group[data-group="${cssEscape(label)}"]`);
         const scroller = document.querySelector('.content-scroll');
@@ -1028,6 +1272,11 @@
         suppressSpyUntil = Date.now() + 1500;
     }
 
+    /**
+     * Triggers a brief highlight flash on a section element.
+     * 
+     * @param {HTMLElement} el - The section element to flash.
+     */
     function flashSection(el) {
         // Brief tint so the user sees the jump landed on the right section.
         // Re-trigger the animation if the class is already present
@@ -1038,10 +1287,21 @@
         el.classList.add('flash-highlight');
     }
 
+    /**
+     * Escapes double quotes in a string for CSS selector usage.
+     * 
+     * @param {string} s - The string to escape.
+     * @returns {string} The escaped string.
+     */
     function cssEscape(s) {
         return s.replace(/"/g, '\\"');
     }
 
+    /**
+     * Determines which settings group is currently visible and updates
+     * the sidebar navigation accordingly. Handles edge cases when at
+     * max scroll.
+     */
     function updateActiveSection() {
         if (Date.now() < suppressSpyUntil) return;
         const scroller = document.querySelector('.content-scroll');
@@ -1082,6 +1342,12 @@
     }
 
     // ---------- UI plumbing ----------
+    /**
+     * Binds UI event handlers to DOM elements.
+     * 
+     * Sets up search input, save button, discard button, scroll spy,
+     * and keyboard shortcuts.
+     */
     function bindUI() {
         const search = document.getElementById('settings-search');
         const clear = document.getElementById('clear-search');

--- a/src/Ankimon/ankimon_items_web/settings.js
+++ b/src/Ankimon/ankimon_items_web/settings.js
@@ -344,6 +344,108 @@
     }
 
     /**
+     * Builds a status indicator for the leaderboard toggle.
+     * 
+     * The status is computed based on:
+     * - Whether username and API key are filled
+     * - Whether leaderboard sync is enabled
+     * 
+     * States:
+     * - Grey "Not connected": No username or API key saved
+     * - Orange "Syncing paused": Credentials saved but sync disabled
+     * - Green "Syncing live": Credentials saved and sync enabled
+     * 
+     * @returns {HTMLElement} The status indicator element.
+     */
+    function buildLeaderboardStatus() {
+        const wrap = document.createElement('div');
+        wrap.className = 'leaderboard-status';
+        
+        // Get current values from settings state
+        const leaderboardSetting = findSetting('misc.leaderboard');
+        const isEnabled = leaderboardSetting ? currentValue(leaderboardSetting) : false;
+        
+        const usernameSetting = findSetting('leaderboard.username');
+        const apiKeySetting = findSetting('leaderboard.api_key');
+        const username = usernameSetting ? (currentValue(usernameSetting) || '').trim() : '';
+        const apiKey = apiKeySetting ? (currentValue(apiKeySetting) || '').trim() : '';
+        
+        // Determine status
+        let dotColor = 'grey';
+        let statusText = 'Not connected';
+        
+        if (username && apiKey) {
+            if (isEnabled) {
+                dotColor = 'green';
+                statusText = 'Syncing live';
+            } else {
+                dotColor = 'orange';
+                statusText = 'Syncing paused';
+            }
+        }
+        
+        // Create dot
+        const dot = document.createElement('span');
+        dot.className = `status-dot status-dot-${dotColor}`;
+        
+        // Create status text
+        const text = document.createElement('span');
+        text.className = 'status-text';
+        text.textContent = statusText;
+        
+        wrap.appendChild(dot);
+        wrap.appendChild(text);
+        
+        return wrap;
+    }
+
+    /**
+     * Builds a boolean toggle control with Enabled/Disabled buttons.
+     * 
+     * Creates a segmented control with two buttons (Enabled/Disabled)
+     * that act as a binary toggle. Clicking either button updates the
+     * setting value and triggers a full re-render.
+     * 
+     * For the leaderboard toggle, adds a status indicator to the right.
+     * 
+     * @param {Object} setting - The setting configuration object.
+     * @returns {HTMLElement} The toggle control container.
+     */
+    function buildToggle(setting) {
+        const wrap = document.createElement('div');
+        wrap.className = 'setting-toggle-wrapper';
+        
+        const toggleWrap = document.createElement('div');
+        toggleWrap.className = 'setting-toggle';
+        
+        const current = currentValue(setting);
+        ['Enabled', 'Disabled'].forEach((label, i) => {
+            const isOn = (i === 0 && current) || (i === 1 && !current);
+            const btn = document.createElement('button');
+            btn.type = 'button';
+            btn.className = 'setting-toggle-option' + (isOn ? ' active' : '') + (i === 1 ? ' off' : '');
+            btn.textContent = label;
+            btn.addEventListener('click', () => {
+                setEdit(setting.key, i === 0);
+                renderAll();  // refresh control + dirty pip
+            });
+            toggleWrap.appendChild(btn);
+        });
+        
+        wrap.appendChild(toggleWrap);
+        
+        // Add status indicator for leaderboard toggle
+        if (setting.key === 'misc.leaderboard') {
+            const statusIndicator = buildLeaderboardStatus();
+            if (statusIndicator) {
+                wrap.appendChild(statusIndicator);
+            }
+        }
+        
+        return wrap;
+    }
+
+    /**
      * Builds a password input field for sensitive credential settings.
      * 
      * Creates a masked input field with placeholder text and change tracking.
@@ -744,35 +846,6 @@
     }
 
     /**
-     * Builds a boolean toggle control with Enabled/Disabled buttons.
-     * 
-     * Creates a segmented control with two buttons (Enabled/Disabled)
-     * that act as a binary toggle. Clicking either button updates the
-     * setting value and triggers a full re-render.
-     * 
-     * @param {Object} setting - The setting configuration object.
-     * @returns {HTMLElement} The toggle control container.
-     */
-    function buildToggle(setting) {
-        const wrap = document.createElement('div');
-        wrap.className = 'setting-toggle';
-        const current = currentValue(setting);
-        ['Enabled', 'Disabled'].forEach((label, i) => {
-            const isOn = (i === 0 && current) || (i === 1 && !current);
-            const btn = document.createElement('button');
-            btn.type = 'button';
-            btn.className = 'setting-toggle-option' + (isOn ? ' active' : '') + (i === 1 ? ' off' : '');
-            btn.textContent = label;
-            btn.addEventListener('click', () => {
-                setEdit(setting.key, i === 0);
-                renderAll();  // refresh control + dirty pip
-            });
-            wrap.appendChild(btn);
-        });
-        return wrap;
-    }
-
-    /**
      * Builds a select dropdown for enumerated settings.
      * 
      * @param {Object} setting - The setting configuration object.
@@ -1060,11 +1133,8 @@
                     if (input) input.classList.add('validation-error');
                 }
                 
-                // ============================================================
-                // FIXED: Do NOT call done() here - user must stay on the page
+                // Do NOT call done() here - user must stay on the page
                 // to fix validation errors before navigating away.
-                // ============================================================
-                // Removed: if (done) done();
                 return;  // Stay on the page and abort save
             }
         }

--- a/src/Ankimon/ankimon_items_web/settings.js
+++ b/src/Ankimon/ankimon_items_web/settings.js
@@ -65,6 +65,40 @@
         });
     }
 
+    // ---------- Leaderboard toggle handling ----------
+    function setupLeaderboardToggle() {
+        const toggleRow = document.querySelector('.setting-row[data-key="misc.leaderboard"]');
+        if (!toggleRow) return;
+        
+        const toggleButtons = toggleRow.querySelectorAll('.setting-toggle-option');
+        if (!toggleButtons.length) return;
+        
+        const usernameRow = document.querySelector('.setting-row[data-key="leaderboard.username"]');
+        const apiKeyRow = document.querySelector('.setting-row[data-key="leaderboard.api_key"]');
+        
+        function updateLeaderboardFields() {
+            const isEnabled = toggleRow.querySelector('.setting-toggle-option.active')?.textContent === 'Enabled';
+            
+            [usernameRow, apiKeyRow].forEach(row => {
+                if (!row) return;
+                const inputs = row.querySelectorAll('.setting-input');
+                inputs.forEach(input => {
+                    input.disabled = !isEnabled;
+                });
+                row.classList.toggle('disabled', !isEnabled);
+            });
+        }
+        
+        toggleButtons.forEach(btn => {
+            btn.addEventListener('click', function() {
+                setTimeout(updateLeaderboardFields, 10);
+            });
+        });
+        
+        // Initial state
+        updateLeaderboardFields();
+    }
+
     // ---------- Rendering ----------
     function renderAll() {
         renderGroupJumps();
@@ -152,6 +186,9 @@
         
         // Setup description links after content is rendered
         setupDescriptionLinks();
+        
+        // Setup leaderboard toggle behavior
+        setupLeaderboardToggle();
     }
 
     function buildSettingRow(setting) {

--- a/src/Ankimon/ankimon_items_web/settings_schema.py
+++ b/src/Ankimon/ankimon_items_web/settings_schema.py
@@ -202,6 +202,29 @@ GROUPS = [
                 ]
             }
         ]
+    },
+    {
+        "label": "Leaderboard",
+        "settings": [
+            {
+                "key": "misc.leaderboard",
+                "label": "Enable Leaderboard Sync",
+                "description": "Share your stats with the Ankimon leaderboard community. When enabled, your progress will be automatically synced.",
+                "type": "boolean",
+            },
+            {
+                "key": "leaderboard.username",
+                "label": "Username",
+                "description": "Your username for the Ankimon leaderboard. This will be displayed publicly on the leaderboard.",
+                "type": "string",
+            },
+            {
+                "key": "leaderboard.api_key",
+                "label": "API Key",
+                "description": 'Your API key for the Ankimon leaderboard. Feel free to get one from the <a href="https://leaderboard.ankimon.com/" target="_blank">Ankimon website</a> (at https://leaderboard.ankimon.com/)!',
+                "type": "password",
+            }
+        ]
     }
 ]
 

--- a/src/Ankimon/ankimon_items_web/settings_schema.py
+++ b/src/Ankimon/ankimon_items_web/settings_schema.py
@@ -55,8 +55,8 @@ GROUPS = [
                     "keys": [
                         ("battle.auto_catch_legendary", "Legendary"),
                         ("battle.auto_catch_mythical",  "Mythical"),
-                        ("battle.auto_catch_ultra",     "Ultra Beast"),
                         ("battle.auto_catch_starter",   "Starter"),
+                        ("battle.auto_catch_ultra",     "Ultra Beast"),
                         ("battle.auto_catch_mega",      "Mega"),
                         ("battle.auto_catch_gmax",      "Gigantamax"),
                         ("battle.auto_catch_regional",  "Regional Form"),
@@ -209,7 +209,7 @@ GROUPS = [
             {
                 "key": "misc.leaderboard",
                 "label": "Enable Leaderboard Sync",
-                "description": "Share your stats with the Ankimon leaderboard community. When enabled, your progress will be automatically synced.",
+                "description": 'Share your stats with the <a href="https://leaderboard.ankimon.com/" target="_blank">Ankimon leaderboard community</a>. When enabled, your progress will be automatically synced.',
                 "type": "boolean",
             },
             {

--- a/src/Ankimon/ankimon_items_web/settings_schema.py
+++ b/src/Ankimon/ankimon_items_web/settings_schema.py
@@ -22,7 +22,6 @@ GROUPS = [
                     "SSH Access",
                     "Prevent Ankimon News on Startup",
                     "AnkiWeb Sync",
-                    "Ankimon Leaderboard",
                     "Developer Mode",
                 ],
             },

--- a/src/Ankimon/ankimon_items_web/settings_schema.py
+++ b/src/Ankimon/ankimon_items_web/settings_schema.py
@@ -205,24 +205,9 @@ GROUPS = [
     {
         "label": "Leaderboard",
         "settings": [
-            {
-                "key": "misc.leaderboard",
-                "label": "Enable Leaderboard Sync",
-                "description": 'Share your stats with the <a href="https://leaderboard.ankimon.com/" target="_blank">Ankimon leaderboard community</a>. When enabled, your progress will be automatically synced.',
-                "type": "boolean",
-            },
-            {
-                "key": "leaderboard.username",
-                "label": "Username",
-                "description": "Your username for the Ankimon leaderboard. This will be displayed publicly on the leaderboard.",
-                "type": "string",
-            },
-            {
-                "key": "leaderboard.api_key",
-                "label": "API Key",
-                "description": 'Your API key for the Ankimon leaderboard. Feel free to get one from the <a href="https://leaderboard.ankimon.com/" target="_blank">Ankimon website</a> (at https://leaderboard.ankimon.com/)!',
-                "type": "password",
-            }
+            "Enable Leaderboard Sync",
+            "Username",
+            "API Key"
         ]
     }
 ]

--- a/src/Ankimon/ankimon_items_web/shop_obj.py
+++ b/src/Ankimon/ankimon_items_web/shop_obj.py
@@ -237,12 +237,21 @@ class SettingsBridge(QObject):
         return self._w.handle_get_caught_pokemon()
 
     # ============================================================
-    # ADDED: Open a URL in the default browser
+    # Open a URL in the default browser with security validation
     # This makes links in settings descriptions clickable
     # ============================================================
     @pyqtSlot(str)
     def openUrl(self, url):
-        """Open a URL in the default browser."""
+        """Open a URL in the default browser.
+        
+        Only allows http:// and https:// schemes to prevent arbitrary
+        protocol handlers from being invoked (security hardening).
+        """
+        # Security: Only allow safe URL schemes
+        if not (url.startswith("http://") or url.startswith("https://")):
+            print(f"Ankimon: Rejected unsafe URL scheme: {url}")
+            return
+        
         try:
             import webbrowser
             webbrowser.open(url)

--- a/src/Ankimon/ankimon_items_web/shop_obj.py
+++ b/src/Ankimon/ankimon_items_web/shop_obj.py
@@ -236,6 +236,19 @@ class SettingsBridge(QObject):
         """Return list of [{id, name, sprite_url}] for all caught/collected Pokémon."""
         return self._w.handle_get_caught_pokemon()
 
+    # ============================================================
+    # ADDED: Open a URL in the default browser
+    # This makes links in settings descriptions clickable
+    # ============================================================
+    @pyqtSlot(str)
+    def openUrl(self, url):
+        """Open a URL in the default browser."""
+        try:
+            import webbrowser
+            webbrowser.open(url)
+        except Exception as e:
+            print(f"Ankimon: Failed to open URL {url}: {e}")
+
 
 class ItemsBridge(QObject):
     """Items-screen actions — only meaningful when Items is loaded."""
@@ -2287,4 +2300,3 @@ class AnkimonItemsWeb(QDialog):
 
 
 # _attribute_xp_and_evs_to_companion has been moved to functions.mobile_sync
-

--- a/src/Ankimon/lang/setting_description.json
+++ b/src/Ankimon/lang/setting_description.json
@@ -64,7 +64,7 @@
     "misc.remove_level_cap": "Allow leveling beyond set level cap.",
     "misc.language": "Select language ID for Pokémon names and descriptions. [1: Japanese (Hir & Kata), 2: Japanese (Roomaji), 3: Korean, 4: Chinese (Traditional), 5: French, 6: German, 7: Spanish, 8: Italian, 9: English, 10: Czech, 11: Japanese, 12: Chinese (Simplified), 13: Portuguese (Brazil), 14: Spanish (Latin America)]",
     "misc.ssh": "Enable SSH if encountering connectivity issues (like Eduroam restrictions).",
-    "misc.leaderboard": "Enable synchronization with Ankimon leaderboard (leaderboard.ankimon.com). \nTo set up, check Ankimon -> Game -> Ankimon Leaderboard and Ankimon -> Ankimon Leaderboard Credentials.",
+    "misc.leaderboard": "Share your stats with the <a href=\"https://leaderboard.ankimon.com/\" target=\"_blank\">Ankimon leaderboard community</a>. When enabled, your progress will be automatically synced.",
     "misc.ankiweb_sync": "Sync your Ankimon SAVE DATA (Pokémon, items, trainer progress) across your own devices that share one AnkiWeb account, by riding Anki's media sync. When ON, your local save is backed up automatically and integrity-checked before any incoming data is applied.\nThis is SEPARATE from Mobile Reviews: reviews done on AnkiMobile/AnkiDroid become battles regardless of this setting.\nTips: don't use 'Delete Unused' when checking media, and avoid playing on two devices between syncs (the most recent sync wins).",
     "misc.YouShallNotPass_Ankimon_News": "If enabled, you will not receive news pop-ups when Ankimon starts (like changelogs and updates).",
     "misc.discord_rich_presence": "Enable Discord Rich Presence for Ankimon. Shows in Discord as 'Playing Ankimon'.",
@@ -73,5 +73,7 @@
     "misc.developer_mode": "Enable developer mode. This will create a backup every time Anki is opened.",
     "trainer.name": "Set the name of your trainer.",
     "trainer.cash_reward_amount": "How much cash you earn for each interval of cards reviewed. [Min: 10, Max: 400]. NOTE: To prevent exploits, the payout is capped based on your daily economy limit and subject to a hard daily cap of 400¥.",
-    "trainer.cash_reward_interval": "Number of cards to review before earning cash. [Min: 5, Max: 100]. Earnings are subject to a maximum daily cap of 400¥."
+    "trainer.cash_reward_interval": "Number of cards to review before earning cash. [Min: 5, Max: 100]. Earnings are subject to a maximum daily cap of 400¥.",
+    "leaderboard.username": "Your username for the Ankimon leaderboard. This will be displayed publicly on the leaderboard.",
+    "leaderboard.api_key": "Your API key for the Ankimon leaderboard. Feel free to get one from the <a href=\"https://leaderboard.ankimon.com/\" target=\"_blank\">Ankimon website</a> (at https://leaderboard.ankimon.com/)!"
 }

--- a/src/Ankimon/lang/setting_name.json
+++ b/src/Ankimon/lang/setting_name.json
@@ -69,7 +69,7 @@
     "misc.remove_level_cap": "Remove Level Cap",
     "misc.language": "Language",
     "misc.ssh": "SSH Access",
-    "misc.leaderboard": "Ankimon Leaderboard",
+    "misc.leaderboard": "Enable Leaderboard Sync",
     "misc.ankiweb_sync": "AnkiWeb Sync",
     "misc.YouShallNotPass_Ankimon_News": "Prevent Ankimon News on Startup",
     "misc.discord_rich_presence": "Discord Rich Presence - Ankimon",
@@ -78,6 +78,7 @@
     "misc.developer_mode": "Developer Mode",
     "trainer.name": "Trainer Name",
     "trainer.cash_reward_amount": "Cash Reward Per Interval",
-    "trainer.cash_reward_interval": "Cards Per Cash Reward"
-
+    "trainer.cash_reward_interval": "Cards Per Cash Reward",
+    "leaderboard.username": "Username",
+    "leaderboard.api_key": "API Key"
 }

--- a/src/Ankimon/menu_buttons.py
+++ b/src/Ankimon/menu_buttons.py
@@ -12,7 +12,7 @@ from aqt.utils import qconnect
 
 from .gui_classes.check_files import FileCheckerApp
 from .pyobj.download_sprites import show_agreement_and_download_dialog
-from .pyobj.ankimon_leaderboard import show_api_key_dialog
+# REMOVED: from .pyobj.ankimon_leaderboard import show_api_key_dialog
 from .pyobj.settings import Settings
 from .pyobj.translator import Translator
 from .pyobj.InfoLogger import ShowInfoLogger
@@ -487,10 +487,16 @@ def create_menu_actions(
     file_check_action.triggered.connect(lambda: FileCheckerApp().exec())
     help_menu.addAction(file_check_action)
 
-    file_check_action = QAction(mw.translator.translate("ankimon_leaderboard_credentials_button"), mw)
-    file_check_action.setMenuRole(QAction.MenuRole.NoRole)
-    file_check_action.triggered.connect(show_api_key_dialog)
-    mw.pokemenu.addAction(file_check_action)
+    # ============================================================
+    # REMOVED: Ankimon Leaderboard Credentials menu item
+    # The leaderboard credentials are now managed in Settings:
+    # Ankimon → Ankimon Settings → Leaderboard
+    # ============================================================
+    # REMOVED BLOCK:
+    # file_check_action = QAction(mw.translator.translate("ankimon_leaderboard_credentials_button"), mw)
+    # file_check_action.setMenuRole(QAction.MenuRole.NoRole)
+    # file_check_action.triggered.connect(show_api_key_dialog)
+    # mw.pokemenu.addAction(file_check_action)
 
     downloader_action = QAction(mw.translator.translate("download_resources_button"), mw)
     downloader_action.setMenuRole(QAction.MenuRole.NoRole)

--- a/src/Ankimon/pyobj/ankimon_leaderboard.py
+++ b/src/Ankimon/pyobj/ankimon_leaderboard.py
@@ -206,7 +206,7 @@ def migrate_credentials_from_db():
     Note:
         - Function exits early if database or settings services are unavailable
         - Only migrates if database has credentials AND settings don't
-        - Preserves the leaderboard enabled/disabled state
+        - The leaderboard enabled/disabled state is preserved automatically
     """
     if services.db is None or services.settings is None:
         return
@@ -224,11 +224,6 @@ def migrate_credentials_from_db():
         if username and api_key and (not settings_username or not settings_api_key):
             services.settings.set("leaderboard.username", username)
             services.settings.set("leaderboard.api_key", api_key)
-            
-            # If leaderboard was enabled in old system, enable it in new system
-            if services.settings.get("misc.leaderboard", False):
-                services.settings.set("misc.leaderboard", True)
-                
             print("Ankimon: Migrated leaderboard credentials from database to settings")
             
     except Exception as e:

--- a/src/Ankimon/pyobj/ankimon_leaderboard.py
+++ b/src/Ankimon/pyobj/ankimon_leaderboard.py
@@ -47,6 +47,16 @@ class ApiKeyDialog(QDialog):
         self.setLayout(layout)
 
     def submit(self):
+        """
+        Handle the submission of username and API key from the legacy dialog.
+        
+        Validates that both fields are filled, then saves the credentials to
+        the settings system rather than the legacy database. Enables leaderboard
+        sync automatically upon successful credential storage.
+        
+        Returns:
+            None: Displays appropriate info messages to the user via showInfo.
+        """
         username = self.username_input.text()
         api_key = self.api_key_input.text()
 
@@ -66,8 +76,27 @@ class ApiKeyDialog(QDialog):
 
 def sync_data_to_leaderboard(data):
     """
-    Sync data to leaderboard using credentials from settings.
-    This replaces the old database-based credential system.
+    Synchronize player statistics with the Ankimon leaderboard server.
+    
+    This function retrieves leaderboard credentials from the settings system
+    and sends a POST request to the leaderboard API with the provided stats.
+    The network request is executed in a background thread to prevent UI
+    freezing during network operations.
+    
+    Args:
+        data (dict): A dictionary containing the player's statistics to be
+            synchronized with the leaderboard. The structure should match
+            what the leaderboard API expects.
+    
+    Returns:
+        None: Results are logged to console; failures are handled silently
+            with console output rather than user-facing dialogs.
+    
+    Note:
+        - The function exits early if leaderboard sync is disabled in settings
+        - Credentials are read from settings (not the legacy database)
+        - Network timeouts are set to 10 seconds
+        - All exceptions are caught and logged to console
     """
     
     # First check if leaderboard is enabled in config
@@ -92,7 +121,16 @@ def sync_data_to_leaderboard(data):
         }
 
         def send_request():
-            """Send the network request in a background thread."""
+            """
+            Send the network request to the leaderboard API.
+            
+            This inner function executes the actual HTTP POST request and handles
+            any network-related exceptions. It runs in a background thread to
+            avoid blocking the main GUI thread.
+            
+            Returns:
+                None: Results and errors are logged to console.
+            """
             try:
                 # Send POST request to leaderboard API
                 response = requests.post(
@@ -119,7 +157,21 @@ def sync_data_to_leaderboard(data):
 
 
 def show_api_key_dialog():
-    """Legacy method - credentials now managed in Settings."""
+    """
+    Display a legacy dialog informing users about the new credential location.
+    
+    This function is a deprecated method that now shows an informational
+    message directing users to the new Settings UI for managing leaderboard
+    credentials. The legacy dialog is kept for backward compatibility but
+    no longer collects credentials directly.
+    
+    Returns:
+        None: Displays a QMessageBox with navigation instructions.
+    
+    Note:
+        This method is deprecated; credentials should be managed through
+        Ankimon → Ankimon Settings → Leaderboard.
+    """
     # Show a dialog telling users where to find the new settings
     msg = QMessageBox()
     msg.setIcon(QMessageBox.Icon.Information)
@@ -136,8 +188,25 @@ def show_api_key_dialog():
 
 def migrate_credentials_from_db():
     """
-    One-time migration from database to settings.
-    Call this during initialization.
+    Migrate leaderboard credentials from the legacy database to the settings system.
+    
+    This function performs a one-time migration of username and API key from
+    the old database storage to the new settings-based storage system. It
+    checks if credentials exist in the database and whether they have already
+    been migrated to settings to avoid overwriting existing settings data.
+    
+    The migration runs during Anki startup and ensures a smooth transition
+    for users who previously configured leaderboard credentials using the
+    legacy system.
+    
+    Returns:
+        None: Migration status is logged to console; failures are caught
+            and logged without interrupting the startup process.
+    
+    Note:
+        - Function exits early if database or settings services are unavailable
+        - Only migrates if database has credentials AND settings don't
+        - Preserves the leaderboard enabled/disabled state
     """
     if services.db is None or services.settings is None:
         return

--- a/src/Ankimon/pyobj/ankimon_leaderboard.py
+++ b/src/Ankimon/pyobj/ankimon_leaderboard.py
@@ -5,13 +5,15 @@ from aqt.utils import showInfo
 from ..resources import user_path_credentials, mypokemon_path
 import json
 import requests
-from aqt import mw # import setting values direct from init file
+from aqt import mw
 from ..services import services
 
-#ANKIMON_LEADERBOARD_API_URL = "https://ankimon.com/api/leaderboard"  # Replace with the actual API URL
-ANKIMON_LEADERBOARD_API_URL = "https://leaderboard-api.ankimon.com/update_stats"  # Replace with the actual API URL
+ANKIMON_LEADERBOARD_API_URL = "https://leaderboard-api.ankimon.com/update_stats"
+
 
 class ApiKeyDialog(QDialog):
+    """Legacy dialog - kept for backward compatibility but deprecated."""
+    
     def __init__(self):
         super().__init__()
 
@@ -48,76 +50,109 @@ class ApiKeyDialog(QDialog):
         api_key = self.api_key_input.text()
 
         if username and api_key:
-            credentials = {
-                "username": username,
-                "api_key": api_key
-            }
-            self.save_credentials(credentials)
-            self.accept()  # Close the dialog if everything is entered
+            # Save to settings instead of database
+            if services.settings:
+                services.settings.set("leaderboard.username", username)
+                services.settings.set("leaderboard.api_key", api_key)
+                services.settings.set("misc.leaderboard", True)
+                showInfo("Credentials saved successfully!")
+                self.accept()
+            else:
+                showInfo("Error: Settings not initialized.")
         else:
             showInfo("Both fields must be filled out.")
 
-    def save_credentials(self, credentials):
-        try:
-            # Save the new credentials to the database
-            for key, value in credentials.items():
-                if services.db:
-                    services.db.set_user_data(key, value)
-            showInfo("Credentials saved successfully!")
-        except Exception as e:
-            showInfo(f"Error saving credentials: {e}")
 
 def sync_data_to_leaderboard(data):
+    """
+    Sync data to leaderboard using credentials from settings.
+    This replaces the old database-based credential system.
+    """
+    
+    # First check if leaderboard is enabled in config
+    if not services.settings or not services.settings.get("misc.leaderboard"):
+        return
 
-        # First check if leaderboard is enabled in config
-        if not services.settings or not services.settings.get("misc.leaderboard"):
+    try:
+        # Get credentials from settings (NOT from database)
+        username = services.settings.get("leaderboard.username", "")
+        api_key = services.settings.get("leaderboard.api_key", "")
+
+        # Validate credentials
+        if not username or not api_key:
+            # Silent fail - user will be notified through settings UI
+            print("Ankimon: Leaderboard credentials missing in settings")
             return
 
-        try:
-            # Load credentials from the database
-            if not services.db:
-                return
-            username = services.db.get_user_data("username")
-            api_key = services.db.get_user_data("api_key")
+        request_data = {
+            "username": username,
+            "api_key": api_key,
+            "stats": data
+        }
 
-            # Validate credentials
-            if (not username or not api_key) and services.db.is_migrated():
-                showInfo("Error: Missing credentials for Ankimon leaderboard. Please set up leaderboard from Ankimon menu or turn off in Settings.")
-                return
+        # Send POST request to leaderboard API
+        response = requests.post(
+            ANKIMON_LEADERBOARD_API_URL,
+            json=request_data,
+            timeout=10  # Add timeout to prevent hanging
+        )
 
+        if response.status_code == 200:
+            print("Ankimon: Data synced to leaderboard successfully")
+        else:
+            print(f"Ankimon: Failed to sync data - Status: {response.status_code}")
 
-            # Check if both username and api_key are available
-            if username and api_key:
-                request_data = {
-                    "username": username,
-                    "api_key": api_key,
-                    "stats": data
-                }
-
-                # Send a POST request to the leaderboard API
-                response = requests.post(
-                    ANKIMON_LEADERBOARD_API_URL,
-                    json=request_data
-                )
-
-                #showInfo(response.text)  # Show the response text for debugging
-
-                # Check if the request was successful
-                #if response.status_code == 200:
-                #    mw.logger.log("log","Data synced successfully to leaderboard!")
-                #else:
-                #    mw.logger.log("log",f"Failed to sync data to leaderboard. Status code: {response.status_code}")
-            #else:
-                #mw.logger.log("Credentials are missing (username or api_key)")
-
-        except requests.exceptions.RequestException as e:
-            showInfo(f"Error: Missing credentials for Ankimon leaderboard. Please set up leaderboard from Ankimon menu or turn off in Settings.\n\n {e}")
-        except Exception as e:
-            showInfo(f"Error: Missing credentials for Ankimon leaderboard. Please set up leaderboard from Ankimon menu or turn off in Settings.\n\n {e}")
-
+    except requests.exceptions.RequestException as e:
+        print(f"Ankimon: Leaderboard sync network error: {e}")
+    except Exception as e:
+        print(f"Ankimon: Unexpected leaderboard error: {e}")
 
 
 def show_api_key_dialog():
-    dialog = ApiKeyDialog()  # Create the dialog instance
-    dialog.exec()  # Show the dialog
+    """Legacy method - credentials now managed in Settings."""
+    # Show a dialog telling users where to find the new settings
+    from aqt.qt import QMessageBox
+    
+    msg = QMessageBox()
+    msg.setIcon(QMessageBox.Icon.Information)
+    msg.setWindowTitle("Leaderboard Credentials Moved")
+    msg.setText(
+        "Leaderboard credentials are now managed in Ankimon Settings.\n\n"
+        "Please go to:\n"
+        "Ankimon → Ankimon Settings → Leaderboard\n\n"
+        "Enter your username and API key there."
+    )
+    msg.setStandardButtons(QMessageBox.StandardButton.Ok)
+    msg.exec()
 
+
+def migrate_credentials_from_db():
+    """
+    One-time migration from database to settings.
+    Call this during initialization.
+    """
+    if not services.db or not services.settings:
+        return
+    
+    try:
+        # Check if we have credentials in database
+        username = services.db.get_user_data("username")
+        api_key = services.db.get_user_data("api_key")
+        
+        # Check if we have them in settings already
+        settings_username = services.settings.get("leaderboard.username", "")
+        settings_api_key = services.settings.get("leaderboard.api_key", "")
+        
+        # If db has credentials but settings don't, migrate them
+        if username and api_key and (not settings_username or not settings_api_key):
+            services.settings.set("leaderboard.username", username)
+            services.settings.set("leaderboard.api_key", api_key)
+            
+            # If leaderboard was enabled in old system, enable it in new system
+            if services.settings.get("misc.leaderboard", False):
+                services.settings.set("misc.leaderboard", True)
+                
+            print("Ankimon: Migrated leaderboard credentials from database to settings")
+            
+    except Exception as e:
+        print(f"Ankimon: Error migrating leaderboard credentials: {e}")

--- a/src/Ankimon/pyobj/ankimon_leaderboard.py
+++ b/src/Ankimon/pyobj/ankimon_leaderboard.py
@@ -1,10 +1,11 @@
 import sys
 import json
+import threading
+import requests
 from PyQt6.QtWidgets import QApplication, QDialog, QVBoxLayout, QLabel, QLineEdit, QPushButton
 from aqt.utils import showInfo
+from aqt.qt import QMessageBox
 from ..resources import user_path_credentials, mypokemon_path
-import json
-import requests
 from aqt import mw
 from ..services import services
 
@@ -51,7 +52,7 @@ class ApiKeyDialog(QDialog):
 
         if username and api_key:
             # Save to settings instead of database
-            if services.settings:
+            if services.settings is not None:
                 services.settings.set("leaderboard.username", username)
                 services.settings.set("leaderboard.api_key", api_key)
                 services.settings.set("misc.leaderboard", True)
@@ -70,7 +71,7 @@ def sync_data_to_leaderboard(data):
     """
     
     # First check if leaderboard is enabled in config
-    if not services.settings or not services.settings.get("misc.leaderboard"):
+    if services.settings is None or not services.settings.get("misc.leaderboard"):
         return
 
     try:
@@ -90,29 +91,36 @@ def sync_data_to_leaderboard(data):
             "stats": data
         }
 
-        # Send POST request to leaderboard API
-        response = requests.post(
-            ANKIMON_LEADERBOARD_API_URL,
-            json=request_data,
-            timeout=10  # Add timeout to prevent hanging
-        )
+        def send_request():
+            """Send the network request in a background thread."""
+            try:
+                # Send POST request to leaderboard API
+                response = requests.post(
+                    ANKIMON_LEADERBOARD_API_URL,
+                    json=request_data,
+                    timeout=10  # Add timeout to prevent hanging
+                )
 
-        if response.status_code == 200:
-            print("Ankimon: Data synced to leaderboard successfully")
-        else:
-            print(f"Ankimon: Failed to sync data - Status: {response.status_code}")
+                if response.status_code == 200:
+                    print("Ankimon: Data synced to leaderboard successfully")
+                else:
+                    print(f"Ankimon: Failed to sync data - Status: {response.status_code}")
+                    
+            except requests.exceptions.RequestException as e:
+                print(f"Ankimon: Leaderboard sync network error: {e}")
+            except Exception as e:
+                print(f"Ankimon: Unexpected leaderboard error: {e}")
 
-    except requests.exceptions.RequestException as e:
-        print(f"Ankimon: Leaderboard sync network error: {e}")
+        # Offload the network request to a background thread to prevent UI freezing
+        threading.Thread(target=send_request, daemon=True).start()
+
     except Exception as e:
-        print(f"Ankimon: Unexpected leaderboard error: {e}")
+        print(f"Ankimon: Unexpected error preparing leaderboard sync: {e}")
 
 
 def show_api_key_dialog():
     """Legacy method - credentials now managed in Settings."""
     # Show a dialog telling users where to find the new settings
-    from aqt.qt import QMessageBox
-    
     msg = QMessageBox()
     msg.setIcon(QMessageBox.Icon.Information)
     msg.setWindowTitle("Leaderboard Credentials Moved")
@@ -131,7 +139,7 @@ def migrate_credentials_from_db():
     One-time migration from database to settings.
     Call this during initialization.
     """
-    if not services.db or not services.settings:
+    if services.db is None or services.settings is None:
         return
     
     try:

--- a/src/Ankimon/pyobj/settings.py
+++ b/src/Ankimon/pyobj/settings.py
@@ -77,7 +77,7 @@ DEFAULT_CONFIG = {
     "misc.leaderboard": False,
     "misc.ankiweb_sync": False,
     "misc.YouShallNotPass_Ankimon_News": False,
-    "misc.show_tip_on_startup": True,  # Added default for Tip of the Day
+    "misc.show_tip_on_startup": True,
     "misc.discord_rich_presence": False,
     "misc.discord_rich_presence_text": 1,
     "misc.developer_mode": False,
@@ -97,6 +97,9 @@ DEFAULT_CONFIG = {
     "mobile.enabled": True,
     "mobile.resolution_mode": "manual",
     "mobile.inactive_companions": [],
+    # Leaderboard settings
+    "leaderboard.username": "",
+    "leaderboard.api_key": "",
 }
 
 

--- a/src/Ankimon/pyobj/settings_window.py
+++ b/src/Ankimon/pyobj/settings_window.py
@@ -342,7 +342,7 @@ class SettingsWindow(QMainWindow):
                             "SSH Access",
                             "Prevent Ankimon News on Startup",
                             "AnkiWeb Sync",
-                            "Ankimon Leaderboard",
+                            # "Ankimon Leaderboard" removed - now in its own section
                             "Developer Mode",
                         ]
                     },
@@ -457,6 +457,16 @@ class SettingsWindow(QMainWindow):
                     "Generation 7",
                     "Generation 8",
                     "Generation 9",
+                ]
+            },
+            # ============================================================
+            # ADDED: Leaderboard section
+            # ============================================================
+            "Leaderboard": {
+                "settings": [
+                    "Enable Leaderboard Sync",
+                    "Username",
+                    "API Key",
                 ]
             },
         }


### PR DESCRIPTION
### Proposed Change
Move "Ankimon Leaderboard Credentials" from Ankimon toolbar to *inside* Ankimon Settings.

### Key Modifications
- API keys can be grouped in Settings as it involves customising users' experience in Ankimon. It also allows the toolbar to be more category-focused.
- Additionally, it improves the UI of the boxes and retains previous input (with keys dotted out) which affirms to the user that they had keyed in their details.
- I've also added `Ankimon leaderboard community` and `Ankimon website` as clickable text which opens `https://leaderboard.ankimon.com/` in the user's default browser
- A user-friendly error is triggered when users attempt to save their settings when Leaderboard Sync is Enabled _but_ the username +/ API key fields are empty.
- There is also a live status indicator that shows `Not connected` for users who have not keyed in their credentials, `Syncing paused` for users with credentials but Disabled the Leaderboard Sync, and `Syncing live` for users with credentials and Sync Enabled.

### Related Issue
_N/A_

### Checklist
- [x] My commit message follows labelling conventions (though I accidentally slipped on the first commit) 
- [x] I have run the code below (credit to `coderabbitai` for the check) with no errors

> `#!/bin/bash
set -euo pipefail
cd /tmp
gh repo clone h0tp-ftw/ankimon repo -- --depth 1 --branch move-leaderboard-credentials -q 2>/dev/null || true
cd repo 2>/dev/null && grep -rn "show_api_key_dialog|ApiKeyDialog" --include=".py" . || true
echo "=== services init order check ==="
grep -n "services.settings\s=|settings =" src/Ankimon/services.py 2>/dev/null | head -20
grep -n "mw.translator|services\b" src/Ankimon/init.py | head -20`

- [x] I have added/updated my entry in `.all-contributorsrc` at the root of the repository to specify my custom `"nickname"` and `"discord_id"` for release announcements and Discord pings.
- [x] I consent to my email being public in the commit history