### PR TITLE
fix(ui): include trade evo items in web ui eligible pokemon

### DIFF
--- a/src/Ankimon/ankimon_items_web/shop_obj.py
+++ b/src/Ankimon/ankimon_items_web/shop_obj.py
@@ -1875,7 +1875,10 @@ class AnkimonItemsWeb(QDialog):
                         normalized_target = target_evo_name.lower().replace(" ", "").replace("-", "").replace("'", "").replace(".", "").replace(":", "")
                         target_data = pokedex_data.get(normalized_target) or pokedex_data.get(target_evo_name.lower())
 
-                        if target_data and target_data.get("evoType") == "useItem":
+                        if target_data and target_data.get("evoType") in (
+                            "useItem",
+                            "trade",
+                        ):
                             # Normalize both sides by stripping spaces, hyphens and
                             # apostrophes so pokedex.json display names (e.g.
                             # "King's Rock") match items.csv identifiers (e.g.


### PR DESCRIPTION
Fixes an issue in the Web-based Bag/Items window where using a trade evolution item (e.g., Protector, Metal Coat) would fail to show the target Pokémon in the selection list. The `get_pokemon_choices` function was updated to check for `trade` as well as `useItem` in the `evoType` field, mirroring the actual game engine's evolution eligibility check.

---
*PR created automatically by Jules for task [3294506413042194228](https://jules.google.com/task/3294506413042194228) started by @h0tp-ftw*