### PR TITLE
fix: synchronize leaderboard stats asynchronously on level up and catch events

### DIFF
--- a/fix_pokemon_level.py
+++ b/fix_pokemon_level.py
@@ -1,0 +1,23 @@
+with open("src/Ankimon/functions/encounter_functions.py", "r") as f:
+    content = f.read()
+
+search_block = """        if not _in_bulk_resolve():
+            if settings_obj.get("gui.pop_up_dialog_message_on_defeat") is True:
+                logger.log_and_showinfo("info", f"{msg}")"""
+
+replace_block = """        if not _in_bulk_resolve():
+            if settings_obj.get("gui.pop_up_dialog_message_on_defeat") is True:
+                logger.log_and_showinfo("info", f"{msg}")
+
+        try:
+            if trainer_card is not None:
+                trainer_card.sync_to_leaderboard()
+        except Exception:
+            pass"""
+
+if search_block in content:
+    content = content.replace(search_block, replace_block)
+    with open("src/Ankimon/functions/encounter_functions.py", "w") as f:
+        f.write(content)
+else:
+    print("Could not find search block")

--- a/src/Ankimon/functions/encounter_functions.py
+++ b/src/Ankimon/functions/encounter_functions.py
@@ -1288,6 +1288,12 @@ def save_main_pokemon_progress(
         if not _in_bulk_resolve():
             if settings_obj.get("gui.pop_up_dialog_message_on_defeat") is True:
                 logger.log_and_showinfo("info", f"{msg}")
+
+        try:
+            if trainer_card is not None:
+                trainer_card.sync_to_leaderboard()
+        except Exception:
+            pass
         main_pokemon.xp = int(max(0, int(main_pokemon.xp) - int(experience)))
 
         # Request to open the pokemon evo window
@@ -1684,6 +1690,14 @@ def save_caught_pokemon(
     try:
         from ..singletons import notify_stats_changed
         notify_stats_changed()
+    except Exception:
+        pass
+
+    try:
+        # Trigger leaderboard sync on catch
+        from ..services import services
+        if services.trainer_card:
+            services.trainer_card.sync_to_leaderboard()
     except Exception:
         pass
 

--- a/src/Ankimon/pyobj/ankimon_leaderboard.py
+++ b/src/Ankimon/pyobj/ankimon_leaderboard.py
@@ -68,11 +68,11 @@ class ApiKeyDialog(QDialog):
             showInfo(f"Error saving credentials: {e}")
 
 def sync_data_to_leaderboard(data):
+    # First check if leaderboard is enabled in config
+    if not services.settings or not services.settings.get("misc.leaderboard"):
+        return
 
-        # First check if leaderboard is enabled in config
-        if not services.settings or not services.settings.get("misc.leaderboard"):
-            return
-
+    def _sync_task():
         try:
             # Load credentials from the database
             if not services.db:
@@ -82,9 +82,9 @@ def sync_data_to_leaderboard(data):
 
             # Validate credentials
             if (not username or not api_key) and services.db.is_migrated():
-                showInfo("Error: Missing credentials for Ankimon leaderboard. Please set up leaderboard from Ankimon menu or turn off in Settings.")
+                # Don't show info popup here since this can trigger during reviews
+                print("Error: Missing credentials for Ankimon leaderboard.")
                 return
-
 
             # Check if both username and api_key are available
             if username and api_key:
@@ -97,23 +97,26 @@ def sync_data_to_leaderboard(data):
                 # Send a POST request to the leaderboard API
                 response = requests.post(
                     ANKIMON_LEADERBOARD_API_URL,
-                    json=request_data
+                    json=request_data,
+                    timeout=5
                 )
 
-                #showInfo(response.text)  # Show the response text for debugging
-
-                # Check if the request was successful
-                #if response.status_code == 200:
-                #    mw.logger.log("log","Data synced successfully to leaderboard!")
-                #else:
-                #    mw.logger.log("log",f"Failed to sync data to leaderboard. Status code: {response.status_code}")
-            #else:
-                #mw.logger.log("Credentials are missing (username or api_key)")
-
         except requests.exceptions.RequestException as e:
-            showInfo(f"Error: Missing credentials for Ankimon leaderboard. Please set up leaderboard from Ankimon menu or turn off in Settings.\n\n {e}")
+            print(f"Error syncing Ankimon leaderboard: {e}")
         except Exception as e:
-            showInfo(f"Error: Missing credentials for Ankimon leaderboard. Please set up leaderboard from Ankimon menu or turn off in Settings.\n\n {e}")
+            print(f"Error syncing Ankimon leaderboard: {e}")
+
+    # Run in background to avoid freezing the UI
+    try:
+        from aqt import mw
+        if getattr(mw, "taskman", None) is not None:
+            mw.taskman.run_in_background(_sync_task)
+        else:
+            _sync_task()
+    except ImportError:
+        _sync_task()
+    except Exception as e:
+        print(f"Failed to run leaderboard sync: {e}")
 
 
 

--- a/src/Ankimon/pyobj/trainer_card.py
+++ b/src/Ankimon/pyobj/trainer_card.py
@@ -65,22 +65,34 @@ class TrainerCard:
         self.cash = cash
 
         # Sync Data to ankimon leaderboard
-        data = {
-            "trainerRank": f"{league}",  # Example rank
-            "trainerName": trainer_name,  # Example trainer name
-            "level": max(1, int(settings_obj.get("trainer.level"))),
-            "pokedex": services.db.execute("SELECT COUNT(DISTINCT pokedex_id) FROM captured_pokemon WHERE pokedex_id IS NOT NULL").fetchone()[0],
-            "caughtPokemon": services.db.get_pokemon_count(),
-            "trainerLevel": self.level,  # Add a logic for trainer's level if applicable
-            "highestLevel": highest_pokemon_level,  # Example highest level
-            "shinies": f"{services.db.get_shiny_count()}",  # Example shinies
-            "cash": cash,  # Example cash,
-            "trainerSprite": f"{settings_obj.get('trainer.sprite') + '.png'}",
-        }
+        self.sync_to_leaderboard()
+
+    def sync_to_leaderboard(self):
+        """Extract data and sync to the leaderboard."""
         try:
+            from ..services import services
+            # Verify database is active before querying
+            if not services.db:
+                return
+
+            league = self.league
+            trainer_name = self.trainer_name
+            highest_pokemon_level = int(self.highest_pokemon_level())
+
+            data = {
+                "trainerRank": f"{league}",
+                "trainerName": trainer_name,
+                "level": max(1, int(self.settings_obj.get("trainer.level"))),
+                "pokedex": services.db.execute("SELECT COUNT(DISTINCT pokedex_id) FROM captured_pokemon WHERE pokedex_id IS NOT NULL").fetchone()[0],
+                "caughtPokemon": services.db.get_pokemon_count(),
+                "trainerLevel": self.level,
+                "highestLevel": highest_pokemon_level,
+                "shinies": f"{services.db.get_shiny_count()}",
+                "cash": self.cash,
+                "trainerSprite": f"{self.settings_obj.get('trainer.sprite') + '.png'}",
+            }
             # Lazy import: ankimon_leaderboard pulls in Qt/Anki, so importing it
-            # at module top would break the headless core. Imported here instead,
-            # and an ImportError simply means "no leaderboard available" (harness).
+            # at module top would break the headless core.
             from .ankimon_leaderboard import sync_data_to_leaderboard
             sync_data_to_leaderboard(data)
         except ImportError:
@@ -232,6 +244,7 @@ class TrainerCard:
         self.logger.log_and_showinfo(
             "game", f"Congratulations! You reached Level {self.level}!"
         )
+        self.sync_to_leaderboard()
 
     def gain_xp(self, tier, allow_to_choose_move=False):
         """Add XP based on defeated Pokémon's tier."""


### PR DESCRIPTION
Fixes the Ankimon leaderboard stats synchronization so it updates immediately when catching a new Pokémon or leveling up, without requiring an Anki restart. Resolves network request blocking on the main GUI thread.

---
*PR created automatically by Jules for task [13044041905473110059](https://jules.google.com/task/13044041905473110059) started by @h0tp-ftw*