### PR TITLE
fix(updater): keep full UI for git checkouts

### DIFF
--- a/harness/scenarios/feature_check.py
+++ b/harness/scenarios/feature_check.py
@@ -172,7 +172,65 @@ def check_update_channel(d, app, db, pc, pool):
             app.processEvents()
 
 
-CHECKS = [check_rename, check_make_favorite, check_catch_grows_collection, check_update_channel]
+def check_update_dialog_git_mode(d, app, db, pc, pool):
+    """The updater on a Git checkout: the dialog must build with the Git banner,
+    land on the Developer tab, and gate its buttons on the checkout state. This is
+    the only place the real __init__ ordering is exercised (the busy-state unit
+    tests use fakes), so it guards the "tab change before progress_bar exists"
+    crash. Every checkout state is driven through the real dialog."""
+    from Ankimon.pyobj import update_manager as um
+    import Ankimon.pyobj.update_dialog as ud
+
+    saved_fetch = {fn: getattr(ud, fn) for fn in ("fetch_releases", "fetch_tags", "fetch_branches", "fetch_open_prs",
+                                                  "is_git_clone", "get_git_checkout_info")}
+    saved_um_fetch = {fn: getattr(um, fn) for fn in ("fetch_branch_sha", "fetch_commit_date", "fetch_branch_commits")}
+    for fn in ("fetch_releases", "fetch_tags", "fetch_branches", "fetch_open_prs"):
+        setattr(ud, fn, lambda *a, **k: [])
+    for fn in saved_um_fetch:
+        setattr(um, fn, lambda *a, **k: None if fn != "fetch_branch_commits" else [])
+    ud.is_git_clone = lambda: True
+
+    cases = [
+        ("clean", {"is_git": True, "branch": "main", "sha": "abc1234", "full_sha": "abc1234" * 5, "dirty": False},
+         dict(pull=True)),
+        ("dirty", {"is_git": True, "branch": "feat", "sha": "abc1234", "full_sha": "abc1234" * 5, "dirty": True},
+         dict(pull=False)),
+        ("detached", {"is_git": True, "branch": "HEAD", "sha": "abc1234", "full_sha": "abc1234" * 5, "dirty": False},
+         dict(pull=False)),
+    ]
+    problems = []
+    try:
+        for label, info, expect in cases:
+            ud.get_git_checkout_info = lambda info=info: info
+            dlg = None
+            try:
+                dlg = ud.UpdateDialog()
+                app.processEvents()
+                if dlg.tabs.currentIndex() != 2:
+                    problems.append("%s: tab=%s" % (label, dlg.tabs.currentIndex()))
+                if dlg.git_pull_btn.isEnabled() != expect["pull"]:
+                    problems.append("%s: pull_enabled=%s" % (label, dlg.git_pull_btn.isEnabled()))
+                if dlg._busy_operations:
+                    problems.append("%s: still busy after load" % label)
+                # The Branch tab must never offer to fetch "detached" as a ref.
+                if label == "detached" and dlg.brrr_update_btn.isEnabled():
+                    problems.append("detached: branch update button enabled")
+            except Exception as e:
+                problems.append("%s: raised %s: %s" % (label, type(e).__name__, e))
+            finally:
+                if dlg is not None:
+                    dlg.close()
+                    app.processEvents()
+    finally:
+        for fn, orig in saved_fetch.items():
+            setattr(ud, fn, orig)
+        for fn, orig in saved_um_fetch.items():
+            setattr(um, fn, orig)
+    return ("update_dialog (git checkout mode)", not problems, "; ".join(problems) or "3 checkout states OK")
+
+
+CHECKS = [check_rename, check_make_favorite, check_catch_grows_collection, check_update_channel,
+          check_update_dialog_git_mode]
 
 
 def _boot():

--- a/harness/scenarios/feature_check.py
+++ b/harness/scenarios/feature_check.py
@@ -120,7 +120,8 @@ def check_update_channel(d, app, db, pc, pool):
     for fn in saved_fetch:
         setattr(ud, fn, lambda *a, **k: [])
     for fn in saved_um_fetch:
-        setattr(um, fn, lambda *a, **k: None if fn != "fetch_branch_commits" else [])
+        # bind per iteration: a late-bound `fn` would make every stub return []
+        setattr(um, fn, (lambda *a, _fn=fn, **k: [] if _fn == "fetch_branch_commits" else None))
     # Preserve the original channel setting to restore after the test
     original_channel = d.services.settings.get("misc.update_channel")
     dlg = None
@@ -183,20 +184,27 @@ def check_update_dialog_git_mode(d, app, db, pc, pool):
 
     saved_fetch = {fn: getattr(ud, fn) for fn in ("fetch_releases", "fetch_tags", "fetch_branches", "fetch_open_prs",
                                                   "is_git_clone", "get_git_checkout_info")}
-    saved_um_fetch = {fn: getattr(um, fn) for fn in ("fetch_branch_sha", "fetch_commit_date", "fetch_branch_commits")}
+    saved_um_fetch = {fn: getattr(um, fn) for fn in ("fetch_branch_sha", "fetch_commit_date", "fetch_branch_commits",
+                                                     "fetch_branch_relation")}
     for fn in ("fetch_releases", "fetch_tags", "fetch_branches", "fetch_open_prs"):
         setattr(ud, fn, lambda *a, **k: [])
-    for fn in saved_um_fetch:
-        setattr(um, fn, lambda *a, **k: None if fn != "fetch_branch_commits" else [])
+    um.fetch_commit_date = lambda *a, **k: None
+    um.fetch_branch_commits = lambda *a, **k: []
+    # The canonical branch is one commit AHEAD of the checkout, so the clean case
+    # must light the Branch tab's update button; dirty/detached must not, and only
+    # the gates under test can make that difference.
+    um.fetch_branch_sha = lambda *a, **k: "f" * 40
+    um.fetch_branch_relation = lambda *a, **k: "ahead"
     ud.is_git_clone = lambda: True
 
+    local = "a" * 40
     cases = [
-        ("clean", {"is_git": True, "branch": "main", "sha": "abc1234", "full_sha": "abc1234" * 5, "dirty": False},
-         dict(pull=True)),
-        ("dirty", {"is_git": True, "branch": "feat", "sha": "abc1234", "full_sha": "abc1234" * 5, "dirty": True},
-         dict(pull=False)),
-        ("detached", {"is_git": True, "branch": "HEAD", "sha": "abc1234", "full_sha": "abc1234" * 5, "dirty": False},
-         dict(pull=False)),
+        ("clean", {"is_git": True, "branch": "main", "sha": local[:7], "full_sha": local, "dirty": False},
+         dict(pull=True, brrr=True)),
+        ("dirty", {"is_git": True, "branch": "feat", "sha": local[:7], "full_sha": local, "dirty": True},
+         dict(pull=False, brrr=False)),
+        ("detached", {"is_git": True, "branch": "HEAD", "sha": local[:7], "full_sha": local, "dirty": False},
+         dict(pull=False, brrr=False)),
     ]
     problems = []
     try:
@@ -212,9 +220,11 @@ def check_update_dialog_git_mode(d, app, db, pc, pool):
                     problems.append("%s: pull_enabled=%s" % (label, dlg.git_pull_btn.isEnabled()))
                 if dlg._busy_operations:
                     problems.append("%s: still busy after load" % label)
-                # The Branch tab must never offer to fetch "detached" as a ref.
-                if label == "detached" and dlg.brrr_update_btn.isEnabled():
-                    problems.append("detached: branch update button enabled")
+                # The Branch tab must offer the fast-forward only when it can
+                # succeed: never on a detached HEAD (the label is not a ref) or a
+                # dirty tree.
+                if dlg.brrr_update_btn.isEnabled() != expect["brrr"]:
+                    problems.append("%s: brrr_enabled=%s" % (label, dlg.brrr_update_btn.isEnabled()))
             except Exception as e:
                 problems.append("%s: raised %s: %s" % (label, type(e).__name__, e))
             finally:

--- a/src/Ankimon/menu_buttons.py
+++ b/src/Ankimon/menu_buttons.py
@@ -281,46 +281,17 @@ def create_menu_actions(
     rate_action.triggered.connect(rate_addon_url)
     mw.pokemenu.addAction(rate_action)
 
-    # Update Ankimon. On a git checkout the file-overwrite updater is unsafe (it
-    # would clobber the working tree), so offer a safe `git pull --ff-only`
-    # instead; otherwise the normal download-based updater dialog.
-    from .pyobj.update_manager import is_git_clone, git_pull_ff_only
-    if is_git_clone():
-        def _git_update():
-            if not askUser(
-                "Update Ankimon by fast-forwarding your git clone "
-                "(git pull --ff-only)?\n\nThis stops safely without making any "
-                "changes if you have local edits or commits.",
-                title="Update Ankimon (git)",
-            ):
-                return
+    # Update Ankimon. Git checkouts use the same full dialog as packaged installs;
+    # the dialog routes branch/PR/tag selections through safe Git operations.
+    def _open_update_dialog():
+        from .pyobj.update_dialog import UpdateDialog
+        dialog = UpdateDialog(parent=mw)
+        dialog.exec()
 
-            from aqt.operations import QueryOp
-
-            def on_done(result):
-                ok, msg = result
-                (showInfo if ok else showWarning)(msg)
-
-            QueryOp(
-                parent=mw, op=lambda col: git_pull_ff_only(), success=on_done
-            ).without_collection().run_in_background()
-
-        update_action = QAction(
-            mw.translator.translate("ankimon_update_button") + " (git pull)", mw
-        )
-        update_action.setMenuRole(QAction.MenuRole.NoRole)
-        update_action.triggered.connect(_git_update)
-        help_menu.addAction(update_action)
-    else:
-        def _open_update_dialog():
-            from .pyobj.update_dialog import UpdateDialog
-            dialog = UpdateDialog(parent=mw)
-            dialog.exec()
-
-        update_action = QAction(mw.translator.translate("ankimon_update_button"), mw)
-        update_action.setMenuRole(QAction.MenuRole.NoRole)
-        update_action.triggered.connect(_open_update_dialog)
-        help_menu.addAction(update_action)
+    update_action = QAction(mw.translator.translate("ankimon_update_button"), mw)
+    update_action.setMenuRole(QAction.MenuRole.NoRole)
+    update_action.triggered.connect(_open_update_dialog)
+    help_menu.addAction(update_action)
 
     # Version
     version_action = QAction(mw.translator.translate("ankimon_version_button"), mw)

--- a/src/Ankimon/pyobj/update_dialog.py
+++ b/src/Ankimon/pyobj/update_dialog.py
@@ -98,11 +98,6 @@ class UpdateDialog(QDialog):
         self.tabs.currentChanged.connect(self._on_tab_changed)
         body.addWidget(self.tabs)
 
-        if select_tab == "sprites":
-            self.tabs.setCurrentIndex(3)
-        elif self._git_clone:
-            self.tabs.setCurrentIndex(2)
-
         self.progress_bar = QProgressBar()
         self.progress_bar.setVisible(False)
         self.progress_bar.setTextVisible(True)
@@ -116,6 +111,14 @@ class UpdateDialog(QDialog):
         )
         self.status_label.setMinimumHeight(24)
         body.addWidget(self.status_label)
+
+        # Pre-select a tab only now: currentChanged is already wired, and landing
+        # on the Developer tab kicks off _load_dev_data() -> _begin_busy(), which
+        # needs progress_bar and status_label to exist.
+        if select_tab == "sprites":
+            self.tabs.setCurrentIndex(3)
+        elif self._git_clone:
+            self.tabs.setCurrentIndex(2)
 
         layout.addLayout(body)
         self._load_data()
@@ -553,8 +556,22 @@ class UpdateDialog(QDialog):
         self.brrr_snooze_checkbox.blockSignals(False)
 
         # 5. Status & Update Button
-        if not remote_sha:
-            self.brrr_status_label.setText("Status:  Could not check connection.")
+        if self._git_clone and active == "detached":
+            self.brrr_status_label.setText(
+                "Status:  Detached checkout. Pick a branch, release, tag, or PR "
+                "from the other tabs."
+            )
+            self.brrr_status_label.setStyleSheet(
+                f"font-size: 13px; font-weight: bold; color: {c['warning']};"
+            )
+            self._set_action_enabled(self.brrr_update_btn, False)
+            self.brrr_update_btn.setText("No Branch Checked Out")
+        elif not remote_sha:
+            self.brrr_status_label.setText(
+                f"Status:  Branch '{active}' was not found on the Ankimon repository."
+                if self._git_clone
+                else "Status:  Could not check connection."
+            )
             self.brrr_status_label.setStyleSheet(
                 f"font-size: 13px; font-weight: bold; color: {c['error']};"
             )
@@ -604,6 +621,16 @@ class UpdateDialog(QDialog):
 
     def _on_brrr_update_clicked(self):
         branch = self.active_branch
+        if self._git_clone:
+            if branch == "detached":
+                return
+            self._run_update(
+                None,
+                f"latest {branch}",
+                source_type="current",
+                source_name="current",
+            )
+            return
         self._run_update(
             lambda progress_cb: _download_branch_zip(branch, progress_cb),
             f"latest {branch}",
@@ -1074,10 +1101,18 @@ class UpdateDialog(QDialog):
             except Exception:
                 pass
 
-            # 2. Get local state
+            # 2. Get local state. update_state.json records archive installs;
+            # a Git checkout's truth is HEAD and the checked-out branch.
             state = read_update_state() or {}
-            local_sha = state.get("commit_sha")
-            branch = state.get("source_name") or "main"
+            if self._git_clone:
+                local_sha = self._git_info.get("full_sha") or None
+                branch = self.active_branch
+                if branch == "detached":
+                    branch = "main"
+                state = dict(state, commit_sha=local_sha)
+            else:
+                local_sha = state.get("commit_sha")
+                branch = state.get("source_name") or "main"
 
             # 3. Fetch remote branch details
             remote_sha = None

--- a/src/Ankimon/pyobj/update_dialog.py
+++ b/src/Ankimon/pyobj/update_dialog.py
@@ -123,15 +123,52 @@ class UpdateDialog(QDialog):
         layout.addLayout(body)
         self._load_data()
 
-    def _build_git_notice(self):
+    def _git_banner_html(self) -> str:
+        import html
+
         c = self._colors
         info = self._git_info
         branch = info.get("branch") or "unknown"
         sha = info.get("sha") or "unknown"
-        detached = branch == "HEAD"
-        display_branch = "detached checkout" if detached else branch
+        display_branch = "detached checkout" if branch == "HEAD" else branch
         state = "local changes" if info.get("dirty") else "clean"
         state_color = c["warning"] if info.get("dirty") else c["success"]
+        # Branch names may legally contain <, > and &; QLabel renders rich text.
+        return (
+            f"<b>{html.escape(display_branch)}</b> · <code>{html.escape(sha)}</code> · "
+            f"<span style='color:{state_color}'><b>{state}</b></span><br>"
+            "Use the same Releases and Developer tabs below. Git fetches the "
+            "selected source from the Ankimon repository and checks it out "
+            "without resetting local branches."
+        )
+
+    def _git_pull_allowed(self) -> bool:
+        info = self._git_info
+        return bool(info.get("branch")) and info.get("branch") != "HEAD" and not info.get("dirty")
+
+    def _apply_git_pull_state(self):
+        # Route through _set_action_enabled so _action_button_states records the
+        # intended state: _end_busy restores from that map, and a plain
+        # setEnabled() would let the button come back enabled after an update
+        # even on a detached or dirty checkout.
+        allowed = self._git_pull_allowed()
+        self._set_action_enabled(self.git_pull_btn, allowed)
+        self.git_pull_btn.setToolTip(
+            "Fast-forward the checked-out branch from the Ankimon repository."
+            if allowed
+            else "Unavailable while detached or while the checkout has local changes."
+        )
+
+    def _refresh_git_state(self):
+        """Re-read the checkout after a Git operation moved it and redraw
+        everything derived from it (banner, pull button, Branch tab)."""
+        self._git_info = get_git_checkout_info()
+        self._git_note.setText(self._git_banner_html())
+        self._apply_git_pull_state()
+        self._load_data()
+
+    def _build_git_notice(self):
+        c = self._colors
 
         group = QGroupBox("Git Workspace Mode")
         group.setStyleSheet(f"""
@@ -152,29 +189,13 @@ class UpdateDialog(QDialog):
         """)
         row = QHBoxLayout(group)
 
-        note = QLabel(
-            f"<b>{display_branch}</b> · <code>{sha}</code> · "
-            f"<span style='color:{state_color}'><b>{state}</b></span><br>"
-            "Use the same Releases and Developer tabs below. Git fetches the "
-            "selected source and checks it out without resetting local branches."
-        )
-        note.setWordWrap(True)
-        note.setStyleSheet(f"font-size: 11px; color: {c['text']};")
-        row.addWidget(note, 1)
+        self._git_note = QLabel(self._git_banner_html())
+        self._git_note.setWordWrap(True)
+        self._git_note.setStyleSheet(f"font-size: 11px; color: {c['text']};")
+        row.addWidget(self._git_note, 1)
 
         self.git_pull_btn = QPushButton("Fast-forward Current Branch")
-        # Route through _set_action_enabled so _action_button_states records the
-        # intended state: _end_busy restores from that map, and a plain
-        # setEnabled() would let the button come back enabled after an update
-        # even on a detached or dirty checkout.
-        self._set_action_enabled(
-            self.git_pull_btn, not detached and not info.get("dirty")
-        )
-        self.git_pull_btn.setToolTip(
-            "Unavailable while detached or while the checkout has local changes."
-            if not self.git_pull_btn.isEnabled()
-            else "Run git pull --ff-only on the current branch."
-        )
+        self._apply_git_pull_state()
         self.git_pull_btn.clicked.connect(
             lambda: self._run_update(
                 None,
@@ -556,6 +577,7 @@ class UpdateDialog(QDialog):
         self.brrr_snooze_checkbox.blockSignals(False)
 
         # 5. Status & Update Button
+        relation = state.get("git_relation") if self._git_clone else None
         if self._git_clone and active == "detached":
             self.brrr_status_label.setText(
                 "Status:  Detached checkout. Pick a branch, release, tag, or PR "
@@ -566,6 +588,18 @@ class UpdateDialog(QDialog):
             )
             self._set_action_enabled(self.brrr_update_btn, False)
             self.brrr_update_btn.setText("No Branch Checked Out")
+        elif self._git_clone and self._git_info.get("dirty"):
+            # Same gate as the banner's pull button: both run the same
+            # fast-forward, and the backend refuses a dirty tree anyway.
+            self.brrr_status_label.setText(
+                "Status:  Local changes present. Commit, stash, or discard them "
+                "before updating."
+            )
+            self.brrr_status_label.setStyleSheet(
+                f"font-size: 13px; font-weight: bold; color: {c['warning']};"
+            )
+            self._set_action_enabled(self.brrr_update_btn, False)
+            self.brrr_update_btn.setText("Checkout Has Local Changes")
         elif not remote_sha:
             self.brrr_status_label.setText(
                 f"Status:  Branch '{active}' was not found on the Ankimon repository."
@@ -576,6 +610,22 @@ class UpdateDialog(QDialog):
                 f"font-size: 13px; font-weight: bold; color: {c['error']};"
             )
             self._set_action_enabled(self.brrr_update_btn, False)
+        elif self._git_clone and local_sha != remote_sha and relation != "ahead":
+            # A SHA mismatch is not an update when the local branch is the one
+            # that is ahead (or has diverged, or holds unpushed commits GitHub
+            # cannot compare): a fast-forward is impossible, so don't offer it.
+            if relation == "behind":
+                why = f"Your checkout is ahead of '{active}' on the Ankimon repository."
+            elif relation == "diverged":
+                why = f"Your checkout has diverged from '{active}' on the Ankimon repository."
+            else:
+                why = "Your checkout has commits that are not on the Ankimon repository."
+            self.brrr_status_label.setText(f"Status:  {why}")
+            self.brrr_status_label.setStyleSheet(
+                f"font-size: 13px; font-weight: bold; color: {c['warning']};"
+            )
+            self._set_action_enabled(self.brrr_update_btn, False)
+            self.brrr_update_btn.setText("Cannot Fast-forward")
         elif local_sha != remote_sha:
             self.brrr_status_label.setText(
                 f"Status:  New Update Available! (Latest: {remote_sha[:7]})"
@@ -1092,6 +1142,7 @@ class UpdateDialog(QDialog):
                 fetch_branch_sha,
                 fetch_commit_date,
                 fetch_branch_commits,
+                fetch_branch_relation,
             )
 
             # 1. Fetch releases
@@ -1120,6 +1171,13 @@ class UpdateDialog(QDialog):
                 remote_sha = fetch_branch_sha(branch)
             except Exception:
                 pass
+            if self._git_clone and local_sha and remote_sha and remote_sha != local_sha:
+                # Which side is ahead decides whether a fast-forward is even
+                # possible; the SHA comparison alone is direction-blind.
+                try:
+                    state["git_relation"] = fetch_branch_relation(local_sha, branch)
+                except Exception:
+                    state["git_relation"] = None
 
             local_commit_date = None
             if local_sha:
@@ -1378,6 +1436,10 @@ class UpdateDialog(QDialog):
             if self._end_busy(busy_token):
                 self.status_label.setText(messages[-1] if messages else msg)
                 self.progress_bar.setValue(100 if success else 0)
+            if success and self._git_clone:
+                # HEAD moved: the banner, pull button and Branch tab all describe
+                # the checkout and must not keep showing the pre-checkout state.
+                self._refresh_git_state()
             if success:
                 QMessageBox.information(
                     self,

--- a/src/Ankimon/pyobj/update_dialog.py
+++ b/src/Ankimon/pyobj/update_dialog.py
@@ -73,6 +73,10 @@ class UpdateDialog(QDialog):
         self.sprites_thread = None
         self._git_clone = is_git_clone()
         self._git_info = get_git_checkout_info() if self._git_clone else {}
+        # Canonical tip of the checked-out branch, learned by _load_data. Starts as
+        # "unknown": an empty string is truthy-safe but distinct from None.
+        self._git_remote_sha = "" if self._git_clone else None
+        self._git_ff_blocked = False
 
         self._apply_theme()
 
@@ -144,7 +148,18 @@ class UpdateDialog(QDialog):
 
     def _git_pull_allowed(self) -> bool:
         info = self._git_info
-        return bool(info.get("branch")) and info.get("branch") != "HEAD" and not info.get("dirty")
+        return (
+            bool(info.get("branch"))
+            and info.get("branch") != "HEAD"
+            and not info.get("dirty")
+            # "current" fetches the checked-out branch from the Ankimon repository;
+            # a local-only or fork branch can only fail. Unknown until _load_data
+            # has asked, so the button starts enabled and busy covers the wait.
+            and self._git_remote_sha is not None
+            # ...and the Branch tab's verdict: when the canonical branch is known
+            # to be behind or diverged a fast-forward cannot succeed either.
+            and not self._git_ff_blocked
+        )
 
     def _apply_git_pull_state(self):
         # Route through _set_action_enabled so _action_button_states records the
@@ -163,6 +178,9 @@ class UpdateDialog(QDialog):
         """Re-read the checkout after a Git operation moved it and redraw
         everything derived from it (banner, pull button, Branch tab)."""
         self._git_info = get_git_checkout_info()
+        # Both describe a different branch now; _load_data re-asks.
+        self._git_remote_sha = None
+        self._git_ff_blocked = False
         self._git_note.setText(self._git_banner_html())
         self._apply_git_pull_state()
         self._load_data()
@@ -578,6 +596,12 @@ class UpdateDialog(QDialog):
 
         # 5. Status & Update Button
         relation = state.get("git_relation") if self._git_clone else None
+        if self._git_clone:
+            # The banner's pull button runs the same fast-forward as this tab's
+            # button, so it follows the same verdict.
+            self._git_remote_sha = remote_sha
+            self._git_ff_blocked = relation in ("behind", "diverged")
+            self._apply_git_pull_state()
         if self._git_clone and active == "detached":
             self.brrr_status_label.setText(
                 "Status:  Detached checkout. Pick a branch, release, tag, or PR "
@@ -602,7 +626,8 @@ class UpdateDialog(QDialog):
             self.brrr_update_btn.setText("Checkout Has Local Changes")
         elif not remote_sha:
             self.brrr_status_label.setText(
-                f"Status:  Branch '{active}' was not found on the Ankimon repository."
+                f"Status:  Branch '{active}' was not found on the Ankimon repository "
+                "(or it could not be reached)."
                 if self._git_clone
                 else "Status:  Could not check connection."
             )
@@ -610,16 +635,19 @@ class UpdateDialog(QDialog):
                 f"font-size: 13px; font-weight: bold; color: {c['error']};"
             )
             self._set_action_enabled(self.brrr_update_btn, False)
-        elif self._git_clone and local_sha != remote_sha and relation != "ahead":
+            if self._git_clone:
+                self.brrr_update_btn.setText("Branch Not on Ankimon Repository")
+        elif self._git_clone and local_sha != remote_sha and relation in ("behind", "diverged"):
             # A SHA mismatch is not an update when the local branch is the one
-            # that is ahead (or has diverged, or holds unpushed commits GitHub
-            # cannot compare): a fast-forward is impossible, so don't offer it.
+            # that is ahead or has diverged: a fast-forward is impossible, so
+            # don't offer it. An UNKNOWN relation (rate limit, offline, a local
+            # commit GitHub has never seen) falls through and offers it instead:
+            # git_checkout_source proves ancestry before moving anything, and
+            # the UI must not state a reason it cannot know.
             if relation == "behind":
                 why = f"Your checkout is ahead of '{active}' on the Ankimon repository."
-            elif relation == "diverged":
-                why = f"Your checkout has diverged from '{active}' on the Ankimon repository."
             else:
-                why = "Your checkout has commits that are not on the Ankimon repository."
+                why = f"Your checkout has diverged from '{active}' on the Ankimon repository."
             self.brrr_status_label.setText(f"Status:  {why}")
             self.brrr_status_label.setStyleSheet(
                 f"font-size: 13px; font-weight: bold; color: {c['warning']};"

--- a/src/Ankimon/pyobj/update_dialog.py
+++ b/src/Ankimon/pyobj/update_dialog.py
@@ -28,6 +28,9 @@ from .update_manager import (
     fetch_branches,
     fetch_open_prs,
     apply_update,
+    is_git_clone,
+    get_git_checkout_info,
+    git_checkout_source,
     _download_zip_to_temp,
     _download_branch_zip,
     _download_pr_zip,
@@ -68,6 +71,8 @@ class UpdateDialog(QDialog):
         self._close_finalized = False
         self._sprites_busy_token = None
         self.sprites_thread = None
+        self._git_clone = is_git_clone()
+        self._git_info = get_git_checkout_info() if self._git_clone else {}
 
         self._apply_theme()
 
@@ -82,6 +87,8 @@ class UpdateDialog(QDialog):
         body.setContentsMargins(20, 16, 20, 16)
 
         body.addLayout(self._build_channel_row())
+        if self._git_clone:
+            body.addWidget(self._build_git_notice())
 
         self.tabs = QTabWidget()
         self.tabs.addTab(self._build_brrr_tab(), f"  Branch: {self.active_branch}  ")
@@ -93,6 +100,8 @@ class UpdateDialog(QDialog):
 
         if select_tab == "sprites":
             self.tabs.setCurrentIndex(3)
+        elif self._git_clone:
+            self.tabs.setCurrentIndex(2)
 
         self.progress_bar = QProgressBar()
         self.progress_bar.setVisible(False)
@@ -110,6 +119,69 @@ class UpdateDialog(QDialog):
 
         layout.addLayout(body)
         self._load_data()
+
+    def _build_git_notice(self):
+        c = self._colors
+        info = self._git_info
+        branch = info.get("branch") or "unknown"
+        sha = info.get("sha") or "unknown"
+        detached = branch == "HEAD"
+        display_branch = "detached checkout" if detached else branch
+        state = "local changes" if info.get("dirty") else "clean"
+        state_color = c["warning"] if info.get("dirty") else c["success"]
+
+        group = QGroupBox("Git Workspace Mode")
+        group.setStyleSheet(f"""
+            QGroupBox {{
+                background-color: {c['header_bg']};
+                border: 2px solid {c['accent']};
+                border-radius: 10px;
+                margin-top: 10px;
+                padding: 18px 12px 12px 12px;
+            }}
+            QGroupBox::title {{
+                color: {c['accent']};
+                subcontrol-origin: margin;
+                left: 12px;
+                padding: 0 6px;
+                font-weight: bold;
+            }}
+        """)
+        row = QHBoxLayout(group)
+
+        note = QLabel(
+            f"<b>{display_branch}</b> · <code>{sha}</code> · "
+            f"<span style='color:{state_color}'><b>{state}</b></span><br>"
+            "Use the same Releases and Developer tabs below. Git fetches the "
+            "selected source and checks it out without resetting local branches."
+        )
+        note.setWordWrap(True)
+        note.setStyleSheet(f"font-size: 11px; color: {c['text']};")
+        row.addWidget(note, 1)
+
+        self.git_pull_btn = QPushButton("Fast-forward Current Branch")
+        # Route through _set_action_enabled so _action_button_states records the
+        # intended state: _end_busy restores from that map, and a plain
+        # setEnabled() would let the button come back enabled after an update
+        # even on a detached or dirty checkout.
+        self._set_action_enabled(
+            self.git_pull_btn, not detached and not info.get("dirty")
+        )
+        self.git_pull_btn.setToolTip(
+            "Unavailable while detached or while the checkout has local changes."
+            if not self.git_pull_btn.isEnabled()
+            else "Run git pull --ff-only on the current branch."
+        )
+        self.git_pull_btn.clicked.connect(
+            lambda: self._run_update(
+                None,
+                "current Git branch",
+                source_type="current",
+                source_name="current",
+            )
+        )
+        row.addWidget(self.git_pull_btn)
+        return group
 
     def _build_channel_row(self):
         """A labeled dropdown to pick the auto-update channel (dialog-only UI).
@@ -143,6 +215,9 @@ class UpdateDialog(QDialog):
 
     @property
     def active_branch(self) -> str:
+        if self._git_clone:
+            branch = self._git_info.get("branch") or "main"
+            return "detached" if branch == "HEAD" else branch
         state = read_update_state()
         if state and state.get("source_type") == "branch":
             return state.get("source_name") or "main"
@@ -617,12 +692,17 @@ class UpdateDialog(QDialog):
         info.setWordWrap(True)
         layout.addWidget(info)
 
-        warning = QLabel(
-            "⚠ Do not use this if you installed Ankimon by cloning the git "
-            "repository. The updater overwrites files in place and would clobber "
-            "your checkout — update with 'git pull' instead. (Your Pokémon "
-            "data and sprites are always preserved.)"
+        warning_text = (
+            "Git workspace mode is active. Sources selected here are fetched from "
+            "the official Ankimon repository and checked out with Git; local "
+            "changes must be committed, stashed, or discarded first."
+            if self._git_clone
+            else
+            "⚠ Pull requests and development branches may contain unreviewed code. "
+            "Only install sources you trust. Your Pokémon data and sprites are "
+            "preserved during archive-based updates."
         )
+        warning = QLabel(warning_text)
         warning.setStyleSheet(
             f"color: {c['warning']}; font-size: 11px; font-weight: bold;"
         )
@@ -1122,14 +1202,19 @@ class UpdateDialog(QDialog):
     # --- Actions ---
 
     def _action_buttons(self):
-        return (
+        buttons = [
             self.brrr_update_btn,
             self.update_latest_btn,
             self.release_btn,
             self.dev_install_btn,
             self.sprites_check_btn,
             self.sprites_update_btn,
-        )
+        ]
+        # Only built in Git-checkout mode, so it must not be assumed present:
+        # _begin_busy() runs on every install, Git or not.
+        if hasattr(self, "git_pull_btn"):
+            buttons.append(self.git_pull_btn)
+        return tuple(buttons)
 
     def _set_action_enabled(self, button, enabled: bool):
         self._action_button_states[button] = enabled
@@ -1174,7 +1259,17 @@ class UpdateDialog(QDialog):
         published_at: str = None,
         extra_warning: str = None,
     ):
-        prompt = f"Update Ankimon to {label}?\n\nYour Pokemon data, settings, and sprites will be preserved."
+        if self._git_clone:
+            prompt = (
+                f"Switch this Git checkout to {label}?\n\n"
+                "Your local branches and commits will not be reset. The checkout "
+                "must be clean, and Anki must be restarted afterward."
+            )
+        else:
+            prompt = (
+                f"Update Ankimon to {label}?\n\n"
+                "Your Pokemon data, settings, and sprites will be preserved."
+            )
         if extra_warning:
             prompt = f"{extra_warning}\n\n{prompt}"
         confirm = QMessageBox.question(
@@ -1187,10 +1282,30 @@ class UpdateDialog(QDialog):
             return
 
         busy_token = self._begin_busy()
-        self.status_label.setText(f"Downloading {label}...")
+        self.status_label.setText(
+            f"Preparing Git checkout for {label}..."
+            if self._git_clone
+            else f"Downloading {label}..."
+        )
 
         def bg(_col):
             nonlocal commit_sha
+            messages = []
+
+            def status_update(m):
+                messages.append(m)
+                mw.taskman.run_on_main(lambda: self.status_label.setText(m))
+
+            if self._git_clone:
+                success, msg = git_checkout_source(
+                    source_type or "current",
+                    source_name,
+                    status_cb=status_update,
+                )
+                # 4-tuple to match on_done's unpack; a Git checkout stamps no
+                # pending addon mod, so pending_mod is None.
+                return success, msg, messages, None
+
             if source_type == "branch" and not commit_sha:
                 commit_sha = fetch_branch_sha(source_name)
 
@@ -1202,11 +1317,6 @@ class UpdateDialog(QDialog):
                     [],
                     None,
                 )
-            messages = []
-
-            def status_update(m):
-                messages.append(m)
-                mw.taskman.run_on_main(lambda: self.status_label.setText(m))
 
             success, msg, pending_mod = apply_update(
                 zip_path,

--- a/src/Ankimon/pyobj/update_dialog.py
+++ b/src/Ankimon/pyobj/update_dialog.py
@@ -28,6 +28,9 @@ from .update_manager import (
     fetch_branches,
     fetch_open_prs,
     apply_update,
+    is_git_clone,
+    get_git_checkout_info,
+    git_checkout_source,
     _download_zip_to_temp,
     _download_branch_zip,
     _download_pr_zip,
@@ -49,6 +52,8 @@ class UpdateDialog(QDialog):
         self._branches = []
         self._prs = []
         self.dev_data_loaded = False
+        self._git_clone = is_git_clone()
+        self._git_info = get_git_checkout_info() if self._git_clone else {}
 
         self._apply_theme()
 
@@ -63,6 +68,8 @@ class UpdateDialog(QDialog):
         body.setContentsMargins(20, 16, 20, 16)
 
         body.addLayout(self._build_channel_row())
+        if self._git_clone:
+            body.addWidget(self._build_git_notice())
 
         self.tabs = QTabWidget()
         self.tabs.addTab(self._build_brrr_tab(), f"  Branch: {self.active_branch}  ")
@@ -74,6 +81,8 @@ class UpdateDialog(QDialog):
 
         if select_tab == "sprites":
             self.tabs.setCurrentIndex(3)
+        elif self._git_clone:
+            self.tabs.setCurrentIndex(2)
 
         self.progress_bar = QProgressBar()
         self.progress_bar.setVisible(False)
@@ -89,6 +98,63 @@ class UpdateDialog(QDialog):
 
         layout.addLayout(body)
         self._load_data()
+
+    def _build_git_notice(self):
+        c = self._colors
+        info = self._git_info
+        branch = info.get("branch") or "unknown"
+        sha = info.get("sha") or "unknown"
+        detached = branch == "HEAD"
+        display_branch = "detached checkout" if detached else branch
+        state = "local changes" if info.get("dirty") else "clean"
+        state_color = c["warning"] if info.get("dirty") else c["success"]
+
+        group = QGroupBox("Git Workspace Mode")
+        group.setStyleSheet(f"""
+            QGroupBox {{
+                background-color: {c['header_bg']};
+                border: 2px solid {c['accent']};
+                border-radius: 10px;
+                margin-top: 10px;
+                padding: 18px 12px 12px 12px;
+            }}
+            QGroupBox::title {{
+                color: {c['accent']};
+                subcontrol-origin: margin;
+                left: 12px;
+                padding: 0 6px;
+                font-weight: bold;
+            }}
+        """)
+        row = QHBoxLayout(group)
+
+        note = QLabel(
+            f"<b>{display_branch}</b> · <code>{sha}</code> · "
+            f"<span style='color:{state_color}'><b>{state}</b></span><br>"
+            "Use the same Releases and Developer tabs below. Git fetches the "
+            "selected source and checks it out without resetting local branches."
+        )
+        note.setWordWrap(True)
+        note.setStyleSheet(f"font-size: 11px; color: {c['text']};")
+        row.addWidget(note, 1)
+
+        self.git_pull_btn = QPushButton("Fast-forward Current Branch")
+        self.git_pull_btn.setEnabled(not detached and not info.get("dirty"))
+        self.git_pull_btn.setToolTip(
+            "Unavailable while detached or while the checkout has local changes."
+            if not self.git_pull_btn.isEnabled()
+            else "Run git pull --ff-only on the current branch."
+        )
+        self.git_pull_btn.clicked.connect(
+            lambda: self._run_update(
+                None,
+                "current Git branch",
+                source_type="current",
+                source_name="current",
+            )
+        )
+        row.addWidget(self.git_pull_btn)
+        return group
 
     def _build_channel_row(self):
         """A labeled dropdown to pick the auto-update channel (dialog-only UI).
@@ -122,6 +188,9 @@ class UpdateDialog(QDialog):
 
     @property
     def active_branch(self) -> str:
+        if self._git_clone:
+            branch = self._git_info.get("branch") or "main"
+            return "detached" if branch == "HEAD" else branch
         state = read_update_state()
         if state and state.get("source_type") == "branch":
             return state.get("source_name") or "main"
@@ -587,12 +656,17 @@ class UpdateDialog(QDialog):
         info.setWordWrap(True)
         layout.addWidget(info)
 
-        warning = QLabel(
-            "⚠ Do not use this if you installed Ankimon by cloning the git "
-            "repository. The updater overwrites files in place and would clobber "
-            "your checkout — update with 'git pull' instead. (Your Pokémon "
-            "data and sprites are always preserved.)"
+        warning_text = (
+            "Git workspace mode is active. Sources selected here are fetched from "
+            "the official Ankimon repository and checked out with Git; local "
+            "changes must be committed, stashed, or discarded first."
+            if self._git_clone
+            else
+            "⚠ Pull requests and development branches may contain unreviewed code. "
+            "Only install sources you trust. Your Pokémon data and sprites are "
+            "preserved during archive-based updates."
         )
+        warning = QLabel(warning_text)
         warning.setStyleSheet(
             f"color: {c['warning']}; font-size: 11px; font-weight: bold;"
         )
@@ -996,6 +1070,12 @@ class UpdateDialog(QDialog):
         self.update_latest_btn.setEnabled(not busy)
         self.release_btn.setEnabled(not busy)
         self.dev_install_btn.setEnabled(not busy)
+        if hasattr(self, "git_pull_btn"):
+            self.git_pull_btn.setEnabled(
+                not busy
+                and self._git_info.get("branch") != "HEAD"
+                and not self._git_info.get("dirty")
+            )
         if not busy:
             self.status_label.setText("")
 
@@ -1013,7 +1093,17 @@ class UpdateDialog(QDialog):
         commit_sha: str = None,
         extra_warning: str = None,
     ):
-        prompt = f"Update Ankimon to {label}?\n\nYour Pokemon data, settings, and sprites will be preserved."
+        if self._git_clone:
+            prompt = (
+                f"Switch this Git checkout to {label}?\n\n"
+                "Your local branches and commits will not be reset. The checkout "
+                "must be clean, and Anki must be restarted afterward."
+            )
+        else:
+            prompt = (
+                f"Update Ankimon to {label}?\n\n"
+                "Your Pokemon data, settings, and sprites will be preserved."
+            )
         if extra_warning:
             prompt = f"{extra_warning}\n\n{prompt}"
         confirm = QMessageBox.question(
@@ -1026,21 +1116,34 @@ class UpdateDialog(QDialog):
             return
 
         self._set_busy(True)
-        self.status_label.setText(f"Downloading {label}...")
+        self.status_label.setText(
+            f"Preparing Git checkout for {label}..."
+            if self._git_clone
+            else f"Downloading {label}..."
+        )
 
         def bg(_col):
             nonlocal commit_sha
+            messages = []
+
+            def status_update(m):
+                messages.append(m)
+                mw.taskman.run_on_main(lambda: self.status_label.setText(m))
+
+            if self._git_clone:
+                success, msg = git_checkout_source(
+                    source_type or "current",
+                    source_name,
+                    status_cb=status_update,
+                )
+                return success, msg, messages
+
             if source_type == "branch" and not commit_sha:
                 commit_sha = fetch_branch_sha(source_name)
 
             zip_path = download_fn(progress_cb=self._on_progress)
             if not zip_path:
                 return False, "Download failed. Check your internet connection.", []
-            messages = []
-
-            def status_update(m):
-                messages.append(m)
-                mw.taskman.run_on_main(lambda: self.status_label.setText(m))
 
             success, msg = apply_update(
                 zip_path, source_type, source_name, commit_sha, status_cb=status_update

--- a/src/Ankimon/pyobj/update_manager.py
+++ b/src/Ankimon/pyobj/update_manager.py
@@ -19,6 +19,7 @@ from ..resources import addon_dir
 REPO_OWNER = "h0tp-ftw"
 REPO_NAME = "ankimon"
 GITHUB_API = f"https://api.github.com/repos/{REPO_OWNER}/{REPO_NAME}"
+GIT_REMOTE_URL = f"https://github.com/{REPO_OWNER}/{REPO_NAME}.git"
 DOWNLOAD_TIMEOUT = 30
 USER_AGENT = "Ankimon-Updater (https://github.com/h0tp-ftw/ankimon)"
 DEFAULT_SUBMODULE_SHA = "f3092b03fbe1e37d1788ef802dee98906d621e36"
@@ -82,21 +83,43 @@ def _git_repo_root() -> Optional[Path]:
 
 
 def is_git_clone() -> bool:
-    """True if Ankimon runs from a git working tree (a dev clone).
+    """True if Ankimon runs from a git working tree.
 
-    The in-place updater would overwrite every file under ``addon_dir`` with the
-    downloaded copy, trashing the working tree and any uncommitted/untracked
-    changes (``.git`` is above ``addon_dir`` so it survives, but the checkout is
-    clobbered). So the destructive updater is hidden for clones; a safe
-    ``git pull --ff-only`` is offered instead (see ``git_pull_ff_only``).
+    Git detection is independent of developer mode: the archive installer must
+    never overwrite a checkout. The updater dialog stays available for clones,
+    but routes selections through safe Git operations instead.
     """
-    try:
-        from ..utils import is_dev_mode
-        if is_dev_mode():
-            return False
-    except Exception:
-        pass
     return _git_repo_root() is not None
+
+
+def get_git_checkout_info() -> dict:
+    """Return lightweight display information for the updater's Git mode."""
+    root = _git_repo_root()
+    info = {"is_git": root is not None, "branch": "", "sha": "", "dirty": False}
+    if root is None or shutil.which("git") is None:
+        return info
+
+    def _git(*args):
+        return subprocess.run(
+            ["git", "-C", str(root), *args],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+
+    try:
+        branch = _git("rev-parse", "--abbrev-ref", "HEAD")
+        sha = _git("rev-parse", "--short", "HEAD")
+        status = _git("status", "--porcelain")
+        if branch.returncode == 0:
+            info["branch"] = branch.stdout.strip()
+        if sha.returncode == 0:
+            info["sha"] = sha.stdout.strip()
+        if status.returncode == 0:
+            info["dirty"] = bool(status.stdout.strip())
+    except (OSError, subprocess.SubprocessError):
+        pass
+    return info
 
 
 def git_pull_ff_only(status_cb=None) -> tuple[bool, str]:
@@ -132,9 +155,23 @@ def git_pull_ff_only(status_cb=None) -> tuple[bool, str]:
         )
 
     try:
+        status = _git("status", "--porcelain", timeout=30)
+        if status.returncode != 0:
+            return False, (status.stderr or status.stdout or "git status failed").strip()
+        if status.stdout.strip():
+            return False, (
+                "Your Ankimon checkout has local changes. Commit, stash, or discard "
+                "them before updating from the updater."
+            )
+
         branch = (
             _git("rev-parse", "--abbrev-ref", "HEAD", timeout=30).stdout or ""
         ).strip() or "HEAD"
+        if branch == "HEAD":
+            return False, (
+                "This checkout is detached. Select a branch, release, tag, or PR in "
+                "the updater instead of pulling the current checkout."
+            )
         log(f"Fast-forwarding '{branch}' (git pull --ff-only)...")
         pull = _git("pull", "--ff-only")
         if pull.returncode != 0:
@@ -158,6 +195,127 @@ def git_pull_ff_only(status_cb=None) -> tuple[bool, str]:
         return False, "git timed out. Update manually with 'git pull'."
     except Exception as e:
         return False, f"git update failed: {e}. Update manually with 'git pull'."
+
+
+def git_checkout_source(
+    source_type: str,
+    source_name: Optional[str] = None,
+    status_cb=None,
+) -> tuple[bool, str]:
+    """Safely move a Git checkout to a branch, PR, tag, or release.
+
+    Existing local branches and commits are never reset. An existing local branch
+    is reattached and fast-forwarded from the official repository; PRs, tags,
+    releases, and branches without a local counterpart are checked out detached.
+    A dirty working tree is refused before any checkout, and submodules are synced.
+    """
+
+    def log(msg):
+        if status_cb:
+            status_cb(msg)
+
+    root = _git_repo_root()
+    if root is None:
+        return False, "Ankimon is not running from a git checkout."
+    if shutil.which("git") is None:
+        return False, "git wasn't found on Anki's PATH."
+
+    def _git(*args, timeout=180):
+        return subprocess.run(
+            ["git", "-C", str(root), *args],
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+
+    try:
+        if source_type == "current":
+            return git_pull_ff_only(status_cb=status_cb)
+
+        status = _git("status", "--porcelain", timeout=30)
+        if status.returncode != 0:
+            return False, (status.stderr or status.stdout or "git status failed").strip()
+        if status.stdout.strip():
+            return False, (
+                "Your Ankimon checkout has local changes. Commit, stash, or discard "
+                "them before switching versions in the updater."
+            )
+
+        if not source_name:
+            return False, "No Git target was selected."
+
+        if source_type == "pr":
+            remote_ref = f"refs/pull/{source_name}/head"
+            display = f"PR #{source_name}"
+        elif source_type == "branch":
+            remote_ref = f"refs/heads/{source_name}"
+            display = f"branch '{source_name}'"
+        elif source_type in {"tag", "release"}:
+            remote_ref = f"refs/tags/{source_name}"
+            display = f"{source_type} '{source_name}'"
+        else:
+            return False, f"Unsupported Git source type: {source_type}"
+
+        log(f"Fetching {display} from the Ankimon repository...")
+        fetch = _git("fetch", "--force", GIT_REMOTE_URL, remote_ref)
+        if fetch.returncode != 0:
+            return False, (
+                f"Could not fetch {display}.\n\n"
+                + (fetch.stderr or fetch.stdout or "Unknown git fetch error").strip()
+            )
+
+        checkout_ref = "FETCH_HEAD"
+        if source_type == "branch":
+            local_branch = _git(
+                "show-ref", "--verify", "--quiet", f"refs/heads/{source_name}",
+                timeout=30,
+            )
+            if local_branch.returncode == 0:
+                checkout = _git("checkout", source_name)
+                if checkout.returncode != 0:
+                    return False, (
+                        f"Could not check out local branch '{source_name}'.\n\n"
+                        + (checkout.stderr or checkout.stdout or "Unknown git checkout error").strip()
+                    )
+                log(f"Fast-forwarding local branch '{source_name}'...")
+                merge = _git("merge", "--ff-only", checkout_ref)
+                if merge.returncode != 0:
+                    return False, (
+                        f"Local branch '{source_name}' could not be fast-forwarded. "
+                        "Your commits were left unchanged.\n\n"
+                        + (merge.stderr or merge.stdout or "Unknown git merge error").strip()
+                    )
+                checkout_ref = None
+
+        if checkout_ref is not None:
+            log(f"Checking out {display}...")
+            checkout = _git("checkout", "--detach", checkout_ref)
+            if checkout.returncode != 0:
+                return False, (
+                    f"Could not check out {display}.\n\n"
+                    + (checkout.stderr or checkout.stdout or "Unknown git checkout error").strip()
+                )
+
+        operation = "Updated" if checkout_ref is None else "Checked out"
+        log("Updating submodules...")
+        sub = _git("submodule", "update", "--init", "--recursive")
+        if sub.returncode != 0:
+            return True, (
+                f"{operation} {display}, but the submodule update failed. Run "
+                "'git submodule update --init --recursive' manually.\n\n"
+                + (sub.stderr or sub.stdout or "").strip()
+            )
+
+        sha = _git("rev-parse", "--short", "HEAD", timeout=30)
+        sha_text = sha.stdout.strip() if sha.returncode == 0 else "the selected commit"
+        return True, (
+            f"{operation} {display} at {sha_text}. Local commits were not rewritten. "
+            "Please restart Anki."
+        )
+    except subprocess.TimeoutExpired:
+        return False, "git timed out while switching the Ankimon checkout."
+    except Exception as e:
+        return False, f"git checkout failed: {e}"
 
 
 def _parse_version(name: str) -> Optional[tuple]:

--- a/src/Ankimon/pyobj/update_manager.py
+++ b/src/Ankimon/pyobj/update_manager.py
@@ -5,6 +5,7 @@ import re
 import shutil
 import subprocess
 import tempfile
+import time
 import urllib.request
 import urllib.error
 import zipfile
@@ -84,8 +85,11 @@ def _git_repo_root() -> Optional[Path]:
         # layouts ".git" is a *file* (containing "gitdir: ..."), not a directory.
         if not (d / ".git").exists():
             continue
+        # samefile (inode identity) rather than comparing resolved path strings:
+        # resolve() does not fold case, so a mis-cased symlink on macOS/Windows
+        # would compare unequal and hand a real checkout to the archive updater.
         try:
-            if (d / "src" / "Ankimon").resolve() == base:
+            if os.path.samefile(d / "src" / "Ankimon", base):
                 return d
         except OSError:
             pass
@@ -116,15 +120,18 @@ def get_git_checkout_info() -> dict:
     if root is None or shutil.which("git") is None:
         return info
 
-    # Called synchronously while the updater dialog is being built, so keep the
-    # worst case short: on a timeout the banner shows "unknown" and the checkout
-    # helpers re-run their own (authoritative) checks before touching anything.
+    # Called synchronously while the updater dialog is being built, so the three
+    # probes share ONE 10s budget: on a timeout the banner shows "unknown" and the
+    # checkout helpers re-run their own (authoritative) checks before touching
+    # anything.
+    deadline = time.monotonic() + 10
+
     def _git(*args):
         return subprocess.run(
             ["git", "-C", str(root), *args],
             capture_output=True,
             text=True,
-            timeout=10,
+            timeout=max(0.5, deadline - time.monotonic()),
         )
 
     try:
@@ -228,10 +235,16 @@ def git_checkout_source(
 ) -> tuple[bool, str]:
     """Safely move a Git checkout to a branch, PR, tag, or release.
 
+    Every source is fetched from the official Ankimon repository (not the
+    checkout's own ``origin``, which for a contributor is their fork), so what the
+    dialog compared against is what gets installed. ``"current"`` means the
+    checked-out branch and is refused on a detached HEAD.
+
     Existing local branches and commits are never reset. An existing local branch
-    is reattached and fast-forwarded from the official repository; PRs, tags,
-    releases, and branches without a local counterpart are checked out detached.
-    A dirty working tree is refused before any checkout, and submodules are synced.
+    is reattached and fast-forwarded; that is refused up front, before HEAD moves,
+    when the local branch has commits the remote lacks. PRs, tags, releases, and
+    branches without a local counterpart are checked out detached. A dirty working
+    tree is refused before any checkout, and submodules are synced.
     """
 
     def log(msg):
@@ -254,7 +267,14 @@ def git_checkout_source(
 
     try:
         if source_type == "current":
-            return git_pull_ff_only(status_cb=status_cb)
+            head = _git("rev-parse", "--abbrev-ref", "HEAD", timeout=30)
+            branch = (head.stdout or "").strip() if head.returncode == 0 else ""
+            if not branch or branch == "HEAD":
+                return False, (
+                    "This checkout is detached. Select a branch, release, tag, or PR "
+                    "in the updater instead of updating the current checkout."
+                )
+            source_type, source_name = "branch", branch
 
         # Tracked modifications only; see git_pull_ff_only for why.
         status = _git("status", "--porcelain", "--untracked-files=no", timeout=30)
@@ -296,6 +316,26 @@ def git_checkout_source(
                 timeout=30,
             )
             if local_branch.returncode == 0:
+                # Prove the fast-forward BEFORE moving HEAD: a refusal must leave
+                # the checkout exactly as it was, not parked on another branch
+                # with an "Update Failed" box on screen.
+                ancestor = _git(
+                    "merge-base", "--is-ancestor",
+                    f"refs/heads/{source_name}", checkout_ref,
+                    timeout=30,
+                )
+                if ancestor.returncode == 1:
+                    return False, (
+                        f"Local branch '{source_name}' has commits that are not on "
+                        "the Ankimon repository, so it cannot be fast-forwarded. "
+                        "Nothing was changed. Push or rebase it, or pick another source."
+                    )
+                if ancestor.returncode != 0:
+                    return False, (
+                        f"Could not compare local branch '{source_name}' with the "
+                        "Ankimon repository. Nothing was changed.\n\n"
+                        + (ancestor.stderr or ancestor.stdout or "Unknown git error").strip()
+                    )
                 checkout = _git("checkout", source_name)
                 if checkout.returncode != 0:
                     return False, (
@@ -305,9 +345,11 @@ def git_checkout_source(
                 log(f"Fast-forwarding local branch '{source_name}'...")
                 merge = _git("merge", "--ff-only", checkout_ref)
                 if merge.returncode != 0:
+                    # Can only happen if the tree changed under us between the
+                    # ancestry check and here; say exactly where HEAD is now.
                     return False, (
-                        f"Local branch '{source_name}' could not be fast-forwarded. "
-                        "Your commits were left unchanged.\n\n"
+                        f"Branch '{source_name}' is now checked out but could not be "
+                        "fast-forwarded; its commits were left unchanged.\n\n"
                         + (merge.stderr or merge.stdout or "Unknown git merge error").strip()
                     )
                 checkout_ref = None
@@ -334,8 +376,7 @@ def git_checkout_source(
         sha = _git("rev-parse", "--short", "HEAD", timeout=30)
         sha_text = sha.stdout.strip() if sha.returncode == 0 else "the selected commit"
         return True, (
-            f"{operation} {display} at {sha_text}. Local commits were not rewritten. "
-            "Please restart Anki."
+            f"{operation} {display} at {sha_text}. Local commits were not rewritten."
         )
     except subprocess.TimeoutExpired:
         return False, "git timed out while switching the Ankimon checkout."
@@ -620,6 +661,21 @@ def fetch_commit_date(sha: str) -> Optional[str]:
     if not sha or len(sha) < 7 or not all(c in "0123456789abcdefABCDEF" for c in sha):
         return None
     return fetch_ref_date(sha)
+
+
+def fetch_branch_relation(local_sha: str, branch: str) -> Optional[str]:
+    """How the remote ``branch`` tip relates to ``local_sha`` (GitHub compare API).
+
+    ``"ahead"``: the remote has commits the local commit lacks (an update is
+    available); ``"behind"``: the local commit is ahead of the remote;
+    ``"identical"``; ``"diverged"``. ``None`` when the comparison is unavailable,
+    which includes a local commit GitHub has never seen (unpushed work).
+    """
+    if not local_sha or not branch:
+        return None
+    data = _api_get(f"compare/{local_sha}...{branch}")
+    status = data.get("status") if isinstance(data, dict) else None
+    return status if status in {"ahead", "behind", "identical", "diverged"} else None
 
 
 def fetch_branch_commits(branch: str, local_sha: Optional[str] = None) -> list[dict]:

--- a/src/Ankimon/pyobj/update_manager.py
+++ b/src/Ankimon/pyobj/update_manager.py
@@ -61,14 +61,19 @@ UPDATE_CHANNELS = (CHANNEL_STABLE, CHANNEL_EXPERIMENTAL, CHANNEL_MAIN)
 
 
 def _git_repo_root() -> Optional[Path]:
-    """Return the git repo root that contains the addon, else None.
+    """Return the root of the Ankimon git checkout that contains the addon, else None.
 
     For a GitHub clone the addon is ``src/Ankimon`` nested in the repo, so the
     ``.git`` directory sits two levels *above* ``addon_dir`` at the repo root —
     hence the upward parent walk. ``resolve()`` first follows the dev symlink
-    from ``addons21/`` into the repo so those parents land on the real repo root;
-    the walk is kept shallow to avoid false positives from an unrelated repo
-    higher up.
+    from ``addons21/`` into the repo so those parents land on the real repo root.
+
+    A ``.git`` alone is not enough: the repo must actually be an Ankimon checkout,
+    i.e. its ``src/Ankimon`` must be this very addon directory. Anki's data folder
+    (or a user's home) can itself be under an unrelated git repo, and running
+    ``git fetch``/``git checkout`` of Ankimon's history inside *that* repo would
+    replace its working tree. Such installs are plain installs: the archive
+    updater serves them and the release polls stay on.
     """
     try:
         base = Path(addon_dir).resolve()
@@ -77,8 +82,14 @@ def _git_repo_root() -> Optional[Path]:
     for d in [base, *list(base.parents)[:3]]:
         # .exists() rather than .is_dir(): in git worktrees and some submodule
         # layouts ".git" is a *file* (containing "gitdir: ..."), not a directory.
-        if (d / ".git").exists():
-            return d
+        if not (d / ".git").exists():
+            continue
+        try:
+            if (d / "src" / "Ankimon").resolve() == base:
+                return d
+        except OSError:
+            pass
+        return None
     return None
 
 
@@ -95,26 +106,36 @@ def is_git_clone() -> bool:
 def get_git_checkout_info() -> dict:
     """Return lightweight display information for the updater's Git mode."""
     root = _git_repo_root()
-    info = {"is_git": root is not None, "branch": "", "sha": "", "dirty": False}
+    info = {
+        "is_git": root is not None,
+        "branch": "",
+        "sha": "",
+        "full_sha": "",
+        "dirty": False,
+    }
     if root is None or shutil.which("git") is None:
         return info
 
+    # Called synchronously while the updater dialog is being built, so keep the
+    # worst case short: on a timeout the banner shows "unknown" and the checkout
+    # helpers re-run their own (authoritative) checks before touching anything.
     def _git(*args):
         return subprocess.run(
             ["git", "-C", str(root), *args],
             capture_output=True,
             text=True,
-            timeout=30,
+            timeout=10,
         )
 
     try:
         branch = _git("rev-parse", "--abbrev-ref", "HEAD")
-        sha = _git("rev-parse", "--short", "HEAD")
-        status = _git("status", "--porcelain")
+        sha = _git("rev-parse", "HEAD")
+        status = _git("status", "--porcelain", "--untracked-files=no")
         if branch.returncode == 0:
             info["branch"] = branch.stdout.strip()
         if sha.returncode == 0:
-            info["sha"] = sha.stdout.strip()
+            info["full_sha"] = sha.stdout.strip()
+            info["sha"] = info["full_sha"][:7]
         if status.returncode == 0:
             info["dirty"] = bool(status.stdout.strip())
     except (OSError, subprocess.SubprocessError):
@@ -155,7 +176,10 @@ def git_pull_ff_only(status_cb=None) -> tuple[bool, str]:
         )
 
     try:
-        status = _git("status", "--porcelain", timeout=30)
+        # Only tracked modifications count as "dirty": untracked files (scratch
+        # scripts, editor droppings) can't be committed or stashed by the message
+        # below, and git itself refuses to overwrite them on a checkout.
+        status = _git("status", "--porcelain", "--untracked-files=no", timeout=30)
         if status.returncode != 0:
             return False, (status.stderr or status.stdout or "git status failed").strip()
         if status.stdout.strip():
@@ -232,7 +256,8 @@ def git_checkout_source(
         if source_type == "current":
             return git_pull_ff_only(status_cb=status_cb)
 
-        status = _git("status", "--porcelain", timeout=30)
+        # Tracked modifications only; see git_pull_ff_only for why.
+        status = _git("status", "--porcelain", "--untracked-files=no", timeout=30)
         if status.returncode != 0:
             return False, (status.stderr or status.stdout or "git status failed").strip()
         if status.stdout.strip():

--- a/src/Ankimon/pyobj/update_manager.py
+++ b/src/Ankimon/pyobj/update_manager.py
@@ -150,84 +150,6 @@ def get_git_checkout_info() -> dict:
     return info
 
 
-def git_pull_ff_only(status_cb=None) -> tuple[bool, str]:
-    """Update a dev clone via ``git pull --ff-only`` (+ submodule update).
-
-    Safe by construction: ``--ff-only`` refuses, without changing anything, when
-    the tree is dirty or the branch has diverged — so it never creates merge
-    conflicts. Returns ``(success, message)``.
-    """
-
-    def log(msg):
-        if status_cb:
-            status_cb(msg)
-
-    root = _git_repo_root()
-    if root is None:
-        return False, "Ankimon is not running from a git checkout."
-
-    if shutil.which("git") is None:
-        return False, (
-            "git wasn't found on Anki's PATH. This is common when Anki is "
-            "launched from the dock/Finder, which doesn't inherit your shell "
-            "PATH. Restart Anki from a terminal, or run 'git pull' in your "
-            "clone yourself."
-        )
-
-    def _git(*args, timeout=180):
-        return subprocess.run(
-            ["git", "-C", str(root), *args],
-            capture_output=True,
-            text=True,
-            timeout=timeout,
-        )
-
-    try:
-        # Only tracked modifications count as "dirty": untracked files (scratch
-        # scripts, editor droppings) can't be committed or stashed by the message
-        # below, and git itself refuses to overwrite them on a checkout.
-        status = _git("status", "--porcelain", "--untracked-files=no", timeout=30)
-        if status.returncode != 0:
-            return False, (status.stderr or status.stdout or "git status failed").strip()
-        if status.stdout.strip():
-            return False, (
-                "Your Ankimon checkout has local changes. Commit, stash, or discard "
-                "them before updating from the updater."
-            )
-
-        branch = (
-            _git("rev-parse", "--abbrev-ref", "HEAD", timeout=30).stdout or ""
-        ).strip() or "HEAD"
-        if branch == "HEAD":
-            return False, (
-                "This checkout is detached. Select a branch, release, tag, or PR in "
-                "the updater instead of pulling the current checkout."
-            )
-        log(f"Fast-forwarding '{branch}' (git pull --ff-only)...")
-        pull = _git("pull", "--ff-only")
-        if pull.returncode != 0:
-            err = (pull.stderr or pull.stdout or "").strip()
-            return False, (
-                f"Could not fast-forward '{branch}'. This is expected if you "
-                "have local changes/commits or no upstream — resolve it manually "
-                "with git.\n\n" + err
-            )
-        log("Updating submodules...")
-        sub = _git("submodule", "update", "--init", "--recursive")
-        out = (pull.stdout or "").strip()
-        if sub.returncode != 0:
-            return True, (
-                f"Updated '{branch}', but the submodule update failed — run "
-                "'git submodule update --init --recursive' manually.\n\n"
-                + (sub.stderr or "").strip()
-            )
-        return True, f"Updated '{branch}' via git pull --ff-only.\n\n{out}"
-    except subprocess.TimeoutExpired:
-        return False, "git timed out. Update manually with 'git pull'."
-    except Exception as e:
-        return False, f"git update failed: {e}. Update manually with 'git pull'."
-
-
 def git_checkout_source(
     source_type: str,
     source_name: Optional[str] = None,
@@ -276,7 +198,9 @@ def git_checkout_source(
                 )
             source_type, source_name = "branch", branch
 
-        # Tracked modifications only; see git_pull_ff_only for why.
+        # Only tracked modifications count as "dirty": untracked files (scratch
+        # scripts, editor droppings) can't be committed or stashed as the message
+        # below asks, and git itself refuses to overwrite them on a checkout.
         status = _git("status", "--porcelain", "--untracked-files=no", timeout=30)
         if status.returncode != 0:
             return False, (status.stderr or status.stdout or "git status failed").strip()

--- a/src/Ankimon/pyobj/update_manager.py
+++ b/src/Ankimon/pyobj/update_manager.py
@@ -19,6 +19,7 @@ from ..resources import addon_dir
 REPO_OWNER = "h0tp-ftw"
 REPO_NAME = "ankimon"
 GITHUB_API = f"https://api.github.com/repos/{REPO_OWNER}/{REPO_NAME}"
+GIT_REMOTE_URL = f"https://github.com/{REPO_OWNER}/{REPO_NAME}.git"
 DOWNLOAD_TIMEOUT = 30
 USER_AGENT = "Ankimon-Updater (https://github.com/h0tp-ftw/ankimon)"
 DEFAULT_SUBMODULE_SHA = "f3092b03fbe1e37d1788ef802dee98906d621e36"
@@ -60,21 +61,43 @@ def _git_repo_root() -> Optional[Path]:
 
 
 def is_git_clone() -> bool:
-    """True if Ankimon runs from a git working tree (a dev clone).
+    """True if Ankimon runs from a git working tree.
 
-    The in-place updater would overwrite every file under ``addon_dir`` with the
-    downloaded copy, trashing the working tree and any uncommitted/untracked
-    changes (``.git`` is above ``addon_dir`` so it survives, but the checkout is
-    clobbered). So the destructive updater is hidden for clones; a safe
-    ``git pull --ff-only`` is offered instead (see ``git_pull_ff_only``).
+    Git detection is independent of developer mode: the archive installer must
+    never overwrite a checkout. The updater dialog stays available for clones,
+    but routes selections through safe Git operations instead.
     """
-    try:
-        from ..utils import is_dev_mode
-        if is_dev_mode():
-            return False
-    except Exception:
-        pass
     return _git_repo_root() is not None
+
+
+def get_git_checkout_info() -> dict:
+    """Return lightweight display information for the updater's Git mode."""
+    root = _git_repo_root()
+    info = {"is_git": root is not None, "branch": "", "sha": "", "dirty": False}
+    if root is None or shutil.which("git") is None:
+        return info
+
+    def _git(*args):
+        return subprocess.run(
+            ["git", "-C", str(root), *args],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+
+    try:
+        branch = _git("rev-parse", "--abbrev-ref", "HEAD")
+        sha = _git("rev-parse", "--short", "HEAD")
+        status = _git("status", "--porcelain")
+        if branch.returncode == 0:
+            info["branch"] = branch.stdout.strip()
+        if sha.returncode == 0:
+            info["sha"] = sha.stdout.strip()
+        if status.returncode == 0:
+            info["dirty"] = bool(status.stdout.strip())
+    except (OSError, subprocess.SubprocessError):
+        pass
+    return info
 
 
 def git_pull_ff_only(status_cb=None) -> tuple[bool, str]:
@@ -110,9 +133,23 @@ def git_pull_ff_only(status_cb=None) -> tuple[bool, str]:
         )
 
     try:
+        status = _git("status", "--porcelain", timeout=30)
+        if status.returncode != 0:
+            return False, (status.stderr or status.stdout or "git status failed").strip()
+        if status.stdout.strip():
+            return False, (
+                "Your Ankimon checkout has local changes. Commit, stash, or discard "
+                "them before updating from the updater."
+            )
+
         branch = (
             _git("rev-parse", "--abbrev-ref", "HEAD", timeout=30).stdout or ""
         ).strip() or "HEAD"
+        if branch == "HEAD":
+            return False, (
+                "This checkout is detached. Select a branch, release, tag, or PR in "
+                "the updater instead of pulling the current checkout."
+            )
         log(f"Fast-forwarding '{branch}' (git pull --ff-only)...")
         pull = _git("pull", "--ff-only")
         if pull.returncode != 0:
@@ -136,6 +173,127 @@ def git_pull_ff_only(status_cb=None) -> tuple[bool, str]:
         return False, "git timed out. Update manually with 'git pull'."
     except Exception as e:
         return False, f"git update failed: {e}. Update manually with 'git pull'."
+
+
+def git_checkout_source(
+    source_type: str,
+    source_name: Optional[str] = None,
+    status_cb=None,
+) -> tuple[bool, str]:
+    """Safely move a Git checkout to a branch, PR, tag, or release.
+
+    Existing local branches and commits are never reset. An existing local branch
+    is reattached and fast-forwarded from the official repository; PRs, tags,
+    releases, and branches without a local counterpart are checked out detached.
+    A dirty working tree is refused before any checkout, and submodules are synced.
+    """
+
+    def log(msg):
+        if status_cb:
+            status_cb(msg)
+
+    root = _git_repo_root()
+    if root is None:
+        return False, "Ankimon is not running from a git checkout."
+    if shutil.which("git") is None:
+        return False, "git wasn't found on Anki's PATH."
+
+    def _git(*args, timeout=180):
+        return subprocess.run(
+            ["git", "-C", str(root), *args],
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+
+    try:
+        if source_type == "current":
+            return git_pull_ff_only(status_cb=status_cb)
+
+        status = _git("status", "--porcelain", timeout=30)
+        if status.returncode != 0:
+            return False, (status.stderr or status.stdout or "git status failed").strip()
+        if status.stdout.strip():
+            return False, (
+                "Your Ankimon checkout has local changes. Commit, stash, or discard "
+                "them before switching versions in the updater."
+            )
+
+        if not source_name:
+            return False, "No Git target was selected."
+
+        if source_type == "pr":
+            remote_ref = f"refs/pull/{source_name}/head"
+            display = f"PR #{source_name}"
+        elif source_type == "branch":
+            remote_ref = f"refs/heads/{source_name}"
+            display = f"branch '{source_name}'"
+        elif source_type in {"tag", "release"}:
+            remote_ref = f"refs/tags/{source_name}"
+            display = f"{source_type} '{source_name}'"
+        else:
+            return False, f"Unsupported Git source type: {source_type}"
+
+        log(f"Fetching {display} from the Ankimon repository...")
+        fetch = _git("fetch", "--force", GIT_REMOTE_URL, remote_ref)
+        if fetch.returncode != 0:
+            return False, (
+                f"Could not fetch {display}.\n\n"
+                + (fetch.stderr or fetch.stdout or "Unknown git fetch error").strip()
+            )
+
+        checkout_ref = "FETCH_HEAD"
+        if source_type == "branch":
+            local_branch = _git(
+                "show-ref", "--verify", "--quiet", f"refs/heads/{source_name}",
+                timeout=30,
+            )
+            if local_branch.returncode == 0:
+                checkout = _git("checkout", source_name)
+                if checkout.returncode != 0:
+                    return False, (
+                        f"Could not check out local branch '{source_name}'.\n\n"
+                        + (checkout.stderr or checkout.stdout or "Unknown git checkout error").strip()
+                    )
+                log(f"Fast-forwarding local branch '{source_name}'...")
+                merge = _git("merge", "--ff-only", checkout_ref)
+                if merge.returncode != 0:
+                    return False, (
+                        f"Local branch '{source_name}' could not be fast-forwarded. "
+                        "Your commits were left unchanged.\n\n"
+                        + (merge.stderr or merge.stdout or "Unknown git merge error").strip()
+                    )
+                checkout_ref = None
+
+        if checkout_ref is not None:
+            log(f"Checking out {display}...")
+            checkout = _git("checkout", "--detach", checkout_ref)
+            if checkout.returncode != 0:
+                return False, (
+                    f"Could not check out {display}.\n\n"
+                    + (checkout.stderr or checkout.stdout or "Unknown git checkout error").strip()
+                )
+
+        operation = "Updated" if checkout_ref is None else "Checked out"
+        log("Updating submodules...")
+        sub = _git("submodule", "update", "--init", "--recursive")
+        if sub.returncode != 0:
+            return True, (
+                f"{operation} {display}, but the submodule update failed. Run "
+                "'git submodule update --init --recursive' manually.\n\n"
+                + (sub.stderr or sub.stdout or "").strip()
+            )
+
+        sha = _git("rev-parse", "--short", "HEAD", timeout=30)
+        sha_text = sha.stdout.strip() if sha.returncode == 0 else "the selected commit"
+        return True, (
+            f"{operation} {display} at {sha_text}. Local commits were not rewritten. "
+            "Please restart Anki."
+        )
+    except subprocess.TimeoutExpired:
+        return False, "git timed out while switching the Ankimon checkout."
+    except Exception as e:
+        return False, f"git checkout failed: {e}"
 
 
 def _parse_version(name: str) -> Optional[tuple]:

--- a/tests/test_update_dialog_busy_state.py
+++ b/tests/test_update_dialog_busy_state.py
@@ -86,6 +86,12 @@ def _load_update_dialog():
             # to import at collection time.
             "published_at_for_tag",
             "stamp_addon_mod",
+            # Git-checkout helpers. The default stub returns None, so
+            # is_git_clone() is falsy here and these tests keep exercising the
+            # non-Git download path.
+            "is_git_clone",
+            "get_git_checkout_info",
+            "git_checkout_source",
         ):
             setattr(update_manager, name, lambda *args, **kwargs: None)
         sys.modules["Ankimon.pyobj.update_manager"] = update_manager
@@ -231,6 +237,11 @@ def _make_dialog():
         _close_finalized=False,
         _sprites_busy_token=None,
         sprites_thread=None,
+        # Non-Git install: _run_update branches on _git_clone to choose between
+        # the download and the git-checkout path, and _git_info gates the
+        # fast-forward button. These fakes exercise the download path.
+        _git_clone=False,
+        _git_info={},
     )
     dialog._action_buttons = types.MethodType(
         update_dialog.UpdateDialog._action_buttons, dialog

--- a/tests/test_update_dialog_busy_state.py
+++ b/tests/test_update_dialog_busy_state.py
@@ -243,6 +243,8 @@ def _make_dialog():
         # fast-forward button. These fakes exercise the download path.
         _git_clone=False,
         _git_info={},
+        _git_remote_sha=None,
+        _git_ff_blocked=False,
     )
     dialog._action_buttons = types.MethodType(
         update_dialog.UpdateDialog._action_buttons, dialog
@@ -289,6 +291,8 @@ def test_git_pull_button_joins_the_busy_cycle_and_restores_its_gate():
     dialog, _ = _make_dialog()
     dialog._git_clone = True
     dialog._git_info = {"branch": "main", "sha": "abc1234", "dirty": True}
+    dialog._git_remote_sha = "f" * 40
+    dialog._git_ff_blocked = False
     dialog.git_pull_btn = _Control(True)
     update_dialog.UpdateDialog._set_action_enabled(dialog, dialog.git_pull_btn, False)
     assert dialog.git_pull_btn in dialog._action_buttons()

--- a/tests/test_update_dialog_busy_state.py
+++ b/tests/test_update_dialog_busy_state.py
@@ -92,6 +92,7 @@ def _load_update_dialog():
             "is_git_clone",
             "get_git_checkout_info",
             "git_checkout_source",
+            "fetch_branch_relation",
         ):
             setattr(update_manager, name, lambda *args, **kwargs: None)
         sys.modules["Ankimon.pyobj.update_manager"] = update_manager
@@ -278,6 +279,31 @@ def test_busy_state_disables_all_actions_and_restores_prior_state():
         True,
     ]
     assert dialog.status_label.text == ""
+
+
+def test_git_pull_button_joins_the_busy_cycle_and_restores_its_gate():
+    # Git-checkout mode adds git_pull_btn. It must be disabled with the others
+    # while busy and come back to the state the checkout gate chose (disabled on
+    # a dirty or detached tree), because _end_busy restores from
+    # _action_button_states rather than re-deriving it.
+    dialog, _ = _make_dialog()
+    dialog._git_clone = True
+    dialog._git_info = {"branch": "main", "sha": "abc1234", "dirty": True}
+    dialog.git_pull_btn = _Control(True)
+    update_dialog.UpdateDialog._set_action_enabled(dialog, dialog.git_pull_btn, False)
+    assert dialog.git_pull_btn in dialog._action_buttons()
+
+    busy_token = update_dialog.UpdateDialog._begin_busy(dialog)
+    assert dialog.git_pull_btn.enabled is False
+    update_dialog.UpdateDialog._end_busy(dialog, busy_token)
+    assert dialog.git_pull_btn.enabled is False
+
+    # A clean, attached checkout is allowed to pull, and that survives a cycle.
+    update_dialog.UpdateDialog._set_action_enabled(dialog, dialog.git_pull_btn, True)
+    busy_token = update_dialog.UpdateDialog._begin_busy(dialog)
+    assert dialog.git_pull_btn.enabled is False
+    update_dialog.UpdateDialog._end_busy(dialog, busy_token)
+    assert dialog.git_pull_btn.enabled is True
 
 
 def test_overlapping_operations_keep_busy_and_apply_latest_button_states():

--- a/tests/test_update_manager.py
+++ b/tests/test_update_manager.py
@@ -12,6 +12,7 @@ what the services-registry refactor targets.)
 
 import importlib.util
 import json
+import os
 import sys
 import time
 import types
@@ -171,7 +172,7 @@ def test_apply_update_refuses_on_git_clone_and_cleans_zip(tmp_path, monkeypatch)
     assert not dummy_zip.exists()  # guard cleaned up the downloaded archive
 
 
-# --- git_pull_ff_only --------------------------------------------------------
+# --- git helpers fakes -------------------------------------------------------
 
 class _FakeProc:
     def __init__(self, returncode=0, stdout="", stderr=""):
@@ -185,111 +186,6 @@ def _fake_git(responses):
     def _run(cmd, **kwargs):
         return responses.get(cmd[3], _FakeProc(0))
     return _run
-
-
-def test_git_pull_reports_not_a_clone(monkeypatch):
-    monkeypatch.setattr(um, "_git_repo_root", lambda: None)
-    ok, msg = um.git_pull_ff_only()
-    assert ok is False
-    assert "not running from a git checkout" in msg.lower()
-
-
-def test_git_pull_handles_git_missing_from_path(tmp_path, monkeypatch):
-    monkeypatch.setattr(um, "_git_repo_root", lambda: tmp_path)
-    monkeypatch.setattr(um.shutil, "which", lambda _name: None)
-    ok, msg = um.git_pull_ff_only()
-    assert ok is False
-    assert "path" in msg.lower()
-
-
-def test_git_pull_success_names_the_branch(tmp_path, monkeypatch):
-    monkeypatch.setattr(um, "_git_repo_root", lambda: tmp_path)
-    monkeypatch.setattr(um.shutil, "which", lambda _name: "/usr/bin/git")
-    monkeypatch.setattr(um.subprocess, "run", _fake_git({
-        "rev-parse": _FakeProc(0, "main\n"),
-        "pull": _FakeProc(0, "Updating 111..222\n"),
-        "submodule": _FakeProc(0, ""),
-    }))
-    ok, msg = um.git_pull_ff_only()
-    assert ok is True
-    assert "main" in msg
-
-
-def test_git_pull_ff_failure_is_safe(tmp_path, monkeypatch):
-    monkeypatch.setattr(um, "_git_repo_root", lambda: tmp_path)
-    monkeypatch.setattr(um.shutil, "which", lambda _name: "/usr/bin/git")
-    monkeypatch.setattr(um.subprocess, "run", _fake_git({
-        "rev-parse": _FakeProc(0, "feature\n"),
-        "pull": _FakeProc(1, "", "fatal: Not possible to fast-forward, aborting."),
-    }))
-    ok, msg = um.git_pull_ff_only()
-    assert ok is False
-    assert "fast-forward" in msg.lower()
-
-
-def test_git_pull_refuses_dirty_tree(tmp_path, monkeypatch):
-    monkeypatch.setattr(um, "_git_repo_root", lambda: tmp_path)
-    monkeypatch.setattr(um.shutil, "which", lambda _name: "/usr/bin/git")
-    monkeypatch.setattr(
-        um.subprocess,
-        "run",
-        _fake_git({"status": _FakeProc(0, " M src/Ankimon/example.py\n")}),
-    )
-
-    ok, msg = um.git_pull_ff_only()
-
-    assert ok is False
-    assert "local changes" in msg.lower()
-
-
-def test_git_dirty_checks_ignore_untracked_files(tmp_path, monkeypatch):
-    # Untracked files can't be "committed, stashed, or discarded" the way the
-    # refusal message says, and git itself refuses to clobber them on checkout.
-    # Both helpers and the banner query must ask git to leave them out.
-    monkeypatch.setattr(um, "_git_repo_root", lambda: tmp_path)
-    monkeypatch.setattr(um.shutil, "which", lambda _name: "/usr/bin/git")
-    status_calls = []
-
-    def _run(cmd, **kwargs):
-        if cmd[3] == "status":
-            status_calls.append(cmd[3:])
-            # A real git honoring --untracked-files=no prints nothing here.
-            return _FakeProc(0, "" if "--untracked-files=no" in cmd else "?? scratch.py\n")
-        if cmd[3] == "rev-parse" and "--abbrev-ref" in cmd:
-            return _FakeProc(0, "main\n")
-        if cmd[3] == "rev-parse":
-            return _FakeProc(0, "0123456789abcdef0123456789abcdef01234567\n")
-        return _FakeProc(0, "")
-
-    monkeypatch.setattr(um.subprocess, "run", _run)
-
-    ok, _ = um.git_pull_ff_only()
-    assert ok is True
-    ok, _ = um.git_checkout_source("tag", "v2.0")
-    assert ok is True
-    info = um.get_git_checkout_info()
-    assert info["dirty"] is False
-    assert info["branch"] == "main"
-    assert info["full_sha"] == "0123456789abcdef0123456789abcdef01234567"
-    assert info["sha"] == "0123456"
-
-    assert status_calls, "every path must run git status"
-    assert all("--untracked-files=no" in c for c in status_calls)
-
-
-def test_git_pull_refuses_detached_checkout(tmp_path, monkeypatch):
-    monkeypatch.setattr(um, "_git_repo_root", lambda: tmp_path)
-    monkeypatch.setattr(um.shutil, "which", lambda _name: "/usr/bin/git")
-    monkeypatch.setattr(
-        um.subprocess,
-        "run",
-        _fake_git({"rev-parse": _FakeProc(0, "HEAD\n")}),
-    )
-
-    ok, msg = um.git_pull_ff_only()
-
-    assert ok is False
-    assert "detached" in msg.lower()
 
 
 # --- git_checkout_source -----------------------------------------------------
@@ -480,12 +376,18 @@ def test_git_checkout_source_reattach_is_atomic_against_real_git(tmp_path, monke
     if not um.shutil.which("git"):
         pytest.skip("git not installed")
 
+    # Hermetic: a contributor's global config (commit.gpgsign, hooks, default
+    # branch) must not be able to fail this test.
+    monkeypatch.setenv("GIT_CONFIG_GLOBAL", os.devnull)
+    monkeypatch.setenv("GIT_CONFIG_NOSYSTEM", "1")
+
     def git(cwd, *args):
         return sp.run(["git", "-C", str(cwd), *args], capture_output=True, text=True, check=True)
 
     canonical = tmp_path / "canonical"
     canonical.mkdir()
-    git(canonical, "init", "-q", "-b", "main")
+    git(canonical, "init", "-q")
+    git(canonical, "symbolic-ref", "HEAD", "refs/heads/main")
     git(canonical, "-c", "user.email=t@example.com", "-c", "user.name=t", "commit", "-q", "--allow-empty", "-m", "base")
     clone = tmp_path / "clone"
     git(tmp_path, "clone", "-q", str(canonical), str(clone))

--- a/tests/test_update_manager.py
+++ b/tests/test_update_manager.py
@@ -102,20 +102,14 @@ def test_is_git_clone_true_when_addon_dir_is_repo(tmp_path, monkeypatch):
     assert um.is_git_clone() is True
 
 
-def test_is_git_clone_false_in_dev_mode(tmp_path, monkeypatch):
-    from unittest.mock import patch
+def test_is_git_clone_stays_true_in_dev_mode(tmp_path, monkeypatch):
     addon = tmp_path / "ankimon"
     addon.mkdir()
     (addon / ".git").mkdir()
     monkeypatch.setattr(um, "addon_dir", addon)
 
-    # When not in dev mode, it returns True because it has a .git folder
-    with patch("Ankimon.utils.is_dev_mode", return_value=False):
-        assert um.is_git_clone() is True
-
-    # When in dev mode, it returns False even with a .git folder
-    with patch("Ankimon.utils.is_dev_mode", return_value=True):
-        assert um.is_git_clone() is False
+    # Developer naming must not disable the checkout safety guard.
+    assert um.is_git_clone() is True
 
 
 def test_is_git_clone_false_for_plain_install(tmp_path, monkeypatch):
@@ -193,6 +187,113 @@ def test_git_pull_ff_failure_is_safe(tmp_path, monkeypatch):
     ok, msg = um.git_pull_ff_only()
     assert ok is False
     assert "fast-forward" in msg.lower()
+
+
+def test_git_pull_refuses_dirty_tree(tmp_path, monkeypatch):
+    monkeypatch.setattr(um, "_git_repo_root", lambda: tmp_path)
+    monkeypatch.setattr(um.shutil, "which", lambda _name: "/usr/bin/git")
+    monkeypatch.setattr(
+        um.subprocess,
+        "run",
+        _fake_git({"status": _FakeProc(0, " M src/Ankimon/example.py\n")}),
+    )
+
+    ok, msg = um.git_pull_ff_only()
+
+    assert ok is False
+    assert "local changes" in msg.lower()
+
+
+def test_git_pull_refuses_detached_checkout(tmp_path, monkeypatch):
+    monkeypatch.setattr(um, "_git_repo_root", lambda: tmp_path)
+    monkeypatch.setattr(um.shutil, "which", lambda _name: "/usr/bin/git")
+    monkeypatch.setattr(
+        um.subprocess,
+        "run",
+        _fake_git({"rev-parse": _FakeProc(0, "HEAD\n")}),
+    )
+
+    ok, msg = um.git_pull_ff_only()
+
+    assert ok is False
+    assert "detached" in msg.lower()
+
+
+# --- git_checkout_source -----------------------------------------------------
+
+
+def test_git_checkout_source_refuses_dirty_tree(tmp_path, monkeypatch):
+    monkeypatch.setattr(um, "_git_repo_root", lambda: tmp_path)
+    monkeypatch.setattr(um.shutil, "which", lambda _name: "/usr/bin/git")
+    monkeypatch.setattr(
+        um.subprocess,
+        "run",
+        _fake_git({"status": _FakeProc(0, " M src/Ankimon/example.py\n")}),
+    )
+
+    ok, msg = um.git_checkout_source("pr", "123")
+
+    assert ok is False
+    assert "local changes" in msg.lower()
+
+
+def test_git_checkout_source_fetches_pr_detached(tmp_path, monkeypatch):
+    monkeypatch.setattr(um, "_git_repo_root", lambda: tmp_path)
+    monkeypatch.setattr(um.shutil, "which", lambda _name: "/usr/bin/git")
+    calls = []
+
+    def _run(cmd, **kwargs):
+        calls.append(cmd[3:])
+        if cmd[3] == "status":
+            return _FakeProc(0, "")
+        if cmd[3] == "rev-parse" and "--abbrev-ref" in cmd:
+            return _FakeProc(0, "main\n")
+        if cmd[3] == "rev-parse" and "--short" in cmd:
+            return _FakeProc(0, "abc1234\n")
+        return _FakeProc(0, "")
+
+    monkeypatch.setattr(um.subprocess, "run", _run)
+
+    ok, msg = um.git_checkout_source("pr", "123")
+
+    assert ok is True
+    assert "PR #123" in msg
+    assert [
+        "fetch",
+        "--force",
+        um.GIT_REMOTE_URL,
+        "refs/pull/123/head",
+    ] in calls
+    assert ["checkout", "--detach", "FETCH_HEAD"] in calls
+    assert ["submodule", "update", "--init", "--recursive"] in calls
+
+
+def test_git_checkout_source_reattaches_existing_branch(tmp_path, monkeypatch):
+    monkeypatch.setattr(um, "_git_repo_root", lambda: tmp_path)
+    monkeypatch.setattr(um.shutil, "which", lambda _name: "/usr/bin/git")
+    calls = []
+
+    def _run(cmd, **kwargs):
+        calls.append(cmd[3:])
+        if cmd[3] == "status":
+            return _FakeProc(0, "")
+        if cmd[3] == "rev-parse" and "--abbrev-ref" in cmd:
+            return _FakeProc(0, "HEAD\n")
+        if cmd[3] == "rev-parse" and "--short" in cmd:
+            return _FakeProc(0, "def5678\n")
+        if cmd[3] == "show-ref":
+            return _FakeProc(0, "")
+        return _FakeProc(0, "")
+
+    monkeypatch.setattr(um.subprocess, "run", _run)
+
+    ok, msg = um.git_checkout_source("branch", "main")
+
+    assert ok is True
+    assert "branch 'main'" in msg
+    assert ["checkout", "main"] in calls
+    assert ["merge", "--ff-only", "FETCH_HEAD"] in calls
+    assert ["checkout", "--detach", "FETCH_HEAD"] not in calls
 
 
 # --- pre-v2.0 version filtering ----------------------------------------------

--- a/tests/test_update_manager.py
+++ b/tests/test_update_manager.py
@@ -97,20 +97,14 @@ def test_is_git_clone_true_when_addon_dir_is_repo(tmp_path, monkeypatch):
     assert um.is_git_clone() is True
 
 
-def test_is_git_clone_false_in_dev_mode(tmp_path, monkeypatch):
-    from unittest.mock import patch
+def test_is_git_clone_stays_true_in_dev_mode(tmp_path, monkeypatch):
     addon = tmp_path / "ankimon"
     addon.mkdir()
     (addon / ".git").mkdir()
     monkeypatch.setattr(um, "addon_dir", addon)
 
-    # When not in dev mode, it returns True because it has a .git folder
-    with patch("Ankimon.utils.is_dev_mode", return_value=False):
-        assert um.is_git_clone() is True
-
-    # When in dev mode, it returns False even with a .git folder
-    with patch("Ankimon.utils.is_dev_mode", return_value=True):
-        assert um.is_git_clone() is False
+    # Developer naming must not disable the checkout safety guard.
+    assert um.is_git_clone() is True
 
 
 def test_is_git_clone_false_for_plain_install(tmp_path, monkeypatch):
@@ -187,6 +181,113 @@ def test_git_pull_ff_failure_is_safe(tmp_path, monkeypatch):
     ok, msg = um.git_pull_ff_only()
     assert ok is False
     assert "fast-forward" in msg.lower()
+
+
+def test_git_pull_refuses_dirty_tree(tmp_path, monkeypatch):
+    monkeypatch.setattr(um, "_git_repo_root", lambda: tmp_path)
+    monkeypatch.setattr(um.shutil, "which", lambda _name: "/usr/bin/git")
+    monkeypatch.setattr(
+        um.subprocess,
+        "run",
+        _fake_git({"status": _FakeProc(0, " M src/Ankimon/example.py\n")}),
+    )
+
+    ok, msg = um.git_pull_ff_only()
+
+    assert ok is False
+    assert "local changes" in msg.lower()
+
+
+def test_git_pull_refuses_detached_checkout(tmp_path, monkeypatch):
+    monkeypatch.setattr(um, "_git_repo_root", lambda: tmp_path)
+    monkeypatch.setattr(um.shutil, "which", lambda _name: "/usr/bin/git")
+    monkeypatch.setattr(
+        um.subprocess,
+        "run",
+        _fake_git({"rev-parse": _FakeProc(0, "HEAD\n")}),
+    )
+
+    ok, msg = um.git_pull_ff_only()
+
+    assert ok is False
+    assert "detached" in msg.lower()
+
+
+# --- git_checkout_source -----------------------------------------------------
+
+
+def test_git_checkout_source_refuses_dirty_tree(tmp_path, monkeypatch):
+    monkeypatch.setattr(um, "_git_repo_root", lambda: tmp_path)
+    monkeypatch.setattr(um.shutil, "which", lambda _name: "/usr/bin/git")
+    monkeypatch.setattr(
+        um.subprocess,
+        "run",
+        _fake_git({"status": _FakeProc(0, " M src/Ankimon/example.py\n")}),
+    )
+
+    ok, msg = um.git_checkout_source("pr", "123")
+
+    assert ok is False
+    assert "local changes" in msg.lower()
+
+
+def test_git_checkout_source_fetches_pr_detached(tmp_path, monkeypatch):
+    monkeypatch.setattr(um, "_git_repo_root", lambda: tmp_path)
+    monkeypatch.setattr(um.shutil, "which", lambda _name: "/usr/bin/git")
+    calls = []
+
+    def _run(cmd, **kwargs):
+        calls.append(cmd[3:])
+        if cmd[3] == "status":
+            return _FakeProc(0, "")
+        if cmd[3] == "rev-parse" and "--abbrev-ref" in cmd:
+            return _FakeProc(0, "main\n")
+        if cmd[3] == "rev-parse" and "--short" in cmd:
+            return _FakeProc(0, "abc1234\n")
+        return _FakeProc(0, "")
+
+    monkeypatch.setattr(um.subprocess, "run", _run)
+
+    ok, msg = um.git_checkout_source("pr", "123")
+
+    assert ok is True
+    assert "PR #123" in msg
+    assert [
+        "fetch",
+        "--force",
+        um.GIT_REMOTE_URL,
+        "refs/pull/123/head",
+    ] in calls
+    assert ["checkout", "--detach", "FETCH_HEAD"] in calls
+    assert ["submodule", "update", "--init", "--recursive"] in calls
+
+
+def test_git_checkout_source_reattaches_existing_branch(tmp_path, monkeypatch):
+    monkeypatch.setattr(um, "_git_repo_root", lambda: tmp_path)
+    monkeypatch.setattr(um.shutil, "which", lambda _name: "/usr/bin/git")
+    calls = []
+
+    def _run(cmd, **kwargs):
+        calls.append(cmd[3:])
+        if cmd[3] == "status":
+            return _FakeProc(0, "")
+        if cmd[3] == "rev-parse" and "--abbrev-ref" in cmd:
+            return _FakeProc(0, "HEAD\n")
+        if cmd[3] == "rev-parse" and "--short" in cmd:
+            return _FakeProc(0, "def5678\n")
+        if cmd[3] == "show-ref":
+            return _FakeProc(0, "")
+        return _FakeProc(0, "")
+
+    monkeypatch.setattr(um.subprocess, "run", _run)
+
+    ok, msg = um.git_checkout_source("branch", "main")
+
+    assert ok is True
+    assert "branch 'main'" in msg
+    assert ["checkout", "main"] in calls
+    assert ["merge", "--ff-only", "FETCH_HEAD"] in calls
+    assert ["checkout", "--detach", "FETCH_HEAD"] not in calls
 
 
 # --- pre-v2.0 version filtering ----------------------------------------------

--- a/tests/test_update_manager.py
+++ b/tests/test_update_manager.py
@@ -367,6 +367,140 @@ def test_git_checkout_source_reattaches_existing_branch(tmp_path, monkeypatch):
     assert ["checkout", "main"] in calls
     assert ["merge", "--ff-only", "FETCH_HEAD"] in calls
     assert ["checkout", "--detach", "FETCH_HEAD"] not in calls
+    # The fast-forward is proven before HEAD moves, not discovered after.
+    ancestry = ["merge-base", "--is-ancestor", "refs/heads/main", "FETCH_HEAD"]
+    assert ancestry in calls
+    assert calls.index(ancestry) < calls.index(["checkout", "main"])
+
+
+def test_git_checkout_source_refuses_unfastforwardable_branch_before_moving_head(
+    tmp_path, monkeypatch
+):
+    # Local main has commits the canonical repo lacks (diverged or ahead). The
+    # refusal must come BEFORE any checkout: the user is on 'feature' and must
+    # still be on 'feature' when the "Update Failed" box appears.
+    monkeypatch.setattr(um, "_git_repo_root", lambda: tmp_path)
+    monkeypatch.setattr(um.shutil, "which", lambda _name: "/usr/bin/git")
+    calls = []
+
+    def _run(cmd, **kwargs):
+        calls.append(cmd[3:])
+        if cmd[3] == "merge-base":
+            return _FakeProc(1, "")  # not an ancestor
+        if cmd[3] == "show-ref":
+            return _FakeProc(0, "")
+        return _FakeProc(0, "")
+
+    monkeypatch.setattr(um.subprocess, "run", _run)
+
+    ok, msg = um.git_checkout_source("branch", "main")
+
+    assert ok is False
+    assert "nothing was changed" in msg.lower()
+    assert not any(c and c[0] in ("checkout", "merge") for c in calls)
+
+
+def test_git_checkout_source_reports_head_position_if_merge_fails_late(
+    tmp_path, monkeypatch
+):
+    # Ancestry said fast-forward is fine, checkout happened, then the merge
+    # failed anyway (tree changed under us). The message must not claim
+    # nothing changed: HEAD is now on the branch.
+    monkeypatch.setattr(um, "_git_repo_root", lambda: tmp_path)
+    monkeypatch.setattr(um.shutil, "which", lambda _name: "/usr/bin/git")
+    monkeypatch.setattr(
+        um.subprocess,
+        "run",
+        _fake_git({
+            "show-ref": _FakeProc(0, ""),
+            "merge": _FakeProc(1, "", "fatal: Not possible to fast-forward, aborting."),
+        }),
+    )
+
+    ok, msg = um.git_checkout_source("branch", "main")
+
+    assert ok is False
+    assert "now checked out" in msg.lower()
+    assert "nothing was changed" not in msg.lower()
+
+
+def test_git_checkout_source_current_fetches_canonical_branch(tmp_path, monkeypatch):
+    # "current" is the checked-out branch fetched from the OFFICIAL repository,
+    # not `git pull` against the checkout's own origin (a contributor's fork):
+    # the dialog compared HEAD against the official branch, so that is what
+    # must be installed.
+    monkeypatch.setattr(um, "_git_repo_root", lambda: tmp_path)
+    monkeypatch.setattr(um.shutil, "which", lambda _name: "/usr/bin/git")
+    calls = []
+
+    def _run(cmd, **kwargs):
+        calls.append(cmd[3:])
+        if cmd[3] == "rev-parse" and "--abbrev-ref" in cmd:
+            return _FakeProc(0, "feature\n")
+        if cmd[3] == "rev-parse":
+            return _FakeProc(0, "abc1234\n")
+        return _FakeProc(0, "")
+
+    monkeypatch.setattr(um.subprocess, "run", _run)
+
+    ok, msg = um.git_checkout_source("current", "current")
+
+    assert ok is True
+    assert "branch 'feature'" in msg
+    assert ["fetch", "--force", um.GIT_REMOTE_URL, "refs/heads/feature"] in calls
+    assert ["merge", "--ff-only", "FETCH_HEAD"] in calls
+    assert not any(c and c[0] == "pull" for c in calls)
+
+
+def test_git_checkout_source_current_refuses_detached_head(tmp_path, monkeypatch):
+    monkeypatch.setattr(um, "_git_repo_root", lambda: tmp_path)
+    monkeypatch.setattr(um.shutil, "which", lambda _name: "/usr/bin/git")
+    calls = []
+
+    def _run(cmd, **kwargs):
+        calls.append(cmd[3:])
+        if cmd[3] == "rev-parse" and "--abbrev-ref" in cmd:
+            return _FakeProc(0, "HEAD\n")
+        return _FakeProc(0, "")
+
+    monkeypatch.setattr(um.subprocess, "run", _run)
+
+    ok, msg = um.git_checkout_source("current", "current")
+
+    assert ok is False
+    assert "detached" in msg.lower()
+    assert not any(c and c[0] in ("fetch", "checkout", "merge") for c in calls)
+
+
+def test_git_checkout_source_reattach_is_atomic_against_real_git(tmp_path, monkeypatch):
+    # Real repositories, no fakes: 'main' diverged locally from the canonical
+    # repo. The refusal must leave HEAD on the branch the user was on.
+    import subprocess as sp
+
+    if not um.shutil.which("git"):
+        pytest.skip("git not installed")
+
+    def git(cwd, *args):
+        return sp.run(["git", "-C", str(cwd), *args], capture_output=True, text=True, check=True)
+
+    canonical = tmp_path / "canonical"
+    canonical.mkdir()
+    git(canonical, "init", "-q", "-b", "main")
+    git(canonical, "-c", "user.email=t@example.com", "-c", "user.name=t", "commit", "-q", "--allow-empty", "-m", "base")
+    clone = tmp_path / "clone"
+    git(tmp_path, "clone", "-q", str(canonical), str(clone))
+    git(clone, "-c", "user.email=t@example.com", "-c", "user.name=t", "commit", "-q", "--allow-empty", "-m", "local only")
+    git(clone, "checkout", "-q", "-b", "feature")
+    git(canonical, "-c", "user.email=t@example.com", "-c", "user.name=t", "commit", "-q", "--allow-empty", "-m", "upstream moved")
+
+    monkeypatch.setattr(um, "_git_repo_root", lambda: clone)
+    monkeypatch.setattr(um, "GIT_REMOTE_URL", str(canonical))
+
+    ok, msg = um.git_checkout_source("branch", "main")
+
+    assert ok is False
+    assert "nothing was changed" in msg.lower()
+    assert git(clone, "rev-parse", "--abbrev-ref", "HEAD").stdout.strip() == "feature"
 
 
 # --- pre-v2.0 version filtering ----------------------------------------------

--- a/tests/test_update_manager.py
+++ b/tests/test_update_manager.py
@@ -93,23 +93,61 @@ def test_is_git_clone_true_when_repo_root_has_dot_git(tmp_path, monkeypatch):
     assert um.is_git_clone() is True
 
 
-def test_is_git_clone_true_when_addon_dir_is_repo(tmp_path, monkeypatch):
-    addon = tmp_path / "ankimon"
-    addon.mkdir()
-    (addon / ".git").mkdir()
-    monkeypatch.setattr(um, "addon_dir", addon)
+def test_is_git_clone_follows_dev_symlink_into_repo(tmp_path, monkeypatch):
+    # The dev setup symlinks addons21/Ankimon -> <repo>/src/Ankimon. The walk
+    # must resolve the link first so the repo root is found through it.
+    addon = tmp_path / "repo" / "src" / "Ankimon"
+    addon.mkdir(parents=True)
+    (tmp_path / "repo" / ".git").mkdir()
+    link = tmp_path / "addons21" / "Ankimon"
+    link.parent.mkdir()
+    try:
+        link.symlink_to(addon, target_is_directory=True)
+    except (OSError, NotImplementedError):
+        pytest.skip("symlinks unavailable")
+    monkeypatch.setattr(um, "addon_dir", link)
 
     assert um.is_git_clone() is True
+    assert um._git_repo_root() == (tmp_path / "repo").resolve()
 
 
 def test_is_git_clone_stays_true_in_dev_mode(tmp_path, monkeypatch):
-    addon = tmp_path / "ankimon"
-    addon.mkdir()
-    (addon / ".git").mkdir()
+    addon = tmp_path / "repo" / "src" / "Ankimon"
+    addon.mkdir(parents=True)
+    (tmp_path / "repo" / ".git").mkdir()
     monkeypatch.setattr(um, "addon_dir", addon)
 
     # Developer naming must not disable the checkout safety guard.
     assert um.is_git_clone() is True
+
+
+def test_is_git_clone_false_when_enclosing_repo_is_not_ankimon(tmp_path, monkeypatch):
+    # Anki's data folder (or $HOME) can itself be a git repo. That is a plain
+    # install: the archive updater must keep serving it, and above all the Git
+    # checkout helpers must never fetch Ankimon's history into that repo.
+    addon = tmp_path / "Anki2" / "addons21" / "1908235722"
+    addon.mkdir(parents=True)
+    (tmp_path / "Anki2" / ".git").mkdir()
+    monkeypatch.setattr(um, "addon_dir", addon)
+
+    assert um.is_git_clone() is False
+    assert um._git_repo_root() is None
+
+    ok, msg = um.git_checkout_source("pr", "123")
+    assert ok is False
+    assert "not running from a git checkout" in msg.lower()
+
+
+def test_is_git_clone_false_when_repo_has_a_different_ankimon(tmp_path, monkeypatch):
+    # A .git above the addon whose src/Ankimon is some *other* directory is not
+    # the checkout this addon runs from.
+    addon = tmp_path / "repo" / "vendor" / "Ankimon"
+    addon.mkdir(parents=True)
+    (tmp_path / "repo" / "src" / "Ankimon").mkdir(parents=True)
+    (tmp_path / "repo" / ".git").mkdir()
+    monkeypatch.setattr(um, "addon_dir", addon)
+
+    assert um.is_git_clone() is False
 
 
 def test_is_git_clone_false_for_plain_install(tmp_path, monkeypatch):
@@ -202,6 +240,41 @@ def test_git_pull_refuses_dirty_tree(tmp_path, monkeypatch):
 
     assert ok is False
     assert "local changes" in msg.lower()
+
+
+def test_git_dirty_checks_ignore_untracked_files(tmp_path, monkeypatch):
+    # Untracked files can't be "committed, stashed, or discarded" the way the
+    # refusal message says, and git itself refuses to clobber them on checkout.
+    # Both helpers and the banner query must ask git to leave them out.
+    monkeypatch.setattr(um, "_git_repo_root", lambda: tmp_path)
+    monkeypatch.setattr(um.shutil, "which", lambda _name: "/usr/bin/git")
+    status_calls = []
+
+    def _run(cmd, **kwargs):
+        if cmd[3] == "status":
+            status_calls.append(cmd[3:])
+            # A real git honoring --untracked-files=no prints nothing here.
+            return _FakeProc(0, "" if "--untracked-files=no" in cmd else "?? scratch.py\n")
+        if cmd[3] == "rev-parse" and "--abbrev-ref" in cmd:
+            return _FakeProc(0, "main\n")
+        if cmd[3] == "rev-parse":
+            return _FakeProc(0, "0123456789abcdef0123456789abcdef01234567\n")
+        return _FakeProc(0, "")
+
+    monkeypatch.setattr(um.subprocess, "run", _run)
+
+    ok, _ = um.git_pull_ff_only()
+    assert ok is True
+    ok, _ = um.git_checkout_source("tag", "v2.0")
+    assert ok is True
+    info = um.get_git_checkout_info()
+    assert info["dirty"] is False
+    assert info["branch"] == "main"
+    assert info["full_sha"] == "0123456789abcdef0123456789abcdef01234567"
+    assert info["sha"] == "0123456"
+
+    assert status_calls, "every path must run git status"
+    assert all("--untracked-files=no" in c for c in status_calls)
 
 
 def test_git_pull_refuses_detached_checkout(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- keep the full Update Ankimon window available for Git checkouts
- route current-branch, PR, branch, tag, and release actions through safe Git commands
- fetch selectable sources from the canonical Ankimon repository
- show a themed Git Workspace banner with branch, commit, and clean/dirty state
- refuse dirty checkouts, protect local commits, and sync submodules after switches

## Validation
- 18 updater tests passed
- Tier 1 harness: 9 of 9 passed
- real offscreen Qt add-on: updater opened in Git mode and Developer tab loaded all 4 source types
- fatal Ruff checks passed
- full suite: 687 passed, 23 skipped, 2 failed; the two Windows gender-symbol encoding failures reproduce unchanged on origin/main
