### PR TITLE
fix(images): handle null pixmap scaling

### DIFF
--- a/src/Ankimon/business.py
+++ b/src/Ankimon/business.py
@@ -47,12 +47,19 @@ def split_japanese_string_by_length(input_string, max_length):
         yield current_line
 
 def resize_pixmap_img(pixmap, max_width):
+    """Scale a pixmap proportionally without crashing on a failed image load.
+
+    Qt represents a missing or unreadable image as a null pixmap whose width and
+    height are both zero. Returning it unchanged lets callers render an empty
+    image or apply their own fallback instead of dividing by zero.
+    """
     original_width = pixmap.width()
     original_height = pixmap.height()
+    if original_width <= 0 or original_height <= 0:
+        return pixmap
     new_width = max_width
     new_height = (original_height * max_width) // original_width
-    pixmap2 = pixmap.scaled(new_width, new_height)
-    return pixmap2
+    return pixmap.scaled(new_width, new_height)
 
 def calc_experience(base_experience, enemy_level):
     exp = base_experience * enemy_level / 7

--- a/tests/test_business_pixmap.py
+++ b/tests/test_business_pixmap.py
@@ -1,0 +1,36 @@
+from Ankimon.business import resize_pixmap_img
+
+
+class FakePixmap:
+    def __init__(self, width, height):
+        self._width = width
+        self._height = height
+        self.scaled_args = None
+
+    def width(self):
+        return self._width
+
+    def height(self):
+        return self._height
+
+    def scaled(self, width, height):
+        self.scaled_args = (width, height)
+        return (width, height)
+
+
+def test_resize_pixmap_returns_null_pixmap_unchanged():
+    pixmap = FakePixmap(0, 0)
+
+    result = resize_pixmap_img(pixmap, 150)
+
+    assert result is pixmap
+    assert pixmap.scaled_args is None
+
+
+def test_resize_pixmap_preserves_aspect_ratio():
+    pixmap = FakePixmap(96, 48)
+
+    result = resize_pixmap_img(pixmap, 150)
+
+    assert result == (150, 75)
+    assert pixmap.scaled_args == (150, 75)


### PR DESCRIPTION
## Summary
- return null or zero-sized pixmaps unchanged instead of dividing by zero
- preserve normal proportional scaling behavior
- add focused regression coverage

## Fuzz finding
Any missing or unreadable image passed to the shared scaler could trigger ZeroDivisionError because Qt reports null pixmaps with width zero.

## Tests
- py -3 -m pytest tests/test_business_pixmap.py -q