### PR TITLE
fix(items): allow trade evolutions to be selected in web UI

### DIFF
--- a/src/Ankimon/ankimon_items_web/shop_obj.py
+++ b/src/Ankimon/ankimon_items_web/shop_obj.py
@@ -1875,7 +1875,7 @@ class AnkimonItemsWeb(QDialog):
                         normalized_target = target_evo_name.lower().replace(" ", "").replace("-", "").replace("'", "").replace(".", "").replace(":", "")
                         target_data = pokedex_data.get(normalized_target) or pokedex_data.get(target_evo_name.lower())
 
-                        if target_data and target_data.get("evoType") == "useItem":
+                        if target_data and target_data.get("evoType") in ("useItem", "trade"):
                             # Normalize both sides by stripping spaces, hyphens and
                             # apostrophes so pokedex.json display names (e.g.
                             # "King's Rock") match items.csv identifiers (e.g.


### PR DESCRIPTION
When a user attempts to use a trade evolution item (like a Protector or Metal Coat) from the new web-based Bag UI, the target Pokémon is completely missing from the selection list. 

This happens because `shop_obj.py` was filtering valid targets by strictly requiring `"evoType" == "useItem"`. However, trade items in Ankimon utilize `"evoType" == "trade"` with an `"evoItem"`. This PR adjusts the filter to allow both types, fixing the bug.

---
*PR created automatically by Jules for task [16647684482269807281](https://jules.google.com/task/16647684482269807281) started by @h0tp-ftw*