### PR TITLE
fix: allow trade items like Metal Coat to be used in UI

### DIFF
--- a/src/Ankimon/ankimon_items_web/shop_obj.py
+++ b/src/Ankimon/ankimon_items_web/shop_obj.py
@@ -1875,7 +1875,7 @@ class AnkimonItemsWeb(QDialog):
                         normalized_target = target_evo_name.lower().replace(" ", "").replace("-", "").replace("'", "").replace(".", "").replace(":", "")
                         target_data = pokedex_data.get(normalized_target) or pokedex_data.get(target_evo_name.lower())
 
-                        if target_data and target_data.get("evoType") == "useItem":
+                        if target_data and target_data.get("evoType") in ("useItem", "trade"):
                             # Normalize both sides by stripping spaces, hyphens and
                             # apostrophes so pokedex.json display names (e.g.
                             # "King's Rock") match items.csv identifiers (e.g.


### PR DESCRIPTION
Fixes a bug where trade evolution items (like Metal Coat, King's Rock, and Dragon Scale) would not show eligible Pokémon in the item picker screen.

**Root Cause:** The `shop_obj.py` item picker filter was hardcoded to only show Pokémon with an `evoType` of `"useItem"`, ignoring `"trade"`. 
**Resolution:** Updated the filter in `shop_obj.py` to allow both `"useItem"` and `"trade"`. 

All existing tests pass successfully.

---
*PR created automatically by Jules for task [5441788011130607164](https://jules.google.com/task/5441788011130607164) started by @h0tp-ftw*