### PR TITLE
feat(move): move ankimon leaderboard credentials to settings

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -229,6 +229,17 @@
       ],
       "nickname": "PENDING_REVIEW",
       "discord_id": "PENDING_REVIEW"
+    },
+    {
+      "login": "Nut2026",
+      "name": "Nut2026",
+      "avatar_url": "https://github.com/Nut2026.png",
+      "profile": "https://github.com/Nut2026",
+      "contributions": [
+        "code"
+      ],
+      "nickname": "Nuz",
+      "discord_id": "1317008280911876109"
     }
   ],
   "contributorsPerLine": 5

--- a/harness/checks/probe_real_webengine.py
+++ b/harness/checks/probe_real_webengine.py
@@ -12,6 +12,7 @@ Run with a display wrapper on Linux:
 
 from __future__ import annotations
 
+import json
 import os
 import pathlib
 import sys
@@ -67,11 +68,45 @@ def _run_javascript(page, script, timeout_ms=10_000):
     return result.get("value")
 
 
+def _edit_and_save(page, key, value):
+    """Edit one rendered Settings input and click the real Save button."""
+    return _run_javascript(
+        page,
+        f"""
+        (() => {{
+            const row = document.querySelector(
+                '.setting-row[data-key=' + {json.dumps(json.dumps(key))} + ']'
+            );
+            const input = row && row.querySelector('input');
+            const save = document.getElementById('save-btn');
+            if (!input || !save) return {{ok: false}};
+            input.value = {json.dumps(value)};
+            input.dispatchEvent(new Event('input', {{bubbles: true}}));
+            const becameDirty = !save.disabled;
+            save.click();
+            return {{ok: true, becameDirty}};
+        }})()
+        """,
+    )
+
+
+def _wait_for_saved(page):
+    return _wait_until(
+        lambda: _run_javascript(
+            page, "document.getElementById('save-status')?.textContent"
+        ) == "All saved"
+    )
+
+
 def main() -> int:
     session = start_real_session(webengine=True, require_webengine=True)
 
     from Ankimon.ankimon_items_web.shop_obj import SCREEN_SETTINGS
     from Ankimon.singletons import get_items_window
+
+    original_secret = "webengine-original-api-secret"
+    session.services.settings.set("leaderboard.username", "WebEngineUser")
+    session.services.settings.set("leaderboard.api_key", original_secret)
 
     window = get_items_window()
     view = window.webview_settings
@@ -116,33 +151,51 @@ def main() -> int:
     assert page_state["hasQtTransport"] is True, page_state
     assert page_state["hasInput"] is True, page_state
 
-    expected_name = "WebEngine CI Trainer"
-    edit_state = _run_javascript(
+    credential_state = _run_javascript(
         page,
         f"""
         (() => {{
-            const row = document.querySelector('.setting-row[data-key="trainer.name"]');
+            const row = document.querySelector(
+                '.setting-row[data-key="leaderboard.api_key"]'
+            );
             const input = row && row.querySelector('input');
-            const save = document.getElementById('save-btn');
-            if (!input || !save) return {{ok: false}};
-            input.value = {expected_name!r};
-            input.dispatchEvent(new Event('input', {{bubbles: true}}));
-            const becameDirty = !save.disabled;
-            save.click();
-            return {{ok: true, becameDirty}};
+            const html = document.documentElement.innerHTML;
+            const inputValues = Array.from(document.querySelectorAll('input'))
+                .map((item) => item.value);
+            return {{
+                hasRow: Boolean(row),
+                type: input ? input.type : null,
+                value: input ? input.value : null,
+                placeholder: input ? input.placeholder : null,
+                secretInHtml: html.includes({json.dumps(original_secret)}),
+                secretInInputs: inputValues.some(
+                    (value) => value.includes({json.dumps(original_secret)})
+                ),
+            }};
         }})()
         """,
     )
+    assert credential_state == {
+        "hasRow": True,
+        "type": "password",
+        "value": "********",
+        "placeholder": "API key saved — type to replace it",
+        "secretInHtml": False,
+        "secretInInputs": False,
+    }, credential_state
+
+    # Saving an unrelated field leaves the masked API-key placeholder untouched.
+    expected_name = "WebEngine CI Trainer"
+    edit_state = _edit_and_save(page, "trainer.name", expected_name)
     assert edit_state == {"ok": True, "becameDirty": True}, edit_state
 
     assert _wait_until(
         lambda: session.services.settings.get("trainer.name") == expected_name
     ), "Clicking Save in the real Settings web page did not persist Trainer Name"
-    assert _wait_until(
-        lambda: _run_javascript(
-            page, "document.getElementById('save-status')?.textContent"
-        ) == "All saved"
-    ), "Settings persisted, but the browser never completed its saved-state refresh"
+    assert _wait_for_saved(page), (
+        "Settings persisted, but the browser never completed its saved-state refresh"
+    )
+    assert session.services.settings.get("leaderboard.api_key") == original_secret
 
     saved_state = _run_javascript(
         page,
@@ -164,9 +217,68 @@ def main() -> int:
         "saveDisabled": True,
     }, saved_state
 
+    replacement_secret = "webengine-replacement-api-secret"
+    replace_state = _edit_and_save(
+        page, "leaderboard.api_key", replacement_secret
+    )
+    assert replace_state == {"ok": True, "becameDirty": True}, replace_state
+    assert _wait_until(
+        lambda: session.services.settings.get("leaderboard.api_key")
+        == replacement_secret
+    ), "Replacing the API key through the real browser did not persist"
+    assert _wait_for_saved(page), "API-key replacement never completed its UI refresh"
+
+    replaced_dom = _run_javascript(
+        page,
+        f"""
+        (() => {{
+            const input = document.querySelector(
+                '.setting-row[data-key="leaderboard.api_key"] input'
+            );
+            return {{
+                value: input ? input.value : null,
+                secretInHtml: document.documentElement.innerHTML.includes(
+                    {json.dumps(replacement_secret)}
+                ),
+            }};
+        }})()
+        """,
+    )
+    assert replaced_dom == {
+        "value": "********",
+        "secretInHtml": False,
+    }, replaced_dom
+
+    clear_state = _edit_and_save(page, "leaderboard.api_key", "")
+    assert clear_state == {"ok": True, "becameDirty": True}, clear_state
+    assert _wait_until(
+        lambda: session.services.settings.get("leaderboard.api_key") == ""
+    ), "Clearing the API key through the real browser did not persist"
+    assert _wait_for_saved(page), "API-key clearing never completed its UI refresh"
+
+    cleared_dom = _run_javascript(
+        page,
+        """
+        (() => {
+            const input = document.querySelector(
+                '.setting-row[data-key="leaderboard.api_key"] input'
+            );
+            return {
+                value: input ? input.value : null,
+                placeholder: input ? input.placeholder : null,
+            };
+        })()
+        """,
+    )
+    assert cleared_dom == {
+        "value": "",
+        "placeholder": "Enter your API key",
+    }, cleared_dom
+
     print(
         "probe_real_webengine: OK "
-        f"({page_state['rowCount']} settings rows, real QWebEngine, DOM save persisted)"
+        f"({page_state['rowCount']} settings rows, real QWebEngine, "
+        "DOM save + API-key lifecycle persisted)"
     )
     window.close()
     return 0

--- a/src/Ankimon/__init__.py
+++ b/src/Ankimon/__init__.py
@@ -56,6 +56,7 @@ from .pyobj.error_handler import show_warning_with_traceback
 from .pyobj.backup_manager import BackupManager
 from .services import services
 from .events import events
+from .pyobj.ankimon_leaderboard import migrate_credentials_from_db
 
 # singletons.py already populated the service registry and mirrored these onto
 # mw (see services.py), so the previous mw.settings_ankimon/logger/settings_obj
@@ -65,6 +66,15 @@ from .events import events
 # instance to keep mw.translator identical to services.translator. Remove this
 # once menu_buttons stops building its own translator.
 mw.translator = translator
+
+# Migrate leaderboard credentials from database to settings
+# This runs once when Anki starts up
+
+try:
+    migrate_credentials_from_db()
+    print("Ankimon: Leaderboard credentials migration checked")
+except Exception as e:
+    print(f"Ankimon: Error during leaderboard credentials migration: {e}")
 
 # Deck-browser / deck-overview team grid (F19). Registration is gated on the
 # gui.team_deck_view setting and reload-safe (F31 registry-anchored record on

--- a/src/Ankimon/__init__.py
+++ b/src/Ankimon/__init__.py
@@ -67,15 +67,6 @@ from .pyobj.ankimon_leaderboard import migrate_credentials_from_db
 # once menu_buttons stops building its own translator.
 mw.translator = translator
 
-# Migrate leaderboard credentials from database to settings
-# This runs once when Anki starts up
-
-try:
-    migrate_credentials_from_db()
-    print("Ankimon: Leaderboard credentials migration checked")
-except Exception as e:
-    print(f"Ankimon: Error during leaderboard credentials migration: {e}")
-
 # Deck-browser / deck-overview team grid (F19). Registration is gated on the
 # gui.team_deck_view setting and reload-safe (F31 registry-anchored record on
 # services), so an add-on reload swaps the handlers instead of stacking them.
@@ -210,6 +201,16 @@ def start_asynchronous_startup():
         #    for the module-level consumers registered above).
         collected_pokemon_ids.update(results["collected_pokemon_ids"])
         init_battle_state(collected_pokemon_ids)
+
+        # LEADERBOARD CREDENTIALS MIGRATION
+        # Now runs here where services.db and services.settings are
+        # guaranteed to be fully initialized.
+
+        try:
+            migrate_credentials_from_db()
+            print("Ankimon: Leaderboard credentials migration checked")
+        except Exception as e:
+            print(f"Ankimon: Error during leaderboard credentials migration: {e}")
 
         # 3. Reviewer UI: collected IDs + shortcut/button wiring. Imported
         #    here (not at module scope) because reviewer_ui pulls lazy F31

--- a/src/Ankimon/__init__.py
+++ b/src/Ankimon/__init__.py
@@ -56,7 +56,11 @@ from .pyobj.error_handler import show_warning_with_traceback
 from .pyobj.backup_manager import BackupManager
 from .services import services
 from .events import events
-from .pyobj.ankimon_leaderboard import migrate_credentials_from_db
+
+# LEADERBOARD CREDENTIALS MIGRATION
+# Moved to build_core() in core.py - runs immediately after
+# services.populate() and BEFORE any TrainerCard construction.
+# This ensures migration completes before any sync can fire.
 
 # singletons.py already populated the service registry and mirrored these onto
 # mw (see services.py), so the previous mw.settings_ankimon/logger/settings_obj
@@ -66,24 +70,6 @@ from .pyobj.ankimon_leaderboard import migrate_credentials_from_db
 # instance to keep mw.translator identical to services.translator. Remove this
 # once menu_buttons stops building its own translator.
 mw.translator = translator
-
-# LEADERBOARD CREDENTIALS MIGRATION
-# This must run BEFORE TrainerCard is constructed (which happens during
-# the from .singletons import ... above and triggers the first sync attempt).
-# services.db and services.settings are already populated via build_core()
-# at import time, so this is the earliest safe point to migrate.
-#
-# Why this is the correct location:
-# 1. services.db and services.settings are fully initialized
-# 2. No TrainerCard/UI logic has run yet
-# 3. The migration completes before any sync can fire
-# 4. No dependency on the async startup QueryOp success callback
-
-try:
-    migrate_credentials_from_db()
-    print("Ankimon: Leaderboard credentials migration checked")
-except Exception as e:
-    print(f"Ankimon: Error during leaderboard credentials migration: {e}")
 
 # Deck-browser / deck-overview team grid (F19). Registration is gated on the
 # gui.team_deck_view setting and reload-safe (F31 registry-anchored record on

--- a/src/Ankimon/__init__.py
+++ b/src/Ankimon/__init__.py
@@ -67,6 +67,24 @@ from .pyobj.ankimon_leaderboard import migrate_credentials_from_db
 # once menu_buttons stops building its own translator.
 mw.translator = translator
 
+# LEADERBOARD CREDENTIALS MIGRATION
+# This must run BEFORE TrainerCard is constructed (which happens during
+# the from .singletons import ... above and triggers the first sync attempt).
+# services.db and services.settings are already populated via build_core()
+# at import time, so this is the earliest safe point to migrate.
+#
+# Why this is the correct location:
+# 1. services.db and services.settings are fully initialized
+# 2. No TrainerCard/UI logic has run yet
+# 3. The migration completes before any sync can fire
+# 4. No dependency on the async startup QueryOp success callback
+
+try:
+    migrate_credentials_from_db()
+    print("Ankimon: Leaderboard credentials migration checked")
+except Exception as e:
+    print(f"Ankimon: Error during leaderboard credentials migration: {e}")
+
 # Deck-browser / deck-overview team grid (F19). Registration is gated on the
 # gui.team_deck_view setting and reload-safe (F31 registry-anchored record on
 # services), so an add-on reload swaps the handlers instead of stacking them.
@@ -201,16 +219,6 @@ def start_asynchronous_startup():
         #    for the module-level consumers registered above).
         collected_pokemon_ids.update(results["collected_pokemon_ids"])
         init_battle_state(collected_pokemon_ids)
-
-        # LEADERBOARD CREDENTIALS MIGRATION
-        # Now runs here where services.db and services.settings are
-        # guaranteed to be fully initialized.
-
-        try:
-            migrate_credentials_from_db()
-            print("Ankimon: Leaderboard credentials migration checked")
-        except Exception as e:
-            print(f"Ankimon: Error during leaderboard credentials migration: {e}")
 
         # 3. Reviewer UI: collected IDs + shortcut/button wiring. Imported
         #    here (not at module scope) because reviewer_ui pulls lazy F31

--- a/src/Ankimon/ankimon_items_web/settings.css
+++ b/src/Ankimon/ankimon_items_web/settings.css
@@ -753,3 +753,20 @@
     to { transform: translateY(0); opacity: 1; }
 }
 
+/* ============================================================
+   Password input field styling
+   ============================================================ */
+.setting-input[type="password"] {
+    font-family: 'JetBrains Mono', monospace;
+    letter-spacing: 2px;
+}
+
+.setting-input[type="password"]::placeholder {
+    letter-spacing: 0px;
+    font-family: 'Outfit', sans-serif;
+}
+
+.setting-row[data-key="leaderboard.api_key"] .setting-label::before {
+    content: '🔒 ';
+    font-size: 0.85rem;
+}

--- a/src/Ankimon/ankimon_items_web/settings.css
+++ b/src/Ankimon/ankimon_items_web/settings.css
@@ -763,7 +763,7 @@
 
 .setting-input[type="password"]::placeholder {
     letter-spacing: 0px;
-    font-family: 'Outfit', sans-serif;
+    font-family: Outfit, sans-serif;
 }
 
 .setting-row[data-key="leaderboard.api_key"] .setting-label::before {

--- a/src/Ankimon/ankimon_items_web/settings.html
+++ b/src/Ankimon/ankimon_items_web/settings.html
@@ -31,9 +31,9 @@
         }
     </style>
     <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700;800;900&family=JetBrains+Mono:wght@500;700&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="shop.css?v=20260633">
-    <link rel="stylesheet" href="settings.css?v=20260633">
-    <link rel="stylesheet" href="nav-switcher.css?v=20260633">
+    <link rel="stylesheet" href="shop.css?v=20260634">
+    <link rel="stylesheet" href="settings.css?v=20260634">
+    <link rel="stylesheet" href="nav-switcher.css?v=20260634">
     <script src="qrc:///qtwebchannel/qwebchannel.js"></script>
 </head>
 <body class="dark-mode">
@@ -164,7 +164,7 @@
 
     <div id="toast" class="shop-toast"></div>
 
-    <script src="nav-switcher.js?v=20260633"></script>
-    <script src="settings.js?v=20260633"></script>
+    <script src="nav-switcher.js?v=20260634"></script>
+    <script src="settings.js?v=20260634"></script>
 </body>
 </html>

--- a/src/Ankimon/ankimon_items_web/settings.js
+++ b/src/Ankimon/ankimon_items_web/settings.js
@@ -182,9 +182,9 @@
 
     /**
      * Builds a password input field for sensitive credential settings.
-     * 
+     *
      * Creates a masked input field with placeholder text and change tracking.
-     * 
+     *
      * @param {Object} setting - The setting configuration object.
      * @returns {HTMLElement} The password input element.
      */

--- a/src/Ankimon/ankimon_items_web/settings.js
+++ b/src/Ankimon/ankimon_items_web/settings.js
@@ -184,7 +184,6 @@
      * Builds a password input field for sensitive credential settings.
      * 
      * Creates a masked input field with placeholder text and change tracking.
-     * Clears validation errors when the user begins typing.
      * 
      * @param {Object} setting - The setting configuration object.
      * @returns {HTMLElement} The password input element.
@@ -199,8 +198,6 @@
             setEdit(setting.key, input.value);
             updateDirtyUI();
             markRowDirty(setting.key);
-            // Clear validation error when user types
-            clearValidationErrors();
         });
         return input;
     }

--- a/src/Ankimon/ankimon_items_web/settings.js
+++ b/src/Ankimon/ankimon_items_web/settings.js
@@ -190,10 +190,20 @@
      */
     function buildPasswordInput(setting) {
         const input = document.createElement('input');
+        const savedPlaceholder = setting.secret_placeholder || '';
         input.type = 'password';
         input.className = 'setting-input';
         input.value = currentValue(setting) ?? '';
-        input.placeholder = 'Enter your API key';
+        input.placeholder = setting.secret_configured
+            ? 'API key saved — type to replace it'
+            : 'Enter your API key';
+        input.autocomplete = 'new-password';
+        input.spellcheck = false;
+        input.addEventListener('focus', () => {
+            if (setting.secret_configured && input.value === savedPlaceholder) {
+                input.select();
+            }
+        });
         input.addEventListener('input', () => {
             setEdit(setting.key, input.value);
             updateDirtyUI();

--- a/src/Ankimon/ankimon_items_web/settings.js
+++ b/src/Ankimon/ankimon_items_web/settings.js
@@ -173,9 +173,36 @@
                 return buildChipGroup(setting);
             case 'wishlist':
                 return buildWishlistControl(setting);
+            case 'password':
+                return buildPasswordInput(setting);
             default:
                 return buildTextInput(setting);
         }
+    }
+
+    /**
+     * Builds a password input field for sensitive credential settings.
+     * 
+     * Creates a masked input field with placeholder text and change tracking.
+     * Clears validation errors when the user begins typing.
+     * 
+     * @param {Object} setting - The setting configuration object.
+     * @returns {HTMLElement} The password input element.
+     */
+    function buildPasswordInput(setting) {
+        const input = document.createElement('input');
+        input.type = 'password';
+        input.className = 'setting-input';
+        input.value = currentValue(setting) ?? '';
+        input.placeholder = 'Enter your API key';
+        input.addEventListener('input', () => {
+            setEdit(setting.key, input.value);
+            updateDirtyUI();
+            markRowDirty(setting.key);
+            // Clear validation error when user types
+            clearValidationErrors();
+        });
+        return input;
     }
 
     function buildWishlistControl(setting) {

--- a/src/Ankimon/ankimon_items_web/settings_schema.py
+++ b/src/Ankimon/ankimon_items_web/settings_schema.py
@@ -213,6 +213,32 @@ GROUPS = [
 ]
 
 
+SECRET_SETTING_PLACEHOLDER = "********"
+
+
+def serialize_secret_setting(value):
+    """Return a browser-safe representation of a stored secret setting."""
+    configured = bool(value)
+    return {
+        "type": "password",
+        "value": SECRET_SETTING_PLACEHOLDER if configured else "",
+        "secret_configured": configured,
+        "secret_placeholder": SECRET_SETTING_PLACEHOLDER,
+    }
+
+
+def is_unchanged_secret_placeholder(value) -> bool:
+    """Whether a web-settings value means "leave the stored secret unchanged"."""
+    return value == SECRET_SETTING_PLACEHOLDER
+
+
+def display_setting_value(key, value):
+    """Redact secrets before rendering a settings-change summary."""
+    if key == "leaderboard.api_key" and value:
+        return SECRET_SETTING_PLACEHOLDER
+    return value
+
+
 # Active region dropdown options — preserved verbatim from the legacy window.
 ACTIVE_REGION_OPTIONS = [
     {"value": None, "label": "No Region"},

--- a/src/Ankimon/ankimon_items_web/settings_schema.py
+++ b/src/Ankimon/ankimon_items_web/settings_schema.py
@@ -22,7 +22,6 @@ GROUPS = [
                     "SSH Access",
                     "Prevent Ankimon News on Startup",
                     "AnkiWeb Sync",
-                    "Ankimon Leaderboard",
                     "Developer Mode",
                 ],
             },
@@ -201,6 +200,14 @@ GROUPS = [
                     {"value": "auto", "label": "Auto-Resolve"}
                 ]
             }
+        ]
+    },
+    {
+        "label": "Leaderboard",
+        "settings": [
+            "Enable Leaderboard Sync",
+            "Username",
+            "API Key"
         ]
     }
 ]

--- a/src/Ankimon/ankimon_items_web/shop_obj.py
+++ b/src/Ankimon/ankimon_items_web/shop_obj.py
@@ -2154,6 +2154,12 @@ class AnkimonItemsWeb(QDialog):
                         names_dict[pid] = f"#{pid}"
             entry["names"] = names_dict
             return entry
+        
+        # Add 'dotted' case for API Key
+        if key == "leaderboard.api_key":
+            entry["type"] = "password"
+            return entry
+        
         if key == "misc.active_region":
             entry["type"] = "select"
             entry["options"] = settings_schema.ACTIVE_REGION_OPTIONS

--- a/src/Ankimon/ankimon_items_web/shop_obj.py
+++ b/src/Ankimon/ankimon_items_web/shop_obj.py
@@ -2154,11 +2154,11 @@ class AnkimonItemsWeb(QDialog):
                         names_dict[pid] = f"#{pid}"
             entry["names"] = names_dict
             return entry
-        
+
         if key == "leaderboard.api_key":
             entry.update(settings_schema.serialize_secret_setting(value))
             return entry
-        
+
         if key == "misc.active_region":
             entry["type"] = "select"
             entry["options"] = settings_schema.ACTIVE_REGION_OPTIONS

--- a/src/Ankimon/ankimon_items_web/shop_obj.py
+++ b/src/Ankimon/ankimon_items_web/shop_obj.py
@@ -2155,9 +2155,8 @@ class AnkimonItemsWeb(QDialog):
             entry["names"] = names_dict
             return entry
         
-        # Add 'dotted' case for API Key
         if key == "leaderboard.api_key":
-            entry["type"] = "password"
+            entry.update(settings_schema.serialize_secret_setting(value))
             return entry
         
         if key == "misc.active_region":
@@ -2214,6 +2213,11 @@ class AnkimonItemsWeb(QDialog):
             for raw_key, raw_val in payload.items():
                 key = str(raw_key)
                 if key not in config:
+                    continue
+                if (
+                    key == "leaderboard.api_key"
+                    and settings_schema.is_unchanged_secret_placeholder(raw_val)
+                ):
                     continue
                 config[key] = self._coerce_incoming(config[key], raw_val)
         except ValueError as e:

--- a/src/Ankimon/core.py
+++ b/src/Ankimon/core.py
@@ -88,14 +88,11 @@ def build_core() -> SimpleNamespace:
     settings_obj = Settings()
     services.populate(settings=settings_obj)
 
-    # LEADERBOARD CREDENTIALS MIGRATION
-    # This runs immediately after services.populate(settings=settings_obj)
-    # and BEFORE any TrainerCard construction or sync attempt.
-  
-    from .pyobj.ankimon_leaderboard import migrate_credentials_from_db
+    # Run before TrainerCard construction, whose initializer can sync stats.
     try:
+        from .pyobj.ankimon_leaderboard import migrate_credentials_from_db
+
         migrate_credentials_from_db()
-        print("Ankimon: Leaderboard credentials migration checked")
     except Exception as e:
         print(f"Ankimon: Error during leaderboard credentials migration: {e}")
 

--- a/src/Ankimon/core.py
+++ b/src/Ankimon/core.py
@@ -88,6 +88,17 @@ def build_core() -> SimpleNamespace:
     settings_obj = Settings()
     services.populate(settings=settings_obj)
 
+    # LEADERBOARD CREDENTIALS MIGRATION
+    # This runs immediately after services.populate(settings=settings_obj)
+    # and BEFORE any TrainerCard construction or sync attempt.
+  
+    from .pyobj.ankimon_leaderboard import migrate_credentials_from_db
+    try:
+        migrate_credentials_from_db()
+        print("Ankimon: Leaderboard credentials migration checked")
+    except Exception as e:
+        print(f"Ankimon: Error during leaderboard credentials migration: {e}")
+
     translator = Translator(language=int(settings_obj.get("misc.language")))
     services.populate(translator=translator)
 
@@ -195,3 +206,4 @@ def bind_runtime_globals() -> None:
         module = importlib.import_module(real_module_path)
         for global_name, attr in mapping.items():
             setattr(module, global_name, getattr(services, attr))
+          

--- a/src/Ankimon/core.py
+++ b/src/Ankimon/core.py
@@ -203,4 +203,3 @@ def bind_runtime_globals() -> None:
         module = importlib.import_module(real_module_path)
         for global_name, attr in mapping.items():
             setattr(module, global_name, getattr(services, attr))
-          

--- a/src/Ankimon/lang/ch_text.json
+++ b/src/Ankimon/lang/ch_text.json
@@ -56,7 +56,6 @@
   "choose_trainer_sprite_button": "选择训练师形象",
   "choose_pokemon_team_button": "选择宝可梦队伍",
   "ankimon_file_checker_button": "Ankimon 文件检查器",
-  "ankimon_leaderboard_credentials_button": "Ankimon 排行榜凭据",
   "download_resources_button": "下载资源",
   "backing_up_files": "正在备份文件",
   "ankimon_button_title": "Ankimon",

--- a/src/Ankimon/lang/cz_text.json
+++ b/src/Ankimon/lang/cz_text.json
@@ -56,7 +56,6 @@
   "choose_trainer_sprite_button": "Vybrat sprite trenéra",
   "choose_pokemon_team_button": "Vybrat tým Pokémonů",
   "ankimon_file_checker_button": "Kontroler souborů Ankimon",
-  "ankimon_leaderboard_credentials_button": "Přihlašovací údaje Ankimon Leaderboard",
   "download_resources_button": "Stáhnout zdroje",
   "backing_up_files": "Zálohování souborů",
   "ankimon_button_title": "Ankimon",

--- a/src/Ankimon/lang/de_text.json
+++ b/src/Ankimon/lang/de_text.json
@@ -56,7 +56,6 @@
   "choose_trainer_sprite_button": "Trainer-Sprite wählen",
   "choose_pokemon_team_button": "Pokémon-Team wählen",
   "ankimon_file_checker_button": "Ankimon-Dateiprüfer",
-  "ankimon_leaderboard_credentials_button": "Ankimon-Bestenliste-Anmeldeinformationen",
   "download_resources_button": "Ressourcen herunterladen",
   "backing_up_files": "Sichere Dateien",
   "ankimon_button_title": "Ankimon",

--- a/src/Ankimon/lang/en_text.json
+++ b/src/Ankimon/lang/en_text.json
@@ -58,7 +58,6 @@
   "choose_trainer_sprite_button": "Choose Trainer Sprite",
   "choose_pokemon_team_button": "Choose Pokemon Team",
   "ankimon_file_checker_button": "Ankimon File Checker",
-  "ankimon_leaderboard_credentials_button": "Ankimon Leaderboard Credentials",
   "download_resources_button": "Download Resources",
   "backing_up_files": "Backing up files",
   "ankimon_button_title": "Ankimon",

--- a/src/Ankimon/lang/es_latam_text.json
+++ b/src/Ankimon/lang/es_latam_text.json
@@ -56,7 +56,6 @@
   "choose_trainer_sprite_button": "Elegir sprite de entrenador",
   "choose_pokemon_team_button": "Elegir equipo Pokémon",
   "ankimon_file_checker_button": "Verificador de archivos de Ankimon",
-  "ankimon_leaderboard_credentials_button": "Credenciales de la tabla de clasificación de Ankimon",
   "download_resources_button": "Descargar recursos",
   "backing_up_files": "Realizando copia de seguridad de archivos",
   "ankimon_button_title": "Ankimon",

--- a/src/Ankimon/lang/fr_text.json
+++ b/src/Ankimon/lang/fr_text.json
@@ -56,7 +56,6 @@
   "choose_trainer_sprite_button": "Choisir le sprite du dresseur",
   "choose_pokemon_team_button": "Choisir l'équipe de Pokémon",
   "ankimon_file_checker_button": "Vérificateur de fichiers Ankimon",
-  "ankimon_leaderboard_credentials_button": "Identifiants du classement Ankimon",
   "download_resources_button": "Télécharger les ressources",
   "backing_up_files": "Sauvegarde des fichiers",
   "ankimon_button_title": "Ankimon",

--- a/src/Ankimon/lang/it_text.json
+++ b/src/Ankimon/lang/it_text.json
@@ -56,7 +56,6 @@
   "choose_trainer_sprite_button": "Scegli Sprite Allenatore",
   "choose_pokemon_team_button": "Scegli Squadra Pokémon",
   "ankimon_file_checker_button": "Verificatore File Ankimon",
-  "ankimon_leaderboard_credentials_button": "Credenziali Classifica Ankimon",
   "download_resources_button": "Scarica Risorse",
   "backing_up_files": "Backup dei file in corso",
   "ankimon_button_title": "Ankimon",

--- a/src/Ankimon/lang/jp_text.json
+++ b/src/Ankimon/lang/jp_text.json
@@ -56,7 +56,6 @@
   "choose_trainer_sprite_button": "トレーナースプライトを選択",
   "choose_pokemon_team_button": "ポケモンチームを選択",
   "ankimon_file_checker_button": "Ankimonファイルチェッカー",
-  "ankimon_leaderboard_credentials_button": "Ankimonリーダーボード認証情報",
   "download_resources_button": "リソースをダウンロード",
   "backing_up_files": "ファイルをバックアップ中",
   "ankimon_button_title": "Ankimon",

--- a/src/Ankimon/lang/kr_text.json
+++ b/src/Ankimon/lang/kr_text.json
@@ -56,7 +56,6 @@
   "choose_trainer_sprite_button": "트레이너 스프라이트 선택",
   "choose_pokemon_team_button": "포켓몬 팀 선택",
   "ankimon_file_checker_button": "Ankimon 파일 검사기",
-  "ankimon_leaderboard_credentials_button": "Ankimon 리더보드 자격증명",
   "download_resources_button": "리소스 다운로드",
   "backing_up_files": "파일 백업 중",
   "ankimon_button_title": "Ankimon",

--- a/src/Ankimon/lang/po_text.json
+++ b/src/Ankimon/lang/po_text.json
@@ -56,7 +56,6 @@
   "choose_trainer_sprite_button": "Escolher Sprite do Treinador",
   "choose_pokemon_team_button": "Escolher Equipe de Pokémon",
   "ankimon_file_checker_button": "Verificador de Arquivos Ankimon",
-  "ankimon_leaderboard_credentials_button": "Credenciais do Ranking Ankimon",
   "download_resources_button": "Baixar Recursos",
   "backing_up_files": "Fazendo backup dos arquivos",
   "ankimon_button_title": "Ankimon",

--- a/src/Ankimon/lang/setting_description.json
+++ b/src/Ankimon/lang/setting_description.json
@@ -64,7 +64,7 @@
     "misc.remove_level_cap": "Allow leveling beyond set level cap.",
     "misc.language": "Select language ID for Pokémon names and descriptions. [1: Japanese (Hir & Kata), 2: Japanese (Roomaji), 3: Korean, 4: Chinese (Traditional), 5: French, 6: German, 7: Spanish, 8: Italian, 9: English, 10: Czech, 11: Japanese, 12: Chinese (Simplified), 13: Portuguese (Brazil), 14: Spanish (Latin America)]",
     "misc.ssh": "Enable SSH if encountering connectivity issues (like Eduroam restrictions).",
-    "misc.leaderboard": "Enable synchronization with Ankimon leaderboard (leaderboard.ankimon.com). \nTo set up, check Ankimon -> Game -> Ankimon Leaderboard and Ankimon -> Ankimon Leaderboard Credentials.",
+    "misc.leaderboard": "Enable synchronization with Ankimon leaderboard. To set up, enter your Username and API Key below.",
     "misc.ankiweb_sync": "Sync your Ankimon SAVE DATA (Pokémon, items, trainer progress) across your own devices that share one AnkiWeb account, by riding Anki's media sync. When ON, your local save is backed up automatically and integrity-checked before any incoming data is applied.\nThis is SEPARATE from Mobile Reviews: reviews done on AnkiMobile/AnkiDroid become battles regardless of this setting.\nTips: don't use 'Delete Unused' when checking media, and avoid playing on two devices between syncs (the most recent sync wins).",
     "misc.YouShallNotPass_Ankimon_News": "If enabled, you will not receive news pop-ups when Ankimon starts (like changelogs and updates).",
     "misc.discord_rich_presence": "Enable Discord Rich Presence for Ankimon. Shows in Discord as 'Playing Ankimon'.",
@@ -73,5 +73,7 @@
     "misc.developer_mode": "Enable developer mode. This will create a backup every time Anki is opened.",
     "trainer.name": "Set the name of your trainer.",
     "trainer.cash_reward_amount": "How much cash you earn for each interval of cards reviewed. [Min: 10, Max: 400]. NOTE: To prevent exploits, the payout is capped based on your daily economy limit and subject to a hard daily cap of 400¥.",
-    "trainer.cash_reward_interval": "Number of cards to review before earning cash. [Min: 5, Max: 100]. Earnings are subject to a maximum daily cap of 400¥."
+    "trainer.cash_reward_interval": "Number of cards to review before earning cash. [Min: 5, Max: 100]. Earnings are subject to a maximum daily cap of 400¥.",
+    "leaderboard.username": "Your username for the Ankimon leaderboard. This will be displayed publicly on the leaderboard.",
+    "leaderboard.api_key": "Your API key for the Ankimon leaderboard. Get one from the Ankimon website at https://leaderboard.ankimon.com/"
 }

--- a/src/Ankimon/lang/setting_name.json
+++ b/src/Ankimon/lang/setting_name.json
@@ -69,7 +69,7 @@
     "misc.remove_level_cap": "Remove Level Cap",
     "misc.language": "Language",
     "misc.ssh": "SSH Access",
-    "misc.leaderboard": "Ankimon Leaderboard",
+    "misc.leaderboard": "Enable Leaderboard Sync",
     "misc.ankiweb_sync": "AnkiWeb Sync",
     "misc.YouShallNotPass_Ankimon_News": "Prevent Ankimon News on Startup",
     "misc.discord_rich_presence": "Discord Rich Presence - Ankimon",
@@ -78,6 +78,7 @@
     "misc.developer_mode": "Developer Mode",
     "trainer.name": "Trainer Name",
     "trainer.cash_reward_amount": "Cash Reward Per Interval",
-    "trainer.cash_reward_interval": "Cards Per Cash Reward"
-
+    "trainer.cash_reward_interval": "Cards Per Cash Reward",
+    "leaderboard.username": "Username",
+    "leaderboard.api_key": "API Key"
 }

--- a/src/Ankimon/lang/sp_text.json
+++ b/src/Ankimon/lang/sp_text.json
@@ -56,7 +56,6 @@
   "choose_trainer_sprite_button": "Elegir sprite de entrenador",
   "choose_pokemon_team_button": "Elegir equipo Pokémon",
   "ankimon_file_checker_button": "Verificador de archivos de Ankimon",
-  "ankimon_leaderboard_credentials_button": "Credenciales de la tabla de clasificación de Ankimon",
   "download_resources_button": "Descargar recursos",
   "backing_up_files": "Realizando copia de seguridad de archivos",
   "ankimon_button_title": "Ankimon",

--- a/src/Ankimon/menu_buttons.py
+++ b/src/Ankimon/menu_buttons.py
@@ -12,7 +12,7 @@ from aqt.utils import qconnect
 
 from .gui_classes.check_files import FileCheckerApp
 from .pyobj.download_sprites import show_agreement_and_download_dialog
-from .pyobj.ankimon_leaderboard import show_api_key_dialog
+# REMOVED: from .pyobj.ankimon_leaderboard import show_api_key_dialog
 from .pyobj.settings import Settings
 from .pyobj.translator import Translator
 from .pyobj.InfoLogger import ShowInfoLogger
@@ -487,10 +487,15 @@ def create_menu_actions(
     file_check_action.triggered.connect(lambda: FileCheckerApp().exec())
     help_menu.addAction(file_check_action)
 
-    file_check_action = QAction(mw.translator.translate("ankimon_leaderboard_credentials_button"), mw)
-    file_check_action.setMenuRole(QAction.MenuRole.NoRole)
-    file_check_action.triggered.connect(show_api_key_dialog)
-    mw.pokemenu.addAction(file_check_action)
+    # REMOVED: Ankimon Leaderboard Credentials menu item
+    # The leaderboard credentials are now managed in Settings:
+    # Ankimon → Ankimon Settings → Leaderboard
+
+    # REMOVED BLOCK:
+    # file_check_action = QAction(mw.translator.translate("ankimon_leaderboard_credentials_button"), mw)
+    # file_check_action.setMenuRole(QAction.MenuRole.NoRole)
+    # file_check_action.triggered.connect(show_api_key_dialog)
+    # mw.pokemenu.addAction(file_check_action)
 
     downloader_action = QAction(mw.translator.translate("download_resources_button"), mw)
     downloader_action.setMenuRole(QAction.MenuRole.NoRole)

--- a/src/Ankimon/menu_buttons.py
+++ b/src/Ankimon/menu_buttons.py
@@ -12,7 +12,6 @@ from aqt.utils import qconnect
 
 from .gui_classes.check_files import FileCheckerApp
 from .pyobj.download_sprites import show_agreement_and_download_dialog
-# REMOVED: from .pyobj.ankimon_leaderboard import show_api_key_dialog
 from .pyobj.settings import Settings
 from .pyobj.translator import Translator
 from .pyobj.InfoLogger import ShowInfoLogger
@@ -487,16 +486,7 @@ def create_menu_actions(
     file_check_action.triggered.connect(lambda: FileCheckerApp().exec())
     help_menu.addAction(file_check_action)
 
-    # REMOVED: Ankimon Leaderboard Credentials menu item
-    # The leaderboard credentials are now managed in Settings:
-    # Ankimon → Ankimon Settings → Leaderboard
-
-    # REMOVED BLOCK:
-    # file_check_action = QAction(mw.translator.translate("ankimon_leaderboard_credentials_button"), mw)
-    # file_check_action.setMenuRole(QAction.MenuRole.NoRole)
-    # file_check_action.triggered.connect(show_api_key_dialog)
-    # mw.pokemenu.addAction(file_check_action)
-
+    # Leaderboard credentials moved to Settings → Leaderboard
     downloader_action = QAction(mw.translator.translate("download_resources_button"), mw)
     downloader_action.setMenuRole(QAction.MenuRole.NoRole)
     downloader_action.triggered.connect(show_agreement_and_download_dialog)

--- a/src/Ankimon/pyobj/ankimon_leaderboard.py
+++ b/src/Ankimon/pyobj/ankimon_leaderboard.py
@@ -135,10 +135,10 @@ def migrate_credentials_from_db():
                 services.settings.set("leaderboard.api_key", api_key)
             
             # Clear legacy database entries after successful migration
-            if (settings_username or username) and (settings_api_key or api_key):
-                services.db.set_user_data("username", "")
-                services.db.set_user_data("api_key", "")
-                print("Ankimon: Migrated and cleared legacy leaderboard credentials")
+            # The condition is guaranteed true here because we checked username and api_key above
+            services.db.set_user_data("username", "")
+            services.db.set_user_data("api_key", "")
+            print("Ankimon: Migrated and cleared legacy leaderboard credentials")
             
     except Exception as e:
         print(f"Ankimon: Error migrating leaderboard credentials: {e}")

--- a/src/Ankimon/pyobj/ankimon_leaderboard.py
+++ b/src/Ankimon/pyobj/ankimon_leaderboard.py
@@ -87,58 +87,28 @@ def sync_data_to_leaderboard(data):
         print(f"Ankimon: Unexpected error preparing leaderboard sync: {e}")
 
 
-def migrate_credentials_from_db():
-    """
-    Migrate leaderboard credentials from the legacy database to the settings system.
-    
-    This function performs a one-time migration of username and API key from
-    the old database storage to the new settings-based storage system. It
-    checks if credentials exist in the database and whether they have already
-    been migrated to settings to avoid overwriting existing settings data.
-    
-    The migration runs during Anki startup and ensures a smooth transition
-    for users who previously configured leaderboard credentials using the
-    legacy system.
-    
-    Returns:
-        None: Migration status is logged to console; failures are caught
-            and logged without interrupting the startup process.
-    
-    Note:
-        - Function exits early if database or settings services are unavailable
-        - Only migrates if database has credentials AND settings don't
-        - After migration, the legacy database entries are cleared to prevent
-          the old credentials from ever resurrecting over future edits
-        - The leaderboard enabled/disabled state is preserved automatically
+def migrate_credentials_from_db() -> bool:
+    """Atomically move legacy leaderboard credentials into Settings.
+
+    Existing Settings values win per field. The database transaction stores any
+    missing replacements and retires the corresponding legacy rows together, so
+    a write failure cannot destroy the user's original credentials.
     """
     if services.db is None or services.settings is None:
-        return
-    
-    try:
-        # Check if we have credentials in database
-        username = services.db.get_user_data("username")
-        api_key = services.db.get_user_data("api_key")
-        
-        # Normalize None values to empty strings for comparison
-        username = "" if username is None else str(username)
-        api_key = "" if api_key is None else str(api_key)
-        
-        # Check if we have them in settings already
-        settings_username = services.settings.get("leaderboard.username", "")
-        settings_api_key = services.settings.get("leaderboard.api_key", "")
-        
-        # If db has credentials, migrate them to settings (only if not already set)
-        if username and api_key:
-            if not settings_username:
-                services.settings.set("leaderboard.username", username)
-            if not settings_api_key:
-                services.settings.set("leaderboard.api_key", api_key)
-            
-            # Clear legacy database entries after successful migration
-            # The condition is guaranteed true here because we checked username and api_key above
-            services.db.set_user_data("username", "")
-            services.db.set_user_data("api_key", "")
-            print("Ankimon: Migrated and cleared legacy leaderboard credentials")
-            
-    except Exception as e:
-        print(f"Ankimon: Error migrating leaderboard credentials: {e}")
+        return False
+
+    migrated = services.db.migrate_user_data_to_config(
+        {
+            "username": "leaderboard.username",
+            "api_key": "leaderboard.api_key",
+        }
+    )
+    if not migrated:
+        return False
+
+    # The DB transaction has already persisted these values. Update the live
+    # Settings object in place without issuing a second, non-atomic write.
+    services.settings.config.update(migrated)
+    services.settings.compute_gui_config()
+    print("Ankimon: Migrated and cleared legacy leaderboard credentials")
+    return True

--- a/src/Ankimon/pyobj/ankimon_leaderboard.py
+++ b/src/Ankimon/pyobj/ankimon_leaderboard.py
@@ -1,17 +1,20 @@
 import sys
 import json
+import threading
 from PyQt6.QtWidgets import QApplication, QDialog, QVBoxLayout, QLabel, QLineEdit, QPushButton
 from aqt.utils import showInfo
+from aqt.qt import QMessageBox
 from ..resources import user_path_credentials, mypokemon_path
-import json
 import requests
-from aqt import mw # import setting values direct from init file
+from aqt import mw
 from ..services import services
 
-#ANKIMON_LEADERBOARD_API_URL = "https://ankimon.com/api/leaderboard"  # Replace with the actual API URL
-ANKIMON_LEADERBOARD_API_URL = "https://leaderboard-api.ankimon.com/update_stats"  # Replace with the actual API URL
+ANKIMON_LEADERBOARD_API_URL = "https://leaderboard-api.ankimon.com/update_stats"
+
 
 class ApiKeyDialog(QDialog):
+    """Legacy dialog - kept for backward compatibility but deprecated."""
+    
     def __init__(self):
         super().__init__()
 
@@ -44,80 +47,184 @@ class ApiKeyDialog(QDialog):
         self.setLayout(layout)
 
     def submit(self):
+        """
+        Handle the submission of username and API key from the legacy dialog.
+        
+        Validates that both fields are filled, then saves the credentials to
+        the settings system rather than the legacy database. Enables leaderboard
+        sync automatically upon successful credential storage.
+        
+        Returns:
+            None: Displays appropriate info messages to the user via showInfo.
+        """
         username = self.username_input.text()
         api_key = self.api_key_input.text()
 
         if username and api_key:
-            credentials = {
-                "username": username,
-                "api_key": api_key
-            }
-            self.save_credentials(credentials)
-            self.accept()  # Close the dialog if everything is entered
+            # Save to settings instead of database
+            if services.settings is not None:
+                services.settings.set("leaderboard.username", username)
+                services.settings.set("leaderboard.api_key", api_key)
+                services.settings.set("misc.leaderboard", True)
+                showInfo("Credentials saved successfully!")
+                self.accept()
+            else:
+                showInfo("Error: Settings not initialized.")
         else:
             showInfo("Both fields must be filled out.")
 
-    def save_credentials(self, credentials):
-        try:
-            # Save the new credentials to the database
-            for key, value in credentials.items():
-                if services.db:
-                    services.db.set_user_data(key, value)
-            showInfo("Credentials saved successfully!")
-        except Exception as e:
-            showInfo(f"Error saving credentials: {e}")
 
 def sync_data_to_leaderboard(data):
+    """
+    Synchronize player statistics with the Ankimon leaderboard server.
+    
+    This function retrieves leaderboard credentials from the settings system
+    and sends a POST request to the leaderboard API with the provided stats.
+    The network request is executed in a background thread to prevent UI
+    freezing during network operations.
+    
+    Args:
+        data (dict): A dictionary containing the player's statistics to be
+            synchronized with the leaderboard. The structure should match
+            what the leaderboard API expects.
+    
+    Returns:
+        None: Results are logged to console; failures are handled silently
+            with console output rather than user-facing dialogs.
+    
+    Note:
+        - The function exits early if leaderboard sync is disabled in settings
+        - Credentials are read from settings (not the legacy database)
+        - Network timeouts are set to 10 seconds
+        - All exceptions are caught and logged to console
+    """
+    
+    # First check if leaderboard is enabled in config
+    if services.settings is None or not services.settings.get("misc.leaderboard"):
+        return
 
-        # First check if leaderboard is enabled in config
-        if not services.settings or not services.settings.get("misc.leaderboard"):
+    try:
+        # Get credentials from settings (NOT from database)
+        username = services.settings.get("leaderboard.username", "")
+        api_key = services.settings.get("leaderboard.api_key", "")
+
+        # Validate credentials
+        if not username or not api_key:
+            # Silent fail - user will be notified through settings UI
+            showInfo("Ankimon: Leaderboard credentials missing in settings")
             return
 
-        try:
-            # Load credentials from the database
-            if not services.db:
-                return
-            username = services.db.get_user_data("username")
-            api_key = services.db.get_user_data("api_key")
+        request_data = {
+            "username": username,
+            "api_key": api_key,
+            "stats": data
+        }
 
-            # Validate credentials
-            if (not username or not api_key) and services.db.is_migrated():
-                showInfo("Error: Missing credentials for Ankimon leaderboard. Please set up leaderboard from Ankimon menu or turn off in Settings.")
-                return
-
-
-            # Check if both username and api_key are available
-            if username and api_key:
-                request_data = {
-                    "username": username,
-                    "api_key": api_key,
-                    "stats": data
-                }
-
-                # Send a POST request to the leaderboard API
+        def send_request():
+            """
+            Send the network request to the leaderboard API.
+            
+            This inner function executes the actual HTTP POST request and handles
+            any network-related exceptions. It runs in a background thread to
+            avoid blocking the main GUI thread.
+            
+            Returns:
+                None: Results and errors are logged to console.
+            """
+            try:
+                # Send POST request to leaderboard API
                 response = requests.post(
                     ANKIMON_LEADERBOARD_API_URL,
-                    json=request_data
+                    json=request_data,
+                    timeout=10  # Add timeout to prevent hanging
                 )
 
-                #showInfo(response.text)  # Show the response text for debugging
+                if response.status_code == 200:
+                    showInfo("Ankimon: Data synced to leaderboard successfully")
+                else:
+                    showInfo(f"Ankimon: Failed to sync data - Status: {response.status_code}")
+                    
+            except requests.exceptions.RequestException as e:
+                showInfo(f"Ankimon: Leaderboard sync network error: {e}")
+            except Exception as e:
+                showInfo(f"Ankimon: Unexpected leaderboard error: {e}")
 
-                # Check if the request was successful
-                #if response.status_code == 200:
-                #    mw.logger.log("log","Data synced successfully to leaderboard!")
-                #else:
-                #    mw.logger.log("log",f"Failed to sync data to leaderboard. Status code: {response.status_code}")
-            #else:
-                #mw.logger.log("Credentials are missing (username or api_key)")
+        # Offload the network request to a background thread to prevent UI freezing
+        threading.Thread(target=send_request, daemon=True).start()
 
-        except requests.exceptions.RequestException as e:
-            showInfo(f"Error: Missing credentials for Ankimon leaderboard. Please set up leaderboard from Ankimon menu or turn off in Settings.\n\n {e}")
-        except Exception as e:
-            showInfo(f"Error: Missing credentials for Ankimon leaderboard. Please set up leaderboard from Ankimon menu or turn off in Settings.\n\n {e}")
-
+    except Exception as e:
+        showInfo(f"Ankimon: Unexpected error preparing leaderboard sync: {e}")
 
 
 def show_api_key_dialog():
-    dialog = ApiKeyDialog()  # Create the dialog instance
-    dialog.exec()  # Show the dialog
+    """
+    Display a legacy dialog informing users about the new credential location.
+    
+    This function is a deprecated method that now shows an informational
+    message directing users to the new Settings UI for managing leaderboard
+    credentials. The legacy dialog is kept for backward compatibility but
+    no longer collects credentials directly.
+    
+    Returns:
+        None: Displays a QMessageBox with navigation instructions.
+    
+    Note:
+        This method is deprecated; credentials should be managed through
+        Ankimon → Ankimon Settings → Leaderboard.
+    """
+    # Show a dialog telling users where to find the new settings
+    msg = QMessageBox()
+    msg.setIcon(QMessageBox.Icon.Information)
+    msg.setWindowTitle("Leaderboard Credentials Moved")
+    msg.setText(
+        "Leaderboard credentials are now managed in Ankimon Settings.\n\n"
+        "Please go to:\n"
+        "Ankimon → Ankimon Settings → Leaderboard\n\n"
+        "Enter your username and API key there."
+    )
+    msg.setStandardButtons(QMessageBox.StandardButton.Ok)
+    msg.exec()
 
+
+def migrate_credentials_from_db():
+    """
+    Migrate leaderboard credentials from the legacy database to the settings system.
+    
+    This function performs a one-time migration of username and API key from
+    the old database storage to the new settings-based storage system. It
+    checks if credentials exist in the database and whether they have already
+    been migrated to settings to avoid overwriting existing settings data.
+    
+    The migration runs during Anki startup and ensures a smooth transition
+    for users who previously configured leaderboard credentials using the
+    legacy system.
+    
+    Returns:
+        None: Migration status is logged to console; failures are caught
+            and logged without interrupting the startup process.
+    
+    Note:
+        - Function exits early if database or settings services are unavailable
+        - Only migrates if database has credentials AND settings don't
+        - The leaderboard enabled/disabled state is preserved automatically
+    """
+    if services.db is None or services.settings is None:
+        return
+    
+    try:
+        # Check if we have credentials in database
+        username = services.db.get_user_data("username")
+        api_key = services.db.get_user_data("api_key")
+        
+        # Check if we have them in settings already
+        settings_username = services.settings.get("leaderboard.username", "")
+        settings_api_key = services.settings.get("leaderboard.api_key", "")
+        
+        # If db has credentials but settings don't, migrate them
+        if username and api_key and (not settings_username or not settings_api_key):
+            services.settings.set("leaderboard.username", username)
+            services.settings.set("leaderboard.api_key", api_key)
+            showInfo("Ankimon: Migrated leaderboard credentials from database to settings")
+            
+    except Exception as e:
+        showInfo(f"Ankimon: Error migrating leaderboard credentials: {e}")

--- a/src/Ankimon/pyobj/ankimon_leaderboard.py
+++ b/src/Ankimon/pyobj/ankimon_leaderboard.py
@@ -140,14 +140,14 @@ def sync_data_to_leaderboard(data):
                 )
 
                 if response.status_code == 200:
-                    showInfo("Ankimon: Data synced to leaderboard successfully")
+                    print("Ankimon: Data synced to leaderboard successfully")
                 else:
-                    showInfo(f"Ankimon: Failed to sync data - Status: {response.status_code}")
+                    print(f"Ankimon: Failed to sync data - Status: {response.status_code}")
                     
             except requests.exceptions.RequestException as e:
-                showInfo(f"Ankimon: Leaderboard sync network error: {e}")
+                print(f"Ankimon: Leaderboard sync network error: {e}")
             except Exception as e:
-                showInfo(f"Ankimon: Unexpected leaderboard error: {e}")
+                print(f"Ankimon: Unexpected leaderboard error: {e}")
 
         # Offload the network request to a background thread to prevent UI freezing
         threading.Thread(target=send_request, daemon=True).start()
@@ -224,7 +224,10 @@ def migrate_credentials_from_db():
         if username and api_key and (not settings_username or not settings_api_key):
             services.settings.set("leaderboard.username", username)
             services.settings.set("leaderboard.api_key", api_key)
-            showInfo("Ankimon: Migrated leaderboard credentials from database to settings")
+            # Clear legacy credentials from DB to prevent re-migration if settings are cleared
+            services.db.set_user_data("username", "")
+            services.db.set_user_data("api_key", "")
+            print("Ankimon: Migrated leaderboard credentials from database to settings")
             
     except Exception as e:
         showInfo(f"Ankimon: Error migrating leaderboard credentials: {e}")

--- a/src/Ankimon/pyobj/ankimon_leaderboard.py
+++ b/src/Ankimon/pyobj/ankimon_leaderboard.py
@@ -1,77 +1,8 @@
-import sys
-import json
 import threading
-from PyQt6.QtWidgets import QApplication, QDialog, QVBoxLayout, QLabel, QLineEdit, QPushButton
-from aqt.utils import showInfo
-from aqt.qt import QMessageBox
-from ..resources import user_path_credentials, mypokemon_path
 import requests
-from aqt import mw
 from ..services import services
 
 ANKIMON_LEADERBOARD_API_URL = "https://leaderboard-api.ankimon.com/update_stats"
-
-
-class ApiKeyDialog(QDialog):
-    """Legacy dialog - kept for backward compatibility but deprecated."""
-    
-    def __init__(self):
-        super().__init__()
-
-        self.setWindowTitle("Enter API Key and Username")
-        self.setGeometry(100, 100, 300, 200)
-
-        # Layout
-        layout = QVBoxLayout()
-
-        # Username input
-        self.username_label = QLabel("Username:")
-        self.username_input = QLineEdit(self)
-        self.username_input.setPlaceholderText("Enter your username")
-        layout.addWidget(self.username_label)
-        layout.addWidget(self.username_input)
-
-        # API Key input
-        self.api_key_label = QLabel("API Key:")
-        self.api_key_input = QLineEdit(self)
-        self.api_key_input.setPlaceholderText("Paste your API key")
-        layout.addWidget(self.api_key_label)
-        layout.addWidget(self.api_key_input)
-
-        # Submit button
-        self.submit_button = QPushButton("Submit", self)
-        self.submit_button.clicked.connect(self.submit)
-        layout.addWidget(self.submit_button)
-
-        # Set layout
-        self.setLayout(layout)
-
-    def submit(self):
-        """
-        Handle the submission of username and API key from the legacy dialog.
-        
-        Validates that both fields are filled, then saves the credentials to
-        the settings system rather than the legacy database. Enables leaderboard
-        sync automatically upon successful credential storage.
-        
-        Returns:
-            None: Displays appropriate info messages to the user via showInfo.
-        """
-        username = self.username_input.text()
-        api_key = self.api_key_input.text()
-
-        if username and api_key:
-            # Save to settings instead of database
-            if services.settings is not None:
-                services.settings.set("leaderboard.username", username)
-                services.settings.set("leaderboard.api_key", api_key)
-                services.settings.set("misc.leaderboard", True)
-                showInfo("Credentials saved successfully!")
-                self.accept()
-            else:
-                showInfo("Error: Settings not initialized.")
-        else:
-            showInfo("Both fields must be filled out.")
 
 
 def sync_data_to_leaderboard(data):
@@ -110,8 +41,8 @@ def sync_data_to_leaderboard(data):
 
         # Validate credentials
         if not username or not api_key:
-            # Silent fail - user will be notified through settings UI
-            showInfo("Ankimon: Leaderboard credentials missing in settings")
+            # Silent fail - user can configure credentials in Settings > Leaderboard
+            print("Ankimon: Leaderboard sync skipped - credentials missing in settings")
             return
 
         request_data = {
@@ -153,37 +84,7 @@ def sync_data_to_leaderboard(data):
         threading.Thread(target=send_request, daemon=True).start()
 
     except Exception as e:
-        showInfo(f"Ankimon: Unexpected error preparing leaderboard sync: {e}")
-
-
-def show_api_key_dialog():
-    """
-    Display a legacy dialog informing users about the new credential location.
-    
-    This function is a deprecated method that now shows an informational
-    message directing users to the new Settings UI for managing leaderboard
-    credentials. The legacy dialog is kept for backward compatibility but
-    no longer collects credentials directly.
-    
-    Returns:
-        None: Displays a QMessageBox with navigation instructions.
-    
-    Note:
-        This method is deprecated; credentials should be managed through
-        Ankimon → Ankimon Settings → Leaderboard.
-    """
-    # Show a dialog telling users where to find the new settings
-    msg = QMessageBox()
-    msg.setIcon(QMessageBox.Icon.Information)
-    msg.setWindowTitle("Leaderboard Credentials Moved")
-    msg.setText(
-        "Leaderboard credentials are now managed in Ankimon Settings.\n\n"
-        "Please go to:\n"
-        "Ankimon → Ankimon Settings → Leaderboard\n\n"
-        "Enter your username and API key there."
-    )
-    msg.setStandardButtons(QMessageBox.StandardButton.Ok)
-    msg.exec()
+        print(f"Ankimon: Unexpected error preparing leaderboard sync: {e}")
 
 
 def migrate_credentials_from_db():
@@ -206,6 +107,8 @@ def migrate_credentials_from_db():
     Note:
         - Function exits early if database or settings services are unavailable
         - Only migrates if database has credentials AND settings don't
+        - After migration, the legacy database entries are cleared to prevent
+          the old credentials from ever resurrecting over future edits
         - The leaderboard enabled/disabled state is preserved automatically
     """
     if services.db is None or services.settings is None:
@@ -216,18 +119,26 @@ def migrate_credentials_from_db():
         username = services.db.get_user_data("username")
         api_key = services.db.get_user_data("api_key")
         
+        # Normalize None values to empty strings for comparison
+        username = "" if username is None else str(username)
+        api_key = "" if api_key is None else str(api_key)
+        
         # Check if we have them in settings already
         settings_username = services.settings.get("leaderboard.username", "")
         settings_api_key = services.settings.get("leaderboard.api_key", "")
         
-        # If db has credentials but settings don't, migrate them
-        if username and api_key and (not settings_username or not settings_api_key):
-            services.settings.set("leaderboard.username", username)
-            services.settings.set("leaderboard.api_key", api_key)
-            # Clear legacy credentials from DB to prevent re-migration if settings are cleared
-            services.db.set_user_data("username", "")
-            services.db.set_user_data("api_key", "")
-            print("Ankimon: Migrated leaderboard credentials from database to settings")
+        # If db has credentials, migrate them to settings (only if not already set)
+        if username and api_key:
+            if not settings_username:
+                services.settings.set("leaderboard.username", username)
+            if not settings_api_key:
+                services.settings.set("leaderboard.api_key", api_key)
+            
+            # Clear legacy database entries after successful migration
+            if (settings_username or username) and (settings_api_key or api_key):
+                services.db.set_user_data("username", "")
+                services.db.set_user_data("api_key", "")
+                print("Ankimon: Migrated and cleared legacy leaderboard credentials")
             
     except Exception as e:
-        showInfo(f"Ankimon: Error migrating leaderboard credentials: {e}")
+        print(f"Ankimon: Error migrating leaderboard credentials: {e}")

--- a/src/Ankimon/pyobj/ankimon_leaderboard.py
+++ b/src/Ankimon/pyobj/ankimon_leaderboard.py
@@ -1,88 +1,55 @@
 import threading
+
 import requests
+
 from ..services import services
+
 
 ANKIMON_LEADERBOARD_API_URL = "https://leaderboard-api.ankimon.com/update_stats"
 
 
 def sync_data_to_leaderboard(data):
+    """Synchronize player statistics with the Ankimon leaderboard server.
+
+    Credentials come from Settings and the HTTP request runs in a daemon thread
+    so review-time UI work is never blocked by the network.
     """
-    Synchronize player statistics with the Ankimon leaderboard server.
-    
-    This function retrieves leaderboard credentials from the settings system
-    and sends a POST request to the leaderboard API with the provided stats.
-    The network request is executed in a background thread to prevent UI
-    freezing during network operations.
-    
-    Args:
-        data (dict): A dictionary containing the player's statistics to be
-            synchronized with the leaderboard. The structure should match
-            what the leaderboard API expects.
-    
-    Returns:
-        None: Results are logged to console; failures are handled silently
-            with console output rather than user-facing dialogs.
-    
-    Note:
-        - The function exits early if leaderboard sync is disabled in settings
-        - Credentials are read from settings (not the legacy database)
-        - Network timeouts are set to 10 seconds
-        - All exceptions are caught and logged to console
-    """
-    
-    # First check if leaderboard is enabled in config
     if services.settings is None or not services.settings.get("misc.leaderboard"):
         return
 
     try:
-        # Get credentials from settings (NOT from database)
         username = services.settings.get("leaderboard.username", "")
         api_key = services.settings.get("leaderboard.api_key", "")
-
-        # Validate credentials
         if not username or not api_key:
-            # Silent fail - user can configure credentials in Settings > Leaderboard
             print("Ankimon: Leaderboard sync skipped - credentials missing in settings")
             return
 
         request_data = {
             "username": username,
             "api_key": api_key,
-            "stats": data
+            "stats": data,
         }
 
         def send_request():
-            """
-            Send the network request to the leaderboard API.
-            
-            This inner function executes the actual HTTP POST request and handles
-            any network-related exceptions. It runs in a background thread to
-            avoid blocking the main GUI thread.
-            
-            Returns:
-                None: Results and errors are logged to console.
-            """
             try:
-                # Send POST request to leaderboard API
                 response = requests.post(
                     ANKIMON_LEADERBOARD_API_URL,
                     json=request_data,
-                    timeout=10  # Add timeout to prevent hanging
+                    timeout=10,
                 )
-
                 if response.status_code == 200:
                     print("Ankimon: Data synced to leaderboard successfully")
                 else:
-                    print(f"Ankimon: Failed to sync data - Status: {response.status_code}")
-                    
+                    print(
+                        "Ankimon: Failed to sync data - "
+                        f"Status: {response.status_code}"
+                    )
             except requests.exceptions.RequestException as e:
                 print(f"Ankimon: Leaderboard sync network error: {e}")
             except Exception as e:
                 print(f"Ankimon: Unexpected leaderboard error: {e}")
 
-        # Offload the network request to a background thread to prevent UI freezing
         threading.Thread(target=send_request, daemon=True).start()
-
     except Exception as e:
         print(f"Ankimon: Unexpected error preparing leaderboard sync: {e}")
 

--- a/src/Ankimon/pyobj/database_manager.py
+++ b/src/Ankimon/pyobj/database_manager.py
@@ -1488,6 +1488,53 @@ class AnkimonDB:
                 result[key] = val
         return result
 
+    def migrate_user_data_to_config(self, key_map: Dict[str, str]) -> Dict[str, str]:
+        """Move legacy ``user_data`` values into empty config keys atomically.
+
+        Existing config values always win. Legacy rows are retired only in the
+        same transaction that persists any missing replacements, so a failed
+        config write cannot destroy the user's original value.
+        """
+        migrated: Dict[str, str] = {}
+        conn = self._get_connection()
+        with conn:
+            with conn.cursor() as cursor:
+                for legacy_key, config_key in key_map.items():
+                    cursor.execute(
+                        "SELECT value FROM user_data WHERE key = ?", (legacy_key,)
+                    )
+                    legacy_row = cursor.fetchone()
+                    legacy_value = (
+                        ""
+                        if legacy_row is None or legacy_row["value"] is None
+                        else str(legacy_row["value"])
+                    )
+
+                    cursor.execute(
+                        "SELECT value FROM config WHERE key = ?", (config_key,)
+                    )
+                    config_row = cursor.fetchone()
+                    config_value = (
+                        ""
+                        if config_row is None or config_row["value"] is None
+                        else str(config_row["value"])
+                    )
+
+                    if not config_value and legacy_value:
+                        cursor.execute(
+                            "INSERT OR REPLACE INTO config (key, value) VALUES (?, ?)",
+                            (config_key, legacy_value),
+                        )
+                        config_value = legacy_value
+                        migrated[config_key] = legacy_value
+
+                    if legacy_value and config_value:
+                        cursor.execute(
+                            "DELETE FROM user_data WHERE key = ?", (legacy_key,)
+                        )
+
+        return migrated
+
     # --- Config Operations (replaces config.obf) ---
 
     def set_config_value(self, key: str, value: Any):

--- a/src/Ankimon/pyobj/settings.py
+++ b/src/Ankimon/pyobj/settings.py
@@ -97,6 +97,8 @@ DEFAULT_CONFIG = {
     "mobile.enabled": True,
     "mobile.resolution_mode": "manual",
     "mobile.inactive_companions": [],
+    "leaderboard.username": "",
+    "leaderboard.api_key": "",
 }
 
 

--- a/src/Ankimon/pyobj/settings_window.py
+++ b/src/Ankimon/pyobj/settings_window.py
@@ -823,8 +823,11 @@ class SettingsWindow(QMainWindow):
         }
 
         if changed_settings:
+            from ..ankimon_items_web.settings_schema import display_setting_value
+
             friendly_changed = {
-                self.friendly_names.get(k, k): v for k, v in changed_settings.items()
+                self.friendly_names.get(k, k): display_setting_value(k, v)
+                for k, v in changed_settings.items()
             }
             changed_message = "\n".join(
                 [f"{key}: {value}" for key, value in friendly_changed.items()]

--- a/src/Ankimon/pyobj/settings_window.py
+++ b/src/Ankimon/pyobj/settings_window.py
@@ -279,6 +279,9 @@ class SettingsWindow(QMainWindow):
             self.input_widgets[key] = button_group
         elif isinstance(value, (int, str, float)):
             line_edit = QLineEdit(str(value))
+            # Mask the API Key field if it's ever rendered in the legacy window
+            if key == "leaderboard.api_key":
+                line_edit.setEchoMode(QLineEdit.EchoMode.Password)
             layout.addWidget(line_edit)
             created_widgets.append(line_edit)
             self.input_widgets[key] = line_edit

--- a/src/Ankimon/pyobj/settings_window.py
+++ b/src/Ankimon/pyobj/settings_window.py
@@ -342,7 +342,6 @@ class SettingsWindow(QMainWindow):
                             "SSH Access",
                             "Prevent Ankimon News on Startup",
                             "AnkiWeb Sync",
-                            "Ankimon Leaderboard",
                             "Developer Mode",
                         ]
                     },
@@ -457,6 +456,13 @@ class SettingsWindow(QMainWindow):
                     "Generation 7",
                     "Generation 8",
                     "Generation 9",
+                ]
+            },
+            "Leaderboard": {
+                "settings": [
+                    "Enable Leaderboard Sync",
+                    "Username",
+                    "API Key",
                 ]
             },
         }

--- a/tests/test_database_manager.py
+++ b/tests/test_database_manager.py
@@ -808,3 +808,54 @@ def test_unresolvable_base_stats_record_left_untouched(temp_env):
 
     assert db.get_pokemon("legacy-uuid-3") == legacy_pk
 
+
+def test_user_data_to_config_migration_preserves_existing_values(temp_env):
+    db, _ = temp_env
+    db.set_user_data("username", "legacy-user")
+    db.set_user_data("api_key", "legacy-key")
+    db.set_config_value("leaderboard.username", "settings-user")
+
+    migrated = db.migrate_user_data_to_config(
+        {
+            "username": "leaderboard.username",
+            "api_key": "leaderboard.api_key",
+        }
+    )
+
+    assert migrated == {"leaderboard.api_key": "legacy-key"}
+    assert db.get_config_value("leaderboard.username") == "settings-user"
+    assert db.get_config_value("leaderboard.api_key") == "legacy-key"
+    assert db.get_user_data("username") is None
+    assert db.get_user_data("api_key") is None
+
+
+def test_user_data_to_config_migration_rolls_back_on_write_failure(temp_env):
+    db, _ = temp_env
+    db.set_user_data("username", "legacy-user")
+    db.set_user_data("api_key", "legacy-key")
+    conn = db._get_connection()
+    conn.execute(
+        """
+        CREATE TRIGGER fail_leaderboard_api_key
+        BEFORE INSERT ON config
+        WHEN NEW.key = 'leaderboard.api_key'
+        BEGIN
+            SELECT RAISE(ABORT, 'injected migration failure');
+        END
+        """
+    )
+    conn.commit()
+
+    with pytest.raises(sqlite3.IntegrityError, match="injected migration failure"):
+        db.migrate_user_data_to_config(
+            {
+                "username": "leaderboard.username",
+                "api_key": "leaderboard.api_key",
+            }
+        )
+
+    assert db.get_config_value("leaderboard.username") is None
+    assert db.get_config_value("leaderboard.api_key") is None
+    assert db.get_user_data("username") == "legacy-user"
+    assert db.get_user_data("api_key") == "legacy-key"
+

--- a/tests/test_leaderboard_credentials.py
+++ b/tests/test_leaderboard_credentials.py
@@ -1,17 +1,16 @@
-"""Security and migration contracts for leaderboard credentials."""
+"""Security, migration, and request contracts for leaderboard credentials."""
 
 import importlib.util
 import json
+import sys
+import types
 from pathlib import Path
+from types import SimpleNamespace
 
 
-_SCHEMA_PATH = (
-    Path(__file__).parent.parent
-    / "src"
-    / "Ankimon"
-    / "ankimon_items_web"
-    / "settings_schema.py"
-)
+_SRC = Path(__file__).parent.parent / "src" / "Ankimon"
+_SCHEMA_PATH = _SRC / "ankimon_items_web" / "settings_schema.py"
+_LEADERBOARD_PATH = _SRC / "pyobj" / "ankimon_leaderboard.py"
 
 
 def _load_settings_schema():
@@ -19,6 +18,27 @@ def _load_settings_schema():
         "ankimon_settings_schema_credentials_test", _SCHEMA_PATH
     )
     module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _load_leaderboard(monkeypatch, services):
+    ankimon_pkg = types.ModuleType("Ankimon")
+    ankimon_pkg.__path__ = [str(_SRC)]
+    pyobj_pkg = types.ModuleType("Ankimon.pyobj")
+    pyobj_pkg.__path__ = [str(_SRC / "pyobj")]
+    services_mod = types.ModuleType("Ankimon.services")
+    services_mod.services = services
+
+    monkeypatch.setitem(sys.modules, "Ankimon", ankimon_pkg)
+    monkeypatch.setitem(sys.modules, "Ankimon.pyobj", pyobj_pkg)
+    monkeypatch.setitem(sys.modules, "Ankimon.services", services_mod)
+
+    spec = importlib.util.spec_from_file_location(
+        "Ankimon.pyobj.ankimon_leaderboard", _LEADERBOARD_PATH
+    )
+    module = importlib.util.module_from_spec(spec)
+    monkeypatch.setitem(sys.modules, spec.name, module)
     spec.loader.exec_module(module)
     return module
 
@@ -58,3 +78,105 @@ def test_secret_placeholder_and_summary_redaction_contract():
         == schema.SECRET_SETTING_PLACEHOLDER
     )
     assert schema.display_setting_value("leaderboard.username", "Nuz") == "Nuz"
+
+
+def test_migration_updates_live_settings_after_atomic_db_write(monkeypatch):
+    class FakeSettings:
+        def __init__(self):
+            self.config = {
+                "leaderboard.username": "",
+                "leaderboard.api_key": "",
+            }
+            self.compute_calls = 0
+
+        def compute_gui_config(self):
+            self.compute_calls += 1
+
+    class FakeDB:
+        def migrate_user_data_to_config(self, key_map):
+            assert key_map == {
+                "username": "leaderboard.username",
+                "api_key": "leaderboard.api_key",
+            }
+            return {
+                "leaderboard.username": "legacy-user",
+                "leaderboard.api_key": "legacy-secret",
+            }
+
+    settings = FakeSettings()
+    module = _load_leaderboard(
+        monkeypatch, SimpleNamespace(db=FakeDB(), settings=settings)
+    )
+
+    assert module.migrate_credentials_from_db() is True
+    assert settings.config["leaderboard.username"] == "legacy-user"
+    assert settings.config["leaderboard.api_key"] == "legacy-secret"
+    assert settings.compute_calls == 1
+
+
+def test_leaderboard_request_uses_settings_and_runs_off_caller_thread(monkeypatch):
+    values = {
+        "misc.leaderboard": True,
+        "leaderboard.username": "Nuz",
+        "leaderboard.api_key": "secret-key",
+    }
+    services = SimpleNamespace(
+        db=object(),
+        settings=SimpleNamespace(get=lambda key, default=None: values.get(key, default)),
+    )
+    module = _load_leaderboard(monkeypatch, services)
+
+    calls = []
+
+    def post(url, *, json, timeout):
+        calls.append((url, json, timeout))
+        return SimpleNamespace(status_code=200)
+
+    class ImmediateThread:
+        def __init__(self, *, target, daemon):
+            assert daemon is True
+            self.target = target
+
+        def start(self):
+            self.target()
+
+    monkeypatch.setattr(module.requests, "post", post)
+    monkeypatch.setattr(module.threading, "Thread", ImmediateThread)
+
+    module.sync_data_to_leaderboard({"caughtPokemon": 12})
+
+    assert calls == [
+        (
+            module.ANKIMON_LEADERBOARD_API_URL,
+            {
+                "username": "Nuz",
+                "api_key": "secret-key",
+                "stats": {"caughtPokemon": 12},
+            },
+            10,
+        )
+    ]
+
+
+def test_leaderboard_request_skips_when_credentials_are_missing(monkeypatch):
+    values = {
+        "misc.leaderboard": True,
+        "leaderboard.username": "Nuz",
+        "leaderboard.api_key": "",
+    }
+    services = SimpleNamespace(
+        db=object(),
+        settings=SimpleNamespace(get=lambda key, default=None: values.get(key, default)),
+    )
+    module = _load_leaderboard(monkeypatch, services)
+
+    started = []
+    monkeypatch.setattr(
+        module.threading,
+        "Thread",
+        lambda **kwargs: started.append(kwargs),
+    )
+
+    module.sync_data_to_leaderboard({"caughtPokemon": 12})
+
+    assert started == []

--- a/tests/test_leaderboard_credentials.py
+++ b/tests/test_leaderboard_credentials.py
@@ -1,0 +1,60 @@
+"""Security and migration contracts for leaderboard credentials."""
+
+import importlib.util
+import json
+from pathlib import Path
+
+
+_SCHEMA_PATH = (
+    Path(__file__).parent.parent
+    / "src"
+    / "Ankimon"
+    / "ankimon_items_web"
+    / "settings_schema.py"
+)
+
+
+def _load_settings_schema():
+    spec = importlib.util.spec_from_file_location(
+        "ankimon_settings_schema_credentials_test", _SCHEMA_PATH
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_secret_setting_serialization_never_exposes_stored_value():
+    schema = _load_settings_schema()
+
+    serialized = schema.serialize_secret_setting("actual-secret-api-key")
+
+    assert "actual-secret-api-key" not in json.dumps(serialized)
+    assert serialized == {
+        "type": "password",
+        "value": schema.SECRET_SETTING_PLACEHOLDER,
+        "secret_configured": True,
+        "secret_placeholder": schema.SECRET_SETTING_PLACEHOLDER,
+    }
+
+
+def test_empty_secret_serializes_as_unconfigured():
+    schema = _load_settings_schema()
+
+    serialized = schema.serialize_secret_setting("")
+
+    assert serialized["value"] == ""
+    assert serialized["secret_configured"] is False
+
+
+def test_secret_placeholder_and_summary_redaction_contract():
+    schema = _load_settings_schema()
+
+    assert schema.is_unchanged_secret_placeholder(
+        schema.SECRET_SETTING_PLACEHOLDER
+    )
+    assert not schema.is_unchanged_secret_placeholder("replacement-key")
+    assert (
+        schema.display_setting_value("leaderboard.api_key", "actual-secret-api-key")
+        == schema.SECRET_SETTING_PLACEHOLDER
+    )
+    assert schema.display_setting_value("leaderboard.username", "Nuz") == "Nuz"


### PR DESCRIPTION
## Proposed Change
Move **Ankimon Leaderboard Credentials** from a separate **menu item** into the **Settings UI**.

## Key Improvements
- API keys can be **grouped in Settings** as it involves **customising users' experience** in Ankimon. It also makes the menu items more **category-focused**.
- Additionally, it **improves the UI** of the boxes and **retains previous input** (with keys dotted out), which affirms to the user that they had keyed in their details.

## What this PR does
- **Add** Leaderboard section to **Settings** with **3 settings**:
  - Enable Leaderboard Sync (toggle)
  - Username (text input)
  - API Key (password input)
- **Remove** `Ankimon Leaderboard Credentials` from the **menu items**. Additionally, remove the then-credential-popup that shows after clicking `Ankimon Leaderboard Credentials`.
- **Add** Leaderboard section to **legacy `settings_window.py`** to pass GitHub's `Integrity Tests`
- Add **migration** that runs once when Anki starts up to **move existing credentials** from **database to settings**
- Add **i18n strings** for the three new settings in `lang/setting_description.json` and `lang/setting_name.json`. It also *removes* the old Ankimon Leaderboard Credentials button in all 11 language files. 

## What each file does
### Web Settings UI
**1. `ankimon_items_web/settings.css`**
   - Add password input field styles for API Key.

**2. `ankimon_items_web/settings.html`**
   - Increments cache-busting version tokens from `v=20260633` to `v=20260634` so browsers download the new settings window.

**3. `ankimon_items_web/settings.js`**
   - Add `buildPasswordInput` to create a masked input field for sensitive credential settings.

**4. `ankimon_items_web/settings_schema.py`**
   - Adds new Leaderboard section below Mobile Reviews with 3 settings: Enable Leaderboard Sync (toggle), Username (text), API Key (password).

**5. `ankimon_items_web/shop_obj.py`**
   - Add masked case for password inputs (API Key)

### Language / i8n
**6. `lang/setting_description.json`**
   - Removes the previous Ankimon Leaderboard description in Technical Settings and adds/replaces it with new Leaderboard section details.

**7. `lang/setting_name.json`**
   - Removes the previous Ankimon Leaderboard name in Technical Settings and adds/replaces it with new Leaderboard section names.

**8. `lang/*_text.json` (all 11 files)**
   - Remove orphaned `ankimon_leaderboard_credentials_button` translation key

### Core Logic
**9. `pyobj/ankimon_leaderboard.py`**
   - Add comments for the legacy API Key dialogue and handle instances where the dialogue happens to be shown
   - Updates `sync_data_to_leaderboard` to retrieve credentials from the settings system
   - Add a function to migrate credentials from the old database storage to the new settings-based storage system.

**10. `pyobj/settings.py`**
- Add Username and API Key fields for the new Leaderboard section

**11. `pyobj/settings_window.py`**
- Adds Leaderboard group to `hierarchical_groups` to pass the settings consistency test in GitHub Actions (the legacy settings window now mirrors the web settings UI).
- Additionally, mask the API Key in the legacy window with `setEchoMode(QLineEdit.EchoMode.Password)` so users who arrive at the window will still have their API Key masked.

### Startup & Menu
**12. `__init__.py`**
- Migration call is now in `core.py` (see 14); add a comment noting the new location.

**13. `core.py`**
- Add `migrate_credentials_from_db()` call in `build_core()` immediately after `services.populate(settings=settings_obj)` and **before** `TrainerCard` construction

**14. `menu_buttons.py`**
- Removes Ankimon Leaderboard Credentials menu item

### Contributor Metadata
**15. `.all-contributorsrc`**
- Add `Nut2026` in the `contributors` list.

## Expected Behaviour
1. `Ankimon Leaderboard Credentials` is no longer seen in menu items.
2. A new section, labelled Leaderboard with 3 settings (Enable Leaderboard Sync, Username, and API Key), is seen at the bottom of Ankimon > Ankimon Settings, below Mobile Reviews.
3. If the user has previously entered their credentials, their Username and API Key should be auto-filled into Username and API Key fields (indicating a successful migration).
4. New/Changes in Username and API Key fields are automatically stored and persist even after users close the Settings window or restart Anki. 
5. Depending on their toggles (Enabled/Disabled), users' progress should be automatically Synced to the [Ankimon Leaderboard](https://leaderboard.ankimon.com/). 

**Before:**
<img width="306" height="231" alt="image" src="https://github.com/user-attachments/assets/3a5ad92c-0202-4029-b1b8-36a4b2bfe940" />

**After:**
<img width="771" height="362" alt="image" src="https://github.com/user-attachments/assets/11e0f342-dda0-4193-a85b-ba3547a7dd95" />

### Not Included (To be delivered in future PRs)
- **Status Indicator** - Live status dot with animations (grey/orange/green) next to the toggle
- **Clickable Links** - Make "Ankimon website" and "Ankimon leaderboard community" text clickable with URL validation
- **Validation** - Prevent saving when sync is enabled, but Username/API Key are empty

### Related Issue
_N/A_

### Checklist
- [x] My code and commit messages follow the code style and guidelines of this project.
- [x] I have personally tested the implementation on Windows and ran terminal checks, which all pass.
- [x] I have added/updated my entry in `.all-contributorsrc` at the root of the repository to specify my custom `"nickname"` and `"discord_id"` for release announcements and Discord pings.