### PR TITLE
fix(db): refresh thread-local connections after database closure

### DIFF
--- a/src/Ankimon/pyobj/ankimon_sync.py
+++ b/src/Ankimon/pyobj/ankimon_sync.py
@@ -831,23 +831,34 @@ class AnkimonDataSync:
             # Profile not loaded yet
             return []
 
-    def _close_live_db_connection(self, target_file: Path) -> None:
-        """If ``target_file`` is the DB file that ``services.db`` currently holds
-        open, close that connection before it is overwritten on disk. The
-        connection reopens lazily against the new file on next use, so callers
-        need not reopen it. Best-effort: any failure is a benign no-op."""
+    def _close_live_db_connection(
+        self, target_file: Path, *, required: bool = False
+    ) -> bool:
+        """Close the live DB when it targets ``target_file``.
+
+        Best-effort callers receive ``False`` on failure. Atomic replacement passes
+        ``required=True`` so an active operation aborts the swap instead of writing
+        over a database that still has live users.
+        """
         try:
             from ..services import services
+
             db = services.db
             if db is None:
-                return
+                return True
             db_path = getattr(db, "db_path", None)
-            if db_path is None:
-                return
-            if Path(db_path).resolve() == Path(target_file).resolve():
-                db.close(2.0)
+            if db_path is None or Path(db_path).resolve() != Path(target_file).resolve():
+                return True
+            closed = bool(db.close(2.0))
+            if required and not closed:
+                raise RuntimeError(
+                    "Database replacement aborted because active operations did not finish"
+                )
+            return closed
         except Exception:
-            pass
+            if required:
+                raise
+            return False
 
     def _checkpoint_live_db(self, source_file: Path) -> None:
         """If ``services.db`` holds a live WAL connection to ``source_file``,
@@ -951,26 +962,14 @@ class AnkimonDataSync:
         an unrelated WAL over the new file and hit 'database disk image is
         malformed'.
 
-        KNOWN LIMITATION: ``_close_live_db_connection`` -> ``db.close()`` closes
-        only the GUI thread's connection, NOT a background thread's
-        ``threading.local`` connection. This import path is not serialized against
-        an in-flight background mobile-resolve (``_mobile_sync_lock``), so if an
-        (opt-in) file-sync import lands mid-resolve, that thread's writes to the
-        pre-replace inode can be orphaned. Pre-existing to this change and narrow
-        (opt-in file-sync overlapping a live resolve); left documented rather than
-        pulling the multi-profile connection model into a hardening pass."""
+        The connection registry requests closure from GUI and background wrappers.
+        If an in-flight operation does not release its lease within the bounded
+        wait, replacement aborts and the original database remains untouched."""
         source_file.parent.mkdir(parents=True, exist_ok=True)
 
         def _release_handles():
-            # Close the connection registry completely to release all OS locks,
-            # then force collection of connection handles, before the rename.
-            try:
-                from ..services import services
-                if services.db:
-                    services.db.close(2.0)
-            except Exception:
-                pass
-            self._close_live_db_connection(source_file)
+            # Refuse to replace a live database when any operation lease remains.
+            self._close_live_db_connection(source_file, required=True)
             gc.collect()
 
         _atomic_write_over(media_file, source_file, before_replace=_release_handles)

--- a/src/Ankimon/pyobj/ankimon_sync.py
+++ b/src/Ankimon/pyobj/ankimon_sync.py
@@ -1,4 +1,5 @@
 import base64
+import contextlib
 import errno
 import filecmp
 import gc
@@ -834,12 +835,7 @@ class AnkimonDataSync:
     def _close_live_db_connection(
         self, target_file: Path, *, required: bool = False
     ) -> bool:
-        """Close the live DB when it targets ``target_file``.
-
-        Best-effort callers receive ``False`` on failure. Atomic replacement passes
-        ``required=True`` so an active operation aborts the swap instead of writing
-        over a database that still has live users.
-        """
+        """Close the live DB when it targets ``target_file``."""
         try:
             from ..services import services
 
@@ -859,6 +855,26 @@ class AnkimonDataSync:
             if required:
                 raise
             return False
+
+    @contextlib.contextmanager
+    def _quiesce_live_db_connection(self, target_file: Path):
+        """Keep connection creation blocked across a live DB file replacement."""
+        from ..services import services
+
+        db = services.db
+        db_path = getattr(db, "db_path", None) if db is not None else None
+        if db is None or db_path is None or Path(db_path).resolve() != Path(target_file).resolve():
+            yield True
+            return
+
+        quiesce = getattr(db, "quiesce", None)
+        if quiesce is None:
+            closed = bool(db.close(2.0))
+            yield closed
+            return
+
+        with quiesce(2.0) as closed:
+            yield closed
 
     def _checkpoint_live_db(self, source_file: Path) -> None:
         """If ``services.db`` holds a live WAL connection to ``source_file``,
@@ -966,20 +982,31 @@ class AnkimonDataSync:
         If an in-flight operation does not release its lease within the bounded
         wait, replacement aborts and the original database remains untouched."""
         source_file.parent.mkdir(parents=True, exist_ok=True)
+        quiescence = self._quiesce_live_db_connection(source_file)
+        entered = False
 
         def _release_handles():
-            # Refuse to replace a live database when any operation lease remains.
-            self._close_live_db_connection(source_file, required=True)
+            nonlocal entered
+            closed = quiescence.__enter__()
+            entered = True
+            if not closed:
+                raise RuntimeError(
+                    "Database replacement aborted because active operations did not finish"
+                )
             gc.collect()
 
-        _atomic_write_over(media_file, source_file, before_replace=_release_handles)
+        try:
+            _atomic_write_over(media_file, source_file, before_replace=_release_handles)
 
-        for sidecar in ("-wal", "-shm"):
-            stale = source_file.with_name(source_file.name + sidecar)
-            try:
-                stale.unlink(missing_ok=True)
-            except Exception:
-                pass
+            for sidecar in ("-wal", "-shm"):
+                stale = source_file.with_name(source_file.name + sidecar)
+                try:
+                    stale.unlink(missing_ok=True)
+                except Exception:
+                    pass
+        finally:
+            if entered:
+                quiescence.__exit__(None, None, None)
 
     def read_configs(self, media_sync_status: bool = False) -> List[str]:
         """

--- a/src/Ankimon/pyobj/ankimon_sync.py
+++ b/src/Ankimon/pyobj/ankimon_sync.py
@@ -845,7 +845,7 @@ class AnkimonDataSync:
             if db_path is None:
                 return
             if Path(db_path).resolve() == Path(target_file).resolve():
-                db.close()
+                db.close(2.0)
         except Exception:
             pass
 
@@ -967,7 +967,7 @@ class AnkimonDataSync:
             try:
                 from ..services import services
                 if services.db:
-                    services.db.close()
+                    services.db.close(2.0)
             except Exception:
                 pass
             self._close_live_db_connection(source_file)

--- a/src/Ankimon/pyobj/database_manager.py
+++ b/src/Ankimon/pyobj/database_manager.py
@@ -172,6 +172,8 @@ class AnkimonDB:
         # and collects the revlog ids here to be flushed after the caller's bulk
         # transaction commits. See begin/flush/discard_deferred_mirror_sync.
         self._deferred_mirror_revlog_ids: Optional[list] = None
+        self._connection_epoch = 0
+        self._connection_epoch_gui = -1
         self._setup_database()
 
     def _prepare_connection(self, conn):
@@ -225,7 +227,8 @@ class AnkimonDB:
         if not _is_main_thread():
             local = self._local_conn
             if (not hasattr(local, "conn") or local.conn is None
-                    or getattr(local, "db_path", None) != self.db_path):
+                    or getattr(local, "db_path", None) != self.db_path
+                    or getattr(local, "epoch", -1) != self._connection_epoch):
                 if getattr(local, "conn", None) is not None:
                     try:
                         local.conn.close()
@@ -234,14 +237,22 @@ class AnkimonDB:
                 conn = sqlite3.connect(str(self.db_path), check_same_thread=False)
                 local.conn = self._prepare_connection(conn)
                 local.db_path = self.db_path
+                local.epoch = self._connection_epoch
             elif not isinstance(local.conn, ConnectionWrapper):
                 local.conn = ConnectionWrapper(local.conn, self)
                 local.db_path = self.db_path
+                local.epoch = self._connection_epoch
             return local.conn
 
-        if self._connection is None:
+        if self._connection is None or self._connection_epoch_gui != self._connection_epoch:
+            if self._connection:
+                try:
+                    self._connection.close()
+                except Exception:
+                    pass
             conn = sqlite3.connect(str(self.db_path), check_same_thread=False)
             self._connection = self._prepare_connection(conn)
+            self._connection_epoch_gui = self._connection_epoch
         elif not isinstance(self._connection, ConnectionWrapper):
             self._connection = ConnectionWrapper(self._connection, self)
         return self._connection
@@ -249,6 +260,7 @@ class AnkimonDB:
     def close(self):
         """Closes all database connections across all threads."""
         with self._conn_lock:
+            self._connection_epoch += 1
             if self._connection:
                 try:
                     self._connection.close()

--- a/src/Ankimon/pyobj/database_manager.py
+++ b/src/Ankimon/pyobj/database_manager.py
@@ -109,6 +109,12 @@ class ConnectionWrapper:
                 except Exception:
                     pass
 
+    def cancel_close(self):
+        """Cancel a deferred close after the manager's drain attempt times out."""
+        with self._lease_lock:
+            if not self._closed:
+                self._close_pending = False
+
     def commit(self):
         # NOTE: Direct raw cursor execution (conn.cursor().execute(...)) bypasses wrapper-level auto-healing.
         self.acquire_lease()
@@ -399,6 +405,7 @@ class AnkimonDB:
         if not _is_main_thread():
             local = self._local_conn
             if (not hasattr(local, "conn") or local.conn is None
+                    or getattr(local.conn, "_closed", False)
                     or getattr(local, "db_path", None) != self.db_path
                     or getattr(local, "epoch", -1) != epoch):
                 if getattr(local, "conn", None) is not None:
@@ -416,7 +423,9 @@ class AnkimonDB:
                 local.epoch = epoch
             return local.conn
 
-        if self._connection is None or self._connection_epoch_gui != epoch:
+        if (self._connection is None
+                or getattr(self._connection, "_closed", False)
+                or self._connection_epoch_gui != epoch):
             if self._connection:
                 try:
                     self._connection.close()
@@ -430,7 +439,12 @@ class AnkimonDB:
         return self._connection
 
     def close(self, wait_seconds: float = 0.0) -> bool:
-        """Close each registered wrapper once within one shared deadline."""
+        """Close each registered wrapper once within one shared deadline.
+
+        A timed-out drain leaves the current generation intact. Callers may abort
+        their transition while the in-flight transaction continues on the same
+        connection instead of reopening mid-transaction against itself.
+        """
         deadline = time.monotonic() + max(0.0, wait_seconds)
         wrappers = []
         seen = set()
@@ -441,27 +455,42 @@ class AnkimonDB:
                 wrappers.append(conn)
 
         with self._conn_lock:
-            self._connection_epoch += 1
             add_wrapper(self._connection)
-            self._connection = None
-
             for conn_ref in self._all_connections:
                 add_wrapper(conn_ref())
-            self._all_connections.clear()
-
             if hasattr(self, "_local_conn"):
                 add_wrapper(getattr(self._local_conn, "conn", None))
+
+        closed_all = True
+        for conn in wrappers:
+            remaining = max(0.0, deadline - time.monotonic())
+            try:
+                closed_all = conn.close(remaining) and closed_all
+            except Exception:
+                closed_all = False
+
+        if not closed_all:
+            for conn in wrappers:
+                try:
+                    conn.cancel_close()
+                except Exception:
+                    pass
+            return False
+
+        with self._conn_lock:
+            self._connection_epoch += 1
+            if self._connection is not None and id(self._connection) in seen:
+                self._connection = None
+            self._all_connections = [
+                conn_ref
+                for conn_ref in self._all_connections
+                if conn_ref() is not None and id(conn_ref()) not in seen
+            ]
+            if (hasattr(self, "_local_conn")
+                    and id(getattr(self._local_conn, "conn", None)) in seen):
                 self._local_conn.conn = None
 
-            closed_all = True
-            for conn in wrappers:
-                remaining = max(0.0, deadline - time.monotonic())
-                try:
-                    closed_all = conn.close(remaining) and closed_all
-                except Exception:
-                    closed_all = False
-
-        return closed_all
+        return True
 
     def repair_database(self):
         """Repair a corrupted/malformed database out-of-place."""

--- a/src/Ankimon/pyobj/database_manager.py
+++ b/src/Ankimon/pyobj/database_manager.py
@@ -64,10 +64,18 @@ class CursorWrapper:
         return False
 
     def execute(self, *args, **kwargs):
-        return self._cursor.execute(*args, **kwargs)
+        self._cursor.execute(*args, **kwargs)
+        return self
 
     def executemany(self, *args, **kwargs):
-        return self._cursor.executemany(*args, **kwargs)
+        self._cursor.executemany(*args, **kwargs)
+        return self
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        return next(self._cursor)
 
     def __getattr__(self, name):
         return getattr(self._cursor, name)
@@ -101,19 +109,23 @@ class ConnectionWrapper:
     def commit(self):
         # NOTE: Direct raw cursor execution (conn.cursor().execute(...)) bypasses wrapper-level auto-healing.
         self.acquire_lease()
+        lease_released = False
         try:
             if not self._disable_commit:
                 try:
                     self._conn.commit()
                 except sqlite3.DatabaseError as e:
                     if self._db_mgr and ("malformed" in str(e).lower() or "disk image" in str(e).lower()) and not self._db_mgr._is_repairing:
+                        self.release_lease()
+                        lease_released = True
                         self._db_mgr.repair_database()
-                        self._conn = self._db_mgr._get_connection()._conn
-                        self._conn.commit()
+                        fresh_conn = self._db_mgr._get_connection()
+                        fresh_conn.commit()
                         return
                     raise
         finally:
-            self.release_lease()
+            if not lease_released:
+                self.release_lease()
 
     def rollback(self):
         self.acquire_lease()
@@ -131,34 +143,40 @@ class ConnectionWrapper:
     def execute(self, *args, **kwargs):
         # NOTE: Direct raw cursor execution (conn.cursor().execute(...)) bypasses wrapper-level auto-healing.
         self.acquire_lease()
+        lease_released = False
         try:
             res = self._conn.execute(*args, **kwargs)
             return CursorWrapper(res, self)
         except sqlite3.DatabaseError as e:
             if self._db_mgr and ("malformed" in str(e).lower() or "disk image" in str(e).lower()) and not self._db_mgr._is_repairing:
+                self.release_lease()
+                lease_released = True
                 self._db_mgr.repair_database()
-                self._conn = self._db_mgr._get_connection()._conn
-                res = self._conn.execute(*args, **kwargs)
-                return CursorWrapper(res, self)
+                fresh_conn = self._db_mgr._get_connection()
+                return fresh_conn.execute(*args, **kwargs)
             raise
         finally:
-            self.release_lease()
+            if not lease_released:
+                self.release_lease()
 
     def executemany(self, *args, **kwargs):
         # NOTE: Direct raw cursor execution (conn.cursor().execute(...)) bypasses wrapper-level auto-healing.
         self.acquire_lease()
+        lease_released = False
         try:
             res = self._conn.executemany(*args, **kwargs)
             return CursorWrapper(res, self)
         except sqlite3.DatabaseError as e:
             if self._db_mgr and ("malformed" in str(e).lower() or "disk image" in str(e).lower()) and not self._db_mgr._is_repairing:
+                self.release_lease()
+                lease_released = True
                 self._db_mgr.repair_database()
-                self._conn = self._db_mgr._get_connection()._conn
-                res = self._conn.executemany(*args, **kwargs)
-                return CursorWrapper(res, self)
+                fresh_conn = self._db_mgr._get_connection()
+                return fresh_conn.executemany(*args, **kwargs)
             raise
         finally:
-            self.release_lease()
+            if not lease_released:
+                self.release_lease()
 
     def cursor(self, *args, **kwargs):
         raw_cursor = self._conn.cursor(*args, **kwargs)
@@ -169,10 +187,14 @@ class ConnectionWrapper:
 
     def __enter__(self):
         self.acquire_lease()
-        if getattr(self, "_txn_depth", 0) == 0:
-            self._conn.execute("BEGIN")
-        self._txn_depth = getattr(self, "_txn_depth", 0) + 1
-        return self
+        try:
+            if getattr(self, "_txn_depth", 0) == 0:
+                self._conn.execute("BEGIN")
+            self._txn_depth = getattr(self, "_txn_depth", 0) + 1
+            return self
+        except Exception:
+            self.release_lease()
+            raise
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         try:

--- a/src/Ankimon/pyobj/database_manager.py
+++ b/src/Ankimon/pyobj/database_manager.py
@@ -332,7 +332,7 @@ class AnkimonDB:
         self._connection: Optional[ConnectionWrapper] = None       # GUI-thread connection
         self._local_conn = threading.local()                       # per-background-thread
         self._all_connections = []
-        self._conn_lock = threading.Lock()
+        self._conn_lock = threading.RLock()
         self._is_repairing = False
         # When non-None, mark_mobile_battle_resolved defers the mirror-DB sync
         # (which commits on a separate connection, escaping any outer transaction)
@@ -397,54 +397,50 @@ class AnkimonDB:
     def _get_connection(self) -> ConnectionWrapper:
         """Gets or creates a database connection for the CURRENT thread.
 
-        GUI thread: the single shared ``self._connection`` (as before, now WAL).
-        Background threads: a dedicated per-thread connection (``check_same_thread``
-        is disabled so a connection may be created off the GUI thread safely, and
-        each thread keeps its own so they never share a cursor)."""
-        epoch = self._connection_epoch
-        if not _is_main_thread():
-            local = self._local_conn
-            if (not hasattr(local, "conn") or local.conn is None
-                    or getattr(local.conn, "_closed", False)
-                    or getattr(local, "db_path", None) != self.db_path
-                    or getattr(local, "epoch", -1) != epoch):
-                if getattr(local, "conn", None) is not None:
+        Connection creation and registration share the lifecycle lock with
+        shutdown, so a raw SQLite handle cannot appear between a close snapshot
+        and the file transition that follows it.
+        """
+        with self._conn_lock:
+            epoch = self._connection_epoch
+            if not _is_main_thread():
+                local = self._local_conn
+                if (not hasattr(local, "conn") or local.conn is None
+                        or getattr(local.conn, "_closed", False)
+                        or getattr(local, "db_path", None) != self.db_path
+                        or getattr(local, "epoch", -1) != epoch):
+                    if getattr(local, "conn", None) is not None:
+                        try:
+                            local.conn.close()
+                        except Exception:
+                            pass
+                    conn = sqlite3.connect(str(self.db_path), check_same_thread=False)
+                    local.conn = self._prepare_connection(conn)
+                    local.db_path = self.db_path
+                    local.epoch = epoch
+                elif not isinstance(local.conn, ConnectionWrapper):
+                    local.conn = ConnectionWrapper(local.conn, self)
+                    local.db_path = self.db_path
+                    local.epoch = epoch
+                return local.conn
+
+            if (self._connection is None
+                    or getattr(self._connection, "_closed", False)
+                    or self._connection_epoch_gui != epoch):
+                if self._connection:
                     try:
-                        local.conn.close()
+                        self._connection.close()
                     except Exception:
                         pass
                 conn = sqlite3.connect(str(self.db_path), check_same_thread=False)
-                local.conn = self._prepare_connection(conn)
-                local.db_path = self.db_path
-                local.epoch = epoch
-            elif not isinstance(local.conn, ConnectionWrapper):
-                local.conn = ConnectionWrapper(local.conn, self)
-                local.db_path = self.db_path
-                local.epoch = epoch
-            return local.conn
+                self._connection = self._prepare_connection(conn)
+                self._connection_epoch_gui = epoch
+            elif not isinstance(self._connection, ConnectionWrapper):
+                self._connection = ConnectionWrapper(self._connection, self)
+            return self._connection
 
-        if (self._connection is None
-                or getattr(self._connection, "_closed", False)
-                or self._connection_epoch_gui != epoch):
-            if self._connection:
-                try:
-                    self._connection.close()
-                except Exception:
-                    pass
-            conn = sqlite3.connect(str(self.db_path), check_same_thread=False)
-            self._connection = self._prepare_connection(conn)
-            self._connection_epoch_gui = epoch
-        elif not isinstance(self._connection, ConnectionWrapper):
-            self._connection = ConnectionWrapper(self._connection, self)
-        return self._connection
-
-    def close(self, wait_seconds: float = 0.0) -> bool:
-        """Close each registered wrapper once within one shared deadline.
-
-        A timed-out drain leaves the current generation intact. Callers may abort
-        their transition while the in-flight transaction continues on the same
-        connection instead of reopening mid-transaction against itself.
-        """
+    def _close_locked(self, wait_seconds: float) -> bool:
+        """Drain and invalidate the current generation with ``_conn_lock`` held."""
         deadline = time.monotonic() + max(0.0, wait_seconds)
         wrappers = []
         seen = set()
@@ -454,12 +450,11 @@ class AnkimonDB:
                 seen.add(id(conn))
                 wrappers.append(conn)
 
-        with self._conn_lock:
-            add_wrapper(self._connection)
-            for conn_ref in self._all_connections:
-                add_wrapper(conn_ref())
-            if hasattr(self, "_local_conn"):
-                add_wrapper(getattr(self._local_conn, "conn", None))
+        add_wrapper(self._connection)
+        for conn_ref in self._all_connections:
+            add_wrapper(conn_ref())
+        if hasattr(self, "_local_conn"):
+            add_wrapper(getattr(self._local_conn, "conn", None))
 
         closed_all = True
         for conn in wrappers:
@@ -477,20 +472,23 @@ class AnkimonDB:
                     pass
             return False
 
-        with self._conn_lock:
-            self._connection_epoch += 1
-            if self._connection is not None and id(self._connection) in seen:
-                self._connection = None
-            self._all_connections = [
-                conn_ref
-                for conn_ref in self._all_connections
-                if conn_ref() is not None and id(conn_ref()) not in seen
-            ]
-            if (hasattr(self, "_local_conn")
-                    and id(getattr(self._local_conn, "conn", None)) in seen):
-                self._local_conn.conn = None
-
+        self._connection_epoch += 1
+        self._connection = None
+        self._all_connections.clear()
+        if hasattr(self, "_local_conn"):
+            self._local_conn.conn = None
         return True
+
+    def close(self, wait_seconds: float = 0.0) -> bool:
+        """Close the current generation within one shared deadline."""
+        with self._conn_lock:
+            return self._close_locked(wait_seconds)
+
+    @contextlib.contextmanager
+    def quiesce(self, wait_seconds: float = 0.0):
+        """Hold the lifecycle barrier after draining all registered connections."""
+        with self._conn_lock:
+            yield self._close_locked(wait_seconds)
 
     def repair_database(self):
         """Repair a corrupted/malformed database out-of-place."""
@@ -641,58 +639,61 @@ class AnkimonDB:
                 dest_conn.commit()
                 dest_conn.close()
                 
-                # Close all connections completely to drop locks.
-                if not self.close(2.0):
-                    raise RuntimeError(
-                        "Database repair aborted because active operations did not finish"
-                    )
-                
-                # Clean up existing corrupted backup
-                if backup_db.exists():
+                # Keep connection creation blocked until the repaired file is in
+                # place; otherwise a new raw handle can appear after close() but
+                # before either rename.
+                with self.quiesce(2.0) as closed:
+                    if not closed:
+                        raise RuntimeError(
+                            "Database repair aborted because active operations did not finish"
+                        )
+
+                    # Clean up existing corrupted backup
+                    if backup_db.exists():
+                        try:
+                            backup_db.unlink()
+                        except Exception:
+                            pass
                     try:
-                        backup_db.unlink()
+                        for attempt in range(3):
+                            try:
+                                db_file.replace(backup_db)
+                                break
+                            except Exception as e:
+                                if attempt == 2:
+                                    self._log("warning", f"Failed to backup corrupt database: {e}")
+                                    break
+                                time.sleep(0.1)
+                                gc.collect()
                     except Exception:
                         pass
-                try:
-                    for attempt in range(3):
-                        try:
-                            db_file.replace(backup_db)
-                            break
-                        except Exception as e:
-                            if attempt == 2:
-                                self._log("warning", f"Failed to backup corrupt database: {e}")
+
+                    # Swap in repaired file and clean WAL/SHM sidecars
+                    try:
+                        for attempt in range(3):
+                            try:
+                                tmp_db.replace(db_file)
                                 break
-                            time.sleep(0.1)
-                            gc.collect()
-                except Exception:
-                    pass
-                    
-                # Swap in repaired file and clean WAL/SHM sidecars
-                try:
-                    for attempt in range(3):
-                        try:
-                            tmp_db.replace(db_file)
-                            break
-                        except Exception:
-                            if attempt == 2:
-                                raise
-                            time.sleep(0.1)
-                            gc.collect()
-                    for sidecar in ("-wal", "-shm"):
-                        sidecar_file = db_file.with_name(db_file.name + sidecar)
-                        try:
-                            if sidecar_file.exists():
-                                sidecar_file.unlink()
-                        except Exception:
-                            pass
-                    self._log("info", "SQLite self-healing completed successfully! Database index repaired.")
-                except Exception as e:
-                    self._log("error", f"Failed to swap repaired database: {e}")
-                    if backup_db.exists() and not db_file.exists():
-                        try:
-                            backup_db.replace(db_file)
-                        except Exception:
-                            pass
+                            except Exception:
+                                if attempt == 2:
+                                    raise
+                                time.sleep(0.1)
+                                gc.collect()
+                        for sidecar in ("-wal", "-shm"):
+                            sidecar_file = db_file.with_name(db_file.name + sidecar)
+                            try:
+                                if sidecar_file.exists():
+                                    sidecar_file.unlink()
+                            except Exception:
+                                pass
+                        self._log("info", "SQLite self-healing completed successfully! Database index repaired.")
+                    except Exception as e:
+                        self._log("error", f"Failed to swap repaired database: {e}")
+                        if backup_db.exists() and not db_file.exists():
+                            try:
+                                backup_db.replace(db_file)
+                            except Exception:
+                                pass
             else:
                 dest_conn.rollback()
                 dest_conn.close()
@@ -719,29 +720,30 @@ class AnkimonDB:
         partial switch can route one transaction's writes across two accounts.
         """
         old_path = self.db_path
-        if not self.close(wait_seconds):
-            raise RuntimeError(
-                "Database switch aborted because active operations did not finish"
-            )
+        with self.quiesce(wait_seconds) as closed:
+            if not closed:
+                raise RuntimeError(
+                    "Database switch aborted because active operations did not finish"
+                )
 
-        self.db_path = user_path / db_filename
-        self._connection = None
-        try:
-            self._setup_database()
-        except Exception:
-            self.db_path = old_path
+            self.db_path = user_path / db_filename
             self._connection = None
             try:
                 self._setup_database()
-            except Exception as restore_error:
-                self._log(
-                    "error",
-                    f"Failed to restore previous database after switch error: {restore_error}",
-                )
-            raise
+            except Exception:
+                self.db_path = old_path
+                self._connection = None
+                try:
+                    self._setup_database()
+                except Exception as restore_error:
+                    self._log(
+                        "error",
+                        f"Failed to restore previous database after switch error: {restore_error}",
+                    )
+                raise
 
-        self._log("info", f"Switched database to {db_filename}")
-        return True
+            self._log("info", f"Switched database to {db_filename}")
+            return True
 
     # --- Obfuscation / De-obfuscation ---
 

--- a/src/Ankimon/pyobj/database_manager.py
+++ b/src/Ankimon/pyobj/database_manager.py
@@ -93,6 +93,7 @@ class ConnectionWrapper:
         self._lease_lock = threading.Lock()
         self._lease_count = 0
         self._close_pending = False
+        self._closed = False
 
     def acquire_lease(self):
         with self._lease_lock:
@@ -100,10 +101,11 @@ class ConnectionWrapper:
 
     def release_lease(self):
         with self._lease_lock:
-            self._lease_count -= 1
-            if self._lease_count <= 0 and self._close_pending:
+            self._lease_count = max(0, self._lease_count - 1)
+            if self._lease_count == 0 and self._close_pending and not self._closed:
                 try:
                     self._conn.close()
+                    self._closed = True
                 except Exception:
                     pass
 
@@ -142,25 +144,23 @@ class ConnectionWrapper:
         finally:
             self.release_lease()
 
-    def close(self, wait_seconds: float = 0.0):
-        """Best-effort close. While another thread holds an operation lease this only
-        sets ``_close_pending``; the real ``sqlite3.close()`` -- and the OS file-handle
-        release -- happens later, in ``release_lease``.
-
-        Callers that must have the handle released before renaming or replacing the DB
-        file (``repair_database``, ``ankimon_sync._release_handles``) should pass
-        ``wait_seconds``. Note that ``gc.collect()`` cannot substitute for this: a
-        ``CursorWrapper`` still bound in a live caller frame is reachable, so no amount
-        of collection will drop its lease."""
-        deadline = time.monotonic() + wait_seconds
+    def close(self, wait_seconds: float = 0.0) -> bool:
+        """Close when leases drain; return ``False`` if the deadline expires."""
+        deadline = time.monotonic() + max(0.0, wait_seconds)
         while True:
             with self._lease_lock:
                 self._close_pending = True
-                if self._lease_count <= 0:
-                    self._conn.close()
-                    return
+                if self._closed:
+                    return True
+                if self._lease_count == 0:
+                    try:
+                        self._conn.close()
+                        self._closed = True
+                        return True
+                    except Exception:
+                        return False
             if time.monotonic() >= deadline:
-                return
+                return False
             time.sleep(0.01)
 
     def execute(self, *args, **kwargs):
@@ -429,33 +429,37 @@ class AnkimonDB:
             self._connection = ConnectionWrapper(self._connection, self)
         return self._connection
 
-    def close(self, wait_seconds: float = 0.0):
-        """Closes all database connections across all threads."""
+    def close(self, wait_seconds: float = 0.0) -> bool:
+        """Request closure of every connection and report whether all drained."""
+        closed_all = True
         with self._conn_lock:
             self._connection_epoch += 1
             if self._connection:
                 try:
-                    self._connection.close(wait_seconds)
+                    closed_all = self._connection.close(wait_seconds) and closed_all
                 except Exception:
-                    pass
+                    closed_all = False
                 self._connection = None
-            
+
             for conn_ref in self._all_connections:
                 conn = conn_ref()
                 if conn is not None:
                     try:
-                        conn.close(wait_seconds)
+                        closed_all = conn.close(wait_seconds) and closed_all
                     except Exception:
-                        pass
+                        closed_all = False
             self._all_connections.clear()
-            
+
             if hasattr(self, "_local_conn"):
                 try:
                     if getattr(self._local_conn, "conn", None) is not None:
-                        self._local_conn.conn.close(wait_seconds)
+                        closed_all = (
+                            self._local_conn.conn.close(wait_seconds) and closed_all
+                        )
                 except Exception:
-                    pass
+                    closed_all = False
                 self._local_conn.conn = None
+        return closed_all
 
     def repair_database(self):
         """Repair a corrupted/malformed database out-of-place."""
@@ -606,8 +610,11 @@ class AnkimonDB:
                 dest_conn.commit()
                 dest_conn.close()
                 
-                # Close all connections completely to drop locks
-                self.close(2.0)
+                # Close all connections completely to drop locks.
+                if not self.close(2.0):
+                    raise RuntimeError(
+                        "Database repair aborted because active operations did not finish"
+                    )
                 
                 # Clean up existing corrupted backup
                 if backup_db.exists():

--- a/src/Ankimon/pyobj/database_manager.py
+++ b/src/Ankimon/pyobj/database_manager.py
@@ -12,6 +12,7 @@ import uuid
 import weakref
 import gc
 import time
+import contextlib
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Union
 
@@ -28,6 +29,50 @@ from ..resources import user_path, csv_file_items_cost, mypokemon_path, mainpoke
 # thread" when there is no QApplication). Backward compatible: on the GUI thread
 # callers get the same single shared connection they always did, now WAL-mode.
 
+class CursorWrapper:
+    """Wraps a sqlite3.Cursor, proxying everything, holding a connection lease
+    during its lifetime to prevent connection closure during in-flight operations."""
+
+    def __init__(self, cursor, conn_wrapper):
+        self._cursor = cursor
+        self._conn_wrapper = conn_wrapper
+        self._lease_released = False
+        self._conn_wrapper.acquire_lease()
+
+    def release_lease(self):
+        if not self._lease_released:
+            self._lease_released = True
+            try:
+                self._conn_wrapper.release_lease()
+            except Exception:
+                pass
+
+    def __del__(self):
+        self.release_lease()
+
+    def close(self):
+        try:
+            self._cursor.close()
+        finally:
+            self.release_lease()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.close()
+        return False
+
+    def execute(self, *args, **kwargs):
+        return self._cursor.execute(*args, **kwargs)
+
+    def executemany(self, *args, **kwargs):
+        return self._cursor.executemany(*args, **kwargs)
+
+    def __getattr__(self, name):
+        return getattr(self._cursor, name)
+
+
 class ConnectionWrapper:
     """Wraps a sqlite3.Connection, proxying everything, with a re-entrant
     ``with conn:`` transaction and an opt-out commit flag (used by bulk paths)."""
@@ -36,85 +81,128 @@ class ConnectionWrapper:
         self._conn = conn
         self._disable_commit = False
         self._db_mgr = db_mgr
+        self._lease_lock = threading.Lock()
+        self._lease_count = 0
+        self._close_pending = False
+
+    def acquire_lease(self):
+        with self._lease_lock:
+            self._lease_count += 1
+
+    def release_lease(self):
+        with self._lease_lock:
+            self._lease_count -= 1
+            if self._lease_count <= 0 and self._close_pending:
+                try:
+                    self._conn.close()
+                except Exception:
+                    pass
 
     def commit(self):
         # NOTE: Direct raw cursor execution (conn.cursor().execute(...)) bypasses wrapper-level auto-healing.
-        if not self._disable_commit:
-            try:
-                self._conn.commit()
-            except sqlite3.DatabaseError as e:
-                if self._db_mgr and ("malformed" in str(e).lower() or "disk image" in str(e).lower()) and not self._db_mgr._is_repairing:
-                    self._db_mgr.repair_database()
-                    self._conn = self._db_mgr._get_connection()._conn
+        self.acquire_lease()
+        try:
+            if not self._disable_commit:
+                try:
                     self._conn.commit()
-                    return
-                raise
+                except sqlite3.DatabaseError as e:
+                    if self._db_mgr and ("malformed" in str(e).lower() or "disk image" in str(e).lower()) and not self._db_mgr._is_repairing:
+                        self._db_mgr.repair_database()
+                        self._conn = self._db_mgr._get_connection()._conn
+                        self._conn.commit()
+                        return
+                    raise
+        finally:
+            self.release_lease()
 
     def rollback(self):
-        self._conn.rollback()
+        self.acquire_lease()
+        try:
+            self._conn.rollback()
+        finally:
+            self.release_lease()
 
     def close(self):
-        self._conn.close()
+        with self._lease_lock:
+            self._close_pending = True
+            if self._lease_count <= 0:
+                self._conn.close()
 
     def execute(self, *args, **kwargs):
         # NOTE: Direct raw cursor execution (conn.cursor().execute(...)) bypasses wrapper-level auto-healing.
+        self.acquire_lease()
         try:
-            return self._conn.execute(*args, **kwargs)
+            res = self._conn.execute(*args, **kwargs)
+            return CursorWrapper(res, self)
         except sqlite3.DatabaseError as e:
             if self._db_mgr and ("malformed" in str(e).lower() or "disk image" in str(e).lower()) and not self._db_mgr._is_repairing:
                 self._db_mgr.repair_database()
                 self._conn = self._db_mgr._get_connection()._conn
-                return self._conn.execute(*args, **kwargs)
+                res = self._conn.execute(*args, **kwargs)
+                return CursorWrapper(res, self)
             raise
+        finally:
+            self.release_lease()
 
     def executemany(self, *args, **kwargs):
         # NOTE: Direct raw cursor execution (conn.cursor().execute(...)) bypasses wrapper-level auto-healing.
+        self.acquire_lease()
         try:
-            return self._conn.executemany(*args, **kwargs)
+            res = self._conn.executemany(*args, **kwargs)
+            return CursorWrapper(res, self)
         except sqlite3.DatabaseError as e:
             if self._db_mgr and ("malformed" in str(e).lower() or "disk image" in str(e).lower()) and not self._db_mgr._is_repairing:
                 self._db_mgr.repair_database()
                 self._conn = self._db_mgr._get_connection()._conn
-                return self._conn.executemany(*args, **kwargs)
+                res = self._conn.executemany(*args, **kwargs)
+                return CursorWrapper(res, self)
             raise
+        finally:
+            self.release_lease()
 
     def cursor(self, *args, **kwargs):
-        return self._conn.cursor(*args, **kwargs)
+        raw_cursor = self._conn.cursor(*args, **kwargs)
+        return CursorWrapper(raw_cursor, self)
 
     def __getattr__(self, name):
         return getattr(self._conn, name)
 
     def __enter__(self):
+        self.acquire_lease()
         if getattr(self, "_txn_depth", 0) == 0:
             self._conn.execute("BEGIN")
         self._txn_depth = getattr(self, "_txn_depth", 0) + 1
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-        self._txn_depth = getattr(self, "_txn_depth", 1) - 1
-        if self._txn_depth == 0:
-            if exc_type is not None:
-                try:
-                    self._conn.rollback()
-                except Exception:
-                    pass
-            else:
-                # Do NOT swallow a commit failure: eating it here makes a lost
-                # write (disk full, or the busy_timeout expiring under write
-                # contention) look like success, so callers such as
-                # queue_mobile_battles / add_mobile_history_entries_batch /
-                # set_mobile_watermark return their success flag while nothing
-                # was persisted. Roll back and let the error propagate so the
-                # caller's error path (and the user) actually see it.
-                try:
-                    self._conn.commit()
-                except Exception:
+        try:
+            self._txn_depth = getattr(self, "_txn_depth", 1) - 1
+            if self._txn_depth == 0:
+                if exc_type is not None:
                     try:
                         self._conn.rollback()
                     except Exception:
                         pass
-                    raise
-        return False
+                else:
+                    # Do NOT swallow a commit failure: eating it here makes a lost
+                    # write (disk full, or the busy_timeout expiring under write
+                    # contention) look like success, so callers such as
+                    # queue_mobile_battles / add_mobile_history_entries_batch /
+                    # set_mobile_watermark return their success flag while nothing
+                    # was persisted. Roll back and let the error propagate so the
+                    # caller's error path (and the user) actually see it.
+                    try:
+                        self._conn.commit()
+                    except Exception:
+                        try:
+                            self._conn.rollback()
+                        except Exception:
+                            pass
+                        raise
+            return False
+        finally:
+            self.release_lease()
+
 
 
 def _is_main_thread() -> bool:
@@ -216,6 +304,16 @@ class AnkimonDB:
             print(f"[{level}] {message}")
 
     # --- Connection Management ---
+
+    @contextlib.contextmanager
+    def lease_connection(self):
+        """Lease a connection wrapper, ensuring it won't be closed until the lease is released."""
+        conn = self._get_connection()
+        conn.acquire_lease()
+        try:
+            yield conn
+        finally:
+            conn.release_lease()
 
     def _get_connection(self) -> ConnectionWrapper:
         """Gets or creates a database connection for the CURRENT thread.
@@ -823,18 +921,18 @@ class AnkimonDB:
         """Executes a custom SQL query and returns the cursor. 
         Useful for caller-specific fast-path queries without cluttering the manager."""
         try:
-            conn = self._get_connection()
-            cursor = conn.cursor()
-            cursor.execute(query, parameters)
-            return cursor
+            with self.lease_connection() as conn:
+                cursor = conn.cursor()
+                cursor.execute(query, parameters)
+                return cursor
         except sqlite3.DatabaseError as e:
             if ("malformed" in str(e).lower() or "disk image" in str(e).lower()) and not self._is_repairing:
                 self.repair_database()
                 # Retry once after repair
-                conn = self._get_connection()
-                cursor = conn.cursor()
-                cursor.execute(query, parameters)
-                return cursor
+                with self.lease_connection() as conn:
+                    cursor = conn.cursor()
+                    cursor.execute(query, parameters)
+                    return cursor
             raise e
 
     def get_pokemons_by_individual_ids(self, ids: List[str]) -> List[Dict[str, Any]]:

--- a/src/Ankimon/pyobj/database_manager.py
+++ b/src/Ankimon/pyobj/database_manager.py
@@ -712,16 +712,36 @@ class AnkimonDB:
             except Exception:
                 pass
 
-    def switch_database(self, db_filename: str):
-        """Close current connections and reopen against a different profile DB file.
+    def switch_database(self, db_filename: str, wait_seconds: float = 2.0) -> bool:
+        """Close the active profile and reopen against ``db_filename``.
 
-        The multi-profile / account-switch primitive (DB layer only). The
-        account-switch menu action that calls this is a deferred Stage-B leaf."""
-        self.close()
+        Refuse to mutate ``db_path`` while any operation still holds a lease; a
+        partial switch can route one transaction's writes across two accounts.
+        """
+        old_path = self.db_path
+        if not self.close(wait_seconds):
+            raise RuntimeError(
+                "Database switch aborted because active operations did not finish"
+            )
+
         self.db_path = user_path / db_filename
         self._connection = None
-        self._setup_database()
+        try:
+            self._setup_database()
+        except Exception:
+            self.db_path = old_path
+            self._connection = None
+            try:
+                self._setup_database()
+            except Exception as restore_error:
+                self._log(
+                    "error",
+                    f"Failed to restore previous database after switch error: {restore_error}",
+                )
+            raise
+
         self._log("info", f"Switched database to {db_filename}")
+        return True
 
     # --- Obfuscation / De-obfuscation ---
 

--- a/src/Ankimon/pyobj/database_manager.py
+++ b/src/Ankimon/pyobj/database_manager.py
@@ -116,12 +116,12 @@ class ConnectionWrapper:
                     self._conn.commit()
                 except sqlite3.DatabaseError as e:
                     msg = str(e).lower()
-                    if self._db_mgr and isinstance(e, sqlite3.ProgrammingError) and "closed database" in msg:
-                        self.release_lease()
-                        lease_released = True
-                        fresh = self._db_mgr._get_connection()
-                        fresh._conn.commit()
-                        return
+                    # NOTE: Deliberately NO "closed database" retry here. Unlike
+                    # execute()/executemany(), commit() has nothing to replay:
+                    # sqlite rolled this connection's transaction back when it was
+                    # closed, so committing a *different* connection would be a
+                    # no-op that reports success for a write that no longer exists.
+                    # Let it raise -- see the __exit__ comment in database_manager.
                     if self._db_mgr and ("malformed" in msg or "disk image" in msg) and not self._db_mgr._is_repairing:
                         self.release_lease()
                         lease_released = True
@@ -141,11 +141,26 @@ class ConnectionWrapper:
         finally:
             self.release_lease()
 
-    def close(self):
-        with self._lease_lock:
-            self._close_pending = True
-            if self._lease_count <= 0:
-                self._conn.close()
+    def close(self, wait_seconds: float = 0.0):
+        """Best-effort close. While another thread holds an operation lease this only
+        sets ``_close_pending``; the real ``sqlite3.close()`` -- and the OS file-handle
+        release -- happens later, in ``release_lease``.
+
+        Callers that must have the handle released before renaming or replacing the DB
+        file (``repair_database``, ``ankimon_sync._release_handles``) should pass
+        ``wait_seconds``. Note that ``gc.collect()`` cannot substitute for this: a
+        ``CursorWrapper`` still bound in a live caller frame is reachable, so no amount
+        of collection will drop its lease."""
+        deadline = time.monotonic() + wait_seconds
+        while True:
+            with self._lease_lock:
+                self._close_pending = True
+                if self._lease_count <= 0:
+                    self._conn.close()
+                    return
+            if time.monotonic() >= deadline:
+                return
+            time.sleep(0.01)
 
     def execute(self, *args, **kwargs):
         # NOTE: Direct raw cursor execution (conn.cursor().execute(...)) bypasses wrapper-level auto-healing.
@@ -408,13 +423,13 @@ class AnkimonDB:
             self._connection = ConnectionWrapper(self._connection, self)
         return self._connection
 
-    def close(self):
+    def close(self, wait_seconds: float = 0.0):
         """Closes all database connections across all threads."""
         with self._conn_lock:
             self._connection_epoch += 1
             if self._connection:
                 try:
-                    self._connection.close()
+                    self._connection.close(wait_seconds)
                 except Exception:
                     pass
                 self._connection = None
@@ -423,7 +438,7 @@ class AnkimonDB:
                 conn = conn_ref()
                 if conn is not None:
                     try:
-                        conn.close()
+                        conn.close(wait_seconds)
                     except Exception:
                         pass
             self._all_connections.clear()
@@ -431,7 +446,7 @@ class AnkimonDB:
             if hasattr(self, "_local_conn"):
                 try:
                     if getattr(self._local_conn, "conn", None) is not None:
-                        self._local_conn.conn.close()
+                        self._local_conn.conn.close(wait_seconds)
                 except Exception:
                     pass
                 self._local_conn.conn = None
@@ -561,7 +576,7 @@ class AnkimonDB:
                 dest_conn.close()
                 
                 # Close all connections completely to drop locks
-                self.close()
+                self.close(2.0)
                 
                 # Clean up existing corrupted backup
                 if backup_db.exists():

--- a/src/Ankimon/pyobj/database_manager.py
+++ b/src/Ankimon/pyobj/database_manager.py
@@ -430,35 +430,37 @@ class AnkimonDB:
         return self._connection
 
     def close(self, wait_seconds: float = 0.0) -> bool:
-        """Request closure of every connection and report whether all drained."""
-        closed_all = True
+        """Close each registered wrapper once within one shared deadline."""
+        deadline = time.monotonic() + max(0.0, wait_seconds)
+        wrappers = []
+        seen = set()
+
+        def add_wrapper(conn):
+            if conn is not None and id(conn) not in seen:
+                seen.add(id(conn))
+                wrappers.append(conn)
+
         with self._conn_lock:
             self._connection_epoch += 1
-            if self._connection:
-                try:
-                    closed_all = self._connection.close(wait_seconds) and closed_all
-                except Exception:
-                    closed_all = False
-                self._connection = None
+            add_wrapper(self._connection)
+            self._connection = None
 
             for conn_ref in self._all_connections:
-                conn = conn_ref()
-                if conn is not None:
-                    try:
-                        closed_all = conn.close(wait_seconds) and closed_all
-                    except Exception:
-                        closed_all = False
+                add_wrapper(conn_ref())
             self._all_connections.clear()
 
             if hasattr(self, "_local_conn"):
+                add_wrapper(getattr(self._local_conn, "conn", None))
+                self._local_conn.conn = None
+
+            closed_all = True
+            for conn in wrappers:
+                remaining = max(0.0, deadline - time.monotonic())
                 try:
-                    if getattr(self._local_conn, "conn", None) is not None:
-                        closed_all = (
-                            self._local_conn.conn.close(wait_seconds) and closed_all
-                        )
+                    closed_all = conn.close(remaining) and closed_all
                 except Exception:
                     closed_all = False
-                self._local_conn.conn = None
+
         return closed_all
 
     def repair_database(self):

--- a/src/Ankimon/pyobj/database_manager.py
+++ b/src/Ankimon/pyobj/database_manager.py
@@ -1070,9 +1070,8 @@ class AnkimonDB:
         cursor = self.execute("SELECT COUNT(*) FROM captured_pokemon WHERE shiny = 1")
         return cursor.fetchone()[0]
 
-    def execute(self, query: str, parameters: tuple = ()) -> sqlite3.Cursor:
-        """Executes a custom SQL query and returns the cursor. 
-        Useful for caller-specific fast-path queries without cluttering the manager."""
+    def execute(self, query: str, parameters: tuple = ()) -> "CursorWrapper":
+        """Execute custom SQL and return a lease-holding cursor wrapper."""
         try:
             with self.lease_connection() as conn:
                 cursor = conn.cursor()

--- a/src/Ankimon/pyobj/database_manager.py
+++ b/src/Ankimon/pyobj/database_manager.py
@@ -182,13 +182,13 @@ class ConnectionWrapper:
                 self.release_lease()
                 lease_released = True
                 fresh = self._db_mgr._get_connection()
-                return CursorWrapper(fresh._conn.execute(*args, **kwargs), fresh)
+                return fresh.execute(*args, **kwargs)
             if self._db_mgr and ("malformed" in msg or "disk image" in msg) and not self._db_mgr._is_repairing:
                 self.release_lease()
                 lease_released = True
                 self._db_mgr.repair_database()
                 fresh = self._db_mgr._get_connection()
-                return CursorWrapper(fresh._conn.execute(*args, **kwargs), fresh)
+                return fresh.execute(*args, **kwargs)
             raise
         finally:
             if not lease_released:
@@ -207,13 +207,13 @@ class ConnectionWrapper:
                 self.release_lease()
                 lease_released = True
                 fresh = self._db_mgr._get_connection()
-                return CursorWrapper(fresh._conn.executemany(*args, **kwargs), fresh)
+                return fresh.executemany(*args, **kwargs)
             if self._db_mgr and ("malformed" in msg or "disk image" in msg) and not self._db_mgr._is_repairing:
                 self.release_lease()
                 lease_released = True
                 self._db_mgr.repair_database()
                 fresh = self._db_mgr._get_connection()
-                return CursorWrapper(fresh._conn.executemany(*args, **kwargs), fresh)
+                return fresh.executemany(*args, **kwargs)
             raise
         finally:
             if not lease_released:

--- a/src/Ankimon/pyobj/database_manager.py
+++ b/src/Ankimon/pyobj/database_manager.py
@@ -33,11 +33,12 @@ class CursorWrapper:
     """Wraps a sqlite3.Cursor, proxying everything, holding a connection lease
     during its lifetime to prevent connection closure during in-flight operations."""
 
-    def __init__(self, cursor, conn_wrapper):
+    def __init__(self, cursor, conn_wrapper, *, lease_acquired=False):
         self._cursor = cursor
         self._conn_wrapper = conn_wrapper
         self._lease_released = False
-        self._conn_wrapper.acquire_lease()
+        if not lease_acquired:
+            self._conn_wrapper.acquire_lease()
 
     def release_lease(self):
         if not self._lease_released:
@@ -213,18 +214,23 @@ class ConnectionWrapper:
                 self.release_lease()
 
     def cursor(self, *args, **kwargs):
+        self.acquire_lease()
         try:
             raw_cursor = self._conn.cursor(*args, **kwargs)
-            return CursorWrapper(raw_cursor, self)
+            return CursorWrapper(raw_cursor, self, lease_acquired=True)
         except sqlite3.DatabaseError as e:
+            self.release_lease()
             msg = str(e).lower()
             if self._db_mgr and isinstance(e, sqlite3.ProgrammingError) and "closed database" in msg:
                 fresh = self._db_mgr._get_connection()
-                return CursorWrapper(fresh._conn.cursor(*args, **kwargs), fresh)
+                return fresh.cursor(*args, **kwargs)
             if self._db_mgr and ("malformed" in msg or "disk image" in msg) and not self._db_mgr._is_repairing:
                 self._db_mgr.repair_database()
                 fresh = self._db_mgr._get_connection()
-                return CursorWrapper(fresh._conn.cursor(*args, **kwargs), fresh)
+                return fresh.cursor(*args, **kwargs)
+            raise
+        except Exception:
+            self.release_lease()
             raise
 
     def __getattr__(self, name):

--- a/src/Ankimon/pyobj/database_manager.py
+++ b/src/Ankimon/pyobj/database_manager.py
@@ -115,12 +115,19 @@ class ConnectionWrapper:
                 try:
                     self._conn.commit()
                 except sqlite3.DatabaseError as e:
-                    if self._db_mgr and ("malformed" in str(e).lower() or "disk image" in str(e).lower()) and not self._db_mgr._is_repairing:
+                    msg = str(e).lower()
+                    if self._db_mgr and isinstance(e, sqlite3.ProgrammingError) and "closed database" in msg:
+                        self.release_lease()
+                        lease_released = True
+                        fresh = self._db_mgr._get_connection()
+                        fresh._conn.commit()
+                        return
+                    if self._db_mgr and ("malformed" in msg or "disk image" in msg) and not self._db_mgr._is_repairing:
                         self.release_lease()
                         lease_released = True
                         self._db_mgr.repair_database()
-                        fresh_conn = self._db_mgr._get_connection()
-                        fresh_conn.commit()
+                        fresh = self._db_mgr._get_connection()
+                        fresh._conn.commit()
                         return
                     raise
         finally:
@@ -148,12 +155,18 @@ class ConnectionWrapper:
             res = self._conn.execute(*args, **kwargs)
             return CursorWrapper(res, self)
         except sqlite3.DatabaseError as e:
-            if self._db_mgr and ("malformed" in str(e).lower() or "disk image" in str(e).lower()) and not self._db_mgr._is_repairing:
+            msg = str(e).lower()
+            if self._db_mgr and isinstance(e, sqlite3.ProgrammingError) and "closed database" in msg:
+                self.release_lease()
+                lease_released = True
+                fresh = self._db_mgr._get_connection()
+                return CursorWrapper(fresh._conn.execute(*args, **kwargs), fresh)
+            if self._db_mgr and ("malformed" in msg or "disk image" in msg) and not self._db_mgr._is_repairing:
                 self.release_lease()
                 lease_released = True
                 self._db_mgr.repair_database()
-                fresh_conn = self._db_mgr._get_connection()
-                return fresh_conn.execute(*args, **kwargs)
+                fresh = self._db_mgr._get_connection()
+                return CursorWrapper(fresh._conn.execute(*args, **kwargs), fresh)
             raise
         finally:
             if not lease_released:
@@ -167,20 +180,37 @@ class ConnectionWrapper:
             res = self._conn.executemany(*args, **kwargs)
             return CursorWrapper(res, self)
         except sqlite3.DatabaseError as e:
-            if self._db_mgr and ("malformed" in str(e).lower() or "disk image" in str(e).lower()) and not self._db_mgr._is_repairing:
+            msg = str(e).lower()
+            if self._db_mgr and isinstance(e, sqlite3.ProgrammingError) and "closed database" in msg:
+                self.release_lease()
+                lease_released = True
+                fresh = self._db_mgr._get_connection()
+                return CursorWrapper(fresh._conn.executemany(*args, **kwargs), fresh)
+            if self._db_mgr and ("malformed" in msg or "disk image" in msg) and not self._db_mgr._is_repairing:
                 self.release_lease()
                 lease_released = True
                 self._db_mgr.repair_database()
-                fresh_conn = self._db_mgr._get_connection()
-                return fresh_conn.executemany(*args, **kwargs)
+                fresh = self._db_mgr._get_connection()
+                return CursorWrapper(fresh._conn.executemany(*args, **kwargs), fresh)
             raise
         finally:
             if not lease_released:
                 self.release_lease()
 
     def cursor(self, *args, **kwargs):
-        raw_cursor = self._conn.cursor(*args, **kwargs)
-        return CursorWrapper(raw_cursor, self)
+        try:
+            raw_cursor = self._conn.cursor(*args, **kwargs)
+            return CursorWrapper(raw_cursor, self)
+        except sqlite3.DatabaseError as e:
+            msg = str(e).lower()
+            if self._db_mgr and isinstance(e, sqlite3.ProgrammingError) and "closed database" in msg:
+                fresh = self._db_mgr._get_connection()
+                return CursorWrapper(fresh._conn.cursor(*args, **kwargs), fresh)
+            if self._db_mgr and ("malformed" in msg or "disk image" in msg) and not self._db_mgr._is_repairing:
+                self._db_mgr.repair_database()
+                fresh = self._db_mgr._get_connection()
+                return CursorWrapper(fresh._conn.cursor(*args, **kwargs), fresh)
+            raise
 
     def __getattr__(self, name):
         return getattr(self._conn, name)
@@ -344,11 +374,12 @@ class AnkimonDB:
         Background threads: a dedicated per-thread connection (``check_same_thread``
         is disabled so a connection may be created off the GUI thread safely, and
         each thread keeps its own so they never share a cursor)."""
+        epoch = self._connection_epoch
         if not _is_main_thread():
             local = self._local_conn
             if (not hasattr(local, "conn") or local.conn is None
                     or getattr(local, "db_path", None) != self.db_path
-                    or getattr(local, "epoch", -1) != self._connection_epoch):
+                    or getattr(local, "epoch", -1) != epoch):
                 if getattr(local, "conn", None) is not None:
                     try:
                         local.conn.close()
@@ -357,14 +388,14 @@ class AnkimonDB:
                 conn = sqlite3.connect(str(self.db_path), check_same_thread=False)
                 local.conn = self._prepare_connection(conn)
                 local.db_path = self.db_path
-                local.epoch = self._connection_epoch
+                local.epoch = epoch
             elif not isinstance(local.conn, ConnectionWrapper):
                 local.conn = ConnectionWrapper(local.conn, self)
                 local.db_path = self.db_path
-                local.epoch = self._connection_epoch
+                local.epoch = epoch
             return local.conn
 
-        if self._connection is None or self._connection_epoch_gui != self._connection_epoch:
+        if self._connection is None or self._connection_epoch_gui != epoch:
             if self._connection:
                 try:
                     self._connection.close()
@@ -372,7 +403,7 @@ class AnkimonDB:
                     pass
             conn = sqlite3.connect(str(self.db_path), check_same_thread=False)
             self._connection = self._prepare_connection(conn)
-            self._connection_epoch_gui = self._connection_epoch
+            self._connection_epoch_gui = epoch
         elif not isinstance(self._connection, ConnectionWrapper):
             self._connection = ConnectionWrapper(self._connection, self)
         return self._connection

--- a/src/Ankimon/singletons.py
+++ b/src/Ankimon/singletons.py
@@ -426,8 +426,14 @@ def swap_ankimon_account():
     from aqt.utils import tooltip
     from .functions.update_main_pokemon import update_main_pokemon
     from .functions.encounter_functions import new_pokemon, clear_encounter_cache
+    from .functions.mobile_sync import _mobile_sync_lock
 
+    mobile_lock_acquired = False
     try:
+        mobile_lock_acquired = _mobile_sync_lock.acquire(blocking=False)
+        if not mobile_lock_acquired:
+            tooltip("Cannot switch accounts while mobile battles are resolving.")
+            return
         # services.db (or its db_path) can be None during init / in headless
         # environments; read the active name inside the try so a missing DB
         # fails gracefully into the tooltip rather than raising an uncaught
@@ -519,6 +525,9 @@ def swap_ankimon_account():
         import traceback
 
         traceback.print_exc()
+    finally:
+        if mobile_lock_acquired:
+            _mobile_sync_lock.release()
 
 
 # DEFERRED seam points (do NOT add here in F31):

--- a/tests/test_database_manager.py
+++ b/tests/test_database_manager.py
@@ -324,13 +324,47 @@ def test_close_reports_timeout_while_cursor_lease_is_active(temp_env):
     db, _ = temp_env
     conn = db._get_connection()
     cursor = conn.cursor()
+    epoch = db._connection_epoch
 
     assert db.close(0.01) is False
+    assert db._connection_epoch == epoch
+    assert db._connection is conn
+    assert conn._close_pending is False
+
     cursor.execute("SELECT 1")
     assert cursor.fetchone()[0] == 1
-
     cursor.close()
+
+    assert conn._closed is False
+    assert db.close(0.1) is True
+    assert db._connection_epoch == epoch + 1
     assert conn._closed is True
+
+
+def test_failed_close_preserves_active_transaction_generation(temp_env):
+    db, _ = temp_env
+    conn = db._get_connection()
+    epoch = db._connection_epoch
+
+    with conn:
+        conn.execute(
+            "INSERT OR REPLACE INTO metadata (key, value) VALUES (?, ?)",
+            ("before_failed_close", "1"),
+        ).close()
+
+        assert db.close(0.0) is False
+        assert db._connection_epoch == epoch
+        assert db._get_connection() is conn
+
+        db.execute(
+            "INSERT OR REPLACE INTO metadata (key, value) VALUES (?, ?)",
+            ("after_failed_close", "2"),
+        ).close()
+
+    assert db.execute(
+        "SELECT value FROM metadata WHERE key = ?",
+        ("after_failed_close",),
+    ).fetchone()[0] == "2"
 
 
 def test_close_deduplicates_wrappers_and_shares_deadline(temp_env):

--- a/tests/test_database_manager.py
+++ b/tests/test_database_manager.py
@@ -367,6 +367,18 @@ def test_failed_close_preserves_active_transaction_generation(temp_env):
     ).fetchone()[0] == "2"
 
 
+def test_switch_database_aborts_when_connections_do_not_drain(temp_env):
+    db, _ = temp_env
+    original_path = db.db_path
+
+    with patch.object(db, "close", return_value=False) as close:
+        with pytest.raises(RuntimeError, match="active operations did not finish"):
+            db.switch_database("ankimonDEV.db")
+
+    close.assert_called_once_with(2.0)
+    assert db.db_path == original_path
+
+
 def test_close_deduplicates_wrappers_and_shares_deadline(temp_env):
     import weakref
 

--- a/tests/test_database_manager.py
+++ b/tests/test_database_manager.py
@@ -319,6 +319,20 @@ def test_thread_local_connection_closes_and_reopens(temp_env):
     
     assert results.get("success") is True
 
+
+def test_close_reports_timeout_while_cursor_lease_is_active(temp_env):
+    db, _ = temp_env
+    conn = db._get_connection()
+    cursor = conn.cursor()
+
+    assert db.close(0.01) is False
+    cursor.execute("SELECT 1")
+    assert cursor.fetchone()[0] == 1
+
+    cursor.close()
+    assert conn._closed is True
+
+
 def test_connection_lease_prevents_closure_during_inflight_operation(temp_env):
     import threading
     db, _ = temp_env
@@ -472,6 +486,16 @@ def test_retry_on_closed_database_error(temp_env):
         assert cursor.fetchone()[0] == 1
 
 
+def test_repair_aborts_when_connections_do_not_drain(temp_env):
+    db, _ = temp_env
+
+    with patch.object(db, "close", return_value=False):
+        with pytest.raises(RuntimeError, match="active operations did not finish"):
+            db.repair_database()
+
+    assert db.db_path.exists()
+    assert not db.db_path.with_name(db.db_path.name + ".tmp").exists()
+
 
 def test_legacy_base_stats_normalization(temp_env):
     """Verify that old database entries without 'base_stats' key are normalized on repair and startup."""
@@ -491,11 +515,11 @@ def test_legacy_base_stats_normalization(temp_env):
     # Save manually to bypass the save_pokemon normalization/check
     obfuscated_data = db._obfuscate(legacy_pk)
     conn = db._get_connection()
-    cursor = conn.cursor()
-    cursor.execute(
-        "INSERT INTO captured_pokemon (individual_id, is_main, data) VALUES (?, 0, ?)",
-        ("legacy-uuid", obfuscated_data)
-    )
+    with conn.cursor() as cursor:
+        cursor.execute(
+            "INSERT INTO captured_pokemon (individual_id, is_main, data) VALUES (?, 0, ?)",
+            ("legacy-uuid", obfuscated_data),
+        )
     conn.commit()
 
     # Check that it starts without base_stats

--- a/tests/test_database_manager.py
+++ b/tests/test_database_manager.py
@@ -333,6 +333,42 @@ def test_close_reports_timeout_while_cursor_lease_is_active(temp_env):
     assert conn._closed is True
 
 
+def test_close_deduplicates_wrappers_and_shares_deadline(temp_env):
+    import weakref
+
+    db, _ = temp_env
+    if db._connection is not None:
+        db._connection.close()
+
+    clock = [100.0]
+
+    class FakeWrapper:
+        def __init__(self, advance):
+            self.advance = advance
+            self.calls = []
+
+        def close(self, wait_seconds):
+            self.calls.append(wait_seconds)
+            clock[0] += self.advance
+            return False
+
+    first = FakeWrapper(0.75)
+    second = FakeWrapper(0.50)
+    db._connection = first
+    db._all_connections = [
+        weakref.ref(first),
+        weakref.ref(first),
+        weakref.ref(second),
+    ]
+    db._local_conn.conn = second
+
+    with patch.object(_db_mod.time, "monotonic", side_effect=lambda: clock[0]):
+        assert db.close(2.0) is False
+
+    assert first.calls == [pytest.approx(2.0)]
+    assert second.calls == [pytest.approx(1.25)]
+
+
 def test_connection_lease_prevents_closure_during_inflight_operation(temp_env):
     import threading
     db, _ = temp_env

--- a/tests/test_database_manager.py
+++ b/tests/test_database_manager.py
@@ -371,64 +371,49 @@ def test_close_deduplicates_wrappers_and_shares_deadline(temp_env):
 
 def test_connection_lease_prevents_closure_during_inflight_operation(temp_env):
     import threading
+
     db, _ = temp_env
-    
     event_paused = threading.Event()
     event_close_done = threading.Event()
     results = {}
-    
-    # Dynamically resolve the correct CursorWrapper class and module from the db instance
+
     conn = db._get_connection()
     with conn.cursor() as cursor:
-        actual_cursor_wrapper_class = cursor.__class__
+        cursor_wrapper_class = cursor.__class__
     db_module = sys.modules[db.__class__.__module__]
-    
-    original_cursor_execute = actual_cursor_wrapper_class.execute
-    original_is_main_thread = db_module._is_main_thread
-    
+    original_execute = cursor_wrapper_class.execute
+
     def patched_cursor_execute(cursor_self, sql, *args, **kwargs):
         if "SELECT 'test_inflight'" in sql:
             event_paused.set()
             assert event_close_done.wait(timeout=5), "database close did not complete"
-        return original_cursor_execute(cursor_self, sql, *args, **kwargs)
-        
-    actual_cursor_wrapper_class.execute = patched_cursor_execute
-    db_module._is_main_thread = lambda: False
-    
-    def thread_func():
+        return original_execute(cursor_self, sql, *args, **kwargs)
+
+    def worker():
         try:
-            try:
-                cursor_thread = db.execute("SELECT 'test_inflight'")
+            with db.execute("SELECT 'test_inflight'") as cursor_thread:
                 results["value"] = cursor_thread.fetchone()[0]
-            except Exception as e:
-                results["error"] = e
-        except Exception as e:
-            results["thread_error"] = str(e)
-            import traceback
-            results["traceback"] = traceback.format_exc()
-                
-    t = threading.Thread(target=thread_func)
-    t.start()
-    
-    try:
-        if not event_paused.wait(timeout=5):
-            print("Thread error:", results.get("thread_error"))
-            print("Traceback:", results.get("traceback"))
-            assert False, f"worker did not initialize: {results.get('thread_error')}"
-        
-        # Close database from main thread. Since background thread holds a lease,
-        # the connection closure should be deferred and the connection should stay alive.
-        db.close()
-        
-        event_close_done.set()
-        t.join(timeout=5)
-        assert not t.is_alive()
-        
-        assert results.get("value") == "test_inflight"
-        assert "error" not in results
-    finally:
-        actual_cursor_wrapper_class.execute = original_cursor_execute
-        db_module._is_main_thread = original_is_main_thread
+        except Exception as exc:
+            results["error"] = exc
+
+    with (
+        patch.object(cursor_wrapper_class, "execute", patched_cursor_execute),
+        patch.object(db_module, "_is_main_thread", return_value=False),
+    ):
+        thread = threading.Thread(target=worker)
+        thread.start()
+        try:
+            assert event_paused.wait(timeout=5), "worker did not initialize"
+            db.close()
+            event_close_done.set()
+            thread.join(timeout=5)
+            assert not thread.is_alive(), "worker did not finish"
+        finally:
+            event_close_done.set()
+            thread.join(timeout=5)
+
+    assert results.get("value") == "test_inflight"
+    assert "error" not in results
 
 
 def test_cursor_handoff_holds_lease_before_close(temp_env):

--- a/tests/test_database_manager.py
+++ b/tests/test_database_manager.py
@@ -368,14 +368,20 @@ def test_failed_close_preserves_active_transaction_generation(temp_env):
 
 
 def test_switch_database_aborts_when_connections_do_not_drain(temp_env):
+    import contextlib
+
     db, _ = temp_env
     original_path = db.db_path
 
-    with patch.object(db, "close", return_value=False) as close:
+    @contextlib.contextmanager
+    def not_drained(wait_seconds=0.0):
+        assert wait_seconds == 2.0
+        yield False
+
+    with patch.object(db, "quiesce", not_drained):
         with pytest.raises(RuntimeError, match="active operations did not finish"):
             db.switch_database("ankimonDEV.db")
 
-    close.assert_called_once_with(2.0)
     assert db.db_path == original_path
 
 
@@ -505,6 +511,79 @@ def test_cursor_handoff_holds_lease_before_close(temp_env):
     assert "error" not in results
 
 
+def test_close_waits_for_connection_registration(temp_env):
+    import threading
+    import time
+
+    db, _ = temp_env
+    entered_prepare = threading.Event()
+    resume_prepare = threading.Event()
+    result = {}
+    original_prepare = db._prepare_connection
+
+    def paused_prepare(raw_conn):
+        entered_prepare.set()
+        assert resume_prepare.wait(timeout=5), "connection registration was not resumed"
+        return original_prepare(raw_conn)
+
+    def create_connection():
+        with patch.object(_db_mod, "_is_main_thread", return_value=False):
+            result["conn"] = db._get_connection()
+
+    def close_database():
+        result["closed"] = db.close(1.0)
+
+    db._prepare_connection = paused_prepare
+    creator = threading.Thread(target=create_connection)
+    closer = threading.Thread(target=close_database)
+    creator.start()
+    assert entered_prepare.wait(timeout=5), "worker did not open its raw connection"
+
+    closer.start()
+    time.sleep(0.05)
+    assert closer.is_alive(), "close bypassed in-progress connection registration"
+
+    resume_prepare.set()
+    creator.join(timeout=5)
+    closer.join(timeout=5)
+    db._prepare_connection = original_prepare
+
+    assert not creator.is_alive()
+    assert not closer.is_alive()
+    assert result["closed"] is True
+    assert result["conn"]._closed is True
+    assert db._all_connections == []
+
+
+def test_quiesce_blocks_reopen_until_transition_finishes(temp_env):
+    import threading
+    import time
+
+    db, _ = temp_env
+    started = threading.Event()
+    acquired = threading.Event()
+    result = {}
+
+    def create_connection():
+        started.set()
+        with patch.object(_db_mod, "_is_main_thread", return_value=False):
+            result["conn"] = db._get_connection()
+        acquired.set()
+
+    with db.quiesce(0.1) as closed:
+        assert closed is True
+        worker = threading.Thread(target=create_connection)
+        worker.start()
+        assert started.wait(timeout=5)
+        time.sleep(0.05)
+        assert not acquired.is_set()
+
+    worker.join(timeout=5)
+    assert not worker.is_alive()
+    assert acquired.is_set()
+    assert result["conn"]._closed is False
+
+
 def test_epoch_double_read_race(temp_env):
     db, _ = temp_env
     original_prepare = db._prepare_connection
@@ -554,9 +633,16 @@ def test_retry_on_closed_database_error(temp_env):
 
 
 def test_repair_aborts_when_connections_do_not_drain(temp_env):
+    import contextlib
+
     db, _ = temp_env
 
-    with patch.object(db, "close", return_value=False):
+    @contextlib.contextmanager
+    def not_drained(wait_seconds=0.0):
+        assert wait_seconds == 2.0
+        yield False
+
+    with patch.object(db, "quiesce", not_drained):
         with pytest.raises(RuntimeError, match="active operations did not finish"):
             db.repair_database()
 

--- a/tests/test_database_manager.py
+++ b/tests/test_database_manager.py
@@ -381,6 +381,49 @@ def test_connection_lease_prevents_closure_during_inflight_operation(temp_env):
         db_module._is_main_thread = original_is_main_thread
 
 
+def test_cursor_handoff_holds_lease_before_close(temp_env):
+    """Closing during cursor wrapping must not invalidate the raw cursor."""
+    import threading
+
+    db, _ = temp_env
+    cursor_created = threading.Event()
+    continue_wrapping = threading.Event()
+    results = {}
+    original_init = _db_mod.CursorWrapper.__init__
+
+    def paused_init(cursor_self, raw_cursor, conn_wrapper, *, lease_acquired=False):
+        cursor_created.set()
+        assert continue_wrapping.wait(timeout=5), "cursor handoff was not resumed"
+        original_init(
+            cursor_self,
+            raw_cursor,
+            conn_wrapper,
+            lease_acquired=lease_acquired,
+        )
+
+    def worker():
+        try:
+            with patch.object(_db_mod, "_is_main_thread", return_value=False):
+                conn = db._get_connection()
+                with conn.cursor() as cursor:
+                    cursor.execute("SELECT 1")
+                    results["value"] = cursor.fetchone()[0]
+        except Exception as exc:
+            results["error"] = exc
+
+    with patch.object(_db_mod.CursorWrapper, "__init__", paused_init):
+        thread = threading.Thread(target=worker)
+        thread.start()
+        assert cursor_created.wait(timeout=5), "worker did not create its cursor"
+        db.close()
+        continue_wrapping.set()
+        thread.join(timeout=5)
+        assert not thread.is_alive(), "worker did not finish"
+
+    assert results.get("value") == 1
+    assert "error" not in results
+
+
 def test_epoch_double_read_race(temp_env):
     db, _ = temp_env
     original_prepare = db._prepare_connection

--- a/tests/test_database_manager.py
+++ b/tests/test_database_manager.py
@@ -305,3 +305,65 @@ def test_thread_local_connection_closes_and_reopens(temp_env):
     
     assert results.get("success") is True
 
+def test_connection_lease_prevents_closure_during_inflight_operation(temp_env):
+    import threading
+    db, _ = temp_env
+    
+    event_paused = threading.Event()
+    event_close_done = threading.Event()
+    results = {}
+    
+    # Dynamically resolve the correct CursorWrapper class and module from the db instance
+    conn = db._get_connection()
+    cursor = conn.cursor()
+    actual_cursor_wrapper_class = cursor.__class__
+    db_module = sys.modules[db.__class__.__module__]
+    
+    original_cursor_execute = actual_cursor_wrapper_class.execute
+    original_is_main_thread = db_module._is_main_thread
+    
+    def patched_cursor_execute(cursor_self, sql, *args, **kwargs):
+        if "SELECT 'test_inflight'" in sql:
+            event_paused.set()
+            event_close_done.wait()
+        return original_cursor_execute(cursor_self, sql, *args, **kwargs)
+        
+    actual_cursor_wrapper_class.execute = patched_cursor_execute
+    db_module._is_main_thread = lambda: False
+    
+    def thread_func():
+        try:
+            try:
+                cursor_thread = db.execute("SELECT 'test_inflight'")
+                results["value"] = cursor_thread.fetchone()[0]
+            except Exception as e:
+                results["error"] = e
+        except Exception as e:
+            results["thread_error"] = str(e)
+            import traceback
+            results["traceback"] = traceback.format_exc()
+                
+    t = threading.Thread(target=thread_func)
+    t.start()
+    
+    try:
+        if not event_paused.wait(timeout=5):
+            print("Thread error:", results.get("thread_error"))
+            print("Traceback:", results.get("traceback"))
+            assert False, f"worker did not initialize: {results.get('thread_error')}"
+        
+        # Close database from main thread. Since background thread holds a lease,
+        # the connection closure should be deferred and the connection should stay alive.
+        db.close()
+        
+        event_close_done.set()
+        t.join(timeout=5)
+        assert not t.is_alive()
+        
+        assert results.get("value") == "test_inflight"
+        assert "error" not in results
+    finally:
+        actual_cursor_wrapper_class.execute = original_cursor_execute
+        db_module._is_main_thread = original_is_main_thread
+
+

--- a/tests/test_database_manager.py
+++ b/tests/test_database_manager.py
@@ -632,6 +632,77 @@ def test_retry_on_closed_database_error(temp_env):
         assert cursor.fetchone()[0] == 1
 
 
+@pytest.mark.parametrize(
+    ("method_name", "operation_args", "expected"),
+    [
+        ("execute", ("SELECT 1",), 1),
+        (
+            "executemany",
+            (
+                "INSERT OR REPLACE INTO metadata (key, value) VALUES (?, ?)",
+                [("retry_handoff_a", "1"), ("retry_handoff_b", "2")],
+            ),
+            2,
+        ),
+    ],
+)
+def test_retry_handoff_holds_lease_before_cursor_wrapper(
+    temp_env, method_name, operation_args, expected
+):
+    import threading
+
+    db, _ = temp_env
+    stale = db._get_connection()
+    stale._conn.close()
+    db._connection_epoch += 1
+
+    entered_handoff = threading.Event()
+    resume_handoff = threading.Event()
+    result = {}
+    original_init = _db_mod.CursorWrapper.__init__
+    paused = False
+
+    def paused_init(cursor_self, raw_cursor, conn_wrapper, *, lease_acquired=False):
+        nonlocal paused
+        if conn_wrapper is not stale and not paused:
+            paused = True
+            entered_handoff.set()
+            assert resume_handoff.wait(timeout=5), "retry handoff was not resumed"
+        original_init(
+            cursor_self,
+            raw_cursor,
+            conn_wrapper,
+            lease_acquired=lease_acquired,
+        )
+
+    def worker():
+        try:
+            with patch.object(_db_mod, "_is_main_thread", return_value=False):
+                cursor = getattr(stale, method_name)(*operation_args)
+                try:
+                    result["value"] = (
+                        cursor.fetchone()[0]
+                        if method_name == "execute"
+                        else cursor.rowcount
+                    )
+                finally:
+                    cursor.close()
+        except Exception as exc:
+            result["error"] = exc
+
+    with patch.object(_db_mod.CursorWrapper, "__init__", paused_init):
+        thread = threading.Thread(target=worker)
+        thread.start()
+        assert entered_handoff.wait(timeout=5), "retry did not reach cursor handoff"
+        assert db.close(0.01) is False
+        resume_handoff.set()
+        thread.join(timeout=5)
+        assert not thread.is_alive()
+
+    assert result.get("value") == expected
+    assert "error" not in result
+
+
 def test_repair_aborts_when_connections_do_not_drain(temp_env):
     import contextlib
 

--- a/tests/test_database_manager.py
+++ b/tests/test_database_manager.py
@@ -277,19 +277,19 @@ def test_thread_local_connection_closes_and_reopens(temp_env):
         with patch("Ankimon.pyobj.database_manager._is_main_thread", return_value=False):
             # Get connection and verify it works
             conn = db._get_connection()
-            cursor = conn.cursor()
-            cursor.execute("SELECT 1")
-            assert cursor.fetchone()[0] == 1
+            with conn.cursor() as cursor:
+                cursor.execute("SELECT 1")
+                assert cursor.fetchone()[0] == 1
             
             # Notify main thread
             event_start.set()
-            event_closed.wait()
+            assert event_closed.wait(timeout=5), "database close was not signaled"
             
             # Get connection again. It should be refreshed automatically
             conn2 = db._get_connection()
-            cursor2 = conn2.cursor()
-            cursor2.execute("SELECT 1")
-            results["success"] = (cursor2.fetchone()[0] == 1)
+            with conn2.cursor() as cursor2:
+                cursor2.execute("SELECT 1")
+                results["success"] = (cursor2.fetchone()[0] == 1)
             
     t = threading.Thread(target=thread_func)
     t.start()
@@ -315,8 +315,8 @@ def test_connection_lease_prevents_closure_during_inflight_operation(temp_env):
     
     # Dynamically resolve the correct CursorWrapper class and module from the db instance
     conn = db._get_connection()
-    cursor = conn.cursor()
-    actual_cursor_wrapper_class = cursor.__class__
+    with conn.cursor() as cursor:
+        actual_cursor_wrapper_class = cursor.__class__
     db_module = sys.modules[db.__class__.__module__]
     
     original_cursor_execute = actual_cursor_wrapper_class.execute
@@ -325,7 +325,7 @@ def test_connection_lease_prevents_closure_during_inflight_operation(temp_env):
     def patched_cursor_execute(cursor_self, sql, *args, **kwargs):
         if "SELECT 'test_inflight'" in sql:
             event_paused.set()
-            event_close_done.wait()
+            assert event_close_done.wait(timeout=5), "database close did not complete"
         return original_cursor_execute(cursor_self, sql, *args, **kwargs)
         
     actual_cursor_wrapper_class.execute = patched_cursor_execute

--- a/tests/test_database_manager.py
+++ b/tests/test_database_manager.py
@@ -367,3 +367,52 @@ def test_connection_lease_prevents_closure_during_inflight_operation(temp_env):
         db_module._is_main_thread = original_is_main_thread
 
 
+def test_epoch_double_read_race(temp_env):
+    db, _ = temp_env
+    original_prepare = db._prepare_connection
+    close_called = False
+    
+    def patched_prepare(conn):
+        nonlocal close_called
+        res = original_prepare(conn)
+        if not close_called:
+            close_called = True
+            db.close()
+        return res
+        
+    db._prepare_connection = patched_prepare
+    
+    import threading
+    results = {}
+    
+    def thread_func():
+        try:
+            with patch("Ankimon.pyobj.database_manager._is_main_thread", return_value=False):
+                conn1 = db._get_connection()
+                conn2 = db._get_connection()
+                with conn2.cursor() as cursor:
+                    cursor.execute("SELECT 1")
+                    results["success"] = (cursor.fetchone()[0] == 1)
+        except Exception as e:
+            results["error"] = str(e)
+            
+    t = threading.Thread(target=thread_func)
+    t.start()
+    t.join(timeout=5)
+    assert not t.is_alive()
+    assert results.get("success") is True
+    assert "error" not in results
+
+
+def test_retry_on_closed_database_error(temp_env):
+    db, _ = temp_env
+    conn = db._get_connection()
+    conn._conn.close()
+    db._connection_epoch += 1
+    
+    with conn.cursor() as cursor:
+        cursor.execute("SELECT 1")
+        assert cursor.fetchone()[0] == 1
+
+
+

--- a/tests/test_database_manager.py
+++ b/tests/test_database_manager.py
@@ -294,13 +294,14 @@ def test_thread_local_connection_closes_and_reopens(temp_env):
     t = threading.Thread(target=thread_func)
     t.start()
     
-    event_start.wait()
+    assert event_start.wait(timeout=5), "worker did not initialize"
     
     # Close database from main thread
     db.close()
     
     event_closed.set()
-    t.join()
+    t.join(timeout=5)
+    assert not t.is_alive(), "worker did not finish"
     
     assert results.get("success") is True
 

--- a/tests/test_database_manager.py
+++ b/tests/test_database_manager.py
@@ -328,7 +328,7 @@ def test_close_reports_timeout_while_cursor_lease_is_active(temp_env):
 
     assert db.close(0.01) is False
     assert db._connection_epoch == epoch
-    assert db._connection is conn
+    assert db._get_connection() is conn
     assert conn._close_pending is False
 
     cursor.execute("SELECT 1")

--- a/tests/test_database_manager.py
+++ b/tests/test_database_manager.py
@@ -264,3 +264,43 @@ def test_database_corruption_self_healing(temp_env):
     # Confirm unique constraint is back by verifying that inserting a duplicate now raises IntegrityError
     with pytest.raises(sqlite3.IntegrityError):
         cursor.execute("INSERT INTO captured_pokemon (individual_id, is_main, data) VALUES ('duplicate-uuid', 0, '{}')")
+
+def test_thread_local_connection_closes_and_reopens(temp_env):
+    import threading
+    db, _ = temp_env
+    
+    results = {}
+    event_start = threading.Event()
+    event_closed = threading.Event()
+    
+    def thread_func():
+        with patch("Ankimon.pyobj.database_manager._is_main_thread", return_value=False):
+            # Get connection and verify it works
+            conn = db._get_connection()
+            cursor = conn.cursor()
+            cursor.execute("SELECT 1")
+            assert cursor.fetchone()[0] == 1
+            
+            # Notify main thread
+            event_start.set()
+            event_closed.wait()
+            
+            # Get connection again. It should be refreshed automatically
+            conn2 = db._get_connection()
+            cursor2 = conn2.cursor()
+            cursor2.execute("SELECT 1")
+            results["success"] = (cursor2.fetchone()[0] == 1)
+            
+    t = threading.Thread(target=thread_func)
+    t.start()
+    
+    event_start.wait()
+    
+    # Close database from main thread
+    db.close()
+    
+    event_closed.set()
+    t.join()
+    
+    assert results.get("success") is True
+

--- a/tests/test_swap_account_main_pokemon.py
+++ b/tests/test_swap_account_main_pokemon.py
@@ -19,6 +19,7 @@ sibling modules, exec the REAL singletons module, drive swap_ankimon_account().
 
 import importlib.util
 import sys
+import threading
 import types
 from types import SimpleNamespace
 from unittest.mock import MagicMock
@@ -59,9 +60,10 @@ class _FakeShopManager:
 def swap_env(monkeypatch):
     """A fully-stubbed singletons module plus captured swap-dependency spies."""
     mw = SimpleNamespace()
+    tooltip = MagicMock()
     monkeypatch.setitem(sys.modules, "aqt", _stub_module("aqt", mw=mw))
     monkeypatch.setitem(
-        sys.modules, "aqt.utils", _stub_module("aqt.utils", tooltip=MagicMock())
+        sys.modules, "aqt.utils", _stub_module("aqt.utils", tooltip=tooltip)
     )
 
     def is_alive(obj):
@@ -155,6 +157,15 @@ def swap_env(monkeypatch):
             clear_encounter_cache=MagicMock(),
         ),
     )
+    mobile_sync_lock = threading.Lock()
+    monkeypatch.setitem(
+        sys.modules,
+        "Ankimon.functions.mobile_sync",
+        _stub_module(
+            "Ankimon.functions.mobile_sync",
+            _mobile_sync_lock=mobile_sync_lock,
+        ),
+    )
     monkeypatch.setitem(
         sys.modules,
         "Ankimon.reviewer_ui",
@@ -184,6 +195,8 @@ def swap_env(monkeypatch):
         services=services,
         main_pokemon=main_pokemon,
         update_main_pokemon=update_main_pokemon,
+        mobile_sync_lock=mobile_sync_lock,
+        tooltip=tooltip,
     )
 
     sys.modules.pop("Ankimon.singletons", None)
@@ -209,3 +222,17 @@ def test_swap_does_not_double_apply_when_mutated_in_place(swap_env):
     swap_env.singletons.swap_ankimon_account()
 
     swap_env.main_pokemon.update_stats.assert_not_called()
+
+
+def test_swap_aborts_while_mobile_resolution_holds_lock(swap_env):
+    swap_env.mobile_sync_lock.acquire()
+    try:
+        swap_env.singletons.swap_ankimon_account()
+    finally:
+        swap_env.mobile_sync_lock.release()
+
+    swap_env.services.db.switch_database.assert_not_called()
+    swap_env.update_main_pokemon.assert_not_called()
+    swap_env.tooltip.assert_called_once_with(
+        "Cannot switch accounts while mobile battles are resolving."
+    )

--- a/tests/test_sync_hardening.py
+++ b/tests/test_sync_hardening.py
@@ -185,6 +185,29 @@ def test_atomic_replace_swaps_file_and_clears_stale_sidecars(tmp_path, monkeypat
         services.db = prev
 
 
+def test_atomic_replace_aborts_when_live_db_does_not_drain(tmp_path):
+    src = tmp_path / "ankimon.db"
+    src.write_bytes(b"LOCAL" + b"\x00" * 600)
+    media = tmp_path / "media.db"
+    media.write_bytes(b"REMOTE" + b"\x00" * 600)
+
+    class BusyDB:
+        db_path = src
+
+        def close(self, wait_seconds=0.0):
+            return False
+
+    prev = services.db
+    services.db = BusyDB()
+    try:
+        with pytest.raises(RuntimeError, match="active operations did not finish"):
+            AnkimonDataSync()._atomic_replace(media, src)
+    finally:
+        services.db = prev
+
+    assert src.read_bytes().startswith(b"LOCAL")
+
+
 def _wire_read_configs(ds, monkeypatch, src, media):
     monkeypatch.setattr(ds, "_migrate_legacy_files", lambda: [])
     monkeypatch.setattr(ds, "_get_source_path", lambda fn: src)

--- a/tests/test_sync_hardening.py
+++ b/tests/test_sync_hardening.py
@@ -185,6 +185,53 @@ def test_atomic_replace_swaps_file_and_clears_stale_sidecars(tmp_path, monkeypat
         services.db = prev
 
 
+def test_atomic_replace_holds_quiescence_through_os_replace(tmp_path, monkeypatch):
+    import contextlib
+    import importlib
+
+    src = tmp_path / "ankimon.db"
+    src.write_bytes(b"LOCAL" + b"\x00" * 600)
+    media = tmp_path / "media.db"
+    media.write_bytes(b"REMOTE" + b"\x00" * 600)
+
+    class QuiescingDB:
+        db_path = src
+        inside = False
+        entered = 0
+        exited = 0
+
+        @contextlib.contextmanager
+        def quiesce(self, wait_seconds=0.0):
+            self.entered += 1
+            self.inside = True
+            try:
+                yield True
+            finally:
+                self.inside = False
+                self.exited += 1
+
+    runtime_services = importlib.import_module("Ankimon.services").services
+    prev = runtime_services.db
+    fake_db = QuiescingDB()
+    runtime_services.db = fake_db
+    original_replace = aksync.os.replace
+
+    def checked_replace(source, destination):
+        assert fake_db.inside, "database lifecycle barrier released before os.replace"
+        return original_replace(source, destination)
+
+    monkeypatch.setattr(aksync.os, "replace", checked_replace)
+    try:
+        AnkimonDataSync()._atomic_replace(media, src)
+    finally:
+        runtime_services.db = prev
+
+    assert src.read_bytes().startswith(b"REMOTE")
+    assert fake_db.entered == 1
+    assert fake_db.exited == 1
+    assert fake_db.inside is False
+
+
 def test_atomic_replace_aborts_when_live_db_does_not_drain(tmp_path):
     src = tmp_path / "ankimon.db"
     src.write_bytes(b"LOCAL" + b"\x00" * 600)

--- a/tests/test_sync_hardening.py
+++ b/tests/test_sync_hardening.py
@@ -197,13 +197,16 @@ def test_atomic_replace_aborts_when_live_db_does_not_drain(tmp_path):
         def close(self, wait_seconds=0.0):
             return False
 
-    prev = services.db
-    services.db = BusyDB()
+    import importlib
+
+    runtime_services = importlib.import_module("Ankimon.services").services
+    prev = runtime_services.db
+    runtime_services.db = BusyDB()
     try:
         with pytest.raises(RuntimeError, match="active operations did not finish"):
             AnkimonDataSync()._atomic_replace(media, src)
     finally:
-        services.db = prev
+        runtime_services.db = prev
 
     assert src.read_bytes().startswith(b"LOCAL")
 


### PR DESCRIPTION
### Summary

This pull request resolves a concurrency bug where background threads (such as the mobile shop review simulation running `run_sim` in `shop_obj.py`) raise a `sqlite3.ProgrammingError: Cannot operate on a closed database` traceback when attempting to read or write from the database.

### Cause of the Bug
1. **Thread-Safe DB Scaffold (PR 615)**:
   - PR 615 introduced a thread-safe connection layer in `AnkimonDB` utilizing `threading.local()` to maintain separate sqlite3 connections per background thread, preventing cursor-sharing conflicts.
   - However, when `AnkimonDB.close()` was executed (typically on the main thread), it looped through all registered connections (`_all_connections`) and called `.close()` on them.
   - Since `threading.local` variables are thread-isolated, the main thread **cannot** clear the cached `conn` attribute on `self._local_conn` belonging to other threads.
   - When the background thread later called `_get_connection()`, it found `local.conn` was not None and returned the closed connection instead of spinning up a new one.

2. **The Connection to PR 639**:
   - Prior to PR 639, `db.close()` was rarely called (only on manual import/export, profile switches, or database repair).
   - **PR 639** (OneDrive/AV file-lock tolerance) expanded connection closing to **every** automatic sync-hook and config save path (`save_configs` and `read_configs`).
   - Consequently, database closures began occurring frequently in the background, making it extremely likely that a running/upcoming background thread task would try to query the closed database before refreshing.

### Implementation details & Concurrency hardening
1. **Thread-Local Connection Epoch Refresh**:
   - Track a connection epoch state (`self._connection_epoch`) in `AnkimonDB`, incremented on each `close()`.
   - In `_get_connection()`, compare the connection's cached epoch (for both the GUI thread and thread-locals) against the current DB epoch and automatically refresh the connection if a mismatch is found.
   - **Stale Epoch Protection**: Refactored `_get_connection()` to capture `self._connection_epoch` locally at the start of the check, protecting against races where `close()` bumps the epoch between the mismatch check and writing the local/GUI cache stamp.
2. **Operation Leases**:
   - Add lease-counting logic to `ConnectionWrapper` and a new `CursorWrapper`.
   - When transactions are active (`__enter__`) or cursors are created (`cursor`), a lease is acquired.
   - `AnkimonDB.close()` sets `_close_pending = True` but defers the actual connection shutdown until all active leases are released. This prevents race conditions where `close()` runs after validation but before cursor/query execution completes.
   - **Auto-Recovery on Closed Connection**: Catch `sqlite3.ProgrammingError: Cannot operate on a closed database` inside `ConnectionWrapper`'s `execute()`, `executemany()`, and `cursor()`. If caught, release the current lease and dynamically retry the query exactly once against a fresh connection wrapper.
   - **Synchronous Bounded Wait for Closure**: Added a `wait_seconds` parameter to `ConnectionWrapper.close()` and `AnkimonDB.close()`. This allows call sites that must release file handles before performing file updates/swaps (specifically `repair_database()` and `ankimon_sync._release_handles()`) to wait and drain outstanding leases before returning.
   - **Commit Correctness**: Unlike queries, a rollback on a closed connection cannot be recovered simply by retrying `commit()` on a fresh connection. Retrying `commit` on a new connection has been omitted to prevent silent rollback failures and data loss.
3. **Regression Tests**:
   - Verified connection refresh after `close()` on background threads.
   - Verified that connection leases prevent connection closure during in-flight operations.
   - Added `test_epoch_double_read_race` verifying stale epoch connection self-healing.
   - Added `test_retry_on_closed_database_error` verifying automatic recovery on closed handles.
   - All tests run and pass.