### PR TITLE
fix: replace invalid with_backend_semantics with without_collection

### DIFF
--- a/src/Ankimon/pyobj/db_diagnostics.py
+++ b/src/Ankimon/pyobj/db_diagnostics.py
@@ -144,7 +144,7 @@ def trigger_database_diagnostics():
                 parent=mw,
                 op=run_repair,
                 success=on_repair_done
-            ).with_backend_semantics().run_in_background()
+            ).without_collection().run_in_background()
 
     if "PYTEST_CURRENT_TEST" in os.environ:
         try:
@@ -158,4 +158,4 @@ def trigger_database_diagnostics():
             parent=mw,
             op=run_check,
             success=on_check_done
-        ).with_backend_semantics().run_in_background()
+        ).without_collection().run_in_background()


### PR DESCRIPTION
fix: replace invalid with_backend_semantics with without_collection

The Anki `QueryOp` method `with_backend_semantics()` does not exist and was causing Anki to crash when running Ankimon database diagnostics. It has been replaced with the correct `without_collection()` method which is used elsewhere in the codebase.

---
*PR created automatically by Jules for task [18110761723260490868](https://jules.google.com/task/18110761723260490868) started by @h0tp-ftw*