### PR TITLE
fix(evolve): evaluate move-based evos after learning new moves

### DIFF
--- a/src/Ankimon/functions/encounter_functions.py
+++ b/src/Ankimon/functions/encounter_functions.py
@@ -1299,41 +1299,7 @@ def save_main_pokemon_progress(
                 logger.log_and_showinfo("info", f"{msg}")
         main_pokemon.xp = int(max(0, int(main_pokemon.xp) - current_lvl_xp_cost))
 
-        # Request to open the pokemon evo window
-        evo_id = check_evolution_for_pokemon(
-            main_pokemon.individual_id,
-            main_pokemon.id,
-            main_pokemon.level,
-            evo_window,
-            main_pokemon.everstone,
-            getattr(main_pokemon, "evolution_rejected", False),
-        )
-        if evo_id is not None:
-            evolution_prompted = True
-            events.emit(
-                "evolution_offered",
-                pokemon=main_pokemon.name,
-                trigger="level",
-                evo_id=evo_id,
-            )
-            # None-safe: return_name_for_id can return None for an unknown id, so
-            # fall back to the numeric id instead of crashing on .capitalize()
-            # (mirrors the friendship-evolution path below).
-            evo_display_name = return_name_for_id(evo_id)
-            evo_display_name = (
-                evo_display_name.capitalize() if evo_display_name else str(evo_id)
-            )
-            if not _in_bulk_resolve():
-                logger.log_and_showinfo(
-                    "info",
-                    translator.translate(
-                        "pokemon_about_to_evolve",
-                        main_pokemon_name=main_pokemon.name,
-                        evo_pokemon_name=evo_display_name,
-                        main_pokemon_level=main_pokemon.level,
-                    ),
-                )
-
+        attacks = None
         if main_pokemon_data:
             mainpkmndata = main_pokemon_data
             if mainpkmndata["name"] == main_pokemon.name.capitalize():
@@ -1402,6 +1368,43 @@ def save_main_pokemon_progress(
                                 "info", f"{new_attack} will be discarded."
                             )
                 mainpkmndata["attacks"] = attacks
+
+        # Request to open the pokemon evo window
+        evo_id = check_evolution_for_pokemon(
+            main_pokemon.individual_id,
+            main_pokemon.id,
+            main_pokemon.level,
+            evo_window,
+            main_pokemon.everstone,
+            getattr(main_pokemon, "evolution_rejected", False),
+            current_attacks=attacks,
+        )
+        if evo_id is not None:
+            evolution_prompted = True
+            events.emit(
+                "evolution_offered",
+                pokemon=main_pokemon.name,
+                trigger="level",
+                evo_id=evo_id,
+            )
+            # None-safe: return_name_for_id can return None for an unknown id, so
+            # fall back to the numeric id instead of crashing on .capitalize()
+            # (mirrors the friendship-evolution path below).
+            evo_display_name = return_name_for_id(evo_id)
+            evo_display_name = (
+                evo_display_name.capitalize() if evo_display_name else str(evo_id)
+            )
+            if not _in_bulk_resolve():
+                logger.log_and_showinfo(
+                    "info",
+                    translator.translate(
+                        "pokemon_about_to_evolve",
+                        main_pokemon_name=main_pokemon.name,
+                        evo_pokemon_name=evo_display_name,
+                        main_pokemon_level=main_pokemon.level,
+                    ),
+                )
+
     experience_till_next_level = int(
         find_experience_for_level(
             main_pokemon.growth_rate,

--- a/src/Ankimon/functions/pokedex_functions.py
+++ b/src/Ankimon/functions/pokedex_functions.py
@@ -1029,6 +1029,7 @@ def check_evolution_for_pokemon(
     evo_window,
     everstone=False,
     evolution_rejected=False,
+    current_attacks=None,
 ):
     """
     Check if a Pokémon evolves by a level (or move-based level-up) condition.
@@ -1132,13 +1133,19 @@ def check_evolution_for_pokemon(
                             required_move = target_data.get("evoMove")
                             knows_move = False
 
-                            pkmn_data = None
-                            try:
-                                pkmn_data = services.db.get_pokemon(individual_id)
-                            except Exception:
+                            p_attacks = None
+                            if current_attacks is not None:
+                                p_attacks = current_attacks
+                            else:
                                 pkmn_data = None
-                            if pkmn_data and "attacks" in pkmn_data:
-                                p_attacks = pkmn_data["attacks"]
+                                try:
+                                    pkmn_data = services.db.get_pokemon(individual_id)
+                                except Exception:
+                                    pkmn_data = None
+                                if pkmn_data and "attacks" in pkmn_data:
+                                    p_attacks = pkmn_data["attacks"]
+
+                            if p_attacks is not None:
                                 if required_move and any(
                                     isinstance(a, str)
                                     and a.lower().replace(" ", "").replace("-", "")


### PR DESCRIPTION
When leveling up, `encounter_functions.py` checked for evolution first, and *then* prompted the user to learn any new moves. If a Pokémon (like Piloswine) evolved by knowing a specific move upon leveling up, the evolution check would fail because the new move had not yet been registered. 

This PR:
- Reorders the logic in `encounter_functions.py` so that move-learning occurs before the evolution check.
- Updates `check_evolution_for_pokemon` to accept an optional `current_attacks` list, avoiding stale database reads during multiple sequential level-ups in a single session.

---
*PR created automatically by Jules for task [1687615634235682326](https://jules.google.com/task/1687615634235682326) started by @h0tp-ftw*