### PR TITLE
test(fuzz): require real WebEngine coverage

### DIFF
--- a/harness/README.md
+++ b/harness/README.md
@@ -115,6 +115,14 @@ Tier-2 scenarios (drive + see the real windows):
 python -m harness.scenarios.pc_box_moves   # open the real PC box, change a caught
                                            # Pokemon's moves (persists to DB) + screenshot
 python -m harness.scenarios.screenshots    # PNGs of the real battle window + PC box
+python -m harness.scenarios.soak 10000     # sustained real-Qt review/RSS soak
+```
+
+The whole-add-on `mega_fuzz` scenario also opens browser-backed menu screens, so
+run `setup_webengine.sh` and export its native-library path as shown above first:
+
+```bash
+python harness/scenarios/mega_fuzz.py --seeds 12 --steps 100 --parallel 2
 ```
 
 `harness/screenshot.py` (`grab(widget, path)`) renders any real widget to a PNG via

--- a/harness/scenarios/mega_fuzz.py
+++ b/harness/scenarios/mega_fuzz.py
@@ -28,7 +28,9 @@ C++ Qt abort uncatchable from Python):
 
 This FINDS bugs; it does not fix them. Expect a lot — that's the point.
 
+    bash harness/setup_webengine.sh                           # one-time; real browser screens are required
     source .tier2/env.sh
+    export LD_LIBRARY_PATH="$PWD/.tier2/we-libs/extract/usr/lib/$(uname -m)-linux-gnu:$LD_LIBRARY_PATH"
     python3 harness/scenarios/mega_fuzz.py                    # sweep seeds (random worlds), report crashers
     python3 harness/scenarios/mega_fuzz.py --world corrupt    # sweep, forcing the corrupt-save world
     python3 harness/scenarios/mega_fuzz.py --replay 7 80      # re-run one seed, verbose, to watch it
@@ -181,7 +183,12 @@ def _run(seed, steps, journal_path, world=None, verbose=False):
 
     # Boot the genuine add-on into the chosen world.
     has_assets = world != "blank"                    # blank = the user who denied the sprite download
-    d = RealDriver(first_run=has_assets, first_encounter=has_assets)
+    d = RealDriver(
+        first_run=has_assets,
+        first_encounter=has_assets,
+        webengine=True,
+        require_webengine=True,
+    )
     import Ankimon.utils as u
     u.close_anki = lambda *a, **k: None              # the monkey must not quit the process
     app = QApplication.instance()


### PR DESCRIPTION
## Summary
- make mega_fuzz request and require genuine PyQt6 WebEngine views
- fail loudly when browser support is unavailable instead of silently using incomplete stubs
- document the WebEngine setup and library-path prerequisite

## Fuzz finding
The whole-add-on fuzzer claimed browser-menu coverage while its lightweight view stubs could not model signals such as loadFinished.

## Tests
- py -3 -m py_compile harness/scenarios/mega_fuzz.py
- focused real-WebEngine blank-world RealDriver boot