### PR TITLE
fix(db): ensure boolean config values are saved and loaded correctly

### DIFF
--- a/src/Ankimon/pyobj/database_manager.py
+++ b/src/Ankimon/pyobj/database_manager.py
@@ -1540,7 +1540,10 @@ class AnkimonDB:
     def set_config_value(self, key: str, value: Any):
         """Sets a config key-value pair."""
         # Store as JSON string to preserve type information
-        str_value = json.dumps(value) if isinstance(value, (dict, list, bool)) else str(value)
+        if isinstance(value, bool):
+            str_value = "true" if value else "false"
+        else:
+            str_value = json.dumps(value) if isinstance(value, (dict, list)) else str(value)
         
         conn = self._get_connection()
         cursor = conn.cursor()
@@ -1559,8 +1562,14 @@ class AnkimonDB:
             val = row["value"]
             # Try to parse as JSON, fallback to string
             try:
-                return json.loads(val)
+                parsed = json.loads(val)
+                return parsed
             except:
+                if isinstance(val, str):
+                    if val.lower() == 'true':
+                        return True
+                    elif val.lower() == 'false':
+                        return False
                 return val
         return default
 
@@ -1574,15 +1583,26 @@ class AnkimonDB:
             try:
                 result[key] = json.loads(val)
             except:
-                result[key] = val
+                if isinstance(val, str):
+                    if val.lower() == 'true':
+                        result[key] = True
+                    elif val.lower() == 'false':
+                        result[key] = False
+                    else:
+                        result[key] = val
+                else:
+                    result[key] = val
         return result
 
     def save_all_config(self, config_dict: Dict[str, Any]):
-        """Bulk saves a config dictionary to the database."""
+        """Saves all config settings from a dictionary."""
         conn = self._get_connection()
         cursor = conn.cursor()
         for key, value in config_dict.items():
-            str_value = json.dumps(value) if isinstance(value, (dict, list, bool)) else str(value)
+            if isinstance(value, bool):
+                str_value = "true" if value else "false"
+            else:
+                str_value = json.dumps(value) if isinstance(value, (dict, list)) else str(value)
             cursor.execute(
                 "INSERT OR REPLACE INTO config (key, value) VALUES (?, ?)",
                 (key, str_value)
@@ -1594,7 +1614,10 @@ class AnkimonDB:
         """Upsert a SINGLE config key (incremental). Avoids rewriting all ~60 config
         rows on every Settings.set — the battle loop awards cash per review, so the
         old save_all_config path rewrote the whole table dozens of times per battle."""
-        str_value = json.dumps(value) if isinstance(value, (dict, list, bool)) else str(value)
+        if isinstance(value, bool):
+            str_value = "true" if value else "false"
+        else:
+            str_value = json.dumps(value) if isinstance(value, (dict, list)) else str(value)
         conn = self._get_connection()
         conn.execute(
             "INSERT OR REPLACE INTO config (key, value) VALUES (?, ?)",

--- a/src/Ankimon/pyobj/database_manager.py
+++ b/src/Ankimon/pyobj/database_manager.py
@@ -1537,23 +1537,6 @@ class AnkimonDB:
 
     # --- Config Operations (replaces config.obf) ---
 
-    def set_config_value(self, key: str, value: Any):
-        """Sets a config key-value pair."""
-        # Store as JSON string to preserve type information
-        if isinstance(value, bool):
-            str_value = "true" if value else "false"
-        else:
-            str_value = json.dumps(value) if isinstance(value, (dict, list)) else str(value)
-        
-        conn = self._get_connection()
-        cursor = conn.cursor()
-        cursor.execute(
-            "INSERT OR REPLACE INTO config (key, value) VALUES (?, ?)",
-            (key, str_value)
-        )
-        conn.commit()
-        return True
-
     def get_config_value(self, key: str, default: Any = None) -> Any:
         """Retrieves a config value by key."""
         cursor = self.execute("SELECT value FROM config WHERE key = ?", (key,))
@@ -1562,10 +1545,12 @@ class AnkimonDB:
             val = row["value"]
             # Try to parse as JSON, fallback to string
             try:
-                parsed = json.loads(val)
-                return parsed
-            except:
-                if isinstance(val, str):
+                return json.loads(val)
+            except (json.JSONDecodeError, TypeError):
+                from .settings import DEFAULT_CONFIG
+
+                # Legacy Python boolean spellings only apply to boolean settings.
+                if isinstance(DEFAULT_CONFIG.get(key), bool) and isinstance(val, str):
                     if val.lower() == 'true':
                         return True
                     elif val.lower() == 'false':
@@ -1582,8 +1567,10 @@ class AnkimonDB:
             val = row["value"]
             try:
                 result[key] = json.loads(val)
-            except:
-                if isinstance(val, str):
+            except (json.JSONDecodeError, TypeError):
+                from .settings import DEFAULT_CONFIG
+
+                if isinstance(DEFAULT_CONFIG.get(key), bool) and isinstance(val, str):
                     if val.lower() == 'true':
                         result[key] = True
                     elif val.lower() == 'false':

--- a/tests/test_settings_init_order.py
+++ b/tests/test_settings_init_order.py
@@ -222,3 +222,78 @@ def test_setting_save_persists_to_db_when_gate_open(isolated_env):
     cfg = db2.get_all_config()
     assert cfg["misc.gen9"] is True
     assert cfg["controls.allow_to_choose_moves"] is True
+
+
+@pytest.mark.parametrize("writer", ["single", "bulk"])
+@pytest.mark.parametrize("reader", ["single", "bulk", "settings"])
+def test_boolean_like_text_remains_text(isolated_env, writer, reader):
+    """Boolean recovery must not change names or credentials into toggles."""
+    env = isolated_env
+    db = env["db_mod"].AnkimonDB()
+    values = {
+        "trainer.name": "False",
+        "trainer.sprite": "True",
+        "leaderboard.username": "TRUE",
+        "leaderboard.api_key": "FALSE",
+        "extension.custom_text": "fAlSe",
+        "battle.daily_average": "False",
+    }
+    try:
+        if writer == "single":
+            for key, value in values.items():
+                db.set_config_value(key, value)
+        else:
+            db.save_all_config(values)
+
+        if reader == "single":
+            actual = {key: db.get_config_value(key) for key in values}
+        elif reader == "bulk":
+            actual = db.get_all_config()
+        else:
+            env["services"].db = db
+            actual = env["settings_mod"].Settings().config
+
+        for key, value in values.items():
+            assert actual[key] == value, key
+            assert isinstance(actual[key], str), key
+    finally:
+        db.close()
+
+
+@pytest.mark.parametrize(
+    "stored, expected",
+    [("False", False), ("TRUE", True), ("fAlSe", False), ("TrUe", True)],
+)
+def test_legacy_boolean_settings_load_as_booleans(isolated_env, stored, expected):
+    env = isolated_env
+    db = env["db_mod"].AnkimonDB()
+    key = "gui.pop_up_dialog_message_on_defeat"
+    try:
+        with db._get_connection() as conn:
+            conn.execute("INSERT INTO config (key, value) VALUES (?, ?)", (key, stored))
+
+        assert db.get_config_value(key) is expected
+        assert db.get_all_config()[key] is expected
+        env["services"].db = db
+        assert env["settings_mod"].Settings().get(key) is expected
+    finally:
+        db.close()
+
+
+@pytest.mark.parametrize("writer", ["single", "bulk"])
+@pytest.mark.parametrize("value", [True, False])
+def test_boolean_config_writes_json_booleans(isolated_env, writer, value):
+    db = isolated_env["db_mod"].AnkimonDB()
+    key = "gui.pop_up_dialog_message_on_defeat"
+    try:
+        if writer == "single":
+            db.set_config_value(key, value)
+        else:
+            db.save_all_config({key: value})
+
+        with db.execute("SELECT value FROM config WHERE key = ?", (key,)) as cursor:
+            assert cursor.fetchone()["value"] == ("true" if value else "false")
+        assert db.get_config_value(key) is value
+        assert db.get_all_config()[key] is value
+    finally:
+        db.close()


### PR DESCRIPTION
Legacy boolean settings stored as Python-style strings such as `"False"` can leave options such as “Pop-Up on Defeat” enabled. Recover those values only for keys with boolean defaults, and serialize newly saved booleans as JSON `true`/`false`.

Both config readers preserve text such as `trainer.name="False"` and `leaderboard.username="TRUE"`. Remove the shadowed setter while retaining the active incremental implementation. Regression tests cover both writers, both readers, `Settings.load_config()`, and legacy boolean recovery.

Validation: 824 passed / 60 skipped in the full pytest suite, all nine Tier-1 harness checks passed, and Ruff passed. Six string-preservation regression cases failed before the fix and passed afterward.

---
*PR created automatically by Jules for task [3411234619816673163](https://jules.google.com/task/3411234619816673163) started by @h0tp-ftw*
