### PR TITLE
test(profile-hooks): repair the stale encounter_functions stub from #746

### DIFF
--- a/tests/test_profile_hooks.py
+++ b/tests/test_profile_hooks.py
@@ -58,12 +58,16 @@ def _exec_profile_hooks(monkeypatch, gui_hooks):
     returns a FRESH module object (fresh handler functions) — exactly what an
     add-on reload produces — while ``Ankimon.services`` is left to the caller.
 
-    The three ``clear_*`` callables are separate MagicMocks so a test can assert
+    The ``clear_*`` callables are separate MagicMocks so a test can assert
     each was called (and so encounter_functions' real pokedex.json import-time
-    IO is never triggered)."""
+    IO is never triggered).
+
+    Every name profile_hooks imports has to appear on the stub below, or the
+    exec fails with ImportError before a single assertion runs."""
     clear_pokedex = MagicMock(name="clear_pokedex_caches")
     clear_learnset = MagicMock(name="clear_learnset_cache")
     clear_encounter = MagicMock(name="clear_encounter_cache")
+    clear_auto_battle = MagicMock(name="clear_auto_battle_override")
 
     monkeypatch.setitem(
         sys.modules,
@@ -137,6 +141,7 @@ def _exec_profile_hooks(monkeypatch, gui_hooks):
         _stub_module(
             "Ankimon.functions.encounter_functions",
             clear_encounter_cache=clear_encounter,
+            clear_auto_battle_override=clear_auto_battle,
         ),
     )
 
@@ -146,7 +151,12 @@ def _exec_profile_hooks(monkeypatch, gui_hooks):
     profile_hooks = importlib.util.module_from_spec(spec)
     monkeypatch.setitem(sys.modules, "Ankimon.profile_hooks", profile_hooks)
     spec.loader.exec_module(profile_hooks)
-    profile_hooks._clears = (clear_pokedex, clear_learnset, clear_encounter)
+    profile_hooks._clears = (
+        clear_pokedex,
+        clear_learnset,
+        clear_encounter,
+        clear_auto_battle,
+    )
     return profile_hooks
 
 


### PR DESCRIPTION
### Description

**Turns the red `Integrity Tests` job green.** That job runs `pytest tests/`, and the whole suite currently reports **7 failed** on `main`.

All 7 are in `tests/test_profile_hooks.py`, all with the same cause:

```
ImportError: cannot import name 'clear_auto_battle_override'
from 'Ankimon.functions.encounter_functions' (unknown location)
```

**This is not a product bug.** `clear_auto_battle_override` is defined at `src/Ankimon/functions/encounter_functions.py:286` and the add-on imports it fine at runtime. The stale thing is the test double.

#746 added a second import to `profile_hooks.py:17`:

```python
from .functions.encounter_functions import clear_encounter_cache, clear_auto_battle_override
```

…but `tests/test_profile_hooks.py` replaces that module with a stub exposing only `clear_encounter_cache`. `_exec_profile_hooks` then execs the real `profile_hooks.py` against it, and the import dies before a single assertion runs — taking all 7 tests in the file with it. It fails in isolation, so it isn't collection-order pollution.

### The fix

Three lines: create the `MagicMock`, put it on the stub, and add it to `_clears` so `_on_profile_close` is actually asserted to call `clear_auto_battle_override()` — the coverage #746 intended but never got. Also left a note on the helper that every name `profile_hooks` imports must appear on the stub, since the failure mode is a collection-time `ImportError` rather than a readable assertion error.

Test-only. No product code touched.

| | `main` | this branch |
|---|---|---|
| `pytest tests/` | 719 passed, **7 failed**, 36 skipped | **726 passed, 0 failed**, 36 skipped |
| `ruff check --select PLE,UP018` | 10 errors | 10 errors (unchanged) |

### Related Issue

Fallout from #746. Also unblocks #757, whose `run_integrity_tests` check is red for this reason and nothing else — it goes green once this lands and its checks are re-run.

### Checklist
- [x] My code follows the code style and guidelines of this project.
- [x] I have run tests locally (`pytest tests/` and `pytest tests/test_addon_integrity.py`) and they all pass.
- [ ] **(Optional)** I have added/updated my entry in `.all-contributorsrc`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
