### PR TITLE
fix(migration): support legacy string item names in database migration

### DIFF
--- a/src/Ankimon/pyobj/database_manager.py
+++ b/src/Ankimon/pyobj/database_manager.py
@@ -1694,11 +1694,21 @@ class AnkimonDB:
                     
                     for item in items_list:
                         if not item: continue
-                        # Support multiple legacy keys for item name
-                        item_name = item.get("item") or item.get("name") or item.get("item_name")
-                        quantity = item.get("quantity", item.get("amount", 1))
+
+                        if isinstance(item, str):
+                            item_name = item
+                            quantity = 1
+                            extra_data = None
+                        elif isinstance(item, dict):
+                            # Support multiple legacy keys for item name
+                            item_name = item.get("item") or item.get("name") or item.get("item_name")
+                            quantity = item.get("quantity", item.get("amount", 1))
+                            extra_data = item
+                        else:
+                            continue
+
                         if item_name:
-                            if self.add_item(item_name, quantity, extra_data=item, commit=False):
+                            if self.add_item(item_name, quantity, extra_data=extra_data, commit=False):
                                 stats["items"] += 1
                     
                     self._get_connection().commit()


### PR DESCRIPTION
Older versions of Ankimon saved item inventory (in `items.json`) as a flat list of strings (e.g. `["poke-ball", "potion"]`). The recent migration scripts inside `database_manager.py` assumed these elements were dictionaries and tried calling `.get()`, resulting in an `AttributeError`.

This patch adds explicit `isinstance(item, str)` type checking logic to the `items.json` migration loop to ensure these strings are safely converted to the expected dictionary format during database migration.

---
*PR created automatically by Jules for task [13343366215602083729](https://jules.google.com/task/13343366215602083729) started by @h0tp-ftw*