### PR TITLE
fix: improve updater busy state (#433)

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -240,6 +240,17 @@
       ],
       "nickname": "Nuz",
       "discord_id": "1317008280911876109"
+    },
+    {
+      "login": "slager2",
+      "name": "slager2",
+      "avatar_url": "https://github.com/slager2.png",
+      "profile": "https://github.com/slager2",
+      "contributions": [
+        "code"
+      ],
+      "nickname": "slager",
+      "discord_id": "955178102097600622"
     }
   ],
   "contributorsPerLine": 5

--- a/src/Ankimon/pyobj/update_dialog.py
+++ b/src/Ankimon/pyobj/update_dialog.py
@@ -62,6 +62,10 @@ class UpdateDialog(QDialog):
         self.dev_data_loaded = False
         self._busy_operations = set()
         self._action_button_states = {}
+        self._closing = False
+        self._close_finalized = False
+        self._sprites_busy_token = None
+        self.sprites_thread = None
 
         self._apply_theme()
 
@@ -814,13 +818,18 @@ class UpdateDialog(QDialog):
 
         dest_dir = Path(user_path_sprites)
         busy_token = self._begin_busy()
+        self._sprites_busy_token = busy_token
         self.sprites_progress.setVisible(True)
         self.sprites_progress.setValue(0)
 
         def settle_busy():
-            self._end_busy(busy_token)
+            if self._sprites_busy_token is busy_token:
+                self._sprites_busy_token = None
+                self._end_busy(busy_token)
 
         def finished(success, message):
+            if self._closing:
+                return
             try:
                 self.sprites_update_btn.setVisible(False)
                 if success:
@@ -838,11 +847,24 @@ class UpdateDialog(QDialog):
                 settle_busy()
 
         def thread_stopped():
-            if busy_token in self._busy_operations:
-                settle_busy()
+            was_active = busy_token in self._busy_operations
+            closing = self._closing
+            settle_busy()
+            self.sprites_thread = None
+            if closing and not self._close_finalized:
+                self.reject()
+            elif was_active:
                 self.sprites_status.setText(
                     "Sprite update stopped unexpectedly. Please try again."
                 )
+
+        def update_progress(value):
+            if not self._closing:
+                self.sprites_progress.setValue(value)
+
+        def update_status(message):
+            if not self._closing:
+                self.sprites_status.setText(message)
 
         try:
             self.sprites_thread = SpriteUpdateDiffThread(
@@ -852,8 +874,12 @@ class UpdateDialog(QDialog):
                 self.sprites_remote_sha,
                 dest_dir,
             )
-            self.sprites_thread.progress_signal.connect(self.sprites_progress.setValue)
-            self.sprites_thread.status_signal.connect(self.sprites_status.setText)
+            self.sprites_thread.progress_signal.connect(
+                lambda value: mw.taskman.run_on_main(lambda: update_progress(value))
+            )
+            self.sprites_thread.status_signal.connect(
+                lambda message: mw.taskman.run_on_main(lambda: update_status(message))
+            )
             self.sprites_thread.finished_signal.connect(
                 lambda success, message: mw.taskman.run_on_main(
                     lambda: finished(success, message)
@@ -865,7 +891,34 @@ class UpdateDialog(QDialog):
             self.sprites_thread.start()
         except Exception as exc:
             settle_busy()
+            self.sprites_thread = None
             self.sprites_status.setText(f"Could not start sprite update: {exc}")
+
+    def _defer_close_for_sprite_thread(self):
+        self._closing = True
+        if self.sprites_thread is not None and self.sprites_thread.isRunning():
+            self.sprites_thread.cancel()
+            self.sprites_status.setText("Cancelling sprite update...")
+            return True
+
+        if self._sprites_busy_token is not None:
+            token = self._sprites_busy_token
+            self._sprites_busy_token = None
+            self._end_busy(token)
+        return False
+
+    def reject(self):
+        if self._defer_close_for_sprite_thread():
+            return
+        self._close_finalized = True
+        super().reject()
+
+    def closeEvent(self, event):
+        if self._defer_close_for_sprite_thread():
+            event.ignore()
+            return
+        self._close_finalized = True
+        super().closeEvent(event)
 
     # --- Data loading ---
 
@@ -1510,7 +1563,11 @@ class BranchUpdateProgressDialog(QDialog):
             )
 
         def on_done(result):
-            success, msg = result
+            try:
+                success, msg = result
+            except Exception as exc:
+                on_failed(exc)
+                return
             self.btn_close.setEnabled(True)
             if success:
                 self.btn_close.setText("Restart Anki")

--- a/src/Ankimon/pyobj/update_dialog.py
+++ b/src/Ankimon/pyobj/update_dialog.py
@@ -49,7 +49,8 @@ class UpdateDialog(QDialog):
         self._branches = []
         self._prs = []
         self.dev_data_loaded = False
-        self._busy_action_states = None
+        self._busy_operations = set()
+        self._action_button_states = {}
 
         self._apply_theme()
 
@@ -79,7 +80,7 @@ class UpdateDialog(QDialog):
         self.progress_bar = QProgressBar()
         self.progress_bar.setVisible(False)
         self.progress_bar.setTextVisible(True)
-        self.progress_bar.setFixedHeight(18)
+        self.progress_bar.setMinimumHeight(self.progress_bar.fontMetrics().height() + 8)
         body.addWidget(self.progress_bar)
 
         self.status_label = QLabel("")
@@ -148,6 +149,8 @@ class UpdateDialog(QDialog):
                 "btn_hover": "#505050",
                 "btn_primary": "#1976d2",
                 "btn_primary_hover": "#1565c0",
+                "progress_text": "#ffffff",
+                "progress_chunk": "#1565c0",
             }
         else:
             self._colors = {
@@ -165,6 +168,8 @@ class UpdateDialog(QDialog):
                 "btn_hover": "#e0e0e0",
                 "btn_primary": "#1976d2",
                 "btn_primary_hover": "#1565c0",
+                "progress_text": "#212121",
+                "progress_chunk": "#90caf9",
             }
         c = self._colors
         self.setStyleSheet(f"""
@@ -217,11 +222,13 @@ class UpdateDialog(QDialog):
                 border: none;
                 background-color: {c["group_border"]};
                 border-radius: 4px;
-                color: {c["text"]};
+                color: {c["progress_text"]};
                 text-align: center;
+                font-weight: bold;
+                padding: 2px;
             }}
             QProgressBar::chunk {{
-                background-color: {c["accent"]};
+                background-color: {c["progress_chunk"]};
                 border-radius: 4px;
             }}
             QTabWidget::pane {{
@@ -382,7 +389,7 @@ class UpdateDialog(QDialog):
             QPushButton:hover {{ background-color: {c["btn_primary_hover"]}; }}
             QPushButton:disabled {{ background-color: {c["btn_bg"]}; color: {c["muted"]}; }}
         """)
-        self.brrr_update_btn.setEnabled(False)
+        self._set_action_enabled(self.brrr_update_btn, False)
         self.brrr_update_btn.clicked.connect(self._on_brrr_update_clicked)
         ctrl_layout.addWidget(self.brrr_update_btn)
 
@@ -458,7 +465,7 @@ class UpdateDialog(QDialog):
             self.brrr_status_label.setStyleSheet(
                 f"font-size: 13px; font-weight: bold; color: {c['error']};"
             )
-            self.brrr_update_btn.setEnabled(False)
+            self._set_action_enabled(self.brrr_update_btn, False)
         elif local_sha != remote_sha:
             self.brrr_status_label.setText(
                 f"Status:  New Update Available! (Latest: {remote_sha[:7]})"
@@ -466,14 +473,14 @@ class UpdateDialog(QDialog):
             self.brrr_status_label.setStyleSheet(
                 f"font-size: 13px; font-weight: bold; color: {c['warning']};"
             )
-            self.brrr_update_btn.setEnabled(True)
+            self._set_action_enabled(self.brrr_update_btn, True)
             self.brrr_update_btn.setText("Update Branch Now")
         else:
             self.brrr_status_label.setText("Status:  Up to date!")
             self.brrr_status_label.setStyleSheet(
                 f"font-size: 13px; font-weight: bold; color: {c['success']};"
             )
-            self.brrr_update_btn.setEnabled(False)
+            self._set_action_enabled(self.brrr_update_btn, False)
             self.brrr_update_btn.setText("Already Up to Date")
 
         # 6. Commits Feed
@@ -551,7 +558,7 @@ class UpdateDialog(QDialog):
             QPushButton:disabled {{ background-color: {c["btn_bg"]}; color: {c["muted"]}; }}
         """)
         self.update_latest_btn.clicked.connect(self._on_latest_release_update)
-        self.update_latest_btn.setEnabled(False)
+        self._set_action_enabled(self.update_latest_btn, False)
         latest_layout.addWidget(self.update_latest_btn)
         layout.addWidget(latest_group)
 
@@ -573,7 +580,7 @@ class UpdateDialog(QDialog):
         self.release_btn = QPushButton("Install Selected Release")
         self.release_btn.setMinimumHeight(34)
         self.release_btn.clicked.connect(self._on_release_update)
-        self.release_btn.setEnabled(False)
+        self._set_action_enabled(self.release_btn, False)
         specific_layout.addWidget(self.release_btn)
         layout.addWidget(specific_group)
 
@@ -863,6 +870,7 @@ class UpdateDialog(QDialog):
                 self.target_combo.addItem("No tags found")
 
     def _load_data(self):
+        busy_token = self._begin_busy()
         self.status_label.setText("Checking for updates...")
 
         def bg(_col):
@@ -911,7 +919,7 @@ class UpdateDialog(QDialog):
             self._releases, state, remote_sha, local_commit_date, commits = result
             self._populate_brrr_ui(state, remote_sha, local_commit_date, commits)
             self._populate_ui()
-            self.status_label.setText("")
+            self._end_busy(busy_token)
 
         QueryOp(
             parent=self, op=bg, success=on_done
@@ -922,7 +930,7 @@ class UpdateDialog(QDialog):
             self._load_dev_data()
 
     def _load_dev_data(self):
-        self._set_busy(True)
+        busy_token = self._begin_busy()
         self.status_label.setText("Loading developer options...")
 
         def bg(_col):
@@ -944,7 +952,6 @@ class UpdateDialog(QDialog):
             return (tags, branches, prs)
 
         def on_done(result):
-            self._set_busy(False)
             self._tags, self._branches, self._prs = result
             self.dev_data_loaded = True
 
@@ -953,7 +960,7 @@ class UpdateDialog(QDialog):
             if source and source not in ("branch_brrr", "main"):
                 self._populate_target(source)
 
-            self.status_label.setText("")
+            self._end_busy(busy_token)
 
         QueryOp(
             parent=self, op=bg, success=on_done
@@ -969,25 +976,28 @@ class UpdateDialog(QDialog):
                     f"font-weight: bold; font-size: 13px; color: {c['success']};"
                 )
                 self.update_latest_btn.setText("Already Up to Date")
+                self._set_action_enabled(self.update_latest_btn, False)
             else:
                 self.latest_tag_label.setText(f"New version available: {latest}")
                 self.latest_tag_label.setStyleSheet(
                     f"font-weight: bold; font-size: 13px; color: {c['warning']};"
                 )
-                self.update_latest_btn.setEnabled(True)
+                self._set_action_enabled(self.update_latest_btn, True)
         else:
             self.latest_tag_label.setText("Could not check for updates.")
             self.latest_tag_label.setStyleSheet(
                 f"font-weight: bold; font-size: 13px; color: {c['error']};"
             )
+            self._set_action_enabled(self.update_latest_btn, False)
 
         self.release_combo.clear()
         if self._releases:
             for r in self._releases:
                 self.release_combo.addItem(r["name"], r)
-            self.release_btn.setEnabled(True)
+            self._set_action_enabled(self.release_btn, True)
         else:
             self.release_combo.addItem("No releases found")
+            self._set_action_enabled(self.release_btn, False)
 
         source = self.source_combo.currentData()
         if source and source != "main":
@@ -995,28 +1005,41 @@ class UpdateDialog(QDialog):
 
     # --- Actions ---
 
-    def _set_busy(self, busy: bool):
-        self.progress_bar.setVisible(busy)
-        self.progress_bar.setValue(0)
-        action_buttons = (
+    def _action_buttons(self):
+        return (
             self.brrr_update_btn,
             self.update_latest_btn,
             self.release_btn,
             self.dev_install_btn,
         )
-        if busy:
-            if self._busy_action_states is None:
-                self._busy_action_states = [
-                    (button, button.isEnabled()) for button in action_buttons
-                ]
-            for button in action_buttons:
-                button.setEnabled(False)
-        elif self._busy_action_states is not None:
-            for button, was_enabled in self._busy_action_states:
-                button.setEnabled(was_enabled)
-            self._busy_action_states = None
-        if not busy:
-            self.status_label.setText("")
+
+    def _set_action_enabled(self, button, enabled: bool):
+        self._action_button_states[button] = enabled
+        button.setEnabled(enabled and not self._busy_operations)
+
+    def _begin_busy(self):
+        token = object()
+        was_idle = not self._busy_operations
+        self._busy_operations.add(token)
+        if was_idle:
+            self.progress_bar.setVisible(True)
+            self.progress_bar.setValue(0)
+        for button in self._action_buttons():
+            self._action_button_states.setdefault(button, button.isEnabled())
+            button.setEnabled(False)
+        return token
+
+    def _end_busy(self, token):
+        if token not in self._busy_operations:
+            return False
+        self._busy_operations.remove(token)
+        if self._busy_operations:
+            return False
+        for button in self._action_buttons():
+            button.setEnabled(self._action_button_states.get(button, False))
+        self.progress_bar.setVisible(False)
+        self.status_label.setText("")
+        return True
 
     def _on_progress(self, current: int, total: int):
         if total > 0:
@@ -1044,7 +1067,7 @@ class UpdateDialog(QDialog):
         if confirm != QMessageBox.StandardButton.Yes:
             return
 
-        self._set_busy(True)
+        busy_token = self._begin_busy()
         self.status_label.setText(f"Downloading {label}...")
 
         def bg(_col):
@@ -1067,10 +1090,10 @@ class UpdateDialog(QDialog):
             return success, msg, messages
 
         def on_done(result):
-            self._set_busy(False)
             success, msg, messages = result
-            self.status_label.setText(messages[-1] if messages else msg)
-            self.progress_bar.setValue(100 if success else 0)
+            if self._end_busy(busy_token):
+                self.status_label.setText(messages[-1] if messages else msg)
+                self.progress_bar.setValue(100 if success else 0)
             if success:
                 QMessageBox.information(
                     self,
@@ -1321,7 +1344,8 @@ class BranchUpdateProgressDialog(QDialog):
         border = "#444444" if is_dark else "#e0e0e0"
         btn_bg = "#3d3d3d" if is_dark else "#eeeeee"
         btn_hover = "#505050" if is_dark else "#e0e0e0"
-        accent = "#4fc3f7" if is_dark else "#1976d2"
+        progress_text = "#ffffff" if is_dark else "#212121"
+        progress_chunk = "#1565c0" if is_dark else "#90caf9"
 
         self.setStyleSheet(f"""
             QDialog {{
@@ -1337,11 +1361,12 @@ class BranchUpdateProgressDialog(QDialog):
                 background-color: {border};
                 border-radius: 4px;
                 text-align: center;
-                height: 16px;
-                color: {text};
+                color: {progress_text};
+                font-weight: bold;
+                padding: 2px;
             }}
             QProgressBar::chunk {{
-                background-color: {accent};
+                background-color: {progress_chunk};
                 border-radius: 4px;
             }}
             QPushButton {{
@@ -1373,6 +1398,8 @@ class BranchUpdateProgressDialog(QDialog):
         self.progress_bar = QProgressBar()
         self.progress_bar.setRange(0, 100)
         self.progress_bar.setValue(0)
+        self.progress_bar.setTextVisible(True)
+        self.progress_bar.setMinimumHeight(self.progress_bar.fontMetrics().height() + 8)
         layout.addWidget(self.progress_bar)
 
         btn_layout = QHBoxLayout()

--- a/src/Ankimon/pyobj/update_dialog.py
+++ b/src/Ankimon/pyobj/update_dialog.py
@@ -49,6 +49,7 @@ class UpdateDialog(QDialog):
         self._branches = []
         self._prs = []
         self.dev_data_loaded = False
+        self._busy_action_states = None
 
         self._apply_theme()
 
@@ -78,13 +79,15 @@ class UpdateDialog(QDialog):
         self.progress_bar = QProgressBar()
         self.progress_bar.setVisible(False)
         self.progress_bar.setTextVisible(True)
-        self.progress_bar.setFixedHeight(8)
+        self.progress_bar.setFixedHeight(18)
         body.addWidget(self.progress_bar)
 
         self.status_label = QLabel("")
         self.status_label.setWordWrap(True)
-        self.status_label.setStyleSheet("font-size: 11px; color: gray; padding: 0 4px;")
-        self.status_label.setFixedHeight(20)
+        self.status_label.setStyleSheet(
+            f"font-size: 12px; font-weight: bold; color: {self._colors['text']}; padding: 2px 4px;"
+        )
+        self.status_label.setMinimumHeight(24)
         body.addWidget(self.status_label)
 
         layout.addLayout(body)
@@ -214,6 +217,8 @@ class UpdateDialog(QDialog):
                 border: none;
                 background-color: {c["group_border"]};
                 border-radius: 4px;
+                color: {c["text"]};
+                text-align: center;
             }}
             QProgressBar::chunk {{
                 background-color: {c["accent"]};
@@ -993,9 +998,23 @@ class UpdateDialog(QDialog):
     def _set_busy(self, busy: bool):
         self.progress_bar.setVisible(busy)
         self.progress_bar.setValue(0)
-        self.update_latest_btn.setEnabled(not busy)
-        self.release_btn.setEnabled(not busy)
-        self.dev_install_btn.setEnabled(not busy)
+        action_buttons = (
+            self.brrr_update_btn,
+            self.update_latest_btn,
+            self.release_btn,
+            self.dev_install_btn,
+        )
+        if busy:
+            if self._busy_action_states is None:
+                self._busy_action_states = [
+                    (button, button.isEnabled()) for button in action_buttons
+                ]
+            for button in action_buttons:
+                button.setEnabled(False)
+        elif self._busy_action_states is not None:
+            for button, was_enabled in self._busy_action_states:
+                button.setEnabled(was_enabled)
+            self._busy_action_states = None
         if not busy:
             self.status_label.setText("")
 

--- a/src/Ankimon/pyobj/update_dialog.py
+++ b/src/Ankimon/pyobj/update_dialog.py
@@ -813,6 +813,9 @@ class UpdateDialog(QDialog):
         _start_query_op(self, bg, done, failed)
 
     def _start_sprites_download(self):
+        if self.sprites_thread is not None and self.sprites_thread.isRunning():
+            return
+
         from .sprite_updater import SpriteUpdateDiffThread
         from ..resources import user_path_sprites
 
@@ -821,77 +824,90 @@ class UpdateDialog(QDialog):
         self._sprites_busy_token = busy_token
         self.sprites_progress.setVisible(True)
         self.sprites_progress.setValue(0)
+        completion_result = None
+        thread = None
 
         def settle_busy():
+            if busy_token in self._busy_operations:
+                self._end_busy(busy_token)
             if self._sprites_busy_token is busy_token:
                 self._sprites_busy_token = None
-                self._end_busy(busy_token)
 
-        def finished(success, message):
-            if self._closing:
-                return
-            try:
-                self.sprites_update_btn.setVisible(False)
-                if success:
-                    try:
-                        manifest_path = dest_dir.parent / "sprites_local_manifest.json"
-                        if manifest_path.exists():
-                            manifest_path.unlink()
-                    except Exception:
-                        pass
-                    self.sprites_status.setText("Update complete! " + message)
-                    self.sprites_progress.setValue(100)
-                else:
-                    self.sprites_status.setText("Update failed: " + message)
-            finally:
-                settle_busy()
+        def record_finished(success, message):
+            nonlocal completion_result
+            completion_result = (success, message)
 
         def thread_stopped():
-            was_active = busy_token in self._busy_operations
             closing = self._closing
-            settle_busy()
-            self.sprites_thread = None
+            try:
+                if not closing and self.sprites_thread is thread:
+                    if completion_result is None:
+                        self.sprites_status.setText(
+                            "Sprite update stopped unexpectedly. Please try again."
+                        )
+                    else:
+                        success, message = completion_result
+                        self.sprites_update_btn.setVisible(False)
+                        if success:
+                            try:
+                                manifest_path = (
+                                    dest_dir.parent / "sprites_local_manifest.json"
+                                )
+                                if manifest_path.exists():
+                                    manifest_path.unlink()
+                            except Exception:
+                                pass
+                            self.sprites_status.setText("Update complete! " + message)
+                            self.sprites_progress.setValue(100)
+                        else:
+                            self.sprites_status.setText("Update failed: " + message)
+            finally:
+                settle_busy()
+                if self.sprites_thread is thread:
+                    self.sprites_thread = None
             if closing and not self._close_finalized:
                 self.reject()
-            elif was_active:
-                self.sprites_status.setText(
-                    "Sprite update stopped unexpectedly. Please try again."
-                )
 
         def update_progress(value):
-            if not self._closing:
+            if (
+                not self._closing
+                and self.sprites_thread is thread
+                and busy_token in self._busy_operations
+            ):
                 self.sprites_progress.setValue(value)
 
         def update_status(message):
-            if not self._closing:
+            if (
+                not self._closing
+                and self.sprites_thread is thread
+                and busy_token in self._busy_operations
+            ):
                 self.sprites_status.setText(message)
 
         try:
-            self.sprites_thread = SpriteUpdateDiffThread(
+            thread = SpriteUpdateDiffThread(
                 self.sprites_added,
                 self.sprites_modified,
                 self.sprites_deleted,
                 self.sprites_remote_sha,
                 dest_dir,
             )
-            self.sprites_thread.progress_signal.connect(
+            self.sprites_thread = thread
+            thread.progress_signal.connect(
                 lambda value: mw.taskman.run_on_main(lambda: update_progress(value))
             )
-            self.sprites_thread.status_signal.connect(
+            thread.status_signal.connect(
                 lambda message: mw.taskman.run_on_main(lambda: update_status(message))
             )
-            self.sprites_thread.finished_signal.connect(
-                lambda success, message: mw.taskman.run_on_main(
-                    lambda: finished(success, message)
-                )
+            thread.finished_signal.connect(
+                record_finished, Qt.ConnectionType.DirectConnection
             )
-            self.sprites_thread.finished.connect(
-                lambda: mw.taskman.run_on_main(thread_stopped)
-            )
-            self.sprites_thread.start()
+            thread.finished.connect(lambda: mw.taskman.run_on_main(thread_stopped))
+            thread.start()
         except Exception as exc:
             settle_busy()
-            self.sprites_thread = None
+            if self.sprites_thread is thread:
+                self.sprites_thread = None
             self.sprites_status.setText(f"Could not start sprite update: {exc}")
 
     def _defer_close_for_sprite_thread(self):

--- a/src/Ankimon/pyobj/update_dialog.py
+++ b/src/Ankimon/pyobj/update_dialog.py
@@ -238,6 +238,7 @@ class UpdateDialog(QDialog):
             }}
             QTabBar::tab {{
                 padding: 8px 16px;
+                color: {c["text"]};
                 border: 1px solid transparent;
                 border-bottom: none;
                 border-top-left-radius: 6px;

--- a/src/Ankimon/pyobj/update_dialog.py
+++ b/src/Ankimon/pyobj/update_dialog.py
@@ -37,6 +37,17 @@ from .update_manager import (
 from ..resources import addon_ver, IS_EXPERIMENTAL_BUILD
 
 
+def _start_query_op(parent, op, success, failure):
+    try:
+        QueryOp(
+            parent=parent, op=op, success=success
+        ).failure(failure).without_collection().run_in_background()
+    except Exception as exc:
+        # Submission happens on the Qt thread, so synchronous failures can use
+        # the same UI-safe cleanup callback as background worker failures.
+        failure(exc)
+
+
 class UpdateDialog(QDialog):
     def __init__(self, parent=None, select_tab=None):
         super().__init__(parent or mw)
@@ -745,92 +756,116 @@ class UpdateDialog(QDialog):
             pass
 
     def _check_sprites(self):
-        self.sprites_check_btn.setEnabled(False)
+        from .sprite_updater import calculate_sprite_diff
+        from ..resources import user_path_sprites
+
+        busy_token = self._begin_busy()
         self.sprites_status.setText("Checking for sprite updates...")
         self.sprites_progress.setValue(0)
         self.sprites_progress.setVisible(False)
         self.sprites_update_btn.setVisible(False)
-        
-        from .sprite_updater import calculate_sprite_diff
-        from ..resources import user_path_sprites
-        from aqt.operations import QueryOp
-        
+
         dest_dir = Path(user_path_sprites)
-        
+
         def bg(_col):
             # Run with ignore_snooze=True since this is a manual check
             return calculate_sprite_diff(dest_dir, silent=False, ignore_snooze=True)
 
-        def done(result):
-            self.sprites_check_btn.setEnabled(True)
-            status = result.get("status")
-            if status == "up_to_date":
-                self.sprites_status.setText("Sprites are already up to date!")
-                self.sprites_progress.setValue(100)
-                self.sprites_progress.setVisible(True)
-            elif status == "error":
-                self.sprites_status.setText(f"Error checking updates: {result.get('error')}")
-            elif status == "update_available":
-                self.sprites_added = result.get("added", [])
-                self.sprites_modified = result.get("modified", [])
-                self.sprites_deleted = result.get("deleted", [])
-                self.sprites_remote_sha = result.get("remote_sha")
-                
-                msg = "A sprites update is available!\n\n"
-                msg += f"  • New sprites: {len(self.sprites_added)}\n"
-                msg += f"  • Modified sprites: {len(self.sprites_modified)}\n"
-                if self.sprites_deleted:
-                    msg += f"  • Obsolete to remove: {len(self.sprites_deleted)}\n"
-                
-                self.sprites_status.setText(msg)
-                self.sprites_update_btn.setVisible(True)
+        def settle_busy():
+            self._end_busy(busy_token)
 
-        QueryOp(
-            parent=self,
-            op=bg,
-            success=done
-        ).without_collection().run_in_background()
+        def done(result):
+            try:
+                status = result.get("status")
+                if status == "up_to_date":
+                    self.sprites_status.setText("Sprites are already up to date!")
+                    self.sprites_progress.setValue(100)
+                    self.sprites_progress.setVisible(True)
+                elif status == "error":
+                    self.sprites_status.setText(
+                        f"Error checking updates: {result.get('error')}"
+                    )
+                elif status == "update_available":
+                    self.sprites_added = result.get("added", [])
+                    self.sprites_modified = result.get("modified", [])
+                    self.sprites_deleted = result.get("deleted", [])
+                    self.sprites_remote_sha = result.get("remote_sha")
+
+                    msg = "A sprites update is available!\n\n"
+                    msg += f"  • New sprites: {len(self.sprites_added)}\n"
+                    msg += f"  • Modified sprites: {len(self.sprites_modified)}\n"
+                    if self.sprites_deleted:
+                        msg += f"  • Obsolete to remove: {len(self.sprites_deleted)}\n"
+
+                    self.sprites_status.setText(msg)
+                    self.sprites_update_btn.setVisible(True)
+            finally:
+                settle_busy()
+
+        def failed(exc):
+            settle_busy()
+            self.sprites_status.setText(f"Error checking sprite updates: {exc}")
+
+        _start_query_op(self, bg, done, failed)
 
     def _start_sprites_download(self):
-        self.sprites_update_btn.setEnabled(False)
-        self.sprites_check_btn.setEnabled(False)
-        self.sprites_progress.setVisible(True)
-        self.sprites_progress.setValue(0)
-        
         from .sprite_updater import SpriteUpdateDiffThread
         from ..resources import user_path_sprites
-        
+
         dest_dir = Path(user_path_sprites)
-        self.sprites_thread = SpriteUpdateDiffThread(
-            self.sprites_added,
-            self.sprites_modified,
-            self.sprites_deleted,
-            self.sprites_remote_sha,
-            dest_dir,
-        )
-            
-        self.sprites_thread.progress_signal.connect(self.sprites_progress.setValue)
-        self.sprites_thread.status_signal.connect(self.sprites_status.setText)
-        
+        busy_token = self._begin_busy()
+        self.sprites_progress.setVisible(True)
+        self.sprites_progress.setValue(0)
+
+        def settle_busy():
+            self._end_busy(busy_token)
+
         def finished(success, message):
-            self.sprites_check_btn.setEnabled(True)
-            self.sprites_update_btn.setVisible(False)
-            self.sprites_update_btn.setEnabled(True)
-            if success:
-                try:
-                    manifest_path = dest_dir.parent / "sprites_local_manifest.json"
-                    if manifest_path.exists():
-                        manifest_path.unlink()
-                except Exception:
-                    pass
-                self.sprites_status.setText("Update complete! " + message)
-                self.sprites_progress.setValue(100)
-            else:
-                self.sprites_status.setText("Update failed: " + message)
-                
-        self.sprites_thread.finished_signal.connect(finished)
-            
-        self.sprites_thread.start()
+            try:
+                self.sprites_update_btn.setVisible(False)
+                if success:
+                    try:
+                        manifest_path = dest_dir.parent / "sprites_local_manifest.json"
+                        if manifest_path.exists():
+                            manifest_path.unlink()
+                    except Exception:
+                        pass
+                    self.sprites_status.setText("Update complete! " + message)
+                    self.sprites_progress.setValue(100)
+                else:
+                    self.sprites_status.setText("Update failed: " + message)
+            finally:
+                settle_busy()
+
+        def thread_stopped():
+            if busy_token in self._busy_operations:
+                settle_busy()
+                self.sprites_status.setText(
+                    "Sprite update stopped unexpectedly. Please try again."
+                )
+
+        try:
+            self.sprites_thread = SpriteUpdateDiffThread(
+                self.sprites_added,
+                self.sprites_modified,
+                self.sprites_deleted,
+                self.sprites_remote_sha,
+                dest_dir,
+            )
+            self.sprites_thread.progress_signal.connect(self.sprites_progress.setValue)
+            self.sprites_thread.status_signal.connect(self.sprites_status.setText)
+            self.sprites_thread.finished_signal.connect(
+                lambda success, message: mw.taskman.run_on_main(
+                    lambda: finished(success, message)
+                )
+            )
+            self.sprites_thread.finished.connect(
+                lambda: mw.taskman.run_on_main(thread_stopped)
+            )
+            self.sprites_thread.start()
+        except Exception as exc:
+            settle_busy()
+            self.sprites_status.setText(f"Could not start sprite update: {exc}")
 
     # --- Data loading ---
 
@@ -917,14 +952,18 @@ class UpdateDialog(QDialog):
             return releases, state, remote_sha, local_commit_date, commits
 
         def on_done(result):
-            self._releases, state, remote_sha, local_commit_date, commits = result
-            self._populate_brrr_ui(state, remote_sha, local_commit_date, commits)
-            self._populate_ui()
-            self._end_busy(busy_token)
+            try:
+                self._releases, state, remote_sha, local_commit_date, commits = result
+                self._populate_brrr_ui(state, remote_sha, local_commit_date, commits)
+                self._populate_ui()
+            finally:
+                self._end_busy(busy_token)
 
-        QueryOp(
-            parent=self, op=bg, success=on_done
-        ).without_collection().run_in_background()
+        def on_failed(exc):
+            if self._end_busy(busy_token):
+                self.status_label.setText(f"Could not check for updates: {exc}")
+
+        _start_query_op(self, bg, on_done, on_failed)
 
     def _on_tab_changed(self, index):
         if index == 2 and not self.dev_data_loaded:
@@ -953,19 +992,24 @@ class UpdateDialog(QDialog):
             return (tags, branches, prs)
 
         def on_done(result):
-            self._tags, self._branches, self._prs = result
-            self.dev_data_loaded = True
+            try:
+                self._tags, self._branches, self._prs = result
+                self.dev_data_loaded = True
 
-            # Repopulate targets in the Developer tab UI if needed
-            source = self.source_combo.currentData()
-            if source and source not in ("branch_brrr", "main"):
-                self._populate_target(source)
+                # Repopulate targets in the Developer tab UI if needed
+                source = self.source_combo.currentData()
+                if source and source not in ("branch_brrr", "main"):
+                    self._populate_target(source)
+            finally:
+                self._end_busy(busy_token)
 
-            self._end_busy(busy_token)
+        def on_failed(exc):
+            if self._end_busy(busy_token):
+                self.status_label.setText(
+                    f"Could not load developer options: {exc}"
+                )
 
-        QueryOp(
-            parent=self, op=bg, success=on_done
-        ).without_collection().run_in_background()
+        _start_query_op(self, bg, on_done, on_failed)
 
     def _populate_ui(self):
         c = self._colors
@@ -1012,6 +1056,8 @@ class UpdateDialog(QDialog):
             self.update_latest_btn,
             self.release_btn,
             self.dev_install_btn,
+            self.sprites_check_btn,
+            self.sprites_update_btn,
         )
 
     def _set_action_enabled(self, button, enabled: bool):
@@ -1091,7 +1137,11 @@ class UpdateDialog(QDialog):
             return success, msg, messages
 
         def on_done(result):
-            success, msg, messages = result
+            try:
+                success, msg, messages = result
+            except Exception as exc:
+                on_failed(exc)
+                return
             if self._end_busy(busy_token):
                 self.status_label.setText(messages[-1] if messages else msg)
                 self.progress_bar.setValue(100 if success else 0)
@@ -1104,9 +1154,17 @@ class UpdateDialog(QDialog):
             else:
                 QMessageBox.warning(self, "Update Failed", msg)
 
-        QueryOp(
-            parent=self, op=bg, success=on_done
-        ).without_collection().run_in_background()
+        def on_failed(exc):
+            if self._end_busy(busy_token):
+                self.status_label.setText(f"Update failed unexpectedly: {exc}")
+                self.progress_bar.setValue(0)
+            QMessageBox.warning(
+                self,
+                "Update Failed",
+                f"The update stopped unexpectedly. Please try again.\n\n{exc}",
+            )
+
+        _start_query_op(self, bg, on_done, on_failed)
 
     def _on_latest_release_update(self):
         if not self._releases:
@@ -1470,9 +1528,19 @@ class BranchUpdateProgressDialog(QDialog):
                 self.progress_bar.setValue(0)
                 QMessageBox.warning(self, "Update Failed", msg)
 
-        QueryOp(
-            parent=self, op=bg, success=on_done
-        ).without_collection().run_in_background()
+        def on_failed(exc):
+            self.btn_close.setEnabled(True)
+            self.status_label.setText(
+                "Update stopped unexpectedly. Please check your connection and try again."
+            )
+            self.progress_bar.setValue(0)
+            QMessageBox.warning(
+                self,
+                "Update Failed",
+                f"The update stopped unexpectedly. Please try again.\n\n{exc}",
+            )
+
+        _start_query_op(self, bg, on_done, on_failed)
 
     def on_progress(self, current: int, total: int):
         if total > 0:

--- a/tests/test_update_dialog_busy_state.py
+++ b/tests/test_update_dialog_busy_state.py
@@ -110,12 +110,16 @@ update_dialog = _load_update_dialog()
 class _Control:
     def __init__(self, enabled=True):
         self.enabled = enabled
+        self.visible = True
 
     def isEnabled(self):
         return self.enabled
 
     def setEnabled(self, enabled):
         self.enabled = enabled
+
+    def setVisible(self, visible):
+        self.visible = visible
 
 
 class _Progress:
@@ -138,24 +142,85 @@ class _Label:
         self.text = text
 
 
-def test_busy_state_disables_all_actions_and_restores_prior_state():
+class _FakeQueryOp:
+    last = None
+    raise_on_run = False
+
+    def __init__(self, *, parent, op, success):
+        self.parent = parent
+        self.op = op
+        self.success = success
+        self.failure_callback = None
+        _FakeQueryOp.last = self
+
+    def failure(self, callback):
+        self.failure_callback = callback
+        return self
+
+    def without_collection(self):
+        return self
+
+    def run_in_background(self):
+        if self.raise_on_run:
+            raise RuntimeError("query submission failed")
+
+    def fail(self, exc):
+        assert self.failure_callback is not None
+        self.failure_callback(exc)
+
+
+class _Signal:
+    def __init__(self):
+        self.callbacks = []
+
+    def connect(self, callback):
+        self.callbacks.append(callback)
+
+    def emit(self, *args):
+        for callback in self.callbacks:
+            callback(*args)
+
+
+class _FakeSpriteThread:
+    def __init__(self, *args):
+        self.progress_signal = _Signal()
+        self.status_signal = _Signal()
+        self.finished_signal = _Signal()
+        self.finished = _Signal()
+        self.started = False
+
+    def start(self):
+        self.started = True
+
+
+def _make_dialog():
     dialog = types.SimpleNamespace(
         progress_bar=_Progress(),
         status_label=_Label(),
+        sprites_status=_Label(),
+        sprites_progress=_Progress(),
         brrr_update_btn=_Control(True),
         update_latest_btn=_Control(False),
         release_btn=_Control(True),
         dev_install_btn=_Control(True),
+        sprites_check_btn=_Control(True),
+        sprites_update_btn=_Control(True),
         _busy_operations=set(),
         _action_button_states={},
     )
-    buttons = (
-        dialog.brrr_update_btn,
-        dialog.update_latest_btn,
-        dialog.release_btn,
-        dialog.dev_install_btn,
+    dialog._action_buttons = types.MethodType(
+        update_dialog.UpdateDialog._action_buttons, dialog
     )
-    dialog._action_buttons = lambda: buttons
+    dialog._set_action_enabled = types.MethodType(
+        update_dialog.UpdateDialog._set_action_enabled, dialog
+    )
+    dialog._begin_busy = types.MethodType(update_dialog.UpdateDialog._begin_busy, dialog)
+    dialog._end_busy = types.MethodType(update_dialog.UpdateDialog._end_busy, dialog)
+    return dialog, dialog._action_buttons()
+
+
+def test_busy_state_disables_all_actions_and_restores_prior_state():
+    dialog, buttons = _make_dialog()
 
     busy_token = update_dialog.UpdateDialog._begin_busy(dialog)
 
@@ -166,28 +231,19 @@ def test_busy_state_disables_all_actions_and_restores_prior_state():
     update_dialog.UpdateDialog._end_busy(dialog, busy_token)
 
     assert dialog.progress_bar.visible is False
-    assert [button.enabled for button in buttons] == [True, False, True, True]
+    assert [button.enabled for button in buttons] == [
+        True,
+        False,
+        True,
+        True,
+        True,
+        True,
+    ]
     assert dialog.status_label.text == ""
 
 
 def test_overlapping_operations_keep_busy_and_apply_latest_button_states():
-    dialog = types.SimpleNamespace(
-        progress_bar=_Progress(),
-        status_label=_Label(),
-        brrr_update_btn=_Control(True),
-        update_latest_btn=_Control(False),
-        release_btn=_Control(True),
-        dev_install_btn=_Control(True),
-        _busy_operations=set(),
-        _action_button_states={},
-    )
-    buttons = (
-        dialog.brrr_update_btn,
-        dialog.update_latest_btn,
-        dialog.release_btn,
-        dialog.dev_install_btn,
-    )
-    dialog._action_buttons = lambda: buttons
+    dialog, buttons = _make_dialog()
 
     first_token = update_dialog.UpdateDialog._begin_busy(dialog)
     dialog.progress_bar.setValue(63)
@@ -209,5 +265,244 @@ def test_overlapping_operations_keep_busy_and_apply_latest_button_states():
     update_dialog.UpdateDialog._end_busy(dialog, second_token)
 
     assert dialog.progress_bar.visible is False
-    assert [button.enabled for button in buttons] == [True, True, False, True]
+    assert [button.enabled for button in buttons] == [
+        True,
+        True,
+        False,
+        True,
+        True,
+        True,
+    ]
     assert dialog.status_label.text == ""
+
+
+def test_query_workflow_failures_restore_all_controls():
+    original_query_op = update_dialog.QueryOp
+    update_dialog.QueryOp = _FakeQueryOp
+    try:
+        for workflow in (
+            update_dialog.UpdateDialog._load_data,
+            update_dialog.UpdateDialog._load_dev_data,
+        ):
+            dialog, buttons = _make_dialog()
+            workflow(dialog)
+
+            assert all(button.enabled is False for button in buttons)
+            _FakeQueryOp.last.fail(RuntimeError("network failed"))
+
+            assert not dialog._busy_operations
+            assert [button.enabled for button in buttons] == [
+                True,
+                False,
+                True,
+                True,
+                True,
+                True,
+            ]
+            assert "failed" in dialog.status_label.text.lower()
+
+        _FakeQueryOp.raise_on_run = True
+        for workflow in (
+            update_dialog.UpdateDialog._load_data,
+            update_dialog.UpdateDialog._load_dev_data,
+        ):
+            dialog, buttons = _make_dialog()
+            workflow(dialog)
+            assert not dialog._busy_operations
+            assert any(button.enabled for button in buttons)
+    finally:
+        _FakeQueryOp.raise_on_run = False
+        update_dialog.QueryOp = original_query_op
+
+
+def test_success_callback_failures_release_busy_tokens():
+    original_query_op = update_dialog.QueryOp
+    update_dialog.QueryOp = _FakeQueryOp
+    dialog, buttons = _make_dialog()
+    dialog._populate_brrr_ui = lambda *args: (_ for _ in ()).throw(
+        RuntimeError("UI failed")
+    )
+    dialog._populate_ui = lambda: None
+    try:
+        update_dialog.UpdateDialog._load_data(dialog)
+        try:
+            _FakeQueryOp.last.success(([], {}, None, None, []))
+        except RuntimeError as exc:
+            assert str(exc) == "UI failed"
+        else:
+            raise AssertionError("success callback should propagate the UI failure")
+
+        assert not dialog._busy_operations
+        assert any(button.enabled for button in buttons)
+
+        dev_dialog, dev_buttons = _make_dialog()
+        dev_dialog.source_combo = types.SimpleNamespace(
+            currentData=lambda: (_ for _ in ()).throw(RuntimeError("UI failed"))
+        )
+        dev_dialog._populate_target = lambda source: None
+        update_dialog.UpdateDialog._load_dev_data(dev_dialog)
+        try:
+            _FakeQueryOp.last.success(([], [], []))
+        except RuntimeError as exc:
+            assert str(exc) == "UI failed"
+        else:
+            raise AssertionError("success callback should propagate the UI failure")
+
+        assert not dev_dialog._busy_operations
+        assert any(button.enabled for button in dev_buttons)
+    finally:
+        update_dialog.QueryOp = original_query_op
+
+
+def test_update_worker_failure_restores_controls():
+    class MessageBox:
+        class StandardButton:
+            Yes = 1
+            No = 2
+
+        warnings = []
+
+        @staticmethod
+        def question(*args, **kwargs):
+            return MessageBox.StandardButton.Yes
+
+        @staticmethod
+        def warning(*args):
+            MessageBox.warnings.append(args)
+
+        @staticmethod
+        def information(*args):
+            pass
+
+    original_query_op = update_dialog.QueryOp
+    original_message_box = update_dialog.QMessageBox
+    update_dialog.QueryOp = _FakeQueryOp
+    update_dialog.QMessageBox = MessageBox
+    dialog, buttons = _make_dialog()
+    try:
+        update_dialog.UpdateDialog._run_update(dialog, lambda **kwargs: None, "test")
+        assert all(button.enabled is False for button in buttons)
+
+        _FakeQueryOp.last.fail(RuntimeError("download crashed"))
+
+        assert not dialog._busy_operations
+        assert any(button.enabled for button in buttons)
+        assert dialog.progress_bar.value == 0
+        assert MessageBox.warnings
+
+        malformed_dialog, malformed_buttons = _make_dialog()
+        update_dialog.UpdateDialog._run_update(
+            malformed_dialog, lambda **kwargs: None, "test"
+        )
+        _FakeQueryOp.last.success(None)
+        assert not malformed_dialog._busy_operations
+        assert any(button.enabled for button in malformed_buttons)
+
+        _FakeQueryOp.raise_on_run = True
+        submission_dialog, submission_buttons = _make_dialog()
+        update_dialog.UpdateDialog._run_update(
+            submission_dialog, lambda **kwargs: None, "test"
+        )
+        assert not submission_dialog._busy_operations
+        assert any(button.enabled for button in submission_buttons)
+    finally:
+        _FakeQueryOp.raise_on_run = False
+        update_dialog.QueryOp = original_query_op
+        update_dialog.QMessageBox = original_message_box
+
+
+def test_sprite_workflows_share_busy_lifecycle():
+    original_query_op = update_dialog.QueryOp
+    original_mw = update_dialog.mw
+    saved_modules = {
+        name: sys.modules.get(name)
+        for name in (
+            "Ankimon",
+            "Ankimon.pyobj",
+            "Ankimon.pyobj.sprite_updater",
+            "Ankimon.resources",
+        )
+    }
+    update_dialog.QueryOp = _FakeQueryOp
+    update_dialog.mw = types.SimpleNamespace(
+        taskman=types.SimpleNamespace(run_on_main=lambda callback: callback())
+    )
+    try:
+        for name, path in (
+            ("Ankimon", _SRC / "Ankimon"),
+            ("Ankimon.pyobj", _SRC / "Ankimon" / "pyobj"),
+        ):
+            package = types.ModuleType(name)
+            package.__path__ = [str(path)]
+            package.__package__ = name
+            sys.modules[name] = package
+
+        sprite_updater = types.ModuleType("Ankimon.pyobj.sprite_updater")
+        sprite_updater.calculate_sprite_diff = lambda *args, **kwargs: None
+        sprite_updater.SpriteUpdateDiffThread = _FakeSpriteThread
+        sys.modules[sprite_updater.__name__] = sprite_updater
+
+        resources = types.ModuleType("Ankimon.resources")
+        resources.user_path_sprites = "/tmp/ankimon-test-sprites"
+        sys.modules[resources.__name__] = resources
+
+        check_dialog, check_buttons = _make_dialog()
+        update_dialog.UpdateDialog._check_sprites(check_dialog)
+        assert all(button.enabled is False for button in check_buttons)
+
+        _FakeQueryOp.last.fail(RuntimeError("sprite check crashed"))
+        assert not check_dialog._busy_operations
+        assert check_dialog.sprites_check_btn.enabled is True
+
+        disabled_check_dialog, _buttons = _make_dialog()
+        disabled_check_dialog._set_action_enabled(
+            disabled_check_dialog.sprites_check_btn, False
+        )
+        update_dialog.UpdateDialog._check_sprites(disabled_check_dialog)
+        _FakeQueryOp.last.fail(RuntimeError("sprite check crashed"))
+        assert disabled_check_dialog.sprites_check_btn.enabled is False
+
+        _FakeQueryOp.raise_on_run = True
+        submission_dialog, submission_buttons = _make_dialog()
+        update_dialog.UpdateDialog._check_sprites(submission_dialog)
+        assert not submission_dialog._busy_operations
+        assert any(button.enabled for button in submission_buttons)
+        _FakeQueryOp.raise_on_run = False
+
+        download_dialog, download_buttons = _make_dialog()
+        download_dialog.sprites_added = []
+        download_dialog.sprites_modified = []
+        download_dialog.sprites_deleted = []
+        download_dialog.sprites_remote_sha = "abc123"
+        update_dialog.UpdateDialog._start_sprites_download(download_dialog)
+        assert all(button.enabled is False for button in download_buttons)
+        assert download_dialog.sprites_thread.started is True
+
+        download_dialog.sprites_thread.finished_signal.emit(False, "simulated failure")
+        assert not download_dialog._busy_operations
+        assert download_dialog.sprites_check_btn.enabled is True
+        assert download_dialog.sprites_update_btn.enabled is True
+        assert download_dialog.sprites_status.text == "Update failed: simulated failure"
+
+        download_dialog.sprites_thread.finished.emit()
+        assert download_dialog.sprites_status.text == "Update failed: simulated failure"
+
+        crashed_dialog, crashed_buttons = _make_dialog()
+        crashed_dialog.sprites_added = []
+        crashed_dialog.sprites_modified = []
+        crashed_dialog.sprites_deleted = []
+        crashed_dialog.sprites_remote_sha = "abc123"
+        update_dialog.UpdateDialog._start_sprites_download(crashed_dialog)
+        assert all(button.enabled is False for button in crashed_buttons)
+        crashed_dialog.sprites_thread.finished.emit()
+        assert not crashed_dialog._busy_operations
+        assert "unexpectedly" in crashed_dialog.sprites_status.text
+    finally:
+        _FakeQueryOp.raise_on_run = False
+        update_dialog.QueryOp = original_query_op
+        update_dialog.mw = original_mw
+        for name, module in saved_modules.items():
+            if module is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = module

--- a/tests/test_update_dialog_busy_state.py
+++ b/tests/test_update_dialog_busy_state.py
@@ -136,7 +136,7 @@ class _Progress:
 
 class _Label:
     def __init__(self):
-        self.text = "Working..."
+        self.text = ""
 
     def setText(self, text):
         self.text = text
@@ -188,9 +188,18 @@ class _FakeSpriteThread:
         self.finished_signal = _Signal()
         self.finished = _Signal()
         self.started = False
+        self.cancelled = False
+        self.running = False
 
     def start(self):
         self.started = True
+        self.running = True
+
+    def cancel(self):
+        self.cancelled = True
+
+    def isRunning(self):
+        return self.running
 
 
 def _make_dialog():
@@ -207,6 +216,10 @@ def _make_dialog():
         sprites_update_btn=_Control(True),
         _busy_operations=set(),
         _action_button_states={},
+        _closing=False,
+        _close_finalized=False,
+        _sprites_busy_token=None,
+        sprites_thread=None,
     )
     dialog._action_buttons = types.MethodType(
         update_dialog.UpdateDialog._action_buttons, dialog
@@ -216,6 +229,9 @@ def _make_dialog():
     )
     dialog._begin_busy = types.MethodType(update_dialog.UpdateDialog._begin_busy, dialog)
     dialog._end_busy = types.MethodType(update_dialog.UpdateDialog._end_busy, dialog)
+    dialog._defer_close_for_sprite_thread = types.MethodType(
+        update_dialog.UpdateDialog._defer_close_for_sprite_thread, dialog
+    )
     return dialog, dialog._action_buttons()
 
 
@@ -244,6 +260,7 @@ def test_busy_state_disables_all_actions_and_restores_prior_state():
 
 def test_overlapping_operations_keep_busy_and_apply_latest_button_states():
     dialog, buttons = _make_dialog()
+    dialog.status_label.setText("Working...")
 
     first_token = update_dialog.UpdateDialog._begin_busy(dialog)
     dialog.progress_bar.setValue(63)
@@ -411,7 +428,7 @@ def test_update_worker_failure_restores_controls():
         update_dialog.QMessageBox = original_message_box
 
 
-def test_sprite_workflows_share_busy_lifecycle():
+def test_sprite_workflows_share_busy_lifecycle(tmp_path):
     original_query_op = update_dialog.QueryOp
     original_mw = update_dialog.mw
     saved_modules = {
@@ -443,7 +460,7 @@ def test_sprite_workflows_share_busy_lifecycle():
         sys.modules[sprite_updater.__name__] = sprite_updater
 
         resources = types.ModuleType("Ankimon.resources")
-        resources.user_path_sprites = "/tmp/ankimon-test-sprites"
+        resources.user_path_sprites = str(tmp_path / "ankimon-test-sprites")
         sys.modules[resources.__name__] = resources
 
         check_dialog, check_buttons = _make_dialog()
@@ -497,10 +514,118 @@ def test_sprite_workflows_share_busy_lifecycle():
         crashed_dialog.sprites_thread.finished.emit()
         assert not crashed_dialog._busy_operations
         assert "unexpectedly" in crashed_dialog.sprites_status.text
+
+        closing_dialog, closing_buttons = _make_dialog()
+        closing_dialog.sprites_added = []
+        closing_dialog.sprites_modified = []
+        closing_dialog.sprites_deleted = []
+        closing_dialog.sprites_remote_sha = "abc123"
+        close_requests = []
+        closing_dialog.reject = lambda: close_requests.append(True)
+        update_dialog.UpdateDialog._start_sprites_download(closing_dialog)
+        closing_thread = closing_dialog.sprites_thread
+
+        update_dialog.UpdateDialog.reject(closing_dialog)
+
+        assert closing_thread.cancelled is True
+        assert closing_dialog._busy_operations
+        assert all(button.enabled is False for button in closing_buttons)
+
+        closing_thread.status_signal.emit("Downloading after cancellation")
+        closing_thread.progress_signal.emit(99)
+        assert closing_dialog.sprites_status.text == "Cancelling sprite update..."
+        assert closing_dialog.sprites_progress.value == 0
+
+        closing_thread.finished_signal.emit(False, "Update cancelled.")
+        assert closing_dialog._busy_operations
+        closing_thread.running = False
+        closing_thread.finished.emit()
+
+        assert not closing_dialog._busy_operations
+        assert closing_dialog.sprites_thread is None
+        assert close_requests == [True]
+        assert closing_dialog.sprites_status.text == "Cancelling sprite update..."
+
+        late_dialog, _buttons = _make_dialog()
+        late_dialog.sprites_added = []
+        late_dialog.sprites_modified = []
+        late_dialog.sprites_deleted = []
+        late_dialog.sprites_remote_sha = "abc123"
+        late_rejects = []
+        late_dialog.reject = lambda: late_rejects.append(True)
+        update_dialog.UpdateDialog._start_sprites_download(late_dialog)
+        late_thread = late_dialog.sprites_thread
+        late_dialog._closing = True
+        late_dialog._close_finalized = True
+        late_thread.running = False
+        late_thread.finished.emit()
+        assert late_rejects == []
     finally:
         _FakeQueryOp.raise_on_run = False
         update_dialog.QueryOp = original_query_op
         update_dialog.mw = original_mw
+        for name, module in saved_modules.items():
+            if module is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = module
+
+
+def test_branch_progress_malformed_result_uses_failure_path():
+    class MessageBox:
+        warnings = []
+
+        @staticmethod
+        def warning(*args):
+            MessageBox.warnings.append(args)
+
+        @staticmethod
+        def information(*args):
+            pass
+
+    original_query_op = update_dialog.QueryOp
+    original_message_box = update_dialog.QMessageBox
+    saved_modules = {
+        name: sys.modules.get(name)
+        for name in ("Ankimon", "Ankimon.pyobj", "Ankimon.pyobj.update_manager")
+    }
+    update_dialog.QueryOp = _FakeQueryOp
+    update_dialog.QMessageBox = MessageBox
+    try:
+        for name, path in (
+            ("Ankimon", _SRC / "Ankimon"),
+            ("Ankimon.pyobj", _SRC / "Ankimon" / "pyobj"),
+        ):
+            package = types.ModuleType(name)
+            package.__path__ = [str(path)]
+            package.__package__ = name
+            sys.modules[name] = package
+
+        manager = types.ModuleType("Ankimon.pyobj.update_manager")
+        manager._download_branch_zip = lambda *args, **kwargs: None
+        manager._download_zip_to_temp = lambda *args, **kwargs: None
+        manager.apply_update = lambda *args, **kwargs: None
+        sys.modules[manager.__name__] = manager
+
+        dialog = types.SimpleNamespace(
+            release=None,
+            branch_name="main",
+            remote_sha="abc123",
+            on_progress=lambda *args: None,
+            btn_close=_Control(False),
+            status_label=_Label(),
+            progress_bar=_Progress(),
+        )
+        update_dialog.BranchUpdateProgressDialog.start_update(dialog)
+        _FakeQueryOp.last.success(None)
+
+        assert dialog.btn_close.enabled is True
+        assert dialog.progress_bar.value == 0
+        assert "unexpectedly" in dialog.status_label.text
+        assert MessageBox.warnings
+    finally:
+        update_dialog.QueryOp = original_query_op
+        update_dialog.QMessageBox = original_message_box
         for name, module in saved_modules.items():
             if module is None:
                 sys.modules.pop(name, None)

--- a/tests/test_update_dialog_busy_state.py
+++ b/tests/test_update_dialog_busy_state.py
@@ -32,7 +32,9 @@ def _load_update_dialog():
         sys.modules["aqt.operations"] = operations
 
         qt = types.ModuleType("aqt.qt")
-        qt.Qt = object
+        qt.Qt = types.SimpleNamespace(
+            ConnectionType=types.SimpleNamespace(DirectConnection=object())
+        )
         for name in (
             "QDialog",
             "QVBoxLayout",
@@ -173,7 +175,7 @@ class _Signal:
     def __init__(self):
         self.callbacks = []
 
-    def connect(self, callback):
+    def connect(self, callback, *args, **kwargs):
         self.callbacks.append(callback)
 
     def emit(self, *args):
@@ -496,12 +498,14 @@ def test_sprite_workflows_share_busy_lifecycle(tmp_path):
         assert download_dialog.sprites_thread.started is True
 
         download_dialog.sprites_thread.finished_signal.emit(False, "simulated failure")
+        assert download_dialog._busy_operations
+        assert all(button.enabled is False for button in download_buttons)
+
+        download_dialog.sprites_thread.running = False
+        download_dialog.sprites_thread.finished.emit()
         assert not download_dialog._busy_operations
         assert download_dialog.sprites_check_btn.enabled is True
         assert download_dialog.sprites_update_btn.enabled is True
-        assert download_dialog.sprites_status.text == "Update failed: simulated failure"
-
-        download_dialog.sprites_thread.finished.emit()
         assert download_dialog.sprites_status.text == "Update failed: simulated failure"
 
         crashed_dialog, crashed_buttons = _make_dialog()
@@ -511,9 +515,50 @@ def test_sprite_workflows_share_busy_lifecycle(tmp_path):
         crashed_dialog.sprites_remote_sha = "abc123"
         update_dialog.UpdateDialog._start_sprites_download(crashed_dialog)
         assert all(button.enabled is False for button in crashed_buttons)
-        crashed_dialog.sprites_thread.finished.emit()
+        crashed_thread = crashed_dialog.sprites_thread
+        crashed_thread.running = False
+        crashed_thread.finished.emit()
         assert not crashed_dialog._busy_operations
         assert "unexpectedly" in crashed_dialog.sprites_status.text
+        crashed_thread.finished_signal.emit(False, "late result")
+        assert "unexpectedly" in crashed_dialog.sprites_status.text
+
+        replacement_dialog, replacement_buttons = _make_dialog()
+        replacement_dialog.sprites_added = []
+        replacement_dialog.sprites_modified = []
+        replacement_dialog.sprites_deleted = []
+        replacement_dialog.sprites_remote_sha = "abc123"
+        update_dialog.UpdateDialog._start_sprites_download(replacement_dialog)
+        old_thread = replacement_dialog.sprites_thread
+
+        update_dialog.UpdateDialog._start_sprites_download(replacement_dialog)
+        assert replacement_dialog.sprites_thread is old_thread
+        assert len(replacement_dialog._busy_operations) == 1
+
+        # The worker has stopped, but its queued QThread.finished callback has
+        # not run yet, so a new operation can replace the stored reference.
+        old_thread.running = False
+        update_dialog.UpdateDialog._start_sprites_download(replacement_dialog)
+        replacement_thread = replacement_dialog.sprites_thread
+
+        old_thread.progress_signal.emit(88)
+        old_thread.status_signal.emit("stale status")
+        old_thread.finished_signal.emit(False, "stale result")
+        old_thread.finished.emit()
+
+        assert replacement_dialog.sprites_thread is replacement_thread
+        assert len(replacement_dialog._busy_operations) == 1
+        assert all(button.enabled is False for button in replacement_buttons)
+        assert replacement_dialog.sprites_progress.value == 0
+        assert "stale status" not in replacement_dialog.sprites_status.text
+        assert "stale result" not in replacement_dialog.sprites_status.text
+
+        replacement_thread.finished_signal.emit(False, "current result")
+        replacement_thread.running = False
+        replacement_thread.finished.emit()
+        assert replacement_dialog.sprites_thread is None
+        assert not replacement_dialog._busy_operations
+        assert replacement_dialog.sprites_status.text == "Update failed: current result"
 
         closing_dialog, closing_buttons = _make_dialog()
         closing_dialog.sprites_added = []

--- a/tests/test_update_dialog_busy_state.py
+++ b/tests/test_update_dialog_busy_state.py
@@ -1,0 +1,168 @@
+"""Focused Tier-1 coverage for the updater dialog's busy-state controls."""
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+
+_SRC = Path(__file__).parent.parent / "src"
+
+
+def _load_update_dialog():
+    module_names = (
+        "aqt",
+        "aqt.operations",
+        "aqt.qt",
+        "aqt.theme",
+        "Ankimon",
+        "Ankimon.pyobj",
+        "Ankimon.pyobj.update_dialog",
+        "Ankimon.pyobj.update_manager",
+        "Ankimon.resources",
+    )
+    saved = {name: sys.modules.get(name) for name in module_names}
+    try:
+        aqt = types.ModuleType("aqt")
+        aqt.mw = None
+        sys.modules["aqt"] = aqt
+
+        operations = types.ModuleType("aqt.operations")
+        operations.QueryOp = object
+        sys.modules["aqt.operations"] = operations
+
+        qt = types.ModuleType("aqt.qt")
+        qt.Qt = object
+        for name in (
+            "QDialog",
+            "QVBoxLayout",
+            "QHBoxLayout",
+            "QLabel",
+            "QPushButton",
+            "QComboBox",
+            "QProgressBar",
+            "QTabWidget",
+            "QWidget",
+            "QMessageBox",
+            "QGroupBox",
+            "QFrame",
+            "QSizePolicy",
+            "QSpacerItem",
+            "QTextBrowser",
+            "QCheckBox",
+        ):
+            setattr(qt, name, type(name, (), {}))
+        sys.modules["aqt.qt"] = qt
+
+        theme = types.ModuleType("aqt.theme")
+        theme.theme_manager = types.SimpleNamespace(night_mode=False)
+        sys.modules["aqt.theme"] = theme
+
+        for name, path in (
+            ("Ankimon", _SRC / "Ankimon"),
+            ("Ankimon.pyobj", _SRC / "Ankimon" / "pyobj"),
+        ):
+            package = types.ModuleType(name)
+            package.__path__ = [str(path)]
+            package.__package__ = name
+            sys.modules[name] = package
+
+        update_manager = types.ModuleType("Ankimon.pyobj.update_manager")
+        for name in (
+            "fetch_releases",
+            "fetch_tags",
+            "fetch_branches",
+            "fetch_open_prs",
+            "apply_update",
+            "_download_zip_to_temp",
+            "_download_branch_zip",
+            "_download_pr_zip",
+            "read_update_state",
+            "fetch_branch_sha",
+        ):
+            setattr(update_manager, name, lambda *args, **kwargs: None)
+        sys.modules["Ankimon.pyobj.update_manager"] = update_manager
+
+        resources = types.ModuleType("Ankimon.resources")
+        resources.addon_ver = "test"
+        resources.IS_EXPERIMENTAL_BUILD = False
+        sys.modules["Ankimon.resources"] = resources
+
+        spec = importlib.util.spec_from_file_location(
+            "Ankimon.pyobj.update_dialog",
+            _SRC / "Ankimon" / "pyobj" / "update_dialog.py",
+        )
+        module = importlib.util.module_from_spec(spec)
+        sys.modules[spec.name] = module
+        spec.loader.exec_module(module)
+        return module
+    finally:
+        for name, module in saved.items():
+            if module is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = module
+
+
+update_dialog = _load_update_dialog()
+
+
+class _Control:
+    def __init__(self, enabled=True):
+        self.enabled = enabled
+
+    def isEnabled(self):
+        return self.enabled
+
+    def setEnabled(self, enabled):
+        self.enabled = enabled
+
+
+class _Progress:
+    def __init__(self):
+        self.visible = False
+        self.value = None
+
+    def setVisible(self, visible):
+        self.visible = visible
+
+    def setValue(self, value):
+        self.value = value
+
+
+class _Label:
+    def __init__(self):
+        self.text = "Working..."
+
+    def setText(self, text):
+        self.text = text
+
+
+def test_busy_state_disables_all_actions_and_restores_prior_state():
+    dialog = types.SimpleNamespace(
+        progress_bar=_Progress(),
+        status_label=_Label(),
+        brrr_update_btn=_Control(True),
+        update_latest_btn=_Control(False),
+        release_btn=_Control(True),
+        dev_install_btn=_Control(True),
+        _busy_action_states=None,
+    )
+    buttons = (
+        dialog.brrr_update_btn,
+        dialog.update_latest_btn,
+        dialog.release_btn,
+        dialog.dev_install_btn,
+    )
+
+    update_dialog.UpdateDialog._set_busy(dialog, True)
+
+    assert dialog.progress_bar.visible is True
+    assert dialog.progress_bar.value == 0
+    assert all(button.enabled is False for button in buttons)
+
+    update_dialog.UpdateDialog._set_busy(dialog, False)
+
+    assert dialog.progress_bar.visible is False
+    assert [button.enabled for button in buttons] == [True, False, True, True]
+    assert dialog.status_label.text == ""

--- a/tests/test_update_dialog_busy_state.py
+++ b/tests/test_update_dialog_busy_state.py
@@ -146,7 +146,8 @@ def test_busy_state_disables_all_actions_and_restores_prior_state():
         update_latest_btn=_Control(False),
         release_btn=_Control(True),
         dev_install_btn=_Control(True),
-        _busy_action_states=None,
+        _busy_operations=set(),
+        _action_button_states={},
     )
     buttons = (
         dialog.brrr_update_btn,
@@ -154,15 +155,59 @@ def test_busy_state_disables_all_actions_and_restores_prior_state():
         dialog.release_btn,
         dialog.dev_install_btn,
     )
+    dialog._action_buttons = lambda: buttons
 
-    update_dialog.UpdateDialog._set_busy(dialog, True)
+    busy_token = update_dialog.UpdateDialog._begin_busy(dialog)
 
     assert dialog.progress_bar.visible is True
     assert dialog.progress_bar.value == 0
     assert all(button.enabled is False for button in buttons)
 
-    update_dialog.UpdateDialog._set_busy(dialog, False)
+    update_dialog.UpdateDialog._end_busy(dialog, busy_token)
 
     assert dialog.progress_bar.visible is False
     assert [button.enabled for button in buttons] == [True, False, True, True]
+    assert dialog.status_label.text == ""
+
+
+def test_overlapping_operations_keep_busy_and_apply_latest_button_states():
+    dialog = types.SimpleNamespace(
+        progress_bar=_Progress(),
+        status_label=_Label(),
+        brrr_update_btn=_Control(True),
+        update_latest_btn=_Control(False),
+        release_btn=_Control(True),
+        dev_install_btn=_Control(True),
+        _busy_operations=set(),
+        _action_button_states={},
+    )
+    buttons = (
+        dialog.brrr_update_btn,
+        dialog.update_latest_btn,
+        dialog.release_btn,
+        dialog.dev_install_btn,
+    )
+    dialog._action_buttons = lambda: buttons
+
+    first_token = update_dialog.UpdateDialog._begin_busy(dialog)
+    dialog.progress_bar.setValue(63)
+    second_token = update_dialog.UpdateDialog._begin_busy(dialog)
+
+    assert dialog.progress_bar.value == 63
+    update_dialog.UpdateDialog._set_action_enabled(
+        dialog, dialog.update_latest_btn, True
+    )
+    update_dialog.UpdateDialog._set_action_enabled(dialog, dialog.release_btn, False)
+    assert all(button.enabled is False for button in buttons)
+
+    update_dialog.UpdateDialog._end_busy(dialog, first_token)
+
+    assert dialog.progress_bar.visible is True
+    assert dialog.status_label.text == "Working..."
+    assert all(button.enabled is False for button in buttons)
+
+    update_dialog.UpdateDialog._end_busy(dialog, second_token)
+
+    assert dialog.progress_bar.visible is False
+    assert [button.enabled for button in buttons] == [True, True, False, True]
     assert dialog.status_label.text == ""


### PR DESCRIPTION
### Description

Improves the updater's visual feedback while an operation is in progress.

- Disables all updater action buttons while the dialog is busy, preventing duplicate or conflicting update actions.
- Restores each button to its previous enabled state when the operation finishes.
- Makes the progress bar taller and keeps its percentage centered and readable.
- Makes the status text larger, bold, theme-aware, and less likely to be clipped.
- Adds focused regression coverage for disabling and restoring updater controls.

This makes it clearer that an update is running and prevents users from starting another updater action before the current one finishes.

### Related Issue

Fixes #433

### Testing

- [x] `python3 harness/check.py` - all 9 Tier-1 checks passed.
- [x] Focused busy-state regression test passed.
- [x] Tested with real PyQt6 widgets from Anki 26.08.
- [x] Tested the addon and updater dialog in a live Anki 26.08 Flatpak session.
- [x] Confirmed that all updater buttons are disabled while busy.
- [x] Confirmed that the original button states are restored after completion.
- [x] Confirmed that the progress percentage and status text remain visible.

### Checklist

- [x] My code follows the code style and guidelines of this project.
- [x] I added regression coverage for the changed behavior.
- [x] I tested the change in a real Anki environment.
<img width="560" height="636" alt="updater-433" src="https://github.com/user-attachments/assets/b60bf494-d1fd-4347-9df1-9df0101e5a64" />
