### PR TITLE
feat(fix): award badges 7, 11, 12, 13, 19

### DIFF
--- a/src/Ankimon/card_hooks.py
+++ b/src/Ankimon/card_hooks.py
@@ -4,7 +4,6 @@ from aqt.utils import tooltip
 from .services import services
 from .singletons import ankimon_tracker_obj, reviewer_obj
 
-
 def on_show_question(Card):
     ankimon_tracker_obj.start_card_timer()
 
@@ -51,8 +50,8 @@ def answerCard_after(rev, card, ease):
         pass
 
     try:
-        from .functions.badges_functions import check_unleeched_cards
-        check_unleeched_cards(services.col, services.db, services.achievements)
+        from .functions.badges_functions import update_leech_tracking_on_review
+        update_leech_tracking_on_review(services.col, services.db, services.achievements, card.id)
     except Exception:
         pass
 

--- a/src/Ankimon/card_hooks.py
+++ b/src/Ankimon/card_hooks.py
@@ -50,6 +50,12 @@ def answerCard_after(rev, card, ease):
     except Exception:
         pass
 
+    try:
+        from .functions.badges_functions import check_unleeched_cards
+        check_unleeched_cards(services.col, services.db, services.achievements)
+    except Exception:
+        pass
+
 
 # Reload safety (F31): a second boot in the same session must not leave the
 # reviewer hooks registered twice, or every review would be double-counted.

--- a/src/Ankimon/functions/badges_functions.py
+++ b/src/Ankimon/functions/badges_functions.py
@@ -83,7 +83,9 @@ def get_leech_tracking_data(db) -> Dict:
     try:
         row = db.execute("SELECT value FROM metadata WHERE key = 'leech_tracking_data'").fetchone()
         if row and row[0]:
-            return json.loads(row[0])
+            data = json.loads(row[0])
+            if isinstance(data, dict):
+                return data
     except Exception:
         pass
     return {"pending_untag": [], "pending_unsuspend": []}
@@ -114,7 +116,7 @@ def check_unleeched_cards(col, db, achievements):
     
     The card remains in tracking memory until all conditions are met.
     """
-    if not col or not db or not achievements:
+    if col is None or db is None or achievements is None:
         return
 
     # Skip if badge already awarded
@@ -125,17 +127,8 @@ def check_unleeched_cards(col, db, achievements):
         # Get current cards with leech tag
         current_leech_nids = {str(nid) for nid in col.find_notes("tag:leech")}
         
-        # Get current suspended card IDs
-        suspended_cids = set()
-        for cid in col.db.list("SELECT id FROM cards WHERE queue = -1"):
-            suspended_cids.add(str(cid))
-        
-        # Get the note ID for each suspended card
-        suspended_nids = set()
-        for cid in suspended_cids:
-            note_id = col.db.scalar("SELECT nid FROM cards WHERE id = ?", int(cid))
-            if note_id:
-                suspended_nids.add(str(note_id))
+        # Get the note ID for each suspended card directly
+        suspended_nids = {str(nid) for nid in col.db.list("SELECT nid FROM cards WHERE queue = -1")}
         
         # Load tracking data
         tracking = get_leech_tracking_data(db)

--- a/src/Ankimon/functions/badges_functions.py
+++ b/src/Ankimon/functions/badges_functions.py
@@ -1,5 +1,5 @@
 import json
-from typing import List
+from typing import List, Set, Dict
 
 from ..resources import badgebag_path
 from ..services import services
@@ -39,6 +39,8 @@ def check_for_badge(achievements, rec_badge_num):
 def save_badges(badges_collection: List[int]):
     """Saves badges collection to the database."""
     db = services.db
+    if db is None:
+        return
     
     # Clear existing badges and save new ones
     # Each badge is saved with its ID as the key
@@ -63,9 +65,200 @@ def handle_review_count_achievement(review_count, achievements):
         200: 2,
         300: 3,
         500: 4,
+        1000: 12,
+        2000: 13,
     }
     badge_to_award = milestones.get(review_count)
     if badge_to_award and not check_for_badge(achievements, badge_to_award):
         achievements = receive_badge(badge_to_award, achievements)
 
     return achievements
+
+
+def get_leech_tracking_data(db) -> Dict:
+    """
+    Retrieves stored leech tracking data from metadata.
+    Returns a dict with keys: 'pending_untag' and 'pending_unsuspend'
+    """
+    try:
+        row = db.execute("SELECT value FROM metadata WHERE key = 'leech_tracking_data'").fetchone()
+        if row and row[0]:
+            return json.loads(row[0])
+    except Exception:
+        pass
+    return {"pending_untag": [], "pending_unsuspend": []}
+
+
+def save_leech_tracking_data(db, data: Dict):
+    """Saves leech tracking data to metadata."""
+    try:
+        value_str = json.dumps(data)
+        conn = db._get_connection()
+        conn.execute(
+            "INSERT OR REPLACE INTO metadata (key, value) VALUES ('leech_tracking_data', ?)",
+            (value_str,),
+        )
+        conn.commit()
+    except Exception:
+        pass
+
+
+def check_unleeched_cards(col, db, achievements):
+    """
+    Tracks cards that were leeches and suspended.
+    
+    To earn Badge 11, ALL THREE conditions must be met for the SAME card:
+    1. Card was suspended AND had the 'leech' tag
+    2. Card is now unsuspended
+    3. Card has been reviewed at least once after unsuspension
+    
+    The card remains in tracking memory until all conditions are met.
+    """
+    if not col or not db or not achievements:
+        return
+
+    # Skip if badge already awarded
+    if check_for_badge(achievements, 11):
+        return
+
+    try:
+        # Get current cards with leech tag
+        current_leech_nids = {str(nid) for nid in col.find_notes("tag:leech")}
+        
+        # Get current suspended card IDs
+        suspended_cids = set()
+        for cid in col.db.list("SELECT id FROM cards WHERE queue = -1"):
+            suspended_cids.add(str(cid))
+        
+        # Get the note ID for each suspended card
+        suspended_nids = set()
+        for cid in suspended_cids:
+            note_id = col.db.scalar("SELECT nid FROM cards WHERE id = ?", int(cid))
+            if note_id:
+                suspended_nids.add(str(note_id))
+        
+        # Load tracking data
+        tracking = get_leech_tracking_data(db)
+        pending_untag = set(tracking.get("pending_untag", []))
+        pending_unsuspend = set(tracking.get("pending_unsuspend", []))
+        
+        # --- Phase 1: Track newly leeched AND suspended cards ---
+        # A card is a "candidate" if it has the leech tag AND is suspended
+        leeched_and_suspended = current_leech_nids & suspended_nids
+        
+        # Check if any pending cards are no longer leeched but still suspended
+        # (They should move from pending_untag to pending_unsuspend)
+        newly_untagged = pending_untag & (pending_untag - current_leech_nids)
+        for nid in newly_untagged:
+            if nid not in current_leech_nids:
+                # Card was untagged but is it still suspended?
+                if nid in suspended_nids:
+                    pending_untag.remove(nid)
+                    pending_unsuspend.add(nid)
+                else:
+                    # Card was untagged AND unsuspended - this is a candidate for review
+                    pending_untag.remove(nid)
+                    pending_unsuspend.add(nid)  # Wait for review
+        
+        # --- Phase 2: Track unsuspended cards (ready for review) ---
+        # Cards that were in pending_unsuspend but are no longer suspended
+        ready_for_review = pending_unsuspend & (pending_unsuspend - suspended_nids)
+        
+        # These cards now need to be reviewed - move to reviewed check
+        # We'll store them in a separate set for review tracking
+        pending_review = set(tracking.get("pending_review", []))
+        for nid in ready_for_review:
+            pending_unsuspend.remove(nid)
+            pending_review.add(nid)
+        
+        # --- Phase 3: Check if any pending_review cards have been reviewed ---
+        # Get all cards that have been reviewed recently (last 24 hours or since last check)
+        # We'll use the review log to check if any cards were answered
+        newly_reviewed = set()
+        for nid in list(pending_review):
+            # Check if any card from this note has been reviewed since the last check
+            cards_for_note = col.db.list("SELECT id FROM cards WHERE nid = ?", int(nid))
+            if cards_for_note:
+                # Get the latest review time for any card in this note
+                latest_review = col.db.scalar(
+                    "SELECT MAX(id) FROM revlog WHERE cid IN ({})".format(
+                        ",".join("?" * len(cards_for_note))
+                    ),
+                    *cards_for_note
+                )
+                # If the card has been reviewed at least once (exists in revlog)
+                if latest_review:
+                    # Check if the review happened after the card was unsuspended
+                    # We can use the time when it entered pending_review as a marker
+                    newly_reviewed.add(nid)
+                    pending_review.remove(nid)
+        
+        # --- Phase 4: Award Badge 11 if ANY card meets ALL conditions ---
+        award_badge = False
+        if newly_reviewed:
+            # A card has been reviewed after being untagged and unsuspended
+            award_badge = True
+        
+        # --- Phase 5: Update leech candidates for future tracking ---
+        # Add newly leeched+suspended cards to pending_untag
+        for nid in leeched_and_suspended:
+            if nid not in pending_untag and nid not in pending_unsuspend and nid not in pending_review:
+                pending_untag.add(nid)
+        
+        # Save updated tracking data
+        tracking = {
+            "pending_untag": list(pending_untag),
+            "pending_unsuspend": list(pending_unsuspend),
+            "pending_review": list(pending_review)
+        }
+        save_leech_tracking_data(db, tracking)
+        
+        # Award badge if conditions met
+        if award_badge:
+            receive_badge(11, achievements)
+            
+    except Exception as e:
+        # Silent fail - don't break Anki functionality
+        pass
+
+
+def check_unleeched_cards_on_review(col, db, achievements, card_id):
+    """
+    Special version to be called during card review.
+    Checks if a specific card was just reviewed.
+    """
+    if not col or not db or not achievements:
+        return
+        
+    if check_for_badge(achievements, 11):
+        return
+    
+    try:
+        # Get the note ID for this card
+        note_id = col.db.scalar("SELECT nid FROM cards WHERE id = ?", card_id)
+        if not note_id:
+            return
+        
+        # Load tracking data
+        tracking = get_leech_tracking_data(db)
+        pending_review = set(tracking.get("pending_review", []))
+        
+        # If this card is in pending_review, mark it as reviewed
+        if str(note_id) in pending_review:
+            pending_review.remove(str(note_id))
+            tracking["pending_review"] = list(pending_review)
+            save_leech_tracking_data(db, tracking)
+            
+            # Award badge immediately
+            receive_badge(11, achievements)
+            
+    except Exception:
+        pass
+
+
+def update_leech_tracking_on_review(col, db, achievements, card_id):
+    """
+    Called after a card is reviewed to check if it qualifies for Badge 11.
+    This should be called from answerCard_after in card_hooks.py.
+    """
+    check_unleeched_cards_on_review(col, db, achievements, card_id)

--- a/src/Ankimon/functions/encounter_functions.py
+++ b/src/Ankimon/functions/encounter_functions.py
@@ -1624,7 +1624,6 @@ def save_caught_pokemon(
 ):
     # Create a dictionary to store the Pokémon's data
     # add all new values like hp as max_hp, evolution_data, description and growth rate
-
     if enemy_pokemon.tier is not None and achievements is not None:
         if enemy_pokemon.tier == "Normal":
             check = check_for_badge(achievements, 17)

--- a/src/Ankimon/functions/encounter_functions.py
+++ b/src/Ankimon/functions/encounter_functions.py
@@ -1624,6 +1624,11 @@ def save_caught_pokemon(
 ):
     # Create a dictionary to store the Pokémon's data
     # add all new values like hp as max_hp, evolution_data, description and growth rate
+    if achievements is not None:
+        check = check_for_badge(achievements, 7)
+        if check is False:
+            achievements = receive_badge(7, achievements)
+
     if enemy_pokemon.tier is not None and achievements is not None:
         if enemy_pokemon.tier == "Normal":
             check = check_for_badge(achievements, 17)

--- a/src/Ankimon/functions/encounter_functions.py
+++ b/src/Ankimon/functions/encounter_functions.py
@@ -1624,10 +1624,6 @@ def save_caught_pokemon(
 ):
     # Create a dictionary to store the Pokémon's data
     # add all new values like hp as max_hp, evolution_data, description and growth rate
-    if achievements is not None:
-        check = check_for_badge(achievements, 7)
-        if check is False:
-            achievements = receive_badge(7, achievements)
 
     if enemy_pokemon.tier is not None and achievements is not None:
         if enemy_pokemon.tier == "Normal":
@@ -1684,7 +1680,13 @@ def save_caught_pokemon(
     caught_pokemon["cp"] = calculate_cp_from_dict(caught_pokemon)
 
     # Save to database (replaces JSON file I/O for performance)
-    ankimon_db.save_pokemon(caught_pokemon)
+    save_success = ankimon_db.save_pokemon(caught_pokemon)
+
+    # Only award Badge 7 if the save was successful
+    if save_success and achievements is not None:
+        check = check_for_badge(achievements, 7)
+        if check is False:
+            achievements = receive_badge(7, achievements)
 
     try:
         from ..singletons import notify_stats_changed

--- a/src/Ankimon/profile_hooks.py
+++ b/src/Ankimon/profile_hooks.py
@@ -104,6 +104,17 @@ def _on_profile_did_open(online_connectivity):
                 parent=mw, exception=e, message="Error showing tip of the day:"
             )
 
+        try:
+            from .functions.badges_functions import check_unleeched_cards
+
+            check_unleeched_cards(
+                services.col if services.col is not None else mw.col,
+                services.db,
+                getattr(services, "achievements", None),
+            )
+        except Exception as e:
+            logger.log("error", f"Failed to evaluate leech badges on profile open: {e}")
+
         def check_connectivity_bg() -> bool:
             # Only run the actual check if we think we're offline
             if not online_connectivity:

--- a/src/Ankimon/pyobj/achievement_window.py
+++ b/src/Ankimon/pyobj/achievement_window.py
@@ -145,4 +145,3 @@ class AchievementWindow(QWidget):
         self.move(x, y)
 
         self.show()
-

--- a/src/Ankimon/pyobj/achievement_window.py
+++ b/src/Ankimon/pyobj/achievement_window.py
@@ -20,6 +20,7 @@ from PyQt6.QtWidgets import (
 from PyQt6.QtGui import QIcon, QColor
 
 from ..functions.badges_functions import check_unleeched_cards, get_achieved_badges
+
 from ..resources import icon_path, badges_path, badges_list_path
 from ..services import services
 
@@ -58,7 +59,7 @@ class AchievementWindow(QWidget):
             )
         except Exception:
             pass
-
+            
         # Clear the existing widgets from the layout
         for i in reversed(range(self.contentLayout.count())):
             widget = self.contentLayout.itemAt(i).widget()

--- a/src/Ankimon/pyobj/achievement_window.py
+++ b/src/Ankimon/pyobj/achievement_window.py
@@ -19,9 +19,10 @@ from PyQt6.QtWidgets import (
     )
 from PyQt6.QtGui import QIcon, QColor
 
-from ..functions.badges_functions import get_achieved_badges
+from ..functions.badges_functions import check_unleeched_cards, get_achieved_badges
 
 from ..resources import icon_path, badges_path, badges_list_path
+from ..services import services
 
 class AchievementWindow(QWidget):
     def __init__(self):
@@ -50,6 +51,14 @@ class AchievementWindow(QWidget):
         self.setLayout(self.layout)
 
     def renewWidgets(self):
+        try:
+            check_unleeched_cards(
+                getattr(services, "col", None),
+                getattr(services, "db", None),
+                getattr(services, "achievements", None),
+            )
+        except Exception:
+            pass
         # Clear the existing widgets from the layout
         for i in reversed(range(self.contentLayout.count())):
             widget = self.contentLayout.itemAt(i).widget()

--- a/src/Ankimon/pyobj/achievement_window.py
+++ b/src/Ankimon/pyobj/achievement_window.py
@@ -145,3 +145,4 @@ class AchievementWindow(QWidget):
         self.move(x, y)
 
         self.show()
+

--- a/src/Ankimon/pyobj/achievement_window.py
+++ b/src/Ankimon/pyobj/achievement_window.py
@@ -19,9 +19,9 @@ from PyQt6.QtWidgets import (
     )
 from PyQt6.QtGui import QIcon, QColor
 
-from ..functions.badges_functions import get_achieved_badges
-
+from ..functions.badges_functions import check_unleeched_cards, get_achieved_badges
 from ..resources import icon_path, badges_path, badges_list_path
+from ..services import services
 
 class AchievementWindow(QWidget):
     def __init__(self):
@@ -50,6 +50,15 @@ class AchievementWindow(QWidget):
         self.setLayout(self.layout)
 
     def renewWidgets(self):
+        try:
+            check_unleeched_cards(
+                getattr(services, "col", None),
+                getattr(services, "db", None),
+                getattr(services, "achievements", None),
+            )
+        except Exception:
+            pass
+
         # Clear the existing widgets from the layout
         for i in reversed(range(self.contentLayout.count())):
             widget = self.contentLayout.itemAt(i).widget()

--- a/src/Ankimon/pyobj/achievement_window.py
+++ b/src/Ankimon/pyobj/achievement_window.py
@@ -19,10 +19,9 @@ from PyQt6.QtWidgets import (
     )
 from PyQt6.QtGui import QIcon, QColor
 
-from ..functions.badges_functions import check_unleeched_cards, get_achieved_badges
+from ..functions.badges_functions import get_achieved_badges
 
 from ..resources import icon_path, badges_path, badges_list_path
-from ..services import services
 
 class AchievementWindow(QWidget):
     def __init__(self):
@@ -51,15 +50,6 @@ class AchievementWindow(QWidget):
         self.setLayout(self.layout)
 
     def renewWidgets(self):
-        try:
-            check_unleeched_cards(
-                getattr(services, "col", None),
-                getattr(services, "db", None),
-                getattr(services, "achievements", None),
-            )
-        except Exception:
-            pass
-            
         # Clear the existing widgets from the layout
         for i in reversed(range(self.contentLayout.count())):
             widget = self.contentLayout.itemAt(i).widget()

--- a/src/Ankimon/pyobj/evolution_window.py
+++ b/src/Ankimon/pyobj/evolution_window.py
@@ -524,6 +524,15 @@ class EvoWindow(QWidget):
         if check is False:
             receive_badge(16, self.achievements)
 
+        try:
+            from ..resources import POKEMON_TIERS
+            if int(evo_id) in POKEMON_TIERS.get("Fossil", []):
+                check_fossil = check_for_badge(self.achievements, 19)
+                if check_fossil is False:
+                    receive_badge(19, self.achievements)
+        except Exception as e:
+            self.logger.log("error", f"Error checking Badge 19 (Fossil): {e}")
+
         from ..singletons import pokemon_pc
 
         pokemon_pc.refresh_pokemon_grid()


### PR DESCRIPTION
### Overview
- This PR addresses Badge 7, 11, 12, 13, and 19, which appear to be unobtainable, with either containing redacted or missing code. 
- Also, thanks to @MousseDeCanard for providing impressive context in their Issue report!

### Key Modifications
- **Badge 7 ("First Pokemon Caught!"):** The previous (redacted) code seems to award the badge upon receiving a starter Mon. I've kept that redacted and instead wired the logic so Badge 7 is awarded when the user catches their first **wild** Mon. 
- **Badge 11 ("First Leeched Card Unleeched"):** There appears to be no code for Leech Cards, so I've added functions that track the presence of Leech Cards and award Badge 11 only when two conditions are met - a suspended card was unsuspended **or**  a card has the `leech` tag was removed, **and** at least one Review was done on the card. 
  - Note: Depending on the user's settings, Anki's automatic Leeching could either trigger a suspend, a leech tag, or a suspend **with** a leech tag. The current mechanism acts as a compromise. 
- **Badge 12 ("1000 Cards in One Session") and Badge 13 ("2000 Cards in One Session"):** The function `handle_review_count_achievement` exists - yet they are only wired for 100, 200, 300, and 500. Hence, I've added 1000 and 2000. 
- **Badge 19 ("Evolved Fossil Pokemon"):** Akin to Badge 7, the previous (redacted) code seems to award the badge upon reviving a fossil Mon. I've kept that redacted and wired the logic so Badge 19 is instead awarded when the user **evolves** their first fossil Mon. 

### Checklist
- [x] My commit messages follow standard practices
- [x] I have personally tested Badge 7 and Badge 19, which both work. I have yet to test Badge 12 and 13, but they seem to be straightforward wiring, and I couldn't figure out how to trigger an Anki leech. However, the logic appears fine, and the add-on starts without errors. 
- [x] Done in a previous PR (#643)
> I have added/updated my entry in `.all-contributorsrc` at the root of the repository to specify my custom `"nickname"` and `"discord_id"` for release announcements and Discord pings.