### PR TITLE
feat(fix): unobtainable badge 12 and 13

### DIFF
--- a/src/Ankimon/functions/badges_functions.py
+++ b/src/Ankimon/functions/badges_functions.py
@@ -63,6 +63,8 @@ def handle_review_count_achievement(review_count, achievements):
         200: 2,
         300: 3,
         500: 4,
+        1000: 12,
+        2000: 13,
     }
     badge_to_award = milestones.get(review_count)
     if badge_to_award and not check_for_badge(achievements, badge_to_award):


### PR DESCRIPTION
### At A Glance
- PR **2 of 4** in response to Issue #409 regarding **5 obtainable badges**
- This PR tackles the **unobtainable Badges 12 and 13** (1000 Cards in one Session, 2000 Cards in one Session)

### Cause of Bug
- In `badges_functions.py`, the `milestones` list in `handle_review_count_achievement` was only wired up to 500, with 1000 and 2000 absent. 

### What this PR does
- Extends code that **awards Badge 12** after the user **reviews 1000 cards in one session**.
- Extends code that **awards Badge 13** after the user **reviews 2000 cards in one session**.

### What each file does
- Only `functions/encounter_functions.py` was updated: **Added `1000` and `2000`** to the **`milestones` list** by **wiring** them to (Badges) `12` and `13` accordingly.

### Expected Behaviour
1. Set up a main Mon and start reviewing. 
2. Review 1000 cards and/or 2000 cards.
3. Visit Ankimon > Profile > Achievements or Ankimon > Profile > Trainer Card (Ctrl+Shift+Q).
4. Either Badge 12 (1000 cards) or Badge 13 (2000 cards) is unlocked and coloured.

<img width="146" height="108" alt="image" src="https://github.com/user-attachments/assets/f990ff4a-5587-4073-9ea3-fc333ed4d0b3" />
<img width="152" height="115" alt="image" src="https://github.com/user-attachments/assets/ab86db43-0b36-4d82-b855-8ddc9c120698" />

### Related Issue
**_Fixes #409_**
_(broken down into 4 separate PRs for focus)_

### Related PRs
- **PR 1 of 4:** #666 - Tackles the unobtainable **Badge 7** (First Pokemon Caught !)
- **PR 3 of 4:** #693 - Tackles the unobtainable **Badge 19** (Evolved Fossil Pokemon)
- **PR 4 of 4:** #696 - Tackles the unobtainable **Badge 11** (First Leech Card unleeched)

### Checklist
- [x] My code and commit messages follow the code style and guidelines of this project.
- [x] I have personally tested the mechanism and successfully received Badge 12 and 13 following the expected flow.