### PR TITLE
chore: keep shell scripts LF

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sh text eol=lf


### PR DESCRIPTION
## Summary
- enforce LF checkout line endings for every shell script
- prevent Windows autocrlf settings from introducing carriage returns into WSL/bash entrypoints

## Fuzz setup finding
Tier 2 setup scripts checked out with CRLF and failed in WSL with tokens such as do followed by a carriage return.

## Checks
- git check-attr text eol -- harness/setup_tier2.sh harness/setup_webengine.sh
- git diff --check