### PR TITLE
fix(sync): tolerate OneDrive/AV file locks during AnkiWeb data sync (#636)

### DIFF
--- a/src/Ankimon/pyobj/ankimon_sync.py
+++ b/src/Ankimon/pyobj/ankimon_sync.py
@@ -55,11 +55,18 @@ SYNC_LOCK_MESSAGE = (
 
 def _is_lock_error(exc: BaseException) -> bool:
     """True if ``exc`` is a transient Windows file-lock error (another process
-    holding the file open). ``PermissionError`` covers the common WinError 5;
-    the winerror set also catches the sharing/lock-violation variants. A non-lock
-    ``OSError`` (e.g. cross-device link, file-not-found) returns False so it still
-    propagates to the normal traceback handler instead of being mistaken for a
-    lock."""
+    such as OneDrive/antivirus holding the file open).
+
+    Gated on Windows (``os.name == "nt"``): on POSIX, ``os.replace`` succeeds
+    over open handles, so a ``PermissionError`` there is a GENUINE permission
+    problem (read-only dir, bad ACL) that must NOT be retried for ~2.5 s or
+    blamed on a sync client — it falls through to the normal traceback handler
+    instead. On Windows, ``PermissionError`` covers the common WinError 5 and the
+    winerror set also catches the sharing/lock-violation variants (32/33). A
+    non-lock ``OSError`` (e.g. cross-device link, file-not-found) always returns
+    False."""
+    if os.name != "nt":
+        return False
     if isinstance(exc, PermissionError):
         return True
     return isinstance(exc, OSError) and getattr(exc, "winerror", None) in _SYNC_LOCK_WINERRORS

--- a/src/Ankimon/pyobj/ankimon_sync.py
+++ b/src/Ankimon/pyobj/ankimon_sync.py
@@ -1147,6 +1147,15 @@ class AnkimonDataSync:
                     _atomic_write_over(source_file, dest_file)
                     synced_files.append(filename)
 
+            # Report success ONLY if something was actually exported. With no
+            # local source file present nothing is copied; returning True here
+            # would make the caller (export_to_ankiweb) claim success, enable
+            # auto-sync, and close the dialog despite a zero-file export.
+            # Symmetric with force_sync_from_media's empty-updated_files guard.
+            if not synced_files:
+                showInfo("No local Ankimon data was found to export.")
+                return False
+
             showInfo(f"Exported {len(synced_files)} files to AnkiWeb: {', '.join(synced_files)}")
             return True
         except Exception as e:

--- a/src/Ankimon/pyobj/ankimon_sync.py
+++ b/src/Ankimon/pyobj/ankimon_sync.py
@@ -1,4 +1,5 @@
 import base64
+import errno
 import filecmp
 import gc
 import json
@@ -76,8 +77,12 @@ def _retry_on_lock(op: Callable[[], Any], delays=None) -> Any:
     """Run ``op()``, retrying while it fails with a transient file-lock error,
     with a bounded backoff between tries. A non-lock error propagates
     immediately; if every attempt is exhausted the last lock error is re-raised
-    for the caller to translate into a friendly message. ``gc.collect()`` between
-    tries drops any lingering handle of our own before the next attempt."""
+    for the caller to translate into a friendly message.
+
+    A blocking lock is held by ANOTHER process (OneDrive/antivirus), so there is
+    no handle of ours to reclaim here — callers that need to drop their own live
+    DB handle (``_atomic_replace``) do the one ``gc.collect()`` that matters
+    before calling in, rather than paying a full-heap scan on every retry."""
     if delays is None:
         delays = _SYNC_LOCK_RETRY_DELAYS
     attempts = len(delays) + 1
@@ -87,7 +92,6 @@ def _retry_on_lock(op: Callable[[], Any], delays=None) -> Any:
         except OSError as e:
             if not _is_lock_error(e) or i == attempts - 1:
                 raise
-            gc.collect()
             time.sleep(delays[i])
 
 
@@ -110,6 +114,91 @@ def _synctmp_path(target_file: Path) -> Path:
     except Exception:
         pass
     return fallback
+
+
+def _is_cross_device_error(exc: BaseException) -> bool:
+    """True if ``exc`` is an OS 'not on the same filesystem' error (POSIX EXDEV /
+    Windows ERROR_NOT_SAME_DEVICE 17): ``os.replace`` can't rename across
+    volumes. This is NOT a lock — it means ``_synctmp_path`` put the temp on a
+    different volume than the destination (an ``st_dev`` value it couldn't foresee
+    as lying: cloned disks, junctions, some overlay/network mounts)."""
+    return isinstance(exc, OSError) and (
+        getattr(exc, "errno", None) == errno.EXDEV
+        or getattr(exc, "winerror", None) == 17
+    )
+
+
+def _atomic_write_over(src: Path, dest: Path, before_replace: Callable[[], Any] = None) -> None:
+    """Copy ``src`` over ``dest`` atomically: write a temp on the same volume as
+    ``dest`` (``_synctmp_path`` prefers the system temp dir, else a sibling), then
+    ``os.replace`` it into place, retrying a transient OneDrive/antivirus lock so
+    a lock or interruption can't leave a half-written destination (issue #636).
+    ``before_replace``, if given, runs once after the copy and just before the
+    replace (e.g. to close a live DB handle on ``dest`` first).
+
+    If the chosen temp turns out to be cross-device — an ``st_dev`` match that
+    ``_synctmp_path`` trusted but ``os.replace`` rejects with EXDEV / WinError 17
+    — retry once via a guaranteed same-directory sibling temp, so the atomic
+    replace still completes instead of surfacing a spurious traceback (the old
+    plain ``shutil.copy2`` never hit this because it wrote straight to ``dest``)."""
+    # Reap a same-named sibling orphaned by an earlier crash between copy and
+    # replace, so a stray '<dest>.synctmp' can't accumulate in — and, for an
+    # export into collection.media, be uploaded to AnkiWeb from — the dest dir.
+    sibling = dest.with_name(dest.name + ".synctmp")
+    try:
+        sibling.unlink(missing_ok=True)
+    except Exception:
+        pass
+
+    tmp = _synctmp_path(dest)
+    try:
+        shutil.copy2(src, tmp)
+        if before_replace is not None:
+            before_replace()
+        try:
+            _retry_on_lock(lambda: os.replace(tmp, dest))
+        except OSError as e:
+            if not _is_cross_device_error(e) or tmp == sibling:
+                raise
+            try:
+                shutil.copy2(src, sibling)
+                _retry_on_lock(lambda: os.replace(sibling, dest))
+            finally:
+                try:
+                    sibling.unlink(missing_ok=True)
+                except Exception:
+                    pass
+    finally:
+        try:
+            tmp.unlink(missing_ok=True)
+        except Exception:
+            pass
+
+
+def _lock_tooltip(action: str, unchanged: bool = False) -> None:
+    """Non-blocking tooltip for a transient file lock on an AUTOMATIC sync path
+    (it self-heals on the next sync, so this never becomes a traceback dialog).
+    Shares one sync-client list with ``SYNC_LOCK_MESSAGE`` so the guidance can't
+    drift between the manual and automatic paths."""
+    tail = "Your local data is unchanged; it" if unchanged else "It"
+    tooltip(
+        f"Ankimon: couldn't {action} right now — a program such as OneDrive, "
+        "Google Drive, Dropbox, or an antivirus is holding the file open. "
+        f"{tail} will retry on the next sync."
+    )
+
+
+def _handle_manual_sync_error(exc: BaseException, message: str) -> bool:
+    """Present a MANUAL (modal) sync failure and return False. A transient file
+    lock (OneDrive/antivirus) that survived the retry gets the single friendly,
+    actionable ``SYNC_LOCK_MESSAGE``; a genuine error gets the raw traceback. The
+    caller early-returns on False, so neither is stacked with a second dialog."""
+    if _is_lock_error(exc):
+        showWarning(SYNC_LOCK_MESSAGE)
+    else:
+        show_warning_with_traceback(parent=mw, exception=exc, message=message)
+    return False
+
 
 class ImprovedPokemonDataSync(QDialog):
     """
@@ -723,16 +812,7 @@ class AnkimonDataSync:
                         # or interruption can't leave a half-written media DB, and
                         # so this automatic pre-sync export tolerates the same
                         # locks the import side does (issue #636).
-                        tmp = _synctmp_path(dest_file)
-                        try:
-                            shutil.copy2(source_file, tmp)
-                            _retry_on_lock(lambda: os.replace(tmp, dest_file))
-                        finally:
-                            try:
-                                if tmp.exists():
-                                    tmp.unlink()
-                            except Exception:
-                                pass
+                        _atomic_write_over(source_file, dest_file)
                         synced_files.append(filename)
 
                 except Exception as e:
@@ -741,12 +821,7 @@ class AnkimonDataSync:
                     # rather than a raw traceback dialog that would pop on every
                     # sync. Genuine errors still get the traceback.
                     if _is_lock_error(e):
-                        tooltip(
-                            f"Ankimon: couldn't stage {filename} for AnkiWeb right "
-                            "now — a program such as OneDrive, Google Drive, or "
-                            "antivirus is holding the file open. It will retry on "
-                            "the next sync."
-                        )
+                        _lock_tooltip(f"stage {filename} for AnkiWeb")
                         continue
                     show_warning_with_traceback(parent=mw, exception=e, message=f"Failed to sync {filename}")
                     continue
@@ -862,10 +937,13 @@ class AnkimonDataSync:
             return False
 
     def _atomic_replace(self, media_file: Path, source_file: Path) -> None:
-        """Overwrite ``source_file`` with ``media_file`` atomically: copy to a
-        temp file in the SAME directory (so ``os.replace`` is an atomic
-        same-filesystem rename, never a half-written destination), after closing
-        the GUI-thread connection to ``source_file``.
+        """Overwrite ``source_file`` with ``media_file`` atomically via
+        ``_atomic_write_over`` (temp on the same volume + ``os.replace``, retrying
+        a transient OneDrive/antivirus lock), after closing the live connection to
+        ``source_file`` so the OS releases its handle before the rename. A
+        persisting lock re-raises for the caller to surface as a friendly message;
+        a non-lock error propagates unchanged. (``_atomic_write_over`` prefers the
+        system temp dir, falling back to a same-directory sibling.)
 
         The media file is a single-file export (no WAL sidecar), so any stale
         ``-wal`` / ``-shm`` belonging to the OLD ``source_file`` must be removed
@@ -882,11 +960,10 @@ class AnkimonDataSync:
         (opt-in file-sync overlapping a live resolve); left documented rather than
         pulling the multi-profile connection model into a hardening pass."""
         source_file.parent.mkdir(parents=True, exist_ok=True)
-        tmp = _synctmp_path(source_file)
-        try:
-            shutil.copy2(media_file, tmp)
 
-            # Close connection registry completely to release all OS locks
+        def _release_handles():
+            # Close the connection registry completely to release all OS locks,
+            # then force collection of connection handles, before the rename.
             try:
                 from ..services import services
                 if services.db:
@@ -894,29 +971,14 @@ class AnkimonDataSync:
             except Exception:
                 pass
             self._close_live_db_connection(source_file)
-
-            # Force collection of connection handles
             gc.collect()
 
-            # Retry over a bounded backoff so a transient OneDrive/antivirus lock
-            # on the source temp or the destination clears on its own (issue
-            # #636); a persisting lock re-raises for the caller to surface as a
-            # friendly message, and a non-lock error propagates unchanged.
-            _retry_on_lock(lambda: os.replace(tmp, source_file))
+        _atomic_write_over(media_file, source_file, before_replace=_release_handles)
 
-            for sidecar in ("-wal", "-shm"):
-                stale = source_file.with_name(source_file.name + sidecar)
-                try:
-                    if stale.exists():
-                        stale.unlink()
-                except Exception:
-                    pass
-        finally:
-            # Clean up the temp file if os.replace never consumed it (an error
-            # between copy and replace), so a stale .synctmp can't linger.
+        for sidecar in ("-wal", "-shm"):
+            stale = source_file.with_name(source_file.name + sidecar)
             try:
-                if tmp.exists():
-                    tmp.unlink()
+                stale.unlink(missing_ok=True)
             except Exception:
                 pass
 
@@ -1006,12 +1068,7 @@ class AnkimonDataSync:
                     # sync. The live save is untouched (the atomic replace aborts
                     # before overwriting). Genuine errors still get the traceback.
                     if _is_lock_error(e):
-                        tooltip(
-                            f"Ankimon: couldn't import {filename} from AnkiWeb right "
-                            "now — a program such as OneDrive, Google Drive, or "
-                            "antivirus is holding the file open. Your local data is "
-                            "unchanged; it will retry on the next sync."
-                        )
+                        _lock_tooltip(f"import {filename} from AnkiWeb", unchanged=True)
                         continue
                     show_warning_with_traceback(parent=mw, exception=e, message=f"Failed to read {filename}")
                     continue
@@ -1087,30 +1144,17 @@ class AnkimonDataSync:
                     # both tolerates the lock (issue #636) and removes the old
                     # non-atomic remove-then-copy window that could leave a
                     # half-written media DB for Anki to upload.
-                    tmp = _synctmp_path(dest_file)
-                    try:
-                        shutil.copy2(source_file, tmp)
-                        _retry_on_lock(lambda: os.replace(tmp, dest_file))
-                    finally:
-                        try:
-                            if tmp.exists():
-                                tmp.unlink()
-                        except Exception:
-                            pass
+                    _atomic_write_over(source_file, dest_file)
                     synced_files.append(filename)
 
             showInfo(f"Exported {len(synced_files)} files to AnkiWeb: {', '.join(synced_files)}")
             return True
         except Exception as e:
-            # A locked media file (OneDrive/antivirus) that survived the retry:
-            # show the single friendly, actionable message instead of a raw
+            # A locked media file (OneDrive/antivirus) that survived the retry
+            # gets the single friendly message; a genuine error gets the
             # traceback. The caller (export_to_ankiweb) early-returns on False,
             # so this is NOT stacked with a second dialog.
-            if _is_lock_error(e):
-                showWarning(SYNC_LOCK_MESSAGE)
-                return False
-            show_warning_with_traceback(parent=mw, exception=e, message="Failed to export to AnkiWeb")
-            return False
+            return _handle_manual_sync_error(e, "Failed to export to AnkiWeb")
 
     def force_sync_from_media(self) -> bool:
         """Force sync all MEDIA files FROM subfolder to local folder (Import from AnkiWeb)."""
@@ -1178,16 +1222,12 @@ class AnkimonDataSync:
             showInfo(f"Imported {len(updated_files)} files from AnkiWeb: {', '.join(updated_files)}\n\nAnki will now close. Please reopen Anki to apply changes!")
             return True
         except Exception as e:
-            # A locked local DB (OneDrive/antivirus) that survived the retry:
-            # show the single friendly, actionable message instead of a raw
-            # traceback. The live save is untouched — the atomic replace aborts
-            # before overwriting. Returning False keeps import_from_ankiweb from
+            # A locked local DB (OneDrive/antivirus) that survived the retry gets
+            # the single friendly message; a genuine error gets the traceback.
+            # The live save is untouched — the atomic replace aborts before
+            # overwriting — and returning False keeps import_from_ankiweb from
             # enabling auto-sync or closing Anki.
-            if _is_lock_error(e):
-                showWarning(SYNC_LOCK_MESSAGE)
-                return False
-            show_warning_with_traceback(parent=mw, exception=e, message="Failed to import from AnkiWeb")
-            return False
+            return _handle_manual_sync_error(e, "Failed to import from AnkiWeb")
 
     def get_sync_folder_info(self) -> Dict[str, str]:
         """Get information about the sync folder for debugging."""

--- a/src/Ankimon/pyobj/ankimon_sync.py
+++ b/src/Ankimon/pyobj/ankimon_sync.py
@@ -4,9 +4,10 @@ import gc
 import json
 import os
 import shutil
+import tempfile
 import time
 from pathlib import Path
-from typing import Dict, List, Any
+from typing import Callable, Dict, List, Any
 
 from aqt import mw, gui_hooks
 from aqt.utils import showInfo, showWarning, tooltip
@@ -17,6 +18,91 @@ from ..utils import close_anki
 
 from PyQt6.QtGui import QTextOption
 from PyQt6.QtWidgets import QLabel, QVBoxLayout, QTextEdit, QPushButton, QDialog, QHBoxLayout, QScrollArea, QWidget
+
+
+# --------------------------------------------------------------------------
+# File-lock tolerance (issue #636)
+# --------------------------------------------------------------------------
+# On Windows, a file-sync client (OneDrive / Google Drive / Dropbox) or an
+# antivirus scanner briefly opens files in the Anki folder to read/upload them.
+# While such a handle is open WITHOUT FILE_SHARE_DELETE, os.replace() cannot
+# rename over (or delete) the file and raises PermissionError [WinError 5], or
+# the sharing/lock-violation variants (32/33). These holds are transient — on a
+# small just-created file they typically clear within a second — so the fix is a
+# bounded retry (the retry, not the message, is the primary fix), falling back
+# to a single friendly, actionable message only if the lock persists.
+
+# WinError codes that mean "another handle is blocking this rename/delete":
+# 5 = ERROR_ACCESS_DENIED (what OneDrive typically yields, incl. delete-pending
+# and cloud/AV filter-driver cases), 32 = ERROR_SHARING_VIOLATION,
+# 33 = ERROR_LOCK_VIOLATION.
+_SYNC_LOCK_WINERRORS = frozenset({5, 32, 33})
+
+# Backoff schedule for retrying a locked file op (~2.5 s worst case, and only on
+# the failure path — the common case succeeds on the first try with no delay).
+_SYNC_LOCK_RETRY_DELAYS = (0.1, 0.2, 0.4, 0.8, 1.0)
+
+# One friendly, actionable message reused by every manual (modal) entry point.
+SYNC_LOCK_MESSAGE = (
+    "Access Denied: another program is holding your Ankimon data file open, so "
+    "the sync could not finish.\n\n"
+    "This is usually OneDrive, Google Drive, Dropbox, or an antivirus that scans "
+    "the Anki folder. Please pause it (or exclude your Anki folder from syncing) "
+    "and try again.\n\n"
+    "Your existing Ankimon data has NOT been changed."
+)
+
+
+def _is_lock_error(exc: BaseException) -> bool:
+    """True if ``exc`` is a transient Windows file-lock error (another process
+    holding the file open). ``PermissionError`` covers the common WinError 5;
+    the winerror set also catches the sharing/lock-violation variants. A non-lock
+    ``OSError`` (e.g. cross-device link, file-not-found) returns False so it still
+    propagates to the normal traceback handler instead of being mistaken for a
+    lock."""
+    if isinstance(exc, PermissionError):
+        return True
+    return isinstance(exc, OSError) and getattr(exc, "winerror", None) in _SYNC_LOCK_WINERRORS
+
+
+def _retry_on_lock(op: Callable[[], Any], delays=None) -> Any:
+    """Run ``op()``, retrying while it fails with a transient file-lock error,
+    with a bounded backoff between tries. A non-lock error propagates
+    immediately; if every attempt is exhausted the last lock error is re-raised
+    for the caller to translate into a friendly message. ``gc.collect()`` between
+    tries drops any lingering handle of our own before the next attempt."""
+    if delays is None:
+        delays = _SYNC_LOCK_RETRY_DELAYS
+    attempts = len(delays) + 1
+    for i in range(attempts):
+        try:
+            return op()
+        except OSError as e:
+            if not _is_lock_error(e) or i == attempts - 1:
+                raise
+            gc.collect()
+            time.sleep(delays[i])
+
+
+def _synctmp_path(target_file: Path) -> Path:
+    """Choose a path for the temp copy that ``os.replace`` will atomically rename
+    over ``target_file``. Prefer the system temp dir when it is on the SAME
+    volume — ``os.replace`` is only atomic within one filesystem — because it
+    lives OUTSIDE the cloud-synced subtree, so OneDrive/Dropbox never opens the
+    freshly-created temp file and cannot lock the rename SOURCE (the dominant
+    cause of issue #636). Fall back to a sibling ``.synctmp`` in the target's own
+    directory (the previous behaviour, guaranteed same-filesystem) when the temp
+    dir is on a different volume or anything goes wrong."""
+    fallback = target_file.with_name(target_file.name + ".synctmp")
+    try:
+        sys_tmp = Path(tempfile.gettempdir())
+        if os.stat(sys_tmp).st_dev == os.stat(target_file.parent).st_dev:
+            fd, name = tempfile.mkstemp(prefix="ankimon-", suffix=".synctmp", dir=str(sys_tmp))
+            os.close(fd)
+            return Path(name)
+    except Exception:
+        pass
+    return fallback
 
 class ImprovedPokemonDataSync(QDialog):
     """
@@ -390,15 +476,19 @@ class ImprovedPokemonDataSync(QDialog):
         """Export local data to AnkiWeb."""
         try:
             success = self.sync_handler.force_sync_to_media()
-            if success:
-                # Enable automatic sync after successful manual sync
-                from .ankimon_sync import enable_automatic_sync
-                enable_automatic_sync()
+            if not success:
+                # force_sync_to_media already told the user WHY nothing was
+                # exported (a file-lock warning, or a traceback for a genuine
+                # error). Don't re-raise it into a SECOND alarming dialog stacked
+                # on top of that message — mirror import_from_ankiweb's contract.
+                return
 
-                tooltip("Data exported to AnkiWeb successfully! Automatic sync is now enabled.")
-                self.close()
-            else:
-                raise Exception("Failed to export data to AnkiWeb.")
+            # Enable automatic sync after a successful manual export.
+            from .ankimon_sync import enable_automatic_sync
+            enable_automatic_sync()
+
+            tooltip("Data exported to AnkiWeb successfully! Automatic sync is now enabled.")
+            self.close()
         except Exception as e:
             self.logger.log("error", f"Failed to export to AnkiWeb: {str(e)}")
             show_warning_with_traceback(parent=self, exception=e, message="Error exporting to AnkiWeb")
@@ -609,21 +699,48 @@ class AnkimonDataSync:
                     if filename.endswith(".db"):
                         self._checkpoint_live_db(source_file)
 
-                    # Copy if destination doesn't exist or files differ
+                    # Copy if destination doesn't exist or files differ.
+                    needs_copy = False
                     if not dest_file.is_file():
-                        shutil.copy2(source_file, dest_file)
-                        synced_files.append(filename)
+                        needs_copy = True
                     elif os.path.getmtime(source_file) >= os.path.getmtime(dest_file):
                         # Source is at least as new as the cloud copy (an exact
                         # mtime tie can't be ordered, so it falls through here
                         # rather than being silently skipped — a genuinely
                         # older source is still correctly excluded below).
-                        if not filecmp.cmp(source_file, dest_file, shallow=False):
-                            os.remove(dest_file)
-                            shutil.copy2(source_file, dest_file)
-                            synced_files.append(filename)
+                        needs_copy = not filecmp.cmp(source_file, dest_file, shallow=False)
+
+                    if needs_copy:
+                        # Write atomically (temp on the same volume + os.replace,
+                        # retrying a transient OneDrive/antivirus lock) so a lock
+                        # or interruption can't leave a half-written media DB, and
+                        # so this automatic pre-sync export tolerates the same
+                        # locks the import side does (issue #636).
+                        tmp = _synctmp_path(dest_file)
+                        try:
+                            shutil.copy2(source_file, tmp)
+                            _retry_on_lock(lambda: os.replace(tmp, dest_file))
+                        finally:
+                            try:
+                                if tmp.exists():
+                                    tmp.unlink()
+                            except Exception:
+                                pass
+                        synced_files.append(filename)
 
                 except Exception as e:
+                    # AUTOMATIC pre-sync export: a transient lock self-heals on
+                    # the next sync, so surface it as a NON-blocking tooltip
+                    # rather than a raw traceback dialog that would pop on every
+                    # sync. Genuine errors still get the traceback.
+                    if _is_lock_error(e):
+                        tooltip(
+                            f"Ankimon: couldn't stage {filename} for AnkiWeb right "
+                            "now — a program such as OneDrive, Google Drive, or "
+                            "antivirus is holding the file open. It will retry on "
+                            "the next sync."
+                        )
+                        continue
                     show_warning_with_traceback(parent=mw, exception=e, message=f"Failed to sync {filename}")
                     continue
 
@@ -758,10 +875,10 @@ class AnkimonDataSync:
         (opt-in file-sync overlapping a live resolve); left documented rather than
         pulling the multi-profile connection model into a hardening pass."""
         source_file.parent.mkdir(parents=True, exist_ok=True)
-        tmp = source_file.with_name(source_file.name + ".synctmp")
+        tmp = _synctmp_path(source_file)
         try:
             shutil.copy2(media_file, tmp)
-            
+
             # Close connection registry completely to release all OS locks
             try:
                 from ..services import services
@@ -770,20 +887,15 @@ class AnkimonDataSync:
             except Exception:
                 pass
             self._close_live_db_connection(source_file)
-            
+
             # Force collection of connection handles
             gc.collect()
-            
-            # Retry loop to allow OS file lock release on Windows
-            for attempt in range(3):
-                try:
-                    os.replace(tmp, source_file)
-                    break
-                except PermissionError:
-                    if attempt == 2:
-                        raise
-                    time.sleep(0.1)
-                    gc.collect()
+
+            # Retry over a bounded backoff so a transient OneDrive/antivirus lock
+            # on the source temp or the destination clears on its own (issue
+            # #636); a persisting lock re-raises for the caller to surface as a
+            # friendly message, and a non-lock error propagates unchanged.
+            _retry_on_lock(lambda: os.replace(tmp, source_file))
 
             for sidecar in ("-wal", "-shm"):
                 stale = source_file.with_name(source_file.name + sidecar)
@@ -876,10 +988,24 @@ class AnkimonDataSync:
                         self._atomic_replace(media_file, source_file)
                     else:
                         self._close_live_db_connection(source_file)
-                        shutil.copy2(media_file, source_file)
+                        _retry_on_lock(lambda: shutil.copy2(media_file, source_file))
                     updated_files.append(filename)
 
                 except Exception as e:
+                    # A locked file (OneDrive/antivirus) on this AUTOMATIC
+                    # post-sync path is transient and self-heals on the next
+                    # sync, so surface it as a NON-blocking tooltip rather than a
+                    # raw traceback dialog that would pop on every background
+                    # sync. The live save is untouched (the atomic replace aborts
+                    # before overwriting). Genuine errors still get the traceback.
+                    if _is_lock_error(e):
+                        tooltip(
+                            f"Ankimon: couldn't import {filename} from AnkiWeb right "
+                            "now — a program such as OneDrive, Google Drive, or "
+                            "antivirus is holding the file open. Your local data is "
+                            "unchanged; it will retry on the next sync."
+                        )
+                        continue
                     show_warning_with_traceback(parent=mw, exception=e, message=f"Failed to read {filename}")
                     continue
 
@@ -948,17 +1074,34 @@ class AnkimonDataSync:
                     if filename.endswith(".db"):
                         self._checkpoint_live_db(source_file)
 
-                    # Remove existing media file if it exists
-                    if dest_file.is_file():
-                        os.remove(dest_file)
-
-                    # Copy LOCAL to MEDIA (Export direction)
-                    shutil.copy2(source_file, dest_file)
+                    # Copy LOCAL to MEDIA (Export direction) atomically: write a
+                    # temp on the same volume, then os.replace it over the media
+                    # file (retrying a transient OneDrive/antivirus lock). This
+                    # both tolerates the lock (issue #636) and removes the old
+                    # non-atomic remove-then-copy window that could leave a
+                    # half-written media DB for Anki to upload.
+                    tmp = _synctmp_path(dest_file)
+                    try:
+                        shutil.copy2(source_file, tmp)
+                        _retry_on_lock(lambda: os.replace(tmp, dest_file))
+                    finally:
+                        try:
+                            if tmp.exists():
+                                tmp.unlink()
+                        except Exception:
+                            pass
                     synced_files.append(filename)
 
             showInfo(f"Exported {len(synced_files)} files to AnkiWeb: {', '.join(synced_files)}")
             return True
         except Exception as e:
+            # A locked media file (OneDrive/antivirus) that survived the retry:
+            # show the single friendly, actionable message instead of a raw
+            # traceback. The caller (export_to_ankiweb) early-returns on False,
+            # so this is NOT stacked with a second dialog.
+            if _is_lock_error(e):
+                showWarning(SYNC_LOCK_MESSAGE)
+                return False
             show_warning_with_traceback(parent=mw, exception=e, message="Failed to export to AnkiWeb")
             return False
 
@@ -1007,7 +1150,7 @@ class AnkimonDataSync:
                         self._atomic_replace(media_file, source_file)
                     else:
                         self._close_live_db_connection(source_file)
-                        shutil.copy2(media_file, source_file)
+                        _retry_on_lock(lambda: shutil.copy2(media_file, source_file))
                     updated_files.append(filename)
 
             # Report success ONLY if something was actually imported. A safety
@@ -1028,6 +1171,14 @@ class AnkimonDataSync:
             showInfo(f"Imported {len(updated_files)} files from AnkiWeb: {', '.join(updated_files)}\n\nAnki will now close. Please reopen Anki to apply changes!")
             return True
         except Exception as e:
+            # A locked local DB (OneDrive/antivirus) that survived the retry:
+            # show the single friendly, actionable message instead of a raw
+            # traceback. The live save is untouched — the atomic replace aborts
+            # before overwriting. Returning False keeps import_from_ankiweb from
+            # enabling auto-sync or closing Anki.
+            if _is_lock_error(e):
+                showWarning(SYNC_LOCK_MESSAGE)
+                return False
             show_warning_with_traceback(parent=mw, exception=e, message="Failed to import from AnkiWeb")
             return False
 

--- a/tests/test_sync_hardening.py
+++ b/tests/test_sync_hardening.py
@@ -374,11 +374,33 @@ def _raise_permission_error(*a, **k):
 
 
 def _no_sleep(monkeypatch):
-    """Make the bounded backoff instant so lock tests don't actually wait."""
+    """Make the bounded backoff instant, and pretend we're on Windows so the
+    lock classification (gated on ``os.name == "nt"``) exercises the real
+    Windows path even on Linux/CI."""
     monkeypatch.setattr(aksync.time, "sleep", lambda *_a, **_k: None)
+    monkeypatch.setattr(aksync.os, "name", "nt")
 
 
-def test_is_lock_error_classification():
+def _spy_synctmp(monkeypatch):
+    """Record the ACTUAL temp paths ``_synctmp_path`` hands out, so a test can
+    assert they were cleaned up. The real path is a randomized system-temp file
+    on the same volume, so a hard-coded sibling ``.synctmp`` assertion would be
+    vacuously true — this checks the path actually used."""
+    created = []
+    real = aksync._synctmp_path
+
+    def spy(target):
+        t = Path(real(target))
+        created.append(t)
+        return t
+
+    monkeypatch.setattr(aksync, "_synctmp_path", spy)
+    return created
+
+
+def test_is_lock_error_classification(monkeypatch):
+    # On Windows, a PermissionError / sharing-violation is a transient lock.
+    monkeypatch.setattr(aksync.os, "name", "nt")
     assert aksync._is_lock_error(PermissionError()) is True
     for code in (5, 32, 33):
         e = OSError()
@@ -390,6 +412,13 @@ def test_is_lock_error_classification():
     enoent.winerror = 2
     assert aksync._is_lock_error(enoent) is False
     assert aksync._is_lock_error(ValueError()) is False
+
+    # On POSIX, os.replace does not fail on open handles, so a PermissionError is
+    # a GENUINE permission problem (not a lock) and must fall through to the
+    # traceback handler rather than the misleading "pause OneDrive" message.
+    monkeypatch.setattr(aksync.os, "name", "posix")
+    assert aksync._is_lock_error(PermissionError()) is False
+    assert aksync._is_lock_error(PermissionError(5, "denied")) is False
 
 
 def test_retry_on_lock_propagates_non_lock_error_without_retrying(monkeypatch):
@@ -438,6 +467,7 @@ def test_atomic_replace_recovers_from_transient_lock(tmp_path, monkeypatch):
     prev = services.db
     services.db = None
     _no_sleep(monkeypatch)
+    created = _spy_synctmp(monkeypatch)
     try:
         src = tmp_path / "ankimon.db"
         src.write_bytes(b"OLD" + b"\x00" * 600)
@@ -459,7 +489,7 @@ def test_atomic_replace_recovers_from_transient_lock(tmp_path, monkeypatch):
 
         assert src.read_bytes().startswith(b"NEW")   # swap eventually succeeded
         assert calls["n"] == 3
-        assert not (tmp_path / "ankimon.db.synctmp").exists()
+        assert created and all(not t.exists() for t in created)   # temp cleaned
     finally:
         services.db = prev
 
@@ -539,6 +569,7 @@ def test_force_export_writes_media_atomically(tmp_path, monkeypatch):
     monkeypatch.setattr(ds, "_ensure_sync_folder_exists", lambda: True)
     monkeypatch.setattr(ds, "_get_source_path", lambda fn: src)
     monkeypatch.setattr(ds, "_get_media_path", lambda fn: dest)
+    created = _spy_synctmp(monkeypatch)
 
     prev = services.db
     services.db = None
@@ -548,7 +579,7 @@ def test_force_export_writes_media_atomically(tmp_path, monkeypatch):
         services.db = prev
 
     assert dest.read_bytes().startswith(b"LOCAL")
-    assert not (tmp_path / "media_ankimon.db.synctmp").exists()
+    assert created and all(not t.exists() for t in created)   # temp cleaned
 
 
 def test_force_export_persistent_lock_shows_warning_not_traceback(tmp_path, monkeypatch):
@@ -563,6 +594,7 @@ def test_force_export_persistent_lock_shows_warning_not_traceback(tmp_path, monk
     monkeypatch.setattr(ds, "_get_source_path", lambda fn: src)
     monkeypatch.setattr(ds, "_get_media_path", lambda fn: dest)
     _no_sleep(monkeypatch)
+    created = _spy_synctmp(monkeypatch)
     monkeypatch.setattr(aksync.os, "replace", _raise_permission_error)
 
     warnings, tracebacks = [], []
@@ -578,7 +610,8 @@ def test_force_export_persistent_lock_shows_warning_not_traceback(tmp_path, monk
 
     assert len(warnings) == 1
     assert tracebacks == []
-    assert not dest.exists()                         # nothing half-written landed
+    assert not dest.exists()                          # nothing half-written landed
+    assert created and all(not t.exists() for t in created)   # temp cleaned on failure
 
 
 def test_save_configs_writes_media_atomically(tmp_path, monkeypatch):

--- a/tests/test_sync_hardening.py
+++ b/tests/test_sync_hardening.py
@@ -158,9 +158,13 @@ def test_integrity_rejects_db_without_core_table(tmp_path):
     assert AnkimonDataSync._verify_sqlite_integrity(p) is False
 
 
-def test_atomic_replace_swaps_file_and_clears_stale_sidecars(tmp_path):
+def test_atomic_replace_swaps_file_and_clears_stale_sidecars(tmp_path, monkeypatch):
     prev = services.db
     services.db = None  # so _close_live_db_connection is a no-op
+    # Capture the ACTUAL temp path used: _synctmp_path prefers a randomized
+    # system-temp file on the same volume, so a hard-coded sibling ".synctmp"
+    # assertion would be vacuously true — this checks the path actually used.
+    created = _spy_synctmp(monkeypatch)
     try:
         src = tmp_path / "ankimon.db"
         src.write_bytes(b"OLD" + b"\x00" * 600)
@@ -176,7 +180,7 @@ def test_atomic_replace_swaps_file_and_clears_stale_sidecars(tmp_path):
         assert src.read_bytes().startswith(b"NEW")
         assert not (tmp_path / "ankimon.db-wal").exists()
         assert not (tmp_path / "ankimon.db-shm").exists()
-        assert not (tmp_path / "ankimon.db.synctmp").exists()
+        assert created and all(not t.exists() for t in created)   # temp cleaned
     finally:
         services.db = prev
 
@@ -374,11 +378,28 @@ def _raise_permission_error(*a, **k):
 
 
 def _no_sleep(monkeypatch):
-    """Make the bounded backoff instant, and pretend we're on Windows so the
-    lock classification (gated on ``os.name == "nt"``) exercises the real
-    Windows path even on Linux/CI."""
+    """Make the bounded backoff instant, and force the lock classification to the
+    Windows answer (PermissionError / sharing-violation => transient lock) so the
+    retry + friendly-message paths run even on Linux/CI.
+
+    This patches ``_is_lock_error`` directly rather than flipping ``os.name`` to
+    ``"nt"``: mutating the process-global ``os.name`` also flips ``pathlib.Path``
+    to ``WindowsPath`` on POSIX, which mangles the system temp path
+    (``/tmp`` -> ``\\tmp``) so ``os.stat`` fails and ``_synctmp_path`` silently
+    falls back to a sibling — the system-temp branch (the actual issue-#636 fix)
+    would then never be exercised, and the ``_spy_synctmp`` re-wrap would write a
+    backslash-named temp into the repo CWD. ``test_is_lock_error_classification``
+    keeps the real ``os.name``-gated coverage of ``_is_lock_error`` itself."""
     monkeypatch.setattr(aksync.time, "sleep", lambda *_a, **_k: None)
-    monkeypatch.setattr(aksync.os, "name", "nt")
+    monkeypatch.setattr(
+        aksync,
+        "_is_lock_error",
+        lambda exc: isinstance(exc, PermissionError)
+        or (
+            isinstance(exc, OSError)
+            and getattr(exc, "winerror", None) in aksync._SYNC_LOCK_WINERRORS
+        ),
+    )
 
 
 def _spy_synctmp(monkeypatch):

--- a/tests/test_sync_hardening.py
+++ b/tests/test_sync_hardening.py
@@ -52,6 +52,7 @@ atexit.register(shutil.rmtree, _USER_DIR, ignore_errors=True)
 from Ankimon.services import services  # noqa: E402
 from Ankimon.pyobj.database_manager import AnkimonDB  # noqa: E402
 from Ankimon.pyobj.ankimon_sync import AnkimonDataSync  # noqa: E402
+import Ankimon.pyobj.ankimon_sync as aksync  # noqa: E402
 from Ankimon.functions import mobile_sync as ms  # noqa: E402
 
 # backup_manager imports askUser at module top; another test module late in a
@@ -361,3 +362,274 @@ def test_backup_returns_false_when_required_file_not_backed_up(tmp_path, monkeyp
         services.db = prev
 
     assert ok is False   # the file we needed protected never landed in the backup
+
+
+# --------------------------------------------------------------------------
+# File-lock tolerance (issue #636): OneDrive/antivirus holding ankimon.db open
+# --------------------------------------------------------------------------
+def _raise_permission_error(*a, **k):
+    """A stand-in for a file op that Windows blocks with PermissionError while
+    another process (OneDrive/antivirus) holds the file open (WinError 5)."""
+    raise PermissionError(5, "Access is denied")
+
+
+def _no_sleep(monkeypatch):
+    """Make the bounded backoff instant so lock tests don't actually wait."""
+    monkeypatch.setattr(aksync.time, "sleep", lambda *_a, **_k: None)
+
+
+def test_is_lock_error_classification():
+    assert aksync._is_lock_error(PermissionError()) is True
+    for code in (5, 32, 33):
+        e = OSError()
+        e.winerror = code
+        assert aksync._is_lock_error(e) is True, code
+    # A non-lock OSError (e.g. file-not-found, winerror 2) must NOT be treated as
+    # a lock — it should still reach the normal traceback handler.
+    enoent = OSError()
+    enoent.winerror = 2
+    assert aksync._is_lock_error(enoent) is False
+    assert aksync._is_lock_error(ValueError()) is False
+
+
+def test_retry_on_lock_propagates_non_lock_error_without_retrying(monkeypatch):
+    _no_sleep(monkeypatch)
+    calls = {"n": 0}
+
+    def op():
+        calls["n"] += 1
+        raise FileNotFoundError(2, "missing")   # not a lock
+
+    with pytest.raises(FileNotFoundError):
+        aksync._retry_on_lock(op)
+    assert calls["n"] == 1                       # propagated immediately, no retry
+
+
+def test_retry_on_lock_recovers_after_transient_failures(monkeypatch):
+    _no_sleep(monkeypatch)
+    calls = {"n": 0}
+
+    def op():
+        calls["n"] += 1
+        if calls["n"] < 3:                       # locked twice, then released
+            raise PermissionError(5, "Access is denied")
+        return "ok"
+
+    assert aksync._retry_on_lock(op) == "ok"
+    assert calls["n"] == 3
+
+
+def test_retry_on_lock_gives_up_after_exhausting_attempts(monkeypatch):
+    _no_sleep(monkeypatch)
+    calls = {"n": 0}
+
+    def op():
+        calls["n"] += 1
+        raise PermissionError(5, "Access is denied")
+
+    with pytest.raises(PermissionError):
+        aksync._retry_on_lock(op)
+    assert calls["n"] == len(aksync._SYNC_LOCK_RETRY_DELAYS) + 1
+
+
+def test_atomic_replace_recovers_from_transient_lock(tmp_path, monkeypatch):
+    """A transient OneDrive/AV lock on os.replace must be retried into a success,
+    not surfaced as an error — the whole point of issue #636's fix."""
+    prev = services.db
+    services.db = None
+    _no_sleep(monkeypatch)
+    try:
+        src = tmp_path / "ankimon.db"
+        src.write_bytes(b"OLD" + b"\x00" * 600)
+        media = tmp_path / "media.db"
+        media.write_bytes(b"NEW" + b"\x00" * 600)
+
+        real_replace = os.replace
+        calls = {"n": 0}
+
+        def flaky_replace(a, b, *ar, **k):
+            calls["n"] += 1
+            if calls["n"] < 3:                   # locked twice, then released
+                raise PermissionError(5, "Access is denied")
+            return real_replace(a, b, *ar, **k)
+
+        monkeypatch.setattr(aksync.os, "replace", flaky_replace)
+
+        AnkimonDataSync()._atomic_replace(media, src)
+
+        assert src.read_bytes().startswith(b"NEW")   # swap eventually succeeded
+        assert calls["n"] == 3
+        assert not (tmp_path / "ankimon.db.synctmp").exists()
+    finally:
+        services.db = prev
+
+
+def test_import_persistent_lock_shows_tooltip_not_traceback(tmp_path, monkeypatch):
+    """AUTOMATIC path (read_configs): a persisting lock must surface as a
+    NON-blocking tooltip (self-heals next sync), never a raw traceback dialog,
+    and must leave the local save untouched."""
+    src = tmp_path / "ankimon.db"
+    src.write_bytes(b"LOCAL" + b"\x00" * 600)
+    media = tmp_path / "media.db"
+    media.write_bytes(b"REMOTE" + b"\x00" * 600)
+
+    ds = AnkimonDataSync()
+    _wire_read_configs(ds, monkeypatch, src, media)
+    monkeypatch.setattr(ds, "_verify_sqlite_integrity", lambda p: True)
+    monkeypatch.setattr(ds, "_backup_before_overwrite", lambda *a: True)
+    _no_sleep(monkeypatch)
+    monkeypatch.setattr(aksync.os, "replace", _raise_permission_error)
+
+    tips, tracebacks = [], []
+    monkeypatch.setattr(aksync, "tooltip", lambda *a, **k: tips.append(a))
+    monkeypatch.setattr(aksync, "show_warning_with_traceback", lambda *a, **k: tracebacks.append(a))
+
+    prev = services.db
+    services.db = None
+    try:
+        updated = ds.read_configs(media_sync_status=False)
+    finally:
+        services.db = prev
+
+    assert updated == []                             # nothing imported
+    assert src.read_bytes().startswith(b"LOCAL")     # local save untouched
+    assert len(tips) == 1                            # one friendly tooltip
+    assert tracebacks == []                          # NO raw traceback dialog
+
+
+def test_force_import_persistent_lock_shows_warning_not_traceback(tmp_path, monkeypatch):
+    """MANUAL import: a persisting lock returns False + a single friendly modal,
+    never a raw traceback, with the local save untouched."""
+    src = tmp_path / "ankimon.db"
+    src.write_bytes(b"LOCAL" + b"\x00" * 600)
+    media = tmp_path / "media.db"
+    media.write_bytes(b"REMOTE" + b"\x00" * 600)
+
+    ds = AnkimonDataSync()
+    monkeypatch.setattr(ds, "_get_source_path", lambda fn: src)
+    monkeypatch.setattr(ds, "_get_media_path", lambda fn: media)
+    monkeypatch.setattr(ds, "_verify_sqlite_integrity", lambda p: True)
+    monkeypatch.setattr(ds, "_backup_before_overwrite", lambda *a: True)
+    _no_sleep(monkeypatch)
+    monkeypatch.setattr(aksync.os, "replace", _raise_permission_error)
+
+    warnings, tracebacks = [], []
+    monkeypatch.setattr(aksync, "showWarning", lambda *a, **k: warnings.append(a))
+    monkeypatch.setattr(aksync, "show_warning_with_traceback", lambda *a, **k: tracebacks.append(a))
+
+    prev = services.db
+    services.db = None
+    try:
+        assert ds.force_sync_from_media() is False
+    finally:
+        services.db = prev
+
+    assert src.read_bytes().startswith(b"LOCAL")     # local save untouched
+    assert len(warnings) == 1
+    assert tracebacks == []
+
+
+def test_force_export_writes_media_atomically(tmp_path, monkeypatch):
+    """Happy-path export lands the file (via the new atomic temp+replace)."""
+    src = tmp_path / "ankimon.db"
+    src.write_bytes(b"LOCAL" + b"\x00" * 600)
+    dest = tmp_path / "media_ankimon.db"            # parent (tmp_path) exists
+
+    ds = AnkimonDataSync()
+    monkeypatch.setattr(ds, "_ensure_sync_folder_exists", lambda: True)
+    monkeypatch.setattr(ds, "_get_source_path", lambda fn: src)
+    monkeypatch.setattr(ds, "_get_media_path", lambda fn: dest)
+
+    prev = services.db
+    services.db = None
+    try:
+        assert ds.force_sync_to_media() is True
+    finally:
+        services.db = prev
+
+    assert dest.read_bytes().startswith(b"LOCAL")
+    assert not (tmp_path / "media_ankimon.db.synctmp").exists()
+
+
+def test_force_export_persistent_lock_shows_warning_not_traceback(tmp_path, monkeypatch):
+    """MANUAL export: a persisting lock returns False + one friendly modal, never
+    a raw traceback (and no leftover temp)."""
+    src = tmp_path / "ankimon.db"
+    src.write_bytes(b"LOCAL" + b"\x00" * 600)
+    dest = tmp_path / "media_ankimon.db"
+
+    ds = AnkimonDataSync()
+    monkeypatch.setattr(ds, "_ensure_sync_folder_exists", lambda: True)
+    monkeypatch.setattr(ds, "_get_source_path", lambda fn: src)
+    monkeypatch.setattr(ds, "_get_media_path", lambda fn: dest)
+    _no_sleep(monkeypatch)
+    monkeypatch.setattr(aksync.os, "replace", _raise_permission_error)
+
+    warnings, tracebacks = [], []
+    monkeypatch.setattr(aksync, "showWarning", lambda *a, **k: warnings.append(a))
+    monkeypatch.setattr(aksync, "show_warning_with_traceback", lambda *a, **k: tracebacks.append(a))
+
+    prev = services.db
+    services.db = None
+    try:
+        assert ds.force_sync_to_media() is False
+    finally:
+        services.db = prev
+
+    assert len(warnings) == 1
+    assert tracebacks == []
+    assert not dest.exists()                         # nothing half-written landed
+
+
+def test_save_configs_writes_media_atomically(tmp_path, monkeypatch):
+    """Automatic pre-sync export (save_configs) stages the file atomically."""
+    src = tmp_path / "ankimon.db"
+    src.write_bytes(b"LOCAL" + b"\x00" * 600)
+    dest = tmp_path / "media_ankimon.db"             # does not exist yet
+
+    ds = AnkimonDataSync()
+    monkeypatch.setattr(ds, "_migrate_legacy_files", lambda: [])
+    monkeypatch.setattr(ds, "_ensure_sync_folder_exists", lambda: True)
+    monkeypatch.setattr(ds, "_get_source_path", lambda fn: src)
+    monkeypatch.setattr(ds, "_get_media_path", lambda fn: dest)
+
+    prev = services.db
+    services.db = None
+    try:
+        synced = ds.save_configs()
+    finally:
+        services.db = prev
+
+    assert synced == ["ankimon.db"]
+    assert dest.read_bytes().startswith(b"LOCAL")
+
+
+def test_save_configs_persistent_lock_shows_tooltip_not_traceback(tmp_path, monkeypatch):
+    """AUTOMATIC pre-sync export: a persisting lock is a non-blocking tooltip and
+    stages nothing — never a raw traceback on every sync."""
+    src = tmp_path / "ankimon.db"
+    src.write_bytes(b"LOCAL" + b"\x00" * 600)
+    dest = tmp_path / "media_ankimon.db"
+
+    ds = AnkimonDataSync()
+    monkeypatch.setattr(ds, "_migrate_legacy_files", lambda: [])
+    monkeypatch.setattr(ds, "_ensure_sync_folder_exists", lambda: True)
+    monkeypatch.setattr(ds, "_get_source_path", lambda fn: src)
+    monkeypatch.setattr(ds, "_get_media_path", lambda fn: dest)
+    _no_sleep(monkeypatch)
+    monkeypatch.setattr(aksync.os, "replace", _raise_permission_error)
+
+    tips, tracebacks = [], []
+    monkeypatch.setattr(aksync, "tooltip", lambda *a, **k: tips.append(a))
+    monkeypatch.setattr(aksync, "show_warning_with_traceback", lambda *a, **k: tracebacks.append(a))
+
+    prev = services.db
+    services.db = None
+    try:
+        synced = ds.save_configs()
+    finally:
+        services.db = prev
+
+    assert synced == []
+    assert len(tips) == 1
+    assert tracebacks == []

--- a/tests/test_sync_hardening.py
+++ b/tests/test_sync_hardening.py
@@ -603,6 +603,28 @@ def test_force_export_writes_media_atomically(tmp_path, monkeypatch):
     assert created and all(not t.exists() for t in created)   # temp cleaned
 
 
+def test_force_export_returns_false_when_no_local_data(tmp_path, monkeypatch):
+    """No local source file => nothing to export: force_sync_to_media must return
+    False (not a false 'Exported 0 files' success), so export_to_ankiweb doesn't
+    enable auto-sync and close the dialog. Symmetric with the import side."""
+    src = tmp_path / "ankimon.db"          # deliberately NOT created
+    dest = tmp_path / "media_ankimon.db"
+
+    ds = AnkimonDataSync()
+    monkeypatch.setattr(ds, "_ensure_sync_folder_exists", lambda: True)
+    monkeypatch.setattr(ds, "_get_source_path", lambda fn: src)
+    monkeypatch.setattr(ds, "_get_media_path", lambda fn: dest)
+
+    prev = services.db
+    services.db = None
+    try:
+        assert ds.force_sync_to_media() is False   # not a false success
+    finally:
+        services.db = prev
+
+    assert not dest.exists()                        # nothing was exported
+
+
 def test_force_export_persistent_lock_shows_warning_not_traceback(tmp_path, monkeypatch):
     """MANUAL export: a persisting lock returns False + one friendly modal, never
     a raw traceback (and no leftover temp)."""


### PR DESCRIPTION
## Summary

Fixes #636 — "Import/Export Data" via the Ankimon Data Sync dialog could crash with a raw `PermissionError [WinError 5]` traceback when OneDrive (or Google Drive / Dropbox / an antivirus) held `ankimon.db` open during the sync swap.

This **supersedes #634** (closed as stale). #634 had the right instinct (a friendly message instead of a traceback) but only guarded the two manual buttons, missed the automatic sync-hook path where the bug actually fires, introduced an export double-dialog, and only failed more politely rather than making the sync succeed. This PR addresses all of that.

## Root cause

The reported traceback ends at `os.replace(...ankimon.db.synctmp -> ...ankimon.db)` inside `_atomic_replace`. On Windows, `os.replace` needs delete rights on **both** the source temp and the destination; a handle held by OneDrive/antivirus without `FILE_SHARE_DELETE` blocks it → `PermissionError [WinError 5]` (or the sharing/lock-violation variants 32/33). These holds are **transient** (typically < 1–2 s on a small file), but the old 3×0.1 s (~0.2 s) retry was too short, and the re-raised error hit a generic `except Exception` that dumped a traceback. Research also indicates the dominant trigger is OneDrive grabbing the freshly-created `.synctmp` as the rename **source**.

## What this PR does

- **Bounded lock-aware retry** (`_retry_on_lock`, ~2.5 s exponential backoff) + a lock classifier (`_is_lock_error`, WinError 5/32/33). The retry — not the message — is the primary fix, so most transient locks now resolve silently. Non-lock errors still propagate to the normal handler.
- **Relocate the temp file** outside the cloud-synced subtree when it's on the same volume (`_synctmp_path`), removing the dominant root cause. `os.replace` stays an atomic same-filesystem rename (with a fallback to the previous sibling-`.synctmp` behaviour on a different volume).
- **Cover every write path**, not just the two manual buttons: manual import/export **and** the automatic `read_configs` / `save_configs` sync-hook paths. Manual paths show one friendly, actionable modal; automatic paths show a **non-blocking tooltip** and self-heal on the next sync (no traceback popping on every background sync).
- **Make the export paths atomic** (temp + `os.replace`), removing the old non-atomic remove-then-copy window that could hand Anki a half-written media DB to upload.
- **Fix an export double-dialog**: `export_to_ankiweb` now early-returns on `False` instead of re-raising into `show_warning_with_traceback`.

All existing safety invariants are untouched — integrity check, pre-import timestamped backup, atomicity, stale `-wal`/`-shm` cleanup — so a persisting lock aborts with the live save **provably intact**. #634's unrelated `get_file_differences`/`media_newer` startup-prompt change is intentionally left out (it can ship separately).

## Testing

- `tests/test_sync_hardening.py`: **+11 tests** — lock classification, retry propagates non-lock errors immediately, retry recovers after transient failures, retry gives up after the budget, `_atomic_replace` recovers from a transient lock, and friendly-vs-traceback surfacing on all four paths (manual import, manual export, automatic import, automatic export).
- Full file: **27 passed**. Related sync/mobile/profile-hook tests: **62 passed**. Tier-1 harness gate (`harness/check.py`, what CI runs): **9/9 green**. Ruff (CI config): clean.
- The Windows-only lock is simulated by monkeypatching `os.replace` to raise `PermissionError` (on POSIX `os.replace` succeeds over open handles), which exercises the real code paths on Linux/CI.

## Notes

A follow-up idea from the investigation (not in this PR): a one-time "your Anki folder is under OneDrive — consider excluding/pausing it" tip as pure prevention.
