### PR TITLE
fix: exclude exp-share from random item pool

### DIFF
--- a/src/Ankimon/utils.py
+++ b/src/Ankimon/utils.py
@@ -346,6 +346,8 @@ USELESS_ITEMS = {
     "max-ether",
     "elixir",
     "ether",
+    # Deprecated / Functional as UI mechanic instead
+    "exp-share",
 }
 
 


### PR DESCRIPTION
Removed `exp-share` from the random item drop pool since it now functions purely as a UI mechanic rather than a held item.

---
*PR created automatically by Jules for task [6139682860254283623](https://jules.google.com/task/6139682860254283623) started by @h0tp-ftw*