### PR TITLE
chore: ignore scratch workspace

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ src/Ankimon/user_files/backups
 .vscode
 .gemini
 .agents
+scratch/
 debug_console.py
 src/Ankimon/user_files/todays_shop.json
 src/Ankimon/user_files/meta.json


### PR DESCRIPTION
Split 5/5 from #631. This isolates the unrelated scratch-directory ignore entry from the sprite updater feature.

Includes:
- adds scratch/ to the repository gitignore

No runtime behavior changes.

Depends on #660. Original contribution by @hakimh2.