### PR TITLE
test(harness): add real WebEngine Tier 2 gate

### DIFF
--- a/.github/workflows/harness.yml
+++ b/.github/workflows/harness.yml
@@ -1,11 +1,12 @@
 name: Harness
 
 # Headless validation on every PR + pushes to main. Free on public repos (standard runners).
-# Two jobs:
+# Three jobs:
 #   tier1 — fast logic gate + a functionality sweep that drives many parts of the game and
 #           fails on any crash (an `error` event). No Qt.
-#   tier2 — boots and *plays* the REAL add-on with offscreen Qt (real windows, real memory).
-# (The harness core needs only `requests` beyond stdlib; Tier 2 needs the full Qt stack.)
+#   tier2 — boots and *plays* the REAL add-on with offscreen Qt (WebEngine may be stubbed).
+#   tier2_webengine — loads the real Chromium-backed Settings shell and saves through its DOM.
+# (The harness core needs only `requests` beyond stdlib; Tier 2 uses harness requirements.)
 
 on:
   pull_request:
@@ -44,20 +45,49 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
-      - name: System deps (Qt + WebEngine + xvfb)
+      - name: System deps (Qt + xvfb)
         run: |
           sudo apt-get update -qq
           sudo apt-get install -y -qq --no-install-recommends \
             xvfb libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 \
             libxcb-randr0 libxcb-render-util0 libxcb-xinerama0 libxcb-xfixes0 \
             libxcb-cursor0 x11-utils libegl1 libpulse0 libnss3 libasound2t64
-      - name: Python deps (real aqt + PyQt6)
+      - name: Python deps (real PyQt6 harness)
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements.txt
+          pip install -r harness/requirements-tier2.txt
       - name: Boot + play the REAL add-on (offscreen)
         env:
           QT_QPA_PLATFORM: offscreen
         run: |
           xvfb-run -a python3 -m harness.checks.probe_real_boot
           xvfb-run -a python3 -m harness.checks.probe_real_play
+
+  tier2_webengine:
+    name: Tier 2 WebEngine — real Settings shell
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: System deps (Chromium + xvfb)
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq --no-install-recommends \
+            xvfb x11-utils libegl1 libgbm1 libnss3 libpulse0 libasound2t64 \
+            libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 \
+            libxcb-randr0 libxcb-render-util0 libxcb-xinerama0 libxcb-xfixes0 \
+            libxcb-cursor0 libxcomposite1 libxdamage1 libxfixes3 libxrandr2 libxtst6
+      - name: Python deps (real PyQt6 + WebEngine)
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r harness/requirements-webengine.txt
+      - name: Load, edit, and save through the real Settings browser
+        env:
+          QT_QPA_PLATFORM: xcb
+          QTWEBENGINE_DISABLE_SANDBOX: '1'
+          QTWEBENGINE_CHROMIUM_FLAGS: --no-sandbox --disable-gpu --disable-dev-shm-usage
+        run: xvfb-run -a python3 -m harness.checks.probe_real_webengine

--- a/harness/README.md
+++ b/harness/README.md
@@ -76,15 +76,27 @@ PC box).
 mode**. Nothing is drawn, but the real widgets/memory/PC box are all live, which
 is what makes real-Qt glitches and "crash after N encounters" reproducible.
 
-It needs PyQt6 + native Qt libs. The setup is **sudo-free** (a venv with pip
-bootstrapped via get-pip.py, and the Qt `.deb`s *downloaded and extracted* into a
-local dir — nothing installed system-wide; `rm -rf .tier2` undoes it):
+Base Tier 2 needs PyQt6 and native Qt libs. The setup is **sudo-free** (a venv
+with pip bootstrapped via get-pip.py, and the Qt `.deb`s *downloaded and
+extracted* into a local dir — nothing installed system-wide; `rm -rf .tier2`
+undoes it). These are harness-only dependencies and are never shipped in the
+`.ankiaddon`:
 
 ```bash
 bash harness/setup_tier2.sh        # one-time: builds .tier2/ (venv + local Qt libs)
 source .tier2/env.sh               # LD_LIBRARY_PATH + QT_QPA_PLATFORM=offscreen + venv
 python -m harness.checks.probe_real_boot   # real add-on boots; objects are the REAL classes
 python -m harness.checks.probe_real_play   # plays via real hooks: real windows, real battles
+```
+
+Real browser screens use the separate `PyQt6-WebEngine` package. Install it only
+when needed, then run the strict browser probe:
+
+```bash
+bash harness/setup_webengine.sh
+source .tier2/env.sh
+export LD_LIBRARY_PATH="$PWD/.tier2/we-libs/extract/usr/lib/$(uname -m)-linux-gnu:$LD_LIBRARY_PATH"
+python -m harness.checks.probe_real_webengine  # real Chromium Settings page + DOM save
 ```
 
 Drive it from Python (same action surface as Tier 1, via real hooks/windows):
@@ -124,8 +136,11 @@ After that, each Tier-2 session symlinks its `sprites/` dir to that cache, so th
 real windows load the real sprites (verified: e.g. `rhyhorn #111` ->
 `front_default/111.png`). Set `ANKIMON_SPRITE_CACHE` to point elsewhere.
 
-Note: the 3 WebEngine windows (pokedex/achievements/help) use lightweight stubs
-so the boot doesn't need the Chromium-based `PyQt6-WebEngine`.
+Normal Tier-2 boot/play probes still allow lightweight WebEngine stubs so they
+remain useful on machines without Chromium. The dedicated
+`probe_real_webengine` check is strict: it imports `PyQt6-WebEngine`, refuses to
+fall back, opens the real HTML Settings shell, edits Trainer Name through the
+DOM, clicks Save, and verifies the SQLite-backed Settings service changed.
 
 ## Drive it from Python
 

--- a/harness/checks/probe_real_webengine.py
+++ b/harness/checks/probe_real_webengine.py
@@ -1,0 +1,176 @@
+"""Tier-2 WebEngine probe: exercise the real Chromium-backed Settings shell.
+
+This probe is intentionally stricter than the normal Tier-2 boot/play checks:
+PyQt6-WebEngine must be importable and the harness must construct genuine
+QWebEngineView instances. It then loads the real Settings HTML/JavaScript,
+changes Trainer Name through the DOM, clicks Save, and verifies that the live
+SQLite-backed Settings service received the change.
+
+Run with a display wrapper on Linux:
+    xvfb-run -a python3 -m harness.checks.probe_real_webengine
+"""
+
+from __future__ import annotations
+
+import os
+import pathlib
+import sys
+import time
+
+# WebEngine must be configured and imported before QApplication is constructed.
+os.environ.setdefault("QTWEBENGINE_DISABLE_SANDBOX", "1")
+os.environ.setdefault(
+    "QTWEBENGINE_CHROMIUM_FLAGS",
+    "--no-sandbox --disable-gpu --disable-dev-shm-usage",
+)
+
+from PyQt6.QtCore import QEventLoop, QTimer
+from PyQt6.QtWebEngineWidgets import QWebEngineView
+from PyQt6.QtWidgets import QApplication
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[2]))
+
+from harness.real_env import start_real_session
+
+
+def _wait_until(predicate, timeout_seconds=15.0):
+    deadline = time.monotonic() + timeout_seconds
+    app = QApplication.instance()
+    while time.monotonic() < deadline:
+        if predicate():
+            return True
+        if app is not None:
+            app.processEvents()
+        time.sleep(0.02)
+    return bool(predicate())
+
+
+def _run_javascript(page, script, timeout_ms=10_000):
+    result = {}
+    loop = QEventLoop()
+    timer = QTimer()
+    timer.setSingleShot(True)
+
+    def finish(value):
+        result["done"] = True
+        result["value"] = value
+        loop.quit()
+
+    timer.timeout.connect(loop.quit)
+    timer.start(timeout_ms)
+    page.runJavaScript(script, finish)
+    loop.exec()
+    timer.stop()
+
+    if not result.get("done"):
+        raise AssertionError("Timed out waiting for QWebEngine JavaScript callback")
+    return result.get("value")
+
+
+def main() -> int:
+    session = start_real_session(webengine=True, require_webengine=True)
+
+    from Ankimon.ankimon_items_web.shop_obj import SCREEN_SETTINGS
+    from Ankimon.singletons import get_items_window
+
+    window = get_items_window()
+    view = window.webview_settings
+    assert isinstance(view, QWebEngineView), type(view)
+    assert type(view).__module__.startswith("PyQt6.QtWebEngine"), type(view).__module__
+
+    window.load_screen(SCREEN_SETTINGS)
+    window.show()
+
+    assert _wait_until(lambda: SCREEN_SETTINGS in window.ready_screens), (
+        "The real Settings page did not emit loadFinished"
+    )
+
+    page = view.page()
+    assert _wait_until(
+        lambda: bool(
+            _run_javascript(
+                page,
+                "Boolean(document.querySelector('.setting-row[data-key=\"trainer.name\"] input'))",
+            )
+        )
+    ), "Settings JavaScript loaded, but the settings rows were never initialized"
+
+    page_state = _run_javascript(
+        page,
+        """
+        (() => {
+            const row = document.querySelector('.setting-row[data-key="trainer.name"]');
+            const input = row && row.querySelector('input');
+            return {
+                title: document.title,
+                rowCount: document.querySelectorAll('.setting-row').length,
+                hasQtTransport: Boolean(window.qt && qt.webChannelTransport),
+                hasInput: Boolean(input),
+                initialValue: input ? input.value : null,
+            };
+        })()
+        """,
+    )
+    assert page_state["title"] == "Ankimon Settings", page_state
+    assert page_state["rowCount"] > 0, page_state
+    assert page_state["hasQtTransport"] is True, page_state
+    assert page_state["hasInput"] is True, page_state
+
+    expected_name = "WebEngine CI Trainer"
+    edit_state = _run_javascript(
+        page,
+        f"""
+        (() => {{
+            const row = document.querySelector('.setting-row[data-key="trainer.name"]');
+            const input = row && row.querySelector('input');
+            const save = document.getElementById('save-btn');
+            if (!input || !save) return {{ok: false}};
+            input.value = {expected_name!r};
+            input.dispatchEvent(new Event('input', {{bubbles: true}}));
+            const becameDirty = !save.disabled;
+            save.click();
+            return {{ok: true, becameDirty}};
+        }})()
+        """,
+    )
+    assert edit_state == {"ok": True, "becameDirty": True}, edit_state
+
+    assert _wait_until(
+        lambda: session.services.settings.get("trainer.name") == expected_name
+    ), "Clicking Save in the real Settings web page did not persist Trainer Name"
+    assert _wait_until(
+        lambda: _run_javascript(
+            page, "document.getElementById('save-status')?.textContent"
+        ) == "All saved"
+    ), "Settings persisted, but the browser never completed its saved-state refresh"
+
+    saved_state = _run_javascript(
+        page,
+        """
+        (() => {
+            const row = document.querySelector('.setting-row[data-key="trainer.name"]');
+            const input = row && row.querySelector('input');
+            return {
+                value: input ? input.value : null,
+                status: document.getElementById('save-status')?.textContent,
+                saveDisabled: document.getElementById('save-btn')?.disabled,
+            };
+        })()
+        """,
+    )
+    assert saved_state == {
+        "value": expected_name,
+        "status": "All saved",
+        "saveDisabled": True,
+    }, saved_state
+
+    print(
+        "probe_real_webengine: OK "
+        f"({page_state['rowCount']} settings rows, real QWebEngine, DOM save persisted)"
+    )
+    window.close()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/harness/fake_aqt.py
+++ b/harness/fake_aqt.py
@@ -27,7 +27,6 @@ What's faked and why:
 from __future__ import annotations
 
 import sys
-import types
 from types import ModuleType, SimpleNamespace
 from unittest.mock import MagicMock
 
@@ -84,6 +83,13 @@ def _make_webengine_stubs(QWidget):
         def __getattr__(self, _):
             return lambda *a, **k: None
 
+    class _StubWebEngineProfile:
+        def __init__(self, *a, **k):
+            pass
+
+        def __getattr__(self, _):
+            return lambda *a, **k: None
+
     class _StubWebEngineSettings:
         class WebAttribute:
             JavascriptEnabled = 0
@@ -121,7 +127,12 @@ def _make_webengine_stubs(QWidget):
             # missing attrs (web-engine-only methods we don't model).
             return lambda *a, **k: None
 
-    return _StubWebEngineView, _StubWebEnginePage, _StubWebEngineSettings
+    return (
+        _StubWebEngineView,
+        _StubWebEnginePage,
+        _StubWebEngineSettings,
+        _StubWebEngineProfile,
+    )
 
 
 # --- the synchronous QueryOp ----------------------------------------------
@@ -323,15 +334,19 @@ def install(app, user_path, real_webengine=False):
     def qconnect(signal, func):
         signal.connect(func)
 
-    web_view = web_page = web_settings = None
+    web_view = web_page = web_settings = web_profile = None
     if real_webengine:
         try:
             from PyQt6.QtWebEngineWidgets import QWebEngineView as web_view
-            from PyQt6.QtWebEngineCore import QWebEnginePage as web_page, QWebEngineSettings as web_settings
+            from PyQt6.QtWebEngineCore import (
+                QWebEnginePage as web_page,
+                QWebEngineProfile as web_profile,
+                QWebEngineSettings as web_settings,
+            )
         except Exception:
-            web_view = web_page = web_settings = None
+            web_view = web_page = web_settings = web_profile = None
     if web_view is None:
-        web_view, web_page, web_settings = _make_webengine_stubs(QWidget)
+        web_view, web_page, web_settings, web_profile = _make_webengine_stubs(QWidget)
 
     # aqt.qt — faithful re-export of real PyQt6 (+ qconnect, sip, webengine stubs).
     qt = ModuleType("aqt.qt")
@@ -344,6 +359,7 @@ def install(app, user_path, real_webengine=False):
     qt.QWebEngineView = web_view
     qt.QWebEnginePage = web_page
     qt.QWebEngineSettings = web_settings
+    qt.QWebEngineProfile = web_profile
 
     # aqt.utils
     utils = ModuleType("aqt.utils")
@@ -359,6 +375,7 @@ def install(app, user_path, real_webengine=False):
     utils.QWebEngineView = web_view
     utils.QWebEnginePage = web_page
     utils.QWebEngineSettings = web_settings
+    utils.QWebEngineProfile = web_profile
 
     class _Tr:
         def __getattr__(self, _):
@@ -422,6 +439,9 @@ def install(app, user_path, real_webengine=False):
         if hasattr(qt, nm):
             setattr(aqt, nm, getattr(qt, nm))
     aqt.QWebEngineView = web_view
+    aqt.QWebEnginePage = web_page
+    aqt.QWebEngineSettings = web_settings
+    aqt.QWebEngineProfile = web_profile
 
     sys.modules["aqt"] = aqt
     sys.modules["aqt.qt"] = qt

--- a/harness/real_env.py
+++ b/harness/real_env.py
@@ -80,7 +80,7 @@ def _seed_assets(user_path):
 
 
 def start_real_session(user_path=None, settings_overrides=None, neuter_network=True,
-                       first_run=False, webengine=False):
+                       first_run=False, webengine=False, require_webengine=False):
     """Boot the real add-on and return handles (app, aqt, services, events).
 
     first_run=True seeds the sprite assets BEFORE the import, so startup's
@@ -112,7 +112,11 @@ def start_real_session(user_path=None, settings_overrides=None, neuter_network=T
             pass
 
     # Real WebEngine (to render the Pokedex / HUD) MUST be imported before the
-    # QApplication exists. Only when requested + importable; else fall back to the stub.
+    # QApplication exists. Ordinary Tier 2 may fall back to the lightweight stub;
+    # dedicated browser probes set require_webengine=True so missing Chromium
+    # bindings fail loudly instead of producing a misleading green check.
+    if require_webengine and not webengine:
+        raise ValueError("require_webengine=True requires webengine=True")
     if webengine:
         os.environ.setdefault("QTWEBENGINE_DISABLE_SANDBOX", "1")
         os.environ.setdefault("QTWEBENGINE_CHROMIUM_FLAGS",
@@ -120,7 +124,11 @@ def start_real_session(user_path=None, settings_overrides=None, neuter_network=T
                               "--in-process-gpu --single-process")
         try:
             import PyQt6.QtWebEngineWidgets  # noqa: F401  (must precede QApplication)
-        except Exception:
+        except Exception as exc:
+            if require_webengine:
+                raise RuntimeError(
+                    "Real QtWebEngine was required but PyQt6-WebEngine could not be imported"
+                ) from exc
             webengine = False
 
     # Real PyQt6 first (needs the offscreen platform + native libs already loadable).

--- a/harness/requirements-tier2.txt
+++ b/harness/requirements-tier2.txt
@@ -1,0 +1,5 @@
+# Developer/CI dependencies for the real-Qt Tier 2 harness.
+# This file is never packaged with the Ankimon add-on.
+PyQt6
+requests
+markdown

--- a/harness/requirements-webengine.txt
+++ b/harness/requirements-webengine.txt
@@ -1,0 +1,4 @@
+# Extra developer/CI dependencies for Chromium-backed Tier 2 probes.
+# This file is never packaged with the Ankimon add-on.
+-r requirements-tier2.txt
+PyQt6-WebEngine

--- a/harness/setup_tier2.sh
+++ b/harness/setup_tier2.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 # setup_tier2.sh — create the sudo-free Tier-2 environment for the Ankimon harness.
 #
-# Tier 2 runs the REAL add-on under real PyQt6 (offscreen). This needs PyQt6 +
-# the native Qt libraries. We get both WITHOUT touching the system:
+# Tier 2 runs the REAL add-on under real PyQt6 (offscreen). We get it WITHOUT
+# touching the system:
 #   * a venv with pip bootstrapped via get-pip.py (no python3-venv/apt needed)
-#   * PyQt6/requests/markdown installed into that venv
+#   * harness/requirements-tier2.txt installed into that venv
 #   * the native Qt .debs DOWNLOADED (not installed) and extracted into a local
 #     dir, reached via LD_LIBRARY_PATH
 #
@@ -35,8 +35,8 @@ if ! "$VENV/bin/python" -m pip --version >/dev/null 2>&1; then
   "$VENV/bin/python" "$T2/get-pip.py"
 fi
 
-echo "==> [2/4] PyQt6 + requests + markdown into the venv"
-"$VENV/bin/pip" install --quiet --upgrade PyQt6 requests markdown
+echo "==> [2/4] real Qt harness dependencies into the venv"
+"$VENV/bin/pip" install --quiet --upgrade -r "$REPO/harness/requirements-tier2.txt"
 
 echo "==> [3/4] download + extract native Qt libs locally (no install)"
 # Core EGL/GL/font/dbus/glib stack the offscreen Qt platform needs. Downloaded
@@ -68,6 +68,7 @@ echo "Next:"
 echo "  source .tier2/env.sh"
 echo "  python -m harness.checks.probe_real_boot"
 echo "  python -m harness.checks.probe_real_play"
+echo "For real Chromium screens, also run: bash harness/setup_webengine.sh"
 echo
 echo "Optional — real Pokemon sprites (pixel-accurate, ~600MB, sudo-free):"
 echo "  python3 harness/fetch_sprites.py"

--- a/harness/setup_webengine.sh
+++ b/harness/setup_webengine.sh
@@ -1,26 +1,35 @@
 #!/usr/bin/env bash
-# harness/setup_webengine.sh — fetch QtWebEngine's native deps, sudo-free.
+# harness/setup_webengine.sh — fetch extra QtWebEngine native deps, sudo-free.
 #
-# QtWebEngine (the reviewer HUD + the Pokedex/help windows) needs a pile of
-# Chromium native libs. On a box that has them (x86 CI), nothing to do. On a
-# minimal/aarch64 box (e.g. this Pi) they're missing, so — exactly like
-# setup_tier2.sh does for the base Qt libs — this downloads the .debs WITHOUT
-# sudo and extracts them locally; you reach them via LD_LIBRARY_PATH.
+# setup_tier2.sh creates the base Qt venv. This script adds the separate
+# PyQt6-WebEngine wheel plus Chromium's native system libraries. Common x86 CI
+# images already have most native libs, while minimal/aarch64 machines may not;
+# missing .debs are downloaded WITHOUT sudo and extracted for LD_LIBRARY_PATH.
 #
 #   bash harness/setup_webengine.sh
 #   source .tier2/env.sh
-#   export LD_LIBRARY_PATH="$PWD/.tier2/we-libs/extract/usr/lib/aarch64-linux-gnu:$LD_LIBRARY_PATH"
+#   export LD_LIBRARY_PATH="$PWD/.tier2/we-libs/extract/usr/lib/$(uname -m)-linux-gnu:$LD_LIBRARY_PATH"
 #   export QTWEBENGINE_DISABLE_SANDBOX=1
 #   export QTWEBENGINE_CHROMIUM_FLAGS="--no-sandbox --disable-gpu --disable-dev-shm-usage --in-process-gpu --single-process"
+#   python3 -m harness.checks.probe_real_webengine
 #   python3 harness/scenarios/hud_render.py 150
 #
 # (Headless Chromium needs --no-sandbox + software GL; the flags above are the set
 # that gets it rendering offscreen on this Pi.)
-set -u
+set -euo pipefail
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+VENV="$ROOT/.tier2/venv"
 WE="$ROOT/.tier2/we-libs"
+ARCH_DIR="$WE/extract/usr/lib/$(uname -m)-linux-gnu"
+
+if [ ! -x "$VENV/bin/python" ]; then
+  echo "Tier-2 venv missing. Run: bash harness/setup_tier2.sh" >&2
+  exit 1
+fi
+
+"$VENV/bin/pip" install --quiet --upgrade -r "$ROOT/harness/requirements-webengine.txt"
 mkdir -p "$WE/debs" "$WE/extract"
-cd "$WE/debs" || exit 1
+cd "$WE/debs"
 
 # libs reported missing by `ldd libQt6WebEngineCore.so` (+ their transitive deps).
 PKGS="libxcomposite1 libxdamage1 libxfixes3 libxrandr2 libxtst6 liblcms2-2 \
@@ -36,5 +45,5 @@ for d in *.deb; do
   [ -f "$d" ] && dpkg-deb -x "$d" "$WE/extract" && n=$((n + 1))
 done
 echo "extracted $n debs -> $WE/extract"
-echo "libs at: $WE/extract/usr/lib/aarch64-linux-gnu"
+echo "libs at: $ARCH_DIR"
 echo "Re-run ldd on libQt6WebEngineCore.so to check for any further 'not found' deps."


### PR DESCRIPTION
## Summary

- split base Qt and optional `PyQt6-WebEngine` harness dependencies
- make real-WebEngine sessions fail instead of silently falling back to stubs
- complete the fake `aqt` WebEngine exports needed by the production web shell
- add a Chromium-backed Settings probe that renders the real page, edits Trainer Name through the DOM, clicks Save, and verifies SQLite persistence
- add a dedicated **Tier 2 WebEngine — real Settings shell** CI job
- update local setup scripts and harness documentation

## Validation

- `python -m harness.checks.probe_real_webengine` — 49 rows rendered; DOM save persisted
- `python -m harness.checks.probe_real_boot` — passed
- `python -m harness.checks.probe_real_play` — passed
- `python harness/check.py` — all 9 Tier-1 checks passed
- `pytest tests/test_addon_integrity.py` — passed
- full suite: 662 passed, 23 skipped; only the two existing Windows Node UTF-8 gender-symbol cases failed
- scoped Ruff, workflow YAML parse, shell syntax, and diff checks passed

The new dependencies are harness/CI-only and are never packaged with the add-on.
