### PR TITLE
fix(updater): defer tab loading until ready

### DIFF
--- a/src/Ankimon/pyobj/update_dialog.py
+++ b/src/Ankimon/pyobj/update_dialog.py
@@ -76,13 +76,7 @@ class UpdateDialog(QDialog):
         self.tabs.addTab(self._build_releases_tab(), "  Releases  ")
         self.tabs.addTab(self._build_dev_tab(), "  Developer  ")
         self.tabs.addTab(self._build_sprites_tab(), "  Sprites  ")
-        self.tabs.currentChanged.connect(self._on_tab_changed)
         body.addWidget(self.tabs)
-
-        if select_tab == "sprites":
-            self.tabs.setCurrentIndex(3)
-        elif self._git_clone:
-            self.tabs.setCurrentIndex(2)
 
         self.progress_bar = QProgressBar()
         self.progress_bar.setVisible(False)
@@ -95,6 +89,14 @@ class UpdateDialog(QDialog):
         self.status_label.setStyleSheet("font-size: 11px; color: gray; padding: 0 4px;")
         self.status_label.setFixedHeight(20)
         body.addWidget(self.status_label)
+
+        # Tab changes can start asynchronous loading and touch the status/progress
+        # widgets, so connect and select only after those widgets exist.
+        self.tabs.currentChanged.connect(self._on_tab_changed)
+        if select_tab == "sprites":
+            self.tabs.setCurrentIndex(3)
+        elif self._git_clone:
+            self.tabs.setCurrentIndex(2)
 
         layout.addLayout(body)
         self._load_data()

--- a/src/Ankimon/pyobj/update_dialog.py
+++ b/src/Ankimon/pyobj/update_dialog.py
@@ -95,13 +95,7 @@ class UpdateDialog(QDialog):
         self.tabs.addTab(self._build_releases_tab(), "  Releases  ")
         self.tabs.addTab(self._build_dev_tab(), "  Developer  ")
         self.tabs.addTab(self._build_sprites_tab(), "  Sprites  ")
-        self.tabs.currentChanged.connect(self._on_tab_changed)
         body.addWidget(self.tabs)
-
-        if select_tab == "sprites":
-            self.tabs.setCurrentIndex(3)
-        elif self._git_clone:
-            self.tabs.setCurrentIndex(2)
 
         self.progress_bar = QProgressBar()
         self.progress_bar.setVisible(False)
@@ -116,6 +110,14 @@ class UpdateDialog(QDialog):
         )
         self.status_label.setMinimumHeight(24)
         body.addWidget(self.status_label)
+
+        # Tab changes can start asynchronous loading and touch the status/progress
+        # widgets, so connect and select only after those widgets exist.
+        self.tabs.currentChanged.connect(self._on_tab_changed)
+        if select_tab == "sprites":
+            self.tabs.setCurrentIndex(3)
+        elif self._git_clone:
+            self.tabs.setCurrentIndex(2)
 
         layout.addLayout(body)
         self._load_data()


### PR DESCRIPTION
## Priority
Low priority: this construction failure is specific to Git-checkout/developer updater mode and should be reviewed after normal-user fixes.

## Summary
- create the progress and status widgets before connecting tab-change callbacks
- select the initial Developer or Sprites tab only after dependent controls exist

## Dependency
Stacked on PR #664 because the automatic Git-checkout tab selection is introduced there.

## Fuzz finding
Opening Update Ankimon on a Git checkout emitted currentChanged during construction and called _set_busy() before progress_bar existed.

## Tests
- py -3 -m pytest tests/test_update_manager.py tests/test_addon_integrity.py -q
- focused real-WebEngine UpdateDialog construction