### PR TITLE
test(fuzz): report the actual last action

### DIFF
--- a/harness/scenarios/mega_fuzz.py
+++ b/harness/scenarios/mega_fuzz.py
@@ -320,6 +320,15 @@ def _signature(caught_line):
     return s[:90]
 
 
+def _last_action(lines):
+    """Return the last journaled user/teardown action, not trailing diagnostics."""
+    prefixes = ("step ", "warmup:", "teardown:", "CONTEXT-ACTION")
+    for line in reversed(lines):
+        if line.strip().startswith(prefixes):
+            return line
+    return lines[-1] if lines else "(no journal written)"
+
+
 def _run_one(seed, steps, world):
     """Run ONE child subprocess and return (seed, rc, journal-lines)."""
     fd, jp = tempfile.mkstemp(prefix="megafuzz_%d_" % seed, suffix=".log")
@@ -379,7 +388,7 @@ def sweep(n_seeds=12, steps=80, world=None, parallel=1):
             print("  seed %3d [%-9s]: survived %d steps  (%d right-clicks, %d context-actions, %d soft errors)%s"
                   % (seed, w, steps, rc_count, ctx_count, len(caught), mem))
         else:
-            culprit = next((l for l in reversed(lines) if not l.startswith("RSS")), lines[-1] if lines else "(no journal written)")
+            culprit = _last_action(lines)
             crashers.append((seed, w, rc, culprit))
             print("  seed %3d [%-9s]: HARD CRASH (exit %d) — last action before death:\n           %s"
                   % (seed, w, rc, culprit))

--- a/tests/test_mega_fuzz_reporting.py
+++ b/tests/test_mega_fuzz_reporting.py
@@ -1,0 +1,28 @@
+from harness.scenarios.mega_fuzz import _last_action
+
+
+def test_last_action_ignores_trailing_error_and_rss_lines():
+    lines = [
+        "SEED 2 STEPS 40 WORLD seeded",
+        "step 37: RIGHT-CLICK PokemonSlotButton 'pokemonSlot' in [Pokémon PC]",
+        "    CONTEXT-ACTION 'Pick as main Pokémon'",
+        "step 38: MENU 'Verify and Repair Database'",
+        "  CAUGHT error event: generic diagnostic text",
+        "RSS final: 350.0 MB (delta +20.0 over 40 steps)",
+    ]
+
+    assert _last_action(lines) == "step 38: MENU 'Verify and Repair Database'"
+
+
+def test_last_action_can_report_a_context_menu_action():
+    lines = [
+        "SEED 7 STEPS 80 WORLD corrupt",
+        "step 37: RIGHT-CLICK PokemonSlotButton 'pokemonSlot' in [Pokémon PC]",
+        "    CONTEXT-ACTION 'Pick as main Pokémon'",
+    ]
+
+    assert _last_action(lines).strip() == "CONTEXT-ACTION 'Pick as main Pokémon'"
+
+
+def test_last_action_handles_an_empty_journal():
+    assert _last_action([]) == "(no journal written)"


### PR DESCRIPTION
## Summary
- identify the last journaled user, context-menu, warm-up, or teardown action
- ignore trailing RSS and generic diagnostic lines when naming a crash culprit
- add focused reporting tests

## Fuzz finding
An abbreviated crash report appeared to blame an earlier PC context action even though a later Verify and Repair Database action was the actual failing callback.

## Tests
- py -3 -m pytest tests/test_mega_fuzz_reporting.py -q