### PR TITLE
fix(bag): show trade-with-item evolutions in the web Pokemon picker

### DIFF
--- a/src/Ankimon/ankimon_items_web/shop_obj.py
+++ b/src/Ankimon/ankimon_items_web/shop_obj.py
@@ -1935,7 +1935,14 @@ class AnkimonItemsWeb(QDialog):
                         normalized_target = target_evo_name.lower().replace(" ", "").replace("-", "").replace("'", "").replace(".", "").replace(":", "")
                         target_data = pokedex_data.get(normalized_target) or pokedex_data.get(target_evo_name.lower())
 
-                        if target_data and target_data.get("evoType") == "useItem":
+                        if target_data and target_data.get("evoType") in ("useItem", "trade"):
+                            # "trade" belongs here alongside "useItem": Ankimon has no
+                            # trading, so the trade-with-held-item species (Rhydon ->
+                            # Rhyperior via Protector, Onix -> Steelix via Metal Coat,
+                            # Seadra -> Kingdra via Dragon Scale, ...) are evolved by
+                            # applying the item directly. Omitting it hid every one of
+                            # them from this picker, which shop.js filters to e === 1.
+                            #
                             # Normalize both sides by stripping spaces, hyphens and
                             # apostrophes so pokedex.json display names (e.g.
                             # "King's Rock") match items.csv identifiers (e.g.

--- a/tests/test_web_bag_trade_evolutions.py
+++ b/tests/test_web_bag_trade_evolutions.py
@@ -1,0 +1,208 @@
+"""Regression: the web bag's Pokemon picker must offer trade-with-item evolutions.
+
+The trap this guards against: ``AnkimonItemsWeb.get_pokemon_choices`` re-implements
+the evolution-eligibility test inline (deliberately — it runs per-Pokemon and must
+stay free of file I/O) instead of calling ``check_evolution_by_item``. The two
+copies drifted: the canonical helper accepts ``evoType`` in ``("useItem", "trade")``
+while the picker's copy only accepted ``"useItem"``, even though the comment above
+it claims to mirror the canonical logic.
+
+``shop.js`` filters the picker to ``c.e === 1`` for evolution items, so an unflagged
+Pokemon does not merely sort lower — it vanishes from the list. That made every
+trade-with-held-item evolution unusable from the bag (reported as "Rhydon doesn't
+appear when I click the Protector"), while the Protector itself was still consumed
+and refunded, so the item looked broken rather than the picker.
+
+The final test pins the two implementations to each other, so a future edit to one
+that is not mirrored in the other fails here rather than in a player's save.
+"""
+
+import importlib
+import json
+import sys
+import types
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+_SRC = Path(__file__).parent.parent / "src"
+_POKEDEX = json.loads(
+    (_SRC / "Ankimon" / "data_files" / "pokedex.json").read_text(encoding="utf-8")
+)
+
+
+def _normalize(name):
+    """Strip the punctuation that separates pokedex display names from keys."""
+    return (
+        (name or "")
+        .lower()
+        .replace(" ", "")
+        .replace("-", "")
+        .replace("'", "")
+        .replace(".", "")
+        .replace(":", "")
+    )
+
+
+def _trade_item_species():
+    """Every plain-form species that evolves from a trade-with-held-item.
+
+    Read out of the real ``pokedex.json`` rather than hard-coded, so a data update
+    that adds one automatically widens the sweep. Regional forms are skipped: their
+    eligibility depends on ``misc.active_region``, which is a separate branch.
+    """
+    cases = []
+    for evo_key, evo in _POKEDEX.items():
+        if evo.get("evoType") != "trade" or not evo.get("evoItem"):
+            continue
+        if evo.get("evoRegion"):
+            continue
+        prevo = _POKEDEX.get(_normalize(evo.get("prevo")))
+        if not prevo:
+            continue
+        prevo_id = prevo.get("actual_id") or prevo.get("species_id")
+        # pokedex.json spells items for display ("Deep Sea Scale", "King's Rock");
+        # the bag passes items.csv identifiers ("deep-sea-scale", "kings-rock").
+        item_identifier = evo["evoItem"].lower().replace("'", "").replace(" ", "-")
+        cases.append(
+            pytest.param(prevo.get("name"), prevo_id, item_identifier, id=f"{evo_key}")
+        )
+    return cases
+
+
+TRADE_ITEM_SPECIES = _trade_item_species()
+
+
+@pytest.fixture(scope="module")
+def shop_obj():
+    """Import the real web-shell host once, headlessly.
+
+    Only the package stubs conftest already installs are needed; everything else
+    (pokedex cache, items.csv, the CP formula) is loaded for real so the test
+    exercises the shipped data. No mock is left in ``sys.modules``: the module
+    imported here is the genuine one, and the ``services`` seam is swapped
+    per-test with an auto-reverting ``patch.object``.
+    """
+    for pkg in (
+        "Ankimon",
+        "Ankimon.functions",
+        "Ankimon.pyobj",
+        "Ankimon.ankimon_items_web",
+    ):
+        mod = sys.modules.get(pkg)
+        if mod is None or not hasattr(mod, "__path__"):
+            mod = types.ModuleType(pkg)
+            mod.__path__ = [str(_SRC / pkg.replace(".", "/"))]
+            mod.__package__ = pkg
+            sys.modules[pkg] = mod
+    try:
+        return importlib.import_module("Ankimon.ankimon_items_web.shop_obj")
+    except Exception as e:  # pragma: no cover - environment guard
+        pytest.skip(f"web-shell host not importable headlessly: {e}")
+
+
+class _StubHost:
+    """The slice of ``AnkimonItemsWeb`` that ``get_pokemon_choices`` actually reads.
+
+    Calling the method unbound against this avoids constructing a QDialog (and a
+    QWebEngineView) for what is a pure data transform.
+    """
+
+    _pokemon_choices_cache = None
+    item_window = None  # no active Pokemon; nothing gets the "m" flag
+
+    def _categorize(self, item_name, is_tm):
+        return "evolution"
+
+
+def _stub_services(rows):
+    class _DB:
+        @staticmethod
+        def get_all_pokemon():
+            return rows
+
+    class _Services:
+        db = _DB
+        settings = None  # -> no active region
+        logger = None
+
+    return _Services
+
+
+def _pokemon(name, pokedex_id):
+    """A collection row with the fields the picker reads (and nothing else)."""
+    return {
+        "individual_id": f"iid-{name}-{pokedex_id}",
+        "id": pokedex_id,
+        "name": name,
+        "nickname": "",
+        "level": 40,
+        "base_stats": {"hp": 50, "atk": 50, "def": 50, "spa": 50, "spd": 50, "spe": 50},
+        "iv": {},
+        "ev": {},
+    }
+
+
+def _choices(shop_obj, rows, item_name):
+    with patch.object(shop_obj, "services", _stub_services(rows)):
+        result = shop_obj.AnkimonItemsWeb.get_pokemon_choices(_StubHost(), item_name)
+    return {c["id"]: c for c in result["choices"]}
+
+
+def test_rhydon_is_offered_the_protector(shop_obj):
+    """The reported bug: Rhydon + Protector, the picker's list came back empty."""
+    rhydon = _pokemon("Rhydon", 112)
+    choices = _choices(shop_obj, [rhydon], "protector")
+
+    assert choices[rhydon["individual_id"]].get("e") == 1
+
+
+def test_use_item_evolutions_are_still_offered(shop_obj):
+    """The other branch of the predicate must keep working (Gloom + Leaf Stone)."""
+    gloom = _pokemon("gloom", 44)
+    choices = _choices(shop_obj, [gloom], "leaf-stone")
+
+    assert choices[gloom["individual_id"]].get("e") == 1
+
+
+def test_wrong_item_is_not_offered(shop_obj):
+    """Eligibility is still per-item: Rhydon does not evolve with a Leaf Stone."""
+    rhydon = _pokemon("Rhydon", 112)
+    choices = _choices(shop_obj, [rhydon], "leaf-stone")
+
+    assert "e" not in choices[rhydon["individual_id"]]
+
+
+def test_species_without_an_item_evolution_is_not_offered(shop_obj):
+    """A Pokemon with no item evolution at all stays unflagged."""
+    pikachu = _pokemon("pikachu", 25)
+    choices = _choices(shop_obj, [pikachu], "protector")
+
+    assert "e" not in choices[pikachu["individual_id"]]
+
+
+@pytest.mark.parametrize("prevo_name,prevo_id,item_identifier", TRADE_ITEM_SPECIES)
+def test_picker_agrees_with_canonical_helper(
+    shop_obj, prevo_name, prevo_id, item_identifier
+):
+    """Both implementations must accept every trade-with-item evolution.
+
+    Ankimon has no trading, so these species are evolved by applying the held item
+    directly — ``check_evolution_by_item`` has always resolved them. Asserting the
+    picker against the helper (rather than against a hard-coded list) is what makes
+    a future one-sided edit fail here.
+    """
+    item_id = shop_obj.return_id_for_item_name(item_identifier)
+    assert item_id, f"{item_identifier} is missing from items.csv"
+
+    assert shop_obj.check_evolution_by_item(prevo_id, item_id), (
+        f"canonical helper no longer resolves {prevo_name} + {item_identifier}"
+    )
+
+    mon = _pokemon(prevo_name, prevo_id)
+    choices = _choices(shop_obj, [mon], item_identifier)
+
+    assert choices[mon["individual_id"]].get("e") == 1, (
+        f"web bag picker hides {prevo_name} when using {item_identifier}"
+    )


### PR DESCRIPTION
### Description

**Symptom (player report):** "I got the refund, but there is no Rhyperior in my collection and Rhydon doesn't appear in the list of Pokémon available to evolve when I click on the Protector in my bag."

**Root cause.** The web bag's Pokémon picker re-implements the evolution-eligibility test inline in `AnkimonItemsWeb.get_pokemon_choices` — deliberately, since it runs per-Pokémon and must stay free of file I/O — rather than calling `check_evolution_by_item`. The two copies drifted:

| | accepted `evoType` |
|---|---|
| `functions/pokedex_functions.py` (canonical) | `("useItem", "trade")` |
| `ankimon_items_web/shop_obj.py` (picker) | `"useItem"` only |

...and the picker's copy sits under a comment that claims it "Mirrors the canonical logic in functions/pokedex_functions.py".

Rhyperior is `evoType: "trade"` / `evoItem: "Protector"`, so Rhydon never got `entry["e"] = 1`. `shop.js` filters the picker to `choices.filter((c) => c.e === 1)` for evolution items, so an unflagged Pokémon doesn't merely sort lower — it **disappears** from the list. The item was still consumed and refunded normally, which is why this reads as a broken item rather than a broken picker.

**Blast radius.** Every trade-with-held-item evolution, web bag only — 16 species: Rhyperior, Steelix, Scizor, Kingdra, Politoed, Slowking, Porygon2, Porygon-Z, Milotic, Huntail, Gorebyss, Electivire, Magmortar, Dusknoir, Aromatisse, Slurpuff. Ankimon has no trading, so these are meant to be evolved by applying the item directly — which `check_evolution_by_item` has always done; only the picker disagreed.

**Fix.** One line: accept `"trade"` alongside `"useItem"`, matching the canonical helper. `shop.js` is left alone — the `e === 1` filter is correct once the backend sets the flag.

### Tests

`tests/test_web_bag_trade_evolutions.py` (new, 20 cases). Four focused cases (Rhydon + Protector; Gloom + Leaf Stone so the `useItem` branch stays pinned; Rhydon + Leaf Stone and Pikachu + Protector as negatives), plus a sweep that asserts the picker against `check_evolution_by_item` for **every** trade-with-item species read out of the real `pokedex.json` — so a future one-sided edit to either copy fails in CI rather than in a player's save.

- Without the fix: **17 failed, 3 passed**
- With the fix: **20 passed**
- Full suite: **761 passed, 60 skipped** (`pytest tests/`, offscreen Qt)

The picker is exercised by calling `get_pokemon_choices` unbound against a small stub host, so no QDialog/QWebEngineView is constructed; the pokedex, `items.csv` and the CP formula are all loaded for real.

### Related Issue

<!-- none filed; reported directly by a player -->

### Follow-up (not in this PR)

The inline copy is a standing drift hazard. Extracting the shared predicate (e.g. `eligible_item_evolutions(evo_list, item_name, active_region)`) so both call sites use one implementation would remove the class of bug entirely, but it rewrites the canonical function that the location/regional evolution tests depend on — better as its own reviewable change than bundled with a one-line fix.

### Checklist
- [x] My code follows the code style and guidelines of this project.
- [x] I have run tests locally (`pytest tests/` and `pytest tests/test_addon_integrity.py`) and they all pass.
- [ ] **(Optional)** I have added/updated my entry in `.all-contributorsrc` at the root of the repository to specify my custom `"nickname"` and `"discord_id"` for release announcements and Discord pings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
