### PR TITLE
fix(cp): repair stale persisted CP left behind by the CPM retune

### DIFF
--- a/src/Ankimon/business.py
+++ b/src/Ankimon/business.py
@@ -84,11 +84,17 @@ def calculate_cpm(level: int) -> float:
     """CP Multiplier — exponential (saturating) function of level.
 
     Models the Pokemon GO idea of a level-scaling multiplier that grows
-    quickly at low levels and tapers off as the Pokemon approaches its
-    level ceiling. The curve asymptotes toward ``3.5`` as level grows —
-    reaching about ``2.42`` at the level-100 cap — and is smooth and
-    defined for any Anki level. The scale is deliberately larger than
-    Pokemon GO's real CPM cap (~``0.84``) to tune Ankimon's CP economy.
+    quickly at low levels and then keeps rewarding levelling across the
+    whole playable range, tapering only gradually. The curve asymptotes
+    toward ``3.5`` as level grows — reaching about ``2.42`` at level 100,
+    roughly 69% of that asymptote, so levels past the (optionally
+    disabled) level-100 cap still raise CP — and is smooth and defined
+    for any Anki level. The scale is deliberately larger than Pokemon
+    GO's real CPM cap (~``0.84``) to tune Ankimon's CP economy.
+
+    Note that ``CP`` scales as ``CPM ** 2``, and that ``cp`` is persisted
+    per-Pokemon, so retuning this function strands old-scale values in the
+    database — see :func:`pokemon_cp_is_stale`.
     """
     return 3.5 * (1 - math.exp(-max(level, 1) / 85))
 
@@ -302,12 +308,34 @@ def calculate_cp_from_dict(pokemon_dict):
     else:
         base_stats = pokemon_dict.get("stats", {})
 
-    level = pokemon_dict.get("level", 1)
+    # Coerce level the same way cp_breakdown_tooltip does: rows restored
+    # from JSON can carry it as a string, and calculate_cpm's max(level, 1)
+    # raises TypeError when comparing str/None against int.
+    level = int(pokemon_dict.get("level", 1) or 1)
     iv = pokemon_dict.get("iv") or {}
     ev = pokemon_dict.get("ev") or {}
 
     attack, defense, stamina = pokemon_go_raw_stats(base_stats, iv, ev)
     return calculate_pokemon_go_cp(attack, defense, stamina, level)
+
+
+def pokemon_cp_is_stale(pokemon_dict: dict) -> bool:
+    """Whether a stored Pokemon's persisted ``cp`` disagrees with the formula.
+
+    ``cp`` is derived data that is *also* persisted (see
+    ``encounter_functions`` at catch time), so retuning :func:`calculate_cpm`
+    leaves old-scale values in the database until something rewrites them.
+    Migration passes use this to decide whether a repair is needed.
+
+    Never raises: a row whose CP cannot be computed is reported as stale so
+    the caller's repair path takes over rather than the check exploding.
+    """
+    if not isinstance(pokemon_dict, dict):
+        return False
+    try:
+        return pokemon_dict.get("cp") != calculate_cp_from_dict(pokemon_dict)
+    except Exception:
+        return True
 
 def bP_none_moves(move):
     target =  move.get("target", None)

--- a/src/Ankimon/business.py
+++ b/src/Ankimon/business.py
@@ -310,8 +310,13 @@ def calculate_cp_from_dict(pokemon_dict):
 
     # Coerce level the same way cp_breakdown_tooltip does: rows restored
     # from JSON can carry it as a string, and calculate_cpm's max(level, 1)
-    # raises TypeError when comparing str/None against int.
-    level = int(pokemon_dict.get("level", 1) or 1)
+    # raises TypeError when comparing str/None against int. A level that is
+    # not a number at all is meaningless rather than merely mistyped, so it
+    # falls back to 1 instead of taking down every CP read on the row.
+    try:
+        level = int(pokemon_dict.get("level", 1) or 1)
+    except (TypeError, ValueError):
+        level = 1
     iv = pokemon_dict.get("iv") or {}
     ev = pokemon_dict.get("ev") or {}
 

--- a/src/Ankimon/pyobj/pc_box.py
+++ b/src/Ankimon/pyobj/pc_box.py
@@ -2518,11 +2518,22 @@ class PokemonPC(QDialog):
             "cp",
         }
 
+        # Imported here rather than at module scope: this is the only call
+        # site, and pc_box's module-level import of ``business`` is widely
+        # stubbed by the test-suite, so a new top-level name would break
+        # unrelated modules that never reach this method.
+        from ..business import pokemon_cp_is_stale
+
+        # A row needs repair if a default field is missing *or* its persisted
+        # ``cp`` no longer matches the current formula. Without the staleness
+        # arm, a save whose fields are all present short-circuits here and
+        # never reaches the "Always recalculate CP" pass below — which is
+        # exactly the population carrying pre-retune CP values.
         is_migration_needed = any(
-            key not in pokemon
+            any(key not in pokemon for key in default_keys)
+            or pokemon_cp_is_stale(pokemon)
             for pokemon in pokemon_list
             if isinstance(pokemon, dict)
-            for key in default_keys
         )
 
         if not is_migration_needed:
@@ -2557,9 +2568,14 @@ class PokemonPC(QDialog):
             if not isinstance(pokemon, dict):
                 continue
 
-            # Always recalculate CP to ensure it matches the current formula in business.py
+            # Always recalculate CP to ensure it matches the current formula in business.py.
+            # This runs for every row on PC-box open, so a single malformed
+            # legacy row must not take the whole window down with it.
             old_cp = pokemon.get("cp")
-            new_cp = calculate_cp_from_dict(pokemon)
+            try:
+                new_cp = calculate_cp_from_dict(pokemon)
+            except Exception:
+                new_cp = old_cp
             if old_cp != new_cp:
                 needs_update = True
                 pokemon_list[i]["cp"] = new_cp

--- a/tests/test_cp_formula.py
+++ b/tests/test_cp_formula.py
@@ -36,6 +36,7 @@ from Ankimon.business import (
     type_compatibility_multiplier,
     calculate_cp_from_dict,
     cp_breakdown_tooltip,
+    pokemon_cp_is_stale,
     _load_type_chart,
 )
 
@@ -358,3 +359,59 @@ class TestFormatCompactNumber:
 
     def test_float_input_truncates_like_int(self):
         assert format_compact_number(2564.9) == "2,564"
+
+
+class TestPokemonCpIsStale:
+    """``cp`` is derived but persisted, so it can drift from the formula."""
+
+    _ROW = {
+        "level": 100,
+        "stats": {"hp": 106, "atk": 110, "def": 90, "spa": 154, "spd": 90, "spe": 130},
+        "iv": {"hp": 31, "atk": 31, "def": 31, "spa": 31, "spd": 31, "spe": 31},
+        "ev": {"hp": 0, "atk": 0, "def": 0, "spa": 0, "spd": 0, "spe": 0},
+    }
+
+    def _row(self, **overrides):
+        row = {k: (dict(v) if isinstance(v, dict) else v) for k, v in self._ROW.items()}
+        row.update(overrides)
+        return row
+
+    def test_matching_cp_is_not_stale(self):
+        row = self._row()
+        row["cp"] = calculate_cp_from_dict(row)
+        assert pokemon_cp_is_stale(row) is False
+
+    def test_value_from_superseded_formula_is_stale(self):
+        # 1460 is what the pre-retune 0.84/20 CPM produced for this Pokemon.
+        assert pokemon_cp_is_stale(self._row(cp=1460)) is True
+
+    def test_missing_cp_is_stale(self):
+        assert pokemon_cp_is_stale(self._row()) is True
+
+    def test_uncomputable_row_reports_stale_rather_than_raising(self):
+        # Callers repair what they can; the check must never be the thing
+        # that takes down a PC-box open.
+        assert pokemon_cp_is_stale({"cp": 1, "stats": "not-a-dict"}) is True
+
+    def test_non_dict_is_not_stale(self):
+        assert pokemon_cp_is_stale(None) is False
+
+
+class TestLevelCoercion:
+    """Rows restored from JSON can carry ``level`` as a string."""
+
+    _ROW = {
+        "stats": {"hp": 50, "atk": 80, "def": 60, "spa": 100, "spd": 70, "spe": 90},
+        "iv": {"hp": 10, "atk": 15, "def": 10, "spa": 15, "spd": 10, "spe": 15},
+        "ev": {"hp": 0, "atk": 0, "def": 0, "spa": 0, "spd": 0, "spe": 0},
+    }
+
+    def test_string_level_matches_int_level(self):
+        as_int = calculate_cp_from_dict({**self._ROW, "level": 50})
+        as_str = calculate_cp_from_dict({**self._ROW, "level": "50"})
+        assert as_str == as_int
+
+    def test_none_level_is_treated_as_one(self):
+        as_none = calculate_cp_from_dict({**self._ROW, "level": None})
+        as_one = calculate_cp_from_dict({**self._ROW, "level": 1})
+        assert as_none == as_one

--- a/tests/test_cp_formula.py
+++ b/tests/test_cp_formula.py
@@ -3,6 +3,8 @@ import sys
 import types
 from pathlib import Path
 
+import pytest
+
 # Stub Ankimon packages so we can import business.py without triggering __init__.py
 _src = Path(__file__).parent.parent / "src"
 for _pkg in ("Ankimon", "Ankimon.functions", "Ankimon.pyobj"):
@@ -415,3 +417,17 @@ class TestLevelCoercion:
         as_none = calculate_cp_from_dict({**self._ROW, "level": None})
         as_one = calculate_cp_from_dict({**self._ROW, "level": 1})
         assert as_none == as_one
+
+    def test_non_numeric_level_falls_back_to_one(self):
+        # A level that is not a number at all is meaningless; it must not
+        # take down the CP read for every consumer of the row.
+        as_garbage = calculate_cp_from_dict({**self._ROW, "level": "???"})
+        as_one = calculate_cp_from_dict({**self._ROW, "level": 1})
+        assert as_garbage == as_one
+
+    def test_malformed_stats_still_raise(self):
+        # Deliberately NOT swallowed: callers that repair rows must be able
+        # to tell "cannot compute" from "computed the floor value", or the
+        # migration pass would overwrite good CP with the minimum clamp.
+        with pytest.raises(Exception):
+            calculate_cp_from_dict({**self._ROW, "level": 50, "stats": "corrupt"})

--- a/tests/test_pc_box_cp_migration.py
+++ b/tests/test_pc_box_cp_migration.py
@@ -1,0 +1,269 @@
+"""Regression tests for stale persisted ``cp`` repair in ``pyobj/pc_box.py``.
+
+``cp`` is derived from ``business.calculate_cpm`` but is *also* persisted per
+Pokemon at catch time, so retuning the CPM formula leaves old-scale values in
+the database. ``PokemonPC.ensure_data_integrity`` contains an "Always
+recalculate CP" pass for exactly that, but it sits behind a quick-check that
+returned early whenever every default field was present — which is precisely
+the shape of a save carrying pre-retune CP. These pin that the quick-check also
+considers CP staleness.
+
+``pc_box.py`` is loaded in isolation with its module-level dependencies stubbed
+(mirroring ``test_pc_box_evolution_button.py``), except that the *real*
+``Ankimon.business`` is installed because the CP maths is what is under test.
+``ensure_data_integrity`` touches no ``self`` state, so it is driven unbound
+against a fake ``services.db`` seam — no Qt widget is constructed.
+"""
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+pytest.importorskip("PyQt6")  # Qt env only; skipped in the aqt-free Tier-1 env.
+
+_MODULE_NAME = "Ankimon.pyobj.pc_box"
+_SRC = Path(__file__).parent.parent / "src"
+
+# Every key the quick-check treats as required. A row holding all of these
+# used to short-circuit the migration regardless of how stale its CP was.
+_DEFAULT_KEYS = (
+    "nickname", "gender", "ability", "type", "attacks", "base_experience",
+    "growth_rate", "everstone", "shiny", "captured_date", "individual_id",
+    "mega", "special_form", "xp", "friendship", "pokemon_defeated", "tier",
+    "is_favorite", "held_item", "cp",
+)
+
+# A Pokemon with real base stats so CP is a meaningful number rather than the
+# minimum clamp. Mirrors the caught-Pokemon shape ("stats" holds base stats).
+_BASE_STATS = {"hp": 106, "atk": 110, "def": 90, "spa": 154, "spd": 90, "spe": 130}
+
+
+def _complete_row(**overrides):
+    """A row that satisfies every default key, so only CP staleness can trigger."""
+    row = {key: "placeholder" for key in _DEFAULT_KEYS}
+    row.update(
+        {
+            "id": 150,
+            "name": "mewtwo",
+            "level": 100,
+            "stats": dict(_BASE_STATS),
+            "iv": {k: 31 for k in _BASE_STATS},
+            "ev": {k: 0 for k in _BASE_STATS},
+        }
+    )
+    row.update(overrides)
+    return row
+
+
+def _make_module(name, **attrs):
+    mod = types.ModuleType(name)
+    for k, v in attrs.items():
+        setattr(mod, k, v)
+    return mod
+
+
+@pytest.fixture
+def pc_box():
+    """Load ``pc_box.py`` with stubbed deps but the real ``business`` module."""
+    from PyQt6 import QtCore, QtGui, QtWidgets
+
+    if not isinstance(QtWidgets.QDialog, type):  # PyQt6 mocked by another test
+        pytest.skip(
+            "real PyQt6 not active (mocked by another test); "
+            "run tests/test_pc_box_cp_migration.py standalone"
+        )
+    if str(_SRC) not in sys.path:
+        sys.path.insert(0, str(_SRC))
+
+    class _AqtQt(types.ModuleType):
+        """``aqt.qt`` re-exporting the real Qt names, mocking anything else.
+
+        Real classes matter because ``PokemonPC`` subclasses ``QDialog``; the
+        long tail of aqt-only helpers can safely be mocks.
+        """
+
+        def __getattr__(self, name):
+            for mod in (QtWidgets, QtGui, QtCore):
+                obj = getattr(mod, name, None)
+                if obj is not None:
+                    return obj
+            return mock.MagicMock()
+
+    services_obj = types.SimpleNamespace(db=None, achievements={})
+
+    class _Stub:
+        def __init__(self, *a, **k):
+            pass
+
+        @classmethod
+        def from_dict(cls, *a, **k):
+            return cls()
+
+        @staticmethod
+        def calc_stat(*a, **k):
+            return 1
+
+    stub_specs = {
+        "Ankimon.pyobj.pokemon_obj": {"PokemonObject": _Stub},
+        "Ankimon.pyobj.reviewer_obj": {"Reviewer_Manager": _Stub},
+        "Ankimon.pyobj.test_window": {"TestWindow": _Stub},
+        "Ankimon.pyobj.translator": {"Translator": _Stub},
+        "Ankimon.pyobj.collection_dialog": {"MainPokemon": _Stub},
+        "Ankimon.gui_classes.pokemon_details": {
+            "PokemonCollectionDetailsSplit": lambda *a, **k: (None, None, None, {}),
+            "remember_attack": mock.MagicMock(),
+        },
+        "Ankimon.pyobj.InfoLogger": {"ShowInfoLogger": _Stub},
+        "Ankimon.pyobj.move_picker": {"MovePickerDialog": _Stub},
+        "Ankimon.pyobj.evolution_window": {"EvoWindow": _Stub},
+        "Ankimon.pyobj.settings": {"Settings": _Stub},
+        "Ankimon.functions.friendship_evolution": {
+            "current_time_label": lambda *a, **k: "Day",
+            "evolution_readiness": lambda *a, **k: {"ready": False, "method": None},
+        },
+        "Ankimon.functions.sprite_functions": {"get_sprite_path": lambda *a, **k: ""},
+        "Ankimon.utils": {
+            "load_custom_font": lambda *a, **k: mock.MagicMock(),
+            "get_tier_by_id": lambda *a, **k: "Normal",
+            "is_alive": lambda obj: obj is not None,
+            "format_move_name": lambda s: str(s).replace("-", " ").title(),
+            "format_pokemon_name": lambda s: str(s).title(),
+        },
+        "Ankimon.resources": {
+            "icon_path": Path("/nonexistent/icon.png"),
+            "items_path": Path("/nonexistent/items"),
+            "csv_file_items_cost": Path("/nonexistent/items_cost.csv"),
+            "poke_evo_path": Path("/nonexistent/evo"),
+            "pokemon_tm_learnset_path": Path("/nonexistent/tm.json"),
+            "addon_dir": Path("/nonexistent/addon"),
+            # Required by the real business module at import time.
+            "csv_file_items": Path("/nonexistent/items.csv"),
+            "csv_file_descriptions": Path("/nonexistent/descriptions.csv"),
+            "effectiveness_chart_file_path": (
+                _SRC / "Ankimon" / "addon_files" / "eff_chart.json"
+            ),
+        },
+        "Ankimon.functions.pokedex_functions": {
+            "find_details_move": lambda m: {"type": "Normal"},
+            "get_all_pokemon_moves": lambda *a, **k: [],
+            "format_lore_name": lambda s: s,
+            "get_pretty_name_for_name": lambda s: str(s).title(),
+            "search_pokedex_by_id": lambda i: "pikachu",
+        },
+        "Ankimon.functions.gui_functions": {
+            "type_icon_path": lambda *a, **k: Path("/nonexistent"),
+            "move_category_path": lambda *a, **k: Path("/nonexistent"),
+        },
+    }
+
+    parent_pkgs = ("Ankimon", "Ankimon.functions", "Ankimon.pyobj", "Ankimon.gui_classes")
+    to_install = {
+        "aqt": _make_module("aqt", mw=mock.MagicMock(), gui_hooks=mock.MagicMock()),
+        "aqt.qt": _AqtQt("aqt.qt"),
+        "aqt.theme": _make_module(
+            "aqt.theme", theme_manager=types.SimpleNamespace(night_mode=False)
+        ),
+        "Ankimon.services": _make_module("Ankimon.services", services=services_obj),
+        _MODULE_NAME: None,
+        **{name: _make_module(name, **attrs) for name, attrs in stub_specs.items()},
+    }
+    saved = {
+        name: sys.modules.get(name)
+        for name in (*to_install, *parent_pkgs, "Ankimon.business")
+    }
+
+    for pkg in parent_pkgs:
+        mod = types.ModuleType(pkg)
+        mod.__path__ = [str(_SRC / pkg.replace(".", "/"))]
+        mod.__package__ = pkg
+        sys.modules[pkg] = mod
+    for name, mod in to_install.items():
+        if mod is not None:
+            sys.modules[name] = mod
+
+    # The real business module — the CP maths is the subject of these tests.
+    sys.modules.pop("Ankimon.business", None)
+    business_spec = importlib.util.spec_from_file_location(
+        "Ankimon.business", _SRC / "Ankimon" / "business.py"
+    )
+    business = importlib.util.module_from_spec(business_spec)
+    sys.modules["Ankimon.business"] = business
+    business_spec.loader.exec_module(business)
+
+    spec = importlib.util.spec_from_file_location(
+        _MODULE_NAME, _SRC / "Ankimon" / "pyobj" / "pc_box.py"
+    )
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[_MODULE_NAME] = module
+    spec.loader.exec_module(module)
+
+    module._services_obj = services_obj  # expose for tests
+    module._business = business
+    try:
+        yield module
+    finally:
+        for name, val in saved.items():
+            if val is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = val
+
+
+def _run_integrity(pc_box, rows):
+    """Drive ensure_data_integrity unbound against a fake db seam."""
+    saved_rows = []
+    pc_box._services_obj.db = types.SimpleNamespace(
+        get_all_pokemon=lambda: rows,
+        save_pokemon=saved_rows.append,
+    )
+    # ensure_data_integrity touches no self state, so a dummy receiver is fine.
+    pc_box.PokemonPC.ensure_data_integrity(object())
+    return saved_rows
+
+
+def test_stale_cp_is_repaired_when_all_default_keys_present(pc_box):
+    """The old-scale CP of a fully-populated legacy row gets rewritten.
+
+    Regression: the quick-check used to return early because no default key
+    was missing, so the "Always recalculate CP" pass never ran and the
+    pre-retune value survived indefinitely.
+    """
+    expected = pc_box._business.calculate_cp_from_dict(_complete_row())
+    row = _complete_row(cp=1460)  # value produced by the superseded 0.84/20 CPM
+    assert row["cp"] != expected, "fixture must actually be stale"
+
+    saved = _run_integrity(pc_box, [row])
+
+    assert row["cp"] == expected
+    assert saved, "the repaired row must be persisted"
+
+
+def test_fresh_row_is_not_rewritten(pc_box):
+    """A row already matching the formula triggers no write.
+
+    This is the control for the test above: it proves the repair there was
+    triggered by CP staleness specifically, not by some missing default key,
+    and that the quick-check still avoids pointless database churn.
+    """
+    row = _complete_row()
+    row["cp"] = pc_box._business.calculate_cp_from_dict(row)
+
+    saved = _run_integrity(pc_box, [row])
+
+    assert saved == []
+
+
+def test_malformed_row_does_not_raise(pc_box):
+    """A corrupt legacy row must not take down PC-box open.
+
+    The CP recompute now runs for every row on every open, so it is on the
+    critical path of the constructor; ``ensure_data_integrity`` is written to
+    repair what it can rather than propagate.
+    """
+    bad = _complete_row(stats="not-a-dict", iv=None, level="???")
+
+    _run_integrity(pc_box, [bad])  # must not raise


### PR DESCRIPTION
## What

Follow-up to #546 (Pokemon-GO CPM economy tuning). That PR retuned `calculate_cpm` from `0.84 * (1 - e^(-L/20))` to `3.5 * (1 - e^(-L/85))`. Because `CP ∝ CPM²`, level-100 CP moved by **~8.4×**.

`cp` is not purely derived — it is **persisted** per Pokemon at catch time (`encounter_functions.py`), so the retune left old-scale values sitting in users' databases.

## The bug

`PokemonPC.ensure_data_integrity` already has an "Always recalculate CP" pass for exactly this case. But it sits behind a quick-check that returns early whenever every default field is present:

```python
is_migration_needed = any(
    key not in pokemon
    for pokemon in pokemon_list
    if isinstance(pokemon, dict)
    for key in default_keys
)
if not is_migration_needed:
    return  # ← taken for any complete row
```

A save carrying pre-retune CP has *all* those keys — including `cp`, written at catch time. So the recompute was **dead code for the only population that needed it**, and the stale value survived indefinitely.

This is user-visible because two surfaces prefer the stored value over a live recomputation:
- `gui_classes/overview_team.py` — `pokemon.get("cp") or calculate_cp_from_dict(pokemon)`
- `ankimon_profile_web/profile_data.py` — `cp = data.get("cp")`, recomputing only if falsy

while `pokemon_details.py`, `pokemon_team_window.py`, `pokemon_obj.cp` and the PC-box CP sort all recompute. The same Pokemon could therefore show one CP in the team overview and another in the details window.

**This reaches shipped users**, not just integration branches:

| tag | `business.py` | persists `cp`? |
|---|---|---|
| `2.03` (2026-06-10) | `0.84 * (1 - exp(-max(level,1)/20))` | yes |
| `2.1-E` (2026-07-08) | `3.5 * (1 - exp(-max(level,1)/85))` | yes |

Upgrading across that boundary strands the old values.

## Changes

- **`business.py`** — add `pokemon_cp_is_stale()`, a never-raising check for whether a stored `cp` still matches the current formula.
- **`pc_box.py`** — fold that check into the migration quick-check so the existing recompute pass actually runs. Imported at the call site rather than module scope: `pc_box`'s module-level `business` import is stubbed by 11 test files, and a new top-level name breaks 229 tests in modules that never reach this method.
- **`pc_box.py`** — guard the recompute. It now runs for every row on every PC-box open, so one malformed legacy row must not take the whole window down (`ensure_data_integrity`'s siblings are all written not to raise).
- **`business.py`** — coerce `level` in `calculate_cp_from_dict`, matching what the sibling `cp_breakdown_tooltip` already does. Rows restored from JSON can carry `level` as a string, and `calculate_cpm`'s `max(level, 1)` raises `TypeError` comparing `str`/`None` against `int`. This mattered more once the recompute became unconditional.
- **`business.py`** — correct the `calculate_cpm` docstring. It still described the *pre-retune* curve ("tapers off as the Pokemon approaches its level ceiling"); the current curve reaches only ~69% of its asymptote at level 100, and the level-100 cap is user-disableable via `misc.remove_level_cap`.

## Verification

- **Full suite: 635 passed / 23 skipped**, vs **625 passed / 23 skipped** on unpatched `origin/main` — exactly +10 (the new tests), no regressions.
- `tests/test_pc_box_cp_migration.py::test_stale_cp_is_repaired_when_all_default_keys_present` **fails without the quick-check fix** and passes with it. It drives the real `ensure_data_integrity` against a fake `services.db` seam, with the real `business` module installed.
- `test_fresh_row_is_not_rewritten` is the control: it proves the repair above was triggered by CP staleness specifically, not by a missing default key, and that the quick-check still avoids pointless DB churn.
- `ruff check --config ci_ruff_check.toml`: **All checks passed!** (`ruff format` deliberately not run — it is not gating and the tree is not format-clean.)

## Limitation: when the repair runs

`ensure_data_integrity` has exactly one call site — `PokemonPC.__init__` (`pc_box.py:701`). So the recompute is triggered by **opening the PC box**, and only then. A user who opens the team overview or the web profile but never the PC box keeps seeing stale CP until they do.

That is pre-existing behaviour of this migration hook, not something this PR changes, and healing the database is the right layer to fix it at — both consumers read `services.db`, so one repair fixes both. But if maintainers prefer belt-and-braces, the alternative is to make the two stored-`cp` reads recompute unconditionally:

- `gui_classes/overview_team.py` — drop the `pokemon.get("cp") or` preference
- `ankimon_profile_web/profile_data.py` — drop the `if not cp` guard

Happy to add that here or in a follow-up, whichever you prefer.

## Not included

Deliberately out of scope, happy to file separately:
- Curve-shape tests. The suite still pins the CPM curve at a single point — a straight line `2.4207 * (level/100)` passes every existing test. Worth adding a concavity + asymptote test.
- `ankimon.db` is whole-file synced through AnkiWeb media with no addon-version or schema gate, so a rescale crosses devices unguarded.
- Naming the `3.5` / `85` constants. Zero-behaviour refactor of hot code; better on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

