### PR TITLE
fix(discord): route rich presence tooltips to main UI thread

### DIFF
--- a/harness/checks/probe_leaves.py
+++ b/harness/checks/probe_leaves.py
@@ -53,6 +53,7 @@ LEAF_MODULES = [
     "Ankimon.functions.trainer_functions",
     "Ankimon.functions.update_main_pokemon",
     "Ankimon.functions.drawing_utils",
+    "Ankimon.functions.discord_function",
     # the big IO helper module
     "Ankimon.utils",
 ]

--- a/src/Ankimon/functions/discord_function.py
+++ b/src/Ankimon/functions/discord_function.py
@@ -42,7 +42,7 @@ class DiscordPresence:
 
         except Exception as e:
             logger.log("error",f"Error with Discord setup: {e}")
-            tooltip("Error with Discord setup. Is Discord running?")
+            mw.taskman.run_on_main(lambda: tooltip("Error with Discord setup. Is Discord running?"))
 
     def _get_special_quotes(self):
         return [
@@ -81,7 +81,7 @@ class DiscordPresence:
                 time.sleep(30)  # Sleep for 30 seconds before updating again
         except Exception as e:
             logger.log("error",f"Error with Discord Rich Presence: {e}")
-            tooltip("Error with Discord Rich Presence. Is Discord running?")
+            mw.taskman.run_on_main(lambda: tooltip("Error with Discord Rich Presence. Is Discord running?"))
 
     def start(self):
         """
@@ -94,7 +94,7 @@ class DiscordPresence:
                 self.thread.start()
         except Exception as e:
             logger.log("error",f"Error starting Discord Rich Presence: {e}")
-            tooltip("Error starting Discord Rich Presence. Is Discord running?")
+            mw.taskman.run_on_main(lambda: tooltip("Error starting Discord Rich Presence. Is Discord running?"))
 
     def stop(self):
         """
@@ -108,7 +108,7 @@ class DiscordPresence:
             self.RPC.clear()
         except Exception as e:
             logger.log("error",f"Error clearing Discord Rich Presence: {e}")
-            tooltip("Error clearing Discord Rich Presence. Please check Logger for info.")
+            mw.taskman.run_on_main(lambda: tooltip("Error clearing Discord Rich Presence. Please check Logger for info."))
 
     def stop_presence(self):
         """
@@ -123,7 +123,7 @@ class DiscordPresence:
                 )
         except Exception as e:
             logger.log("error",f"Error stopping Discord Rich Presence: {e}")
-            tooltip("Error stopping Discord Rich Presence. Please check Logger for info.")
+            mw.taskman.run_on_main(lambda: tooltip("Error stopping Discord Rich Presence. Please check Logger for info."))
 
 def check_conflicting_discord_addons():
     """

--- a/src/Ankimon/functions/discord_function.py
+++ b/src/Ankimon/functions/discord_function.py
@@ -4,9 +4,10 @@ import time
 
 from ..pyobj.ankimon_tracker import AnkimonTracker
 from ..addon_files.lib.pypresence import Presence
-from aqt.utils import showWarning, tooltip
+from aqt.utils import showWarning
 from aqt import mw
 from ..pyobj.error_handler import show_warning_with_traceback
+from ..services import services
 logger = mw.logger
 
 class DiscordPresence:
@@ -42,7 +43,7 @@ class DiscordPresence:
 
         except Exception as e:
             logger.log("error",f"Error with Discord setup: {e}")
-            mw.taskman.run_on_main(lambda: tooltip("Error with Discord setup. Is Discord running?"))
+            mw.taskman.run_on_main(lambda: services.ui.notify("warning", "Error with Discord setup. Is Discord running?"))
 
     def _get_special_quotes(self):
         return [
@@ -81,7 +82,7 @@ class DiscordPresence:
                 time.sleep(30)  # Sleep for 30 seconds before updating again
         except Exception as e:
             logger.log("error",f"Error with Discord Rich Presence: {e}")
-            mw.taskman.run_on_main(lambda: tooltip("Error with Discord Rich Presence. Is Discord running?"))
+            mw.taskman.run_on_main(lambda: services.ui.notify("warning", "Error with Discord Rich Presence. Is Discord running?"))
 
     def start(self):
         """
@@ -94,7 +95,7 @@ class DiscordPresence:
                 self.thread.start()
         except Exception as e:
             logger.log("error",f"Error starting Discord Rich Presence: {e}")
-            mw.taskman.run_on_main(lambda: tooltip("Error starting Discord Rich Presence. Is Discord running?"))
+            mw.taskman.run_on_main(lambda: services.ui.notify("warning", "Error starting Discord Rich Presence. Is Discord running?"))
 
     def stop(self):
         """
@@ -108,7 +109,7 @@ class DiscordPresence:
             self.RPC.clear()
         except Exception as e:
             logger.log("error",f"Error clearing Discord Rich Presence: {e}")
-            mw.taskman.run_on_main(lambda: tooltip("Error clearing Discord Rich Presence. Please check Logger for info."))
+            mw.taskman.run_on_main(lambda: services.ui.notify("warning", "Error clearing Discord Rich Presence. Please check Logger for info."))
 
     def stop_presence(self):
         """
@@ -123,7 +124,7 @@ class DiscordPresence:
                 )
         except Exception as e:
             logger.log("error",f"Error stopping Discord Rich Presence: {e}")
-            mw.taskman.run_on_main(lambda: tooltip("Error stopping Discord Rich Presence. Please check Logger for info."))
+            mw.taskman.run_on_main(lambda: services.ui.notify("warning", "Error stopping Discord Rich Presence. Please check Logger for info."))
 
 def check_conflicting_discord_addons():
     """

--- a/src/Ankimon/functions/discord_function.py
+++ b/src/Ankimon/functions/discord_function.py
@@ -4,11 +4,15 @@ import time
 
 from ..pyobj.ankimon_tracker import AnkimonTracker
 from ..addon_files.lib.pypresence import Presence
-from aqt.utils import showWarning
+from aqt.utils import tooltip
 from aqt import mw
 from ..pyobj.error_handler import show_warning_with_traceback
-from ..services import services
 logger = mw.logger
+
+
+def _show_discord_error(message):
+    mw.taskman.run_on_main(lambda: tooltip(message))
+
 
 class DiscordPresence:
     def __init__(self, client_id, large_image_url, ankimon_tracker, logger, settings_obj, parent=mw):
@@ -43,7 +47,7 @@ class DiscordPresence:
 
         except Exception as e:
             logger.log("error",f"Error with Discord setup: {e}")
-            mw.taskman.run_on_main(lambda: services.ui.notify("warning", "Error with Discord setup. Is Discord running?"))
+            _show_discord_error("Error with Discord setup. Is Discord running?")
 
     def _get_special_quotes(self):
         return [
@@ -82,7 +86,9 @@ class DiscordPresence:
                 time.sleep(30)  # Sleep for 30 seconds before updating again
         except Exception as e:
             logger.log("error",f"Error with Discord Rich Presence: {e}")
-            mw.taskman.run_on_main(lambda: services.ui.notify("warning", "Error with Discord Rich Presence. Is Discord running?"))
+            _show_discord_error(
+                "Error with Discord Rich Presence. Is Discord running?"
+            )
 
     def start(self):
         """
@@ -95,7 +101,9 @@ class DiscordPresence:
                 self.thread.start()
         except Exception as e:
             logger.log("error",f"Error starting Discord Rich Presence: {e}")
-            mw.taskman.run_on_main(lambda: services.ui.notify("warning", "Error starting Discord Rich Presence. Is Discord running?"))
+            _show_discord_error(
+                "Error starting Discord Rich Presence. Is Discord running?"
+            )
 
     def stop(self):
         """
@@ -109,7 +117,9 @@ class DiscordPresence:
             self.RPC.clear()
         except Exception as e:
             logger.log("error",f"Error clearing Discord Rich Presence: {e}")
-            mw.taskman.run_on_main(lambda: services.ui.notify("warning", "Error clearing Discord Rich Presence. Please check Logger for info."))
+            _show_discord_error(
+                "Error clearing Discord Rich Presence. Please check Logger for info."
+            )
 
     def stop_presence(self):
         """
@@ -124,7 +134,9 @@ class DiscordPresence:
                 )
         except Exception as e:
             logger.log("error",f"Error stopping Discord Rich Presence: {e}")
-            mw.taskman.run_on_main(lambda: services.ui.notify("warning", "Error stopping Discord Rich Presence. Please check Logger for info."))
+            _show_discord_error(
+                "Error stopping Discord Rich Presence. Please check Logger for info."
+            )
 
 def check_conflicting_discord_addons():
     """

--- a/src/Ankimon/functions/discord_function.py
+++ b/src/Ankimon/functions/discord_function.py
@@ -1,28 +1,46 @@
+from __future__ import annotations
+
 import threading
 import random
 import time
+from typing import TYPE_CHECKING
 
-from ..pyobj.ankimon_tracker import AnkimonTracker
 from ..addon_files.lib.pypresence import Presence
-from aqt.utils import tooltip
-from aqt import mw
-from ..pyobj.error_handler import show_warning_with_traceback
-logger = mw.logger
+from ..events import events
+
+if TYPE_CHECKING:
+    from ..pyobj.ankimon_tracker import AnkimonTracker
 
 
-def _show_discord_error(message):
-    mw.taskman.run_on_main(lambda: tooltip(message))
+def _show_discord_error(message: str) -> None:
+    events.emit("tooltip", message=message)
+    try:
+        from aqt import mw
+        from aqt.utils import tooltip
+
+        mw.taskman.run_on_main(lambda: tooltip(message))
+    except Exception:
+        # The notification is best-effort during headless runs and shutdown.
+        return
 
 
 class DiscordPresence:
-    def __init__(self, client_id, large_image_url, ankimon_tracker, logger, settings_obj, parent=mw):
+    def __init__(
+        self,
+        client_id,
+        large_image_url,
+        ankimon_tracker,
+        logger,
+        settings_obj,
+        parent=None,
+    ):
         self.loop = False
+        self.logger_obj = logger
         try:
             self.RPC = Presence(client_id)
             self.RPC.connect()
             self.large_image_url = large_image_url
             self.ankimon_tracker: AnkimonTracker = ankimon_tracker
-            self.logger_obj = mw.logger
             self.settings = settings_obj
             self.start_time = time.time()
             self.thread = None
@@ -43,10 +61,10 @@ class DiscordPresence:
             conflicting_addons = check_conflicting_discord_addons()
             if conflicting_addons:
                 conflict_list = ', '.join(conflicting_addons)
-                logger.log_and_showinfo("warning", f"⚠️ Conflicting Discord Rich Presence addons detected: \n{conflict_list}\n\nPlease remove them to avoid issues with Ankimon's Discord status, or turn off Discord Rich Presence in Ankimon settings :) ")
+                self.logger_obj.log_and_showinfo("warning", f"⚠️ Conflicting Discord Rich Presence addons detected: \n{conflict_list}\n\nPlease remove them to avoid issues with Ankimon's Discord status, or turn off Discord Rich Presence in Ankimon settings :) ")
 
         except Exception as e:
-            logger.log("error",f"Error with Discord setup: {e}")
+            self.logger_obj.log("error",f"Error with Discord setup: {e}")
             _show_discord_error("Error with Discord setup. Is Discord running?")
 
     def _get_special_quotes(self):
@@ -85,7 +103,7 @@ class DiscordPresence:
                 )
                 time.sleep(30)  # Sleep for 30 seconds before updating again
         except Exception as e:
-            logger.log("error",f"Error with Discord Rich Presence: {e}")
+            self.logger_obj.log("error",f"Error with Discord Rich Presence: {e}")
             _show_discord_error(
                 "Error with Discord Rich Presence. Is Discord running?"
             )
@@ -100,7 +118,7 @@ class DiscordPresence:
                 self.thread = threading.Thread(target=self.update_presence, daemon=True)
                 self.thread.start()
         except Exception as e:
-            logger.log("error",f"Error starting Discord Rich Presence: {e}")
+            self.logger_obj.log("error",f"Error starting Discord Rich Presence: {e}")
             _show_discord_error(
                 "Error starting Discord Rich Presence. Is Discord running?"
             )
@@ -116,7 +134,7 @@ class DiscordPresence:
                 self.thread = None  # Reset the thread
             self.RPC.clear()
         except Exception as e:
-            logger.log("error",f"Error clearing Discord Rich Presence: {e}")
+            self.logger_obj.log("error",f"Error clearing Discord Rich Presence: {e}")
             _show_discord_error(
                 "Error clearing Discord Rich Presence. Please check Logger for info."
             )
@@ -133,7 +151,7 @@ class DiscordPresence:
                     large_image=self.large_image_url
                 )
         except Exception as e:
-            logger.log("error",f"Error stopping Discord Rich Presence: {e}")
+            self.logger_obj.log("error",f"Error stopping Discord Rich Presence: {e}")
             _show_discord_error(
                 "Error stopping Discord Rich Presence. Please check Logger for info."
             )
@@ -201,6 +219,13 @@ def check_conflicting_discord_addons():
 
     except Exception as e:
         # Return empty list if checking fails entirely
-        if hasattr(mw, 'logger') and mw.logger:
-            mw.logger.log("error", f"Error checking for conflicting Discord addons: {e}")
+        try:
+            from ..services import services
+
+            if services.logger is not None:
+                services.logger.log(
+                    "error", f"Error checking for conflicting Discord addons: {e}"
+                )
+        except Exception:
+            pass
         return []

--- a/tests/test_discord_presence_threading.py
+++ b/tests/test_discord_presence_threading.py
@@ -30,6 +30,7 @@ def discord_env(monkeypatch):
     logger = MagicMock()
     tooltip = MagicMock()
     presenter_notify = MagicMock()
+    event_emit = MagicMock()
     mw = types.SimpleNamespace(
         addonManager=types.SimpleNamespace(allAddons=lambda: []),
         logger=logger,
@@ -76,6 +77,10 @@ def discord_env(monkeypatch):
     )
     modules[services_module.__name__] = services_module
 
+    events_module = types.ModuleType("Ankimon.events")
+    events_module.events = types.SimpleNamespace(emit=event_emit)
+    modules[events_module.__name__] = events_module
+
     for name, module in modules.items():
         monkeypatch.setitem(sys.modules, name, module)
 
@@ -94,6 +99,7 @@ def discord_env(monkeypatch):
     spec.loader.exec_module(module)
 
     return types.SimpleNamespace(
+        event_emit=event_emit,
         logger=logger,
         module=module,
         mw=mw,
@@ -106,12 +112,19 @@ def discord_env(monkeypatch):
 def _assert_queued_tooltip(env, message):
     env.tooltip.assert_not_called()
     env.presenter_notify.assert_not_called()
+    env.event_emit.assert_called_once_with("tooltip", message=message)
     assert len(env.taskman.callbacks) == 1
 
     env.taskman.callbacks.pop()()
 
     env.tooltip.assert_called_once_with(message)
     env.presenter_notify.assert_not_called()
+
+
+def _presence_without_init(env):
+    instance = object.__new__(env.module.DiscordPresence)
+    instance.logger_obj = env.logger
+    return instance
 
 
 def test_setup_failure_queues_non_modal_tooltip(discord_env, monkeypatch):
@@ -139,7 +152,7 @@ def test_setup_failure_queues_non_modal_tooltip(discord_env, monkeypatch):
 
 def test_update_failure_queues_tooltip_from_worker(discord_env):
     main_thread = threading.get_ident()
-    instance = object.__new__(discord_env.module.DiscordPresence)
+    instance = _presence_without_init(discord_env)
     instance.loop = True
     instance.RPC = types.SimpleNamespace(
         update=MagicMock(side_effect=RuntimeError("connection lost"))
@@ -162,7 +175,7 @@ def test_update_failure_queues_tooltip_from_worker(discord_env):
 
 
 def test_start_failure_queues_non_modal_tooltip(discord_env):
-    instance = object.__new__(discord_env.module.DiscordPresence)
+    instance = _presence_without_init(discord_env)
     instance.thread = types.SimpleNamespace(
         is_alive=MagicMock(side_effect=RuntimeError("thread failed"))
     )
@@ -176,7 +189,7 @@ def test_start_failure_queues_non_modal_tooltip(discord_env):
 
 
 def test_stop_failure_queues_non_modal_tooltip(discord_env):
-    instance = object.__new__(discord_env.module.DiscordPresence)
+    instance = _presence_without_init(discord_env)
     instance.loop = True
     instance.thread = None
     instance.RPC = types.SimpleNamespace(
@@ -192,7 +205,7 @@ def test_stop_failure_queues_non_modal_tooltip(discord_env):
 
 
 def test_stop_presence_failure_queues_non_modal_tooltip(discord_env):
-    instance = object.__new__(discord_env.module.DiscordPresence)
+    instance = _presence_without_init(discord_env)
     instance.loop = True
     instance.RPC = types.SimpleNamespace(
         update=MagicMock(side_effect=RuntimeError("update failed"))

--- a/tests/test_discord_presence_threading.py
+++ b/tests/test_discord_presence_threading.py
@@ -1,0 +1,207 @@
+import importlib.util
+import sys
+import threading
+import types
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+
+class _Taskman:
+    def __init__(self):
+        self.callbacks = []
+        self.calling_threads = []
+
+    def run_on_main(self, callback):
+        self.callbacks.append(callback)
+        self.calling_threads.append(threading.get_ident())
+
+
+def _package(name):
+    module = types.ModuleType(name)
+    module.__path__ = []
+    return module
+
+
+@pytest.fixture
+def discord_env(monkeypatch):
+    taskman = _Taskman()
+    logger = MagicMock()
+    tooltip = MagicMock()
+    presenter_notify = MagicMock()
+    mw = types.SimpleNamespace(
+        addonManager=types.SimpleNamespace(allAddons=lambda: []),
+        logger=logger,
+        taskman=taskman,
+    )
+
+    modules = {
+        "Ankimon": _package("Ankimon"),
+        "Ankimon.functions": _package("Ankimon.functions"),
+        "Ankimon.pyobj": _package("Ankimon.pyobj"),
+        "Ankimon.addon_files": _package("Ankimon.addon_files"),
+        "Ankimon.addon_files.lib": _package("Ankimon.addon_files.lib"),
+        "aqt": _package("aqt"),
+    }
+    modules["aqt"].mw = mw
+
+    aqt_utils = types.ModuleType("aqt.utils")
+    aqt_utils.showWarning = MagicMock()
+    aqt_utils.tooltip = tooltip
+    modules["aqt.utils"] = aqt_utils
+
+    tracker_module = types.ModuleType("Ankimon.pyobj.ankimon_tracker")
+    tracker_module.AnkimonTracker = object
+    modules[tracker_module.__name__] = tracker_module
+
+    class _Presence:
+        def __init__(self, client_id):
+            self.client_id = client_id
+
+        def connect(self):
+            return None
+
+    presence_module = types.ModuleType("Ankimon.addon_files.lib.pypresence")
+    presence_module.Presence = _Presence
+    modules[presence_module.__name__] = presence_module
+
+    error_module = types.ModuleType("Ankimon.pyobj.error_handler")
+    error_module.show_warning_with_traceback = MagicMock()
+    modules[error_module.__name__] = error_module
+
+    services_module = types.ModuleType("Ankimon.services")
+    services_module.services = types.SimpleNamespace(
+        ui=types.SimpleNamespace(notify=presenter_notify)
+    )
+    modules[services_module.__name__] = services_module
+
+    for name, module in modules.items():
+        monkeypatch.setitem(sys.modules, name, module)
+
+    source = (
+        Path(__file__).parents[1]
+        / "src"
+        / "Ankimon"
+        / "functions"
+        / "discord_function.py"
+    )
+    spec = importlib.util.spec_from_file_location(
+        "Ankimon.functions.discord_function", source
+    )
+    module = importlib.util.module_from_spec(spec)
+    monkeypatch.setitem(sys.modules, spec.name, module)
+    spec.loader.exec_module(module)
+
+    return types.SimpleNamespace(
+        logger=logger,
+        module=module,
+        mw=mw,
+        presenter_notify=presenter_notify,
+        taskman=taskman,
+        tooltip=tooltip,
+    )
+
+
+def _assert_queued_tooltip(env, message):
+    env.tooltip.assert_not_called()
+    env.presenter_notify.assert_not_called()
+    assert len(env.taskman.callbacks) == 1
+
+    env.taskman.callbacks.pop()()
+
+    env.tooltip.assert_called_once_with(message)
+    env.presenter_notify.assert_not_called()
+
+
+def test_setup_failure_queues_non_modal_tooltip(discord_env, monkeypatch):
+    class _FailingPresence:
+        def __init__(self, client_id):
+            pass
+
+        def connect(self):
+            raise RuntimeError("Discord is closed")
+
+    monkeypatch.setattr(discord_env.module, "Presence", _FailingPresence)
+
+    discord_env.module.DiscordPresence(
+        "client-id",
+        "image",
+        object(),
+        discord_env.logger,
+        types.SimpleNamespace(get=lambda key: 1),
+    )
+
+    _assert_queued_tooltip(
+        discord_env, "Error with Discord setup. Is Discord running?"
+    )
+
+
+def test_update_failure_queues_tooltip_from_worker(discord_env):
+    main_thread = threading.get_ident()
+    instance = object.__new__(discord_env.module.DiscordPresence)
+    instance.loop = True
+    instance.RPC = types.SimpleNamespace(
+        update=MagicMock(side_effect=RuntimeError("connection lost"))
+    )
+    instance.settings = types.SimpleNamespace(get=lambda key: 1)
+    instance.quotes = ["Reviewing"]
+    instance.large_image_url = "image"
+    instance.start_time = 0
+
+    worker = threading.Thread(target=instance.update_presence)
+    worker.start()
+    worker.join()
+
+    assert discord_env.taskman.calling_threads == [worker.ident]
+    assert worker.ident != main_thread
+    _assert_queued_tooltip(
+        discord_env,
+        "Error with Discord Rich Presence. Is Discord running?",
+    )
+
+
+def test_start_failure_queues_non_modal_tooltip(discord_env):
+    instance = object.__new__(discord_env.module.DiscordPresence)
+    instance.thread = types.SimpleNamespace(
+        is_alive=MagicMock(side_effect=RuntimeError("thread failed"))
+    )
+
+    instance.start()
+
+    _assert_queued_tooltip(
+        discord_env,
+        "Error starting Discord Rich Presence. Is Discord running?",
+    )
+
+
+def test_stop_failure_queues_non_modal_tooltip(discord_env):
+    instance = object.__new__(discord_env.module.DiscordPresence)
+    instance.loop = True
+    instance.thread = None
+    instance.RPC = types.SimpleNamespace(
+        clear=MagicMock(side_effect=RuntimeError("clear failed"))
+    )
+
+    instance.stop()
+
+    _assert_queued_tooltip(
+        discord_env,
+        "Error clearing Discord Rich Presence. Please check Logger for info.",
+    )
+
+
+def test_stop_presence_failure_queues_non_modal_tooltip(discord_env):
+    instance = object.__new__(discord_env.module.DiscordPresence)
+    instance.loop = True
+    instance.RPC = types.SimpleNamespace(
+        update=MagicMock(side_effect=RuntimeError("update failed"))
+    )
+    instance.large_image_url = "image"
+
+    instance.stop_presence()
+
+    _assert_queued_tooltip(
+        discord_env,
+        "Error stopping Discord Rich Presence. Please check Logger for info.",
+    )


### PR DESCRIPTION
### Description

Fixes a crash that occurs when Anki users review cards with Ankimon's Discord Rich Presence enabled while Discord is closed.

Discord connection failures can occur on the Rich Presence background thread. Calling `aqt.utils.tooltip` from that worker can segfault PyQt, so every Discord error path now queues the tooltip through `mw.taskman.run_on_main`.

The follow-up fixes preserve the original non-modal, auto-dismissing tooltip behavior instead of routing warnings through `services.ui.notify`, which opens a modal dialog in production. The module also resolves Anki UI dependencies lazily, uses its injected logger, and participates in the headless leaf-import gate.

Focused regression tests cover setup, background updates, thread startup, clearing, and break-state updates.

### Related Issue

None. Originated from Jules task [17503123025909003055](https://jules.google.com/task/17503123025909003055).

### Validation

- `python3 -m pytest tests/ -q` — 702 passed, 34 skipped
- `python3 harness/check.py` — all 9 Tier-1 checks passed, including 27 headless leaf imports
- `ruff check --config ci_ruff_check.toml harness/checks/probe_leaves.py src/Ankimon/functions/discord_function.py tests/test_discord_presence_threading.py`

### Checklist

- [x] My code follows the code style and guidelines of this project.
- [x] I have run tests locally (`pytest tests/` and `pytest tests/test_addon_integrity.py`) and they all pass.
- [ ] **(Optional)** I have added/updated my entry in `.all-contributorsrc` at the root of the repository to specify my custom `"nickname"` and `"discord_id"` for release announcements and Discord pings.

---

*PR created automatically by Jules for task [17503123025909003055](https://jules.google.com/task/17503123025909003055) started by @h0tp-ftw*
