### PR TITLE
fix: update probopass evolution to use thunder stone

### DIFF
--- a/src/Ankimon/data_files/pokedex.json
+++ b/src/Ankimon/data_files/pokedex.json
@@ -21112,8 +21112,8 @@
     "weightkg": 340,
     "color": "Gray",
     "prevo": "Nosepass",
-    "evoType": "levelExtra",
-    "evoCondition": "near a special magnetic field",
+    "evoType": "useItem",
+    "evoItem": "Thunder Stone",
     "eggGroups": [
       "Mineral"
     ],


### PR DESCRIPTION
Probopass's evolution condition was previously set to `levelExtra` ("near a special magnetic field"), which is impossible to fulfill in Ankimon. This pull request updates the requirement to use a Thunder Stone (`evoType: "useItem"`, `evoItem: "Thunder Stone"`), matching modern Pokémon game mechanics and allowing Nosepass to correctly evolve.

---
*PR created automatically by Jules for task [18174766395252068157](https://jules.google.com/task/18174766395252068157) started by @h0tp-ftw*