### PR TITLE
feat(fix): unobtainable badge 11

### DIFF
--- a/src/Ankimon/__init__.py
+++ b/src/Ankimon/__init__.py
@@ -106,10 +106,19 @@ from .card_hooks import register_card_hooks
 
 register_card_hooks()
 
-# --- Browser hooks for card suspension > unsuspension and leech tagged > leech tag removed detection ---
-from .functions.browser_hooks import register_browser_hooks
-
-register_browser_hooks()
+# Browser hooks for card suspension > unsuspension and leech tagged > leech tag removed detection
+# Guarded so an import failure (e.g., aqt.browser in older Anki versions) cannot
+# abort add-on load. All other integration points in this file are similarly
+# guarded; this aligns with that pattern.
+try:
+    from .functions.browser_hooks import register_browser_hooks
+    register_browser_hooks()
+except Exception as e:
+    # Log the error but continue loading - badge 11 browser hooks will be disabled
+    try:
+        logger.log("error", f"Failed to register browser hooks for Badge 11: {e}")
+    except Exception:
+        pass
 
 setupHooks(None, ankimon_tracker_obj)
 

--- a/src/Ankimon/__init__.py
+++ b/src/Ankimon/__init__.py
@@ -106,6 +106,11 @@ from .card_hooks import register_card_hooks
 
 register_card_hooks()
 
+# --- Browser hooks for card suspension > unsuspension and leech tagged > leech tag removed detection ---
+from .functions.browser_hooks import register_browser_hooks
+
+register_browser_hooks()
+
 setupHooks(None, ankimon_tracker_obj)
 
 # --- Changelog check ---

--- a/src/Ankimon/card_hooks.py
+++ b/src/Ankimon/card_hooks.py
@@ -49,7 +49,21 @@ def answerCard_after(rev, card, ease):
         record_desktop_review(revlog_id, card_id=card.id)
     except Exception:
         pass
-
+    
+    # Check for Badge 11 on card review
+    # If this card was previously unsuspended OR had its leech tag removed,
+    # and is now being reviewed, award Badge 11
+    try:
+        from .functions.badges_functions import update_leech_tracking_on_review
+        update_leech_tracking_on_review(
+            rev.mw.col if hasattr(rev, 'mw') and hasattr(rev.mw, 'col') else services.col,
+            services.db,
+            getattr(services, 'achievements', None),
+            card.id
+        )
+    except Exception as e:
+        # Silent fail - don't break Anki functionality
+        pass
 
 # Reload safety (F31): a second boot in the same session must not leave the
 # reviewer hooks registered twice, or every review would be double-counted.

--- a/src/Ankimon/card_hooks.py
+++ b/src/Ankimon/card_hooks.py
@@ -3,7 +3,6 @@ from aqt.utils import tooltip
 
 from .services import services
 from .singletons import ankimon_tracker_obj, reviewer_obj
-from .singletons import logger
 
 def on_show_question(Card):
     ankimon_tracker_obj.start_card_timer()
@@ -61,9 +60,10 @@ def answerCard_after(rev, card, ease):
             getattr(services, 'achievements', None),
             card.id
         )
-    except Exception as e:
-        # Log the error for diagnosability without breaking Anki functionality
-        logger.log("error", f"Failed to update leech tracking for card {card.id}: {e}")
+    except Exception:
+        # `pass` to not break Anki functionality
+        # Future note: add logging for diagnosability
+        pass
 
 # Reload safety (F31): a second boot in the same session must not leave the
 # reviewer hooks registered twice, or every review would be double-counted.

--- a/src/Ankimon/card_hooks.py
+++ b/src/Ankimon/card_hooks.py
@@ -2,8 +2,8 @@ from aqt import gui_hooks, mw, utils
 from aqt.utils import tooltip
 
 from .services import services
-from .singletons import ankimon_tracker_obj, reviewer_obj, logger
-
+from .singletons import ankimon_tracker_obj, reviewer_obj
+from .singletons import logger
 
 def on_show_question(Card):
     ankimon_tracker_obj.start_card_timer()

--- a/src/Ankimon/card_hooks.py
+++ b/src/Ankimon/card_hooks.py
@@ -1,8 +1,13 @@
 from aqt import gui_hooks, mw, utils
 from aqt.utils import tooltip
+import logging
 
 from .services import services
 from .singletons import ankimon_tracker_obj, reviewer_obj
+
+# Set up logger for this module
+logger = logging.getLogger(__name__)
+
 
 def on_show_question(Card):
     ankimon_tracker_obj.start_card_timer()
@@ -60,10 +65,13 @@ def answerCard_after(rev, card, ease):
             getattr(services, 'achievements', None),
             card.id
         )
-    except Exception:
-        # `pass` to not break Anki functionality
-        # Future note: add logging for diagnosability
-        pass
+    except Exception as e:
+        # Preserve review-flow protection by not raising exceptions
+        # Log the error for diagnosability
+        logger.error(
+            f"Failed to update leech tracking for card {card.id}: {e}",
+            exc_info=True
+        )
 
 # Reload safety (F31): a second boot in the same session must not leave the
 # reviewer hooks registered twice, or every review would be double-counted.

--- a/src/Ankimon/card_hooks.py
+++ b/src/Ankimon/card_hooks.py
@@ -2,7 +2,7 @@ from aqt import gui_hooks, mw, utils
 from aqt.utils import tooltip
 
 from .services import services
-from .singletons import ankimon_tracker_obj, reviewer_obj
+from .singletons import ankimon_tracker_obj, reviewer_obj, logger
 
 
 def on_show_question(Card):
@@ -56,14 +56,14 @@ def answerCard_after(rev, card, ease):
     try:
         from .functions.badges_functions import update_leech_tracking_on_review
         update_leech_tracking_on_review(
-            rev.mw.col if hasattr(rev, 'mw') and hasattr(rev.mw, 'col') else services.col,
+            rev.mw.col,
             services.db,
             getattr(services, 'achievements', None),
             card.id
         )
     except Exception as e:
-        # Silent fail - don't break Anki functionality
-        pass
+        # Log the error for diagnosability without breaking Anki functionality
+        logger.log("error", f"Failed to update leech tracking for card {card.id}: {e}")
 
 # Reload safety (F31): a second boot in the same session must not leave the
 # reviewer hooks registered twice, or every review would be double-counted.

--- a/src/Ankimon/functions/badges_functions.py
+++ b/src/Ankimon/functions/badges_functions.py
@@ -119,12 +119,12 @@ def _get_metadata(db, key: str, default=None):
 
 def check_unleeched_cards(col, db, achievements):
     """
-    Tracks cards that were previously leeches or suspended.
-    
+    Tracks cards that were previously leeches.
+
     Badge 11 is awarded when EITHER condition is met:
-    1. A suspended card was unsuspended
+    1. A leech card that was suspended is unsuspended
     OR
-    2. A card with the 'leech' tag had the tag removed
+    2. A card with the 'leech' tag has the tag removed
     
     AND the card is reviewed at least once after the change.
     
@@ -153,14 +153,18 @@ def check_unleeched_cards(col, db, achievements):
         # Load stored tracking data
         stored_candidates = get_pending_badge_11_candidates(db)
 
-        # --- Check for newly unsuspended cards (Condition 1) ---
-        # We need to compare with previously stored suspended cards
-        # Ensure we always work with sets by coercing the result
-        prev_suspended = _get_metadata(db, 'prev_suspended_nids', set())
-        prev_suspended_nids = set(prev_suspended) if isinstance(prev_suspended, (list, set)) else set()
+        # --- Check for newly unsuspended leech cards (Condition 1) ---
+        # Only a note that was both tagged as a leech and suspended at the
+        # previous snapshot qualifies. Tracking every suspended card would let
+        # an unrelated manual suspension earn the leech achievement.
+        prev_suspended = _get_metadata(db, "prev_suspended_leech_nids", set())
+        prev_suspended_leech_nids = (
+            set(prev_suspended)
+            if isinstance(prev_suspended, (list, set))
+            else set()
+        )
 
-        # Find cards that WERE suspended but ARE NOT suspended anymore
-        newly_unsuspended = prev_suspended_nids - suspended_nids
+        newly_unsuspended = prev_suspended_leech_nids - suspended_nids
 
         # Add these as candidates (unless they already are)
         if newly_unsuspended:
@@ -176,8 +180,12 @@ def check_unleeched_cards(col, db, achievements):
                 if nid in existing_nids:
                     stored_candidates.add(str(nid))
 
-        # Save current suspended IDs for next comparison
-        _save_metadata(db, 'prev_suspended_nids', list(suspended_nids))
+        # Save only currently suspended leech notes for the next comparison.
+        _save_metadata(
+            db,
+            "prev_suspended_leech_nids",
+            list(suspended_nids & current_leech_nids),
+        )
 
         # --- Check for newly untagged cards (Condition 2) ---
         # Load previously leeched cards from metadata

--- a/src/Ankimon/functions/badges_functions.py
+++ b/src/Ankimon/functions/badges_functions.py
@@ -1,5 +1,5 @@
 import json
-from typing import List
+from typing import List, Set, Dict
 
 from ..resources import badgebag_path
 from ..services import services
@@ -69,3 +69,191 @@ def handle_review_count_achievement(review_count, achievements):
         achievements = receive_badge(badge_to_award, achievements)
 
     return achievements
+
+def get_pending_badge_11_candidates(db) -> Set[str]:
+    """
+    Retrieves stored note IDs that are candidates for Badge 11.
+    These are cards that have been either:
+    - Unsuspended (was suspended before)
+    - Untagged (had 'leech' tag removed)
+    But haven't been reviewed yet.
+    """
+    try:
+        row = db.execute("SELECT value FROM metadata WHERE key = 'badge_11_candidates'").fetchone()
+        if row and row[0]:
+            return set(json.loads(row[0]))
+    except Exception:
+        pass
+    return set()
+
+
+def save_pending_badge_11_candidates(db, candidates: Set[str]):
+    """Saves pending Badge 11 candidates to metadata."""
+    try:
+        value_str = json.dumps(list(candidates))
+        conn = db._get_connection()
+        conn.execute(
+            "INSERT OR REPLACE INTO metadata (key, value) VALUES ('badge_11_candidates', ?)",
+            (value_str,),
+        )
+        conn.commit()
+    except Exception:
+        pass
+
+
+def check_unleeched_cards(col, db, achievements):
+    """
+    Tracks cards that were previously leeches or suspended.
+    
+    Badge 11 is awarded when EITHER condition is met:
+    1. A suspended card was unsuspended
+    OR
+    2. A card with the 'leech' tag had the tag removed
+    
+    AND the card is reviewed at least once after the change.
+    
+    Cards that meet condition 1 or 2 are stored as "candidates"
+    until they are reviewed.
+    """
+    if not col or not db or not achievements:
+        return
+
+    # Skip if badge already awarded
+    if check_for_badge(achievements, 11):
+        return
+
+    try:
+        # Get current suspended card IDs
+        suspended_cids = set()
+        for cid in col.db.list("SELECT id FROM cards WHERE queue = -1"):
+            suspended_cids.add(str(cid))
+
+        # Get the note ID for each suspended card
+        suspended_nids = set()
+        for cid in suspended_cids:
+            note_id = col.db.scalar("SELECT nid FROM cards WHERE id = ?", int(cid))
+            if note_id:
+                suspended_nids.add(str(note_id))
+
+        # Get current cards with leech tag
+        current_leech_nids = {str(nid) for nid in col.find_notes("tag:leech")}
+
+        # Load stored tracking data
+        stored_candidates = get_pending_badge_11_candidates(db)
+
+        # --- Check for newly unsuspended cards (Condition 1) ---
+        # We need to compare with previously stored suspended cards
+        # Load previously suspended cards from metadata
+        prev_suspended_nids = set()
+        try:
+            row = db.execute("SELECT value FROM metadata WHERE key = 'prev_suspended_nids'").fetchone()
+            if row and row[0]:
+                prev_suspended_nids = set(json.loads(row[0]))
+        except Exception:
+            pass
+
+        # Find cards that WERE suspended but ARE NOT suspended anymore
+        newly_unsuspended = prev_suspended_nids - suspended_nids
+
+        # Add these as candidates (unless they already are)
+        for nid in newly_unsuspended:
+            # Verify the card still exists
+            if col.db.scalar("SELECT id FROM notes WHERE id = ?", int(nid)):
+                stored_candidates.add(str(nid))
+
+        # Save current suspended IDs for next comparison
+        try:
+            value_str = json.dumps(list(suspended_nids))
+            conn = db._get_connection()
+            conn.execute(
+                "INSERT OR REPLACE INTO metadata (key, value) VALUES ('prev_suspended_nids', ?)",
+                (value_str,),
+            )
+            conn.commit()
+        except Exception:
+            pass
+
+        # --- Check for newly untagged cards (Condition 2) ---
+        # Load previously leeched cards from metadata
+        prev_leech_nids = set()
+        try:
+            row = db.execute("SELECT value FROM metadata WHERE key = 'prev_leech_nids'").fetchone()
+            if row and row[0]:
+                prev_leech_nids = set(json.loads(row[0]))
+        except Exception:
+            pass
+
+        # Find cards that WERE leeched but ARE NOT leeched anymore
+        newly_untagged = prev_leech_nids - current_leech_nids
+
+        # Add these as candidates (unless they already are)
+        for nid in newly_untagged:
+            # Verify the card still exists
+            if col.db.scalar("SELECT id FROM notes WHERE id = ?", int(nid)):
+                stored_candidates.add(str(nid))
+
+        # Save current leech IDs for next comparison
+        try:
+            value_str = json.dumps(list(current_leech_nids))
+            conn = db._get_connection()
+            conn.execute(
+                "INSERT OR REPLACE INTO metadata (key, value) VALUES ('prev_leech_nids', ?)",
+                (value_str,),
+            )
+            conn.commit()
+        except Exception:
+            pass
+
+        # Save updated candidates
+        save_pending_badge_11_candidates(db, stored_candidates)
+
+        # Note: Badge 11 is NOT awarded here.
+        # It will be awarded when the card is reviewed
+        # (see check_and_award_badge_11_on_review below)
+
+    except Exception:
+        # Silent fail - don't break Anki functionality
+        pass
+
+
+def check_and_award_badge_11_on_review(col, db, achievements, card_id):
+    """
+    Called when a card is reviewed.
+    If the card is in the candidates list, award Badge 11.
+    """
+    if not col or not db or not achievements:
+        return
+
+    if check_for_badge(achievements, 11):
+        return
+
+    try:
+        # Get the note ID for this card
+        note_id = col.db.scalar("SELECT nid FROM cards WHERE id = ?", card_id)
+        if not note_id:
+            return
+
+        note_id_str = str(note_id)
+
+        # Get pending candidates
+        candidates = get_pending_badge_11_candidates(db)
+
+        # If this card is a candidate, award the badge
+        if note_id_str in candidates:
+            # Remove from candidates (cleanup)
+            candidates.remove(note_id_str)
+            save_pending_badge_11_candidates(db, candidates)
+
+            # Award Badge 11
+            receive_badge(11, achievements)
+
+    except Exception:
+        pass
+
+
+def update_leech_tracking_on_review(col, db, achievements, card_id):
+    """
+    Called after a card is reviewed to check if it qualifies for Badge 11.
+    This should be called from answerCard_after in card_hooks.py.
+    """
+    check_and_award_badge_11_on_review(col, db, achievements, card_id)

--- a/src/Ankimon/functions/badges_functions.py
+++ b/src/Ankimon/functions/badges_functions.py
@@ -131,7 +131,8 @@ def check_unleeched_cards(col, db, achievements):
     Cards that meet condition 1 or 2 are stored as "candidates"
     until they are reviewed.
     """
-    if not col or not db or not achievements:
+    # Use explicit None checks so empty achievements dict ({}) doesn't cause early return
+    if col is None or db is None or achievements is None:
         return
 
     # Skip if badge already awarded
@@ -139,17 +140,12 @@ def check_unleeched_cards(col, db, achievements):
         return
 
     try:
-        # Get current suspended card IDs
-        suspended_cids = set()
-        for cid in col.db.list("SELECT id FROM cards WHERE queue = -1"):
-            suspended_cids.add(str(cid))
-
-        # Get the note ID for each suspended card
-        suspended_nids = set()
-        for cid in suspended_cids:
-            note_id = col.db.scalar("SELECT nid FROM cards WHERE id = ?", int(cid))
-            if note_id:
-                suspended_nids.add(str(note_id))
+        # Get suspended card IDs with their note IDs in a single query
+        # This replaces the N+1 pattern of listing all cids then querying each nid
+        suspended_rows = col.db.all(
+            "SELECT id, nid FROM cards WHERE queue = -1"
+        )
+        suspended_nids = {str(row[1]) for row in suspended_rows if row[1] is not None}
 
         # Get current cards with leech tag
         current_leech_nids = {str(nid) for nid in col.find_notes("tag:leech")}
@@ -165,10 +161,18 @@ def check_unleeched_cards(col, db, achievements):
         newly_unsuspended = prev_suspended_nids - suspended_nids
 
         # Add these as candidates (unless they already are)
-        for nid in newly_unsuspended:
-            # Verify the card still exists
-            if col.db.scalar("SELECT id FROM notes WHERE id = ?", int(nid)):
-                stored_candidates.add(str(nid))
+        if newly_unsuspended:
+            # Verify notes still exist with a single query
+            nid_list = [int(nid) for nid in newly_unsuspended]
+            placeholders = ','.join('?' * len(nid_list))
+            existing_rows = col.db.all(
+                f"SELECT id FROM notes WHERE id IN ({placeholders})", *nid_list
+            ) if nid_list else []
+            existing_nids = {str(row[0]) for row in existing_rows}
+            
+            for nid in newly_unsuspended:
+                if nid in existing_nids:
+                    stored_candidates.add(str(nid))
 
         # Save current suspended IDs for next comparison
         _save_metadata(db, 'prev_suspended_nids', list(suspended_nids))
@@ -181,10 +185,18 @@ def check_unleeched_cards(col, db, achievements):
         newly_untagged = prev_leech_nids - current_leech_nids
 
         # Add these as candidates (unless they already are)
-        for nid in newly_untagged:
-            # Verify the card still exists
-            if col.db.scalar("SELECT id FROM notes WHERE id = ?", int(nid)):
-                stored_candidates.add(str(nid))
+        if newly_untagged:
+            # Verify notes still exist with a single query
+            nid_list = [int(nid) for nid in newly_untagged]
+            placeholders = ','.join('?' * len(nid_list))
+            existing_rows = col.db.all(
+                f"SELECT id FROM notes WHERE id IN ({placeholders})", *nid_list
+            ) if nid_list else []
+            existing_nids = {str(row[0]) for row in existing_rows}
+            
+            for nid in newly_untagged:
+                if nid in existing_nids:
+                    stored_candidates.add(str(nid))
 
         # Save current leech IDs for next comparison
         _save_metadata(db, 'prev_leech_nids', list(current_leech_nids))
@@ -206,7 +218,8 @@ def check_and_award_badge_11_on_review(col, db, achievements, card_id):
     Called when a card is reviewed.
     If the card is in the candidates list, award Badge 11.
     """
-    if not col or not db or not achievements:
+    # Use explicit None checks so empty achievements dict ({}) doesn't cause early return
+    if col is None or db is None or achievements is None:
         return
 
     if check_for_badge(achievements, 11):

--- a/src/Ankimon/functions/badges_functions.py
+++ b/src/Ankimon/functions/badges_functions.py
@@ -155,7 +155,9 @@ def check_unleeched_cards(col, db, achievements):
 
         # --- Check for newly unsuspended cards (Condition 1) ---
         # We need to compare with previously stored suspended cards
-        prev_suspended_nids = _get_metadata(db, 'prev_suspended_nids', set())
+        # Ensure we always work with sets by coercing the result
+        prev_suspended = _get_metadata(db, 'prev_suspended_nids', set())
+        prev_suspended_nids = set(prev_suspended) if isinstance(prev_suspended, (list, set)) else set()
 
         # Find cards that WERE suspended but ARE NOT suspended anymore
         newly_unsuspended = prev_suspended_nids - suspended_nids
@@ -179,7 +181,9 @@ def check_unleeched_cards(col, db, achievements):
 
         # --- Check for newly untagged cards (Condition 2) ---
         # Load previously leeched cards from metadata
-        prev_leech_nids = _get_metadata(db, 'prev_leech_nids', set())
+        # Ensure we always work with sets by coercing the result
+        prev_leech = _get_metadata(db, 'prev_leech_nids', set())
+        prev_leech_nids = set(prev_leech) if isinstance(prev_leech, (list, set)) else set()
 
         # Find cards that WERE leeched but ARE NOT leeched anymore
         newly_untagged = prev_leech_nids - current_leech_nids

--- a/src/Ankimon/functions/badges_functions.py
+++ b/src/Ankimon/functions/badges_functions.py
@@ -89,16 +89,32 @@ def get_pending_badge_11_candidates(db) -> Set[str]:
 
 def save_pending_badge_11_candidates(db, candidates: Set[str]):
     """Saves pending Badge 11 candidates to metadata."""
+    _save_metadata(db, 'badge_11_candidates', list(candidates))
+
+
+def _save_metadata(db, key: str, value):
+    """Helper to upsert a key-value pair into the metadata table."""
     try:
-        value_str = json.dumps(list(candidates))
+        value_str = json.dumps(value) if not isinstance(value, str) else value
         conn = db._get_connection()
         conn.execute(
-            "INSERT OR REPLACE INTO metadata (key, value) VALUES ('badge_11_candidates', ?)",
-            (value_str,),
+            "INSERT OR REPLACE INTO metadata (key, value) VALUES (?, ?)",
+            (key, value_str),
         )
         conn.commit()
     except Exception:
         pass
+
+
+def _get_metadata(db, key: str, default=None):
+    """Helper to retrieve a value from the metadata table."""
+    try:
+        row = db.execute("SELECT value FROM metadata WHERE key = ?", (key,)).fetchone()
+        if row and row[0]:
+            return json.loads(row[0])
+    except Exception:
+        pass
+    return default
 
 
 def check_unleeched_cards(col, db, achievements):
@@ -143,14 +159,7 @@ def check_unleeched_cards(col, db, achievements):
 
         # --- Check for newly unsuspended cards (Condition 1) ---
         # We need to compare with previously stored suspended cards
-        # Load previously suspended cards from metadata
-        prev_suspended_nids = set()
-        try:
-            row = db.execute("SELECT value FROM metadata WHERE key = 'prev_suspended_nids'").fetchone()
-            if row and row[0]:
-                prev_suspended_nids = set(json.loads(row[0]))
-        except Exception:
-            pass
+        prev_suspended_nids = _get_metadata(db, 'prev_suspended_nids', set())
 
         # Find cards that WERE suspended but ARE NOT suspended anymore
         newly_unsuspended = prev_suspended_nids - suspended_nids
@@ -162,26 +171,11 @@ def check_unleeched_cards(col, db, achievements):
                 stored_candidates.add(str(nid))
 
         # Save current suspended IDs for next comparison
-        try:
-            value_str = json.dumps(list(suspended_nids))
-            conn = db._get_connection()
-            conn.execute(
-                "INSERT OR REPLACE INTO metadata (key, value) VALUES ('prev_suspended_nids', ?)",
-                (value_str,),
-            )
-            conn.commit()
-        except Exception:
-            pass
+        _save_metadata(db, 'prev_suspended_nids', list(suspended_nids))
 
         # --- Check for newly untagged cards (Condition 2) ---
         # Load previously leeched cards from metadata
-        prev_leech_nids = set()
-        try:
-            row = db.execute("SELECT value FROM metadata WHERE key = 'prev_leech_nids'").fetchone()
-            if row and row[0]:
-                prev_leech_nids = set(json.loads(row[0]))
-        except Exception:
-            pass
+        prev_leech_nids = _get_metadata(db, 'prev_leech_nids', set())
 
         # Find cards that WERE leeched but ARE NOT leeched anymore
         newly_untagged = prev_leech_nids - current_leech_nids
@@ -193,16 +187,7 @@ def check_unleeched_cards(col, db, achievements):
                 stored_candidates.add(str(nid))
 
         # Save current leech IDs for next comparison
-        try:
-            value_str = json.dumps(list(current_leech_nids))
-            conn = db._get_connection()
-            conn.execute(
-                "INSERT OR REPLACE INTO metadata (key, value) VALUES ('prev_leech_nids', ?)",
-                (value_str,),
-            )
-            conn.commit()
-        except Exception:
-            pass
+        _save_metadata(db, 'prev_leech_nids', list(current_leech_nids))
 
         # Save updated candidates
         save_pending_badge_11_candidates(db, stored_candidates)

--- a/src/Ankimon/functions/browser_hooks.py
+++ b/src/Ankimon/functions/browser_hooks.py
@@ -1,3 +1,17 @@
+"""
+Browser hooks for Badge 11 detection and tracking.
+
+This module monitors browser operations that affect card suspension status and
+tag modifications. It detects when cards are unsuspended or have their 'leech'
+tag removed, which are prerequisites for earning Badge 11. The hooks trigger
+the badge eligibility check after relevant operations, updating the candidate
+set for future review-based badge awarding.
+
+For efficiency, only operations that can affect Badge 11 eligibility trigger
+the expensive check. The module supports reload safety by preventing duplicate
+hook registrations during add-on reloads.
+"""
+
 from aqt import gui_hooks, mw
 from .badges_functions import check_unleeched_cards
 from ..services import services
@@ -14,6 +28,8 @@ except ImportError:
 _HANDLER_RECORD = "_browser_hook_handlers"
 
 # Operation types that can affect Badge 11 candidates
+# These operations change suspension status or tags, which may create candidates
+# for Badge 11 (cards that were previously suspended or leeched)
 _RELEVANT_OPERATIONS = {
     'suspend_cards',
     'unsuspend_cards',
@@ -25,7 +41,16 @@ _RELEVANT_OPERATIONS = {
 
 
 def on_browser_will_remove_selected(browser):
-    """Called before cards are removed. Runs the badge check only on removal."""
+    """
+    Fallback hook called before cards are removed from the browser.
+    
+    This is a less efficient alternative to browser_operation_did_execute,
+    triggered on every removal operation. It checks for Badge 11 candidates
+    by scanning all cards for state changes.
+    
+    Args:
+        browser: The browser instance performing the removal operation.
+    """
     try:
         check_unleeched_cards(
             services.col if services.col is not None else mw.col,
@@ -33,14 +58,22 @@ def on_browser_will_remove_selected(browser):
             getattr(services, 'achievements', None),
         )
     except Exception:
+        # Silently fail to preserve Anki functionality
         pass
 
 
 def on_operation_did_execute(operation_name, *args, **kwargs):
     """
-    Called after any browser operation executes.
-    Only runs the expensive badge check for operations that affect 
+    Hook called after any browser operation executes.
+    
+    Only runs the badge eligibility check for operations that affect
     suspension status or tags (which impact Badge 11 eligibility).
+    This provides a more efficient mechanism than checking on every
+    selection or removal, as it triggers only on relevant state changes.
+    
+    Args:
+        operation_name: The name of the executed operation (e.g., 'unsuspend_cards').
+        *args, **kwargs: Additional arguments passed by the hook.
     """
     # Skip if this operation doesn't affect Badge 11 candidates
     if operation_name not in _RELEVANT_OPERATIONS:
@@ -53,13 +86,25 @@ def on_operation_did_execute(operation_name, *args, **kwargs):
             getattr(services, 'achievements', None),
         )
     except Exception:
+        # Silently fail to preserve Anki functionality
         pass
 
 
 def register_browser_hooks():
     """
     Register browser hooks for Badge 11 detection.
-    Reload-safe: removes previously registered hooks before appending new ones.
+    
+    This function sets up the browser hooks needed to track card state changes
+    that could make cards eligible for Badge 11. It prioritizes the more
+    efficient browser_operation_did_execute hook when available, falling back
+    to browser_will_remove_selected for older Anki versions.
+    
+    Implements reload safety (F31) by removing previously registered hooks
+    before appending new ones. This prevents duplicate processing when the
+    add-on is reloaded during the same Anki session.
+    
+    The hooks are stored in the services registry to survive module re-execution
+    and enable proper cleanup during reloads.
     """
     # Remove previous registration first (F31 pattern)
     for hook, handler in getattr(services, _HANDLER_RECORD, ()):

--- a/src/Ankimon/functions/browser_hooks.py
+++ b/src/Ankimon/functions/browser_hooks.py
@@ -2,15 +2,30 @@ from aqt import gui_hooks, mw
 from .badges_functions import check_unleeched_cards
 from ..services import services
 
+# Use a string type annotation to avoid runtime import of aqt.browser
+# This prevents ModuleNotFoundError on Anki versions where aqt.browser doesn't exist
 try:
     from aqt.browser import Browser  # noqa: F401
     HAS_BROWSER_IMPORT = True
 except ImportError:
     HAS_BROWSER_IMPORT = False
 
+# Reload safety (F31): track registered handlers on services to prevent duplicate registration
+_HANDLER_RECORD = "_browser_hook_handlers"
 
-def on_browser_did_change_row(browser):
-    """Called when the selected row changes in the browser."""
+# Operation types that can affect Badge 11 candidates
+_RELEVANT_OPERATIONS = {
+    'suspend_cards',
+    'unsuspend_cards',
+    'add_tags',
+    'remove_tags',
+    'set_tags',
+    'clear_tags',
+}
+
+
+def on_browser_will_remove_selected(browser):
+    """Called before cards are removed. Runs the badge check only on removal."""
     try:
         check_unleeched_cards(
             services.col if services.col is not None else mw.col,
@@ -21,8 +36,16 @@ def on_browser_did_change_row(browser):
         pass
 
 
-def on_browser_will_remove_selected(browser):
-    """Called before cards are removed."""
+def on_operation_did_execute(operation_name, *args, **kwargs):
+    """
+    Called after any browser operation executes.
+    Only runs the expensive badge check for operations that affect 
+    suspension status or tags (which impact Badge 11 eligibility).
+    """
+    # Skip if this operation doesn't affect Badge 11 candidates
+    if operation_name not in _RELEVANT_OPERATIONS:
+        return
+    
     try:
         check_unleeched_cards(
             services.col if services.col is not None else mw.col,
@@ -34,9 +57,31 @@ def on_browser_will_remove_selected(browser):
 
 
 def register_browser_hooks():
-    """Register browser hooks for Badge 11 detection."""
-    if hasattr(gui_hooks, 'browser_did_change_row'):
-        gui_hooks.browser_did_change_row.append(on_browser_did_change_row)
+    """
+    Register browser hooks for Badge 11 detection.
+    Reload-safe: removes previously registered hooks before appending new ones.
+    """
+    # Remove previous registration first (F31 pattern)
+    for hook, handler in getattr(services, _HANDLER_RECORD, ()):
+        try:
+            hook.remove(handler)
+        except (ValueError, AttributeError):
+            # Handler may already be removed - that's fine
+            pass
+
+    handlers = []
+
+    # Use operation_did_execute for efficient Badge 11 checking
+    # This only runs on actual state-changing operations, not on every selection
+    if hasattr(gui_hooks, 'browser_operation_did_execute'):
+        handlers.append((gui_hooks.browser_operation_did_execute, on_operation_did_execute))
+    elif hasattr(gui_hooks, 'browser_will_remove_selected'):
+        # Fallback: only check on removal if operation hook isn't available
+        handlers.append((gui_hooks.browser_will_remove_selected, on_browser_will_remove_selected))
+
+    # Register all handlers
+    for hook, handler in handlers:
+        hook.append(handler)
     
-    if hasattr(gui_hooks, 'browser_will_remove_selected'):
-        gui_hooks.browser_will_remove_selected.append(on_browser_will_remove_selected)
+    # Store the handlers for reload safety
+    setattr(services, _HANDLER_RECORD, handlers)

--- a/src/Ankimon/functions/browser_hooks.py
+++ b/src/Ankimon/functions/browser_hooks.py
@@ -1,10 +1,15 @@
 from aqt import gui_hooks, mw
-from aqt.browser import Browser
 from .badges_functions import check_unleeched_cards
 from ..services import services
 
+try:
+    from aqt.browser import Browser  # noqa: F401
+    HAS_BROWSER_IMPORT = True
+except ImportError:
+    HAS_BROWSER_IMPORT = False
 
-def on_browser_did_change_row(browser: Browser):
+
+def on_browser_did_change_row(browser):
     """Called when the selected row changes in the browser."""
     try:
         check_unleeched_cards(
@@ -16,7 +21,7 @@ def on_browser_did_change_row(browser: Browser):
         pass
 
 
-def on_browser_will_remove_selected(browser: Browser):
+def on_browser_will_remove_selected(browser):
     """Called before cards are removed."""
     try:
         check_unleeched_cards(
@@ -30,14 +35,8 @@ def on_browser_will_remove_selected(browser: Browser):
 
 def register_browser_hooks():
     """Register browser hooks for Badge 11 detection."""
-    # Hook available in Anki 2.1+
     if hasattr(gui_hooks, 'browser_did_change_row'):
         gui_hooks.browser_did_change_row.append(on_browser_did_change_row)
     
-    # Hook available in newer Anki versions
     if hasattr(gui_hooks, 'browser_will_remove_selected'):
         gui_hooks.browser_will_remove_selected.append(on_browser_will_remove_selected)
-    
-    # Fallback for older versions: use browser_did_fetch (if available)
-    if hasattr(gui_hooks, 'browser_did_fetch'):
-        gui_hooks.browser_did_fetch.append(on_browser_did_change_row)

--- a/src/Ankimon/functions/browser_hooks.py
+++ b/src/Ankimon/functions/browser_hooks.py
@@ -1,0 +1,43 @@
+from aqt import gui_hooks, mw
+from aqt.browser import Browser
+from .badges_functions import check_unleeched_cards
+from ..services import services
+
+
+def on_browser_did_change_row(browser: Browser):
+    """Called when the selected row changes in the browser."""
+    try:
+        check_unleeched_cards(
+            services.col if services.col is not None else mw.col,
+            services.db,
+            getattr(services, 'achievements', None),
+        )
+    except Exception:
+        pass
+
+
+def on_browser_will_remove_selected(browser: Browser):
+    """Called before cards are removed."""
+    try:
+        check_unleeched_cards(
+            services.col if services.col is not None else mw.col,
+            services.db,
+            getattr(services, 'achievements', None),
+        )
+    except Exception:
+        pass
+
+
+def register_browser_hooks():
+    """Register browser hooks for Badge 11 detection."""
+    # Hook available in Anki 2.1+
+    if hasattr(gui_hooks, 'browser_did_change_row'):
+        gui_hooks.browser_did_change_row.append(on_browser_did_change_row)
+    
+    # Hook available in newer Anki versions
+    if hasattr(gui_hooks, 'browser_will_remove_selected'):
+        gui_hooks.browser_will_remove_selected.append(on_browser_will_remove_selected)
+    
+    # Fallback for older versions: use browser_did_fetch (if available)
+    if hasattr(gui_hooks, 'browser_did_fetch'):
+        gui_hooks.browser_did_fetch.append(on_browser_did_change_row)

--- a/src/Ankimon/functions/browser_hooks.py
+++ b/src/Ankimon/functions/browser_hooks.py
@@ -13,80 +13,32 @@ hook registrations during add-on reloads.
 """
 
 from aqt import gui_hooks, mw
-from .badges_functions import check_unleeched_cards
+
 from ..services import services
+from .badges_functions import check_unleeched_cards
 
-# Use a string type annotation to avoid runtime import of aqt.browser
-# This prevents ModuleNotFoundError on Anki versions where aqt.browser doesn't exist
-try:
-    from aqt.browser import Browser  # noqa: F401
-    HAS_BROWSER_IMPORT = True
-except ImportError:
-    HAS_BROWSER_IMPORT = False
-
-# Reload safety (F31): track registered handlers on services to prevent duplicate registration
+# Reload safety (F31): track registered handlers on services to prevent duplicate registration.
 _HANDLER_RECORD = "_browser_hook_handlers"
 
-# Operation types that can affect Badge 11 candidates
-# These operations change suspension status or tags, which may create candidates
-# for Badge 11 (cards that were previously suspended or leeched)
-_RELEVANT_OPERATIONS = {
-    'suspend_cards',
-    'unsuspend_cards',
-    'add_tags',
-    'remove_tags',
-    'set_tags',
-    'clear_tags',
-}
 
+def on_operation_did_execute(changes, _handler):
+    """Refresh Badge 11 snapshots after card or note state changes.
 
-def on_browser_will_remove_selected(browser):
+    Anki's public hook supplies an ``OpChanges`` object rather than an operation
+    name. Suspension changes set ``card``; tag edits set ``note_text``. Ignore
+    unrelated operations so ordinary UI refreshes do not scan the collection.
     """
-    Fallback hook called before cards are removed from the browser.
-    
-    This is a less efficient alternative to browser_operation_did_execute,
-    triggered on every removal operation. It checks for Badge 11 candidates
-    by scanning all cards for state changes.
-    
-    Args:
-        browser: The browser instance performing the removal operation.
-    """
-    try:
-        check_unleeched_cards(
-            services.col if services.col is not None else mw.col,
-            services.db,
-            getattr(services, 'achievements', None),
-        )
-    except Exception:
-        # Silently fail to preserve Anki functionality
-        pass
-
-
-def on_operation_did_execute(operation_name, *args, **kwargs):
-    """
-    Hook called after any browser operation executes.
-    
-    Only runs the badge eligibility check for operations that affect
-    suspension status or tags (which impact Badge 11 eligibility).
-    This provides a more efficient mechanism than checking on every
-    selection or removal, as it triggers only on relevant state changes.
-    
-    Args:
-        operation_name: The name of the executed operation (e.g., 'unsuspend_cards').
-        *args, **kwargs: Additional arguments passed by the hook.
-    """
-    # Skip if this operation doesn't affect Badge 11 candidates
-    if operation_name not in _RELEVANT_OPERATIONS:
+    if not (getattr(changes, "card", False) or getattr(changes, "note_text", False)):
         return
-    
+
     try:
         check_unleeched_cards(
             services.col if services.col is not None else mw.col,
             services.db,
-            getattr(services, 'achievements', None),
+            getattr(services, "achievements", None),
         )
     except Exception:
-        # Silently fail to preserve Anki functionality
+        # Badge tracking must never interrupt Anki's operation-completion path.
         pass
 
 
@@ -94,10 +46,8 @@ def register_browser_hooks():
     """
     Register browser hooks for Badge 11 detection.
     
-    This function sets up the browser hooks needed to track card state changes
-    that could make cards eligible for Badge 11. It prioritizes the more
-    efficient browser_operation_did_execute hook when available, falling back
-    to browser_will_remove_selected for older Anki versions.
+    This function uses Anki's public ``operation_did_execute`` hook so card
+    suspension and note-tag changes are observed immediately in the same session.
     
     Implements reload safety (F31) by removing previously registered hooks
     before appending new ones. This prevents duplicate processing when the
@@ -115,14 +65,9 @@ def register_browser_hooks():
             pass
 
     handlers = []
-
-    # Use operation_did_execute for efficient Badge 11 checking
-    # This only runs on actual state-changing operations, not on every selection
-    if hasattr(gui_hooks, 'browser_operation_did_execute'):
-        handlers.append((gui_hooks.browser_operation_did_execute, on_operation_did_execute))
-    elif hasattr(gui_hooks, 'browser_will_remove_selected'):
-        # Fallback: only check on removal if operation hook isn't available
-        handlers.append((gui_hooks.browser_will_remove_selected, on_browser_will_remove_selected))
+    operation_hook = getattr(gui_hooks, "operation_did_execute", None)
+    if operation_hook is not None:
+        handlers.append((operation_hook, on_operation_did_execute))
 
     # Register all handlers
     for hook, handler in handlers:

--- a/src/Ankimon/profile_hooks.py
+++ b/src/Ankimon/profile_hooks.py
@@ -104,6 +104,19 @@ def _on_profile_did_open(online_connectivity):
                 parent=mw, exception=e, message="Error showing tip of the day:"
             )
 
+        # Check for Badge 11 candidates on profile open
+        # This detects cards that have been unsuspended OR untagged
+        # and adds them to the candidates list for later review
+        try:
+            from .functions.badges_functions import check_unleeched_cards
+            check_unleeched_cards(
+                services.col if services.col is not None else mw.col,
+                services.db,
+                getattr(services, "achievements", None),
+            )
+        except Exception as e:
+            logger.log("error", f"Failed to evaluate leech badges on profile open: {e}")
+
         def check_connectivity_bg() -> bool:
             # Only run the actual check if we think we're offline
             if not online_connectivity:


### PR DESCRIPTION
### At A Glance
- PR **4 of 4** in response to Issue #409 regarding **5 obtainable badges**. 
- This PR tackles the **unobtainable Badge 11** (First Leech Card unleeched)

### Cause of Bug
- There is **no logic** for detecting leech cards, card suspension, or leech tags on cards, so the mechanism for awarding Badge 11 was not seen anywhere. 

### The Mechanism Applied
*(to fix the bug - that's the unobtainable badge)*

1. In this mechanism, **"Leech cards"** are **defined** as:
  a. Cards that are **suspended**
  and/or (since different users have different Anki settings on what automatic action Anki takes upon leeching a card)
  b. Cards that have a **`leech` tag**

2. To be taken as a **Leech to Unleeched Card candidate**, Ankimon detects if:
  a. A **suspended** card is **unsuspended**
  and/or
  b. A card with the **`leech` tag** has the tag **removed**

3. Lastly, to be **eligible for Badge 11**, a user has to:
  a. **Have** a **leech card**
  b. **Unleech** the leech card
  c. **Review** the particular **unleeched** card **at least once**

### What this PR does
- **Adds** code and hooks that monitor users' **leeched-to-unleeched cards** and whether card candidates are **reviewed**, which includes:
  - Detects **suspended** cards and whether they are **unsuspended**
  - Detects cards with the **`leech` tag** and whether the cards have the **`leech` tag removed**
  - Detects when **unleeched cards** are **reviewed** at least once
- Implements code that **awards Badge 11** after **both** requirements are met.

### What each file does
- `__init__.py`: **Activates `browser_hooks`** upon Ankimon **initialisation**
- `card_hooks.py`: **Checks** if the leech-to-unleeched card **candidate** was **reviewed** and **awards** Badge 11 accordingly
- `profile_hooks.py`: **Detects** leech-to-unleeched **card candidates**** on **profile open**
- `functions/badges_functions.py`: Adds **5 functions** necessary to **detect** and **save** card candidates, **monitor** them, as well as to **award** Badge 11 when criteria match. The functions include `get_pending_badge_11_candidates`, `save_pending_badge_11_candidates`, `check_unleeched_cards`, `check_and_award_badge_11_on_review`, and `update_leech_tracking_on_review`.
- `functions/browser_hooks.py`: This is a **new file** created to **detect live** if **cards change state(s)** from suspended to unsuspended and/or `leech`-tagged to `leech`-untagged.

### Expected Behaviour
1. User has a suspended card, a card with a `leech` tag, or a suspended card with a `leech` tag.
2. User either unsuspends the card or removes the `leech` tag from the card.
3. User encounters the particular card in a review, and reviews it at least once.
4. User visits their Achievements section and sees that Badge 11 is unlocked and coloured.

<img width="155" height="111" alt="image" src="https://github.com/user-attachments/assets/c9502221-8f04-4f89-9c45-d689742dbf45" />

### Related Issue
**_Fixes #409_**
_(broken down into 4 separate PRs for focus)_

### Related PRs
- **PR 1 of 4:** #666 - Tackles the unobtainable **Badge 7** (First Pokemon Caught !)
- **PR 2 of 4:** #690 - Tackles the unobtainable **Badge 12 and 13** (1000 Cards in one Session, 2000 Cards in one Session)
- **PR 3 of 4:** #693 - Tackles the unobtainable **Badge 19** (Evolve Fossil Mon)

### Checklist
- [x] My code and commit messages follow the code style and guidelines of this project.
- [x] I have personally tested the mechanism and successfully received Badge 11 following the expected flow.