### PR TITLE
fix(ui): rename 'fighting' status to 'Battling' in UI

### DIFF
--- a/src/Ankimon/const.py
+++ b/src/Ankimon/const.py
@@ -36,7 +36,7 @@ status_colors_html = {
     "confusion": {"background": "#FFA500", "outline": "#CC8400", "name": "Confusion"},
     "flinching": {"background": "#808080", "outline": "#666666", "name": "Flinching"},
     "fainted": {"background": "#000000", "outline": "#000000", "text_color": "#FFFFFF", "name": "Fainted"},
-    "fighting": {"background": "#C03028", "outline": "#7D1F1A", "name": "Fighting"},  # Example colors for Fighting
+    "fighting": {"background": "#C03028", "outline": "#7D1F1A", "name": "Battling"},  # Example colors for Fighting
 }
 
 # Get the profile folder. Guarded so const imports headless (no Anki): the

--- a/src/Ankimon/const.py
+++ b/src/Ankimon/const.py
@@ -36,7 +36,7 @@ status_colors_html = {
     "confusion": {"background": "#FFA500", "outline": "#CC8400", "name": "Confusion"},
     "flinching": {"background": "#808080", "outline": "#666666", "name": "Flinching"},
     "fainted": {"background": "#000000", "outline": "#000000", "text_color": "#FFFFFF", "name": "Fainted"},
-    "fighting": {"background": "#C03028", "outline": "#7D1F1A", "name": "Battling"},  # Example colors for Fighting
+    "fighting": {"background": "#C03028", "outline": "#7D1F1A", "name": "Battling"},  # Example colors for Battling status
 }
 
 # Get the profile folder. Guarded so const imports headless (no Anki): the

--- a/src/Ankimon/const.py
+++ b/src/Ankimon/const.py
@@ -36,7 +36,7 @@ status_colors_html = {
     "confusion": {"background": "#FFA500", "outline": "#CC8400", "name": "Confusion"},
     "flinching": {"background": "#808080", "outline": "#666666", "name": "Flinching"},
     "fainted": {"background": "#000000", "outline": "#000000", "text_color": "#FFFFFF", "name": "Fainted"},
-    "fighting": {"background": "#C03028", "outline": "#7D1F1A", "name": "Battling"},  # Example colors for Battling status
+    "fighting": {"background": "#C03028", "outline": "#7D1F1A", "name": "Battling"},  # Example colors for Fighting
 }
 
 # Get the profile folder. Guarded so const imports headless (no Anki): the


### PR DESCRIPTION
Changes the display name of the default status condition in Ankimon (`"fighting"`) to `"Battling"` in the UI configuration instead of `"Fighting"` which causes confusion since users often mistake it as the elemental type.

---
*PR created automatically by Jules for task [5266026680504163160](https://jules.google.com/task/5266026680504163160) started by @h0tp-ftw*