### PR TITLE
test(webview): decode Node output as UTF-8

### DIFF
--- a/tests/test_battle_webview_index_html.py
+++ b/tests/test_battle_webview_index_html.py
@@ -64,6 +64,7 @@ def run_node_json(script):
         [NODE, "-e", script],
         capture_output=True,
         text=True,
+        encoding="utf-8",
         timeout=10,
     )
     assert result.returncode == 0, f"node script failed:\n{result.stderr}"


### PR DESCRIPTION
## Summary
- explicitly decode Node subprocess output as UTF-8
- keep Unicode battle-webview assertions portable across Windows system code pages

## Fuzz validation finding
The full Windows test suite failed while decoding gender symbols from Node even though the JavaScript behavior was correct.

## Tests
- py -3 -m pytest tests/test_battle_webview_index_html.py -q