### PR TITLE
fix(sync): add manual ankiweb sync option to menu

### DIFF
--- a/src/Ankimon/menu_buttons.py
+++ b/src/Ankimon/menu_buttons.py
@@ -197,6 +197,26 @@ def create_menu_actions(
         qconnect(export_main_to_showdown.triggered, export_to_pkmn_showdown)
         export_menu.addAction(export_main_to_showdown)
 
+        manual_sync_action = export_menu.addAction("AnkiWeb Data Sync")
+
+        def open_manual_sync_dialog():
+            from .singletons import settings_obj, logger
+            from .pyobj.ankimon_sync import show_manual_sync_dialog
+
+            # We need to keep a reference to the dialog so it doesn't get garbage collected
+            if not hasattr(mw, "ankimon_sync_dialog") or getattr(mw, "ankimon_sync_dialog") is None or not mw.ankimon_sync_dialog.isVisible():
+                mw.ankimon_sync_dialog = show_manual_sync_dialog(settings_obj, logger)
+            else:
+                mw.ankimon_sync_dialog.raise_()
+                mw.ankimon_sync_dialog.activateWindow()
+
+        try:
+            from aqt.utils import qconnect
+            qconnect(manual_sync_action.triggered, open_manual_sync_dialog)
+        except ImportError:
+            manual_sync_action.triggered.connect(open_manual_sync_dialog)
+
+
         export_all_to_showdown = QAction(mw.translator.translate("export_all_pokemon_button"), mw)
         export_all_to_showdown.setMenuRole(QAction.MenuRole.NoRole)
         qconnect(export_all_to_showdown.triggered, export_all_pkmn_showdown)

--- a/src/Ankimon/pyobj/ankimon_sync.py
+++ b/src/Ankimon/pyobj/ankimon_sync.py
@@ -286,12 +286,12 @@ class ImprovedPokemonDataSync(QDialog):
             if not differences:
                 self.header_label.setText(
                     "Ankimon Data Sync:\n"
-                    "✅ All data is synchronized. No differences found."
+                    "✅ All data is synchronized, or your local data is newer. No incoming changes found."
                 )
-                self.local_text_area.setPlainText("No differences found.")
-                self.web_text_area.setPlainText("No differences found.")
-                self.export_button.setEnabled(False)
-                self.import_button.setEnabled(False)
+                self.local_text_area.setPlainText("No incoming differences found.")
+                self.web_text_area.setPlainText("No incoming differences found.")
+                self.export_button.setEnabled(True)  # Allow manual export
+                self.import_button.setEnabled(True)  # Allow manual import
                 return
 
             self.header_label.setText(
@@ -1272,6 +1272,19 @@ def get_sync_info():
         return get_ankimon_sync().get_sync_folder_info()
     except Exception as e:
         return {'error': str(e)}
+
+
+def show_manual_sync_dialog(settings_obj, logger):
+    """Force show the sync dialog, regardless of differences, for manual syncing."""
+    try:
+        dialog = ImprovedPokemonDataSync(settings_obj, logger)
+        dialog.show()
+        return dialog
+    except Exception as e:
+        logger.log("error", f"Failed to open manual sync dialog: {str(e)}")
+        from .error_handler import show_warning_with_traceback
+        show_warning_with_traceback(parent=None, exception=e, message="Error opening sync dialog")
+        return None
 
 def check_and_sync_pokemon_data(settings_obj, logger):
     """


### PR DESCRIPTION
Users on the main branch who have an older local database would not
be prompted with the ImprovedPokemonDataSync dialog during startup
due to strict mtime checks on the cloud DB. Since there was no way
to manually invoke the sync dialog to force an export to the cloud,
users were permanently stuck.

This patch adds an "AnkiWeb Data Sync" menu item to the Ankimon > Export
menu that launches the sync dialog. It also modifies the dialog so that
when no incoming differences are detected, the Export/Import buttons remain
enabled to allow manual forcing of data to or from AnkiWeb.

---
*PR created automatically by Jules for task [13426935208819871497](https://jules.google.com/task/13426935208819871497) started by @h0tp-ftw*