### PR TITLE
fix(updater): stop the in-app updater causing AnkiWeb downgrade prompts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,12 +11,24 @@ on:
         required: false
         type: string
 
-# This workflow runs the ENTIRE release in one job on the built-in GITHUB_TOKEN
-# (which never expires) — prepare -> integrity test -> commit + tag -> build ->
-# publish. It deliberately does NOT hand off to main.yml via a tag push: GitHub
-# won't trigger a second workflow from a tag pushed with GITHUB_TOKEN, and a PAT
-# just to trigger that hand-off is a fragile, expiring dependency. Folding the
-# build+publish in here removes it entirely.
+# This workflow runs the WHOLE release on the built-in GITHUB_TOKEN (which never
+# expires) — prepare -> integrity test -> commit + tag -> build, then a manual
+# approval gate, then publish. It deliberately does NOT hand off to main.yml via
+# a tag push: GitHub won't trigger a second workflow from a tag pushed with
+# GITHUB_TOKEN, and a PAT just to trigger that hand-off is a fragile, expiring
+# dependency. Folding the build+publish in here removes it entirely.
+#
+# It is split across two jobs on purpose. AnkiWeb must be updated BEFORE the
+# GitHub release exists, because Anki decides an add-on is out of date by
+# comparing timestamps rather than version numbers — whichever channel publishes
+# last looks newer, so a GitHub-first release leaves in-app updater users being
+# offered the AnkiWeb build. AnkiWeb has no upload API (scripting the private one
+# is against its Terms), so the upload is a human step and the `ankiweb`
+# environment gate is what forces it to happen in the right order.
+#
+#   dispatch -> build (bump, tag, package) -> [you upload to AnkiWeb, approve] -> publish
+#
+# The step-by-step is on the `publish` job below.
 #
 # NOTE: pushing the version-bump commit to `main` uses a GitHub App installation
 # token (minted below via create-github-app-token) — `main` has a ruleset that

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,12 +11,21 @@ on:
         required: false
         type: string
 
-# This workflow runs the WHOLE release on the built-in GITHUB_TOKEN (which never
-# expires) — prepare -> integrity test -> commit + tag -> build, then a manual
-# approval gate, then publish. It deliberately does NOT hand off to main.yml via
+# This workflow runs the whole release end to end — prepare -> integrity test ->
+# commit + tag -> build, then a manual approval gate, then publish — without any
+# long-lived stored credential. It deliberately does NOT hand off to main.yml via
 # a tag push: GitHub won't trigger a second workflow from a tag pushed with
 # GITHUB_TOKEN, and a PAT just to trigger that hand-off is a fragile, expiring
-# dependency. Folding the build+publish in here removes it entirely.
+# dependency to have to store and rotate. Folding the build+publish in here
+# removes it entirely.
+#
+# On tokens: GITHUB_TOKEN is scoped to a single job. Actions mints a fresh one
+# per job and it dies when that job ends (6h ceiling on hosted runners), so it is
+# not one token spanning the run. That is precisely what makes the approval gate
+# safe to wait on for days: `publish` is issued its own new token when it finally
+# starts, rather than needing one to survive the wait. The tag push and the
+# release creation each use their job's GITHUB_TOKEN; the push to `main` needs
+# more than that, and uses the App installation token — see the NOTE below.
 #
 # It is split across two jobs on purpose. AnkiWeb must be updated BEFORE the
 # GitHub release exists, because Anki decides an add-on is out of date by
@@ -369,6 +378,13 @@ jobs:
           name: "${{ needs.build.outputs.module_name }} v${{ needs.build.outputs.release_tag }}"
           body_path: patched_changelog.md
           files: build/*.ankiaddon
+          # Belt and braces with the verification step above: this action's
+          # default is to publish happily when `files` matches nothing, which at
+          # this point in the run would mean a release with no add-on attached
+          # and AnkiWeb already updated. The two guards are independent — this
+          # one keeps holding if the glob above ever drifts from the one the
+          # verification step checks.
+          fail_on_unmatched_files: true
           draft: false
           generate_release_notes: false
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,11 +26,19 @@ on:
 # unaffected (the ruleset targets the main branch only), so they stay on
 # GITHUB_TOKEN.
 jobs:
-  release:
+  # Everything up to a finished .ankiaddon. The version bump, the tag and the
+  # push to main all happen here, because `aab build` dates the manifest from
+  # the tag and so needs it to exist first. An abandoned run therefore leaves
+  # main claiming a version that was never released — recoverable by approving
+  # the held run (it waits 30 days), or by reverting the bump and deleting the tag.
+  build:
     runs-on: ubuntu-latest
     permissions:
       contents: write
       pull-requests: read
+    outputs:
+      release_tag: ${{ steps.vars.outputs.release_tag }}
+      module_name: ${{ steps.vars.outputs.module_name }}
     # Bind the workflow_dispatch inputs to env vars once, then reference them as
     # "$VERSION" / "$HIGHLIGHTS" in every run: block. Expanding
     # ${{ github.event.inputs.* }} straight into a shell script is a
@@ -264,11 +272,50 @@ jobs:
               f.write(content)
           EOF
 
+      - name: Hand the package to the publish job
+        uses: actions/upload-artifact@v4
+        with:
+          name: ankiaddon
+          path: |
+            build/*.ankiaddon
+            patched_changelog.md
+          if-no-files-found: error
+          retention-days: 30
+
+  # AnkiWeb has no public upload API, and scripting the private one is against
+  # its Terms — so the upload stays a human step. It has to happen BEFORE the
+  # GitHub release exists, because Anki compares timestamps rather than version
+  # numbers: whichever channel is published last looks newer. Publishing to
+  # GitHub first leaves every in-app updater user with a meta.json "mod" older
+  # than the AnkiWeb listing, which is exactly the state that offers them the
+  # AnkiWeb build as an "update".
+  #
+  # The environment holds this job until a required reviewer approves it.
+  # Configure it once: Settings → Environments → New environment → "ankiweb",
+  # then add yourself under "Required reviewers".
+  #
+  #   1. Download the "ankiaddon" artifact from this run.
+  #   2. Upload Ankimon.ankiaddon at https://ankiweb.net/shared/addons/
+  #   3. Approve this job. The GitHub release then goes out, dated after it.
+  publish:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    environment:
+      name: ankiweb
+      url: https://ankiweb.net/shared/addons/
+    steps:
+      - name: Download the package built above
+        uses: actions/download-artifact@v4
+        with:
+          name: ankiaddon
+
       - name: Create GitHub release
         uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v3.0.1
         with:
-          tag_name: ${{ steps.vars.outputs.release_tag }}
-          name: "${{ steps.vars.outputs.module_name }} v${{ steps.vars.outputs.release_tag }}"
+          tag_name: ${{ needs.build.outputs.release_tag }}
+          name: "${{ needs.build.outputs.module_name }} v${{ needs.build.outputs.release_tag }}"
           body_path: patched_changelog.md
           files: build/*.ankiaddon
           draft: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -284,8 +284,19 @@ jobs:
               f.write(content)
           EOF
 
+      # Pinned to a commit, like the third-party actions above. The artifact is
+      # the only thing crossing the approval gate — between this upload and the
+      # download below sits a human step and an arbitrary wait, so a mutable tag
+      # here means the code that carries the release could change underneath a
+      # run that is already half-approved.
+      #
+      # Both paths are relative to the workspace, so the artifact's root is their
+      # least common ancestor — the workspace — and the layout the publish job
+      # sees is "build/*.ankiaddon" plus "patched_changelog.md" at the top level.
+      # The publish job's paths depend on that; the verification step there fails
+      # the run if it ever stops holding.
       - name: Hand the package to the publish job
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: ankiaddon
           path: |
@@ -319,9 +330,37 @@ jobs:
       url: https://ankiweb.net/shared/addons/
     steps:
       - name: Download the package built above
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: ankiaddon
+
+      # By the time this job runs, AnkiWeb has already been updated — that is the
+      # whole point of the gate above. So this is the last moment a missing file
+      # can still be caught for free: publishing a release with no .ankiaddon
+      # attached, or with an empty body, would leave the two channels
+      # disagreeing with no way to un-publish the AnkiWeb upload. Assert the
+      # layout the build job produced rather than trusting it, so a future change
+      # to the upload paths fails loudly here instead of shipping a broken release.
+      - name: Verify the artifact is complete
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          if [ ! -s patched_changelog.md ]; then
+            echo "::error::patched_changelog.md is missing or empty — the release body would be blank."
+            exit 1
+          fi
+          packages=(build/*.ankiaddon)
+          if [ ${#packages[@]} -eq 0 ]; then
+            echo "::error::No build/*.ankiaddon in the artifact — the release would ship without the add-on."
+            ls -R . || true
+            exit 1
+          fi
+          # The changelog's download link is hard-coded to this exact filename.
+          if [ ! -s build/Ankimon.ankiaddon ]; then
+            echo "::error::build/Ankimon.ankiaddon is missing or empty — the changelog's download link would 404."
+            exit 1
+          fi
+          echo "Publishing ${#packages[@]} package(s): ${packages[*]}"
 
       - name: Create GitHub release
         uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v3.0.1

--- a/docs/updater_porting_guide.md
+++ b/docs/updater_porting_guide.md
@@ -212,9 +212,21 @@ without this step `mod` keeps describing whichever build *Anki* last installed,
 and Anki offers the AnkiWeb copy as an update to a newer GitHub build. Accepting
 it downgrades the user. This is the whole reason `stamp_addon_mod` exists.
 
-Add it as the **last** thing `apply_update(...)` does, after the backup cleanup —
-anything that can still raise must run before it, or a late failure will roll the
-code back while leaving `meta.json` dated as the new build:
+**Split this across two threads.** `apply_update(...)` runs in a `QueryOp`
+worker, but `meta.json` is Anki's file: `writeConfig`, `toggleEnabled` and
+`write_addon_meta` all read-modify-write the whole dict, and all of them run on
+the main thread. A worker doing its own read-modify-write races them — its
+snapshot, taken before a concurrent config write, gets replaced over the top and
+silently reverts it. Writing the file atomically prevents a *torn* file; it does
+nothing about a *stale* one.
+
+So resolve the timestamp in the worker (it needs the network) and return it;
+write it from the `QueryOp` success callback, which Anki guarantees runs on the
+main thread.
+
+Resolve it as the **last** thing `apply_update(...)` does, after the backup
+cleanup — anything that can still raise must run before it — and return it only
+on the success path, so a rolled-back install reports `None`:
 
 ```diff
              # Save local update metadata
@@ -222,20 +234,53 @@ code back while leaving `meta.json` dated as the new build:
 
              # ... cleanup(), final log(), backup rmtree ...
 
-+            # Date meta.json by the build just installed. Guarded separately:
-+            # resolving the timestamp needs the network, and a GitHub hiccup
-+            # must not fail an install that already succeeded.
++            # Work out the date to stamp meta.json with, but do NOT write it
++            # here — see below. Guarded separately: resolving needs the network,
++            # and a GitHub hiccup must not fail an install that already
++            # succeeded.
++            pending_mod = None
 +            try:
-+                mtime = resolve_build_mtime(
++                pending_mod = resolve_build_mtime(
 +                    source_type, source_name, commit_sha, published_at
 +                )
-+                if mtime and stamp_addon_mod(mtime):
-+                    log("Recorded install date for Anki's update check.")
 +            except Exception as e:
 +                print(f"Ankimon Updater: Could not date the install: {e}")
 +
-             return True, "Ankimon updated successfully!"
+-            return True, "Ankimon updated successfully!"
++            return True, "Ankimon updated successfully!", pending_mod
 ```
+
+Every other `return` in the function — the git-clone guard, the archive checks
+and the rollback handler — grows a third element of `None`. Then, in the dialog's
+success callback:
+
+```diff
+         def on_done(result):
+             try:
+-                success, msg = result
++                success, msg, pending_mod = result
+             except Exception as exc:
+                 on_failed(exc)
+                 return
++            # Main thread (QueryOp guarantees it) — the only safe place to
++            # read-modify-write meta.json. `success` is what authorises the
++            # write: dating a rolled-back build as the new one would make Anki
++            # read the old code as current and suppress the update that repairs it.
++            if success and pending_mod:
++                stamp_addon_mod(pending_mod)
+```
+
+Do this at **every** call site — it is easy to convert one and leave another
+unpacking a two-tuple, and because the unpack sits inside a broad `except` the
+mistake shows up only as a runtime "update failed unexpectedly", never as a
+traceback. Cover each path with a test that round-trips the worker function into
+the success callback.
+
+`stamp_addon_mod` deliberately edits the single key it owns rather than going
+through `AddonManager.write_addon_meta`, which re-derives six fields from an
+`AddonMeta` dataclass (`disabled`, `conflicts`, `min_point_version`,
+`max_point_version`, `branch_index`, `update_enabled`) and writes
+non-atomically.
 
 A release (or a tag naming one) is dated by its `published_at`; anything else by
 the commit it was built from. The value never moves backwards, and the commit
@@ -312,16 +357,20 @@ def check_branch_update(online_connectivity: bool, ssh: bool):
                 # Download branch code
                 zip_path = _download_branch_zip(branch_name, progress_cb=prog_dialog._on_progress)
                 if not zip_path:
-                    return False, "Download failed. Check connection."
+                    return False, "Download failed. Check connection.", None
 
-                # Install
+                # Install. Returns the date to stamp meta.json with rather than
+                # writing it — this is a worker thread; see "Stamp the install date".
                 from .pyobj.update_manager import apply_update
-                success, msg = apply_update(zip_path, "branch", branch_name, remote_sha, status_cb=status_update)
-                return success, msg
+                return apply_update(zip_path, "branch", branch_name, remote_sha, status_cb=status_update)
 
             def on_update_done(update_result):
                 prog_dialog.close()
-                success, msg = update_result
+                success, msg, pending_mod = update_result
+                # Main thread: the only safe place to read-modify-write meta.json.
+                if success and pending_mod:
+                    from .pyobj.update_manager import stamp_addon_mod
+                    stamp_addon_mod(pending_mod)
                 if success:
                     from aqt.utils import showInfo
                     showInfo("Update complete! Please restart Anki for changes to take effect.")

--- a/docs/updater_porting_guide.md
+++ b/docs/updater_porting_guide.md
@@ -43,6 +43,12 @@ During extraction, standard updates completely replace the addon folder. To prev
 2. `HelpInfos.html`, `updateinfos.md`, `meta.json` (root settings files).
 3. `update_state.json` (updater's own status file).
 
+`meta.json` is preserved through extraction but must then be **re-dated** — see
+[Stamp the install date](#modify-stamp-the-install-date) below. Preserving it
+alone is not enough: Anki decides an add-on is out of date by comparing that
+file's `mod` timestamp against AnkiWeb's, so carrying the old value forward makes
+Anki offer the AnkiWeb build as an "update" to code that is already newer.
+
 ---
 
 ## 3. Step-by-Step Porting Changes & Diffs
@@ -197,6 +203,43 @@ Modify the final section of `apply_update(...)` to write the update state upon s
 +
              return True, "Ankimon updated successfully!"
 ```
+
+#### [MODIFY] Stamp the install date
+
+`AddonManager.install()` is the only thing that normally writes `meta.json`'s
+`mod`, and an in-app updater bypasses it entirely — it copies files in place. So
+without this step `mod` keeps describing whichever build *Anki* last installed,
+and Anki offers the AnkiWeb copy as an update to a newer GitHub build. Accepting
+it downgrades the user. This is the whole reason `stamp_addon_mod` exists.
+
+Add it as the **last** thing `apply_update(...)` does, after the backup cleanup —
+anything that can still raise must run before it, or a late failure will roll the
+code back while leaving `meta.json` dated as the new build:
+
+```diff
+             # Save local update metadata
+             save_update_state(source_type, source_name, commit_sha or "")
+
+             # ... cleanup(), final log(), backup rmtree ...
+
++            # Date meta.json by the build just installed. Guarded separately:
++            # resolving the timestamp needs the network, and a GitHub hiccup
++            # must not fail an install that already succeeded.
++            try:
++                mtime = resolve_build_mtime(
++                    source_type, source_name, commit_sha, published_at
++                )
++                if mtime and stamp_addon_mod(mtime):
++                    log("Recorded install date for Anki's update check.")
++            except Exception as e:
++                print(f"Ankimon Updater: Could not date the install: {e}")
++
+             return True, "Ankimon updated successfully!"
+```
+
+A release (or a tag naming one) is dated by its `published_at`; anything else by
+the commit it was built from. The value never moves backwards, and the commit
+path is capped at the present so a skewed clock cannot pin `mod` into the future.
 
 ---
 

--- a/src/Ankimon/pyobj/update_dialog.py
+++ b/src/Ankimon/pyobj/update_dialog.py
@@ -1313,6 +1313,18 @@ class UpdateDialog(QDialog):
                     source_type="tag",
                     source_name=data["name"],
                     commit_sha=data["name"],
+                    # Every tag the picker offers names a published release, and
+                    # installs byte-identical code to the Releases tab. Date it
+                    # the same way, or the tag's (earlier) commit timestamp lets
+                    # the AnkiWeb upload look newer than the code just installed.
+                    published_at=next(
+                        (
+                            r.get("published_at")
+                            for r in (self._releases or [])
+                            if r.get("name") == data["name"]
+                        ),
+                        None,
+                    ),
                 )
 
 

--- a/src/Ankimon/pyobj/update_dialog.py
+++ b/src/Ankimon/pyobj/update_dialog.py
@@ -33,6 +33,7 @@ from .update_manager import (
     _download_pr_zip,
     read_update_state,
     fetch_branch_sha,
+    published_at_for_tag,
 )
 from ..resources import addon_ver, IS_EXPERIMENTAL_BUILD
 
@@ -1317,13 +1318,8 @@ class UpdateDialog(QDialog):
                     # installs byte-identical code to the Releases tab. Date it
                     # the same way, or the tag's (earlier) commit timestamp lets
                     # the AnkiWeb upload look newer than the code just installed.
-                    published_at=next(
-                        (
-                            r.get("published_at")
-                            for r in (self._releases or [])
-                            if r.get("name") == data["name"]
-                        ),
-                        None,
+                    published_at=published_at_for_tag(
+                        data["name"], self._releases
                     ),
                 )
 

--- a/src/Ankimon/pyobj/update_dialog.py
+++ b/src/Ankimon/pyobj/update_dialog.py
@@ -1169,6 +1169,7 @@ class UpdateDialog(QDialog):
         source_type: str = None,
         source_name: str = None,
         commit_sha: str = None,
+        published_at: str = None,
         extra_warning: str = None,
     ):
         prompt = f"Update Ankimon to {label}?\n\nYour Pokemon data, settings, and sprites will be preserved."
@@ -1201,7 +1202,12 @@ class UpdateDialog(QDialog):
                 mw.taskman.run_on_main(lambda: self.status_label.setText(m))
 
             success, msg = apply_update(
-                zip_path, source_type, source_name, commit_sha, status_cb=status_update
+                zip_path,
+                source_type,
+                source_name,
+                commit_sha,
+                published_at,
+                status_cb=status_update,
             )
             return success, msg, messages
 
@@ -1245,6 +1251,7 @@ class UpdateDialog(QDialog):
             source_type="release",
             source_name=r["name"],
             commit_sha=r["name"],
+            published_at=r.get("published_at"),
         )
 
     def _on_release_update(self):
@@ -1258,6 +1265,7 @@ class UpdateDialog(QDialog):
                 source_type="release",
                 source_name=data["name"],
                 commit_sha=data["name"],
+                published_at=data.get("published_at"),
             )
 
     def _on_dev_install(self):
@@ -1561,6 +1569,7 @@ class BranchUpdateProgressDialog(QDialog):
         else:
             source_type, source_name, commit_sha = "branch", self.branch_name, self.remote_sha
             download = lambda: _download_branch_zip(self.branch_name, progress_cb=self.on_progress)
+        published_at = release.get("published_at") if release else None
 
         def bg(_col):
             zip_path = download()
@@ -1575,6 +1584,7 @@ class BranchUpdateProgressDialog(QDialog):
                 source_type=source_type,
                 source_name=source_name,
                 commit_sha=commit_sha,
+                published_at=published_at,
                 status_cb=status_update,
             )
 

--- a/src/Ankimon/pyobj/update_dialog.py
+++ b/src/Ankimon/pyobj/update_dialog.py
@@ -34,6 +34,7 @@ from .update_manager import (
     read_update_state,
     fetch_branch_sha,
     published_at_for_tag,
+    stamp_addon_mod,
 )
 from ..resources import addon_ver, IS_EXPERIMENTAL_BUILD
 
@@ -1195,14 +1196,19 @@ class UpdateDialog(QDialog):
 
             zip_path = download_fn(progress_cb=self._on_progress)
             if not zip_path:
-                return False, "Download failed. Check your internet connection.", []
+                return (
+                    False,
+                    "Download failed. Check your internet connection.",
+                    [],
+                    None,
+                )
             messages = []
 
             def status_update(m):
                 messages.append(m)
                 mw.taskman.run_on_main(lambda: self.status_label.setText(m))
 
-            success, msg = apply_update(
+            success, msg, pending_mod = apply_update(
                 zip_path,
                 source_type,
                 source_name,
@@ -1210,14 +1216,20 @@ class UpdateDialog(QDialog):
                 published_at,
                 status_cb=status_update,
             )
-            return success, msg, messages
+            return success, msg, messages, pending_mod
 
         def on_done(result):
             try:
-                success, msg, messages = result
+                success, msg, messages, pending_mod = result
             except Exception as exc:
                 on_failed(exc)
                 return
+            # Date meta.json here, not in the worker above: QueryOp guarantees
+            # this callback runs on the main thread, which is the thread Anki
+            # read-modify-writes meta.json from. Doing it in the worker would
+            # let a stale snapshot overwrite a concurrent config change.
+            if success and pending_mod:
+                stamp_addon_mod(pending_mod)
             if self._end_busy(busy_token):
                 self.status_label.setText(messages[-1] if messages else msg)
                 self.progress_bar.setValue(100 if success else 0)
@@ -1568,6 +1580,7 @@ class BranchUpdateProgressDialog(QDialog):
             _download_branch_zip,
             _download_zip_to_temp,
             apply_update,
+            stamp_addon_mod,
         )
 
         release = self.release
@@ -1582,7 +1595,7 @@ class BranchUpdateProgressDialog(QDialog):
         def bg(_col):
             zip_path = download()
             if not zip_path:
-                return False, "Download failed. Check your internet connection."
+                return False, "Download failed. Check your internet connection.", None
 
             def status_update(msg):
                 mw.taskman.run_on_main(lambda: self.status_label.setText(msg))
@@ -1598,10 +1611,14 @@ class BranchUpdateProgressDialog(QDialog):
 
         def on_done(result):
             try:
-                success, msg = result
+                success, msg, pending_mod = result
             except Exception as exc:
                 on_failed(exc)
                 return
+            # Main thread (QueryOp guarantees it), which is where meta.json has
+            # to be written — see the matching note on the release/tag path.
+            if success and pending_mod:
+                stamp_addon_mod(pending_mod)
             self.btn_close.setEnabled(True)
             if success:
                 self.btn_close.setText("Restart Anki")

--- a/src/Ankimon/pyobj/update_manager.py
+++ b/src/Ankimon/pyobj/update_manager.py
@@ -488,20 +488,33 @@ def resolve_build_mtime(
 ) -> Optional[int]:
     """Epoch seconds describing the build about to be installed.
 
-    A release is dated by when it went public, because that is the timestamp
-    AnkiWeb's own listing is compared against; everything else is dated by the
-    commit it was built from. None means "could not tell", and the caller then
-    leaves ``mod`` untouched rather than guessing.
+    A release — or a tag naming one — is dated by when that release went public,
+    because that is the timestamp AnkiWeb's listing is compared against. The
+    tag's own commit is typically minutes older, and under the AnkiWeb-first
+    release order that gap is enough for the AnkiWeb upload to land in between,
+    which would re-offer the identical version as an "update".
+
+    Anything else is dated by the commit it was built from. The result is capped
+    at the present: a commit dated in the future (a skewed clock, or a crafted
+    committer date on a PR build) would otherwise be written to ``mod`` and,
+    because the stamp never moves backwards, suppress AnkiWeb updates until that
+    date arrived. None means "could not tell", and the caller leaves ``mod`` alone.
     """
-    if source_type == "release":
-        published = _parse_iso8601(published_at)
-        if published:
-            return published
-    for ref in (commit_sha, source_name):
-        resolved = _parse_iso8601(fetch_ref_date(ref)) if ref else None
-        if resolved:
-            return resolved
-    return None
+    import time
+
+    resolved = None
+    if source_type in ("release", "tag"):
+        resolved = _parse_iso8601(published_at)
+    if not resolved:
+        # commit_sha and source_name are the same string on the release and tag
+        # paths, so dedupe rather than repeat a request that already failed.
+        for ref in dict.fromkeys(r for r in (commit_sha, source_name) if r):
+            resolved = _parse_iso8601(fetch_ref_date(ref))
+            if resolved:
+                break
+    if not resolved:
+        return None
+    return min(resolved, int(time.time()))
 
 
 def stamp_addon_mod(timestamp: int) -> bool:
@@ -910,19 +923,6 @@ def apply_update(
             if source_type and source_name:
                 save_update_state(source_type, source_name, commit_sha or "")
 
-            # Date meta.json by the build just installed, so Anki stops treating
-            # whichever build it last installed as the newer copy. Resolving the
-            # timestamp needs the network, so it gets its own guard — a GitHub
-            # hiccup must not turn a finished install into a rollback.
-            try:
-                mtime = resolve_build_mtime(
-                    source_type, source_name, commit_sha, published_at
-                )
-                if mtime and stamp_addon_mod(mtime):
-                    log("Recorded install date for Anki's update check.")
-            except Exception as e:
-                print(f"Ankimon Updater: Could not date the install: {e}")
-
             cleanup()
             log(f"Update complete. Installed {installed} files.")
 
@@ -931,6 +931,25 @@ def apply_update(
                 shutil.rmtree(backup_dir)
             except Exception:
                 pass
+
+            # Date meta.json by the build just installed, so Anki stops treating
+            # whichever build it last installed as the newer copy.
+            #
+            # Deliberately the last thing done, after every statement that could
+            # still raise into the rollback handler below. Stamping earlier would
+            # let a late failure restore the old code while leaving meta.json
+            # dated as the new build — Anki would then believe the rolled-back
+            # install is current and suppress the very update that repairs it.
+            # Resolving the timestamp also needs the network, so it is guarded
+            # separately: a GitHub hiccup must not fail a finished install.
+            try:
+                mtime = resolve_build_mtime(
+                    source_type, source_name, commit_sha, published_at
+                )
+                if mtime and stamp_addon_mod(mtime):
+                    log("Recorded install date for Anki's update check.")
+            except Exception as e:
+                print(f"Ankimon Updater: Could not date the install: {e}")
 
             return True, "Update applied successfully. Please restart Anki."
 

--- a/src/Ankimon/pyobj/update_manager.py
+++ b/src/Ankimon/pyobj/update_manager.py
@@ -32,6 +32,23 @@ MIN_UPDATER_VERSION = (2, 0)
 # SHA first, so rejecting the name only costs an undated install, never a wrong one.
 _SAFE_REF_RE = re.compile(r"^[A-Za-z0-9._-]{1,64}$")
 
+
+def _is_safe_ref(ref: Optional[str]) -> bool:
+    """Whether ``ref`` may be interpolated into an API path.
+
+    The character class above still admits the dot segments ``.`` and ``..``,
+    which a URL normaliser resolves away *before* the request is sent — so
+    ``commits/..`` would address the repo endpoint rather than a commit. No real
+    Git ref can contain either (``git check-ref-format`` rejects a component
+    starting with ``.`` and any ``..``), so refusing them costs nothing and lets
+    the guard actually mean what it says: anything not plainly a ref fails
+    closed, and the install goes undated rather than mis-dated.
+    """
+    if not ref or not _SAFE_REF_RE.match(ref):
+        return False
+    return not ref.startswith(".") and ".." not in ref
+
+
 # Auto-update channels (user-selectable in the update dialog). "stable" and
 # "experimental" are release channels told apart by the tag suffix — an
 # experimental release tag ends in "-E" (e.g. "2.02-E"), a stable one does not
@@ -398,7 +415,7 @@ def fetch_ref_date(ref: str) -> Optional[str]:
     the pickers offer are version-shaped, so anything stranger fails closed
     (no date, hence no timestamp stamped) rather than being sent to the API.
     """
-    if not ref or not _SAFE_REF_RE.match(ref):
+    if not _is_safe_ref(ref):
         return None
     data = _api_get(f"commits/{ref}")
     commit = data.get("commit") if isinstance(data, dict) else None
@@ -452,10 +469,12 @@ def get_meta_json_path() -> Path:
 def _write_json_atomic(path: Path, data: dict) -> None:
     """Write ``data`` as JSON via temp file + ``os.replace``.
 
-    meta.json belongs to Anki, which read-modify-writes it on the main thread
-    (``AddonManager.write_addon_meta``) while this can run from an updater
-    worker. A half-written file makes Anki's ``addonMeta()`` fall back to an
-    empty dict, silently discarding ``config``, ``disabled`` and ``mod``.
+    meta.json belongs to Anki, and a half-written file makes ``addonMeta()``
+    fall back to an empty dict, silently discarding ``config``, ``disabled`` and
+    ``mod``. Anki's own writer (``AddonManager.writeAddonMeta``) is a plain
+    truncating ``open(..., "w")``, so a crash mid-write can do exactly that;
+    replacing the file in one step means a reader sees either the old metadata
+    or the new one.
     """
     tmp = path.with_name(f"{path.name}.{os.getpid()}.tmp")
     try:
@@ -540,6 +559,26 @@ def published_at_for_tag(tag: str, releases: list) -> Optional[str]:
 def stamp_addon_mod(timestamp: int) -> bool:
     """Record ``timestamp`` as meta.json's ``mod`` — the field Anki dates the
     installed build by. Returns whether anything was written.
+
+    **Call this on Anki's main thread only.** meta.json is Anki's file, not
+    ours: ``writeConfig``, ``toggleEnabled`` and ``write_addon_meta`` all
+    read-modify-write the whole dict, and all of them run on the main thread.
+    This function does the same read-modify-write, so running it from the
+    updater worker would race them — the worker's snapshot, taken before a
+    concurrent ``config`` write, would be replaced over the top of that write
+    and silently revert it. Atomic replacement prevents a *torn* file; it does
+    nothing about a *stale* one. Being on the main thread is what makes the
+    read and the write one indivisible step relative to Anki's own. That is why
+    ``apply_update`` resolves the timestamp in the worker but hands it back for
+    the ``QueryOp`` success callback to stamp.
+
+    Anki's ``AddonManager.write_addon_meta`` is the obvious alternative and is
+    deliberately not used: it re-derives ``disabled``, ``conflicts``,
+    ``min_point_version``, ``max_point_version``, ``branch_index`` and
+    ``update_enabled`` from an ``AddonMeta`` dataclass, so it rewrites six
+    fields we have no business touching, and it writes non-atomically. Editing
+    the single key we own, atomically, on the same thread Anki writes from is
+    strictly narrower.
 
     Anki decides an add-on is out of date with ``installed_at >= server_mtime``,
     where ``installed_at`` is this key (``AddonMeta.is_latest``). Only
@@ -828,7 +867,17 @@ def apply_update(
     commit_sha: Optional[str] = None,
     published_at: Optional[str] = None,
     status_cb=None,
-) -> tuple[bool, str]:
+) -> tuple[bool, str, Optional[int]]:
+    """Install the downloaded build. Runs in the updater's ``QueryOp`` worker.
+
+    Returns ``(ok, message, pending_mod)``. ``pending_mod`` is the epoch second
+    the install should be dated by, for the caller to pass to
+    ``stamp_addon_mod`` *from the main thread* — see that function for why the
+    write cannot happen here. It is None whenever nothing should be stamped:
+    a failed or rolled-back install, or a build date that could not be
+    resolved.
+    """
+
     def log(msg):
         if status_cb:
             status_cb(msg)
@@ -846,11 +895,15 @@ def apply_update(
     # above addon_dir and is untouched, but the checkout is still clobbered.)
     if is_git_clone():
         cleanup()
-        return False, (
-            "Detected a git checkout of Ankimon. The in-app updater overwrites "
-            "the addon's files in place and would clobber your working tree "
-            "(you'd lose uncommitted changes). Update your clone with 'git pull' "
-            "instead."
+        return (
+            False,
+            (
+                "Detected a git checkout of Ankimon. The in-app updater overwrites "
+                "the addon's files in place and would clobber your working tree "
+                "(you'd lose uncommitted changes). Update your clone with 'git pull' "
+                "instead."
+            ),
+            None,
         )
 
     log("Fetching latest .gitignore from main...")
@@ -862,11 +915,11 @@ def apply_update(
         with zipfile.ZipFile(zip_path) as zf:
             names = zf.namelist()
             if not names:
-                return False, "ZIP archive is empty."
+                return False, "ZIP archive is empty.", None
 
             src_prefix = _find_src_prefix(names)
             if not src_prefix:
-                return False, "Could not find src/Ankimon/ in the archive."
+                return False, "Could not find src/Ankimon/ in the archive.", None
 
             new_files = {}
             for name in names:
@@ -880,7 +933,7 @@ def apply_update(
                 new_files[rel_path] = name
 
             if not new_files:
-                return False, "No addon files found in the archive."
+                return False, "No addon files found in the archive.", None
 
             log(f"Archive validated: {len(new_files)} files to install.")
 
@@ -957,26 +1010,34 @@ def apply_update(
             except Exception:
                 pass
 
-            # Date meta.json by the build just installed, so Anki stops treating
-            # whichever build it last installed as the newer copy.
+            # Work out the date to stamp meta.json with, so Anki stops treating
+            # whichever build it last installed as the newer copy. Resolving it
+            # needs the network, which is why it happens here in the worker; the
+            # write itself does not happen here at all — it is handed back for
+            # the caller's main-thread success callback, because meta.json is
+            # Anki's file and Anki read-modify-writes it from the main thread.
+            # See stamp_addon_mod for the full argument.
             #
-            # Deliberately the last thing done, after every statement that could
-            # still raise into the rollback handler below. Stamping earlier would
-            # let a late failure restore the old code while leaving meta.json
-            # dated as the new build — Anki would then believe the rolled-back
-            # install is current and suppress the very update that repairs it.
-            # Resolving the timestamp also needs the network, so it is guarded
-            # separately: a GitHub hiccup must not fail a finished install.
+            # Deliberately resolved last, after every statement that could still
+            # raise into the rollback handler below, and returned only on this
+            # success path. A rolled-back install must report None: stamping a
+            # restored old build as the new one would make Anki believe the
+            # rollback is current and suppress the very update that repairs it.
+            # The lookup is guarded separately so a GitHub hiccup cannot fail an
+            # install that has already finished.
+            pending_mod = None
             try:
-                mtime = resolve_build_mtime(
+                pending_mod = resolve_build_mtime(
                     source_type, source_name, commit_sha, published_at
                 )
-                if mtime and stamp_addon_mod(mtime):
-                    log("Recorded install date for Anki's update check.")
             except Exception as e:
                 print(f"Ankimon Updater: Could not date the install: {e}")
 
-            return True, "Update applied successfully. Please restart Anki."
+            return (
+                True,
+                "Update applied successfully. Please restart Anki.",
+                pending_mod,
+            )
 
     except Exception as e:
         # --- Rollback ---
@@ -1002,4 +1063,4 @@ def apply_update(
                 pass
 
         cleanup()
-        return False, f"Update failed and was rolled back: {e}"
+        return False, f"Update failed and was rolled back: {e}", None

--- a/src/Ankimon/pyobj/update_manager.py
+++ b/src/Ankimon/pyobj/update_manager.py
@@ -26,8 +26,10 @@ DEFAULT_SUBMODULE_SHA = "f3092b03fbe1e37d1788ef802dee98906d621e36"
 # updater out (older versions predate it), so pre-2.0 versions are filtered from
 # the release/tag pickers — going back would break the update feature itself.
 MIN_UPDATER_VERSION = (2, 0)
-# Refs that may be interpolated into an API path. Every tag and branch the
-# pickers offer matches this; anything else is refused rather than requested.
+# Refs that may be interpolated into an API path. Tags are version-shaped and
+# always match; branch names often do not (``add/foo``, ``agent/bar``), and are
+# deliberately refused rather than requested — the branch paths resolve a commit
+# SHA first, so rejecting the name only costs an undated install, never a wrong one.
 _SAFE_REF_RE = re.compile(r"^[A-Za-z0-9._-]{1,64}$")
 
 # Auto-update channels (user-selectable in the update dialog). "stable" and
@@ -494,27 +496,45 @@ def resolve_build_mtime(
     release order that gap is enough for the AnkiWeb upload to land in between,
     which would re-offer the identical version as an "update".
 
-    Anything else is dated by the commit it was built from. The result is capped
-    at the present: a commit dated in the future (a skewed clock, or a crafted
-    committer date on a PR build) would otherwise be written to ``mod`` and,
-    because the stamp never moves backwards, suppress AnkiWeb updates until that
-    date arrived. None means "could not tell", and the caller leaves ``mod`` alone.
+    Anything else is dated by the commit it was built from, and *that* value is
+    capped at the present: a commit dated in the future (a skewed clock, or a
+    crafted committer date on a PR build) would otherwise be written to ``mod``
+    and, because the stamp never moves backwards, suppress AnkiWeb updates until
+    that date arrived. The cap is deliberately not applied to ``published_at`` —
+    that comes from GitHub's clock, not the committer's, so capping it against a
+    slow local clock could only corrupt a value that was already correct.
+
+    None means "could not tell", and the caller leaves ``mod`` alone.
     """
     import time
 
-    resolved = None
     if source_type in ("release", "tag"):
-        resolved = _parse_iso8601(published_at)
-    if not resolved:
-        # commit_sha and source_name are the same string on the release and tag
-        # paths, so dedupe rather than repeat a request that already failed.
-        for ref in dict.fromkeys(r for r in (commit_sha, source_name) if r):
-            resolved = _parse_iso8601(fetch_ref_date(ref))
-            if resolved:
-                break
-    if not resolved:
+        published = _parse_iso8601(published_at)
+        if published:
+            return published
+    # commit_sha and source_name are the same string on the release and tag
+    # paths, so dedupe rather than repeat a request that already failed.
+    for ref in dict.fromkeys(r for r in (commit_sha, source_name) if r):
+        resolved = _parse_iso8601(fetch_ref_date(ref))
+        if resolved:
+            return min(resolved, int(time.time()))
+    return None
+
+
+def published_at_for_tag(tag: str, releases: list) -> Optional[str]:
+    """The publish date of the release this tag names, if we already have it.
+
+    Every tag the picker offers names a published release and installs
+    byte-identical code, so a tag install should be dated exactly like the
+    equivalent release install. Returns None when the tag names no release we
+    know about, and the caller falls back to the tag's commit date.
+    """
+    if not tag or not releases:
         return None
-    return min(resolved, int(time.time()))
+    for release in releases:
+        if isinstance(release, dict) and release.get("name") == tag:
+            return release.get("published_at")
+    return None
 
 
 def stamp_addon_mod(timestamp: int) -> bool:
@@ -528,9 +548,14 @@ def stamp_addon_mod(timestamp: int) -> bool:
     build Anki last installed, and AnkiWeb's copy looks newer than a GitHub
     build that is in fact ahead of it. That is the accidental-downgrade prompt.
 
-    Never moves ``mod`` backwards: installing an older tag must not mask a
-    genuinely newer AnkiWeb release. A meta.json that Anki did not create is
-    left alone, as is one that no longer parses as a JSON object.
+    Never moves ``mod`` backwards. Note what that does and does not buy: since
+    Anki compares ``installed_at >= server_mtime``, a *lower* ``mod`` is what
+    surfaces an AnkiWeb build, so refusing to lower it means a deliberate
+    downgrade keeps the build the user chose instead of having AnkiWeb's silently
+    offered back over the top. It also makes the stamp monotonic, so introducing
+    it can never leave a user worse off than the un-stamped behaviour they have
+    today. A meta.json that Anki did not create is left alone, as is one that no
+    longer parses as a JSON object.
     """
     try:
         if not timestamp or timestamp <= 0:

--- a/src/Ankimon/pyobj/update_manager.py
+++ b/src/Ankimon/pyobj/update_manager.py
@@ -26,6 +26,9 @@ DEFAULT_SUBMODULE_SHA = "f3092b03fbe1e37d1788ef802dee98906d621e36"
 # updater out (older versions predate it), so pre-2.0 versions are filtered from
 # the release/tag pickers — going back would break the update feature itself.
 MIN_UPDATER_VERSION = (2, 0)
+# Refs that may be interpolated into an API path. Every tag and branch the
+# pickers offer matches this; anything else is refused rather than requested.
+_SAFE_REF_RE = re.compile(r"^[A-Za-z0-9._-]{1,64}$")
 
 # Auto-update channels (user-selectable in the update dialog). "stable" and
 # "experimental" are release channels told apart by the tag suffix — an
@@ -348,6 +351,9 @@ def fetch_releases() -> list[dict]:
             "name": r["tag_name"],
             "body": r.get("body", ""),
             "zipball_url": r["zipball_url"],
+            # When the release went public, which is the timestamp AnkiWeb's own
+            # listing is compared against. Not the same as the tag's commit date.
+            "published_at": r.get("published_at") or r.get("created_at"),
         }
         for r in data
         if _is_supported_version(r["tag_name"])
@@ -383,16 +389,28 @@ def fetch_branch_sha(branch: str) -> Optional[str]:
     return None
 
 
-def fetch_commit_date(sha: str) -> Optional[str]:
-    if not sha or len(sha) < 7 or not all(c in "0123456789abcdefABCDEF" for c in sha):
+def fetch_ref_date(ref: str) -> Optional[str]:
+    """Committer date (ISO 8601) of whatever ``ref`` resolves to — SHA or tag.
+
+    Deliberately narrow about what it will put in a URL: the tags and branches
+    the pickers offer are version-shaped, so anything stranger fails closed
+    (no date, hence no timestamp stamped) rather than being sent to the API.
+    """
+    if not ref or not _SAFE_REF_RE.match(ref):
         return None
-    data = _api_get(f"commits/{sha}")
+    data = _api_get(f"commits/{ref}")
     commit = data.get("commit") if isinstance(data, dict) else None
     if isinstance(commit, dict):
         committer = commit.get("committer") or {}
         author = commit.get("author") or {}
         return committer.get("date") or author.get("date")
     return None
+
+
+def fetch_commit_date(sha: str) -> Optional[str]:
+    if not sha or len(sha) < 7 or not all(c in "0123456789abcdefABCDEF" for c in sha):
+        return None
+    return fetch_ref_date(sha)
 
 
 def fetch_branch_commits(branch: str, local_sha: Optional[str] = None) -> list[dict]:
@@ -423,6 +441,107 @@ def fetch_branch_commits(branch: str, local_sha: Optional[str] = None) -> list[d
 
 def get_update_state_path() -> Path:
     return addon_dir / "user_files" / "update_state.json"
+
+
+def get_meta_json_path() -> Path:
+    return addon_dir / "meta.json"
+
+
+def _write_json_atomic(path: Path, data: dict) -> None:
+    """Write ``data`` as JSON via temp file + ``os.replace``.
+
+    meta.json belongs to Anki, which read-modify-writes it on the main thread
+    (``AddonManager.write_addon_meta``) while this can run from an updater
+    worker. A half-written file makes Anki's ``addonMeta()`` fall back to an
+    empty dict, silently discarding ``config``, ``disabled`` and ``mod``.
+    """
+    tmp = path.with_name(f"{path.name}.{os.getpid()}.tmp")
+    try:
+        tmp.write_text(json.dumps(data, indent=2), encoding="utf-8")
+        os.replace(tmp, path)
+    except Exception:
+        try:
+            tmp.unlink()
+        except Exception:
+            pass
+        raise
+
+
+def _parse_iso8601(value: Optional[str]) -> Optional[int]:
+    """GitHub's ``2026-08-08T11:02:30Z`` as epoch seconds, or None."""
+    if not value:
+        return None
+    try:
+        from datetime import datetime, timezone
+
+        parsed = datetime.strptime(value, "%Y-%m-%dT%H:%M:%SZ")
+        return int(parsed.replace(tzinfo=timezone.utc).timestamp())
+    except Exception:
+        return None
+
+
+def resolve_build_mtime(
+    source_type: Optional[str],
+    source_name: Optional[str],
+    commit_sha: Optional[str],
+    published_at: Optional[str] = None,
+) -> Optional[int]:
+    """Epoch seconds describing the build about to be installed.
+
+    A release is dated by when it went public, because that is the timestamp
+    AnkiWeb's own listing is compared against; everything else is dated by the
+    commit it was built from. None means "could not tell", and the caller then
+    leaves ``mod`` untouched rather than guessing.
+    """
+    if source_type == "release":
+        published = _parse_iso8601(published_at)
+        if published:
+            return published
+    for ref in (commit_sha, source_name):
+        resolved = _parse_iso8601(fetch_ref_date(ref)) if ref else None
+        if resolved:
+            return resolved
+    return None
+
+
+def stamp_addon_mod(timestamp: int) -> bool:
+    """Record ``timestamp`` as meta.json's ``mod`` — the field Anki dates the
+    installed build by. Returns whether anything was written.
+
+    Anki decides an add-on is out of date with ``installed_at >= server_mtime``,
+    where ``installed_at`` is this key (``AddonMeta.is_latest``). Only
+    ``AddonManager.install()`` ever writes it, and the in-app updater bypasses
+    that machinery entirely — so left alone the value keeps describing whichever
+    build Anki last installed, and AnkiWeb's copy looks newer than a GitHub
+    build that is in fact ahead of it. That is the accidental-downgrade prompt.
+
+    Never moves ``mod`` backwards: installing an older tag must not mask a
+    genuinely newer AnkiWeb release. A meta.json that Anki did not create is
+    left alone, as is one that no longer parses as a JSON object.
+    """
+    try:
+        if not timestamp or timestamp <= 0:
+            return False
+        path = get_meta_json_path()
+        if not path.exists():
+            # No meta.json means Anki is not managing this install (git clone,
+            # hand-unzipped copy); inventing one would fabricate metadata.
+            return False
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+        except Exception:
+            return False
+        if not isinstance(data, dict):
+            return False
+        current = data.get("mod")
+        if isinstance(current, (int, float)) and timestamp <= current:
+            return False
+        data["mod"] = int(timestamp)
+        _write_json_atomic(path, data)
+        return True
+    except Exception as e:
+        print(f"Ankimon Updater: Failed to stamp meta.json mod: {e}")
+        return False
 
 
 def save_update_state(
@@ -669,6 +788,7 @@ def apply_update(
     source_type: Optional[str] = None,
     source_name: Optional[str] = None,
     commit_sha: Optional[str] = None,
+    published_at: Optional[str] = None,
     status_cb=None,
 ) -> tuple[bool, str]:
     def log(msg):
@@ -789,6 +909,19 @@ def apply_update(
             # --- Save update state if provided ---
             if source_type and source_name:
                 save_update_state(source_type, source_name, commit_sha or "")
+
+            # Date meta.json by the build just installed, so Anki stops treating
+            # whichever build it last installed as the newer copy. Resolving the
+            # timestamp needs the network, so it gets its own guard — a GitHub
+            # hiccup must not turn a finished install into a rollback.
+            try:
+                mtime = resolve_build_mtime(
+                    source_type, source_name, commit_sha, published_at
+                )
+                if mtime and stamp_addon_mod(mtime):
+                    log("Recorded install date for Anki's update check.")
+            except Exception as e:
+                print(f"Ankimon Updater: Could not date the install: {e}")
 
             cleanup()
             log(f"Update complete. Installed {installed} files.")

--- a/src/Ankimon/pyobj/update_manager.py
+++ b/src/Ankimon/pyobj/update_manager.py
@@ -427,6 +427,13 @@ def fetch_ref_date(ref: str) -> Optional[str]:
 
 
 def fetch_commit_date(sha: str) -> Optional[str]:
+    """Committer date (ISO 8601) of a commit SHA, or None.
+
+    Narrower than ``fetch_ref_date``: the argument must look like a SHA (hex,
+    at least the 7 characters GitHub's short form uses), so a branch or tag name
+    is refused here even though the endpoint would accept it. Callers that hold
+    a name rather than a SHA want ``fetch_ref_date``.
+    """
     if not sha or len(sha) < 7 or not all(c in "0123456789abcdefABCDEF" for c in sha):
         return None
     return fetch_ref_date(sha)
@@ -463,6 +470,12 @@ def get_update_state_path() -> Path:
 
 
 def get_meta_json_path() -> Path:
+    """Anki's metadata file for this add-on.
+
+    Anki's, not ours — it also holds ``config``, ``disabled`` and the rest, so
+    anything writing here edits only the key it owns. Indirected through a
+    function so tests can point it at a temp directory.
+    """
     return addon_dir / "meta.json"
 
 

--- a/tests/test_profile_hooks.py
+++ b/tests/test_profile_hooks.py
@@ -58,12 +58,16 @@ def _exec_profile_hooks(monkeypatch, gui_hooks):
     returns a FRESH module object (fresh handler functions) — exactly what an
     add-on reload produces — while ``Ankimon.services`` is left to the caller.
 
-    The three ``clear_*`` callables are separate MagicMocks so a test can assert
+    The ``clear_*`` callables are separate MagicMocks so a test can assert
     each was called (and so encounter_functions' real pokedex.json import-time
-    IO is never triggered)."""
+    IO is never triggered).
+
+    Every name profile_hooks imports has to appear on the stub below, or the
+    exec fails with ImportError before a single assertion runs."""
     clear_pokedex = MagicMock(name="clear_pokedex_caches")
     clear_learnset = MagicMock(name="clear_learnset_cache")
     clear_encounter = MagicMock(name="clear_encounter_cache")
+    clear_auto_battle = MagicMock(name="clear_auto_battle_override")
 
     monkeypatch.setitem(
         sys.modules,
@@ -137,6 +141,7 @@ def _exec_profile_hooks(monkeypatch, gui_hooks):
         _stub_module(
             "Ankimon.functions.encounter_functions",
             clear_encounter_cache=clear_encounter,
+            clear_auto_battle_override=clear_auto_battle,
         ),
     )
 
@@ -146,7 +151,12 @@ def _exec_profile_hooks(monkeypatch, gui_hooks):
     profile_hooks = importlib.util.module_from_spec(spec)
     monkeypatch.setitem(sys.modules, "Ankimon.profile_hooks", profile_hooks)
     spec.loader.exec_module(profile_hooks)
-    profile_hooks._clears = (clear_pokedex, clear_learnset, clear_encounter)
+    profile_hooks._clears = (
+        clear_pokedex,
+        clear_learnset,
+        clear_encounter,
+        clear_auto_battle,
+    )
     return profile_hooks
 
 

--- a/tests/test_update_dialog_busy_state.py
+++ b/tests/test_update_dialog_busy_state.py
@@ -81,6 +81,10 @@ def _load_update_dialog():
             "_download_pr_zip",
             "read_update_state",
             "fetch_branch_sha",
+            # This tuple mirrors update_dialog's `from .update_manager import`
+            # list — a name added there must be added here, or this module fails
+            # to import at collection time.
+            "published_at_for_tag",
         ):
             setattr(update_manager, name, lambda *args, **kwargs: None)
         sys.modules["Ankimon.pyobj.update_manager"] = update_manager

--- a/tests/test_update_dialog_busy_state.py
+++ b/tests/test_update_dialog_busy_state.py
@@ -699,6 +699,12 @@ def test_branch_progress_malformed_result_uses_failure_path():
 
 
 class _StampSpy:
+    """Stands in for stamp_addon_mod, recording the timestamps it is handed.
+
+    An empty ``calls`` list is the assertion that matters in most of these
+    tests: it means no meta.json write was attempted from that phase.
+    """
+
     def __init__(self):
         self.calls = []
 

--- a/tests/test_update_dialog_busy_state.py
+++ b/tests/test_update_dialog_busy_state.py
@@ -85,6 +85,7 @@ def _load_update_dialog():
             # list — a name added there must be added here, or this module fails
             # to import at collection time.
             "published_at_for_tag",
+            "stamp_addon_mod",
         ):
             setattr(update_manager, name, lambda *args, **kwargs: None)
         sys.modules["Ankimon.pyobj.update_manager"] = update_manager
@@ -117,9 +118,13 @@ class _Control:
     def __init__(self, enabled=True):
         self.enabled = enabled
         self.visible = True
+        self.text = ""
 
     def isEnabled(self):
         return self.enabled
+
+    def setText(self, text):
+        self.text = text
 
     def setEnabled(self, enabled):
         self.enabled = enabled
@@ -654,6 +659,7 @@ def test_branch_progress_malformed_result_uses_failure_path():
         manager._download_branch_zip = lambda *args, **kwargs: None
         manager._download_zip_to_temp = lambda *args, **kwargs: None
         manager.apply_update = lambda *args, **kwargs: None
+        manager.stamp_addon_mod = lambda *args, **kwargs: None
         sys.modules[manager.__name__] = manager
 
         dialog = types.SimpleNamespace(
@@ -672,6 +678,272 @@ def test_branch_progress_malformed_result_uses_failure_path():
         assert dialog.progress_bar.value == 0
         assert "unexpectedly" in dialog.status_label.text
         assert MessageBox.warnings
+    finally:
+        update_dialog.QueryOp = original_query_op
+        update_dialog.QMessageBox = original_message_box
+        for name, module in saved_modules.items():
+            if module is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = module
+
+
+# --- meta.json is stamped on the main thread, never in the worker --------------
+#
+# apply_update runs in a QueryOp worker and returns the date to stamp rather than
+# writing it, because meta.json is Anki's file and Anki read-modify-writes it from
+# the main thread. QueryOp guarantees the success callback runs there, so that is
+# where the write belongs. Both tests below round-trip bg -> on_done: a tuple-arity
+# mismatch between the two would otherwise surface only at runtime, as a silent
+# "Update failed unexpectedly" (on_done's unpack is inside a broad except).
+
+
+class _StampSpy:
+    def __init__(self):
+        self.calls = []
+
+    def __call__(self, timestamp):
+        self.calls.append(timestamp)
+        return True
+
+
+def test_release_update_stamps_meta_json_from_the_success_callback():
+    class MessageBox:
+        class StandardButton:
+            Yes = 1
+            No = 2
+
+        @staticmethod
+        def question(*args, **kwargs):
+            return MessageBox.StandardButton.Yes
+
+        @staticmethod
+        def warning(*args):
+            pass
+
+        @staticmethod
+        def information(*args):
+            pass
+
+    original_query_op = update_dialog.QueryOp
+    original_message_box = update_dialog.QMessageBox
+    original_apply = update_dialog.apply_update
+    original_stamp = update_dialog.stamp_addon_mod
+    spy = _StampSpy()
+    update_dialog.QueryOp = _FakeQueryOp
+    update_dialog.QMessageBox = MessageBox
+    update_dialog.stamp_addon_mod = spy
+    update_dialog.apply_update = lambda *a, **k: (
+        True,
+        "Update applied successfully.",
+        1786186950,
+    )
+    dialog, _buttons = _make_dialog()
+    dialog._on_progress = lambda *args: None
+    try:
+        update_dialog.UpdateDialog._run_update(
+            dialog,
+            lambda **kwargs: "/tmp/update.zip",
+            "2.4",
+            source_type="release",
+            source_name="2.4",
+            commit_sha="2.4",
+            published_at="2026-08-08T11:02:30Z",
+        )
+        # Worker phase: it must not have stamped anything yet.
+        result = _FakeQueryOp.last.op(None)
+        assert spy.calls == []
+
+        # Main-thread phase.
+        _FakeQueryOp.last.success(result)
+        assert spy.calls == [1786186950]
+        assert dialog.progress_bar.value == 100
+    finally:
+        update_dialog.QueryOp = original_query_op
+        update_dialog.QMessageBox = original_message_box
+        update_dialog.apply_update = original_apply
+        update_dialog.stamp_addon_mod = original_stamp
+
+
+def test_release_update_does_not_stamp_when_the_install_failed():
+    """The rollback guard. apply_update returns None on the rollback path, but
+    the callback must refuse a stamp on any failure regardless — dating a
+    restored old build as the new one would make Anki suppress the update that
+    repairs it."""
+
+    class MessageBox:
+        class StandardButton:
+            Yes = 1
+            No = 2
+
+        @staticmethod
+        def question(*args, **kwargs):
+            return MessageBox.StandardButton.Yes
+
+        @staticmethod
+        def warning(*args):
+            pass
+
+        @staticmethod
+        def information(*args):
+            pass
+
+    original_query_op = update_dialog.QueryOp
+    original_message_box = update_dialog.QMessageBox
+    original_apply = update_dialog.apply_update
+    original_stamp = update_dialog.stamp_addon_mod
+    spy = _StampSpy()
+    update_dialog.QueryOp = _FakeQueryOp
+    update_dialog.QMessageBox = MessageBox
+    update_dialog.stamp_addon_mod = spy
+    # A timestamp alongside a failure: only the success flag may authorise a write.
+    update_dialog.apply_update = lambda *a, **k: (
+        False,
+        "Update failed and was rolled back: boom",
+        1786186950,
+    )
+    dialog, _buttons = _make_dialog()
+    dialog._on_progress = lambda *args: None
+    try:
+        update_dialog.UpdateDialog._run_update(
+            dialog, lambda **kwargs: "/tmp/update.zip", "2.4", source_type="release"
+        )
+        _FakeQueryOp.last.success(_FakeQueryOp.last.op(None))
+        assert spy.calls == []
+        assert dialog.progress_bar.value == 0
+    finally:
+        update_dialog.QueryOp = original_query_op
+        update_dialog.QMessageBox = original_message_box
+        update_dialog.apply_update = original_apply
+        update_dialog.stamp_addon_mod = original_stamp
+
+
+def test_branch_progress_dialog_also_stamps_on_the_main_thread():
+    """The second call site. It imports from update_manager locally and unpacks
+    its own tuple, so it can drift out of step with the release path."""
+
+    class MessageBox:
+        @staticmethod
+        def warning(*args):
+            pass
+
+        @staticmethod
+        def information(*args):
+            pass
+
+    original_query_op = update_dialog.QueryOp
+    original_message_box = update_dialog.QMessageBox
+    saved_modules = {
+        name: sys.modules.get(name)
+        for name in ("Ankimon", "Ankimon.pyobj", "Ankimon.pyobj.update_manager")
+    }
+    spy = _StampSpy()
+    update_dialog.QueryOp = _FakeQueryOp
+    update_dialog.QMessageBox = MessageBox
+    try:
+        for name, path in (
+            ("Ankimon", _SRC / "Ankimon"),
+            ("Ankimon.pyobj", _SRC / "Ankimon" / "pyobj"),
+        ):
+            package = types.ModuleType(name)
+            package.__path__ = [str(path)]
+            package.__package__ = name
+            sys.modules[name] = package
+
+        manager = types.ModuleType("Ankimon.pyobj.update_manager")
+        manager._download_branch_zip = lambda *args, **kwargs: "/tmp/update.zip"
+        manager._download_zip_to_temp = lambda *args, **kwargs: "/tmp/update.zip"
+        manager.apply_update = lambda *a, **k: (True, "Update applied.", 1786186950)
+        manager.stamp_addon_mod = spy
+        sys.modules[manager.__name__] = manager
+
+        dialog = types.SimpleNamespace(
+            release=None,
+            branch_name="main",
+            remote_sha="abc123",
+            on_progress=lambda *args: None,
+            btn_close=_Control(False),
+            status_label=_Label(),
+            progress_bar=_Progress(),
+        )
+        update_dialog.BranchUpdateProgressDialog.start_update(dialog)
+
+        result = _FakeQueryOp.last.op(None)
+        assert spy.calls == []  # worker phase writes nothing
+
+        _FakeQueryOp.last.success(result)
+        assert spy.calls == [1786186950]
+        assert dialog.progress_bar.value == 100
+    finally:
+        update_dialog.QueryOp = original_query_op
+        update_dialog.QMessageBox = original_message_box
+        for name, module in saved_modules.items():
+            if module is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = module
+
+
+def test_branch_progress_dialog_does_not_stamp_when_the_install_failed():
+    """The branch path's rollback guard, which is a separate copy from the
+    release path's and can drift out of step with it."""
+
+    class MessageBox:
+        @staticmethod
+        def warning(*args):
+            pass
+
+        @staticmethod
+        def information(*args):
+            pass
+
+    original_query_op = update_dialog.QueryOp
+    original_message_box = update_dialog.QMessageBox
+    saved_modules = {
+        name: sys.modules.get(name)
+        for name in ("Ankimon", "Ankimon.pyobj", "Ankimon.pyobj.update_manager")
+    }
+    spy = _StampSpy()
+    update_dialog.QueryOp = _FakeQueryOp
+    update_dialog.QMessageBox = MessageBox
+    try:
+        for name, path in (
+            ("Ankimon", _SRC / "Ankimon"),
+            ("Ankimon.pyobj", _SRC / "Ankimon" / "pyobj"),
+        ):
+            package = types.ModuleType(name)
+            package.__path__ = [str(path)]
+            package.__package__ = name
+            sys.modules[name] = package
+
+        manager = types.ModuleType("Ankimon.pyobj.update_manager")
+        manager._download_branch_zip = lambda *args, **kwargs: "/tmp/update.zip"
+        manager._download_zip_to_temp = lambda *args, **kwargs: "/tmp/update.zip"
+        # A timestamp alongside a failure: only the success flag may authorise a
+        # write. Dating a rolled-back build as the new one would make Anki read
+        # the restored old code as current and suppress the update that fixes it.
+        manager.apply_update = lambda *a, **k: (
+            False,
+            "Update failed and was rolled back: boom",
+            1786186950,
+        )
+        manager.stamp_addon_mod = spy
+        sys.modules[manager.__name__] = manager
+
+        dialog = types.SimpleNamespace(
+            release=None,
+            branch_name="main",
+            remote_sha="abc123",
+            on_progress=lambda *args: None,
+            btn_close=_Control(False),
+            status_label=_Label(),
+            progress_bar=_Progress(),
+        )
+        update_dialog.BranchUpdateProgressDialog.start_update(dialog)
+        _FakeQueryOp.last.success(_FakeQueryOp.last.op(None))
+
+        assert spy.calls == []
+        assert dialog.progress_bar.value == 0
     finally:
         update_dialog.QueryOp = original_query_op
         update_dialog.QMessageBox = original_message_box

--- a/tests/test_update_manager.py
+++ b/tests/test_update_manager.py
@@ -13,7 +13,9 @@ what the services-registry refactor targets.)
 import importlib.util
 import json
 import sys
+import time
 import types
+import zipfile
 from pathlib import Path
 
 _SRC = Path(__file__).parent.parent / "src"
@@ -352,3 +354,102 @@ def test_stamp_addon_mod_rejects_nonpositive(tmp_path, monkeypatch):
     assert um.stamp_addon_mod(0) is False
     assert um.stamp_addon_mod(-1) is False
     assert json.loads(path.read_text(encoding="utf-8"))["mod"] == 100
+
+
+def test_resolve_build_mtime_dates_a_tag_by_its_release(monkeypatch):
+    """Tags name published releases and install identical code, so they share a date."""
+    called = []
+    monkeypatch.setattr(um, "fetch_ref_date", lambda ref: called.append(ref))
+    ts = um.resolve_build_mtime("tag", "2.4", "2.4", "2026-08-08T11:02:30Z")
+    assert ts == 1786186950
+    assert called == []
+
+
+def test_resolve_build_mtime_clamps_a_future_commit_date(monkeypatch):
+    """A skewed clock or a crafted committer date must not pin mod into the future.
+
+    stamp_addon_mod never moves backwards, so an unclamped future value would
+    suppress every AnkiWeb update until that date actually arrived.
+    """
+    monkeypatch.setattr(um, "fetch_ref_date", lambda _ref: "2099-01-01T00:00:00Z")
+    before = int(time.time())
+    ts = um.resolve_build_mtime("pr", "123", "abc1234def")
+    assert ts is not None
+    assert before <= ts <= int(time.time())
+
+
+def test_resolve_build_mtime_does_not_repeat_a_failed_lookup(monkeypatch):
+    """commit_sha and source_name are the same string on the tag/release paths."""
+    called = []
+    monkeypatch.setattr(um, "fetch_ref_date", lambda ref: called.append(ref))
+    assert um.resolve_build_mtime("tag", "2.4", "2.4") is None
+    assert called == ["2.4"]
+
+
+# --- apply_update end to end ---------------------------------------------------
+
+
+def _staged_install(tmp_path, monkeypatch):
+    """Set apply_update up to run past the git-clone guard against a temp dir."""
+    addon = tmp_path / "addon"
+    addon.mkdir()
+    (addon / "old.py").write_text("old", encoding="utf-8")
+    (addon / "meta.json").write_text(
+        json.dumps({"mod": 100, "config": {"k": 1}, "disabled": False}),
+        encoding="utf-8",
+    )
+    zip_path = tmp_path / "update.zip"
+    with zipfile.ZipFile(zip_path, "w") as zf:
+        zf.writestr("ankimon-main/src/Ankimon/__init__.py", "new")
+        zf.writestr("ankimon-main/src/Ankimon/new.py", "new")
+
+    monkeypatch.setattr(um, "addon_dir", addon)
+    monkeypatch.setattr(um, "is_git_clone", lambda: False)
+    monkeypatch.setattr(um, "_get_gitignore_patterns", lambda: [])
+    monkeypatch.setattr(um, "_fetch_submodule_sha", lambda _ref: None)
+    monkeypatch.setattr(um, "_download_and_extract_submodule", lambda *a, **k: None)
+    monkeypatch.setattr(um, "save_update_state", lambda *a, **k: None)
+    monkeypatch.setattr(um, "get_meta_json_path", lambda: addon / "meta.json")
+    monkeypatch.setattr(um, "fetch_ref_date", lambda _ref: None)  # no network
+    return addon, zip_path
+
+
+def test_apply_update_stamps_mod_from_the_release_date(tmp_path, monkeypatch):
+    """The published_at threaded from the dialog reaches meta.json."""
+    addon, zip_path = _staged_install(tmp_path, monkeypatch)
+
+    ok, _msg = um.apply_update(
+        str(zip_path), "release", "2.4", "2.4", "2026-08-08T11:02:30Z"
+    )
+
+    assert ok is True
+    meta = json.loads((addon / "meta.json").read_text(encoding="utf-8"))
+    assert meta["mod"] == 1786186950
+    # Anki owns the rest of this file; the install must not cost it anything.
+    assert meta["config"] == {"k": 1}
+    assert meta["disabled"] is False
+
+
+def test_apply_update_does_not_stamp_when_the_install_rolls_back(tmp_path, monkeypatch):
+    """A late failure restores the old build, so meta.json must not claim the new one.
+
+    Stamping before the rollback handler would leave old code on disk dated as the
+    new build -- Anki would read it as current and suppress the update that repairs it.
+    """
+    addon, zip_path = _staged_install(tmp_path, monkeypatch)
+
+    def explode(msg):
+        if "Update complete" in msg:
+            raise RuntimeError("taskman gone")
+
+    ok, _msg = um.apply_update(
+        str(zip_path),
+        "release",
+        "2.4",
+        "2.4",
+        "2026-08-08T11:02:30Z",
+        status_cb=explode,
+    )
+
+    assert ok is False
+    assert json.loads((addon / "meta.json").read_text(encoding="utf-8"))["mod"] == 100

--- a/tests/test_update_manager.py
+++ b/tests/test_update_manager.py
@@ -11,6 +11,7 @@ what the services-registry refactor targets.)
 """
 
 import importlib.util
+import json
 import sys
 import types
 from pathlib import Path
@@ -218,3 +219,136 @@ def test_fetch_tags_filters_pre_2_0(monkeypatch):
         {"name": "1.3962-E", "zipball_url": "z"},
     ])
     assert [t["name"] for t in um.fetch_tags()] == ["2.0-E"]
+
+
+# --- dating the installed build ------------------------------------------------
+#
+# Anki decides an addon is out of date by comparing meta.json's "mod" against
+# AnkiWeb's listing timestamp, not by comparing version numbers. The in-app
+# updater copies files in place and never goes through AddonManager.install(),
+# which is the only thing that normally writes "mod" -- so without an explicit
+# stamp the value keeps describing whichever build Anki last installed, and
+# AnkiWeb's copy looks newer than a GitHub build that is actually ahead of it.
+
+
+def _meta_at(tmp_path, monkeypatch, content=None):
+    """Point the updater at a throwaway meta.json (never the real addon dir)."""
+    path = tmp_path / "meta.json"
+    if content is not None:
+        path.write_text(content, encoding="utf-8")
+    monkeypatch.setattr(um, "get_meta_json_path", lambda: path)
+    return path
+
+
+def test_parse_iso8601_handles_github_timestamps():
+    assert um._parse_iso8601("1970-01-01T00:00:00Z") == 0
+    assert um._parse_iso8601("2026-08-08T11:02:30Z") == 1786186950
+    assert um._parse_iso8601(None) is None
+    assert um._parse_iso8601("not a date") is None
+
+
+def test_fetch_releases_keeps_published_at(monkeypatch):
+    monkeypatch.setattr(um, "_api_get", lambda _ep: [
+        {"tag_name": "2.4", "zipball_url": "z", "body": "",
+         "published_at": "2026-08-08T11:02:30Z"},
+    ])
+    assert um.fetch_releases()[0]["published_at"] == "2026-08-08T11:02:30Z"
+
+
+def test_fetch_ref_date_refuses_unsafe_refs(monkeypatch):
+    seen = []
+    monkeypatch.setattr(um, "_api_get", lambda ep: seen.append(ep))
+    assert um.fetch_ref_date("../../../etc/passwd") is None
+    assert um.fetch_ref_date("feature/slashes") is None
+    assert um.fetch_ref_date("") is None
+    assert seen == []  # nothing unsafe reached the API
+
+
+def test_fetch_commit_date_still_rejects_non_hex(monkeypatch):
+    seen = []
+    monkeypatch.setattr(um, "_api_get", lambda ep: seen.append(ep))
+    assert um.fetch_commit_date("not-a-sha") is None
+    assert um.fetch_commit_date("") is None
+    assert seen == []
+
+
+def test_resolve_build_mtime_prefers_release_published_at(monkeypatch):
+    called = []
+    monkeypatch.setattr(um, "fetch_ref_date", lambda ref: called.append(ref))
+    ts = um.resolve_build_mtime("release", "2.4", "2.4", "2026-08-08T11:02:30Z")
+    assert ts == 1786186950
+    assert called == []  # a release needs no extra round trip
+
+
+def test_resolve_build_mtime_falls_back_to_commit_date(monkeypatch):
+    monkeypatch.setattr(
+        um, "fetch_ref_date",
+        lambda ref: "2026-01-02T03:04:05Z" if ref == "abc1234def" else None,
+    )
+    assert um.resolve_build_mtime("branch", "main", "abc1234def") == 1767323045
+
+
+def test_resolve_build_mtime_dates_a_tag_by_its_name(monkeypatch):
+    monkeypatch.setattr(
+        um, "fetch_ref_date",
+        lambda ref: "2026-01-02T03:04:05Z" if ref == "2.4" else None,
+    )
+    assert um.resolve_build_mtime("tag", "2.4", None) == 1767323045
+
+
+def test_resolve_build_mtime_returns_none_when_unresolvable(monkeypatch):
+    monkeypatch.setattr(um, "fetch_ref_date", lambda _ref: None)
+    assert um.resolve_build_mtime("branch", "main", "deadbeef1") is None
+
+
+def test_stamp_addon_mod_writes_when_newer(tmp_path, monkeypatch):
+    path = _meta_at(
+        tmp_path, monkeypatch,
+        '{"mod": 100, "config": {"a": 1}, "disabled": false, "name": "Ankimon"}',
+    )
+    assert um.stamp_addon_mod(500) is True
+    data = json.loads(path.read_text(encoding="utf-8"))
+    assert data["mod"] == 500
+    # Anki owns every other key in this file; none of them may be lost.
+    assert data["config"] == {"a": 1}
+    assert data["disabled"] is False
+    assert data["name"] == "Ankimon"
+
+
+def test_stamp_addon_mod_stamps_when_key_absent(tmp_path, monkeypatch):
+    path = _meta_at(tmp_path, monkeypatch, '{"name": "Ankimon"}')
+    assert um.stamp_addon_mod(500) is True
+    assert json.loads(path.read_text(encoding="utf-8"))["mod"] == 500
+
+
+def test_stamp_addon_mod_never_moves_backwards(tmp_path, monkeypatch):
+    """Installing an older tag must not mask a genuinely newer AnkiWeb release."""
+    path = _meta_at(tmp_path, monkeypatch, '{"mod": 900}')
+    assert um.stamp_addon_mod(500) is False
+    assert json.loads(path.read_text(encoding="utf-8"))["mod"] == 900
+
+
+def test_stamp_addon_mod_is_a_noop_when_unchanged(tmp_path, monkeypatch):
+    _meta_at(tmp_path, monkeypatch, '{"mod": 500}')
+    assert um.stamp_addon_mod(500) is False
+
+
+def test_stamp_addon_mod_leaves_missing_meta_alone(tmp_path, monkeypatch):
+    """No meta.json means Anki is not managing this install (clone / hand-unzip)."""
+    path = _meta_at(tmp_path, monkeypatch)
+    assert um.stamp_addon_mod(500) is False
+    assert not path.exists()
+
+
+def test_stamp_addon_mod_leaves_unparseable_meta_untouched(tmp_path, monkeypatch):
+    path = _meta_at(tmp_path, monkeypatch, "{not json")
+    assert um.stamp_addon_mod(500) is False
+    assert path.read_text(encoding="utf-8") == "{not json"
+    assert list(tmp_path.iterdir()) == [path]  # and no stray temp file
+
+
+def test_stamp_addon_mod_rejects_nonpositive(tmp_path, monkeypatch):
+    path = _meta_at(tmp_path, monkeypatch, '{"mod": 100}')
+    assert um.stamp_addon_mod(0) is False
+    assert um.stamp_addon_mod(-1) is False
+    assert json.loads(path.read_text(encoding="utf-8"))["mod"] == 100

--- a/tests/test_update_manager.py
+++ b/tests/test_update_manager.py
@@ -131,9 +131,10 @@ def test_apply_update_refuses_on_git_clone_and_cleans_zip(tmp_path, monkeypatch)
     dummy_zip = tmp_path / "update.zip"
     dummy_zip.write_bytes(b"PK\x03\x04")
 
-    ok, msg = um.apply_update(str(dummy_zip))
+    ok, msg, pending_mod = um.apply_update(str(dummy_zip))
 
     assert ok is False
+    assert pending_mod is None
     assert "git" in msg.lower()
     assert not dummy_zip.exists()  # guard cleaned up the downloaded archive
 
@@ -320,6 +321,22 @@ def test_fetch_ref_date_refuses_unsafe_refs(monkeypatch):
     assert seen == []  # nothing unsafe reached the API
 
 
+def test_fetch_ref_date_refuses_dot_segments(monkeypatch):
+    """The character class alone admits ".." — a URL normaliser eats it, and
+    ``commits/..`` then addresses the repo rather than a commit."""
+    seen = []
+    monkeypatch.setattr(um, "_api_get", lambda ep: seen.append(ep))
+    for ref in ("..", ".", "...", "..%2f", "2.0..2.1", ".hidden"):
+        assert um.fetch_ref_date(ref) is None, ref
+    assert seen == []
+
+
+def test_is_safe_ref_still_accepts_real_tags():
+    """The tags and SHAs the pickers actually offer must keep resolving."""
+    for ref in ("2.03", "2.02-E", "v1.9.1", "abc1234def", "main", "some_branch"):
+        assert um._is_safe_ref(ref) is True, ref
+
+
 def test_fetch_commit_date_still_rejects_non_hex(monkeypatch):
     seen = []
     monkeypatch.setattr(um, "_api_get", lambda ep: seen.append(ep))
@@ -490,8 +507,8 @@ def _staged_install(tmp_path, monkeypatch):
     return addon, zip_path
 
 
-def test_apply_update_stamps_mod_from_the_release_date(tmp_path, monkeypatch):
-    """The published_at threaded from the dialog reaches meta.json."""
+def test_apply_update_returns_the_release_date_to_stamp(tmp_path, monkeypatch):
+    """The published_at threaded from the dialog comes back as pending_mod."""
     addon, zip_path = _staged_install(tmp_path, monkeypatch)
 
     seen = {}
@@ -504,27 +521,80 @@ def test_apply_update_stamps_mod_from_the_release_date(tmp_path, monkeypatch):
     monkeypatch.setattr(um, "resolve_build_mtime", _spy)
 
     # Distinct values in every slot, so a transposed argument cannot pass.
-    ok, _msg = um.apply_update(
+    ok, _msg, pending_mod = um.apply_update(
         str(zip_path), "release", "rel-name", "sha-value", "2026-08-08T11:02:30Z"
     )
 
     assert ok is True
     assert seen["args"] == ("release", "rel-name", "sha-value", "2026-08-08T11:02:30Z")
-    meta = json.loads((addon / "meta.json").read_text(encoding="utf-8"))
-    assert meta["mod"] == 1786186950
-    # Anki owns the rest of this file; the install must not cost it anything.
-    assert meta["config"] == {"k": 1}
-    assert meta["disabled"] is False
+    assert pending_mod == 1786186950
     # and the install really happened
     assert (addon / "new.py").exists()
     assert not (addon / "old.py").exists()
 
 
+def test_apply_update_never_writes_meta_json_itself(tmp_path, monkeypatch):
+    """The structural half of the concurrency fix.
+
+    apply_update runs in a QueryOp worker. meta.json is Anki's file and Anki
+    read-modify-writes it from the main thread, so the worker must not touch it
+    at all — it resolves the timestamp and hands it back. If this assertion ever
+    fails, the read-modify-write has crept back onto the worker thread and the
+    lost-update race is live again.
+    """
+    addon, zip_path = _staged_install(tmp_path, monkeypatch)
+    before = (addon / "meta.json").read_text(encoding="utf-8")
+
+    ok, _msg, pending_mod = um.apply_update(
+        str(zip_path), "release", "2.4", "2.4", "2026-08-08T11:02:30Z"
+    )
+
+    assert ok is True
+    assert pending_mod == 1786186950  # resolved, but deliberately not written
+    assert (addon / "meta.json").read_text(encoding="utf-8") == before
+
+
+def test_a_concurrent_config_write_survives_the_stamp(tmp_path, monkeypatch):
+    """The regression this worker/main-thread split exists for.
+
+    Anki keeps running while the updater worker installs. If the worker had
+    snapshotted meta.json and written it back, a config Anki wrote in between —
+    the add-on config dialog, an enable/disable toggle — would be reverted to
+    that snapshot. Resolving in the worker and writing on the main thread means
+    the write reads whatever is actually on disk at the moment it runs.
+    """
+    addon, zip_path = _staged_install(tmp_path, monkeypatch)
+    meta_path = addon / "meta.json"
+
+    # --- worker thread: install, resolve the date, touch nothing else ---
+    ok, _msg, pending_mod = um.apply_update(
+        str(zip_path), "release", "2.4", "2.4", "2026-08-08T11:02:30Z"
+    )
+    assert ok is True and pending_mod == 1786186950
+
+    # --- main thread, meanwhile: Anki writes a config change ---
+    meta_path.write_text(
+        json.dumps({"mod": 100, "config": {"k": 2, "added": True}, "disabled": True}),
+        encoding="utf-8",
+    )
+
+    # --- main thread: the stamp, reading current state rather than a snapshot ---
+    assert um.stamp_addon_mod(pending_mod) is True
+
+    meta = json.loads(meta_path.read_text(encoding="utf-8"))
+    assert meta["mod"] == 1786186950
+    # The change that a stale snapshot would have silently discarded.
+    assert meta["config"] == {"k": 2, "added": True}
+    assert meta["disabled"] is True
+
+
 def test_apply_update_does_not_stamp_when_the_install_rolls_back(tmp_path, monkeypatch):
     """A late failure restores the old build, so meta.json must not claim the new one.
 
-    Stamping before the rollback handler would leave old code on disk dated as the
-    new build -- Anki would read it as current and suppress the update that repairs it.
+    Returning a timestamp here would have the caller date restored old code as
+    the new build -- Anki would read it as current and suppress the update that
+    repairs it. The guard is that the rollback path returns None, and the
+    dialog's success callback only stamps when the install actually succeeded.
     """
     addon, zip_path = _staged_install(tmp_path, monkeypatch)
 
@@ -532,7 +602,7 @@ def test_apply_update_does_not_stamp_when_the_install_rolls_back(tmp_path, monke
         if "Update complete" in msg:
             raise RuntimeError("taskman gone")
 
-    ok, msg = um.apply_update(
+    ok, msg, pending_mod = um.apply_update(
         str(zip_path),
         "release",
         "2.4",
@@ -542,6 +612,7 @@ def test_apply_update_does_not_stamp_when_the_install_rolls_back(tmp_path, monke
     )
 
     assert ok is False
+    assert pending_mod is None  # nothing for the caller to stamp
     # The rollback really ran: the previous build's files are back. (It restores
     # the backup over the top rather than deleting files the update added, so
     # new.py survives — pre-existing behaviour, not what this test is about.)

--- a/tests/test_update_manager.py
+++ b/tests/test_update_manager.py
@@ -18,6 +18,8 @@ import types
 import zipfile
 from pathlib import Path
 
+import pytest
+
 _SRC = Path(__file__).parent.parent / "src"
 
 
@@ -257,6 +259,58 @@ def test_fetch_releases_keeps_published_at(monkeypatch):
     assert um.fetch_releases()[0]["published_at"] == "2026-08-08T11:02:30Z"
 
 
+def test_fetch_releases_falls_back_to_created_at(monkeypatch):
+    """A draft promoted later can carry a null published_at."""
+    monkeypatch.setattr(um, "_api_get", lambda _ep: [
+        {"tag_name": "2.4", "zipball_url": "z", "body": "",
+         "published_at": None, "created_at": "2026-07-01T09:00:00Z"},
+    ])
+    assert um.fetch_releases()[0]["published_at"] == "2026-07-01T09:00:00Z"
+
+
+def test_published_at_for_tag_matches_the_named_release():
+    releases = [
+        {"name": "2.3-E", "published_at": "2026-08-08T11:02:30Z"},
+        {"name": "2.4", "published_at": "2026-09-01T10:00:00Z"},
+    ]
+    assert um.published_at_for_tag("2.4", releases) == "2026-09-01T10:00:00Z"
+
+
+def test_published_at_for_tag_returns_none_when_unknown():
+    releases = [{"name": "2.3-E", "published_at": "2026-08-08T11:02:30Z"}]
+    assert um.published_at_for_tag("9.9", releases) is None
+    assert um.published_at_for_tag("2.3-E", []) is None
+    assert um.published_at_for_tag("", releases) is None
+    assert um.published_at_for_tag("2.3-E", None) is None
+
+
+def test_published_at_for_tag_tolerates_malformed_entries():
+    """The picker's list is whatever the API returned; don't trust its shape."""
+    releases = [None, "junk", {}, {"name": "2.4"}]
+    assert um.published_at_for_tag("2.4", releases) is None
+
+
+def test_fetch_ref_date_resolves_a_tag_name(monkeypatch):
+    """The reason this function exists: commits/<tag> works, and dates a release."""
+    seen = []
+
+    def _api(endpoint):
+        seen.append(endpoint)
+        return {"commit": {"committer": {"date": "2026-08-08T11:02:30Z"}}}
+
+    monkeypatch.setattr(um, "_api_get", _api)
+    assert um.fetch_ref_date("2.3-E") == "2026-08-08T11:02:30Z"
+    assert seen == ["commits/2.3-E"]
+
+
+def test_fetch_ref_date_falls_back_to_author_date(monkeypatch):
+    monkeypatch.setattr(
+        um, "_api_get",
+        lambda _ep: {"commit": {"author": {"date": "2026-01-02T03:04:05Z"}}},
+    )
+    assert um.fetch_ref_date("abc1234def") == "2026-01-02T03:04:05Z"
+
+
 def test_fetch_ref_date_refuses_unsafe_refs(monkeypatch):
     seen = []
     monkeypatch.setattr(um, "_api_get", lambda ep: seen.append(ep))
@@ -324,7 +378,13 @@ def test_stamp_addon_mod_stamps_when_key_absent(tmp_path, monkeypatch):
 
 
 def test_stamp_addon_mod_never_moves_backwards(tmp_path, monkeypatch):
-    """Installing an older tag must not mask a genuinely newer AnkiWeb release."""
+    """A deliberate downgrade keeps the build the user chose.
+
+    Anki compares ``installed_at >= server_mtime``, so lowering ``mod`` is what
+    surfaces an AnkiWeb build. Refusing to lower it means installing an older tag
+    does not invite Anki to put the AnkiWeb copy straight back over the top, and
+    it keeps the stamp monotonic so it can never leave a user worse off.
+    """
     path = _meta_at(tmp_path, monkeypatch, '{"mod": 900}')
     assert um.stamp_addon_mod(500) is False
     assert json.loads(path.read_text(encoding="utf-8"))["mod"] == 900
@@ -346,7 +406,23 @@ def test_stamp_addon_mod_leaves_unparseable_meta_untouched(tmp_path, monkeypatch
     path = _meta_at(tmp_path, monkeypatch, "{not json")
     assert um.stamp_addon_mod(500) is False
     assert path.read_text(encoding="utf-8") == "{not json"
-    assert list(tmp_path.iterdir()) == [path]  # and no stray temp file
+
+
+def test_write_json_atomic_leaves_no_temp_file_behind(tmp_path):
+    """The temp file must be renamed away on success and removed on failure."""
+    path = tmp_path / "meta.json"
+    um._write_json_atomic(path, {"mod": 1})
+    assert json.loads(path.read_text(encoding="utf-8")) == {"mod": 1}
+    assert list(tmp_path.iterdir()) == [path]
+
+    class _Unserialisable:
+        pass
+
+    with pytest.raises(TypeError):
+        um._write_json_atomic(path, {"mod": _Unserialisable()})
+    # the original survives and the aborted temp file is gone
+    assert json.loads(path.read_text(encoding="utf-8")) == {"mod": 1}
+    assert list(tmp_path.iterdir()) == [path]
 
 
 def test_stamp_addon_mod_rejects_nonpositive(tmp_path, monkeypatch):
@@ -418,16 +494,30 @@ def test_apply_update_stamps_mod_from_the_release_date(tmp_path, monkeypatch):
     """The published_at threaded from the dialog reaches meta.json."""
     addon, zip_path = _staged_install(tmp_path, monkeypatch)
 
+    seen = {}
+    real_resolve = um.resolve_build_mtime
+
+    def _spy(source_type, source_name, commit_sha, published_at=None):
+        seen["args"] = (source_type, source_name, commit_sha, published_at)
+        return real_resolve(source_type, source_name, commit_sha, published_at)
+
+    monkeypatch.setattr(um, "resolve_build_mtime", _spy)
+
+    # Distinct values in every slot, so a transposed argument cannot pass.
     ok, _msg = um.apply_update(
-        str(zip_path), "release", "2.4", "2.4", "2026-08-08T11:02:30Z"
+        str(zip_path), "release", "rel-name", "sha-value", "2026-08-08T11:02:30Z"
     )
 
     assert ok is True
+    assert seen["args"] == ("release", "rel-name", "sha-value", "2026-08-08T11:02:30Z")
     meta = json.loads((addon / "meta.json").read_text(encoding="utf-8"))
     assert meta["mod"] == 1786186950
     # Anki owns the rest of this file; the install must not cost it anything.
     assert meta["config"] == {"k": 1}
     assert meta["disabled"] is False
+    # and the install really happened
+    assert (addon / "new.py").exists()
+    assert not (addon / "old.py").exists()
 
 
 def test_apply_update_does_not_stamp_when_the_install_rolls_back(tmp_path, monkeypatch):
@@ -442,7 +532,7 @@ def test_apply_update_does_not_stamp_when_the_install_rolls_back(tmp_path, monke
         if "Update complete" in msg:
             raise RuntimeError("taskman gone")
 
-    ok, _msg = um.apply_update(
+    ok, msg = um.apply_update(
         str(zip_path),
         "release",
         "2.4",
@@ -452,4 +542,10 @@ def test_apply_update_does_not_stamp_when_the_install_rolls_back(tmp_path, monke
     )
 
     assert ok is False
+    # The rollback really ran: the previous build's files are back. (It restores
+    # the backup over the top rather than deleting files the update added, so
+    # new.py survives — pre-existing behaviour, not what this test is about.)
+    assert "rolled back" in msg.lower()
+    assert (addon / "old.py").read_text(encoding="utf-8") == "old"
+    # ...and meta.json still describes the build that is actually on disk
     assert json.loads((addon / "meta.json").read_text(encoding="utf-8"))["mod"] == 100


### PR DESCRIPTION
### Description

**The bug:** after updating in-app, Anki offers the *older* AnkiWeb build as an update, and accepting it downgrades you.

**Why:** Anki decides an add-on is out of date by comparing **timestamps, not version numbers** — `AddonMeta.is_latest()` is `installed_at >= server_update_time`, where `installed_at` is `meta.json`'s `mod`. That key is only ever written by `AddonManager.install()`, and `apply_update()` bypasses that machinery entirely: it copies files in place and preserves `meta.json` (dropping it would take Anki's `config` and `disabled` with it).

So after an in-app update `mod` still describes whichever build **Anki** last installed. Once AnkiWeb publishes anything newer than that stale timestamp, Anki correctly concludes AnkiWeb is newer and offers it — even when the installed GitHub build is far ahead. There's no escape hatch: `get_updated_addons()`'s `compatible()` fallback only fires on a *negative* `max_point_version`, and ours is positive (`250205`).

#### 1. Stamp `mod` with the build actually installed

`apply_update()` now dates `meta.json` by what it installed — a release (or a tag naming one) by its `published_at`, everything else by the commit it was built from.

- **Never moves backwards.** Anki compares `installed_at >= server_mtime`, so a *lower* `mod` is what surfaces an AnkiWeb build. Refusing to lower it means a deliberate downgrade keeps the build you chose, and makes the stamp monotonic — introducing it can't leave anyone worse off than today.
- **Commit dates are capped at the present**, so a skewed clock or a crafted `GIT_COMMITTER_DATE` on a PR build can't pin `mod` into the future. `published_at` is *not* capped — it's GitHub's clock, not the committer's.
- **Atomic write** (temp + `os.replace`), since Anki read-modify-writes the same file on the main thread. A `meta.json` Anki didn't create is left alone, as is one that no longer parses.
- **Stamped last**, after every statement that could still raise into the rollback handler. Stamping earlier let a late failure restore the old code while leaving `meta.json` dated as the new build — Anki would then read the rolled-back install as current and suppress the update that repairs it. There's a regression test for exactly this; it fails on the old ordering.

#### 2. Publish to AnkiWeb *before* GitHub

Because the comparison is by timestamp, whichever channel is published **last** looks newer. Publishing to GitHub first leaves every in-app updater user with a `mod` older than the AnkiWeb listing — precisely the state that offers them the AnkiWeb build.

AnkiWeb has no public upload API and scripting the private one is against its Terms ([dae](https://forums.ankiweb.net/t/authentication-with-ankiweb-for-add-on-deploy-from-github/40999): *"You're accessing a private API, which is against the T&Cs"*; the API request, ankitects/anki#4869, is open and in backlog). The upload can't be automated — but its **ordering** can be enforced. `release.yml` now splits at the finished `.ankiaddon` with an `ankiweb` environment gate between the halves: `build` hands the package over as a workflow artifact, `publish` waits for a required reviewer, then creates the release.

#### 3. Repair the `test_profile_hooks.py` stub

#746 added `clear_auto_battle_override` to `profile_hooks.py`'s imports but not to the test's stub of `encounter_functions`, so all 7 tests in that file died at collection and `Integrity Tests` was red on `main`. Three lines; product code untouched. Included here so this PR is green on its own.

### Release procedure after this merges

1. Dispatch `release.yml` as usual.
2. When it pauses, download the `ankiaddon` artifact from the run.
3. Upload `Ankimon.ankiaddon` at https://ankiweb.net/shared/addons/
4. Approve the held job. The GitHub release goes out, dated after AnkiWeb.

⚠️ The bump, tag and push to `main` stay in `build`, because `aab` dates the manifest from the tag and so needs it to exist first. **A held run that's never approved leaves `main` bumped and tagged with no release** — recoverable by approving later (runs hold 30 days) or by reverting the bump and deleting the tag. This is also documented in the workflow header so it survives the merge.

### Verification

The gate was smoke-tested live on a throwaway branch (dispatching `release.yml` itself would cut a release): the artifact handoff preserves the `build/` prefix, both `.ankiaddon` assets survive, `body_path` resolves, `needs.build.outputs` cross the job boundary, and the `gated` job correctly sat unstarted awaiting approval. That branch and its run are deleted.

| | `origin/main` | this branch |
|---|---|---|
| `pytest tests/` | 719 passed, **7 failed**, 36 skipped | **753 passed, 0 failed**, 36 skipped |
| `ruff check --select PLE,UP018` | 10 errors | 10 errors (unchanged) |
| `actionlint release.yml` | 5 shellcheck notes | 5 shellcheck notes (unchanged) |

`pytest tests/test_addon_integrity.py` passes. +34 tests, no new lint.

<sub>Note: `Tier 1` went red once on an earlier push and passed on re-run at the identical SHA with no code change — `harness/checks/probe_persistence.py:69` (`expected +3 caught`, got +4) is flaky, pre-existing, and unrelated to this diff. Worth a separate look.</sub>

### Related Issue

Addresses the same symptom as #755, from the other end. #755 sets `update_enabled=False` to suppress the prompt; the difficulty is that `prompt_to_update` is OR-gated across *all* pending add-ons, the manual "Check for Updates" button ignores the flag entirely, and a single "Update All" click re-checks the row and persists `update_enabled=True` back to `meta.json`. Fixing `mod` removes the reason Anki offers the downgrade at all, so no flag is needed. #755's two file-safety guards — the atomic write and the corrupt-file bail — are carried over here. Happy to close this if you'd rather take #755 forward.

### Checklist
- [x] My code follows the code style and guidelines of this project.
- [x] I have run tests locally (`pytest tests/` and `pytest tests/test_addon_integrity.py`) and they all pass.
- [ ] **(Optional)** I have added/updated my entry in `.all-contributorsrc`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
