### PR TITLE
fix(export): wire Pokepaste browser action

### DIFF
--- a/src/Ankimon/functions/pokemon_showdown_functions.py
+++ b/src/Ankimon/functions/pokemon_showdown_functions.py
@@ -5,6 +5,7 @@ from aqt.qt import QDialog, QLabel,Qt, QVBoxLayout
 from PyQt6.QtWidgets import QDialog, QLabel, QPushButton, QVBoxLayout, QLineEdit
 
 from ..functions.pokedex_functions import search_pokedex
+from ..functions.url_functions import open_browser_window
 
 from ..utils import save_error_code
 


### PR DESCRIPTION
## Summary
- import the existing Pokepaste browser helper used by the export dialog
- prevent the Open Pokepaste button from raising NameError

## Fuzz finding
The corrupt-world export seed opened the Pokepaste dialog and raised NameError because open_browser_window was not defined in the module.

## Tests
- py -3 -m pytest tests/test_addon_integrity.py -q