### PR TITLE
fix: prevent hot-reload deadlock and delay

### DIFF
--- a/src/Ankimon/__init__.py
+++ b/src/Ankimon/__init__.py
@@ -209,6 +209,8 @@ def start_asynchronous_startup():
     from aqt.operations import QueryOp
     from .startup import run_startup_background_checks, run_startup_ui_callbacks
 
+    services._startup_in_progress = True
+
     def on_startup_complete(results):
         # 1. Qt half of the startup sequence (migration dialog, sprite
         #    downloader, first-enemy stat application, starter window, rate
@@ -325,6 +327,9 @@ def start_asynchronous_startup():
             except Exception:
                 pass
 
+        services._startup_in_progress = False
+        services._is_reloading = False
+
     def on_startup_failed(exc):
         # QueryOp offers no automatic recovery: if the background half raises
         # (e.g. a locked/corrupt ankimon.db in one of the unguarded is_migrated /
@@ -344,6 +349,9 @@ def start_asynchronous_startup():
             )
         except Exception:
             pass
+
+        services._startup_in_progress = False
+        services._is_reloading = False
 
     QueryOp(
         parent=mw,

--- a/src/Ankimon/__init__.py
+++ b/src/Ankimon/__init__.py
@@ -211,7 +211,17 @@ def start_asynchronous_startup():
 
     services._startup_in_progress = True
 
-    def on_startup_complete(results):
+    def clear_startup_lifecycle_flags():
+        # Both flags gate the developer hot-reload: restart_ankimon() blocks on
+        # _startup_in_progress before purging modules, and _is_reloading tells
+        # run_startup_background_checks to skip backups for the reload's own
+        # startup. Leaving either one set after a failed boot would hang the
+        # next reload or silently suppress backups for the rest of the session,
+        # so every exit path below runs this.
+        services._startup_in_progress = False
+        services._is_reloading = False
+
+    def run_startup_ui_sequence(results):
         # 1. Qt half of the startup sequence (migration dialog, sprite
         #    downloader, first-enemy stat application, starter window, rate
         #    prompt).
@@ -327,8 +337,16 @@ def start_asynchronous_startup():
             except Exception:
                 pass
 
-        services._startup_in_progress = False
-        services._is_reloading = False
+    def on_startup_complete(results):
+        # QueryOp does not route an exception raised by its *success* callback
+        # to .failure() — it propagates to Anki's top-level handler instead. So
+        # the flag reset has to be a finally, or a single failing Qt-half step
+        # (a raising migration dialog, a missing singleton) would strand the
+        # lifecycle flags and wedge every later hot-reload.
+        try:
+            run_startup_ui_sequence(results)
+        finally:
+            clear_startup_lifecycle_flags()
 
     def on_startup_failed(exc):
         # QueryOp offers no automatic recovery: if the background half raises
@@ -350,14 +368,20 @@ def start_asynchronous_startup():
         except Exception:
             pass
 
-        services._startup_in_progress = False
-        services._is_reloading = False
+        clear_startup_lifecycle_flags()
 
-    QueryOp(
-        parent=mw,
-        op=lambda _col: run_startup_background_checks(backup_manager),
-        success=on_startup_complete,
-    ).failure(on_startup_failed).without_collection().run_in_background()
+    try:
+        QueryOp(
+            parent=mw,
+            op=lambda _col: run_startup_background_checks(backup_manager),
+            success=on_startup_complete,
+        ).failure(on_startup_failed).without_collection().run_in_background()
+    except Exception:
+        # The op never got scheduled, so neither callback will ever run. Clear
+        # the flags here too, otherwise the next hot-reload waits on a startup
+        # that will never finish.
+        clear_startup_lifecycle_flags()
+        raise
 
 
 # --- Discord integration ---

--- a/src/Ankimon/reloader.py
+++ b/src/Ankimon/reloader.py
@@ -41,6 +41,7 @@ import importlib
 import sys
 import traceback
 
+from PyQt6.QtCore import QCoreApplication, QEvent
 from PyQt6.QtWidgets import QApplication, QWidget
 from aqt import gui_hooks, mw
 
@@ -222,6 +223,21 @@ def _teardown_windows(addon_package, services):
                 pass
 
 
+def _flush_deferred_widget_deletes():
+    """Destroy closed Qt/WebEngine objects before their modules are purged.
+
+    ``deleteLater()`` only schedules destruction. Purging and re-importing the
+    add-on while old QWebEngine pages are still alive can release their profile
+    first and crash Qt during shutdown or the next reload.
+    """
+    app = QApplication.instance()
+    if app is None:
+        return
+    for _ in range(2):
+        QCoreApplication.sendPostedEvents(None, QEvent.Type.DeferredDelete)
+        app.processEvents()
+
+
 def _purge_addon_modules(addon_package):
     """Drop the add-on's submodules from ``sys.modules`` so the re-import is fresh.
 
@@ -264,6 +280,7 @@ def teardown_ankimon(addon_package):
     _restore_reviewer_wraps()
     _delete_reload_shortcuts(services)
     _teardown_windows(addon_package, services)
+    _flush_deferred_widget_deletes()
 
     # Drop the cached DB singleton (closes its connection). The registry still
     # holds the same AnkimonDB instance with its db_path intact, so the reused

--- a/src/Ankimon/reloader.py
+++ b/src/Ankimon/reloader.py
@@ -45,6 +45,13 @@ from PyQt6.QtWidgets import QApplication, QWidget
 from aqt import gui_hooks, mw
 
 
+# Longest the reload blocks the GUI thread waiting for an in-flight startup
+# QueryOp. Generous enough for a slow first boot (legacy backup + dev-mode disk
+# copy + DB migration on a large collection), bounded so a wedged startup costs
+# the developer one tooltip instead of a frozen Anki that needs force-quitting.
+_STARTUP_WAIT_TIMEOUT_SECONDS = 30.0
+
+
 def restart_ankimon():
     """Tear the add-on down and re-import it in place (developer hot-reload)."""
     import time
@@ -53,26 +60,58 @@ def restart_ankimon():
 
     from .services import services
 
-    # Wait for the active startup QueryOp before purging modules. Otherwise its
-    # worker can hold a database connection lock while waiting for Python's
-    # import lock, as teardown waits for that same database lock.
-    while getattr(services, "_startup_in_progress", False):
-        QApplication.processEvents()
-        time.sleep(0.02)
-
-    addon_package = __name__.split(".")[0]
-    services._is_reloading = True
+    # Re-entrancy guard. The wait loop below pumps the Qt event queue while the
+    # Ctrl+Shift+R QShortcut and the "Restart Ankimon" menu action are both
+    # still live and enabled, so a second trigger can land *inside* this call
+    # and start a concurrent teardown of half-purged modules. The flag lives on
+    # the registry, not at module scope, because _purge_addon_modules() drops
+    # this module while the reload is still running.
+    if getattr(services, "_reload_in_progress", False):
+        return
+    services._reload_in_progress = True
     try:
-        teardown_ankimon(addon_package)
-        importlib.import_module(addon_package)
-        tooltip("Ankimon reloaded.")
-    except Exception as exc:  # surface any reload failure to the developer
-        message = f"Ankimon reload failed: {exc}\n{traceback.format_exc()}"
-        print(message)
+        # Wait for the active startup QueryOp before purging modules. Otherwise
+        # its worker can hold a database connection lock while waiting for
+        # Python's import lock, as teardown waits for that same database lock.
+        deadline = time.monotonic() + _STARTUP_WAIT_TIMEOUT_SECONDS
+        while getattr(services, "_startup_in_progress", False):
+            if time.monotonic() >= deadline:
+                # Purging now is exactly what deadlocks, so abort the reload
+                # rather than trade a slow startup for a hung Anki.
+                print(
+                    "Ankimon reload aborted: startup still running after "
+                    f"{_STARTUP_WAIT_TIMEOUT_SECONDS:.0f}s."
+                )
+                try:
+                    tooltip("Ankimon reload skipped — startup still running.")
+                except Exception:
+                    pass
+                return
+            QApplication.processEvents()
+            time.sleep(0.02)
+
+        addon_package = __name__.split(".")[0]
+        services._is_reloading = True
         try:
-            tooltip("Ankimon reload failed — see console.")
-        except Exception:
-            pass
+            teardown_ankimon(addon_package)
+            importlib.import_module(addon_package)
+            tooltip("Ankimon reloaded.")
+        except Exception as exc:  # surface any reload failure to the developer
+            # A successful re-import starts a fresh startup QueryOp, and *its*
+            # callbacks own clearing _is_reloading. If we failed before that
+            # (teardown raised, or the edited module has a syntax error) nothing
+            # else will clear the flag, and every later startup in this session
+            # would keep silently skipping its backups.
+            if not getattr(services, "_startup_in_progress", False):
+                services._is_reloading = False
+            message = f"Ankimon reload failed: {exc}\n{traceback.format_exc()}"
+            print(message)
+            try:
+                tooltip("Ankimon reload failed — see console.")
+            except Exception:
+                pass
+    finally:
+        services._reload_in_progress = False
 
 
 def _handler_belongs_to_addon(handler, addon_package):

--- a/src/Ankimon/reloader.py
+++ b/src/Ankimon/reloader.py
@@ -47,9 +47,21 @@ from aqt import gui_hooks, mw
 
 def restart_ankimon():
     """Tear the add-on down and re-import it in place (developer hot-reload)."""
+    import time
+
     from aqt.utils import tooltip
 
+    from .services import services
+
+    # Wait for the active startup QueryOp before purging modules. Otherwise its
+    # worker can hold a database connection lock while waiting for Python's
+    # import lock, as teardown waits for that same database lock.
+    while getattr(services, "_startup_in_progress", False):
+        QApplication.processEvents()
+        time.sleep(0.02)
+
     addon_package = __name__.split(".")[0]
+    services._is_reloading = True
     try:
         teardown_ankimon(addon_package)
         importlib.import_module(addon_package)

--- a/src/Ankimon/services.py
+++ b/src/Ankimon/services.py
@@ -98,6 +98,11 @@ class Services:
         # The Anki collection (``mw.col``) when running inside Anki; None headless.
         self.col = None
 
+        # Developer hot-reload lifecycle. The registry survives module purges,
+        # so these flags coordinate the old startup worker with the new import.
+        self._startup_in_progress = False
+        self._is_reloading = False
+
     def populate(
         self,
         *,
@@ -171,6 +176,8 @@ class Services:
         self.pokemon_pc = None
         self.reviewer = None
         self.col = None
+        self._startup_in_progress = False
+        self._is_reloading = False
 
 
 # The single shared registry instance. Import this, not the class.

--- a/src/Ankimon/services.py
+++ b/src/Ankimon/services.py
@@ -102,6 +102,9 @@ class Services:
         # so these flags coordinate the old startup worker with the new import.
         self._startup_in_progress = False
         self._is_reloading = False
+        # Re-entrancy guard for restart_ankimon itself: its wait loop pumps the
+        # Qt event queue, which can re-trigger the reload shortcut mid-teardown.
+        self._reload_in_progress = False
 
     def populate(
         self,
@@ -178,6 +181,7 @@ class Services:
         self.col = None
         self._startup_in_progress = False
         self._is_reloading = False
+        self._reload_in_progress = False
 
 
 # The single shared registry instance. Import this, not the class.

--- a/src/Ankimon/startup.py
+++ b/src/Ankimon/startup.py
@@ -78,23 +78,29 @@ def run_startup_background_checks(backup_manager=None):
     logger.log_and_showinfo("game", translator.translate("startup"))
     logger.log_and_showinfo("game", translator.translate("backing_up_files"))
 
-    # 1. Run the legacy file backup; report failures on the main thread.
+    # 1. Run backups unless this startup was triggered by a developer hot-reload.
     backup_error = None
-    try:
-        run_backup()
-    except Exception as e:
-        backup_error = e
+    from .services import services
 
-    # Dev-mode auto-backup (disk copy — background work). __init__ passes its
-    # module-level BackupManager so profile hooks and the menu share the same
-    # instance; constructing one here keeps this function standalone-callable.
-    if backup_manager is None:
-        backup_manager = BackupManager(logger, settings_obj)
-    try:
-        if settings_obj.get("misc.developer_mode"):
-            backup_manager.create_backup(manual=False)
-    except Exception as e:
-        logger.log("error", f"Error in background backup creation: {e}")
+    is_reloading = getattr(services, "_is_reloading", False)
+    if not is_reloading:
+        try:
+            run_backup()
+        except Exception as e:
+            backup_error = e
+
+        # Dev-mode auto-backup (disk copy — background work). __init__ passes its
+        # module-level BackupManager so profile hooks and the menu share the same
+        # instance; constructing one here keeps this function standalone-callable.
+        if backup_manager is None:
+            backup_manager = BackupManager(logger, settings_obj)
+        try:
+            if settings_obj.get("misc.developer_mode"):
+                backup_manager.create_backup(manual=False)
+        except Exception as e:
+            logger.log("error", f"Error in background backup creation: {e}")
+    else:
+        logger.log("info", "Skipping background backups during hot-reload.")
 
     # 2. Read-only DB checks.
     is_migrated = ankimon_db.is_migrated()

--- a/tests/test_async_startup_boot.py
+++ b/tests/test_async_startup_boot.py
@@ -905,6 +905,58 @@ def test_startup_failure_clears_reload_lifecycle_flags(boot_env):
     assert boot_env.services._is_reloading is False
 
 
+def test_success_callback_failure_clears_reload_lifecycle_flags(boot_env):
+    """QueryOp routes only *op* exceptions to .failure(); a raising success
+    callback propagates instead, so the flag reset has to be a finally."""
+
+    def fail_ui_startup(results):
+        raise RuntimeError("qt half boom")
+
+    sys.modules["Ankimon.startup"].run_startup_ui_callbacks = fail_ui_startup
+    boot_env.services._is_reloading = True
+
+    with pytest.raises(RuntimeError, match="qt half boom"):
+        boot_env.exec_init()
+
+    # Left set, restart_ankimon() would block on _startup_in_progress until its
+    # timeout on every later Ctrl+Shift+R, and backups would stay suppressed.
+    assert boot_env.services._startup_in_progress is False
+    assert boot_env.services._is_reloading is False
+
+
+def test_unschedulable_queryop_clears_reload_lifecycle_flags(boot_env):
+    """If run_in_background() raises, neither callback ever runs."""
+    monkey = SyncQueryOp.run_in_background
+
+    def fail_to_schedule(self):
+        raise RuntimeError("taskman gone")
+
+    SyncQueryOp.run_in_background = fail_to_schedule
+    boot_env.services._is_reloading = True
+    try:
+        with pytest.raises(RuntimeError, match="taskman gone"):
+            boot_env.exec_init()
+    finally:
+        SyncQueryOp.run_in_background = monkey
+
+    assert boot_env.services._startup_in_progress is False
+    assert boot_env.services._is_reloading is False
+
+
+def test_services_declares_and_resets_the_hot_reload_flags(boot_env):
+    """The registry is what survives _purge_addon_modules, so the hot-reload
+    flags have to live there and come back false on a profile-level reset."""
+    services = boot_env.services
+    for attr in ("_startup_in_progress", "_is_reloading", "_reload_in_progress"):
+        assert getattr(services, attr) is False
+        setattr(services, attr, True)
+
+    services.reset()
+
+    for attr in ("_startup_in_progress", "_is_reloading", "_reload_in_progress"):
+        assert getattr(services, attr) is False
+
+
 def test_changelog_keeps_real_connectivity(boot_env):
     """exp stubbed online_connectivity=False and dropped the changelog call;
     the port must keep both on the REAL connectivity result."""

--- a/tests/test_async_startup_boot.py
+++ b/tests/test_async_startup_boot.py
@@ -909,7 +909,15 @@ def test_success_callback_failure_clears_reload_lifecycle_flags(boot_env):
     """QueryOp routes only *op* exceptions to .failure(); a raising success
     callback propagates instead, so the flag reset has to be a finally."""
 
+    observed = []
+
     def fail_ui_startup(results):
+        observed.append(
+            (
+                boot_env.services._startup_in_progress,
+                boot_env.services._is_reloading,
+            )
+        )
         raise RuntimeError("qt half boom")
 
     sys.modules["Ankimon.startup"].run_startup_ui_callbacks = fail_ui_startup
@@ -918,6 +926,9 @@ def test_success_callback_failure_clears_reload_lifecycle_flags(boot_env):
     with pytest.raises(RuntimeError, match="qt half boom"):
         boot_env.exec_init()
 
+    # Pin the *transition*: both flags were still set when the callback blew
+    # up, so the final False below can only come from the finally.
+    assert observed == [(True, True)]
     # Left set, restart_ankimon() would block on _startup_in_progress until its
     # timeout on every later Ctrl+Shift+R, and backups would stay suppressed.
     assert boot_env.services._startup_in_progress is False
@@ -926,9 +937,16 @@ def test_success_callback_failure_clears_reload_lifecycle_flags(boot_env):
 
 def test_unschedulable_queryop_clears_reload_lifecycle_flags(boot_env):
     """If run_in_background() raises, neither callback ever runs."""
-    monkey = SyncQueryOp.run_in_background
+    real_run_in_background = SyncQueryOp.run_in_background
+    observed = []
 
     def fail_to_schedule(self):
+        observed.append(
+            (
+                boot_env.services._startup_in_progress,
+                boot_env.services._is_reloading,
+            )
+        )
         raise RuntimeError("taskman gone")
 
     SyncQueryOp.run_in_background = fail_to_schedule
@@ -937,8 +955,9 @@ def test_unschedulable_queryop_clears_reload_lifecycle_flags(boot_env):
         with pytest.raises(RuntimeError, match="taskman gone"):
             boot_env.exec_init()
     finally:
-        SyncQueryOp.run_in_background = monkey
+        SyncQueryOp.run_in_background = real_run_in_background
 
+    assert observed == [(True, True)]
     assert boot_env.services._startup_in_progress is False
     assert boot_env.services._is_reloading is False
 

--- a/tests/test_async_startup_boot.py
+++ b/tests/test_async_startup_boot.py
@@ -478,6 +478,28 @@ def test_dev_mode_auto_backup_uses_passed_manager(startup_env):
     assert FakeBackupManager.instances == [manager]
 
 
+def test_hot_reload_skips_both_background_backups(startup_env, monkeypatch):
+    env = startup_env
+    env.settings.config["misc.developer_mode"] = True
+    services = sys.modules["Ankimon.services"].services
+    monkeypatch.setattr(services, "_is_reloading", True, raising=False)
+
+    manager = FakeBackupManager(env.logger, env.settings)
+    results = env.mod.run_startup_background_checks(manager)
+
+    assert results["backup_manager"] is manager
+    assert _called(env, "run_backup") == []
+    assert manager.create_calls == []
+    assert (
+        "log",
+        "info",
+        "Skipping background backups during hot-reload.",
+    ) in env.calls
+    # The remainder of startup still runs normally.
+    assert _called(env, "generate_random_pokemon")
+    assert _called(env, "count_items_and_rewrite")
+
+
 def test_auto_catch_migration_folds_legacy_key_once(startup_env):
     env = startup_env
     env.settings.config["battle.automatic_catch_special"] = False
@@ -860,6 +882,27 @@ def test_boot_ordering_background_then_ui_then_menu(boot_env):
     # The QueryOp ran collection-free.
     assert len(SyncQueryOp.instances) == 1
     assert SyncQueryOp.instances[0].without_collection_called is True
+    assert boot_env.services._startup_in_progress is False
+    assert boot_env.services._is_reloading is False
+
+
+def test_startup_failure_clears_reload_lifecycle_flags(boot_env):
+    observed_startup_flags = []
+
+    def fail_background_startup(backup_manager=None):
+        observed_startup_flags.append(boot_env.services._startup_in_progress)
+        raise RuntimeError("startup boom")
+
+    sys.modules[
+        "Ankimon.startup"
+    ].run_startup_background_checks = fail_background_startup
+    boot_env.services._is_reloading = True
+
+    boot_env.exec_init()
+
+    assert observed_startup_flags == [True]
+    assert boot_env.services._startup_in_progress is False
+    assert boot_env.services._is_reloading is False
 
 
 def test_changelog_keeps_real_connectivity(boot_env):

--- a/tests/test_reloader.py
+++ b/tests/test_reloader.py
@@ -1,0 +1,89 @@
+"""Regression tests for the developer hot-reload lifecycle."""
+
+import importlib.util
+import sys
+import time
+import types
+from pathlib import Path
+from types import SimpleNamespace
+
+
+_SRC = Path(__file__).parent.parent / "src"
+
+
+def _module(name, **attrs):
+    mod = types.ModuleType(name)
+    for key, value in attrs.items():
+        setattr(mod, key, value)
+    return mod
+
+
+def test_restart_waits_for_startup_before_teardown(monkeypatch):
+    calls = []
+    services = SimpleNamespace(_startup_in_progress=True)
+
+    class FakeApplication:
+        @staticmethod
+        def processEvents():
+            calls.append("process_events")
+            services._startup_in_progress = False
+
+        @staticmethod
+        def allWidgets():
+            return []
+
+    pyqt6 = _module("PyQt6")
+    pyqt6.__path__ = []
+    qtwidgets = _module(
+        "PyQt6.QtWidgets",
+        QApplication=FakeApplication,
+        QWidget=type("QWidget", (), {}),
+    )
+    pyqt6.QtWidgets = qtwidgets
+    monkeypatch.setitem(sys.modules, "PyQt6", pyqt6)
+    monkeypatch.setitem(sys.modules, "PyQt6.QtWidgets", qtwidgets)
+
+    aqt = _module("aqt", gui_hooks=SimpleNamespace(), mw=SimpleNamespace())
+    aqt.__path__ = []
+    monkeypatch.setitem(sys.modules, "aqt", aqt)
+    monkeypatch.setitem(
+        sys.modules,
+        "aqt.utils",
+        _module("aqt.utils", tooltip=lambda message: calls.append(("tooltip", message))),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "Ankimon.services",
+        _module("Ankimon.services", services=services),
+    )
+
+    spec = importlib.util.spec_from_file_location(
+        "Ankimon.reloader", _SRC / "Ankimon" / "reloader.py"
+    )
+    mod = importlib.util.module_from_spec(spec)
+    monkeypatch.setitem(sys.modules, "Ankimon.reloader", mod)
+    spec.loader.exec_module(mod)
+
+    monkeypatch.setattr(
+        mod,
+        "teardown_ankimon",
+        lambda addon_package: calls.append(("teardown", addon_package)),
+    )
+    monkeypatch.setattr(
+        mod.importlib,
+        "import_module",
+        lambda addon_package: calls.append(("import", addon_package)),
+    )
+    monkeypatch.setattr(time, "sleep", lambda delay: calls.append(("sleep", delay)))
+
+    mod.restart_ankimon()
+
+    assert calls[:4] == [
+        "process_events",
+        ("sleep", 0.02),
+        ("teardown", "Ankimon"),
+        ("import", "Ankimon"),
+    ]
+    assert calls[-1] == ("tooltip", "Ankimon reloaded.")
+    # The asynchronous startup callbacks own clearing this flag.
+    assert services._is_reloading is True

--- a/tests/test_reloader.py
+++ b/tests/test_reloader.py
@@ -18,15 +18,20 @@ def _module(name, **attrs):
     return mod
 
 
-def test_restart_waits_for_startup_before_teardown(monkeypatch):
-    calls = []
-    services = SimpleNamespace(_startup_in_progress=True)
+def _load_reloader(monkeypatch, services, calls, on_process_events=None):
+    """Import reloader.py against fake Qt/aqt modules and return the module.
+
+    ``on_process_events`` is invoked by the fake ``QApplication.processEvents``,
+    which is how a test drives what happens while ``restart_ankimon`` is
+    pumping the Qt event queue (startup finishing, a re-entrant trigger, …).
+    """
 
     class FakeApplication:
         @staticmethod
         def processEvents():
             calls.append("process_events")
-            services._startup_in_progress = False
+            if on_process_events is not None:
+                on_process_events()
 
         @staticmethod
         def allWidgets():
@@ -75,6 +80,27 @@ def test_restart_waits_for_startup_before_teardown(monkeypatch):
         lambda addon_package: calls.append(("import", addon_package)),
     )
     monkeypatch.setattr(time, "sleep", lambda delay: calls.append(("sleep", delay)))
+    return mod
+
+
+def _fake_clock(monkeypatch):
+    """Make time.monotonic() advance only when the reload sleeps."""
+    now = {"t": 0.0}
+    monkeypatch.setattr(time, "monotonic", lambda: now["t"])
+    monkeypatch.setattr(
+        time, "sleep", lambda delay: now.__setitem__("t", now["t"] + delay)
+    )
+    return now
+
+
+def test_restart_waits_for_startup_before_teardown(monkeypatch):
+    calls = []
+    services = SimpleNamespace(_startup_in_progress=True)
+
+    def finish_startup():
+        services._startup_in_progress = False
+
+    mod = _load_reloader(monkeypatch, services, calls, finish_startup)
 
     mod.restart_ankimon()
 
@@ -87,3 +113,111 @@ def test_restart_waits_for_startup_before_teardown(monkeypatch):
     assert calls[-1] == ("tooltip", "Ankimon reloaded.")
     # The asynchronous startup callbacks own clearing this flag.
     assert services._is_reloading is True
+    # The guard is released so the next Ctrl+Shift+R still works.
+    assert services._reload_in_progress is False
+
+
+def test_restart_aborts_when_startup_never_finishes(monkeypatch):
+    """A wedged startup must cost a tooltip, not a permanently frozen Anki."""
+    calls = []
+    services = SimpleNamespace(_startup_in_progress=True)
+    mod = _load_reloader(monkeypatch, services, calls)
+    _fake_clock(monkeypatch)
+
+    mod.restart_ankimon()
+
+    assert ("teardown", "Ankimon") not in calls
+    assert ("import", "Ankimon") not in calls
+    assert calls[-1] == ("tooltip", "Ankimon reload skipped — startup still running.")
+    # Aborting must not leave the reload wedged for the next attempt either.
+    assert services._reload_in_progress is False
+    assert getattr(services, "_is_reloading", False) is False
+
+
+def test_restart_ignores_a_reentrant_trigger(monkeypatch):
+    """processEvents() can re-fire Ctrl+Shift+R; the second call must no-op."""
+    calls = []
+    services = SimpleNamespace(_startup_in_progress=True)
+    holder = {}
+
+    def reenter():
+        services._startup_in_progress = False
+        holder["mod"].restart_ankimon()
+
+    mod = _load_reloader(monkeypatch, services, calls, reenter)
+    holder["mod"] = mod
+
+    mod.restart_ankimon()
+
+    assert [c for c in calls if c == ("teardown", "Ankimon")] == [
+        ("teardown", "Ankimon")
+    ]
+    assert [c for c in calls if c == ("import", "Ankimon")] == [("import", "Ankimon")]
+    assert services._reload_in_progress is False
+
+
+def test_restart_clears_reload_flag_when_teardown_fails(monkeypatch):
+    calls = []
+    services = SimpleNamespace(_startup_in_progress=False)
+    mod = _load_reloader(monkeypatch, services, calls)
+    monkeypatch.setattr(
+        mod,
+        "teardown_ankimon",
+        lambda addon_package: (_ for _ in ()).throw(RuntimeError("teardown boom")),
+    )
+
+    mod.restart_ankimon()
+
+    assert ("import", "Ankimon") not in calls
+    assert calls[-1] == ("tooltip", "Ankimon reload failed — see console.")
+    # No replacement startup was ever scheduled, so nothing else would clear
+    # this; leaving it set would suppress backups for the rest of the session.
+    assert services._is_reloading is False
+    assert services._reload_in_progress is False
+
+
+def test_restart_clears_reload_flag_when_reimport_fails(monkeypatch):
+    """The common case: the developer saved a file with a syntax error."""
+    calls = []
+    services = SimpleNamespace(_startup_in_progress=False)
+    mod = _load_reloader(monkeypatch, services, calls)
+    monkeypatch.setattr(
+        mod.importlib,
+        "import_module",
+        lambda addon_package: (_ for _ in ()).throw(SyntaxError("bad edit")),
+    )
+
+    mod.restart_ankimon()
+
+    assert ("teardown", "Ankimon") in calls
+    assert calls[-1] == ("tooltip", "Ankimon reload failed — see console.")
+    assert services._is_reloading is False
+    assert services._reload_in_progress is False
+
+
+def test_restart_leaves_reload_flag_to_the_replacement_startup(monkeypatch):
+    """If the re-import scheduled a new startup, that startup owns the flag."""
+    calls = []
+    services = SimpleNamespace(_startup_in_progress=False)
+
+    def reimport(addon_package):
+        calls.append(("import", addon_package))
+        # What __init__.py does on re-import: kick off the new startup QueryOp.
+        services._startup_in_progress = True
+
+    def failing_tooltip(message):
+        calls.append(("tooltip", message))
+        raise RuntimeError("mw is going away")
+
+    mod = _load_reloader(monkeypatch, services, calls)
+    monkeypatch.setattr(mod.importlib, "import_module", reimport)
+    monkeypatch.setitem(
+        sys.modules, "aqt.utils", _module("aqt.utils", tooltip=failing_tooltip)
+    )
+
+    mod.restart_ankimon()
+
+    # Clearing _is_reloading here would let the replacement startup run the
+    # backups that the hot-reload path exists to skip.
+    assert services._is_reloading is True
+    assert services._reload_in_progress is False

--- a/tests/test_reloader_qt.py
+++ b/tests/test_reloader_qt.py
@@ -1,0 +1,151 @@
+"""Real-Qt tests for the hot-reload's deferred-delete flush.
+
+``_flush_deferred_widget_deletes`` is the whole of PR #686, and what it claims
+only holds if ``QCoreApplication.sendPostedEvents(None, QEvent.Type.DeferredDelete)``
+really destroys objects that ``deleteLater()`` merely *scheduled* — including
+at the same event-loop level the reload runs at, which is the case a plain
+``processEvents()`` deliberately skips. A fake ``QApplication`` cannot show
+that, so these run against real Qt (the Tier-2 / integrity-test env) and skip
+cleanly in the aqt-free Tier-1 env.
+
+Kept out of ``test_reloader.py`` on purpose: that file installs fake ``PyQt6``
+modules in ``sys.modules``, which is exactly what would invalidate these.
+
+Run standalone with::
+
+    pytest tests/test_reloader_qt.py
+"""
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+pytest.importorskip("PyQt6")  # Qt env only; skipped in the aqt-free Tier-1 env.
+
+
+_SRC = Path(__file__).parent.parent / "src"
+
+
+@pytest.fixture(autouse=True)
+def _env_guard():
+    """Skip gracefully when another test file has mocked PyQt6 in this run.
+
+    Un-mocking a compiled Qt extension mid-process is not reliable, so skip
+    rather than fail. Matches ``test_move_picker.py``.
+    """
+    from PyQt6.QtWidgets import QWidget
+
+    if not isinstance(QWidget, type):  # PyQt6 was mocked by another test
+        pytest.skip(
+            "real PyQt6 not active (mocked by another test); "
+            "run tests/test_reloader_qt.py standalone"
+        )
+    yield
+
+
+@pytest.fixture
+def reloader(monkeypatch):
+    """Import the real reloader.py against real Qt and a stubbed ``aqt``."""
+
+    def _stub(name, **attrs):
+        mod = types.ModuleType(name)
+        for key, value in attrs.items():
+            setattr(mod, key, value)
+        return mod
+
+    aqt = _stub("aqt", gui_hooks=SimpleNamespace(), mw=SimpleNamespace())
+    aqt.__path__ = []
+    monkeypatch.setitem(sys.modules, "aqt", aqt)
+    monkeypatch.setitem(
+        sys.modules, "aqt.utils", _stub("aqt.utils", tooltip=lambda message: None)
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "Ankimon.services",
+        _stub("Ankimon.services", services=SimpleNamespace()),
+    )
+
+    spec = importlib.util.spec_from_file_location(
+        "Ankimon.reloader", _SRC / "Ankimon" / "reloader.py"
+    )
+    mod = importlib.util.module_from_spec(spec)
+    monkeypatch.setitem(sys.modules, "Ankimon.reloader", mod)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_plain_process_events_leaves_deferred_deletes_alive(qapp, reloader):
+    """The control. Without this, the flush would be redundant with the
+    ``processEvents()`` calls teardown already makes."""
+    from PyQt6 import sip
+    from PyQt6.QtWidgets import QWidget
+
+    widget = QWidget()
+    widget.deleteLater()
+
+    qapp.processEvents()
+
+    assert not sip.isdeleted(widget)
+    widget.deleteLater()  # leave nothing for the next test to collect
+    reloader._flush_deferred_widget_deletes()
+
+
+def test_flush_destroys_deferred_deleted_widgets(qapp, reloader):
+    """The claim PR #686 rests on: after the flush the C++ objects are gone,
+    so the module purge can no longer strand a live QWebEngine page."""
+    from PyQt6 import sip
+    from PyQt6.QtWidgets import QWidget
+
+    parent = QWidget()
+    child = QWidget(parent)
+    destroyed = []
+    parent.destroyed.connect(lambda *_: destroyed.append("parent"))
+
+    parent.close()
+    parent.deleteLater()
+    assert not sip.isdeleted(parent)  # deleteLater() alone destroys nothing
+
+    reloader._flush_deferred_widget_deletes()
+
+    assert destroyed == ["parent"]
+    assert sip.isdeleted(parent)
+    # Children go with the parent — the QWebEngine page/profile ownership case.
+    assert sip.isdeleted(child)
+
+
+def test_flush_collects_deletes_scheduled_during_destruction(qapp, reloader):
+    """Why the flush loops instead of sending posted events once.
+
+    Destroying one object can schedule the next through *queued* work — which
+    is the shape WebEngine teardown takes. A queued connection lands as a
+    metacall event, so the first ``sendPostedEvents(..., DeferredDelete)`` pass
+    cannot see it; only the interleaved ``processEvents()`` dispatches it, and
+    the ``deleteLater()`` it then posts needs a second DeferredDelete pass.
+    Drop the flush to a single iteration and this test fails.
+    """
+    from PyQt6 import sip
+    from PyQt6.QtCore import Qt
+    from PyQt6.QtWidgets import QWidget
+
+    first = QWidget()
+    second = QWidget()
+    first.destroyed.connect(second.deleteLater, Qt.ConnectionType.QueuedConnection)
+
+    first.deleteLater()
+    reloader._flush_deferred_widget_deletes()
+
+    assert sip.isdeleted(first)
+    assert sip.isdeleted(second)
+
+
+def test_flush_is_a_noop_without_a_qapplication(reloader, monkeypatch):
+    """Headless callers (and Anki mid-shutdown) must not trip over the flush."""
+    monkeypatch.setattr(
+        reloader.QApplication, "instance", staticmethod(lambda: None)
+    )
+
+    reloader._flush_deferred_widget_deletes()  # must not raise

--- a/tests/test_reloader_qt.py
+++ b/tests/test_reloader_qt.py
@@ -9,7 +9,12 @@ that, so these run against real Qt (the Tier-2 / integrity-test env) and skip
 cleanly in the aqt-free Tier-1 env.
 
 Kept out of ``test_reloader.py`` on purpose: that file installs fake ``PyQt6``
-modules in ``sys.modules``, which is exactly what would invalidate these.
+modules in ``sys.modules``, which is exactly what would invalidate these. It
+restores them via ``monkeypatch``, so real Qt is back by the time this module
+runs — but that only holds because ``test_reloader_qt`` sorts *after*
+``test_reloader``. If collection order ever changes (a rename, xdist, a
+shuffling plugin), ``_env_guard`` below turns these into skips rather than
+failures, so re-run this file standalone before trusting a green suite.
 
 Run standalone with::
 


### PR DESCRIPTION
## Summary
- wait for an active startup QueryOp before hot-reload teardown to avoid the import-lock/DB-lock deadlock
- keep the reload flag set until asynchronous startup success or failure callbacks finish
- skip legacy and developer backups during hot-reload while preserving normal startup behavior
- release the lifecycle flags on **every** exit path so a partial boot or a failed reload cannot strand them
- add regression coverage for wait ordering, backup gating, and lifecycle cleanup

## Priority
Low: this affects the developer-only Restart Ankimon hot-reload workflow. No normal-user code path changes behaviour — the backup skip is gated on `_is_reloading`, which is only ever set by `restart_ankimon`.

## Follow-up commit (`ba1b33c`)
Addresses the CodeRabbit review finding, plus the two adjacent ways the same flags could get stranded.

**Success-callback failures (the CodeRabbit finding).** `QueryOp` routes only *op* exceptions to `.failure()`; an exception raised by the **success** callback propagates to Anki's top-level handler instead. So the trailing flag reset in `on_startup_complete` was skipped whenever any Qt-half step raised, leaving `_startup_in_progress` set — and the next Ctrl+Shift+R would then spin in the pre-teardown wait loop forever. The Qt half is now `run_startup_ui_sequence()` and the reset is a `finally`. Same treatment for a `run_in_background()` that never schedules the op.

**Reload failures (the CodeRabbit finding).** A failed teardown or re-import — most commonly the developer just saved a file with a syntax error, which is precisely when hot-reload gets used — left `_is_reloading` set with no replacement startup to clear it, silently suppressing startup backups for the rest of the session. Now cleared in the exception path unless the re-import already scheduled a new startup that owns it.

**Two things beyond the CodeRabbit ask**, both failure modes of the wait loop this PR introduces:

- *The wait is now bounded* (30s). An unbounded `while` on a flag means any future path that strands `_startup_in_progress` turns Ctrl+Shift+R into a permanently frozen Anki that needs force-quitting. On timeout the reload aborts rather than purging modules, because purging mid-startup is the exact deadlock this PR exists to fix.
- *`restart_ankimon` is now re-entrancy guarded.* The wait loop pumps the Qt event queue while the Ctrl+Shift+R `QShortcut` and the "Restart Ankimon" menu action are both still live and enabled, so a second trigger could land inside the first call and start a concurrent teardown of half-purged modules. The guard lives on the `services` registry rather than at module scope because `_purge_addon_modules()` drops `reloader` mid-reload.

## The finding reproduces — verified end-to-end, not just in unit tests

Drove a real hot-reload against the genuine add-on booted under real offscreen Qt (Tier-2 harness, real windows open), on the previously-approved commit `081ff5` vs the fixed branch. Same script, same profile. The trigger appeared on its own: the re-import's startup success callback raised, which is precisely the ownership gap CodeRabbit flagged.

| | `081ff5` (before) | fixed branch |
| --- | --- | --- |
| flags after a failed reload | `_startup_in_progress=True`, `_is_reloading=True` — both stranded | both `False` |
| the next reload | **HUNG** — still spinning after 20s | **returned** |

In real Anki the left column is a frozen UI needing a force-quit, because the wait loop this PR introduced was unbounded. Both halves of the follow-up are load-bearing: the `finally` clears the flags, and the 30s bound makes the failure survivable even if some future path strands them again.

## Branch brought up to date with main
It was 88 commits behind. Merged `origin/main` in cleanly — zero conflicts.

## Tests
- `python3 -m pytest tests/ -q` → **772 passed, 40 skipped, 0 failed**
- `python3 -m ruff check --config ci_ruff_check.toml` on all changed files → clean
- Tier-2 end-to-end reload: registry identity preserved across the purge, `services.db` still alive, flags cleared, re-entrant trigger suppressed, bounded wait honoured to within 0.02s

8 new regression tests: success-callback failure, unschedulable QueryOp, failed teardown, failed re-import, replacement-startup flag ownership, wait timeout, re-entrancy, and the registry defaults/reset.

## Stack
PR #686 (WebEngine deferred-delete flush) is stacked on this branch.
