### PR TITLE
fix: correctly configure move-based evolutions for generation 9 pokemon

### DIFF
--- a/src/Ankimon/data_files/pokedex.json
+++ b/src/Ankimon/data_files/pokedex.json
@@ -41614,8 +41614,8 @@
     "weightkg": 95.1,
     "color": "Gray",
     "prevo": "Stantler",
-    "evoType": "other",
-    "evoCondition": "Use Agile style Psyshield Bash 20 times",
+    "evoType": "levelMove",
+    "evoMove": "Psyshield Bash",
     "eggGroups": [
       "Field"
     ],
@@ -41857,8 +41857,8 @@
     "weightkg": 60.5,
     "color": "Black",
     "prevo": "Qwilfish-Hisui",
-    "evoType": "other",
-    "evoCondition": "Use Strong style Barb Barrage 20 times",
+    "evoType": "levelMove",
+    "evoMove": "Barb Barrage",
     "eggGroups": [
       "Water 2"
     ],
@@ -44695,8 +44695,8 @@
     "weightkg": 56,
     "color": "Gray",
     "prevo": "Primeape",
-    "evoType": "other",
-    "evoCondition": "Use Rage Fist 20 times and level-up",
+    "evoType": "levelMove",
+    "evoMove": "Rage Fist",
     "eggGroups": [
       "Field"
     ],


### PR DESCRIPTION
Fixes a bug where Primeape, Stantler, and Hisuian Qwilfish could not evolve due to their evolution type being incorrectly set to `"other"`.

Because the game engine does not track move usage counts, their `evoType` has been updated to `"levelMove"` and the `evoMove` has been populated with their respective moves (Rage Fist, Psyshield Bash, Barb Barrage). This allows them to evolve upon leveling up while knowing the move.

---
*PR created automatically by Jules for task [5664947551375828317](https://jules.google.com/task/5664947551375828317) started by @h0tp-ftw*