### PR TITLE
fix: revert fainted status to fighting when HP is greater than 0

### DIFF
--- a/src/Ankimon/functions/battle_functions.py
+++ b/src/Ankimon/functions/battle_functions.py
@@ -612,6 +612,10 @@ def validate_pokemon_status(pokemon):
     if hasattr(pokemon, "hp") and pokemon.hp <= 0 and current_status != "fainted":
         return "fainted"
 
+    # If Pokemon has HP > 0 but status is fainted, revert to fighting
+    if hasattr(pokemon, "hp") and pokemon.hp > 0 and current_status == "fainted":
+        return "fighting"
+
     return current_status
 
 

--- a/src/Ankimon/functions/battle_functions.py
+++ b/src/Ankimon/functions/battle_functions.py
@@ -769,7 +769,5 @@ def calculate_hp(base_stat_hp, level, ev, iv):
     ev_value = ev["hp"] / 4
     iv_value = iv["hp"]
     # hp = int(((iv + 2 * (base_stat_hp + ev) + 100) * level) / 100 + 10)
-    hp = int(
-        ((((2 * base_stat_hp) + iv_value + ev_value) * level) / 100) + level + 10
-    )
+    hp = int(((((2 * base_stat_hp) + iv_value + ev_value) * level) / 100) + level + 10)
     return hp

--- a/tests/test_battle_functions.py
+++ b/tests/test_battle_functions.py
@@ -1,0 +1,38 @@
+import sys
+import types
+import pytest
+from pathlib import Path
+from unittest.mock import MagicMock
+
+_src = Path(__file__).parent.parent / "src"
+for _pkg in ("Ankimon", "Ankimon.functions"):
+    _mod = types.ModuleType(_pkg)
+    _mod.__path__ = [str(_src / _pkg.replace(".", "/"))]
+    _mod.__package__ = _pkg
+    sys.modules[_pkg] = _mod
+
+if "Ankimon" in sys.modules and "Ankimon.functions" in sys.modules:
+    setattr(sys.modules["Ankimon"], "functions", sys.modules["Ankimon.functions"])
+
+sys.modules["aqt"] = MagicMock()
+sys.modules["aqt.qt"] = MagicMock()
+sys.modules["aqt.utils"] = MagicMock()
+
+from Ankimon.functions.battle_functions import validate_pokemon_status
+
+class MockPokemon:
+    def __init__(self, hp, battle_status):
+        self.hp = hp
+        self.battle_status = battle_status
+
+def test_validate_pokemon_status_fainted_hp_0():
+    poke = MockPokemon(0, "fighting")
+    assert validate_pokemon_status(poke) == "fainted"
+
+def test_validate_pokemon_status_healed():
+    poke = MockPokemon(50, "fainted")
+    assert validate_pokemon_status(poke) == "fighting"
+
+def test_validate_pokemon_status_normal():
+    poke = MockPokemon(50, "fighting")
+    assert validate_pokemon_status(poke) == "fighting"

--- a/tests/test_battle_functions.py
+++ b/tests/test_battle_functions.py
@@ -20,18 +20,22 @@ sys.modules["aqt.utils"] = MagicMock()
 
 from Ankimon.functions.battle_functions import validate_pokemon_status
 
+
 class MockPokemon:
     def __init__(self, hp, battle_status):
         self.hp = hp
         self.battle_status = battle_status
 
+
 def test_validate_pokemon_status_fainted_hp_0():
     poke = MockPokemon(0, "fighting")
     assert validate_pokemon_status(poke) == "fainted"
 
+
 def test_validate_pokemon_status_healed():
     poke = MockPokemon(50, "fainted")
     assert validate_pokemon_status(poke) == "fighting"
+
 
 def test_validate_pokemon_status_normal():
     poke = MockPokemon(50, "fighting")


### PR DESCRIPTION
Fixes a bug where a Pokémon is stuck with the "fainted" battle status, preventing it from attacking, even though its HP is greater than 0. 

A test case has been added in `tests/test_battle_functions.py` to ensure that healing a Pokémon restores its status from `"fainted"` back to `"fighting"`.

---
*PR created automatically by Jules for task [8983221886811240380](https://jules.google.com/task/8983221886811240380) started by @h0tp-ftw*