### PR TITLE
fix(ui): remove hardcoded opacity toggle on '9' key press

### DIFF
--- a/src/Ankimon/web/index.html
+++ b/src/Ankimon/web/index.html
@@ -258,18 +258,6 @@
 				topPoke.classList.remove('opattack');
 			}
 		}
-
-		// Toggle opacity on '9' key press
-		document.addEventListener('keydown', function(event) {
-			if (event.key === '9') {
-				var htmlElement = document.documentElement;
-				if (htmlElement.style.opacity === '0') {
-					htmlElement.style.opacity = '1';
-				} else {
-					htmlElement.style.opacity = '0';
-				}
-			}
-		});
 	}
 	catch (error) {
 		console.log(error)


### PR DESCRIPTION
This pull request removes a hardcoded JavaScript event listener in `src/Ankimon/web/index.html` that would toggle the document's opacity when the '9' key was pressed.

Because '9' is the default keybind for the "Cycle Team" functionality, users pressing '9' would experience their battle screen turning completely invisible while their team cycled.

This fix removes the conflict and ensures the battle screen remains visible during team cycling. Users can still hide the interface using their configured "Key for Opening/Closing Ankimon" shortcut.

---
*PR created automatically by Jules for task [2175155163645804886](https://jules.google.com/task/2175155163645804886) started by @h0tp-ftw*