### PR TITLE
fix: revert fainted status to fighting when HP is restored

### DIFF
--- a/src/Ankimon/functions/battle_functions.py
+++ b/src/Ankimon/functions/battle_functions.py
@@ -612,6 +612,10 @@ def validate_pokemon_status(pokemon):
     if hasattr(pokemon, "hp") and pokemon.hp <= 0 and current_status != "fainted":
         return "fainted"
 
+    # If Pokemon is NOT fainted but status is fainted, override back to fighting
+    if hasattr(pokemon, "hp") and pokemon.hp > 0 and current_status == "fainted":
+        return "fighting"
+
     return current_status
 
 


### PR DESCRIPTION
Fixes an issue where a Pokémon continues to receive "affected by Fainted!" battle messages after being healed from 0 HP.

### Root Cause
When a Pokémon's HP dropped to 0, `validate_pokemon_status` would appropriately force the `battle_status` to `"fainted"`. However, if the Pokémon was healed or cycled out such that its HP went above 0, the function did not revert the `"fainted"` status back to `"fighting"`.

### Fix
Added a condition to `validate_pokemon_status` in `src/Ankimon/functions/battle_functions.py` to revert the status to `"fighting"` if `hp > 0` and `battle_status == "fainted"`.

---
*PR created automatically by Jules for task [9360338987372486162](https://jules.google.com/task/9360338987372486162) started by @h0tp-ftw*