### PR TITLE
feat(fix): unobtainable badge 7

### DIFF
--- a/src/Ankimon/functions/encounter_functions.py
+++ b/src/Ankimon/functions/encounter_functions.py
@@ -1695,7 +1695,13 @@ def save_caught_pokemon(
     caught_pokemon["cp"] = calculate_cp_from_dict(caught_pokemon)
 
     # Save to database (replaces JSON file I/O for performance)
-    ankimon_db.save_pokemon(caught_pokemon)
+    save_success = ankimon_db.save_pokemon(caught_pokemon)
+
+    # Only award Badge 7 ("First Pokemon Caught !") if the save was successful
+    if save_success and achievements is not None:
+        check = check_for_badge(achievements, 7)
+        if check is False:
+            achievements = receive_badge(7, achievements)
 
     try:
         from ..singletons import notify_stats_changed

--- a/src/Ankimon/pyobj/starter_window.py
+++ b/src/Ankimon/pyobj/starter_window.py
@@ -223,10 +223,6 @@ class StarterWindow(QWidget):
         self.show()
         self.starter = True
         self.logger.log_and_showinfo("info","You have chosen your Starter Pokemon ! \n You can now close this window ! \n Please restart your Anki to restart your Pokemon Journey!")
-        #global achievments
-        #check = check_for_badge(achievements, 7)
-        #if check is False:
-        #    receive_badge(7, achievements)
 
     def display_fossil_pokemon(self, fossil_id, fossil_name):
         self.clear_layout(self.layout())


### PR DESCRIPTION
### At A Glance
- PR **1 of 4** in response to Issue #409 regarding **5 obtainable badges**. 
- This PR tackles the **unobtainable Badge 7** (First Pokemon Caught !)

### Cause of Bug
- Badge 7 was originally awarded after users **received their Starter Mon**
- That particular code, in `starter_window.py`, was **redacted** (commented-out)

### What this PR does
- Implements code that **awards Badge 7** after the user **captures their first wild Mon**.
- Makes sure that the badge was awarded only **after** the captured Mon was **successfully saved** in the user **database**. 
- **Removes** the **redacted** (commented-out) code that **previously awards** Badge 7 upon **receiving a Starter Mon**. This aligns with the badge's title ("First Mon Caught" instead of "First Mon Received") to make it a little more exciting for users.

### What each file does
- `functions/encounter_functions.py`: Where the **logic for awarding Badge 7** upon successful save of captured Mon resides.
- `pyobj/starter_window.py`: Edited for tidy-ups. No code additions; the **commented-out code** that previously implied badge awarding upon receiving a Starter was **removed**.

### Expected Behaviour
1. Set up a main Mon and start reviewing. 
2. Battle a Mon and capture 'em.
3. Visit Ankimon > Profile > Achievements or Ankimon > Profile > Trainer Card (Ctrl+Shift+Q).
4. The seventh badge from the left is now unlocked and coloured!

<img width="139" height="133" alt="image" src="https://github.com/user-attachments/assets/4950a1d3-2a63-46bd-8d8f-472aead6a484" />

### Related Issue
**_Fixes #409_**
_(broken down into 4 separate PRs for focus)_

### Related PRs
- **PR 2 of 4:** #690 - Tackles the unobtainable **Badge 12 and 13** (1000 Cards in one Session, 2000 Cards in one Session)
- **PR 3 of 4:** #693 - Tackles the unobtainable **Badge 19** (Evolved Fossil Pokemon)
- **PR 4 of 4:** #696 - Tackles the unobtainable **Badge 11** (First Leech Card unleeched)

### Checklist
- [x] My code and commit messages follow the code style and guidelines of this project.
- [x] I have personally tested the mechanism and successfully received Badge 7 following the expected flow.