### PR TITLE
fix(battle-ui): keep the Ankimon window alive when a sprite is missing

### DIFF
--- a/src/Ankimon/business.py
+++ b/src/Ankimon/business.py
@@ -47,8 +47,17 @@ def split_japanese_string_by_length(input_string, max_length):
         yield current_line
 
 def resize_pixmap_img(pixmap, max_width):
+    """Scale a pixmap to ``max_width``, keeping its aspect ratio.
+
+    A pixmap whose image failed to load is null and reports a width of 0, so
+    the aspect-ratio maths would raise "integer division or modulo by zero" and
+    take the whole window down (issue #101). Nothing sensible can be scaled
+    from a null pixmap, so hand it back untouched — Qt draws it as a no-op.
+    """
     original_width = pixmap.width()
     original_height = pixmap.height()
+    if original_width <= 0:
+        return pixmap
     new_width = max_width
     new_height = (original_height * max_width) // original_width
     pixmap2 = pixmap.scaled(new_width, new_height)

--- a/src/Ankimon/functions/create_css_for_reviewer.py
+++ b/src/Ankimon/functions/create_css_for_reviewer.py
@@ -432,9 +432,9 @@ body.dark #ankimon-hud #MyPokeImage,
 """
 
     if xp_bar_config:
-        # experience_for_next_lvl is 0 for a growth rate the exp table does not
-        # know (or a level outside it); render an empty bar rather than raising
-        # a ZeroDivisionError out of the HUD (issue #101).
+        # Guard the divisor: experience_for_next_lvl arrives from the caller's
+        # exp-table lookup, and a 0 (or None) would raise a ZeroDivisionError
+        # out of the HUD, so render an empty bar (issue #101).
         _exp_next = int(experience_for_next_lvl or 0)
         xp_bar_percent = (
             int((int(main_pokemon.xp or 0) / _exp_next) * 100) if _exp_next else 0

--- a/src/Ankimon/functions/create_css_for_reviewer.py
+++ b/src/Ankimon/functions/create_css_for_reviewer.py
@@ -432,6 +432,13 @@ body.dark #ankimon-hud #MyPokeImage,
 """
 
     if xp_bar_config:
+        # experience_for_next_lvl is 0 for a growth rate the exp table does not
+        # know (or a level outside it); render an empty bar rather than raising
+        # a ZeroDivisionError out of the HUD (issue #101).
+        _exp_next = int(experience_for_next_lvl or 0)
+        xp_bar_percent = (
+            int((int(main_pokemon.xp or 0) / _exp_next) * 100) if _exp_next else 0
+        )
         css += f"""
 /* XP bar - matte, outlined, no glow */
 #ankimon-hud #xp-bar {{
@@ -440,7 +447,7 @@ body.dark #ankimon-hud #MyPokeImage,
   left: 50px;
   right: 5px;
   z-index: 9999;
-  width: {int((int(main_pokemon.xp or 0) / int(experience_for_next_lvl)) * 100)}%;
+  width: {xp_bar_percent}%;
   height: 10px;
   border-radius: 5px;
   background: rgba(0, 191, 255, 0.85);

--- a/src/Ankimon/functions/reviewer_iframe.py
+++ b/src/Ankimon/functions/reviewer_iframe.py
@@ -42,7 +42,9 @@ def create_iframe_html(main_pokemon, enemy_pokemon, settings_obj, textmsg):
     mainpokemon_attack = False
     enemypokemon_attack = False
     experience_for_next_lvl = int(find_experience_for_level(f"{main_pokemon.growth_rate}", int(main_pokemon.level), settings_obj))
-    xp_bar_width = int((int(main_pokemon.xp or 0) / experience_for_next_lvl) * 100)
+    # 0 comes back for a growth rate the exp table does not know (or a level
+    # outside it); render an empty bar instead of dividing by zero (issue #101).
+    xp_bar_width = int((int(main_pokemon.xp or 0) / experience_for_next_lvl) * 100) if experience_for_next_lvl else 0
     ankimon_package = mw.addonManager.addonFromModule(__name__)
     general_url = f"""/_addons/{ankimon_package}/web/"""
     sprites_url = f"""/_addons/{ankimon_package}/user_files/sprites/"""

--- a/src/Ankimon/functions/reviewer_iframe.py
+++ b/src/Ankimon/functions/reviewer_iframe.py
@@ -42,8 +42,8 @@ def create_iframe_html(main_pokemon, enemy_pokemon, settings_obj, textmsg):
     mainpokemon_attack = False
     enemypokemon_attack = False
     experience_for_next_lvl = int(find_experience_for_level(f"{main_pokemon.growth_rate}", int(main_pokemon.level), settings_obj))
-    # 0 comes back for a growth rate the exp table does not know (or a level
-    # outside it); render an empty bar instead of dividing by zero (issue #101).
+    # Guard the divisor: a 0 out of the exp-table lookup would raise a
+    # ZeroDivisionError out of the HUD, so render an empty bar (issue #101).
     xp_bar_width = int((int(main_pokemon.xp or 0) / experience_for_next_lvl) * 100) if experience_for_next_lvl else 0
     ankimon_package = mw.addonManager.addonFromModule(__name__)
     general_url = f"""/_addons/{ankimon_package}/web/"""

--- a/src/Ankimon/pyobj/starter_window.py
+++ b/src/Ankimon/pyobj/starter_window.py
@@ -279,27 +279,34 @@ class StarterWindow(QWidget):
         pixmap_bckg = QPixmap()
         pixmap_bckg.load(str(bckgimage_path))
 
+        def load_starter_sprite(path):
+            """Load a starter sprite, falling back to the substitute.
+
+            ``QPixmap.load`` returns False for a missing file rather than
+            raising, so a sprite that never downloaded would otherwise be
+            drawn blank — and used to crash the screen outright in the
+            aspect-ratio maths below (issue #101).
+            """
+            pixmap = QPixmap()
+            if not pixmap.load(str(path)):
+                pixmap.load(str(frontdefault / "substitute.png"))
+            return pixmap
+
         # Display the Pokémon image
-        water_path = frontdefault / f"{water_id}.png"
         water_label = QLabel()
-        water_pixmap = QPixmap()
-        water_pixmap.load(str(water_path))
+        water_pixmap = load_starter_sprite(frontdefault / f"{water_id}.png")
 
         # Display the Pokémon image
-        fire_path = frontdefault / f"{fire_id}.png"
         fire_label = QLabel()
-        fire_pixmap = QPixmap()
-        fire_pixmap.load(str(fire_path))
+        fire_pixmap = load_starter_sprite(frontdefault / f"{fire_id}.png")
 
         # Display the Pokémon image
-        grass_path = frontdefault / f"{grass_id}.png"
         grass_label = QLabel()
-        grass_pixmap = QPixmap()
-        grass_pixmap.load(str(grass_path))
+        grass_pixmap = load_starter_sprite(frontdefault / f"{grass_id}.png")
 
-        # Use the shared helper: this local copy shadowed it and lacked its
-        # null-pixmap guard, so a starter sprite that never downloaded crashed
-        # the starter screen with a division by zero (issue #101).
+        # Use the shared helper: the local copy that lived here shadowed it and
+        # lacked its null-pixmap guard, so a starter sprite that never
+        # downloaded crashed the starter screen (issue #101).
         water_pixmap = resize_pixmap_img(water_pixmap, 150)
         fire_pixmap = resize_pixmap_img(fire_pixmap, 150)
         grass_pixmap = resize_pixmap_img(grass_pixmap, 150)

--- a/src/Ankimon/pyobj/starter_window.py
+++ b/src/Ankimon/pyobj/starter_window.py
@@ -297,18 +297,12 @@ class StarterWindow(QWidget):
         grass_pixmap = QPixmap()
         grass_pixmap.load(str(grass_path))
 
-        def resize_pixmap_img(pixmap):
-            max_width = 150
-            original_width = pixmap.width()
-            original_height = pixmap.height()
-            new_width = max_width
-            new_height = (original_height * max_width) // original_width
-            pixmap2 = pixmap.scaled(new_width, new_height)
-            return pixmap2
-
-        water_pixmap = resize_pixmap_img(water_pixmap)
-        fire_pixmap = resize_pixmap_img(fire_pixmap)
-        grass_pixmap = resize_pixmap_img(grass_pixmap)
+        # Use the shared helper: this local copy shadowed it and lacked its
+        # null-pixmap guard, so a starter sprite that never downloaded crashed
+        # the starter screen with a division by zero (issue #101).
+        water_pixmap = resize_pixmap_img(water_pixmap, 150)
+        fire_pixmap = resize_pixmap_img(fire_pixmap, 150)
+        grass_pixmap = resize_pixmap_img(grass_pixmap, 150)
 
         # Merge the background image and the Pokémon image
         merged_pixmap = QPixmap(pixmap_bckg.size())

--- a/src/Ankimon/pyobj/starter_window.py
+++ b/src/Ankimon/pyobj/starter_window.py
@@ -265,6 +265,21 @@ class StarterWindow(QWidget):
 
         return water_starter_button, fire_starter_button, grass_start_button
 
+    def _load_sprite(self, path):
+        """Load a Pokémon sprite, falling back to the substitute.
+
+        ``QPixmap.load`` returns False for a missing file rather than raising,
+        so a sprite that never downloaded would otherwise be drawn blank — and
+        used to crash the screen outright in the aspect-ratio maths (issue
+        #101). Every screen in this window loads its sprite through here so the
+        substitute shows consistently: previously the preview screen fell back
+        but the confirmation and fossil screens still went blank.
+        """
+        pixmap = QPixmap()
+        if not pixmap.load(str(path)):
+            pixmap.load(str(frontdefault / "substitute.png"))
+        return pixmap
+
     def pokemon_display_starter(self, water_start, fire_start, grass_start):
         bckgimage_path = addon_dir / "addon_sprites" / "starter_screen" / "bckg.png"
         water_id = int(search_pokedex(water_start, "species_id"))
@@ -275,30 +290,17 @@ class StarterWindow(QWidget):
         pixmap_bckg = QPixmap()
         pixmap_bckg.load(str(bckgimage_path))
 
-        def load_starter_sprite(path):
-            """Load a starter sprite, falling back to the substitute.
-
-            ``QPixmap.load`` returns False for a missing file rather than
-            raising, so a sprite that never downloaded would otherwise be
-            drawn blank — and used to crash the screen outright in the
-            aspect-ratio maths below (issue #101).
-            """
-            pixmap = QPixmap()
-            if not pixmap.load(str(path)):
-                pixmap.load(str(frontdefault / "substitute.png"))
-            return pixmap
-
         # Display the Pokémon image
         water_label = QLabel()
-        water_pixmap = load_starter_sprite(frontdefault / f"{water_id}.png")
+        water_pixmap = self._load_sprite(frontdefault / f"{water_id}.png")
 
         # Display the Pokémon image
         fire_label = QLabel()
-        fire_pixmap = load_starter_sprite(frontdefault / f"{fire_id}.png")
+        fire_pixmap = self._load_sprite(frontdefault / f"{fire_id}.png")
 
         # Display the Pokémon image
         grass_label = QLabel()
-        grass_pixmap = load_starter_sprite(frontdefault / f"{grass_id}.png")
+        grass_pixmap = self._load_sprite(frontdefault / f"{grass_id}.png")
 
         # Use the shared helper: the local copy that lived here shadowed it and
         # lacked its null-pixmap guard, so a starter sprite that never
@@ -348,10 +350,8 @@ class StarterWindow(QWidget):
         pixmap_bckg.load(str(bckgimage_path))
 
         # Display the Pokémon image
-        image_path = frontdefault / f"{id}.png"
         image_label = QLabel()
-        image_pixmap = QPixmap()
-        image_pixmap.load(str(image_path))
+        image_pixmap = self._load_sprite(frontdefault / f"{id}.png")
         image_pixmap = resize_pixmap_img(image_pixmap, 250)
 
         # Merge the background image and the Pokémon image
@@ -388,10 +388,8 @@ class StarterWindow(QWidget):
         pixmap_bckg.load(str(bckgimage_path))
 
         # Display the Pokémon image
-        image_path = frontdefault / f"{id}.png"
         image_label = QLabel()
-        image_pixmap = QPixmap()
-        image_pixmap.load(str(image_path))
+        image_pixmap = self._load_sprite(frontdefault / f"{id}.png")
         image_pixmap = resize_pixmap_img(image_pixmap, 250)
 
         # Merge the background image and the Pokémon image

--- a/src/Ankimon/pyobj/test_window.py
+++ b/src/Ankimon/pyobj/test_window.py
@@ -51,6 +51,7 @@ from .error_handler import show_warning_with_traceback
 from ..business import (
     calculate_present_power,
     format_compact_number,
+    resize_pixmap_img,
     type_compatibility_multiplier,
 )
 
@@ -363,6 +364,26 @@ class TestWindow(QWidget):
 
         return image_label
 
+    def _load_sprite(self, pokemon, side):
+        """Load a Pokémon's sprite, falling back to the substitute.
+
+        ``QPixmap.load`` reports failure by *returning False*, not by raising,
+        so the ``try/except`` this replaces never fired: a sprite the user
+        never downloaded left a null pixmap behind and the window died in the
+        aspect-ratio maths (issue #101). Check the return value instead.
+
+        ``get_sprite_path`` stays inside the ``try`` so a raising lookup still
+        reaches the substitute, exactly as before.
+        """
+        pixmap = QPixmap()
+        try:
+            loaded = pixmap.load(str(pokemon.get_sprite_path(side, "png")))
+        except Exception:
+            loaded = False
+        if not loaded:
+            pixmap.load(str(self.default_path))
+        return pixmap
+
     def window_show(self, bckgimage_path, lang_name):
         ui_path = battle_ui_path
 
@@ -375,38 +396,19 @@ class TestWindow(QWidget):
 
         # Display the Pokémon image
         image_label = QLabel()
-        pixmap = QPixmap()
-
-        try:
-            pixmap.load(str(self.enemy_pokemon.get_sprite_path("front", "png")))
-        except:
-            pixmap.load(str(self.default_path))
+        pixmap = self._load_sprite(self.enemy_pokemon, "front")
 
         # Display the Main Pokémon image
-        pixmap2 = QPixmap()
+        pixmap2 = self._load_sprite(self.main_pokemon, "back")
 
-        try:
-            pixmap2.load(str(self.main_pokemon.get_sprite_path("back", "png")))
-        except:
-            pixmap2.load(str(self.default_path))
+        # Scale both to a fixed width, keeping the aspect ratio. Reading the
+        # dimensions back off the scaled pixmaps keeps the draw offsets correct
+        # even when a sprite is missing and cannot be scaled at all.
+        pixmap = resize_pixmap_img(pixmap, 150)
+        pixmap2 = resize_pixmap_img(pixmap2, 150)
 
-        # Calculate the new dimensions to maintain the aspect ratio
-        max_width = 150
-        original_width = pixmap.width()
-        original_height = pixmap.height()
-        new_width = max_width
-        new_height = (original_height * max_width) // original_width
-
-        pixmap = pixmap.scaled(new_width, new_height)
-
-        # Calculate the new dimensions to maintain the aspect ratio
-        max_width = 150
-        original_width2 = pixmap2.width()
-        original_height2 = pixmap2.height()
-        new_width2 = max_width
-        new_height2 = (original_height2 * max_width) // original_width2
-
-        pixmap2 = pixmap2.scaled(new_width2, new_height2)
+        new_width, new_height = pixmap.width(), pixmap.height()
+        new_width2, new_height2 = pixmap2.width(), pixmap2.height()
 
         # Merge the background image and the Pokémon image
         merged_pixmap = QPixmap(pixmap_bckg.size())
@@ -455,7 +457,11 @@ class TestWindow(QWidget):
         )
 
         mainxp_bar_width = 5
-        mainpokemon_xp_value = int(((self.main_pokemon.xp or 0) / experience) * 148)
+        # find_experience_for_level returns 0 for a growth rate it does not
+        # know or a level outside the exp table, so guard the divisor here too.
+        mainpokemon_xp_value = (
+            int(((self.main_pokemon.xp or 0) / experience) * 148) if experience else 0
+        )
 
         # Paint XP Bar
         painter.setBrush(QColor(58, 155, 220))
@@ -540,8 +546,11 @@ class TestWindow(QWidget):
         return image_label, msg_font
 
     def draw_hp_bar(self, x, y, h, w, hp, max_hp, painter):
-        pokemon_hp_percent = int((hp / max_hp) * 100)
-        hp_bar_value = int(w * (hp / max_hp))
+        # A corrupt save can carry max_hp = 0; draw an empty bar rather than
+        # letting the whole battle window die on the division (issue #101).
+        hp_fraction = (hp / max_hp) if max_hp else 0
+        pokemon_hp_percent = int(hp_fraction * 100)
+        hp_bar_value = int(w * hp_fraction)
 
         # Draw the HP bar
         if pokemon_hp_percent < 25:
@@ -581,38 +590,19 @@ class TestWindow(QWidget):
         image_label = QLabel()
 
         # Display the Pokémon image
-        pixmap = QPixmap()
-
-        try:
-            pixmap.load(str(self.enemy_pokemon.get_sprite_path("front", "png")))
-        except:
-            pixmap.load(str(self.default_path))
+        pixmap = self._load_sprite(self.enemy_pokemon, "front")
 
         # Display the Main Pokémon image
-        pixmap2 = QPixmap()
+        pixmap2 = self._load_sprite(self.main_pokemon, "back")
 
-        try:
-            pixmap2.load(str(self.main_pokemon.get_sprite_path("back", "png")))
-        except:
-            pixmap2.load(str(self.default_path))
+        # Scale both to a fixed width, keeping the aspect ratio. Reading the
+        # dimensions back off the scaled pixmaps keeps the draw offsets correct
+        # even when a sprite is missing and cannot be scaled at all.
+        pixmap = resize_pixmap_img(pixmap, 150)
+        pixmap2 = resize_pixmap_img(pixmap2, 150)
 
-        # Calculate the new dimensions to maintain the aspect ratio
-        max_width = 150
-        original_width = pixmap.width()
-        original_height = pixmap.height()
-        new_width = max_width
-        new_height = (original_height * max_width) // original_width
-
-        pixmap = pixmap.scaled(new_width, new_height)
-
-        # Calculate the new dimensions to maintain the aspect ratio
-        max_width = 150
-        original_width2 = pixmap2.width()
-        original_height2 = pixmap2.height()
-        new_width2 = max_width
-        new_height2 = (original_height2 * max_width) // original_width2
-
-        pixmap2 = pixmap2.scaled(new_width2, new_height2)
+        new_width, new_height = pixmap.width(), pixmap.height()
+        new_width2, new_height2 = pixmap2.width(), pixmap2.height()
 
         # Merge the background image and the Pokémon image
         merged_pixmap = QPixmap(pixmap_bckg.size())
@@ -663,7 +653,11 @@ class TestWindow(QWidget):
         )
 
         mainxp_bar_width = 5
-        mainpokemon_xp_value = int(((self.main_pokemon.xp or 0) / experience) * 148)
+        # find_experience_for_level returns 0 for a growth rate it does not
+        # know or a level outside the exp table, so guard the divisor here too.
+        mainpokemon_xp_value = (
+            int(((self.main_pokemon.xp or 0) / experience) * 148) if experience else 0
+        )
 
         # Paint XP Bar
         painter.setBrush(QColor(58, 155, 220))
@@ -758,22 +752,7 @@ class TestWindow(QWidget):
         item_pixmap = QPixmap()
         item_pixmap.load(str(item_path))
 
-        def resize_pixmap_img(pixmap):
-            max_width = 100
-            original_width = pixmap.width()
-            original_height = pixmap.height()
-
-            if original_width == 0:
-                return pixmap  # Avoid division by zero
-
-            new_width = max_width
-            new_height = (original_height * max_width) // original_width
-
-            pixmap2 = pixmap.scaled(new_width, new_height)
-
-            return pixmap2
-
-        item_pixmap = resize_pixmap_img(item_pixmap)
+        item_pixmap = resize_pixmap_img(item_pixmap, 100)
 
         # Merge the background image and the Pokémon image
         merged_pixmap = QPixmap(pixmap_bckg.size())
@@ -855,22 +834,7 @@ class TestWindow(QWidget):
             item_pixmap = QPixmap()
             item_pixmap.load(str(badge_path))
 
-            def resize_pixmap_img(pixmap):
-                max_width = 100
-                original_width = pixmap.width()
-                original_height = pixmap.height()
-
-                if original_width == 0:
-                    return pixmap  # Avoid division by zero
-
-                new_width = max_width
-                new_height = (original_height * max_width) // original_width
-
-                pixmap2 = pixmap.scaled(new_width, new_height)
-
-                return pixmap2
-
-            item_pixmap = resize_pixmap_img(item_pixmap)
+            item_pixmap = resize_pixmap_img(item_pixmap, 100)
 
             # Merge the background image and the Pokémon image
             merged_pixmap = QPixmap(pixmap_bckg.size())

--- a/src/Ankimon/pyobj/test_window.py
+++ b/src/Ankimon/pyobj/test_window.py
@@ -457,8 +457,9 @@ class TestWindow(QWidget):
         )
 
         mainxp_bar_width = 5
-        # find_experience_for_level returns 0 for a growth rate it does not
-        # know or a level outside the exp table, so guard the divisor here too.
+        # Guard the divisor: a 0 out of the exp-table lookup would take the
+        # whole render down with a ZeroDivisionError, so draw an empty bar
+        # instead (issue #101).
         mainpokemon_xp_value = (
             int(((self.main_pokemon.xp or 0) / experience) * 148) if experience else 0
         )
@@ -653,8 +654,9 @@ class TestWindow(QWidget):
         )
 
         mainxp_bar_width = 5
-        # find_experience_for_level returns 0 for a growth rate it does not
-        # know or a level outside the exp table, so guard the divisor here too.
+        # Guard the divisor: a 0 out of the exp-table lookup would take the
+        # whole render down with a ZeroDivisionError, so draw an empty bar
+        # instead (issue #101).
         mainpokemon_xp_value = (
             int(((self.main_pokemon.xp or 0) / experience) * 148) if experience else 0
         )

--- a/tests/test_resize_pixmap_img.py
+++ b/tests/test_resize_pixmap_img.py
@@ -1,0 +1,93 @@
+"""``business.resize_pixmap_img`` must survive a pixmap that failed to load.
+
+Issue #101: a sprite the user never downloaded yields a NULL QPixmap, whose
+``width()`` is 0. The aspect-ratio maths then raised ``ZeroDivisionError:
+integer division or modulo by zero`` and took the Ankimon window down with it.
+
+This helper is the single place every window scales a sprite through, so the
+guard is pinned here in Tier 1 — no Qt required, it only needs the
+``width()``/``height()``/``scaled()`` trio that QPixmap provides.
+"""
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+_SRC = Path(__file__).parent.parent / "src"
+sys.path.insert(0, str(_SRC))
+
+
+@pytest.fixture
+def resize_pixmap_img():
+    """Load the REAL ``business`` module, ignoring any stub in sys.modules.
+
+    Several test files replace ``Ankimon.business`` with a MagicMock, so a
+    plain module-level import would bind a mock when the suite runs as a whole.
+    Executing the file directly — the trick ``conftest.py`` uses to restore
+    ``Ankimon.resources`` — sidesteps that, and never registers the module, so
+    this test cannot perturb anyone else's stubs either.
+    """
+    spec = importlib.util.spec_from_file_location(
+        "Ankimon.business", _SRC / "Ankimon" / "business.py"
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)  # relative imports resolve via spec.parent
+    return module.resize_pixmap_img
+
+
+class _FakePixmap:
+    """The slice of the QPixmap surface ``resize_pixmap_img`` touches."""
+
+    def __init__(self, width, height):
+        self._width = width
+        self._height = height
+        self.scaled_to = None
+
+    def width(self):
+        return self._width
+
+    def height(self):
+        return self._height
+
+    def scaled(self, width, height):
+        self.scaled_to = (width, height)
+        return _FakePixmap(width, height)
+
+
+def test_null_pixmap_is_returned_untouched_instead_of_raising(resize_pixmap_img):
+    null = _FakePixmap(0, 0)
+
+    result = resize_pixmap_img(null, 150)
+
+    assert result is null  # handed back as-is
+    assert null.scaled_to is None  # never scaled
+
+
+def test_zero_width_with_nonzero_height_also_survives(resize_pixmap_img):
+    """Qt can report an odd null pixmap; the width is what divides."""
+    odd = _FakePixmap(0, 40)
+
+    assert resize_pixmap_img(odd, 150) is odd
+
+
+@pytest.mark.parametrize(
+    ("width", "height", "max_width", "expected"),
+    [
+        (100, 200, 150, (150, 300)),  # scales up, ratio kept
+        (200, 100, 150, (150, 75)),  # scales down, ratio kept
+        (96, 96, 150, (150, 150)),  # square
+        (150, 60, 150, (150, 60)),  # already at max_width
+    ],
+)
+def test_valid_pixmap_still_scales_by_aspect_ratio(
+    resize_pixmap_img, width, height, max_width, expected
+):
+    """The guard must not disturb the normal path."""
+    pixmap = _FakePixmap(width, height)
+
+    result = resize_pixmap_img(pixmap, max_width)
+
+    assert pixmap.scaled_to == expected
+    assert (result.width(), result.height()) == expected

--- a/tests/test_test_window_gui.py
+++ b/tests/test_test_window_gui.py
@@ -80,8 +80,9 @@ class _FakePokemon:
         self.xp = kw.get("xp", 0)
         self.growth_rate = kw.get("growth_rate", "medium")
         self.cp = kw.get("cp", 345)
-        # Point at a file that does not exist to model a sprite the user never
-        # downloaded (issue #101).
+        # Defaults to a real PNG so the sprite-scaling math runs; the issue #101
+        # tests override it with a path that does not exist, modelling a sprite
+        # the user never downloaded.
         self.sprite_path = kw.get("sprite_path", _REAL_SPRITE)
 
     def get_sprite_path(self, side, ext):
@@ -527,15 +528,23 @@ def test_zero_max_hp_does_not_crash_the_hp_bar(make_window, tw_module):
         painter.end()
 
 
-def test_unknown_growth_rate_does_not_crash_the_xp_bar(make_window):
-    """``find_experience_for_level`` returns 0 for a growth rate it can't map.
+@pytest.mark.parametrize(
+    "render", ["pokemon_display_first_encounter", "pokemon_display_battle"]
+)
+def test_zero_experience_does_not_crash_the_xp_bar(
+    make_window, tw_module, monkeypatch, render
+):
+    """A 0 from the exp-table lookup draws an empty XP bar, not a traceback.
 
-    ``mobile_sync`` writes a capitalized "Medium", which misses the lowercase
-    exp-table column and yields 0 — the XP-bar divisor.
+    Patched at the module seam instead of asserting a particular
+    ``find_experience_for_level`` return value, so this pins the divisor guard
+    itself and stays valid however that lookup behaves — main clamps its
+    sub-100 result to ``max(1, experience)``, so no real growth rate reaches 0
+    today. Both renders compute the divisor (``window_show`` for the first
+    encounter, ``pokemon_display_battle`` for the rest), so both are driven.
     """
-    from Ankimon.functions.pokemon_functions import find_experience_for_level
-
-    assert int(find_experience_for_level("Medium", 4, False)) == 0  # the divisor
+    monkeypatch.setattr(tw_module, "find_experience_for_level", lambda *a, **kw: 0)
 
     win = make_window(main=_FakePokemon("scatterbug", 664, growth_rate="Medium", xp=10))
-    assert win.pokemon_display_battle() is not None
+
+    assert getattr(win, render)() is not None

--- a/tests/test_test_window_gui.py
+++ b/tests/test_test_window_gui.py
@@ -439,17 +439,18 @@ def test_death_buttons_route_through_hook_registry_seam(make_window, monkeypatch
 # The reporter hit it whenever Scatterbug (id 664) was their main Pokemon —
 # only the main's *back* sprite was absent.
 
-_MISSING_SPRITE = (
-    _SRC / "Ankimon" / "user_files" / "sprites" / "back_default" / "664.png"
-)
 
+@pytest.fixture
+def missing_sprite(tmp_path):
+    """A sprite path guaranteed not to exist.
 
-@pytest.fixture(autouse=True)
-def _missing_sprite_is_really_missing():
-    assert not _MISSING_SPRITE.exists(), (
-        f"{_MISSING_SPRITE} now exists — pick another absent path so these "
-        "tests still model a sprite that failed to download"
-    )
+    Deliberately NOT a path under ``user_files/sprites/`` — that directory is
+    gitignored and gets populated by the real sprite download, so a developer
+    who has fetched sprites would silently be testing a sprite that IS there.
+    """
+    path = tmp_path / "back_default" / "664.png"
+    assert not path.exists()
+    return path
 
 
 @pytest.mark.parametrize(
@@ -457,20 +458,20 @@ def _missing_sprite_is_really_missing():
 )
 @pytest.mark.parametrize("missing", ["main", "enemy", "both"])
 def test_missing_sprite_renders_instead_of_dividing_by_zero(
-    make_window, render, missing
+    make_window, missing_sprite, render, missing
 ):
     """Both battle renders survive a sprite file that isn't on disk."""
     main = _FakePokemon(
         "scatterbug",
         664,
         type=["bug"],
-        sprite_path=_MISSING_SPRITE if missing in ("main", "both") else _REAL_SPRITE,
+        sprite_path=missing_sprite if missing in ("main", "both") else _REAL_SPRITE,
     )
     enemy = _FakePokemon(
         "charizard",
         6,
         type=["fire", "flying"],
-        sprite_path=_MISSING_SPRITE if missing in ("enemy", "both") else _REAL_SPRITE,
+        sprite_path=missing_sprite if missing in ("enemy", "both") else _REAL_SPRITE,
     )
 
     win = make_window(main=main, enemy=enemy)
@@ -479,7 +480,9 @@ def test_missing_sprite_renders_instead_of_dividing_by_zero(
     assert label is not None
 
 
-def test_missing_sprite_falls_back_to_the_substitute_pixmap(make_window):
+def test_missing_sprite_falls_back_to_the_substitute_pixmap(
+    make_window, missing_sprite
+):
     """The fallback actually loads — the user sees a substitute, not a blank.
 
     The old ``try/except`` around ``QPixmap.load`` never fired, so the
@@ -487,7 +490,7 @@ def test_missing_sprite_falls_back_to_the_substitute_pixmap(make_window):
     here because the shipped substitute.png only lands in ``user_files`` after
     the runtime sprite download.
     """
-    main = _FakePokemon("scatterbug", 664, sprite_path=_MISSING_SPRITE)
+    main = _FakePokemon("scatterbug", 664, sprite_path=missing_sprite)
     win = make_window(main=main)
     win.default_path = _REAL_SPRITE
 

--- a/tests/test_test_window_gui.py
+++ b/tests/test_test_window_gui.py
@@ -545,6 +545,8 @@ def test_zero_experience_does_not_crash_the_xp_bar(
     """
     monkeypatch.setattr(tw_module, "find_experience_for_level", lambda *a, **kw: 0)
 
-    win = make_window(main=_FakePokemon("scatterbug", 664, growth_rate="Medium", xp=10))
+    # The growth rate is deliberately left at the default: the patch above makes
+    # it irrelevant, and that is the point — the divisor is what is under test.
+    win = make_window(main=_FakePokemon("scatterbug", 664, xp=10))
 
     assert getattr(win, render)() is not None

--- a/tests/test_test_window_gui.py
+++ b/tests/test_test_window_gui.py
@@ -80,9 +80,12 @@ class _FakePokemon:
         self.xp = kw.get("xp", 0)
         self.growth_rate = kw.get("growth_rate", "medium")
         self.cp = kw.get("cp", 345)
+        # Point at a file that does not exist to model a sprite the user never
+        # downloaded (issue #101).
+        self.sprite_path = kw.get("sprite_path", _REAL_SPRITE)
 
     def get_sprite_path(self, side, ext):
-        return _REAL_SPRITE
+        return self.sprite_path
 
 
 class _FakeClock:
@@ -426,3 +429,110 @@ def test_death_buttons_route_through_hook_registry_seam(make_window, monkeypatch
     calls.clear()
     win.catch_button.click()
     assert calls == [("catch", {6, 25})]
+
+
+# --- issue #101: a missing sprite must not take the window down -------------
+#
+# `QPixmap.load` reports a missing/corrupt file by returning False rather than
+# raising, so a sprite the user never downloaded left a NULL pixmap (width 0)
+# and the aspect-ratio maths blew up with "integer division or modulo by zero".
+# The reporter hit it whenever Scatterbug (id 664) was their main Pokemon —
+# only the main's *back* sprite was absent.
+
+_MISSING_SPRITE = (
+    _SRC / "Ankimon" / "user_files" / "sprites" / "back_default" / "664.png"
+)
+
+
+@pytest.fixture(autouse=True)
+def _missing_sprite_is_really_missing():
+    assert not _MISSING_SPRITE.exists(), (
+        f"{_MISSING_SPRITE} now exists — pick another absent path so these "
+        "tests still model a sprite that failed to download"
+    )
+
+
+@pytest.mark.parametrize(
+    "render", ["pokemon_display_first_encounter", "pokemon_display_battle"]
+)
+@pytest.mark.parametrize("missing", ["main", "enemy", "both"])
+def test_missing_sprite_renders_instead_of_dividing_by_zero(
+    make_window, render, missing
+):
+    """Both battle renders survive a sprite file that isn't on disk."""
+    main = _FakePokemon(
+        "scatterbug",
+        664,
+        type=["bug"],
+        sprite_path=_MISSING_SPRITE if missing in ("main", "both") else _REAL_SPRITE,
+    )
+    enemy = _FakePokemon(
+        "charizard",
+        6,
+        type=["fire", "flying"],
+        sprite_path=_MISSING_SPRITE if missing in ("enemy", "both") else _REAL_SPRITE,
+    )
+
+    win = make_window(main=main, enemy=enemy)
+
+    label = getattr(win, render)()  # used to raise ZeroDivisionError
+    assert label is not None
+
+
+def test_missing_sprite_falls_back_to_the_substitute_pixmap(make_window):
+    """The fallback actually loads — the user sees a substitute, not a blank.
+
+    The old ``try/except`` around ``QPixmap.load`` never fired, so the
+    substitute was never reached. ``default_path`` is pointed at a real PNG
+    here because the shipped substitute.png only lands in ``user_files`` after
+    the runtime sprite download.
+    """
+    main = _FakePokemon("scatterbug", 664, sprite_path=_MISSING_SPRITE)
+    win = make_window(main=main)
+    win.default_path = _REAL_SPRITE
+
+    pixmap = win._load_sprite(main, "back")
+
+    assert not pixmap.isNull()
+    assert pixmap.width() > 0
+
+
+def test_raising_sprite_lookup_still_reaches_the_substitute(make_window):
+    """A ``get_sprite_path`` that blows up must fall back, as it always did."""
+
+    class _Exploding(_FakePokemon):
+        def get_sprite_path(self, side, ext):
+            raise RuntimeError("pokedex lookup failed")
+
+    main = _Exploding("scatterbug", 664)
+    win = make_window(main=main)
+    win.default_path = _REAL_SPRITE
+
+    assert not win._load_sprite(main, "back").isNull()
+
+
+def test_zero_max_hp_does_not_crash_the_hp_bar(make_window, tw_module):
+    """A corrupt save carrying max_hp = 0 draws an empty bar, not a traceback."""
+    from PyQt6.QtGui import QPainter, QPixmap
+
+    win = make_window()
+    canvas = QPixmap(100, 100)
+    painter = QPainter(canvas)
+    try:
+        assert win.draw_hp_bar(0, 0, 8, 116, 0, 0, painter) is painter
+    finally:
+        painter.end()
+
+
+def test_unknown_growth_rate_does_not_crash_the_xp_bar(make_window):
+    """``find_experience_for_level`` returns 0 for a growth rate it can't map.
+
+    ``mobile_sync`` writes a capitalized "Medium", which misses the lowercase
+    exp-table column and yields 0 — the XP-bar divisor.
+    """
+    from Ankimon.functions.pokemon_functions import find_experience_for_level
+
+    assert int(find_experience_for_level("Medium", 4, False)) == 0  # the divisor
+
+    win = make_window(main=_FakePokemon("scatterbug", 664, growth_rate="Medium", xp=10))
+    assert win.pokemon_display_battle() is not None


### PR DESCRIPTION
Fixes Unlucky-Life/ankimon#101 — *"New error when opening Ankimon window: Integer division or modulo by zero"*.

## The bug

Opening the Ankimon window raised `ZeroDivisionError: integer division or modulo by zero` whenever a Pokémon's sprite file wasn't on disk. The reporter only hit it with **Scatterbug as their main** — because the main Pokémon is the only one whose ***back*** sprite gets loaded, and that was the file they were missing.

Two bugs stacked up:

1. **`QPixmap.load` reports failure by returning `False`, not by raising.** So the `try/except` that was meant to fall back to `substitute.png` never fired — a failed load silently left a null pixmap behind.
2. **A null pixmap has width 0**, and the aspect-ratio maths right after is `(height * max_width) // width`. Hence the crash — and because it escaped with a `QPainter` still active on the pixmap, Qt could abort the process outright rather than just showing an error.

## Why it stayed hidden

The scaling snippet had been **copy-pasted four times**. The item and badge copies already carried a guard:

```python
if original_width == 0:
    return pixmap  # Avoid division by zero
```

…but the two that render the *Pokémon sprites* — and the shared `business.resize_pixmap_img` they all should have been using — did not. Rather than add a fourth guard, this routes every call site through the shared helper and guards it **once**.

## Changes

- `business.resize_pixmap_img` returns a null pixmap untouched (the one guard that now covers every window).
- `test_window` loads sprites through a new `_load_sprite`, which checks `load`'s return value. `get_sprite_path` stays *inside* the `try`, so a raising lookup still reaches the substitute exactly as before.
- Removed the three duplicate local `resize_pixmap_img` definitions (2× `test_window`, 1× `starter_window`). The `starter_window` one **shadowed the import and lacked the guard**, so a missing starter sprite crashed the very first screen a new user sees.
- Guarded the sibling divisions that fail the same way on the same render, so the window doesn't just move its crash down a few lines:
  - `draw_hp_bar` when `max_hp == 0` (corrupt save),
  - the XP bar's `find_experience_for_level` divisor, same divisor also guarded in the reviewer HUD (`reviewer_iframe`, `create_css_for_reviewer`). **Correction to an earlier revision of this description:** `main` has since clamped that lookup's sub-100 result to `max(1, experience)` (#630), so a capitalized `"Medium"` out of `mobile_sync` no longer reaches `0`. These stay as defence-in-depth on the divisor — removing the guard segfaults the process (see below) — and the test now pins them at the `test_window` seam instead of depending on what the lookup returns.

Behavior for users: a missing sprite now renders the **substitute sprite** instead of taking the window down; if sprites were never downloaded at all, the window still opens.

## Verification

Reproduced and fixed against the **real** `test_window` under real PyQt6 (Tier-2 harness), driving both render entry points:

| | `pokemon_display_first_encounter` | `pokemon_display_battle` |
|---|---|---|
| main sprite missing (the Scatterbug case) | crash → **renders** | crash → **renders** |
| enemy sprite missing | crash → **renders** | crash → **renders** |
| both present (control) | renders → renders | renders → renders |

**4 crashes → 0.**

- Full suite: **693 passed, 35 skipped** (`QT_QPA_PLATFORM=offscreen pytest tests/`), same as `main` plus the new tests. Re-run after merging current `main` (`d79e595c`) into the branch.
- Focused Qt module standalone: **20 passed** (`pytest tests/test_test_window_gui.py`).
- Guards confirmed load-bearing, not decorative: deleting the XP-bar guard from both render sites makes the new test fail *and* the process **segfault** (exit 139) — the `ZeroDivisionError` escapes with a `QPainter` still active, so Qt takes the process down. Restored, 20/20 pass.
- Harness Tier-1 gate: **all 9 checks green**. Tier-2 `probe_real_boot` + `probe_real_play`: OK.
- `mega_fuzz --world blank,first_run` (the no-sprites worlds): `main` 8/8 seeds hard-crashed, this branch 7/8 — one seed now survives. The remaining crashes are a pre-existing *harness* gap (`ImportError: cannot import name 'QWebEnginePage' from 'aqt'` in the Trainer Card / Item Shop menus), unrelated to this change.
- `ruff check --config ci_ruff_check.toml`: clean. Every file I touched that was `ruff format`-clean on `main` stays clean; I deliberately did **not** mass-reformat the four files that were already format-dirty on `main`, to keep the diff reviewable.

## Tests added

- **`tests/test_resize_pixmap_img.py`** (new, Tier-1 — no Qt, so it actually runs in CI): pins the shared helper's guard plus the normal scaling path. This is the CI-enforced regression guard, and because every call site now routes through this one function, guarding it guards them all.
- **`tests/test_test_window_gui.py`**: +11 Qt cases driving both real renders with an absent sprite, the substitute fallback, the raising-lookup fallback, `max_hp = 0`, and a `0` XP divisor at both of its call sites.

All new tests were confirmed **red on `main`** and green here. One caveat worth flagging: that Qt module skips when the whole directory is run (another test stubs `PyQt6`), which is pre-existing and applies to its 9 existing tests too — so in CI it skips, and it needs `pytest tests/test_test_window_gui.py` standalone. That's precisely why the Tier-1 file was added alongside it.

## Review follow-ups

- **`test_test_window_gui.py` hard-coded a `find_experience_for_level` return (@h0tp-ftw, blocking).** Confirmed: on current `main` the call returns `1`, not `0`, so the assertion failed `assert 1 == 0` and took the focused suite with it. Fixed by patching `find_experience_for_level` at the `test_window` seam as suggested — the guard under test is the *divisor*, not the exp-table lookup, so pinning it there keeps the test valid however that lookup behaves. It now also drives **both** divisor sites (`window_show` for the first encounter, `pokemon_display_battle` for the rest) rather than only one.
- Reworded the four comments that asserted the lookup "returns 0 for a growth rate it does not know" — with #630's clamp in place that is no longer true, so they now describe the guard defensively rather than claiming behavior `main` does not have.
- **Starter sprites had no substitute fallback (@coderabbitai).** Fixed in 2494d18 — `load_starter_sprite` checks `QPixmap.load`'s return value.
- **Missing-sprite test relied on a repo asset (@coderabbitai).** Fixed in 2494d18 — a `missing_sprite` fixture builds the path under `tmp_path`.
- **Fallback only covered the starter *preview* screen (@coderabbitai).** Fixed in f9d745e9 — the fallback was a closure inside `pokemon_display_starter`, so `pokemon_display_chosen_starter` and `pokemon_display_fossil_pokemon` still loaded directly: a missing file showed `substitute.png` before selection, then went blank immediately after confirming it and on every fossil reward. Promoted to `StarterWindow._load_sprite` and routed all three screens through it. Neither of those screens could *crash* — `resize_pixmap_img` already guards the division — so this is the cosmetic half of the same bug.
- Merged current `main` into the branch, which is what surfaced the blocking finding in the first place.

## Sweep: no crash sites remain

Checked every other aspect-ratio division in the codebase for the issue #101 pattern. All are already safe, so this PR closes the crash class rather than a single instance of it:

| Site | Why it is safe |
|---|---|
| `evolution_window.py:241,251` | behind `if original_width > max_width:` — a null pixmap's width `0` fails it, so the division is skipped |
| `pc_box.py:1736` | same `> max_width` guard |
| `pokemon_details.py:192` | explicit `if original_width > 0:` |
| `business.py:62` | the guard this PR adds |

The remaining variance was blank-vs-substitute, not crash-vs-render — which is what f9d745e9 settles for the starter window. `evolution_window` still renders blank rather than the substitute on a missing sprite; that is pre-existing, cannot crash, and is left out deliberately to keep this PR to the crash class plus the screens already in the diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

