### PR TITLE
fix(migration): handle flat string arrays in legacy items.json during DB initialization

### DIFF
--- a/src/Ankimon/pyobj/database_manager.py
+++ b/src/Ankimon/pyobj/database_manager.py
@@ -1695,10 +1695,19 @@ class AnkimonDB:
                     for item in items_list:
                         if not item: continue
                         # Support multiple legacy keys for item name
-                        item_name = item.get("item") or item.get("name") or item.get("item_name")
-                        quantity = item.get("quantity", item.get("amount", 1))
+                        if isinstance(item, str):
+                            item_name = item
+                            quantity = 1
+                            extra_data = None
+                        elif isinstance(item, dict):
+                            item_name = item.get("item") or item.get("name") or item.get("item_name")
+                            quantity = item.get("quantity", item.get("amount", 1))
+                            extra_data = item
+                        else:
+                            continue
+
                         if item_name:
-                            if self.add_item(item_name, quantity, extra_data=item, commit=False):
+                            if self.add_item(item_name, quantity, extra_data=extra_data, commit=False):
                                 stats["items"] += 1
                     
                     self._get_connection().commit()


### PR DESCRIPTION
Fixes an issue where users migrating from older versions of Ankimon would crash during the database initialization step. Legacy `items.json` files saved items as a flat array of strings (`["item1", "item2"]`). While this was fixed in `migration_dialog.py`, the same bug persisted in `database_manager.py`'s fallback migration code, resulting in an `AttributeError: 'str' object has no attribute 'get'`. 

This patch updates `database_manager.py` to properly use `isinstance()` checks before looking up attributes, matching the fix applied elsewhere.

---
*PR created automatically by Jules for task [2057252859931832774](https://jules.google.com/task/2057252859931832774) started by @h0tp-ftw*