### PR TITLE
fix: prevent modal collision during startup database migration

### DIFF
--- a/src/Ankimon/changelog.py
+++ b/src/Ankimon/changelog.py
@@ -269,6 +269,15 @@ def schedule_branch_update_check(online_connectivity: bool, ssh: bool) -> None:
     """
 
     def _on_profile_open() -> None:
+        # Prevent modal dialog collisions on macOS during startup.
+        # If the database needs migration, the MigrationDialog is currently
+        # blocking the main thread. Spawning update/sprite modals simultaneously
+        # will cause a UI deadlock.
+        from .services import services
+        if services.db is not None and not services.db.is_migrated():
+            _log_info("Skipping update checks: Database migration is pending.")
+            return
+
         if online_connectivity:
             check_for_update(online_connectivity, ssh)
         try:


### PR DESCRIPTION
This PR fixes an issue where Ankimon completely freezes during startup when a database migration is needed. The freeze is caused by a race condition on macOS when two modal dialogs (the Database Migration dialog and the Sprite Update dialog) attempt to take focus at the exact same time.

The fix introduces a guard in `changelog.py::_on_profile_open` to verify that `services.db.is_migrated()` is true before executing the background update checks, effectively deferring the sprite check to the next session once the database is fully migrated.

---
*PR created automatically by Jules for task [6045728413708011354](https://jules.google.com/task/6045728413708011354) started by @h0tp-ftw*