### PR TITLE
fix(ui): unhide evolution requirement text in details panel

### DIFF
--- a/src/Ankimon/gui_classes/pokemon_details.py
+++ b/src/Ankimon/gui_classes/pokemon_details.py
@@ -396,12 +396,11 @@ def PokemonCollectionDetailsSplit(
         attacks_label.setFixedWidth(230)
         attacks_label.setFixedHeight(80)
 
-        # Friendship-evolution UI (classic single-panel path): an actionable
-        # "Evolve now" button when the Pokémon is ready, otherwise the
-        # requirement line (e.g. "40 friendship to evolve into Espeon · needs
-        # Day"). Only shown when relevant, and only when the caller did not
-        # supply its own trigger_evo_callback (which renders the button in the
-        # right-hand column instead).
+        # Evolution UI: show the requirement line whenever the Pokémon is not
+        # ready (e.g. "40 friendship to evolve into Espeon · needs Day").
+        # When ready, the classic path renders its own "Evolve now" button only
+        # if the caller did not supply trigger_evo_callback; callback callers
+        # render their evolve button in the right-hand column instead.
         evolution_req_widget = None
         # A secondary note shown alongside the Evolve button when the user
         # previously rejected this evolution (soft state) — the manual button

--- a/src/Ankimon/gui_classes/pokemon_details.py
+++ b/src/Ankimon/gui_classes/pokemon_details.py
@@ -414,8 +414,8 @@ def PokemonCollectionDetailsSplit(
         show_evolution_ui = readiness["method"] is not None and (
             readiness["method"] != "friendship" or friendship_time_enabled
         )
-        if trigger_evo_callback is None:
-            if show_evolution_ui and readiness["ready"]:
+        if show_evolution_ui:
+            if trigger_evo_callback is None and readiness["ready"]:
                 evo_name = readiness["evo_name"] or "the next form"
                 evolve_now_button = QPushButton(f"✨ Evolve into {evo_name} now")
                 evolve_now_button.setFont(custom_font)
@@ -451,7 +451,7 @@ def PokemonCollectionDetailsSplit(
                     evolution_note_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
                     evolution_note_label.setStyleSheet("color: #FF69B4;")
                     evolution_note_widget = evolution_note_label
-            elif show_evolution_ui and readiness["status_text"]:
+            elif not readiness["ready"] and readiness["status_text"]:
                 evolution_req_label = QLabel(readiness["status_text"])
                 evolution_req_label.setFont(custom_font)
                 evolution_req_label.setWordWrap(True)

--- a/tests/test_pokemon_details_gui.py
+++ b/tests/test_pokemon_details_gui.py
@@ -533,6 +533,37 @@ def test_status_text_requirement_line_is_shown_when_not_ready(details):
     assert any("40 friendship to evolve into Raichu" in t for t in _labels(header))
 
 
+@pytest.mark.parametrize(
+    ("method", "status_text"),
+    [
+        ("friendship", "40 friendship to evolve into Raichu"),
+        ("level", "Evolves into Raichu at Lv20"),
+    ],
+)
+def test_callback_path_keeps_requirement_text_when_not_ready(
+    details, method, status_text
+):
+    """A caller-owned evolve button must not suppress unmet requirements."""
+    details._test_readiness.update(
+        {
+            "evolvable": True,
+            "ready": False,
+            "method": method,
+            "evo_id": 26,
+            "evo_name": "Raichu",
+            "status_text": status_text,
+        }
+    )
+    header, _, _, _ = details.PokemonCollectionDetailsSplit(
+        **_details_kwargs(trigger_evo_callback=lambda method: None)
+    )
+
+    assert status_text in _labels(header)
+    assert not any(
+        b.objectName() == "evolveNowButton" for b in _buttons(header)
+    )
+
+
 def test_callback_path_renders_button_and_invokes_callback(details):
     _make_ready(details, method="level")
     calls = []


### PR DESCRIPTION
Resolves a bug where the PC Box Pokémon details panel failed to display the friendship or level requirements if the `trigger_evo_callback` was passed. This re-enables the UI element that says "X friendship to evolve into Y".

---
*PR created automatically by Jules for task [2244677053842829066](https://jules.google.com/task/2244677053842829066) started by @h0tp-ftw*