### PR TITLE
fix: rename default status badge from "Fighting" to "Battling"

### DIFF
--- a/src/Ankimon/const.py
+++ b/src/Ankimon/const.py
@@ -36,7 +36,7 @@ status_colors_html = {
     "confusion": {"background": "#FFA500", "outline": "#CC8400", "name": "Confusion"},
     "flinching": {"background": "#808080", "outline": "#666666", "name": "Flinching"},
     "fainted": {"background": "#000000", "outline": "#000000", "text_color": "#FFFFFF", "name": "Fainted"},
-    "fighting": {"background": "#C03028", "outline": "#7D1F1A", "name": "Fighting"},  # Example colors for Fighting
+    "fighting": {"background": "#C03028", "outline": "#7D1F1A", "name": "Battling"},  # Example colors for Fighting
 }
 
 # Get the profile folder. Guarded so const imports headless (no Anki): the


### PR DESCRIPTION
Fixes the text on the status badge for healthy Pokemon to show "Battling" instead of "Fighting". This clears up common user confusion where the default combat status badge was mistaken for the "Fighting" elemental type. The underlying `fighting` key is preserved for internal state logic.

---
*PR created automatically by Jules for task [10628371305530729386](https://jules.google.com/task/10628371305530729386) started by @h0tp-ftw*