### PR TITLE
fix(items): handle empty reward pool

### DIFF
--- a/src/Ankimon/pyobj/test_window.py
+++ b/src/Ankimon/pyobj/test_window.py
@@ -1085,10 +1085,14 @@ class TestWindow(QWidget):
         Receive_Window.show()
 
     def display_item(self):
+        item_name = random_item()
+        if item_name is None:
+            return
+
         Receive_Window = QDialog(mw)
         layout = QHBoxLayout()
 
-        item_widget = self.pokemon_display_item(random_item())
+        item_widget = self.pokemon_display_item(item_name)
 
         layout.addWidget(item_widget)
 

--- a/src/Ankimon/utils.py
+++ b/src/Ankimon/utils.py
@@ -349,11 +349,22 @@ USELESS_ITEMS = {
 }
 
 
-def random_item():
+def random_item() -> Optional[str]:
+    """Grant and return a random item with an available sprite.
+
+    A fresh/partial asset installation may have no item sprite directory, or all
+    present files may be filtered out. In that case there is no renderable reward,
+    so return ``None`` instead of raising from ``os.listdir``/``random.choice``.
+    """
     item_names: list[str] = []
 
+    try:
+        files = os.listdir(items_path)
+    except OSError:
+        return None
+
     # Iterate over each file in the directory
-    for file in os.listdir(items_path):
+    for file in files:
         # Check if the file is a .png file
         if not file.endswith(".png"):
             continue
@@ -379,6 +390,9 @@ def random_item():
             continue
 
         item_names.append(name)
+
+    if not item_names:
+        return None
 
     item_name = random.choice(item_names)
     # add item to item list

--- a/tests/test_random_item.py
+++ b/tests/test_random_item.py
@@ -1,0 +1,35 @@
+def test_random_item_returns_none_when_sprite_directory_is_missing(monkeypatch, tmp_path):
+    import Ankimon.utils as utils
+
+    missing = tmp_path / "missing-items"
+    granted = []
+    monkeypatch.setattr(utils, "items_path", missing)
+    monkeypatch.setattr(utils, "give_item", granted.append)
+
+    assert utils.random_item() is None
+    assert granted == []
+
+
+def test_random_item_returns_none_when_no_eligible_sprites_exist(monkeypatch, tmp_path):
+    import Ankimon.utils as utils
+
+    (tmp_path / "master-ball.png").write_bytes(b"")
+    (tmp_path / "readme.txt").write_text("not a sprite", encoding="utf-8")
+    granted = []
+    monkeypatch.setattr(utils, "items_path", tmp_path)
+    monkeypatch.setattr(utils, "give_item", granted.append)
+
+    assert utils.random_item() is None
+    assert granted == []
+
+
+def test_random_item_grants_an_eligible_item(monkeypatch, tmp_path):
+    import Ankimon.utils as utils
+
+    (tmp_path / "potion.png").write_bytes(b"")
+    granted = []
+    monkeypatch.setattr(utils, "items_path", tmp_path)
+    monkeypatch.setattr(utils, "give_item", granted.append)
+
+    assert utils.random_item() == "potion"
+    assert granted == ["potion"]


### PR DESCRIPTION
## Summary
- return no reward when the item sprite directory is missing or has no eligible items
- avoid calling random.choice() on an empty sequence
- skip the reward popup when no renderable item is available
- cover missing, filtered-only, and valid item pools

## Fuzz finding
The real-Qt soak emitted Cannot choose from an empty sequence when the item reward timer fired in a partial asset environment.

## Tests
- py -3 -m pytest tests/test_random_item.py tests/test_addon_integrity.py -q