### PR TITLE
Fix Pokémon Showdown Export Formatting

### DIFF
--- a/src/Ankimon/functions/pokemon_showdown_functions.py
+++ b/src/Ankimon/functions/pokemon_showdown_functions.py
@@ -21,13 +21,16 @@ def export_to_pkmn_showdown():
     # EV dict was mutated in place; __setattr__ doesn't catch dict-item
     # changes, so drop the cached CP manually.
     main_pokemon.invalidate_cp_cache()
+
+    pokemon_type_text = ' '.join(t.capitalize() for t in main_pokemon.type)
+
     # Format the Pokemon info
-    pokemon_info = "{} ({})\nAbility: {}\nLevel: {}\nType: {}\nEVs: {} HP / {} Atk / {} Def / {} SpA / {} SpD / {} Spe\n IVs: {} HP / {} Atk / {} Def / {} SpA / {} SpD / {} Spe ".format(
+    pokemon_info = "{} ({})\nAbility: {}\nLevel: {}\nType: {}\nEVs: {} HP / {} Atk / {} Def / {} SpA / {} SpD / {} Spe\nIVs: {} HP / {} Atk / {} Def / {} SpA / {} SpD / {} Spe ".format(
         main_pokemon.name,
         main_pokemon.gender,
         main_pokemon.ability,
         main_pokemon.level,
-        main_pokemon.type,
+        pokemon_type_text,
         main_pokemon.ev["hp"],
         main_pokemon.ev["atk"],
         main_pokemon.ev["def"],
@@ -99,11 +102,7 @@ def export_all_pkmn_showdown():
                 pokemon_level = pokemon['level']
                 pokemon_ability = pokemon['ability']
                 pokemon_type = pokemon['type']
-                pokemon_type_text = pokemon_type[0].capitalize()
-                if len(pokemon_type) > 1:
-                    pokemon_type_text = ""
-                    pokemon_type_text += f"{pokemon_type[0].capitalize()}"
-                    pokemon_type_text += f" {pokemon_type[1].capitalize()}"
+                pokemon_type_text = ' '.join(t.capitalize() for t in pokemon_type)
                 pokemon_attacks = pokemon['attacks']
                 pokemon_ev = pokemon['ev']
                 pokemon_iv = pokemon['iv']
@@ -197,11 +196,7 @@ def flex_pokemon_collection():
                 pokemon_level = pokemon['level']
                 pokemon_ability = pokemon['ability']
                 pokemon_type = pokemon['type']
-                pokemon_type_text = pokemon_type[0].capitalize()
-                if len(pokemon_type) > 1:
-                    pokemon_type_text = ""
-                    pokemon_type_text += f"{pokemon_type[0].capitalize()}"
-                    pokemon_type_text += f" {pokemon_type[1].capitalize()}"
+                pokemon_type_text = ' '.join(t.capitalize() for t in pokemon_type)
                 pokemon_attacks = pokemon['attacks']
                 pokemon_ev = pokemon['ev']
                 pokemon_iv = pokemon['iv']


### PR DESCRIPTION
Fixes two bugs in the Ankimon Pokémon Showdown exporter:
1. `Type` was previously formatting as a raw Python list (e.g. `['Grass', 'Poison']`). This updates it to capitalize the list items and combine them as space-separated text.
2. `IVs` had an errant space preceding the string ` IVs: `. Pokémon Showdown's team importer is very strict and this caused the importer to silently discard the entire IV stat block.

---
*PR created automatically by Jules for task [11371826824734552222](https://jules.google.com/task/11371826824734552222) started by @h0tp-ftw*