### PR TITLE
fix: cache random_item file listing to prevent UI micro-stutters

### DIFF
--- a/src/Ankimon/profile_hooks.py
+++ b/src/Ankimon/profile_hooks.py
@@ -15,6 +15,7 @@ from .pyobj.error_handler import show_warning_with_traceback
 from .functions.pokedex_functions import clear_pokedex_caches
 from .functions.learnset_retrieval import clear_learnset_cache
 from .functions.encounter_functions import clear_encounter_cache
+from .utils import clear_utils_caches
 
 sync_dialog = None
 
@@ -38,6 +39,7 @@ def _on_profile_close():
         clear_pokedex_caches()
         clear_learnset_cache()
         clear_encounter_cache()
+        clear_utils_caches()
     except Exception as e:
         logger.log("error", f"Error clearing caches on profile close: {e}")
 

--- a/src/Ankimon/utils.py
+++ b/src/Ankimon/utils.py
@@ -349,36 +349,48 @@ USELESS_ITEMS = {
 }
 
 
+_random_item_cache = None
+
+def clear_utils_caches():
+    """Clear performance caches in utils.py when profile closes."""
+    global _random_item_cache
+    _random_item_cache = None
+
 def random_item():
-    item_names: list[str] = []
+    global _random_item_cache
+    if _random_item_cache is None:
+        item_names: list[str] = []
 
-    # Iterate over each file in the directory
-    for file in os.listdir(items_path):
-        # Check if the file is a .png file
-        if not file.endswith(".png"):
-            continue
+        # Iterate over each file in the directory
+        for file in os.listdir(items_path):
+            # Check if the file is a .png file
+            if not file.endswith(".png"):
+                continue
 
-        # File name without the .png extension to the list
-        name = file[:-4]
+            # File name without the .png extension to the list
+            name = file[:-4]
 
-        if name in USELESS_ITEMS:
-            continue
-        if name.endswith("-ball"):
-            continue
-        if name.endswith("-repel"):
-            continue
-        if name.endswith("-incense"):
-            continue
-        if name.endswith("-fang"):
-            continue
-        if name.endswith("dust"):
-            continue
-        if name.endswith("-piece"):
-            continue
-        if name.endswith("-nugget"):
-            continue
+            if name in USELESS_ITEMS:
+                continue
+            if name.endswith("-ball"):
+                continue
+            if name.endswith("-repel"):
+                continue
+            if name.endswith("-incense"):
+                continue
+            if name.endswith("-fang"):
+                continue
+            if name.endswith("dust"):
+                continue
+            if name.endswith("-piece"):
+                continue
+            if name.endswith("-nugget"):
+                continue
 
-        item_names.append(name)
+            item_names.append(name)
+        _random_item_cache = item_names
+    else:
+        item_names = _random_item_cache
 
     item_name = random.choice(item_names)
     # add item to item list

--- a/tests/test_profile_hooks.py
+++ b/tests/test_profile_hooks.py
@@ -64,6 +64,7 @@ def _exec_profile_hooks(monkeypatch, gui_hooks):
     clear_pokedex = MagicMock(name="clear_pokedex_caches")
     clear_learnset = MagicMock(name="clear_learnset_cache")
     clear_encounter = MagicMock(name="clear_encounter_cache")
+    clear_utils = MagicMock(name="clear_utils_caches")
 
     monkeypatch.setitem(
         sys.modules,
@@ -86,7 +87,7 @@ def _exec_profile_hooks(monkeypatch, gui_hooks):
     )
     monkeypatch.setitem(
         sys.modules, "Ankimon.utils",
-        _stub_module("Ankimon.utils", test_online_connectivity=lambda: False),
+        _stub_module("Ankimon.utils", test_online_connectivity=lambda: False, clear_utils_caches=clear_utils),
     )
     monkeypatch.setitem(
         sys.modules,
@@ -146,7 +147,7 @@ def _exec_profile_hooks(monkeypatch, gui_hooks):
     profile_hooks = importlib.util.module_from_spec(spec)
     monkeypatch.setitem(sys.modules, "Ankimon.profile_hooks", profile_hooks)
     spec.loader.exec_module(profile_hooks)
-    profile_hooks._clears = (clear_pokedex, clear_learnset, clear_encounter)
+    profile_hooks._clears = (clear_pokedex, clear_learnset, clear_encounter, clear_utils)
     return profile_hooks
 
 


### PR DESCRIPTION
Closes #712 

This fixes a micro-stutter issue that triggers Anki's 'Processing...' progress dialog during reviews when the \`gui.pop_up_dialog_message_on_item\` setting is disabled.

When the popup is disabled, \`battle_loop\` falls back to calling \`random_item()\` directly to grant the item without a visual prompt. Previously, \`random_item()\` performed a synchronous disk read via \`os.listdir(items_path)\` every single time it was called. While fast, running this directly on the main thread during the \`answerCard_after\` hook was blocking the Anki UI just long enough to trip its native \`mw.progress\` timeout.

This patch adds a global in-memory cache (\`_random_item_cache\`) to store the item filenames. The directory is only listed on the first call, and subsequent item rewards are served instantly from the cached list. The cache is securely wired into Anki's \`_on_profile_close\` hook via a new \`clear_utils_caches()\` function, ensuring it correctly flushes and resets when a user switches profiles. 

\`test_profile_hooks.py\` was also updated to mock the new clear function to satisfy the cache-clearing unit tests.

---
*PR created automatically by Jules for task [10211330962396418119](https://jules.google.com/task/10211330962396418119) started by @h0tp-ftw*