### PR TITLE
Fix UI trade evolution bug

### DIFF
--- a/src/Ankimon/ankimon_items_web/shop_obj.py
+++ b/src/Ankimon/ankimon_items_web/shop_obj.py
@@ -1875,7 +1875,7 @@ class AnkimonItemsWeb(QDialog):
                         normalized_target = target_evo_name.lower().replace(" ", "").replace("-", "").replace("'", "").replace(".", "").replace(":", "")
                         target_data = pokedex_data.get(normalized_target) or pokedex_data.get(target_evo_name.lower())
 
-                        if target_data and target_data.get("evoType") == "useItem":
+                        if target_data and target_data.get("evoType") in ("useItem", "trade"):
                             # Normalize both sides by stripping spaces, hyphens and
                             # apostrophes so pokedex.json display names (e.g.
                             # "King's Rock") match items.csv identifiers (e.g.


### PR DESCRIPTION
Fixes a bug where trade-evolution Pokémon were not shown in the item picker when an evolution item was used on them.

---
*PR created automatically by Jules for task [3258967137527937493](https://jules.google.com/task/3258967137527937493) started by @h0tp-ftw*