### PR TITLE
fix: properly sync everstone flag to held item status

### DIFF
--- a/src/Ankimon/pyobj/pokemon_obj.py
+++ b/src/Ankimon/pyobj/pokemon_obj.py
@@ -608,16 +608,29 @@ class PokemonObject:
         db.update_item_quantity(held_item, -1)
         self.held_item = held_item
 
+        if held_item == "everstone":
+            self.everstone = True
+        else:
+            self.everstone = False
+
         # Save to captured_pokemon in database
         pokemon_data = db.get_pokemon(self.individual_id)
         if pokemon_data:
             pokemon_data["held_item"] = held_item
+            if held_item == "everstone":
+                pokemon_data["everstone"] = True
+            else:
+                pokemon_data["everstone"] = False
             db.save_pokemon(pokemon_data)
 
         # Also update main_pokemon if this is the main pokemon
         main_pokemon = db.get_main_pokemon()
         if main_pokemon and main_pokemon.get("individual_id") == self.individual_id:
             main_pokemon["held_item"] = held_item
+            if held_item == "everstone":
+                main_pokemon["everstone"] = True
+            else:
+                main_pokemon["everstone"] = False
             db.save_main_pokemon(main_pokemon)
 
         # Sync the in-memory main_pokemon singleton if it is the target.
@@ -627,6 +640,10 @@ class PokemonObject:
             and getattr(main_pkmn, "individual_id", None) == self.individual_id
         ):
             main_pkmn.held_item = held_item
+            if held_item == "everstone":
+                main_pkmn.everstone = True
+            else:
+                main_pkmn.everstone = False
 
     def remove_held_item(self) -> None:
         """
@@ -637,6 +654,8 @@ class PokemonObject:
 
         db = services.db
 
+        self.everstone = False
+
         from ..utils import give_item  # lazy: avoids the utils<->pokedex<->pokemon_obj cycle
         give_item(self.held_item)  # We put the item back in the item bag
         self.held_item = None
@@ -645,12 +664,16 @@ class PokemonObject:
         pokemon_data = db.get_pokemon(self.individual_id)
         if pokemon_data:
             pokemon_data["held_item"] = None
+            if pokemon_data.get("everstone", False):
+                pokemon_data["everstone"] = False
             db.save_pokemon(pokemon_data)
 
         # Also update main_pokemon if this is the main pokemon
         main_pokemon = db.get_main_pokemon()
         if main_pokemon and main_pokemon.get("individual_id") == self.individual_id:
             main_pokemon["held_item"] = None
+            if main_pokemon.get("everstone", False):
+                main_pokemon["everstone"] = False
             db.save_main_pokemon(main_pokemon)
 
         # Sync the in-memory main_pokemon singleton if it is the target.
@@ -660,6 +683,7 @@ class PokemonObject:
             and getattr(main_pkmn, "individual_id", None) == self.individual_id
         ):
             main_pkmn.held_item = None
+            main_pkmn.everstone = False
 
 
 class PokemonEncoder(json.JSONEncoder):


### PR DESCRIPTION
When a Pokémon holds an Everstone, an `everstone` attribute is used as a flag to disable evolutions. However, when users assign a new item or remove the held item, the `everstone` flag never cleared, permanently trapping the Pokémon from ever evolving. 

This commit updates `give_held_item` and `remove_held_item` in `PokemonObject` to explicitly set `self.everstone = False` when an item is removed, and only set it to `True` when the item explicitly is an `everstone`.

This fix automatically works retroactively on users' stuck Pokémon; when they equip or remove an item, it will clear the bugged flag.

---
*PR created automatically by Jules for task [5466011602299805125](https://jules.google.com/task/5466011602299805125) started by @h0tp-ftw*