### PR TITLE
add(functionality): defeat or capture on demand

### DIFF
--- a/src/Ankimon/functions/encounter_functions.py
+++ b/src/Ankimon/functions/encounter_functions.py
@@ -1745,7 +1745,13 @@ def save_caught_pokemon(
     caught_pokemon["cp"] = calculate_cp_from_dict(caught_pokemon)
 
     # Save to database (replaces JSON file I/O for performance)
-    ankimon_db.save_pokemon(caught_pokemon)
+    save_success = ankimon_db.save_pokemon(caught_pokemon)
+
+    # Only award Badge 7 ("First Pokemon Caught !") if the save was successful
+    if save_success and achievements is not None:
+        check = check_for_badge(achievements, 7)
+        if check is False:
+            achievements = receive_badge(7, achievements)
 
     try:
         from ..singletons import notify_stats_changed

--- a/src/Ankimon/functions/encounter_functions.py
+++ b/src/Ankimon/functions/encounter_functions.py
@@ -8,7 +8,14 @@ import uuid
 from datetime import datetime
 from typing import TYPE_CHECKING, Union
 
-from aqt.utils import tooltip
+# Tooltip import - fallback for headless test environment
+try:
+    from aqt.utils import tooltip
+except (ImportError, ModuleNotFoundError):
+    # Fallback for harness tests (no Qt)
+    def tooltip(msg, period=2000):
+        print(f"[Ankimon Tooltip] {msg}")
+
 from ..services import services
 from ..events import events
 from ..functions.pokemon_functions import (

--- a/src/Ankimon/functions/encounter_functions.py
+++ b/src/Ankimon/functions/encounter_functions.py
@@ -6,7 +6,7 @@ import os
 import random
 import uuid
 from datetime import datetime
-from typing import TYPE_CHECKING, Union
+from typing import TYPE_CHECKING, Literal, Optional, Union
 
 # Tooltip import - fallback for headless test environment
 try:
@@ -230,10 +230,12 @@ OVERHAUL_PITY_DIVISOR = 50.0
 
 # AUTO-BATTLE OVERRIDE SYSTEM
 # Override state for auto-battle: None, "catch", or "defeat"
-_auto_battle_override = None
+_auto_battle_override: Optional[Literal["catch", "defeat"]] = None
 
 
-def toggle_auto_battle_override(action: str) -> str:
+def toggle_auto_battle_override(
+    action: Literal["catch", "defeat"],
+) -> Optional[Literal["catch", "defeat"]]:
     """
     Toggle the auto-battle override for the current encounter.
     
@@ -258,12 +260,12 @@ def toggle_auto_battle_override(action: str) -> str:
     return _auto_battle_override
 
 
-def get_auto_battle_override() -> str:
+def get_auto_battle_override() -> Optional[Literal["catch", "defeat"]]:
     """Get the current override state."""
     return _auto_battle_override
 
 
-def clear_auto_battle_override():
+def clear_auto_battle_override() -> None:
     """Clear the override state (called when a new encounter starts)."""
     global _auto_battle_override
     _auto_battle_override = None
@@ -1841,6 +1843,9 @@ def handle_enemy_faint(
             auto_battle_setting = 0  # fallback
     except ValueError:
         auto_battle_setting = 0  # fallback
+
+    if auto_battle_setting == 0:
+        clear_auto_battle_override()
 
     is_mega = enemy_pokemon.id in encounter_data.MEGA
     is_gmax = enemy_pokemon.id in encounter_data.GMAX

--- a/src/Ankimon/functions/encounter_functions.py
+++ b/src/Ankimon/functions/encounter_functions.py
@@ -1842,25 +1842,6 @@ def handle_enemy_faint(
     except ValueError:
         auto_battle_setting = 0  # fallback
 
-    # --- Wishlist fast-path (runs regardless of auto_battle_setting) ---
-    _wishlist = settings_obj.get("battle.auto_catch_wishlist", [])
-    if isinstance(_wishlist, list) and enemy_pokemon.id in _wishlist:
-        ankimon_tracker_obj.faint_processed = True
-        catch_pokemon(
-            enemy_pokemon,
-            ankimon_tracker_obj,
-            logger,
-            "",
-            collected_pokemon_ids,
-            achievements,
-        )
-        new_pokemon(enemy_pokemon, test_window, ankimon_tracker_obj, reviewer_obj)
-        main_pokemon.reset_bonuses()
-        ankimon_tracker_obj.general_card_count_for_battle = 0
-        clear_auto_battle_override()
-        return
-    # --- End wishlist fast-path ---
-
     is_mega = enemy_pokemon.id in encounter_data.MEGA
     is_gmax = enemy_pokemon.id in encounter_data.GMAX
     is_regional = enemy_pokemon.id in encounter_data.REGIONAL_FORM_REGION
@@ -1914,6 +1895,25 @@ def handle_enemy_faint(
         clear_auto_battle_override()
         return
     # --- END OVERRIDE CHECK ---
+
+    # --- Wishlist fast-path (runs after override check) ---
+    _wishlist = settings_obj.get("battle.auto_catch_wishlist", [])
+    if isinstance(_wishlist, list) and enemy_pokemon.id in _wishlist:
+        ankimon_tracker_obj.faint_processed = True
+        catch_pokemon(
+            enemy_pokemon,
+            ankimon_tracker_obj,
+            logger,
+            "",
+            collected_pokemon_ids,
+            achievements,
+        )
+        new_pokemon(enemy_pokemon, test_window, ankimon_tracker_obj, reviewer_obj)
+        main_pokemon.reset_bonuses()
+        ankimon_tracker_obj.general_card_count_for_battle = 0
+        clear_auto_battle_override()
+        return
+    # --- End wishlist fast-path ---
 
     # --- Normal auto-battle logic (no override) ---
     if auto_battle_setting == 3:  # Catch if uncollected

--- a/src/Ankimon/functions/encounter_functions.py
+++ b/src/Ankimon/functions/encounter_functions.py
@@ -1864,35 +1864,39 @@ def handle_enemy_faint(
     if _auto_battle_override == "catch":
         # Override: Force catch
         ankimon_tracker_obj.faint_processed = True
-        catch_pokemon(
-            enemy_pokemon,
-            ankimon_tracker_obj,
-            logger,
-            "",
-            collected_pokemon_ids,
-            achievements,
-        )
-        new_pokemon(enemy_pokemon, test_window, ankimon_tracker_obj, reviewer_obj)
-        main_pokemon.reset_bonuses()
-        ankimon_tracker_obj.general_card_count_for_battle = 0
-        clear_auto_battle_override()
+        try:
+            catch_pokemon(
+                enemy_pokemon,
+                ankimon_tracker_obj,
+                logger,
+                "",
+                collected_pokemon_ids,
+                achievements,
+            )
+            new_pokemon(enemy_pokemon, test_window, ankimon_tracker_obj, reviewer_obj)
+            main_pokemon.reset_bonuses()
+            ankimon_tracker_obj.general_card_count_for_battle = 0
+        finally:
+            clear_auto_battle_override()
         return
         
     elif _auto_battle_override == "defeat":
         # Override: Force defeat
         ankimon_tracker_obj.faint_processed = True
-        kill_pokemon(
-            main_pokemon,
-            enemy_pokemon,
-            evo_window,
-            logger,
-            achievements,
-            trainer_card,
-        )
-        new_pokemon(enemy_pokemon, test_window, ankimon_tracker_obj, reviewer_obj)
-        main_pokemon.reset_bonuses()
-        ankimon_tracker_obj.general_card_count_for_battle = 0
-        clear_auto_battle_override()
+        try:
+            kill_pokemon(
+                main_pokemon,
+                enemy_pokemon,
+                evo_window,
+                logger,
+                achievements,
+                trainer_card,
+            )
+            new_pokemon(enemy_pokemon, test_window, ankimon_tracker_obj, reviewer_obj)
+            main_pokemon.reset_bonuses()
+            ankimon_tracker_obj.general_card_count_for_battle = 0
+        finally:
+            clear_auto_battle_override()
         return
     # --- END OVERRIDE CHECK ---
 

--- a/src/Ankimon/functions/encounter_functions.py
+++ b/src/Ankimon/functions/encounter_functions.py
@@ -8,6 +8,7 @@ import uuid
 from datetime import datetime
 from typing import TYPE_CHECKING, Union
 
+from aqt.utils import tooltip
 from ..services import services
 from ..events import events
 from ..functions.pokemon_functions import (
@@ -220,6 +221,45 @@ OVERHAUL_PITY_THRESHOLDS = {
 OVERHAUL_PITY_DIVISOR = 50.0
 # ==============================================================================
 
+# AUTO-BATTLE OVERRIDE SYSTEM
+# Override state for auto-battle: None, "catch", or "defeat"
+_auto_battle_override = None
+
+
+def toggle_auto_battle_override(action: str) -> str:
+    """
+    Toggle the auto-battle override for the current encounter.
+    
+    Args:
+        action: "catch" or "defeat"
+    
+    Returns:
+        Current override state as a string: None, "catch", or "defeat"
+    """
+    global _auto_battle_override
+    
+    # If the same action is already set, clear it (toggle off)
+    if _auto_battle_override == action:
+        _auto_battle_override = None
+        tooltip(f"Override removed: Auto-battle behavior restored")
+    else:
+        # Set the new override
+        _auto_battle_override = action
+        action_display = "Catch" if action == "catch" else "Defeat"
+        tooltip(f"Override set: Will {action_display} when fainted!")
+    
+    return _auto_battle_override
+
+
+def get_auto_battle_override() -> str:
+    """Get the current override state."""
+    return _auto_battle_override
+
+
+def clear_auto_battle_override():
+    """Clear the override state (called when a new encounter starts)."""
+    global _auto_battle_override
+    _auto_battle_override = None
 
 def calculate_mastery_index_ep(total_reviews, daily_average, trainer_level):
     """
@@ -1098,6 +1138,9 @@ def new_pokemon(
     Returns:
         PokemonObject: The updated `pokemon` object representing the newly generated wild Pokémon ready for battle.
     """
+    # Clear any auto-battle override from previous encounter
+    clear_auto_battle_override()
+
     ankimon_tracker.faint_processed = False
     ankimon_tracker.caught = 0
 
@@ -1695,13 +1738,7 @@ def save_caught_pokemon(
     caught_pokemon["cp"] = calculate_cp_from_dict(caught_pokemon)
 
     # Save to database (replaces JSON file I/O for performance)
-    save_success = ankimon_db.save_pokemon(caught_pokemon)
-
-    # Only award Badge 7 ("First Pokemon Caught !") if the save was successful
-    if save_success and achievements is not None:
-        check = check_for_badge(achievements, 7)
-        if check is False:
-            achievements = receive_badge(7, achievements)
+    ankimon_db.save_pokemon(caught_pokemon)
 
     try:
         from ..singletons import notify_stats_changed
@@ -1778,7 +1815,7 @@ def handle_enemy_faint(
     achievements: dict,
 ):
     """
-    Handles what automatically happens when the enemy Pokémon faints, based on auto-battle settings.
+    Handles what automatically happens when the enemy Pokémon faints, based on auto-battle settings and user overrides.
     """
     if ankimon_tracker_obj.faint_processed:
         return
@@ -1807,6 +1844,7 @@ def handle_enemy_faint(
         new_pokemon(enemy_pokemon, test_window, ankimon_tracker_obj, reviewer_obj)
         main_pokemon.reset_bonuses()
         ankimon_tracker_obj.general_card_count_for_battle = 0
+        clear_auto_battle_override()
         return
     # --- End wishlist fast-path ---
 
@@ -1828,6 +1866,43 @@ def handle_enemy_faint(
         or (is_regional and settings_obj.get("battle.auto_catch_regional", True))
     )
 
+    # --- CHECK FOR USER OVERRIDE FIRST ---
+    if _auto_battle_override == "catch":
+        # Override: Force catch
+        ankimon_tracker_obj.faint_processed = True
+        catch_pokemon(
+            enemy_pokemon,
+            ankimon_tracker_obj,
+            logger,
+            "",
+            collected_pokemon_ids,
+            achievements,
+        )
+        new_pokemon(enemy_pokemon, test_window, ankimon_tracker_obj, reviewer_obj)
+        main_pokemon.reset_bonuses()
+        ankimon_tracker_obj.general_card_count_for_battle = 0
+        clear_auto_battle_override()
+        return
+        
+    elif _auto_battle_override == "defeat":
+        # Override: Force defeat
+        ankimon_tracker_obj.faint_processed = True
+        kill_pokemon(
+            main_pokemon,
+            enemy_pokemon,
+            evo_window,
+            logger,
+            achievements,
+            trainer_card,
+        )
+        new_pokemon(enemy_pokemon, test_window, ankimon_tracker_obj, reviewer_obj)
+        main_pokemon.reset_bonuses()
+        ankimon_tracker_obj.general_card_count_for_battle = 0
+        clear_auto_battle_override()
+        return
+    # --- END OVERRIDE CHECK ---
+
+    # --- Normal auto-battle logic (no override) ---
     if auto_battle_setting == 3:  # Catch if uncollected
         enemy_id = enemy_pokemon.id
         # Check cache instead of file
@@ -1905,6 +1980,7 @@ def handle_enemy_faint(
 
     main_pokemon.reset_bonuses()
     ankimon_tracker_obj.general_card_count_for_battle = 0
+    clear_auto_battle_override()
 
 
 def handle_main_pokemon_faint(

--- a/src/Ankimon/functions/encounter_functions.py
+++ b/src/Ankimon/functions/encounter_functions.py
@@ -1837,6 +1837,32 @@ def catch_pokemon(
         pokemon_pc.refresh_pokemon_grid()
 
 
+def _enemy_protected_by_auto_catch(enemy_pokemon: PokemonObject) -> bool:
+    """Whether enemy_pokemon's tier is covered by an "always auto-catch" setting.
+
+    Legendary/Mythical/Ultra/Starter/Mega/Gmax/Regional Pokémon are each
+    exempted from being defeated (auto or override) via their own
+    battle.auto_catch_* setting, defaulting to on.
+    """
+    is_mega = enemy_pokemon.id in encounter_data.MEGA
+    is_gmax = enemy_pokemon.id in encounter_data.GMAX
+    is_regional = enemy_pokemon.id in encounter_data.REGIONAL_FORM_REGION
+    is_legendary = enemy_pokemon.tier == "Legendary"
+    is_mythical = enemy_pokemon.tier == "Mythical"
+    is_ultra = enemy_pokemon.tier == "Ultra"
+    is_starter = enemy_pokemon.tier == "Starter"
+
+    return (
+        (is_legendary and settings_obj.get("battle.auto_catch_legendary", True))
+        or (is_mythical and settings_obj.get("battle.auto_catch_mythical", True))
+        or (is_ultra and settings_obj.get("battle.auto_catch_ultra", True))
+        or (is_starter and settings_obj.get("battle.auto_catch_starter", True))
+        or (is_mega and settings_obj.get("battle.auto_catch_mega", True))
+        or (is_gmax and settings_obj.get("battle.auto_catch_gmax", True))
+        or (is_regional and settings_obj.get("battle.auto_catch_regional", True))
+    )
+
+
 def handle_enemy_faint(
     main_pokemon: PokemonObject,
     enemy_pokemon: PokemonObject,
@@ -1881,17 +1907,31 @@ def handle_enemy_faint(
         return
         
     elif _auto_battle_override == "defeat":
-        # Override: Force defeat
+        # Override: Force defeat, unless the enemy is protected by an
+        # "always auto-catch" tier setting (legendary/mythical/ultra/
+        # starter/mega/gmax/regional) — an explicit defeat override should
+        # not be able to permanently kill a protected Pokémon, e.g. via a
+        # misclick or a toggle the user forgot was still armed.
         ankimon_tracker_obj.faint_processed = True
         try:
-            kill_pokemon(
-                main_pokemon,
-                enemy_pokemon,
-                evo_window,
-                logger,
-                achievements,
-                trainer_card,
-            )
+            if _enemy_protected_by_auto_catch(enemy_pokemon):
+                catch_pokemon(
+                    enemy_pokemon,
+                    ankimon_tracker_obj,
+                    logger,
+                    "",
+                    collected_pokemon_ids,
+                    achievements,
+                )
+            else:
+                kill_pokemon(
+                    main_pokemon,
+                    enemy_pokemon,
+                    evo_window,
+                    logger,
+                    achievements,
+                    trainer_card,
+                )
             new_pokemon(enemy_pokemon, test_window, ankimon_tracker_obj, reviewer_obj)
             main_pokemon.reset_bonuses()
             ankimon_tracker_obj.general_card_count_for_battle = 0
@@ -1918,27 +1958,12 @@ def handle_enemy_faint(
         return
     # --- End wishlist fast-path ---
 
-    # Tier flags / the "always auto-catch this tier" safety net are only
-    # needed by the normal auto-battle branches below (the override and
-    # wishlist fast-paths above already returned without them), so compute
-    # them here rather than unconditionally at the top of the function.
-    is_mega = enemy_pokemon.id in encounter_data.MEGA
-    is_gmax = enemy_pokemon.id in encounter_data.GMAX
-    is_regional = enemy_pokemon.id in encounter_data.REGIONAL_FORM_REGION
-    is_legendary = enemy_pokemon.tier == "Legendary"
-    is_mythical = enemy_pokemon.tier == "Mythical"
-    is_ultra = enemy_pokemon.tier == "Ultra"
-    is_starter = enemy_pokemon.tier == "Starter"
-
-    should_catch_always = (
-        (is_legendary and settings_obj.get("battle.auto_catch_legendary", True))
-        or (is_mythical and settings_obj.get("battle.auto_catch_mythical", True))
-        or (is_ultra and settings_obj.get("battle.auto_catch_ultra", True))
-        or (is_starter and settings_obj.get("battle.auto_catch_starter", True))
-        or (is_mega and settings_obj.get("battle.auto_catch_mega", True))
-        or (is_gmax and settings_obj.get("battle.auto_catch_gmax", True))
-        or (is_regional and settings_obj.get("battle.auto_catch_regional", True))
-    )
+    # The "always auto-catch this tier" safety net is only needed by the
+    # normal auto-battle branches below (the wishlist fast-path above and
+    # the defeat-override branch above already resolved it or returned
+    # without it), so compute it here rather than unconditionally at the
+    # top of the function.
+    should_catch_always = _enemy_protected_by_auto_catch(enemy_pokemon)
 
     # --- Normal auto-battle logic (no override) ---
     if auto_battle_setting == 3:  # Catch if uncollected

--- a/src/Ankimon/functions/encounter_functions.py
+++ b/src/Ankimon/functions/encounter_functions.py
@@ -233,6 +233,24 @@ OVERHAUL_PITY_DIVISOR = 50.0
 _auto_battle_override: Optional[Literal["catch", "defeat"]] = None
 
 
+def get_auto_battle_setting(settings_source=None) -> int:
+    """Read ``battle.automatic_battle`` clamped to the valid [0, 3] range.
+
+    Centralizes the parse-with-fallback logic that used to be copy-pasted
+    across ``handle_enemy_faint`` and the reviewer-button shortcut functions
+    (with drifting exception handling between the copies). Falls back to 0
+    (manual mode) on any missing/non-numeric/out-of-range value.
+    """
+    source = settings_source if settings_source is not None else settings_obj
+    try:
+        value = int(source.get("battle.automatic_battle"))
+        if not (0 <= value <= 3):
+            return 0
+        return value
+    except (ValueError, TypeError):
+        return 0
+
+
 def toggle_auto_battle_override(
     action: Literal["catch", "defeat"],
 ) -> Optional[Literal["catch", "defeat"]]:
@@ -1837,33 +1855,10 @@ def handle_enemy_faint(
 
     events.emit("faint", who="enemy", pokemon=enemy_pokemon.name, id=enemy_pokemon.id)
 
-    try:
-        auto_battle_setting = int(settings_obj.get("battle.automatic_battle"))
-        if not (0 <= auto_battle_setting <= 3):
-            auto_battle_setting = 0  # fallback
-    except ValueError:
-        auto_battle_setting = 0  # fallback
+    auto_battle_setting = get_auto_battle_setting(settings_obj)
 
     if auto_battle_setting == 0:
         clear_auto_battle_override()
-
-    is_mega = enemy_pokemon.id in encounter_data.MEGA
-    is_gmax = enemy_pokemon.id in encounter_data.GMAX
-    is_regional = enemy_pokemon.id in encounter_data.REGIONAL_FORM_REGION
-    is_legendary = enemy_pokemon.tier == "Legendary"
-    is_mythical = enemy_pokemon.tier == "Mythical"
-    is_ultra = enemy_pokemon.tier == "Ultra"
-    is_starter = enemy_pokemon.tier == "Starter"
-
-    should_catch_always = (
-        (is_legendary and settings_obj.get("battle.auto_catch_legendary", True))
-        or (is_mythical and settings_obj.get("battle.auto_catch_mythical", True))
-        or (is_ultra and settings_obj.get("battle.auto_catch_ultra", True))
-        or (is_starter and settings_obj.get("battle.auto_catch_starter", True))
-        or (is_mega and settings_obj.get("battle.auto_catch_mega", True))
-        or (is_gmax and settings_obj.get("battle.auto_catch_gmax", True))
-        or (is_regional and settings_obj.get("battle.auto_catch_regional", True))
-    )
 
     # --- CHECK FOR USER OVERRIDE FIRST ---
     if _auto_battle_override == "catch":
@@ -1920,9 +1915,30 @@ def handle_enemy_faint(
         new_pokemon(enemy_pokemon, test_window, ankimon_tracker_obj, reviewer_obj)
         main_pokemon.reset_bonuses()
         ankimon_tracker_obj.general_card_count_for_battle = 0
-        clear_auto_battle_override()
         return
     # --- End wishlist fast-path ---
+
+    # Tier flags / the "always auto-catch this tier" safety net are only
+    # needed by the normal auto-battle branches below (the override and
+    # wishlist fast-paths above already returned without them), so compute
+    # them here rather than unconditionally at the top of the function.
+    is_mega = enemy_pokemon.id in encounter_data.MEGA
+    is_gmax = enemy_pokemon.id in encounter_data.GMAX
+    is_regional = enemy_pokemon.id in encounter_data.REGIONAL_FORM_REGION
+    is_legendary = enemy_pokemon.tier == "Legendary"
+    is_mythical = enemy_pokemon.tier == "Mythical"
+    is_ultra = enemy_pokemon.tier == "Ultra"
+    is_starter = enemy_pokemon.tier == "Starter"
+
+    should_catch_always = (
+        (is_legendary and settings_obj.get("battle.auto_catch_legendary", True))
+        or (is_mythical and settings_obj.get("battle.auto_catch_mythical", True))
+        or (is_ultra and settings_obj.get("battle.auto_catch_ultra", True))
+        or (is_starter and settings_obj.get("battle.auto_catch_starter", True))
+        or (is_mega and settings_obj.get("battle.auto_catch_mega", True))
+        or (is_gmax and settings_obj.get("battle.auto_catch_gmax", True))
+        or (is_regional and settings_obj.get("battle.auto_catch_regional", True))
+    )
 
     # --- Normal auto-battle logic (no override) ---
     if auto_battle_setting == 3:  # Catch if uncollected
@@ -2002,7 +2018,10 @@ def handle_enemy_faint(
 
     main_pokemon.reset_bonuses()
     ankimon_tracker_obj.general_card_count_for_battle = 0
-    clear_auto_battle_override()
+    # No explicit clear_auto_battle_override() here: every branch above either
+    # already called new_pokemon() (which clears it as its first statement) or
+    # is the manual-mode branch, which already cleared it earlier in this
+    # function when auto_battle_setting == 0 was detected.
 
 
 def handle_main_pokemon_faint(

--- a/src/Ankimon/profile_hooks.py
+++ b/src/Ankimon/profile_hooks.py
@@ -14,7 +14,7 @@ from .pyobj.pokemon_trade import check_and_award_monthly_pokemon
 from .pyobj.error_handler import show_warning_with_traceback
 from .functions.pokedex_functions import clear_pokedex_caches
 from .functions.learnset_retrieval import clear_learnset_cache
-from .functions.encounter_functions import clear_encounter_cache
+from .functions.encounter_functions import clear_encounter_cache, clear_auto_battle_override
 
 sync_dialog = None
 
@@ -26,6 +26,14 @@ sync_dialog = None
 # than a module-level flag: it survives a re-execution of this module (an
 # add-on reload), so re-registering swaps the handler in place instead of
 # stacking a second copy onto gui_hooks.profile_will_close.
+#
+# The pending auto-battle catch/defeat override (encounter_functions.py's
+# _auto_battle_override) is the same kind of process-lifetime bare global as
+# these caches, so it needs the same treatment: without clearing it here, a
+# user who arms an override in one profile and switches profiles before the
+# wild Pokemon faints would carry that override into the next profile, where
+# it could silently force-catch/force-defeat the first faint under
+# auto-battle before that profile's user has touched anything.
 _CLOSE_HANDLER_RECORD = "_profile_close_cache_clear_handler"
 _DID_OPEN_HANDLER_RECORD = "_profile_did_open_handler"
 _WILL_CLOSE_BACKUP_RECORD = "_profile_will_close_backup_handler"
@@ -38,6 +46,7 @@ def _on_profile_close():
         clear_pokedex_caches()
         clear_learnset_cache()
         clear_encounter_cache()
+        clear_auto_battle_override()
     except Exception as e:
         logger.log("error", f"Error clearing caches on profile close: {e}")
 

--- a/src/Ankimon/reviewer_ui.py
+++ b/src/Ankimon/reviewer_ui.py
@@ -16,6 +16,7 @@ from .singletons import (
 )
 from .functions.encounter_functions import (
     catch_pokemon,
+    get_auto_battle_setting,
     kill_pokemon,
     new_pokemon,
     toggle_auto_battle_override,
@@ -179,15 +180,7 @@ def catch_shortcut_function():
             update_hud=True,
         )
     else:
-        # Check if auto-battle is enabled
-        try:
-            auto_battle_setting = int(services.settings.get("battle.automatic_battle"))
-            if not (0 <= auto_battle_setting <= 3):
-                auto_battle_setting = 0  # fallback
-        except (ValueError, TypeError):
-            auto_battle_setting = 0
-        
-        if auto_battle_setting == 0:
+        if get_auto_battle_setting(services.settings) == 0:
             # Auto-battle disabled - show the original message
             tooltip("You only catch a pokemon once it's fainted!")
         else:
@@ -213,15 +206,7 @@ def defeat_shortcut_function():
             update_hud=True,
         )
     else:
-        # Check if auto-battle is enabled
-        try:
-            auto_battle_setting = int(services.settings.get("battle.automatic_battle"))
-            if not (0 <= auto_battle_setting <= 3):
-                auto_battle_setting = 0  # fallback
-        except (ValueError, TypeError):
-            auto_battle_setting = 0
-        
-        if auto_battle_setting == 0:
+        if get_auto_battle_setting(services.settings) == 0:
             # Auto-battle disabled - show the original message
             tooltip("Wild pokemon has to be fainted to defeat it!")
         else:

--- a/src/Ankimon/reviewer_ui.py
+++ b/src/Ankimon/reviewer_ui.py
@@ -18,6 +18,7 @@ from .functions.encounter_functions import (
     catch_pokemon,
     kill_pokemon,
     new_pokemon,
+    toggle_auto_battle_override,
 )
 from .texts import _bottomHTML_template, button_style
 
@@ -178,7 +179,18 @@ def catch_shortcut_function():
             update_hud=True,
         )
     else:
-        tooltip("You only catch a pokemon once it's fainted!")
+        # Check if auto-battle is enabled
+        try:
+            auto_battle_setting = int(services.settings.get("battle.automatic_battle"))
+        except (ValueError, TypeError):
+            auto_battle_setting = 0
+        
+        if auto_battle_setting == 0:
+            # Auto-battle disabled - show the original message
+            tooltip("You only catch a pokemon once it's fainted!")
+        else:
+            # Auto-battle enabled - toggle override
+            toggle_auto_battle_override("catch")
 
 
 def defeat_shortcut_function():
@@ -199,7 +211,18 @@ def defeat_shortcut_function():
             update_hud=True,
         )
     else:
-        tooltip("Wild pokemon has to be fainted to defeat it!")
+        # Check if auto-battle is enabled
+        try:
+            auto_battle_setting = int(services.settings.get("battle.automatic_battle"))
+        except (ValueError, TypeError):
+            auto_battle_setting = 0
+        
+        if auto_battle_setting == 0:
+            # Auto-battle disabled - show the original message
+            tooltip("Wild pokemon has to be fainted to defeat it!")
+        else:
+            # Auto-battle enabled - toggle override
+            toggle_auto_battle_override("defeat")
 
 
 def team_cycle_shortcut_function():

--- a/src/Ankimon/reviewer_ui.py
+++ b/src/Ankimon/reviewer_ui.py
@@ -182,6 +182,8 @@ def catch_shortcut_function():
         # Check if auto-battle is enabled
         try:
             auto_battle_setting = int(services.settings.get("battle.automatic_battle"))
+            if not (0 <= auto_battle_setting <= 3):
+                auto_battle_setting = 0  # fallback
         except (ValueError, TypeError):
             auto_battle_setting = 0
         
@@ -214,6 +216,8 @@ def defeat_shortcut_function():
         # Check if auto-battle is enabled
         try:
             auto_battle_setting = int(services.settings.get("battle.automatic_battle"))
+            if not (0 <= auto_battle_setting <= 3):
+                auto_battle_setting = 0  # fallback
         except (ValueError, TypeError):
             auto_battle_setting = 0
         

--- a/tests/test_auto_battle_override_regressions.py
+++ b/tests/test_auto_battle_override_regressions.py
@@ -1,0 +1,156 @@
+"""Regression tests for auto-battle override resolution."""
+
+import runpy
+from functools import lru_cache
+from pathlib import Path
+from types import SimpleNamespace
+from unittest import mock
+
+
+@lru_cache(maxsize=None)
+def _load_ef():
+    """Load ``encounter_functions`` via the sibling module's harness.
+
+    ``test_encounter_functions.py`` installs MagicMock stubs for Ankimon.utils,
+    Ankimon.resources, Ankimon.const and friends as an import-time side effect.
+    Doing that at *collection* time would leak: this module sorts before
+    test_cp_formula.py, so every module collected after it would bind mocks
+    instead of the real helpers.  Loading lazily keeps collection clean — by the
+    time a test here runs, the other modules have bound their real symbols and
+    conftest's autouse ``restore_package_stubs`` repairs the stubs afterwards.
+    """
+    return runpy.run_path(
+        str(Path(__file__).with_name("test_encounter_functions.py"))
+    )["ef"]
+
+
+def _run_override_scenario(
+    auto_battle_setting: int,
+    override: str,
+    *,
+    wishlist_ids=(),
+    collected_ids=(),
+):
+    ef = _load_ef()
+    original_names = (
+        "settings_obj",
+        "encounter_data",
+        "ankimon_tracker_obj",
+        "catch_pokemon",
+        "kill_pokemon",
+        "new_pokemon",
+        "_auto_battle_override",
+    )
+    originals = {name: getattr(ef, name) for name in original_names}
+
+    settings = mock.MagicMock()
+    wishlist = list(wishlist_ids)
+
+    def get_setting(key, default=None):
+        if key == "battle.automatic_battle":
+            return auto_battle_setting
+        if key == "battle.auto_catch_wishlist":
+            return wishlist
+        if key.startswith("battle.auto_catch_"):
+            return False
+        return default
+
+    settings.get = get_setting
+    tracker = mock.MagicMock()
+    tracker.faint_processed = False
+    catch = mock.MagicMock()
+    defeat = mock.MagicMock()
+    new = mock.MagicMock()
+    main_pokemon = mock.MagicMock()
+    enemy_pokemon = mock.MagicMock(
+        id=25,
+        name="Pikachu",
+        shiny=False,
+        tier="Normal",
+    )
+    test_window = mock.MagicMock()
+    evo_window = mock.MagicMock()
+    reviewer_obj = mock.MagicMock()
+    logger = mock.MagicMock()
+    achievements = {}
+
+    try:
+        ef.settings_obj = settings
+        ef.encounter_data = SimpleNamespace(
+            MEGA=set(),
+            GMAX=set(),
+            REGIONAL_FORM_REGION={},
+        )
+        ef.ankimon_tracker_obj = tracker
+        ef.catch_pokemon = catch
+        ef.kill_pokemon = defeat
+        ef.new_pokemon = new
+        ef._auto_battle_override = override
+
+        ef.handle_enemy_faint(
+            main_pokemon,
+            enemy_pokemon,
+            set(collected_ids),
+            test_window,
+            evo_window,
+            reviewer_obj,
+            logger,
+            achievements,
+        )
+
+        return SimpleNamespace(
+            tracker=tracker,
+            catch=catch,
+            defeat=defeat,
+            new=new,
+            main_pokemon=main_pokemon,
+            enemy_pokemon=enemy_pokemon,
+            test_window=test_window,
+            reviewer_obj=reviewer_obj,
+            override_after=ef.get_auto_battle_override(),
+        )
+    finally:
+        for name, value in originals.items():
+            setattr(ef, name, value)
+
+
+def _assert_completed_override(result):
+    result.new.assert_called_once_with(
+        result.enemy_pokemon,
+        result.test_window,
+        result.tracker,
+        result.reviewer_obj,
+    )
+    result.main_pokemon.reset_bonuses.assert_called_once_with()
+    assert result.tracker.faint_processed is True
+    assert result.tracker.general_card_count_for_battle == 0
+    assert result.override_after is None
+
+
+def test_catch_override_supersedes_auto_defeat():
+    result = _run_override_scenario(2, "catch")
+
+    result.catch.assert_called_once()
+    result.defeat.assert_not_called()
+    _assert_completed_override(result)
+
+
+def test_defeat_override_supersedes_auto_catch():
+    result = _run_override_scenario(1, "defeat")
+
+    result.defeat.assert_called_once()
+    result.catch.assert_not_called()
+    _assert_completed_override(result)
+
+
+def test_defeat_override_precedes_wishlist_and_catch_if_new():
+    result = _run_override_scenario(
+        3,
+        "defeat",
+        wishlist_ids=(25,),
+        collected_ids=(),
+    )
+
+    result.defeat.assert_called_once()
+    result.catch.assert_not_called()
+    _assert_completed_override(result)

--- a/tests/test_auto_battle_override_regressions.py
+++ b/tests/test_auto_battle_override_regressions.py
@@ -30,6 +30,8 @@ def _run_override_scenario(
     *,
     wishlist_ids=(),
     collected_ids=(),
+    enemy_tier="Normal",
+    auto_catch_overrides=None,
 ):
     ef = _load_ef()
     original_names = (
@@ -45,6 +47,7 @@ def _run_override_scenario(
 
     settings = mock.MagicMock()
     wishlist = list(wishlist_ids)
+    auto_catch_overrides = auto_catch_overrides or {}
 
     def get_setting(key, default=None):
         if key == "battle.automatic_battle":
@@ -52,7 +55,7 @@ def _run_override_scenario(
         if key == "battle.auto_catch_wishlist":
             return wishlist
         if key.startswith("battle.auto_catch_"):
-            return False
+            return auto_catch_overrides.get(key, False)
         return default
 
     settings.get = get_setting
@@ -66,7 +69,7 @@ def _run_override_scenario(
         id=25,
         name="Pikachu",
         shiny=False,
-        tier="Normal",
+        tier=enemy_tier,
     )
     test_window = mock.MagicMock()
     evo_window = mock.MagicMock()
@@ -149,6 +152,45 @@ def test_defeat_override_precedes_wishlist_and_catch_if_new():
         "defeat",
         wishlist_ids=(25,),
         collected_ids=(),
+    )
+
+    result.defeat.assert_called_once()
+    result.catch.assert_not_called()
+    _assert_completed_override(result)
+
+
+def test_defeat_override_yields_to_legendary_auto_catch_safety_net():
+    result = _run_override_scenario(
+        1,
+        "defeat",
+        enemy_tier="Legendary",
+        auto_catch_overrides={"battle.auto_catch_legendary": True},
+    )
+
+    result.catch.assert_called_once()
+    result.defeat.assert_not_called()
+    _assert_completed_override(result)
+
+
+def test_defeat_override_yields_to_mythical_auto_catch_safety_net():
+    result = _run_override_scenario(
+        1,
+        "defeat",
+        enemy_tier="Mythical",
+        auto_catch_overrides={"battle.auto_catch_mythical": True},
+    )
+
+    result.catch.assert_called_once()
+    result.defeat.assert_not_called()
+    _assert_completed_override(result)
+
+
+def test_defeat_override_kills_legendary_when_safety_net_disabled():
+    result = _run_override_scenario(
+        1,
+        "defeat",
+        enemy_tier="Legendary",
+        auto_catch_overrides={"battle.auto_catch_legendary": False},
     )
 
     result.defeat.assert_called_once()

--- a/tests/test_encounter_functions.py
+++ b/tests/test_encounter_functions.py
@@ -303,6 +303,77 @@ def test_handle_enemy_faint_auto_catch_regional_disabled():
         ef.kill_pokemon = orig_kill
 
 
+def test_auto_battle_override_toggle_returns_none_when_cleared():
+    """Toggling an active override off is a valid nullable state transition."""
+    original_override = ef.get_auto_battle_override()
+    try:
+        ef.clear_auto_battle_override()
+
+        assert ef.toggle_auto_battle_override("catch") == "catch"
+        assert ef.get_auto_battle_override() == "catch"
+        assert ef.toggle_auto_battle_override("catch") is None
+        assert ef.get_auto_battle_override() is None
+    finally:
+        ef._auto_battle_override = original_override
+
+
+def test_handle_enemy_faint_manual_mode_clears_stale_override():
+    """Manual mode must not execute an override selected before auto-battle was off."""
+    original_settings = ef.settings_obj
+    original_tracker = ef.ankimon_tracker_obj
+    original_catch = ef.catch_pokemon
+    original_new = ef.new_pokemon
+    original_kill = ef.kill_pokemon
+    original_override = ef.get_auto_battle_override()
+
+    try:
+        settings = mock.MagicMock()
+        settings.get = lambda key, default=None: (
+            0 if key == "battle.automatic_battle" else default
+        )
+        tracker = mock.MagicMock()
+        tracker.faint_processed = False
+        catch = mock.MagicMock()
+        new = mock.MagicMock()
+        kill = mock.MagicMock()
+        main_pokemon = mock.MagicMock()
+        enemy_pokemon = mock.MagicMock(
+            id=25, name="Pikachu", shiny=False, tier="Normal"
+        )
+        test_window = mock.MagicMock()
+
+        ef.settings_obj = settings
+        ef.ankimon_tracker_obj = tracker
+        ef.catch_pokemon = catch
+        ef.new_pokemon = new
+        ef.kill_pokemon = kill
+        ef._auto_battle_override = "catch"
+
+        ef.handle_enemy_faint(
+            main_pokemon,
+            enemy_pokemon,
+            set(),
+            test_window,
+            mock.MagicMock(),
+            mock.MagicMock(),
+            mock.MagicMock(),
+            {},
+        )
+
+        test_window.display_pokemon_death.assert_called_once()
+        catch.assert_not_called()
+        kill.assert_not_called()
+        new.assert_not_called()
+        assert ef.get_auto_battle_override() is None
+    finally:
+        ef.settings_obj = original_settings
+        ef.ankimon_tracker_obj = original_tracker
+        ef.catch_pokemon = original_catch
+        ef.new_pokemon = original_new
+        ef.kill_pokemon = original_kill
+        ef._auto_battle_override = original_override
+
+
 def test_meets_prerequisites_fusion_and_normal():
     # Ensure the real _player_owns_base_form logic is used (in case simulation tests mutated it)
     def real_owns_base_form(actual_id, collected_ids):


### PR DESCRIPTION
### At A Glance
- This PR adds a new functionality that allows the **Defeat** Mon and **Capture** Mon **reviewer buttons** to **override auto-battle** modes.

### What this PR does
- This has been a requested feature on both Discord and GitHub. It allows users to **actively choose** whether to **defeat** or **capture** a Mon **in addition** to the **existing auto-battle** settings.
- Now, when Defeat or Capture buttons are clicked:
  - If any **auto-battle** modes are on (auto-catch, auto-defeat, catch-if-new)
    1. The **tooltips** "Override set: Will Defeat when fainted!" and "Override set: Will Catch when fainted!" appear. 
    2. The **Mon** is Defeated/Captured **according to the button pressed** when its **HP turns 0**. 
    3. If **no buttons are pressed** or the button state **defaults to normal** (i.e., two clicks on the same button cancel out), the Mon is Defeated/Captured **according to the default auto-battle** mode. 
  - If **auto-battle is disabled**, the **regular** tooltips and behaviour are **unchanged**. 
- Additional points:
  - The button states **return to default** with every **new wild Mon** (automatic battle continues unless either button is clicked).
  - The buttons are coded to **"cancel out"**, i.e. only **one button can be active at a time** (clicking on one button deactivates the other), and **reclicking** on an already active button **restores** its state to **default**. 

### What each file does
- **`functions/encounter_functions.py`:** The **code** that controls the **Defeat/Capture override** according to the user's auto-battle mode resides here. 
- **`reviewer_ui.py`:** **Wires** the **override code** to the **reviewer buttons** (Defeat Mon and Capture Mon).

### Expected Behaviour
1. User has auto-defeat on. They stumble upon a Mon they would like to catch. (It could look good, have a catchy name, or be one that put up a tough stand against their main Mon.)
2. User clicks on the Capture Mon button and "reserves" a capture.
3. The Mon is automatically captured upon fainting. 
4. When a new wild Mon appears, auto-defeat continues until the user initiates another override. 

- Vice versa with auto-capture. The same goes for capture-if-new. 
- If the user has auto-battle disabled, the button behaviours are the same as they are before this feature is implemented (the default). 

**Example of Tooltip shown when Defeat/Capture are pressed with auto-battle mode on:**
<img width="240" height="53" alt="image" src="https://github.com/user-attachments/assets/2da0464b-fca8-491c-a6e8-8400bc52db74" />
<img width="234" height="54" alt="image" src="https://github.com/user-attachments/assets/6a7deab7-6685-41e6-a025-6e28747154c3" />

**Tooltip remains the same when auto-battle mode is off:**
<img width="269" height="47" alt="image" src="https://github.com/user-attachments/assets/af6dd9b9-0c65-4203-baaa-113aba2cf624" />
<img width="269" height="55" alt="image" src="https://github.com/user-attachments/assets/3203d515-735b-411a-89a2-5a53a1a44de5" />

### Reality Check

*(as per the current code scope/file changes)*

**Certain Technical Limitations**:
- **Reviewer button styles** can be **overridden by UI add-ons** such as Onigiri. Having reviewer buttons inherit a certain border colour requires a workaround that would require further investigation.
- **Reviewer button texts** are loaded on startup and are **immutable** until a **hard refresh** is executed. This functionality requires a **dynamic** change of button text, if possible, and could be further investigated. 

Therefore, **Potential Improvements for Future PRs (excluded for focus in initial PR):**
- Have **buttons** to **change colour** or have colourful **borders** when clicked. 
- Have **button text** to **change** accordingly based on the **selected behaviour**. 

### Related Issue
**Fixes _#253_**

### Checklist
- [x] My code and commit messages follow the code style and guidelines of this project.
- [x] I have personally tested the buttons; they behave and function as intended.