### PR TITLE
fix(reload): flush deferred WebEngine deletes

### DIFF
--- a/src/Ankimon/reloader.py
+++ b/src/Ankimon/reloader.py
@@ -41,6 +41,7 @@ import importlib
 import sys
 import traceback
 
+from PyQt6.QtCore import QCoreApplication, QEvent
 from PyQt6.QtWidgets import QApplication, QWidget
 from aqt import gui_hooks, mw
 
@@ -222,6 +223,21 @@ def _teardown_windows(addon_package, services):
                 pass
 
 
+def _flush_deferred_widget_deletes():
+    """Destroy closed Qt/WebEngine objects before their modules are purged.
+
+    ``deleteLater()`` only schedules destruction. Purging and re-importing the
+    add-on while old QWebEngine pages are still alive can release their profile
+    first and crash Qt during shutdown or the next reload.
+    """
+    app = QApplication.instance()
+    if app is None:
+        return
+    for _ in range(2):
+        QCoreApplication.sendPostedEvents(None, QEvent.Type.DeferredDelete)
+        app.processEvents()
+
+
 def _purge_addon_modules(addon_package):
     """Drop the add-on's submodules from ``sys.modules`` so the re-import is fresh.
 
@@ -264,6 +280,7 @@ def teardown_ankimon(addon_package):
     _restore_reviewer_wraps()
     _delete_reload_shortcuts(services)
     _teardown_windows(addon_package, services)
+    _flush_deferred_widget_deletes()
 
     # Drop the cached DB singleton (closes its connection). The registry still
     # holds the same AnkimonDB instance with its db_path intact, so the reused

--- a/tests/test_reloader_qt.py
+++ b/tests/test_reloader_qt.py
@@ -1,0 +1,151 @@
+"""Real-Qt tests for the hot-reload's deferred-delete flush.
+
+``_flush_deferred_widget_deletes`` is the whole of PR #686, and what it claims
+only holds if ``QCoreApplication.sendPostedEvents(None, QEvent.Type.DeferredDelete)``
+really destroys objects that ``deleteLater()`` merely *scheduled* — including
+at the same event-loop level the reload runs at, which is the case a plain
+``processEvents()`` deliberately skips. A fake ``QApplication`` cannot show
+that, so these run against real Qt (the Tier-2 / integrity-test env) and skip
+cleanly in the aqt-free Tier-1 env.
+
+Kept out of ``test_reloader.py`` on purpose: that file installs fake ``PyQt6``
+modules in ``sys.modules``, which is exactly what would invalidate these.
+
+Run standalone with::
+
+    pytest tests/test_reloader_qt.py
+"""
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+pytest.importorskip("PyQt6")  # Qt env only; skipped in the aqt-free Tier-1 env.
+
+
+_SRC = Path(__file__).parent.parent / "src"
+
+
+@pytest.fixture(autouse=True)
+def _env_guard():
+    """Skip gracefully when another test file has mocked PyQt6 in this run.
+
+    Un-mocking a compiled Qt extension mid-process is not reliable, so skip
+    rather than fail. Matches ``test_move_picker.py``.
+    """
+    from PyQt6.QtWidgets import QWidget
+
+    if not isinstance(QWidget, type):  # PyQt6 was mocked by another test
+        pytest.skip(
+            "real PyQt6 not active (mocked by another test); "
+            "run tests/test_reloader_qt.py standalone"
+        )
+    yield
+
+
+@pytest.fixture
+def reloader(monkeypatch):
+    """Import the real reloader.py against real Qt and a stubbed ``aqt``."""
+
+    def _stub(name, **attrs):
+        mod = types.ModuleType(name)
+        for key, value in attrs.items():
+            setattr(mod, key, value)
+        return mod
+
+    aqt = _stub("aqt", gui_hooks=SimpleNamespace(), mw=SimpleNamespace())
+    aqt.__path__ = []
+    monkeypatch.setitem(sys.modules, "aqt", aqt)
+    monkeypatch.setitem(
+        sys.modules, "aqt.utils", _stub("aqt.utils", tooltip=lambda message: None)
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "Ankimon.services",
+        _stub("Ankimon.services", services=SimpleNamespace()),
+    )
+
+    spec = importlib.util.spec_from_file_location(
+        "Ankimon.reloader", _SRC / "Ankimon" / "reloader.py"
+    )
+    mod = importlib.util.module_from_spec(spec)
+    monkeypatch.setitem(sys.modules, "Ankimon.reloader", mod)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_plain_process_events_leaves_deferred_deletes_alive(qapp, reloader):
+    """The control. Without this, the flush would be redundant with the
+    ``processEvents()`` calls teardown already makes."""
+    from PyQt6 import sip
+    from PyQt6.QtWidgets import QWidget
+
+    widget = QWidget()
+    widget.deleteLater()
+
+    qapp.processEvents()
+
+    assert not sip.isdeleted(widget)
+    widget.deleteLater()  # leave nothing for the next test to collect
+    reloader._flush_deferred_widget_deletes()
+
+
+def test_flush_destroys_deferred_deleted_widgets(qapp, reloader):
+    """The claim PR #686 rests on: after the flush the C++ objects are gone,
+    so the module purge can no longer strand a live QWebEngine page."""
+    from PyQt6 import sip
+    from PyQt6.QtWidgets import QWidget
+
+    parent = QWidget()
+    child = QWidget(parent)
+    destroyed = []
+    parent.destroyed.connect(lambda *_: destroyed.append("parent"))
+
+    parent.close()
+    parent.deleteLater()
+    assert not sip.isdeleted(parent)  # deleteLater() alone destroys nothing
+
+    reloader._flush_deferred_widget_deletes()
+
+    assert destroyed == ["parent"]
+    assert sip.isdeleted(parent)
+    # Children go with the parent — the QWebEngine page/profile ownership case.
+    assert sip.isdeleted(child)
+
+
+def test_flush_collects_deletes_scheduled_during_destruction(qapp, reloader):
+    """Why the flush loops instead of sending posted events once.
+
+    Destroying one object can schedule the next through *queued* work — which
+    is the shape WebEngine teardown takes. A queued connection lands as a
+    metacall event, so the first ``sendPostedEvents(..., DeferredDelete)`` pass
+    cannot see it; only the interleaved ``processEvents()`` dispatches it, and
+    the ``deleteLater()`` it then posts needs a second DeferredDelete pass.
+    Drop the flush to a single iteration and this test fails.
+    """
+    from PyQt6 import sip
+    from PyQt6.QtCore import Qt
+    from PyQt6.QtWidgets import QWidget
+
+    first = QWidget()
+    second = QWidget()
+    first.destroyed.connect(second.deleteLater, Qt.ConnectionType.QueuedConnection)
+
+    first.deleteLater()
+    reloader._flush_deferred_widget_deletes()
+
+    assert sip.isdeleted(first)
+    assert sip.isdeleted(second)
+
+
+def test_flush_is_a_noop_without_a_qapplication(reloader, monkeypatch):
+    """Headless callers (and Anki mid-shutdown) must not trip over the flush."""
+    monkeypatch.setattr(
+        reloader.QApplication, "instance", staticmethod(lambda: None)
+    )
+
+    reloader._flush_deferred_widget_deletes()  # must not raise

--- a/tests/test_reloader_qt.py
+++ b/tests/test_reloader_qt.py
@@ -9,7 +9,12 @@ that, so these run against real Qt (the Tier-2 / integrity-test env) and skip
 cleanly in the aqt-free Tier-1 env.
 
 Kept out of ``test_reloader.py`` on purpose: that file installs fake ``PyQt6``
-modules in ``sys.modules``, which is exactly what would invalidate these.
+modules in ``sys.modules``, which is exactly what would invalidate these. It
+restores them via ``monkeypatch``, so real Qt is back by the time this module
+runs — but that only holds because ``test_reloader_qt`` sorts *after*
+``test_reloader``. If collection order ever changes (a rename, xdist, a
+shuffling plugin), ``_env_guard`` below turns these into skips rather than
+failures, so re-run this file standalone before trusting a green suite.
 
 Run standalone with::
 


### PR DESCRIPTION
## Summary
- flush Qt deferred-delete events after closing addon widgets, so QWebEngine pages are destroyed **before** their Python modules and profiles are purged
- reduces profile-release warnings and reload/shutdown segmentation faults
- adds real-Qt regression coverage proving the flush does what it claims

## Priority
Low: this affects the developer-only Restart Ankimon hot-reload workflow and should be reviewed after normal-user fixes.

## Dependency
Stacked on #663, which fixes separate hot-reload startup races. Merge that first.

## Fuzz finding
Restart Ankimon could purge modules while `deleteLater()`'d widgets were still alive, leaving WebEngine pages attached to a released profile.

## Why this isn't a no-op (`3fe477a`)
The whole PR is 17 lines, and its correctness rests entirely on one Qt semantic: `QCoreApplication.sendPostedEvents(None, QEvent.Type.DeferredDelete)` destroys objects that `deleteLater()` merely *scheduled*, **including at the same event-loop level** — which is the case a plain `processEvents()` deliberately skips. If that were not true, these 17 lines would do nothing, since teardown already calls `processEvents()` elsewhere.

`tests/test_reloader.py` cannot demonstrate that: it installs fake `PyQt6` modules in `sys.modules`, and a fake `QApplication` proves nothing about `DeferredDelete`. So `tests/test_reloader_qt.py` runs against **real Qt** in the Tier-2 / integrity-test env, and skips cleanly where PyQt6 is absent or has been mocked by another test file (same guard as `test_move_picker.py`).

Mutation testing confirms every line is load-bearing:

| Mutation | Result |
| --- | --- |
| drop `sendPostedEvents(..., DeferredDelete)`, keep `processEvents()` | **2 tests fail** — widgets survive the flush, so the purge can still strand a live WebEngine page |
| `range(2)` → `range(1)` | **1 test fails** — the queued-connection case, which is the shape WebEngine teardown actually takes |
| `QApplication.instance() is None` branch | covered directly |

## Measured effect on a real reload
Real hot-reload cycles against the genuine add-on under real offscreen Qt (Tier-2 harness) with `test_window`, `pokemon_pc` and `evo_window` open, counting `QApplication.allWidgets()`. Only difference between columns is this PR's 17 lines; both deterministic across repeated runs.

| live widgets after | without the flush | with the flush |
| --- | --- | --- |
| baseline | 554 | 554 |
| reload 1 | **1110** (+556) | **572** (+18) |
| reload 2 | **1666** (+1112) | **587** (+33) |

Every reload without the flush strands ~556 live `QWidget`s: the window tree is rebuilt while the old one is still alive, because `deleteLater()` had only *scheduled* it and the module purge ran first. That is the "WebEngine page outliving its released profile" shape, and it compounds per reload. The flush removes ~97% of it.

## Tests
- `python3 -m pytest tests/ -q` → **776 passed, 40 skipped, 0 failed**
- `python3 -m pytest tests/test_reloader_qt.py -q` → 4 passed against real Qt
- `python3 -m pytest tests/test_addon_integrity.py -q` → passes; the module-scope `PyQt6.QtCore` import keeps the headless-import contract
- `python3 -m ruff check --config ci_ruff_check.toml` on changed files → clean
