### PR TITLE
fix(ui): delete expired battle tooltips

### DIFF
--- a/harness/checks/probe_real_tooltip_cleanup.py
+++ b/harness/checks/probe_real_tooltip_cleanup.py
@@ -1,0 +1,51 @@
+"""Tier-2 regression probe: battle tooltip widgets must not accumulate.
+
+Run after sourcing the base Tier-2 environment::
+
+    source .tier2/env.sh
+    python -m harness.checks.probe_real_tooltip_cleanup
+"""
+
+from __future__ import annotations
+
+import gc
+
+from PyQt6.QtCore import QCoreApplication, QEvent
+from PyQt6.QtWidgets import QApplication
+
+from harness.real_driver import RealDriver
+
+
+def _custom_labels(app: QApplication):
+    return [widget for widget in app.allWidgets() if type(widget).__name__ == "CustomLabel"]
+
+
+def main() -> int:
+    driver = RealDriver(
+        settings_overrides={
+            "battle.cards_per_round": 1,
+            "battle.automatic_battle": 2,
+            "audio.sounds": False,
+            "audio.sound_effects": False,
+            "gui.reviewer_text_message_box_time": 0,
+        }
+    )
+    app = QApplication.instance()
+    assert app is not None
+
+    for _ in range(100):
+        driver.answer("good")
+        app.processEvents()
+
+    QCoreApplication.sendPostedEvents(None, QEvent.Type.DeferredDelete)
+    app.processEvents()
+    gc.collect()
+
+    labels = _custom_labels(app)
+    assert not labels, f"{len(labels)} expired battle tooltip labels are still alive"
+    print("probe_real_tooltip_cleanup: OK (100 reviews, 0 retained CustomLabel widgets)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/Ankimon/functions/drawing_utils.py
+++ b/src/Ankimon/functions/drawing_utils.py
@@ -40,7 +40,7 @@ def tooltipWithColour(
     class CustomLabel(QLabel):
         def mousePressEvent(self, evt):
             evt.accept()
-            self.hide()
+            self.close()
 
     aw = parent or QApplication.activeWindow()
     if aw is None:
@@ -61,6 +61,10 @@ def tooltipWithColour(
         x = aw.mapToGlobal(QPoint(x + round(aw.width() / 2), 0)).x()
         y = aw.mapToGlobal(QPoint(0, aw.height() - (180 + y_offset))).y()
         lab = CustomLabel(aw)
+        # These tooltip windows are created for nearly every review. Hiding them
+        # leaves each label owned by the reviewer window forever, causing linear
+        # widget/RSS growth. Closing with WA_DeleteOnClose frees the C++ widget.
+        lab.setAttribute(Qt.WidgetAttribute.WA_DeleteOnClose, True)
         lab.setFrameShape(QFrame.Shape.StyledPanel)
         lab.setLineWidth(2)
         lab.setWindowFlags(Qt.WindowType.ToolTip)
@@ -80,11 +84,11 @@ def tooltipWithColour(
         lab.move(QPoint(x - round(lab.width() * 0.5 * xref), y))
         try:
             QTimer.singleShot(
-                period, lambda: lab.hide() if lab and not sip.isdeleted(lab) else None
+                period, lambda: lab.close() if lab and not sip.isdeleted(lab) else None
             )
-        except:
+        except Exception:
             QTimer.singleShot(
-                3000, lambda: lab.hide() if lab and not sip.isdeleted(lab) else None
+                3000, lambda: lab.close() if lab and not sip.isdeleted(lab) else None
             )
         logger = services.logger
         if logger is not None:


### PR DESCRIPTION
## Summary
- close battle tooltip labels instead of merely hiding them
- enable Qt delete-on-close so expired widgets release their C++ objects
- stop linear widget and RSS growth during long review sessions

## Fuzz finding
Long-term Tier 2 simulation retained roughly one CustomLabel per review. Before the fix, 449 labels remained after 500 reviews and RSS grew about 42.7 MB per 1,000 reviews.

## Tests
- py -3 -m pytest tests/test_addon_integrity.py -q
- focused real-Qt creation and deletion of 100 tooltip labels

A separate stacked PR adds the dedicated long-run regression probe.