### PR TITLE
feat(settings): add Pop-Up on Item Receive toggle

### DIFF
--- a/src/Ankimon/ankimon_items_web/settings_schema.py
+++ b/src/Ankimon/ankimon_items_web/settings_schema.py
@@ -110,6 +110,7 @@ GROUPS = [
             "View Main Pokémon Front",
             "XP Bar Location",
             "Pop-Up on Defeat",
+            "Pop-Up on Item Receive",
         ],
         "chip_group": {
             "label": "HUD Element Toggles",

--- a/src/Ankimon/battle_loop.py
+++ b/src/Ankimon/battle_loop.py
@@ -113,13 +113,17 @@ def on_review_card(*args):
             # Reward the item every time this trigger fires (main granted it
             # unconditionally). display_item() both rolls+grants the reward (via
             # random_item -> give_item) AND paints the popup; the grant is the
-            # actual reward, the QDialog is only the visual. Liveness guard (F24):
-            # the seam window may have been closed (its C++ object deleted) since
-            # boot. When it's dead we still roll+grant the reward directly via
-            # random_item() so it is never silently dropped — only the popup is
-            # skipped.
+            # actual reward, the QDialog is only the visual. Two reasons we may
+            # skip the popup: the user turned it off (it interrupts reviews), or
+            # the liveness guard (F24) found the seam window dead — it may have
+            # been closed (its C++ object deleted) since boot. In both cases we
+            # still roll+grant the reward directly via random_item() so it is
+            # never silently dropped; only the popup is skipped.
             item_window = services.test_window
-            if is_alive(item_window):
+            show_item_popup = settings_obj.get(
+                "gui.pop_up_dialog_message_on_item", True
+            )
+            if show_item_popup and is_alive(item_window):
                 try:
                     item_window.display_item()
                 except RuntimeError:

--- a/src/Ankimon/battle_loop.py
+++ b/src/Ankimon/battle_loop.py
@@ -85,12 +85,7 @@ def on_review_card(*args):
     # the seam — ``__init__``'s ``_on_review_card_gated`` forwards to this
     # function only once ``services.startup_finished`` is True (F32) — so this
     # body always runs against a fully-booted registry.
-    """
-    Process a review event by updating rewards, advancing battle state, and refreshing the battle display.
-    
-    Parameters:
-    	args: Event arguments forwarded by the review hook.
-    """
+    """Process a review event and advance the current battle state."""
     global _state
     s = _state
 

--- a/src/Ankimon/battle_loop.py
+++ b/src/Ankimon/battle_loop.py
@@ -85,6 +85,12 @@ def on_review_card(*args):
     # the seam — ``__init__``'s ``_on_review_card_gated`` forwards to this
     # function only once ``services.startup_finished`` is True (F32) — so this
     # body always runs against a fully-booted registry.
+    """
+    Process a review event by updating rewards, advancing battle state, and refreshing the battle display.
+    
+    Parameters:
+    	args: Event arguments forwarded by the review hook.
+    """
     global _state
     s = _state
 

--- a/src/Ankimon/config.json
+++ b/src/Ankimon/config.json
@@ -23,6 +23,7 @@
     "gui.gif_in_collection": true,
     "gui.styling_in_reviewer": true,
     "gui.pop_up_dialog_message_on_defeat": false,
+    "gui.pop_up_dialog_message_on_item": true,
     "gui.review_hp_bar_thickness": 2,
     "gui.reviewer_image_gif": false,
     "gui.reviewer_text_message_box": true,

--- a/src/Ankimon/config.md
+++ b/src/Ankimon/config.md
@@ -37,9 +37,6 @@ Reviewer Pop Up Messages:
 Decide if you would like to see the anki popup messages in the anki reviewer when your pokemon levels up or when a wild pokemon is defeated
 - `pop_up_dialog_message_on_defeat` [True/False]
 
-Decide if you would like to see the pop-up window when you receive an item. Turning this off still awards the item, it just does not interrupt your reviews.
-- `pop_up_dialog_message_on_item` [True/False]
-
 Sounds:
 You can decide if you want Pokemon Battle Cries in the anki reviewer once a pokemon appears.
 - `sounds` [True/False]

--- a/src/Ankimon/config.md
+++ b/src/Ankimon/config.md
@@ -37,6 +37,9 @@ Reviewer Pop Up Messages:
 Decide if you would like to see the anki popup messages in the anki reviewer when your pokemon levels up or when a wild pokemon is defeated
 - `pop_up_dialog_message_on_defeat` [True/False]
 
+Decide if you would like to see the pop-up window when you receive an item. Turning this off still awards the item, it just does not interrupt your reviews.
+- `pop_up_dialog_message_on_item` [True/False]
+
 Sounds:
 You can decide if you want Pokemon Battle Cries in the anki reviewer once a pokemon appears.
 - `sounds` [True/False]

--- a/src/Ankimon/lang/setting_description.json
+++ b/src/Ankimon/lang/setting_description.json
@@ -25,6 +25,7 @@
     "gui.gif_in_collection": "Show animated sprites (GIFs) instead of static sprites in the collection view.",
     "gui.styling_in_reviewer": "Apply custom CSS styles to enhance reviewer visuals.",
     "gui.pop_up_dialog_message_on_defeat": "Show a pop-up message when a wild Pokémon is defeated.",
+    "gui.pop_up_dialog_message_on_item": "Show a pop-up window when you receive an item. Turning this off still awards the item, it just does not interrupt your reviews.",
     "gui.review_hp_bar_thickness": "Set the HP bar thickness for reviews [2: 8px, 3: 12px, 4: 16px, 5: 20px].",
     "gui.reviewer_image_gif": "Display Pokémon GIFs in the reviewer window.",
     "gui.reviewer_text_message_box": "Enable colorful pop-up messages in the reviewer.",

--- a/src/Ankimon/lang/setting_name.json
+++ b/src/Ankimon/lang/setting_name.json
@@ -28,6 +28,7 @@
     "gui.gif_in_collection": "Show GIFs in Collection",
     "gui.styling_in_reviewer": "Styling in Reviewer",
     "gui.pop_up_dialog_message_on_defeat": "Pop-Up on Defeat",
+    "gui.pop_up_dialog_message_on_item": "Pop-Up on Item Receive",
     "gui.review_hp_bar_thickness": "HP Bar Thickness",
     "gui.reviewer_image_gif": "Reviewer Image as GIF",
     "gui.reviewer_text_message_box": "Show Text Message Box in Reviewer",

--- a/src/Ankimon/pyobj/settings.py
+++ b/src/Ankimon/pyobj/settings.py
@@ -35,6 +35,7 @@ DEFAULT_CONFIG = {
     "gui.gif_in_collection": True,
     "gui.styling_in_reviewer": True,
     "gui.pop_up_dialog_message_on_defeat": False,
+    "gui.pop_up_dialog_message_on_item": True,
     "gui.review_hp_bar_thickness": 2,
     "gui.reviewer_image_gif": False,
     "gui.reviewer_text_message_box": True,

--- a/src/Ankimon/pyobj/settings_window.py
+++ b/src/Ankimon/pyobj/settings_window.py
@@ -409,6 +409,7 @@ class SettingsWindow(QMainWindow):
                     "View Main Pokémon Front",
                     "XP Bar Location",
                     "Pop-Up on Defeat",
+                    "Pop-Up on Item Receive",
                 ],
                 "subgroups": {
                     "HUD Element Toggles": {

--- a/src/Ankimon/pyobj/settings_window.py
+++ b/src/Ankimon/pyobj/settings_window.py
@@ -297,6 +297,9 @@ class SettingsWindow(QMainWindow):
         return button
 
     def setup_ui(self):
+        """
+        Builds the settings window interface, including the logo, search bar, hierarchical settings sections, and save control.
+        """
         self.setMinimumSize(450, 600)
         central_widget = QWidget()
         self.setCentralWidget(central_widget)

--- a/tests/test_item_popup_toggle.py
+++ b/tests/test_item_popup_toggle.py
@@ -72,7 +72,15 @@ def _subrun(body):
 
 
 def _scenario(popup_enabled):
-    """Fire the item trigger exactly once with the setting on/off."""
+    """
+    Run the item-reward scenario with the pop-up setting enabled or disabled.
+    
+    Parameters:
+        popup_enabled (bool): Whether the item pop-up dialog is enabled.
+    
+    Returns:
+        dict: Scenario results, including dialog call count, item quantities, and error details.
+    """
     return _subrun(
         _SPY_WINDOW
         + "from harness.driver import Driver\n"
@@ -113,7 +121,9 @@ def _scenario(popup_enabled):
 
 
 def test_item_popup_disabled_still_grants_item():
-    """Setting OFF: no QDialog is painted, but the item is still awarded."""
+    """
+    Verify that disabling the item pop-up still awards the item without displaying the dialog.
+    """
     r = _scenario(popup_enabled=False)
     assert r["errors"] == 0, "item branch raised: %s" % r["first_error"]
     assert r["display_item_calls"] == 0, (

--- a/tests/test_item_popup_toggle.py
+++ b/tests/test_item_popup_toggle.py
@@ -1,0 +1,199 @@
+"""
+Regression test: ``gui.pop_up_dialog_message_on_item`` suppresses the item
+pop-up WITHOUT dropping the item.
+
+The trap this guards against: ``test_window.display_item()`` both rolls+grants
+the reward (``random_item`` -> ``give_item``) *and* paints the QDialog. Gating
+the call naively on the new setting would silently rob the user of the item
+whenever they turned the pop-up off. ``battle_loop`` must fall through to
+``random_item()`` instead, exactly as it already does for a dead window.
+
+Isolation: same contract as ``test_headless_harness.py`` — the rest of the unit
+suite stubs ``aqt``/``Ankimon.*`` in ``sys.modules`` at import time, so each
+scenario runs in a CLEAN child interpreter and asserts on a JSON result.
+
+Runs under pytest (CI) or as a plain script:  python3 tests/test_item_popup_toggle.py
+"""
+
+import json
+import pathlib
+import subprocess
+import sys
+
+_repo = pathlib.Path(__file__).resolve().parents[1]
+_MARKER = "HARNESS_RESULT:"
+
+# Force the Tier-1 contract in the child: NO Qt — see test_headless_harness.py.
+_BLOCK_QT = (
+    "import sys\n"
+    "class _NoQt:\n"
+    "    _b = ('aqt', 'PyQt6', 'PyQt5')\n"
+    "    def find_spec(self, name, path=None, target=None):\n"
+    "        if name.split('.')[0] in self._b:\n"
+    "            raise ModuleNotFoundError(name + ' blocked: harness Tier-1 is Qt-free')\n"
+    "        return None\n"
+    "sys.meta_path.insert(0, _NoQt())\n"
+)
+
+# A stand-in for the seam window that is *alive* (objectName() works, so
+# is_alive() returns True) and records whether display_item() was called.
+# Deliberately does NOT grant an item, so the assertions can tell the popup
+# path and the direct-grant path apart.
+_SPY_WINDOW = (
+    "class _SpyWindow:\n"
+    "    def __init__(self):\n"
+    "        self.display_item_calls = 0\n"
+    "    def objectName(self):\n"
+    "        return 'SpyWindow'\n"
+    "    def display_item(self):\n"
+    "        self.display_item_calls += 1\n"
+    "    def __getattr__(self, name):\n"
+    "        return lambda *a, **k: None\n"
+)
+
+
+def _subrun(body):
+    """Run a scenario in a clean child interpreter, return its JSON result."""
+    src = _BLOCK_QT + "import json\n" + body
+    proc = subprocess.run(
+        [sys.executable, "-c", src],
+        cwd=str(_repo),
+        capture_output=True,
+        text=True,
+        timeout=300,
+    )
+    for line in proc.stdout.splitlines():
+        if line.startswith(_MARKER):
+            return json.loads(line[len(_MARKER):])
+    raise AssertionError(
+        "child produced no result marker\nSTDOUT:\n%s\nSTDERR:\n%s"
+        % (proc.stdout, proc.stderr)
+    )
+
+
+def _scenario(popup_enabled):
+    """Fire the item trigger exactly once with the setting on/off."""
+    return _subrun(
+        _SPY_WINDOW
+        + "from harness.driver import Driver\n"
+        + "d = Driver(settings_overrides={\n"
+        + "    'battle.cards_per_round': 1,\n"
+        + "    'gui.pop_up_dialog_message_on_item': %r,\n" % bool(popup_enabled)
+        + "})\n"
+        # Driver() runs harness bootstrap(), which is what makes the top-level
+        # ``Ankimon`` package importable — so this import must come after it.
+        + "from Ankimon import battle_loop\n"
+        # random_item() picks the reward by listing the item sprite directory,
+        # which the throwaway harness profile does not ship. Seed a few names so
+        # the grant path can actually complete — otherwise random_item() raises
+        # FileNotFoundError, battle_loop swallows it, and the test would pass
+        # for the wrong reason (no item, but also no popup).
+        + "import os\n"
+        + "from Ankimon.utils import items_path\n"
+        + "os.makedirs(items_path, exist_ok=True)\n"
+        + "for _n in ('potion', 'ether', 'revive'):\n"
+        + "    open(os.path.join(items_path, _n + '.png'), 'wb').close()\n"
+        + "spy = _SpyWindow()\n"
+        + "d.services.test_window = spy\n"
+        + "before = len(d.services.db.get_all_items())\n"
+        # Arm the trigger so the very next answered card fires the item branch.
+        + "battle_loop._state.item_receive_value = 1\n"
+        + "events = d.answer('good')\n"
+        + "after = d.services.db.get_all_items()\n"
+        + "errs = [e for e in events if e['type'] == 'error']\n"
+        + "print(%r + json.dumps({\n" % _MARKER
+        + "    'display_item_calls': spy.display_item_calls,\n"
+        + "    'items_before': before,\n"
+        + "    'items_after': len(after),\n"
+        + "    'total_qty': sum(i.get('quantity', 0) for i in after),\n"
+        + "    'errors': len(errs),\n"
+        + "    'first_error': (errs[0].get('exception') if errs else None),\n"
+        + "}))"
+    )
+
+
+def test_item_popup_disabled_still_grants_item():
+    """Setting OFF: no QDialog is painted, but the item is still awarded."""
+    r = _scenario(popup_enabled=False)
+    assert r["errors"] == 0, "item branch raised: %s" % r["first_error"]
+    assert r["display_item_calls"] == 0, (
+        "display_item() was called with the pop-up setting disabled — "
+        "the toggle does not actually suppress the dialog"
+    )
+    assert r["total_qty"] >= 1, (
+        "no item was granted with the pop-up disabled — the reward was "
+        "silently dropped along with the dialog (items_before=%s items_after=%s)"
+        % (r["items_before"], r["items_after"])
+    )
+
+
+def test_item_popup_enabled_shows_dialog():
+    """Setting ON (the default): behaviour is unchanged — the dialog is shown."""
+    r = _scenario(popup_enabled=True)
+    assert r["errors"] == 0, "item branch raised: %s" % r["first_error"]
+    assert r["display_item_calls"] == 1, (
+        "display_item() was not called with the pop-up setting enabled "
+        "(calls=%s) — the default behaviour regressed" % r["display_item_calls"]
+    )
+
+
+def test_item_popup_setting_is_registered_everywhere():
+    """The key must exist in the defaults AND be reachable from both settings
+    surfaces. Both UIs resolve entries by *display name* via setting_name.json,
+    so a missing name mapping ships the toggle invisible."""
+    import importlib.util
+
+    src = _repo / "src" / "Ankimon"
+    key = "gui.pop_up_dialog_message_on_item"
+
+    names = json.loads((src / "lang" / "setting_name.json").read_text(encoding="utf-8"))
+    descs = json.loads(
+        (src / "lang" / "setting_description.json").read_text(encoding="utf-8")
+    )
+    assert key in names, "%s missing from setting_name.json" % key
+    assert key in descs, "%s missing from setting_description.json" % key
+    label = names[key]
+
+    config = json.loads((src / "config.json").read_text(encoding="utf-8"))
+    assert config.get(key) is True, "%s should default to True in config.json" % key
+
+    # settings_schema has no third-party imports, so it loads standalone.
+    spec = importlib.util.spec_from_file_location(
+        "_ankimon_item_popup_schema", src / "ankimon_items_web" / "settings_schema.py"
+    )
+    schema = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(schema)
+    web_labels = [
+        s
+        for g in schema.GROUPS
+        for s in g.get("settings", [])
+        if isinstance(s, str)
+    ] + [
+        s
+        for g in schema.GROUPS
+        for sub in g.get("subgroups", [])
+        for s in sub.get("settings", [])
+        if isinstance(s, str)
+    ]
+    assert label in web_labels, (
+        "%r not listed in settings_schema.GROUPS — the toggle would be "
+        "invisible in the web settings screen" % label
+    )
+
+    desktop = (src / "pyobj" / "settings_window.py").read_text(encoding="utf-8")
+    assert '"%s"' % label in desktop, (
+        "%r not listed in settings_window.py — the toggle would be invisible "
+        "in the desktop settings window" % label
+    )
+
+    defaults = (src / "pyobj" / "settings.py").read_text(encoding="utf-8")
+    assert '"%s": True' % key in defaults, (
+        "%s missing from DEFAULT_CONFIG — existing users would not get the key" % key
+    )
+
+
+if __name__ == "__main__":
+    test_item_popup_setting_is_registered_everywhere()
+    test_item_popup_disabled_still_grants_item()
+    test_item_popup_enabled_shows_dialog()
+    print("item popup toggle tests: OK")

--- a/tests/test_item_popup_toggle.py
+++ b/tests/test_item_popup_toggle.py
@@ -72,15 +72,7 @@ def _subrun(body):
 
 
 def _scenario(popup_enabled):
-    """
-    Run the item-reward scenario with the pop-up setting enabled or disabled.
-    
-    Parameters:
-        popup_enabled (bool): Whether the item pop-up dialog is enabled.
-    
-    Returns:
-        dict: Scenario results, including dialog call count, item quantities, and error details.
-    """
+    """Run the item-reward scenario with the popup enabled or disabled."""
     return _subrun(
         _SPY_WINDOW
         + "from harness.driver import Driver\n"


### PR DESCRIPTION
### Description

Adds a **Pop-Up on Item Receive** toggle so the item reward dialog can be turned off without interrupting reviews.

Requested by @MochiGirl on Discord:

> I don't like my reviews getting interrupted by item pop ups that I have to manually click exit on. Can you please fix this with a toggle enable/disable switch in the settings?

Every other interrupting reviewer dialog is already gated by a setting — `gui.pop_up_dialog_message_on_defeat` covers the defeat dialog. The item dialog was the one that was missed, so this is as much a consistency fix in the settings surface as a new feature.

New key `gui.pop_up_dialog_message_on_item`, **defaulting to `True`** so existing behaviour is unchanged for everyone who hasn't asked for it. No migration needed: `Settings.__init__` merges `DEFAULT_CONFIG` into saved configs for missing keys, so upgrading users pick it up automatically.

#### The part worth reviewing

`display_item()` both rolls+grants the reward *and* paints the dialog — the grant is a side effect of building the widget:

```python
def display_item(self):
    Receive_Window = QDialog(mw)
    layout = QHBoxLayout()
    item_widget = self.pokemon_display_item(random_item())   # <- grant happens here
```

So gating the call naively would silently rob the user of the item every time they turned the pop-up off. Instead the disabled path falls through to `random_item()` directly — reusing the exact branch the existing dead-window liveness guard (F24) already takes:

```python
item_window = services.test_window
show_item_popup = settings_obj.get("gui.pop_up_dialog_message_on_item", True)
if show_item_popup and is_alive(item_window):
    try:
        item_window.display_item()
    except RuntimeError:
        pass
else:
    try:
        random_item()
    except Exception:
        pass
```

The existing liveness and exception guards are untouched; only the popup is gated.

#### Both settings surfaces

Both UIs resolve entries by **display name** via `lang/setting_name.json`, so the entry has to be added in two places — patching only one ships the toggle invisible in the other:

- `pyobj/settings_window.py` — desktop settings window
- `ankimon_items_web/settings_schema.py` — web settings screen (consumed by `shop_obj.py:GROUPS`)

Widget type is inferred from the value (`isinstance(value, bool)`), so no type registration is needed, and `validate_and_clamp` only touches specific numeric keys, so booleans pass through untouched.

#### Tests

`tests/test_item_popup_toggle.py` covers the behaviour end-to-end through the headless harness (same clean-child-interpreter contract as `test_headless_harness.py`):

- **setting off** → `display_item()` is never called, but the item is still awarded
- **setting on** → the dialog still shows (default behaviour unchanged)
- **registration** → the key is present in `DEFAULT_CONFIG`, `config.json`, both `lang/` files, and *both* settings surfaces

Both behavioural assertions were mutation-checked to confirm they have teeth — reverting the gate to ignore the setting fails the first test, and a naive gate that drops the reward fails it on exactly the `total_qty >= 1` assertion.

One test-environment note: `random_item()` picks the reward by listing the item sprite directory, which the throwaway harness profile does not ship. The test seeds a few sprite names first — otherwise `random_item()` raises `FileNotFoundError`, `battle_loop` swallows it, and the test would pass for the wrong reason (no popup, but also no item).

#### Relationship to #522

This is a **fresh port onto current `main`**, not a rebase of [#522](https://github.com/h0tp-ftw/ankimon/pull/522). That PR was closed with:

> Closing this stale conflicting draft. The optional-popup feature can be ported later, but this branch predates current reward and dead-window handling and is cheaper to replace than repair.

Differences from #522, which that assessment predicted:

- #522 branched before the current liveness-guarded reward block landed in `battle_loop.py`; this builds on it rather than reverting it.
- #522 used an inline `from .utils import random_item` (flagged in its review). Unnecessary now — `random_item` is imported at module top on current `main`.
- #522 predated `ankimon_items_web/settings_schema.py` entirely, so it would have shipped the toggle invisible in the web settings screen.
- #522 had no tests.

### Related Issue

Closes #694

### Checklist
- [x] My code follows the code style and guidelines of this project.
- [x] I have run tests locally (`pytest tests/` and `pytest tests/test_addon_integrity.py`) and they all pass.
- [ ] **(Optional)** I have added/updated my entry in `.all-contributorsrc` at the root of the repository to specify my custom `"nickname"` and `"discord_id"` for release announcements and Discord pings.

<sub>Local run: `687 passed, 23 skipped`; `ruff check --config ci_ruff_check.toml` clean on all changed files.</sub>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
