### PR TITLE
test(webengine): use Chromium multiprocess mode

### DIFF
--- a/harness/real_env.py
+++ b/harness/real_env.py
@@ -119,9 +119,10 @@ def start_real_session(user_path=None, settings_overrides=None, neuter_network=T
         raise ValueError("require_webengine=True requires webengine=True")
     if webengine:
         os.environ.setdefault("QTWEBENGINE_DISABLE_SANDBOX", "1")
-        os.environ.setdefault("QTWEBENGINE_CHROMIUM_FLAGS",
-                              "--no-sandbox --disable-gpu --disable-dev-shm-usage "
-                              "--in-process-gpu --single-process")
+        os.environ.setdefault(
+            "QTWEBENGINE_CHROMIUM_FLAGS",
+            "--no-sandbox --disable-gpu --disable-dev-shm-usage",
+        )
         try:
             import PyQt6.QtWebEngineWidgets  # noqa: F401  (must precede QApplication)
         except Exception as exc:

--- a/harness/setup_webengine.sh
+++ b/harness/setup_webengine.sh
@@ -10,7 +10,7 @@
 #   source .tier2/env.sh
 #   export LD_LIBRARY_PATH="$PWD/.tier2/we-libs/extract/usr/lib/$(uname -m)-linux-gnu:$LD_LIBRARY_PATH"
 #   export QTWEBENGINE_DISABLE_SANDBOX=1
-#   export QTWEBENGINE_CHROMIUM_FLAGS="--no-sandbox --disable-gpu --disable-dev-shm-usage --in-process-gpu --single-process"
+#   export QTWEBENGINE_CHROMIUM_FLAGS="--no-sandbox --disable-gpu --disable-dev-shm-usage"
 #   python3 -m harness.checks.probe_real_webengine
 #   python3 harness/scenarios/hud_render.py 150
 #


### PR DESCRIPTION
## Summary
- remove single-process and in-process GPU flags from the default Tier 2 Chromium configuration
- retain no-sandbox, disabled GPU, and disabled shared-memory flags for offscreen execution
- update the documented command to match

## Fuzz finding
Single-process Chromium aborted when Ankimon created multiple WebEngine profiles and pages.

## Tests
- python -m harness.checks.probe_real_webengine