### PR TITLE
test(ui): guard tooltip widget cleanup

### DIFF
--- a/harness/checks/probe_real_tooltip_cleanup.py
+++ b/harness/checks/probe_real_tooltip_cleanup.py
@@ -1,0 +1,51 @@
+"""Tier-2 regression probe: battle tooltip widgets must not accumulate.
+
+Run after sourcing the base Tier-2 environment::
+
+    source .tier2/env.sh
+    python -m harness.checks.probe_real_tooltip_cleanup
+"""
+
+from __future__ import annotations
+
+import gc
+
+from PyQt6.QtCore import QCoreApplication, QEvent
+from PyQt6.QtWidgets import QApplication
+
+from harness.real_driver import RealDriver
+
+
+def _custom_labels(app: QApplication):
+    return [widget for widget in app.allWidgets() if type(widget).__name__ == "CustomLabel"]
+
+
+def main() -> int:
+    driver = RealDriver(
+        settings_overrides={
+            "battle.cards_per_round": 1,
+            "battle.automatic_battle": 2,
+            "audio.sounds": False,
+            "audio.sound_effects": False,
+            "gui.reviewer_text_message_box_time": 0,
+        }
+    )
+    app = QApplication.instance()
+    assert app is not None
+
+    for _ in range(100):
+        driver.answer("good")
+        app.processEvents()
+
+    QCoreApplication.sendPostedEvents(None, QEvent.Type.DeferredDelete)
+    app.processEvents()
+    gc.collect()
+
+    labels = _custom_labels(app)
+    assert not labels, f"{len(labels)} expired battle tooltip labels are still alive"
+    print("probe_real_tooltip_cleanup: OK (100 reviews, 0 retained CustomLabel widgets)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add a real-Qt Tier 2 probe for battle tooltip lifetime
- run 100 reviews with immediate tooltip expiry
- assert no expired CustomLabel widgets remain after deferred deletes are processed

## Dependency
Stacked on PR #668, which contains the runtime deletion fix.

## Finding targeted
There was no automated real-Qt regression check capable of detecting the per-review tooltip widget leak.

## Tests
- python -m harness.checks.probe_real_tooltip_cleanup