### PR TITLE
fix(pc): ignore stale slot actions

### DIFF
--- a/src/Ankimon/pyobj/pc_box.py
+++ b/src/Ankimon/pyobj/pc_box.py
@@ -549,6 +549,12 @@ def clear_layout(layout):
         item = layout.takeAt(0)
         widget = item.widget()
         if widget is not None:
+            # Removing a widget from a layout does not hide it immediately.
+            # Disable and detach stale slots before deleteLater() so an account
+            # switch/filter refresh cannot leave clickable old Pokémon behind.
+            widget.setEnabled(False)
+            widget.hide()
+            widget.setParent(None)
             widget.deleteLater()
         elif item.layout():
             clear_layout(item.layout())
@@ -2052,9 +2058,7 @@ class PokemonPC(QDialog):
             lambda: self.show_pokemon_details(pokemon)
         )
         main_pokemon_action.triggered.connect(
-            lambda: self.main_pokemon_function_callback(
-                services.db.get_pokemon(pokemon["individual_id"])
-            )
+            lambda: self.pick_as_main_pokemon(pokemon)
         )
         make_favorite_action.triggered.connect(lambda: self.toggle_favorite(pokemon))
         give_held_item.triggered.connect(lambda: self.give_held_item(pokemon))
@@ -2072,6 +2076,20 @@ class PokemonPC(QDialog):
 
         # Show the menu at the button's position, aligned below the button
         menu.exec(button.mapToGlobal(button.rect().topRight()))
+
+    def pick_as_main_pokemon(self, pokemon_stub):
+        """Select a live database record as main, ignoring stale grid entries."""
+        individual_id = pokemon_stub.get("individual_id")
+        pokemon = services.db.get_pokemon(individual_id) if individual_id else None
+        if not pokemon:
+            if self.logger:
+                self.logger.log(
+                    "warning",
+                    f"Cannot select missing Pokémon {individual_id!r} as main; refreshing PC.",
+                )
+            self.refresh_pokemon_grid()
+            return
+        self.main_pokemon_function_callback(pokemon)
 
     def show_pokemon_details(self, pokemon_stub):
         """


### PR DESCRIPTION
## Priority
Low priority: this was reproduced through the developer-only account switch workflow and should be reviewed after the normal-user fixes.

## Summary
- immediately hide, disable, and detach removed PC grid widgets before deferred deletion
- resolve Pick as main Pokemon against the currently active database
- refresh safely when a stale slot references a record from the previous account

## Fuzz finding
After Switch Account (DEV/Normal), an old PC slot could remain clickable until Qt processed deleteLater(). Picking it as main passed None into MainPokemon and raised AttributeError.

## Tests
- py -3 -m pytest tests/test_pc_box_cp_migration.py tests/test_pc_box_evolution_button.py tests/test_addon_integrity.py -q