### PR TITLE
fix: properly clear volatile statuses on new wild pokemon encounters

### DIFF
--- a/src/Ankimon/functions/encounter_functions.py
+++ b/src/Ankimon/functions/encounter_functions.py
@@ -1163,6 +1163,7 @@ def new_pokemon(
             "accuracy": 0,
             "evasion": 0,
         },
+        "volatile_status": set(),
         "tier": tier,
         "ev_yield": ev_yield,
         "shiny": is_shiny,


### PR DESCRIPTION
Fixes an issue where a newly spawned wild Pokémon incorrectly inherits the volatile statuses (like dive, dig, fly, confused) from the previously defeated wild Pokémon, which could cause bugs like all subsequent encounters being "submerged" and unhittable.

---
*PR created automatically by Jules for task [11735141135365380196](https://jules.google.com/task/11735141135365380196) started by @h0tp-ftw*