### PR TITLE
fix: render evolution rejection note and button in PC Box split UI

### DIFF
--- a/src/Ankimon/gui_classes/pokemon_details.py
+++ b/src/Ankimon/gui_classes/pokemon_details.py
@@ -408,6 +408,19 @@ def PokemonCollectionDetailsSplit(
         )
         if trigger_evo_callback is None:
             if show_evolution_ui and readiness["ready"]:
+                if readiness.get("rejected"):
+                    evolution_note_label = QLabel(
+                        "Evolution rejected — tap Evolve now to override"
+                    )
+                    evolution_note_label.setFont(custom_font)
+                    evolution_note_label.setWordWrap(True)
+                    evolution_note_label.setFixedWidth(230)
+                    evolution_note_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
+                    evolution_note_label.setStyleSheet("color: #FF69B4;")
+                    evolution_note_widget = evolution_note_label
+                else:
+                    evolution_note_widget = None
+
                 evo_name = readiness["evo_name"] or "the next form"
                 evolve_now_button = QPushButton(f"✨ Evolve into {evo_name} now")
                 evolve_now_button.setFont(custom_font)
@@ -433,17 +446,7 @@ def PokemonCollectionDetailsSplit(
                 qconnect(evolve_now_button.clicked, evolve_now)
                 evolution_req_widget = evolve_now_button
 
-                if readiness.get("rejected"):
-                    evolution_note_label = QLabel(
-                        "Evolution rejected — tap Evolve now to override"
-                    )
-                    evolution_note_label.setFont(custom_font)
-                    evolution_note_label.setWordWrap(True)
-                    evolution_note_label.setFixedWidth(230)
-                    evolution_note_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
-                    evolution_note_label.setStyleSheet("color: #FF69B4;")
-                    evolution_note_widget = evolution_note_label
-            elif show_evolution_ui and readiness["status_text"]:
+            elif show_evolution_ui and readiness.get("status_text"):
                 evolution_req_label = QLabel(readiness["status_text"])
                 evolution_req_label.setFont(custom_font)
                 evolution_req_label.setWordWrap(True)
@@ -558,50 +561,70 @@ def PokemonCollectionDetailsSplit(
         # Caller-driven evolution trigger (split-panel path): render the evolve
         # button in the right-hand column and delegate the actual evolution to
         # the callback. The same friendship master-toggle gating applies.
-        if readiness["ready"] and trigger_evo_callback and show_evolution_ui:
-            translator = services.translator or Translator(language)
-            evolve_text = translator.translate(
-                "evolve_now_button",
-                evo_name=readiness["evo_name"] or "the next form",
-            )
-            evolve_now_button = QPushButton(evolve_text.upper())
-            evolve_now_button.setCursor(Qt.CursorShape.PointingHandCursor)
-            evolve_now_button.setObjectName("evolveNowButton")
+        if trigger_evo_callback and show_evolution_ui:
+            if readiness["ready"]:
+                if readiness.get("rejected"):
+                    evolution_note_label = QLabel(
+                        "Evolution rejected — tap Evolve now to override"
+                    )
+                    evolution_note_label.setFont(custom_font)
+                    evolution_note_label.setWordWrap(True)
+                    evolution_note_label.setFixedWidth(230)
+                    evolution_note_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
+                    evolution_note_label.setStyleSheet("color: #FF69B4;")
+                    TopR_layout_Box.addWidget(evolution_note_label)
 
-            # Match TM button typography/color exactly, but increase height to 40px
-            evolve_now_button.setFixedHeight(40)
-            evolve_now_button.setStyleSheet("""
-                QPushButton {
-                    background: qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 #2563eb, stop:1 #1d4ed8);
-                    color: #f8fafc;
-                    font-size: 11px;
-                    font-weight: 800;
-                    letter-spacing: 0.5px;
-                    border: 1px solid #1e40af;
-                    border-radius: 6px;
-                    margin-top: 12px;
-                    padding: 4px 8px;
-                    text-align: center;
-                }
-                QPushButton:hover {
-                    background: qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 #3b82f6, stop:1 #2563eb);
-                    border-color: #3b82f6;
-                    margin-top: 12px;
-                    padding: 4px 8px;
-                    text-align: center;
-                }
-                QPushButton:pressed {
-                    background: #1e40af;
-                    margin-top: 12px;
-                    padding: 5px 8px 3px 8px;
-                    text-align: center;
-                }
-            """)
-            qconnect(
-                evolve_now_button.clicked,
-                lambda: trigger_evo_callback(readiness["method"]),
-            )
-            TopR_layout_Box.addWidget(evolve_now_button)
+                translator = services.translator or Translator(language)
+                evolve_text = translator.translate(
+                    "evolve_now_button",
+                    evo_name=readiness["evo_name"] or "the next form",
+                )
+                evolve_now_button = QPushButton(evolve_text.upper())
+                evolve_now_button.setCursor(Qt.CursorShape.PointingHandCursor)
+                evolve_now_button.setObjectName("evolveNowButton")
+
+                # Match TM button typography/color exactly, but increase height to 40px
+                evolve_now_button.setFixedHeight(40)
+                evolve_now_button.setStyleSheet("""
+                    QPushButton {
+                        background: qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 #2563eb, stop:1 #1d4ed8);
+                        color: #f8fafc;
+                        font-size: 11px;
+                        font-weight: 800;
+                        letter-spacing: 0.5px;
+                        border: 1px solid #1e40af;
+                        border-radius: 6px;
+                        margin-top: 12px;
+                        padding: 4px 8px;
+                        text-align: center;
+                    }
+                    QPushButton:hover {
+                        background: qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 #3b82f6, stop:1 #2563eb);
+                        border-color: #3b82f6;
+                        margin-top: 12px;
+                        padding: 4px 8px;
+                        text-align: center;
+                    }
+                    QPushButton:pressed {
+                        background: #1e40af;
+                        margin-top: 12px;
+                        padding: 5px 8px 3px 8px;
+                        text-align: center;
+                    }
+                """)
+                qconnect(
+                    evolve_now_button.clicked,
+                    lambda: trigger_evo_callback(readiness["method"]),
+                )
+                TopR_layout_Box.addWidget(evolve_now_button)
+            elif readiness.get("status_text"):
+                evolution_req_label = QLabel(readiness["status_text"])
+                evolution_req_label.setFont(custom_font)
+                evolution_req_label.setWordWrap(True)
+                evolution_req_label.setFixedWidth(230)
+                evolution_req_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
+                evolution_req_label.setStyleSheet("color: #FF69B4;")
+                TopR_layout_Box.addWidget(evolution_req_label)
 
         TopR_widget = QWidget()
         TopR_widget.setLayout(TopR_layout_Box)


### PR DESCRIPTION
Fixes a bug where the 'Evolve now' button and 'Evolution rejected' notice would fail to display inside the PC Box (split layout) when an automatic evolution was previously rejected.

---
*PR created automatically by Jules for task [4118996526844441604](https://jules.google.com/task/4118996526844441604) started by @h0tp-ftw*