### PR TITLE
feat: add toggle for Mega Evolutions in wild encounters

### DIFF
--- a/src/Ankimon/ankimon_items_web/settings_schema.py
+++ b/src/Ankimon/ankimon_items_web/settings_schema.py
@@ -179,6 +179,12 @@ GROUPS = [
         },
     },
     {
+        "label": "Special Evolutions",
+        "settings": [
+            "misc.enable_megas",
+        ],
+    },
+    {
         "label": "Mobile Reviews",
         "settings": [
             {

--- a/src/Ankimon/config.json
+++ b/src/Ankimon/config.json
@@ -7,18 +7,19 @@
     "battle.auto_catch_mega": true,
     "battle.auto_catch_gmax": true,
     "battle.auto_catch_regional": true,
-    "battle.auto_catch_wishlist": [25, 133],
+    "battle.auto_catch_wishlist": [
+        25,
+        133
+    ],
     "battle.cards_per_round": 2,
     "battle.daily_average": 100,
     "battle.card_max_time": 60,
-
     "controls.pokemon_buttons": true,
     "controls.defeat_key": "5",
     "controls.catch_key": "6",
     "controls.team_cycle_key": "9",
     "controls.key_for_opening_closing_ankimon": "Ctrl+N",
     "controls.allow_to_choose_moves": false,
-
     "gui.animate_time": true,
     "gui.gif_in_collection": true,
     "gui.styling_in_reviewer": true,
@@ -46,11 +47,9 @@
     "gui.hud_owned_indicator": true,
     "gui.hud_enemy_shiny_indicator": true,
     "gui.hud_player_shiny_indicator": true,
-
     "audio.sound_effects": false,
     "audio.sounds": true,
     "audio.battle_sounds": false,
-
     "misc.gen1": true,
     "misc.gen2": true,
     "misc.gen3": true,
@@ -61,6 +60,7 @@
     "misc.gen8": false,
     "misc.gen9": false,
     "misc.active_region": null,
+    "misc.enable_megas": true,
     "misc.remove_level_cap": false,
     "misc.leaderboard": false,
     "misc.language": 9,
@@ -70,7 +70,6 @@
     "misc.discord_rich_presence_text": 1,
     "misc.show_tip_on_startup": true,
     "misc.last_tip_index": 0,
-
     "trainer.name": "Ash",
     "trainer.sprite": "ash",
     "trainer.id": 0,

--- a/src/Ankimon/config.md
+++ b/src/Ankimon/config.md
@@ -14,6 +14,10 @@ If you want to play with Pokemon from a certain generation, set them as True
 - `Generation8` [True/False]
 - `Generation9` [True/False]
 
+Special Evolutions:
+You can decide if you want Mega Evolutions and similar special forms to spawn in the wild
+- `Enable Mega Evolutions` [True/False]
+
 Pokemon Gif Animations:
 You can decide if you want the Gif Animations in the anki reviewer
 - `reviewer_image_gif` [True/False]
@@ -96,7 +100,7 @@ Setting `catch_key` to a letter allows you to catch pokemons inside of the revie
 Setting `defeat_key` to a letter allows you to defeat pokemons inside of the reviewer when their hp reaches 0 by pressing control and your letter - default is F.
 - `defeat_key` [A - Z]
 
-`review_hp_bar_thickness` sets the pixel thickness of the HP bar in the reviewer. 
+`review_hp_bar_thickness` sets the pixel thickness of the HP bar in the reviewer.
 - Setting it to `2` will result in an 8px thickness.
 - Setting it to `3` will result in a 12px thickness.
 - Setting it to `4` will result in a 16px thickness.

--- a/src/Ankimon/functions/encounter_functions.py
+++ b/src/Ankimon/functions/encounter_functions.py
@@ -671,6 +671,9 @@ def check_id_ok(id_num: Union[int, list[int]]):
     # Mega/Gmax forms have actual_ids >= 10000, which fall outside
     # the normal gen ranges. Resolve to base species for generation check.
     if id_num >= 10000:
+        if id_num in encounter_data.MEGA and not settings_obj.get("misc.enable_megas", True):
+            return False
+
         name = search_pokedex_by_id(id_num)
         if not name or name == "Pokémon not found":
             return True  # fallback

--- a/src/Ankimon/lang/setting_description.json
+++ b/src/Ankimon/lang/setting_description.json
@@ -62,6 +62,7 @@
     "misc.gen7": "Include Pokémon from Generation 7.",
     "misc.gen8": "Include Pokémon from Generation 8.",
     "misc.gen9": "Include Pokémon from Generation 9.",
+    "misc.enable_megas": "Allow Mega Evolutions to spawn in wild encounters.",
     "misc.remove_level_cap": "Allow leveling beyond set level cap.",
     "misc.language": "Select language ID for Pokémon names and descriptions. [1: Japanese (Hir & Kata), 2: Japanese (Roomaji), 3: Korean, 4: Chinese (Traditional), 5: French, 6: German, 7: Spanish, 8: Italian, 9: English, 10: Czech, 11: Japanese, 12: Chinese (Simplified), 13: Portuguese (Brazil), 14: Spanish (Latin America)]",
     "misc.ssh": "Enable SSH if encountering connectivity issues (like Eduroam restrictions).",

--- a/src/Ankimon/lang/setting_name.json
+++ b/src/Ankimon/lang/setting_name.json
@@ -67,6 +67,7 @@
     "misc.gen7": "Generation 7",
     "misc.gen8": "Generation 8",
     "misc.gen9": "Generation 9",
+    "misc.enable_megas": "Enable Mega Evolutions",
     "misc.remove_level_cap": "Remove Level Cap",
     "misc.language": "Language",
     "misc.ssh": "SSH Access",

--- a/src/Ankimon/pyobj/settings.py
+++ b/src/Ankimon/pyobj/settings.py
@@ -72,6 +72,7 @@ DEFAULT_CONFIG = {
     "misc.gen8": True,
     "misc.gen9": False,
     "misc.active_region": None,
+    "misc.enable_megas": True,
     "misc.remove_level_cap": False,
     "misc.language": 9,
     "misc.ssh": True,

--- a/src/Ankimon/pyobj/settings_window.py
+++ b/src/Ankimon/pyobj/settings_window.py
@@ -370,6 +370,7 @@ class SettingsWindow(QMainWindow):
                     "Always Catch: Mega Evolution",
                     "Always Catch: Gigantamax",
                     "Always Catch: Regional Form",
+                    "Enable Mega Evolutions",
                     "Cards per Round",
                     "Review Based Damage",
                     "Friendship & Time Evolution",


### PR DESCRIPTION
Introduced `misc.enable_megas` configuration setting (default True) to optionally prevent Mega Evolution and Special Form Pokémon from appearing during wild encounters. This provides players the ability to avoid spoilers from these mechanics if desired.

- Added setting to `config.json`, `settings.py`, and localization dictionaries
- Added to web config schema and legacy config window
- Modified `check_id_ok` in `encounter_functions.py` to block encounters with IDs matching `encounter_data.MEGA` when the setting is false
- Updated `config.md` documentation

---
*PR created automatically by Jules for task [6713207164187039920](https://jules.google.com/task/6713207164187039920) started by @h0tp-ftw*