### PR TITLE
fix(updater): prevent Anki native updater from prompting outdated AnkiWeb releases

### DIFF
--- a/src/Ankimon/changelog.py
+++ b/src/Ankimon/changelog.py
@@ -164,6 +164,7 @@ def check_branch_update(online_connectivity: bool, ssh: bool):
 
     def bg(_col):
         try:
+            sync_ankiweb_update_state()
             from .pyobj.update_manager import fetch_branch_sha, fetch_branch_commits
 
             remote_sha = fetch_branch_sha(source_name)
@@ -216,6 +217,42 @@ def check_for_update(online_connectivity: bool, ssh: bool):
         _poll_release_channel(channel)
 
 
+def sync_ankiweb_update_state() -> bool:
+    """Check if the latest STABLE release tag on GitHub is newer than local addon_ver.
+
+    If a strictly newer stable tag exists on GitHub: enables Anki's native update check
+    (update_enabled: True).
+    Otherwise: disables Anki's native update check (update_enabled: False) to prevent
+    AnkiWeb from prompting older web versions for users on experimental (-E) or newer builds.
+    Returns the boolean value set to update_enabled.
+    """
+    from .pyobj.update_manager import (
+        latest_release_for_channel,
+        is_newer_version,
+        set_anki_update_enabled,
+        CHANNEL_STABLE,
+    )
+
+    try:
+        stable_release = latest_release_for_channel(CHANNEL_STABLE)
+        stable_tag = stable_release.get("name") if stable_release else None
+        if stable_tag and is_newer_version(stable_tag, addon_ver):
+            set_anki_update_enabled(True)
+            _log_info(
+                f"sync_ankiweb_update_state: update_enabled=True (stable {stable_tag} > local {addon_ver})"
+            )
+            return True
+        else:
+            set_anki_update_enabled(False)
+            _log_info(
+                f"sync_ankiweb_update_state: update_enabled=False (stable {stable_tag} <= local {addon_ver})"
+            )
+            return False
+    except Exception as e:
+        _log_info(f"sync_ankiweb_update_state failed: {e}")
+        return False
+
+
 def _poll_release_channel(channel: str):
     """Prompt when the newest release on a release channel (stable/experimental)
     is strictly newer than the installed version.
@@ -242,6 +279,7 @@ def _poll_release_channel(channel: str):
 
     def bg(_col):
         try:
+            sync_ankiweb_update_state()
             return latest_release_for_channel(channel)
         except Exception as e:
             return e
@@ -267,6 +305,10 @@ def schedule_branch_update_check(online_connectivity: bool, ssh: bool) -> None:
     The branch updater retains its connectivity gate. The sprite updater runs
     independently because its background request path handles network failures.
     """
+    # Disable native AnkiWeb update check early so offline/unverified boots stay protected
+    from .pyobj.update_manager import set_anki_update_enabled
+
+    set_anki_update_enabled(False)
 
     def _on_profile_open() -> None:
         if online_connectivity:

--- a/src/Ankimon/pyobj/update_manager.py
+++ b/src/Ankimon/pyobj/update_manager.py
@@ -488,6 +488,58 @@ def read_update_state() -> Optional[dict]:
     return None
 
 
+def get_meta_json_path() -> Path:
+    return addon_dir / "meta.json"
+
+
+def set_anki_update_enabled(enabled: bool) -> bool:
+    """Toggle Anki's native update check in meta.json.
+
+    When False, Anki skips checking AnkiWeb for updates to this addon, preventing
+    accidental downgrades to older web releases. Preserves all other meta.json keys
+    (e.g., config, disabled, mod).
+    """
+    try:
+        path = get_meta_json_path()
+        data = {}
+        if path.exists():
+            try:
+                content = json.loads(path.read_text(encoding="utf-8"))
+                if isinstance(content, dict):
+                    data = content
+            except Exception:
+                data = {}
+        if data.get("update_enabled") != enabled:
+            data["update_enabled"] = enabled
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(json.dumps(data, indent=2), encoding="utf-8")
+        return True
+    except Exception as e:
+        try:
+            from ..services import services
+
+            if services.logger:
+                services.logger.log(
+                    "error", f"Failed to set meta.json update_enabled={enabled}: {e}"
+                )
+        except Exception:
+            pass
+        return False
+
+
+def get_anki_update_enabled() -> Optional[bool]:
+    """Read update_enabled flag from meta.json, or None if file missing/unreadable."""
+    try:
+        path = get_meta_json_path()
+        if path.exists():
+            data = json.loads(path.read_text(encoding="utf-8"))
+            if isinstance(data, dict):
+                return data.get("update_enabled")
+    except Exception:
+        pass
+    return None
+
+
 def _download_zip_to_temp(url: str, progress_cb=None) -> Optional[str]:
     req = _make_request(url)
     try:
@@ -789,6 +841,9 @@ def apply_update(
             # --- Save update state if provided ---
             if source_type and source_name:
                 save_update_state(source_type, source_name, commit_sha or "")
+
+            # Ensure newly installed build starts with AnkiWeb auto-update disabled
+            set_anki_update_enabled(False)
 
             cleanup()
             log(f"Update complete. Installed {installed} files.")

--- a/tests/test_ankiweb_update_toggle.py
+++ b/tests/test_ankiweb_update_toggle.py
@@ -1,0 +1,138 @@
+"""Tests for meta.json update_enabled toggle and sync_ankiweb_update_state.
+
+Ensures that AnkiWeb auto-update checking is disabled to prevent accidental downgrades
+unless a strictly newer STABLE release exists on GitHub.
+"""
+
+import json
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+for _name in [
+    "aqt",
+    "aqt.qt",
+    "aqt.utils",
+    "aqt.gui_hooks",
+    "aqt.operations",
+    "aqt.reviewer",
+    "aqt.webview",
+    "aqt.main",
+    "anki",
+    "anki.hooks",
+    "anki.collection",
+]:
+    sys.modules.setdefault(_name, MagicMock())
+sys.modules["aqt.operations"].QueryOp = MagicMock()
+
+from Ankimon.pyobj import update_manager as um
+from Ankimon import changelog
+
+
+def test_meta_json_toggle_preserves_existing_keys(tmp_path: Path):
+    meta_path = tmp_path / "meta.json"
+    initial_data = {
+        "name": "Ankimon",
+        "mod": 1745007743,
+        "disabled": False,
+        "config": {"some_key": "some_val"},
+    }
+    meta_path.write_text(json.dumps(initial_data), encoding="utf-8")
+
+    with patch.object(um, "get_meta_json_path", return_value=meta_path):
+        assert um.get_anki_update_enabled() is None
+
+        # Disable update
+        assert um.set_anki_update_enabled(False) is True
+        assert um.get_anki_update_enabled() is False
+
+        saved = json.loads(meta_path.read_text(encoding="utf-8"))
+        assert saved["name"] == "Ankimon"
+        assert saved["mod"] == 1745007743
+        assert saved["disabled"] is False
+        assert saved["config"] == {"some_key": "some_val"}
+        assert saved["update_enabled"] is False
+
+        # Re-enable update
+        assert um.set_anki_update_enabled(True) is True
+        assert um.get_anki_update_enabled() is True
+        saved = json.loads(meta_path.read_text(encoding="utf-8"))
+        assert saved["update_enabled"] is True
+        assert saved["config"] == {"some_key": "some_val"}
+
+
+def test_meta_json_toggle_creates_file_if_missing(tmp_path: Path):
+    meta_path = tmp_path / "meta.json"
+    assert not meta_path.exists()
+
+    with patch.object(um, "get_meta_json_path", return_value=meta_path):
+        assert um.set_anki_update_enabled(False) is True
+        assert meta_path.exists()
+        saved = json.loads(meta_path.read_text(encoding="utf-8"))
+        assert saved["update_enabled"] is False
+
+
+def test_sync_ankiweb_update_state_cases(tmp_path: Path):
+    meta_path = tmp_path / "meta.json"
+
+    with patch.object(um, "get_meta_json_path", return_value=meta_path):
+        # Case 1: Local E (2.3-E), newer stable (2.4) -> enabled = True
+        with patch.object(
+            um,
+            "latest_release_for_channel",
+            return_value={"name": "2.4", "body": "", "zipball_url": ""},
+        ), patch("Ankimon.changelog.addon_ver", "2.3-E"):
+            res = changelog.sync_ankiweb_update_state()
+            assert res is True
+            assert um.get_anki_update_enabled() is True
+
+        # Case 2: Local E (2.3-E), older stable (2.2) -> enabled = False
+        with patch.object(
+            um,
+            "latest_release_for_channel",
+            return_value={"name": "2.2", "body": "", "zipball_url": ""},
+        ), patch("Ankimon.changelog.addon_ver", "2.3-E"):
+            res = changelog.sync_ankiweb_update_state()
+            assert res is False
+            assert um.get_anki_update_enabled() is False
+
+        # Case 3: Local stable (2.2), newer stable (2.3) -> enabled = True
+        with patch.object(
+            um,
+            "latest_release_for_channel",
+            return_value={"name": "2.3", "body": "", "zipball_url": ""},
+        ), patch("Ankimon.changelog.addon_ver", "2.2"):
+            res = changelog.sync_ankiweb_update_state()
+            assert res is True
+            assert um.get_anki_update_enabled() is True
+
+        # Case 4: Local stable (2.3), older stable (2.2) -> enabled = False
+        with patch.object(
+            um,
+            "latest_release_for_channel",
+            return_value={"name": "2.2", "body": "", "zipball_url": ""},
+        ), patch("Ankimon.changelog.addon_ver", "2.3"):
+            res = changelog.sync_ankiweb_update_state()
+            assert res is False
+            assert um.get_anki_update_enabled() is False
+
+        # Case 5: Local E (2.3-E), older stable (2.2), newer E (2.4-E)
+        # Note: latest_release_for_channel(CHANNEL_STABLE) returns the stable release 2.2
+        with patch.object(
+            um,
+            "latest_release_for_channel",
+            return_value={"name": "2.2", "body": "", "zipball_url": ""},
+        ), patch("Ankimon.changelog.addon_ver", "2.3-E"):
+            res = changelog.sync_ankiweb_update_state()
+            assert res is False
+            assert um.get_anki_update_enabled() is False
+
+
+def test_sync_ankiweb_update_state_no_releases(tmp_path: Path):
+    meta_path = tmp_path / "meta.json"
+    with patch.object(um, "get_meta_json_path", return_value=meta_path), patch.object(
+        um, "latest_release_for_channel", return_value=None
+    ), patch("Ankimon.changelog.addon_ver", "2.3-E"):
+        res = changelog.sync_ankiweb_update_state()
+        assert res is False
+        assert um.get_anki_update_enabled() is False

--- a/tests/test_profile_hooks.py
+++ b/tests/test_profile_hooks.py
@@ -137,6 +137,7 @@ def _exec_profile_hooks(monkeypatch, gui_hooks):
         _stub_module(
             "Ankimon.functions.encounter_functions",
             clear_encounter_cache=clear_encounter,
+            clear_auto_battle_override=MagicMock(),
         ),
     )
 


### PR DESCRIPTION
### Problem
When users run newer or experimental builds from GitHub, Anki's native desktop add-on manager detects an updated timestamp on AnkiWeb and displays Anki's native update dialog. Accepting this prompt overwrites and downgrades their local installation with the older AnkiWeb version.

### Solution
- **Control Anki's Native Add-on Updater**: Added `set_anki_update_enabled()` in `update_manager.py` to toggle `"update_enabled"` in `meta.json` (the setting Anki's native add-on manager reads to decide whether to check AnkiWeb), while preserving user configs and metadata.
- **Safe Boot Default**: Default `update_enabled: false` on startup and after applying updates, preventing Anki's native updater from prompting when offline or unverified.
- **Strict Stable Tag Comparison**: Added `sync_ankiweb_update_state()` in `changelog.py` to query the latest STABLE tag on GitHub:
  - If a strictly newer stable tag exists: enables Anki's native add-on updater (`update_enabled: true`).
  - If local version is equal or newer (or on an experimental build while stable is older): disables Anki's native add-on updater (`update_enabled: false`).
- **Tests**: Added `tests/test_ankiweb_update_toggle.py` validating all 5 version matrix scenarios.

### Verification
- `python harness/check.py`: 9/9 Tier-1 checks green
- `pytest tests/test_ankiweb_update_toggle.py`: 4/4 passed
