### PR TITLE
test(harness): mirror QueryOp backend semantics

### DIFF
--- a/harness/fake_aqt.py
+++ b/harness/fake_aqt.py
@@ -146,6 +146,9 @@ def _make_query_op():
         def without_collection(self):
             return self
 
+        def with_backend_semantics(self):
+            return self
+
         def with_progress(self, *a, **k):
             return self
 


### PR DESCRIPTION
## Summary
- add the chainable with_backend_semantics method to the synchronous fake QueryOp
- keep database diagnostics and repair actions compatible with the real Anki operation API

## Fuzz finding
Verify and Repair Database aborted Tier 2 because the fake host lacked this valid QueryOp method.

## Tests
- py -3 harness/check.py