### PR TITLE
fix(gui): change hardcoded reviewer yellow HP bar to orange

### DIFF
--- a/src/Ankimon/functions/create_css_for_reviewer.py
+++ b/src/Ankimon/functions/create_css_for_reviewer.py
@@ -20,14 +20,14 @@ def create_css_for_reviewer(
     if enemy_hp_true_percent <= 25:
         enemy_hp_color = "rgba(255, 0, 0, 0.85)"  # Red
     elif enemy_hp_true_percent <= 50:
-        enemy_hp_color = "rgba(255, 255, 0, 0.85)"  # Yellow
+        enemy_hp_color = "rgba(255, 140, 0, 0.85)"  # Orange
     else:
         enemy_hp_color = "rgba(114, 230, 96, 0.85)"  # Green
 
     if main_hp_true_percent <= 25:
         main_hp_color = "rgba(255, 0, 0, 0.85)"  # Red
     elif main_hp_true_percent <= 50:
-        main_hp_color = "rgba(255, 255, 0, 0.85)"  # Yellow
+        main_hp_color = "rgba(255, 140, 0, 0.85)"  # Orange
     else:
         main_hp_color = "rgba(114, 230, 96, 0.85)"  # Green
 

--- a/src/Ankimon/web/index.html
+++ b/src/Ankimon/web/index.html
@@ -156,7 +156,7 @@
 			if (percentage <= 25) {
 				return 'rgba(255, 0, 0, 0.7)';
 			} else if (percentage <= 50) {
-				return 'rgba(255, 255, 0, 0.7)';
+				return 'rgba(255, 140, 0, 0.7)';
 			} else if (percentage <= 75) {
 				return 'rgba(255, 140, 0, 0.7)';
 			} else {


### PR DESCRIPTION
- Changed the hardcoded 50% health bar color from yellow (`rgba(255, 255, 0)`) to orange (`rgba(255, 140, 0)`) in `src/Ankimon/functions/create_css_for_reviewer.py`.
- Changed the corresponding 50% health bar color to orange in `src/Ankimon/web/index.html`.
- This ensures better contrast for users utilizing blue-light filtering apps (e.g., f.lux) where yellow often becomes indistinguishable from white or light gray.

---
*PR created automatically by Jules for task [4275673942619653996](https://jules.google.com/task/4275673942619653996) started by @h0tp-ftw*