### PR TITLE
fix: remove Heatran-Mega from wild encounters

### DIFF
--- a/src/Ankimon/functions/encounter_data.py
+++ b/src/Ankimon/functions/encounter_data.py
@@ -1163,7 +1163,6 @@ MEGA_AND_SPECIAL = [
     10308,  # staraptormega          (species=398)
     10309,  # garchompmegaz          (species=445)
     10310,  # lucariomegaz           (species=448)
-    10311,  # heatranmega            (species=485)  [Sub-Legendary tag — still Mega]
     10312,  # darkraimega            (species=491)  [Mythical tag — still Mega]
     10313,  # golurkmega             (species=623)
     10315,  # crabominablemega       (species=740)


### PR DESCRIPTION
Fixes the issue where a "Mega Heatran" was randomly appearing in battles and using the exact same sprite as the normal Heatran. Because Heatran doesn't actually have an official Mega Evolution, it just falls back to the default sprite since there is no asset for it.

This removes it from the `encounter_data` tables so players won't be encountering fake duplicates while reviewing cards, but leaves it in `pokedex.json` so if anyone has already caught it, they will still own it.

---
*PR created automatically by Jules for task [9473714610651761909](https://jules.google.com/task/9473714610651761909) started by @h0tp-ftw*