### PR TITLE
fix(ui): stop the battle window cropping the scene on both axes

### DIFF
--- a/src/Ankimon/profile_hooks.py
+++ b/src/Ankimon/profile_hooks.py
@@ -14,7 +14,7 @@ from .pyobj.pokemon_trade import check_and_award_monthly_pokemon
 from .pyobj.error_handler import show_warning_with_traceback
 from .functions.pokedex_functions import clear_pokedex_caches
 from .functions.learnset_retrieval import clear_learnset_cache
-from .functions.encounter_functions import clear_encounter_cache
+from .functions.encounter_functions import clear_encounter_cache, clear_auto_battle_override
 
 sync_dialog = None
 
@@ -46,7 +46,7 @@ def _on_profile_close():
         clear_pokedex_caches()
         clear_learnset_cache()
         clear_encounter_cache()
-
+        clear_auto_battle_override()
     except Exception as e:
         logger.log("error", f"Error clearing caches on profile close: {e}")
 

--- a/src/Ankimon/profile_hooks.py
+++ b/src/Ankimon/profile_hooks.py
@@ -14,7 +14,7 @@ from .pyobj.pokemon_trade import check_and_award_monthly_pokemon
 from .pyobj.error_handler import show_warning_with_traceback
 from .functions.pokedex_functions import clear_pokedex_caches
 from .functions.learnset_retrieval import clear_learnset_cache
-from .functions.encounter_functions import clear_encounter_cache, clear_auto_battle_override
+from .functions.encounter_functions import clear_encounter_cache
 
 sync_dialog = None
 
@@ -46,7 +46,7 @@ def _on_profile_close():
         clear_pokedex_caches()
         clear_learnset_cache()
         clear_encounter_cache()
-        clear_auto_battle_override()
+
     except Exception as e:
         logger.log("error", f"Error clearing caches on profile close: {e}")
 

--- a/src/Ankimon/pyobj/test_window.py
+++ b/src/Ankimon/pyobj/test_window.py
@@ -154,7 +154,7 @@ class TestWindow(QWidget):
         self.setStyleSheet("background-color: rgb(44,44,44);")
         self._reset_window_title()
         self.setWindowIcon(QIcon(str(icon_path)))
-        self.setFixedSize(556, 300)
+        self.setFixedWidth(556)
 
     def open_dynamic_window(self):
         # Create and show the dynamic window

--- a/src/Ankimon/pyobj/test_window.py
+++ b/src/Ankimon/pyobj/test_window.py
@@ -126,6 +126,12 @@ class TestWindow(QWidget):
         layout = self.layout()
         self.clear_layout(layout)
 
+        # The battle scene is a full-bleed backdrop, not a widget on a page, so
+        # the layout keeps no contents margins: QVBoxLayout's default 11px inset
+        # left only 534px for a 556px-wide scene, silently cropping 11px off
+        # each side (the window is sized to the scene, see setFixedWidth below).
+        layout.setContentsMargins(0, 0, 0, 0)
+
         # Main label that will persist and show everything (Logo, Battle, Death)
         self.main_label = QLabel()
         self.main_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
@@ -154,6 +160,14 @@ class TestWindow(QWidget):
         self.setStyleSheet("background-color: rgb(44,44,44);")
         self._reset_window_title()
         self.setWindowIcon(QIcon(str(icon_path)))
+        # Pin the width to the battle scenes' own width (the art is 556x371 with
+        # the dialog box, 555x258 without) and let the layout own the height.
+        # A fixed 556x300 cropped every view: the scene with its dialog box needs
+        # 371, so the message bar at its foot was cut off, and the death screen
+        # needs 297 for the pokedex card plus the catch/defeat row. Heights vary
+        # per view, and Qt only ever raises a shown top-level window's minimum,
+        # so the window grows to whichever view needs the most and then holds
+        # steady — no per-view resize flicker.
         self.setFixedWidth(556)
 
     def open_dynamic_window(self):

--- a/tests/test_test_window_gui.py
+++ b/tests/test_test_window_gui.py
@@ -233,8 +233,8 @@ def test_init_ui_builds_persistent_scaffolding(make_window):
     assert win.button_widget.isHidden()
 
     # Fixed 556x300 window (exp's fixed size/styling)
-    assert (win.minimumWidth(), win.minimumHeight()) == (556, 300)
-    assert (win.maximumWidth(), win.maximumHeight()) == (556, 300)
+    assert win.minimumWidth() == 556
+    assert win.maximumWidth() == 556
     assert "rgb(44,44,44)" in win.styleSheet()
 
     # The Ankimon logo landed on the persistent label

--- a/tests/test_test_window_gui.py
+++ b/tests/test_test_window_gui.py
@@ -3,10 +3,15 @@
 Pins the OBSERVABLE contract of the ported encounter display:
 
 * ``init_ui`` builds ONE persistent layout (a ``main_label`` plus a hidden
-  death-screen ``button_widget``) and a fixed 556x300 window — no
+  death-screen ``button_widget``) in a margin-free window pinned to the battle
+  scenes' 556px width, with the height left to the layout — no
   rebuild-per-encounter: the layout and label objects keep their identity
   across ``display_first_encounter`` / ``display_battle`` /
   ``display_pokemon_death`` calls.
+* No view is cropped: every scene the window renders fits inside
+  ``main_label`` at its natural size (the regression a fixed 556x300 window
+  caused — it cut the message bar off the foot of the battle scene and clipped
+  11px off each side of it).
 * ``_get_display_name`` routes mega/gmax internal names through the base's
   ``pokedex_functions.get_pretty_name_for_name`` (expectations validated
   against the real ``data_files/pokedex.json``), and everything else through
@@ -232,15 +237,90 @@ def test_init_ui_builds_persistent_scaffolding(make_window):
     assert layout.itemAt(1).widget() is win.button_widget
     assert win.button_widget.isHidden()
 
-    # Fixed 556x300 window (exp's fixed size/styling)
-    assert win.minimumWidth() == 556
-    assert win.maximumWidth() == 556
+    # Width is pinned to the battle scenes' own width; the height is the
+    # layout's to decide, so a taller view can never be cut off.
+    assert win.minimumWidth() == win.maximumWidth() == 556
+    assert win.maximumHeight() > win.minimumHeight()
+
+    # No contents margins: the 556px-wide scene has to reach both edges of a
+    # 556px-wide window, and QVBoxLayout's default 11px inset would crop it.
+    margins = layout.contentsMargins()
+    assert (margins.left(), margins.right()) == (0, 0)
+
     assert "rgb(44,44,44)" in win.styleSheet()
 
     # The Ankimon logo landed on the persistent label
     assert win.main_label.pixmap() is not None
     assert not win.main_label.pixmap().isNull()
     assert win.windowTitle() == "Ankimon Window"
+
+
+@pytest.mark.parametrize("view", ["first_encounter", "battle", "death"])
+def test_no_view_is_cropped(make_window, qapp, view):
+    """Every view renders at its natural size — nothing is cut off.
+
+    The regression this pins: ``init_ui`` used to pin the window to 556x300,
+    but the battle scene WITH its dialog box is 556x371, so the message bar
+    along its foot fell outside the window entirely. Both axes were wrong —
+    the layout's default 11px side margins also left the 556px-wide scene only
+    534px to draw in, shaving 11px off each side of every view.
+
+    Asserting on ``main_label`` rather than on the size constraints is what
+    makes this bite: a QLabel silently centre-crops a pixmap too big for it,
+    so the only honest question is whether the label is at least as large as
+    what it was handed. The window has to be shown for Qt to resolve the
+    layout against the real constraints (the suite runs offscreen).
+    """
+    win = make_window()
+    win.show()
+    qapp.processEvents()
+
+    if view == "first_encounter":
+        win.ankimon_tracker_obj.pokemon_encounter = 0  # the 556x371 scene
+        win.display_first_encounter()
+    elif view == "battle":
+        win.ankimon_tracker_obj.pokemon_encounter = 3  # the 555x258 scene
+        win.display_battle()
+    else:
+        win.display_pokemon_death()
+    qapp.processEvents()
+
+    pixmap = win.main_label.pixmap()
+    assert pixmap is not None and not pixmap.isNull()
+
+    assert win.main_label.width() >= pixmap.width(), (
+        f"{view}: {pixmap.width()}px-wide art cropped to a "
+        f"{win.main_label.width()}px label"
+    )
+    assert win.main_label.height() >= pixmap.height(), (
+        f"{view}: {pixmap.height()}px-tall art cropped to a "
+        f"{win.main_label.height()}px label"
+    )
+
+    win.hide()
+
+
+def test_death_view_keeps_room_for_the_buttons(make_window, qapp):
+    """The catch/defeat row is inside the window, not pushed past its foot.
+
+    The death view is the tallest thing after the battle scene — the pokedex
+    card plus the button row — and it is the view a fixed height is most
+    likely to clip, since the buttons are added below the art rather than
+    drawn into it.
+    """
+    win = make_window()
+    win.show()
+    qapp.processEvents()
+    win.display_pokemon_death()
+    qapp.processEvents()
+
+    assert not win.button_widget.isHidden()
+    button_bottom = win.button_widget.geometry().bottom()
+    assert button_bottom <= win.height(), (
+        f"catch/defeat row ends at y={button_bottom} in a {win.height()}px window"
+    )
+
+    win.hide()
 
 
 def test_layout_identity_persists_across_display_calls(make_window):


### PR DESCRIPTION
### Description

Fixes the battle window cutting off the bottom of the battle scene and its text bar.

The window was pinned to a hardcoded `556x300`, but the battle scene art is **556x371** with its dialog box (and 555x258 without). Two separate crops fell out of that:

* **Vertically** — the message bar along the foot of the scene fell outside the window entirely. The death view was clipped too: it needs 297px for the pokedex card plus the catch/defeat button row.
* **Horizontally** — `QVBoxLayout`'s default 11px contents margins left the 556px-wide art only **534px** to draw in. A `QLabel` centre-crops a pixmap that's too big for it without complaining, so **11px was being shaved off each side of every view**, silently, in every release that shipped the fixed size.

`setFixedWidth(556)` on its own only fixes the first one — the window is still 556 wide, the margins still take 22 of it, and the art is still cropped. So this also clears the layout's contents margins: the scene is a full-bleed backdrop rather than a widget on a page, and the 556 the window is pinned to is exactly the width of the art.

Height is left to the layout, as the original commit intended. Qt only ever raises a shown top-level window's minimum and never shrinks it, so the window settles at whichever view needs the most and then holds steady — the views don't fight each other for size and there's no per-view resize flicker.

#### Also in this PR (outside the title, flagging deliberately)

* **Reverted the `clear_auto_battle_override` deletion in `profile_hooks.py`.** The second commit removed it as "a spurious import left behind from an incomplete prior commit" — but it isn't spurious: the function is defined at `functions/encounter_functions.py:286` and existed at this branch's merge base. What actually failed CI was `tests/test_profile_hooks.py`, whose stub of `encounter_functions` didn't expose the attribute — a test-side gap, fixed properly on main in #757. Deleting the production call silenced the test by removing the behaviour it covered. That behaviour matters: `_auto_battle_override` is a process-lifetime global, so without the clear, a user who arms a catch/defeat override and switches profiles before the wild Pokémon faints carries the override into the next profile, where it can silently force-catch or force-defeat the first faint under auto-battle. `profile_hooks.py` is now byte-identical to main.
* **Merged `main`** (rather than rebasing, to keep Jules' commits intact), which brings in the #757 test-stub fix so the restored import passes CI for the right reason.

#### On the review feedback

CodeRabbit suggested asserting `minimumHeight() < maximumHeight()`. That passes for *any* unpinned height, cropped or not, so the tests assert the contract that was actually broken instead: **`main_label` is at least as large as the pixmap it was handed**, checked per view. That formulation fails against the old `556x300` window *and* against a fixed width with the margins left in, so it pins the regression from both directions.

CodeRabbit also flagged `display_first_start_up()` (the `setGeometry(x, y, 256, 256)` at line 184) as a path that could still clip. It has **no callers anywhere in the repo** — it's dead code — so it can't affect the runtime flow. Left alone as out of scope.

### Related Issue

<!-- No linked issue; reported as a UI truncation bug. -->

### Checklist
- [x] My code follows the code style and guidelines of this project.
- [x] I have run tests locally (`pytest tests/` and `pytest tests/test_addon_integrity.py`) and they all pass.
- [ ] **(Optional)** I have added/updated my entry in `.all-contributorsrc`.

<details>
<summary>Verification evidence</summary>

* `pytest tests/` → **761 passed, 40 skipped**, 0 failures (offscreen Qt).
* `ruff check --config ci_ruff_check.toml` and `ruff format --check` → clean on both changed files.
* Harness **Tier 2** (`probe_real_boot`, `probe_real_play`) → both OK; the play probe ran 28 answers through 4 encounters, 3 faints, 2 catches and 1 defeat. Tier 1 fails identically on unpatched `main` in this local macOS env (a pre-existing PyQt6/QApplication issue that doesn't occur in CI, which installs no PyQt6) — same 3 failures, same scenarios, patched and unpatched.
* **Mutation-checked the new tests**: reverting to `setFixedSize(556, 300)` fails 4 tests; applying the fixed width *without* clearing the margins still fails 3 — so the tests genuinely catch both the original bug and the incomplete fix.
* Measured offscreen with the logo forced to fail to load (so nothing seeds an initial height): the window still grows 300 → 371 when the first encounter renders, and the battle → encounter transition (258 → 371) grows correctly, confirming the height doesn't depend on the logo's incidental size.

</details>
