### PR TITLE
test(soak): retain error event details

### DIFF
--- a/harness/scenarios/soak.py
+++ b/harness/scenarios/soak.py
@@ -50,6 +50,7 @@ def run(n=10000, tier="real", sample=1000, verbose=True):
         d = Driver(settings_overrides=overrides)
 
     kinds = Counter()
+    error_details = Counter()
     gc.collect()
     if app:
         app.processEvents()
@@ -60,6 +61,9 @@ def run(n=10000, tier="real", sample=1000, verbose=True):
     for i in range(1, n + 1):
         for e in d.answer("good"):
             kinds[e["type"]] += 1
+            if e["type"] == "error":
+                detail = e.get("exception") or e.get("message") or repr(e)
+                error_details[str(detail)] += 1
         # Pump the loop so Qt actually frees deleteLater'd widgets (real tier).
         if app and i % 50 == 0:
             app.processEvents()
@@ -83,13 +87,18 @@ def run(n=10000, tier="real", sample=1000, verbose=True):
         "rss_start_mb": round(rss0, 1), "rss_end_mb": round(rss_end, 1),
         "growth_mb": round(growth, 1), "mb_per_1k_reviews": round(growth / n * 1000, 3),
         "encounters": kinds["encounter"], "errors": kinds["error"],
+        "error_details": dict(error_details),
     }
     if verbose:
         print(f"\nsoak ({tier}): {n} reviews in {dt:.1f}s ({n / dt:.0f}/s)")
         print(f"  RSS {rss0:.1f} -> {rss_end:.1f} MB  (growth {growth:+.1f} MB, "
               f"{growth / n * 1000:.3f} MB per 1000 reviews)")
         print(f"  encounters {kinds['encounter']}, errors {kinds['error']}")
-    assert kinds["error"] == 0, f"{kinds['error']} error events during soak"
+        for detail, count in error_details.most_common():
+            print(f"  error x{count}: {detail}")
+    assert kinds["error"] == 0, (
+        f"{kinds['error']} error events during soak: {dict(error_details)}"
+    )
     return result
 
 


### PR DESCRIPTION
## Summary
- aggregate error-event exception and message text during soak runs
- include details in the returned result, console report, and assertion failure

## Fuzz finding
The first real-Qt soak reported only an error count, which hid the empty-sequence exception needed to locate the item reward defect.

## Tests
- py -3 -m py_compile harness/scenarios/soak.py
- 10-review Tier 1 soak with an empty error-details result