### PR TITLE
fix(gui): correctly update HUD HP bar when switching main pokemon

### DIFF
--- a/src/Ankimon/pyobj/collection_dialog.py
+++ b/src/Ankimon/pyobj/collection_dialog.py
@@ -122,6 +122,12 @@ def MainPokemon(
 
     reviewer = Container()
     reviewer.web = mw.reviewer.web
+
+    # Update the cached main_pokemon reference inside reviewer_obj so the HUD draws the new pokemon
+    reviewer_obj.main_pokemon = main_pokemon
+
+    # Invalidate cache and trigger a fresh render
+    reviewer_obj.invalidate_hud_cache()
     reviewer_obj.update_life_bar(reviewer, 0, 0)
 
     if test_window.isVisible():

--- a/src/Ankimon/pyobj/collection_dialog.py
+++ b/src/Ankimon/pyobj/collection_dialog.py
@@ -18,6 +18,37 @@ from ..pyobj.test_window import TestWindow
 from ..pyobj.reviewer_obj import Reviewer_Manager
 from ..functions.pokedex_functions import search_pokedex, search_pokedex_by_id
 
+
+def _resolve_persisted_hp(pokemon_data):
+    """Return the first HP field that survives integer conversion, else ``None``.
+
+    Mirrors ``update_main_pokemon._normalize_loaded_hp`` -- the function that
+    reads this row back at the next Anki launch -- so the switch path and the
+    load path agree on which stored field wins. Keep the two in sync.
+
+    A field is only usable once it converts to ``int``: a malformed
+    ``current_hp`` (``"??"``, ``{}``, ``float("nan")``) must fall through to a
+    valid ``hp`` rather than being handed to the constructor, where
+    ``PokemonObject._normalize_hp`` would silently swap it for max HP and
+    ``db.save_main_pokemon()`` would persist that free full heal.
+
+    Only ``None`` is skipped without a conversion attempt -- ``0`` is a fainted
+    Pokemon and is a perfectly valid answer. Clamping to the Pokemon's range is
+    left to the constructor, which does it for both fields anyway. ``None`` here
+    means "neither field is usable"; the constructor then fills in max HP, which
+    is what ``_normalize_loaded_hp`` falls back to as well.
+    """
+    for candidate in (pokemon_data.get("current_hp"), pokemon_data.get("hp")):
+        if candidate is None:
+            continue
+        try:
+            return int(candidate)
+        except (TypeError, ValueError, OverflowError):
+            continue
+
+    return None
+
+
 def MainPokemon(
     pokemon_data: dict,
     main_pokemon: PokemonObject,
@@ -65,10 +96,10 @@ def MainPokemon(
     # Reading ``hp`` first would resurrect that stale value -- re-picking the
     # current main right after a win would still be a free heal, which is the
     # bug this whole change exists to remove. ``hp`` stays as the fallback for
-    # rows written before the mirror existed.
-    persisted_hp = pokemon_data.get("current_hp")
-    if persisted_hp is None:
-        persisted_hp = pokemon_data.get("hp")
+    # rows written before the mirror existed -- and it has to catch a
+    # *malformed* ``current_hp`` too, not just a missing one, hence
+    # _resolve_persisted_hp rather than a plain ``is None`` check.
+    persisted_hp = _resolve_persisted_hp(pokemon_data)
 
     # Create NEW PokemonObject instance using class constructor
     new_main_pokemon = PokemonObject(

--- a/src/Ankimon/pyobj/collection_dialog.py
+++ b/src/Ankimon/pyobj/collection_dialog.py
@@ -47,14 +47,24 @@ def MainPokemon(
     pokemon_id = pokemon_data.get("id")
     pokemon_name = search_pokedex_by_id(pokemon_id)
     base_stats = search_pokedex(pokemon_name, "baseStats")
-    current_hp = PokemonObject.calc_stat(
-        "hp",
-        base_stats["hp"],
-        pokemon_data["level"],
-        pokemon_data["iv"]["hp"],
-        pokemon_data["ev"]["hp"],
-        pokemon_data.get("nature", "serious"),
-    )
+    # HP: hand the constructor the PERSISTED values and let PokemonObject
+    # normalize them. Passing a freshly computed max-HP stat here (the old
+    # behaviour) silently full-healed the incoming main and, via
+    # db.save_main_pokemon(to_dict()) below, persisted that full HP.
+    #
+    # ``hp`` is the live field -- to_dict() labels it "Current HP", and
+    # battle_loop/item_window write it -- with ``current_hp`` as its mirror.
+    # Partially migrated records can carry one without the other (see
+    # update_main_pokemon._normalize_loaded_hp), so fall back to the mirror
+    # when ``hp`` is missing or null; otherwise _normalize_hp resolves a None
+    # ``hp`` to full max HP and we re-persist the very heal this fixes.
+    # Deliberately NOT _normalize_loaded_hp's current_hp-first order:
+    # item_window.Check_Heal_Item bumps ``hp`` alone, so preferring the mirror
+    # would silently undo a potion used just before the switch.
+    persisted_hp = pokemon_data.get("hp")
+    if persisted_hp is None:
+        persisted_hp = pokemon_data.get("current_hp")
+
     # Create NEW PokemonObject instance using class constructor
     new_main_pokemon = PokemonObject(
         name=pokemon_name,
@@ -67,12 +77,15 @@ def MainPokemon(
         attacks=pokemon_data.get("attacks", ["Struggle"]),
         base_experience=pokemon_data.get("base_experience", 0),
         growth_rate=pokemon_data.get("growth_rate", "medium"),
-        current_hp=current_hp,
+        # ``or`` not a get() default: a record holding an explicit null nature
+        # would otherwise reach get_nature_stat_mult() and blow up on None.lower().
+        nature=pokemon_data.get("nature") or "serious",
+        hp=persisted_hp,
+        current_hp=pokemon_data.get("current_hp"),
         gender=pokemon_data.get("gender", "N"),
         shiny=pokemon_data.get("shiny", False),
         individual_id=pokemon_data.get("individual_id", str(uuid.uuid4())),
         id=pokemon_data.get("id", 133),
-        status=pokemon_data.get("status", None),
         volatile_status=set(pokemon_data.get("volatile_status", [])),
         xp=pokemon_data.get("xp", 0),
         nickname=pokemon_data.get("nickname", ""),
@@ -80,6 +93,7 @@ def MainPokemon(
         friendship=pokemon_data.get("friendship", 0),
         pokemon_defeated=pokemon_data.get("pokemon_defeated", 0),
         everstone=pokemon_data.get("everstone", False),
+        evolution_rejected=pokemon_data.get("evolution_rejected", False),
         mega=pokemon_data.get("mega", False),
         special_form=pokemon_data.get("special_form", None),
         tier=pokemon_data.get("tier", None),
@@ -96,7 +110,6 @@ def MainPokemon(
         "everstone",
         "mega",
         "special_form",
-        "current_hp",
         "base_experience",
     ]
     for attr in extra_fields:
@@ -116,19 +129,14 @@ def MainPokemon(
         ),
     )
 
-    # Update UI components
-    class Container(object):
-        pass
-
-    reviewer = Container()
-    reviewer.web = mw.reviewer.web
-
-    # Update the cached main_pokemon reference inside reviewer_obj so the HUD draws the new pokemon
-    reviewer_obj.main_pokemon = main_pokemon
-
-    # Invalidate cache and trigger a fresh render
-    reviewer_obj.invalidate_hud_cache()
-    reviewer_obj.update_life_bar(reviewer, 0, 0)
+    # Update UI components. refresh_hud() is Reviewer_Manager's single entry
+    # point for a repaint: it builds the reviewer shim itself and is guarded, so
+    # no reviewer/webview is a silent no-op instead of an AttributeError that
+    # would abort the rest of this function. No extra bookkeeping is needed
+    # here: reviewer_obj.main_pokemon IS the object line above mutated in place,
+    # and db.save_main_pokemon() already invalidated the HUD cache via
+    # _clear_reviewer_ownership_cache().
+    reviewer_obj.refresh_hud()
 
     if test_window.isVisible():
         test_window.display_first_encounter()

--- a/src/Ankimon/pyobj/collection_dialog.py
+++ b/src/Ankimon/pyobj/collection_dialog.py
@@ -40,30 +40,35 @@ def MainPokemon(
         if main_pokemon is not None and getattr(main_pokemon, "individual_id", None) and db.get_main_pokemon():
             # Use main_pokemon.to_dict() to capture in-memory stats like xp.
             db.save_pokemon(main_pokemon.to_dict())
-    except Exception:
-        pass  # If no main pokemon exists, just continue
+    except Exception as exc:
+        # Keep going -- a failure here must not block the switch -- but do not
+        # swallow it silently: since the incoming main is no longer full-healed,
+        # this save is the only thing preserving the outgoing Pokemon's HP.
+        logger.log("error", f"Could not save outgoing main pokemon: {exc}")
 
     # --- Now proceed to set the new mainpokemon as before ---
     pokemon_id = pokemon_data.get("id")
     pokemon_name = search_pokedex_by_id(pokemon_id)
     base_stats = search_pokedex(pokemon_name, "baseStats")
-    # HP: hand the constructor the PERSISTED values and let PokemonObject
-    # normalize them. Passing a freshly computed max-HP stat here (the old
+    # HP: hand the constructor the PERSISTED value and let PokemonObject
+    # normalize it. Passing a freshly computed max-HP stat here (the old
     # behaviour) silently full-healed the incoming main and, via
     # db.save_main_pokemon(to_dict()) below, persisted that full HP.
     #
-    # ``hp`` is the live field -- to_dict() labels it "Current HP", and
-    # battle_loop/item_window write it -- with ``current_hp`` as its mirror.
-    # Partially migrated records can carry one without the other (see
-    # update_main_pokemon._normalize_loaded_hp), so fall back to the mirror
-    # when ``hp`` is missing or null; otherwise _normalize_hp resolves a None
-    # ``hp`` to full max HP and we re-persist the very heal this fixes.
-    # Deliberately NOT _normalize_loaded_hp's current_hp-first order:
-    # item_window.Check_Heal_Item bumps ``hp`` alone, so preferring the mirror
-    # would silently undo a potion used just before the switch.
-    persisted_hp = pokemon_data.get("hp")
+    # ``current_hp`` FIRST, matching update_main_pokemon._normalize_loaded_hp --
+    # the function that reads this row back at the next Anki launch. On a stored
+    # record ``current_hp`` is the authoritative field and ``hp`` is the one that
+    # goes stale, because every writer that refreshes a single key refreshes
+    # ``current_hp``: encounter_functions.save_main_pokemon_progress after each
+    # defeat, evolution_window when a Pokemon evolves, and the fossil/trade
+    # record builders, which emit ``current_hp`` with no ``hp`` key at all.
+    # Reading ``hp`` first would resurrect that stale value -- re-picking the
+    # current main right after a win would still be a free heal, which is the
+    # bug this whole change exists to remove. ``hp`` stays as the fallback for
+    # rows written before the mirror existed.
+    persisted_hp = pokemon_data.get("current_hp")
     if persisted_hp is None:
-        persisted_hp = pokemon_data.get("current_hp")
+        persisted_hp = pokemon_data.get("hp")
 
     # Create NEW PokemonObject instance using class constructor
     new_main_pokemon = PokemonObject(
@@ -80,8 +85,12 @@ def MainPokemon(
         # ``or`` not a get() default: a record holding an explicit null nature
         # would otherwise reach get_nature_stat_mult() and blow up on None.lower().
         nature=pokemon_data.get("nature") or "serious",
+        # One resolved value into BOTH fields. to_dict() persists them
+        # independently, so letting them diverge here writes a row whose two HP
+        # keys disagree, and whichever one _normalize_loaded_hp does not pick is
+        # silently discarded at the next launch.
         hp=persisted_hp,
-        current_hp=pokemon_data.get("current_hp"),
+        current_hp=persisted_hp,
         gender=pokemon_data.get("gender", "N"),
         shiny=pokemon_data.get("shiny", False),
         individual_id=pokemon_data.get("individual_id", str(uuid.uuid4())),
@@ -101,20 +110,16 @@ def MainPokemon(
         is_favorite=pokemon_data.get("is_favorite", False),
         held_item=pokemon_data.get("held_item"),
     )
-    # Set any additional fields not in constructor
-    extra_fields = [
-        "captured_date",
-        "tier",
-        "friendship",
-        "pokemon_defeated",
-        "everstone",
-        "mega",
-        "special_form",
-        "base_experience",
-    ]
-    for attr in extra_fields:
-        if attr in pokemon_data:
-            setattr(new_main_pokemon, attr, pokemon_data[attr])
+    # ``mega`` and ``special_form`` are the only fields the constructor does not
+    # assign -- they fall into **kwargs and are dropped -- so they have to be set
+    # here. Set them UNCONDITIONALLY: __dict__.update() below cannot clear an
+    # attribute that new_main_pokemon does not carry, so skipping the assignment
+    # for a record that lacks the key leaves the OUTGOING Pokemon's value on the
+    # object and save_main_pokemon() then writes it onto the INCOMING Pokemon's
+    # row. The six other fields this loop used to copy are all real constructor
+    # parameters, already assigned above from the same pokemon_data.
+    new_main_pokemon.mega = pokemon_data.get("mega", False)
+    new_main_pokemon.special_form = pokemon_data.get("special_form", None)
 
     # Update existing reference
     main_pokemon.__dict__.update(new_main_pokemon.__dict__)
@@ -131,10 +136,10 @@ def MainPokemon(
 
     # Update UI components. refresh_hud() is Reviewer_Manager's single entry
     # point for a repaint: it builds the reviewer shim itself and is guarded, so
-    # no reviewer/webview is a silent no-op instead of an AttributeError that
-    # would abort the rest of this function. No extra bookkeeping is needed
-    # here: reviewer_obj.main_pokemon IS the object line above mutated in place,
-    # and db.save_main_pokemon() already invalidated the HUD cache via
+    # no reviewer/webview is a silent no-op rather than an AttributeError on
+    # mw.reviewer.web. No extra bookkeeping is needed here:
+    # reviewer_obj.main_pokemon IS the object mutated in place above, and
+    # db.save_main_pokemon() already invalidated the HUD cache via
     # _clear_reviewer_ownership_cache().
     reviewer_obj.refresh_hud()
 

--- a/src/Ankimon/pyobj/item_window.py
+++ b/src/Ankimon/pyobj/item_window.py
@@ -607,6 +607,11 @@ class ItemWindow(QWidget):
         self.main_pokemon.hp += heal_points
         if self.main_pokemon.hp > (self.main_pokemon.max_hp):
             self.main_pokemon.hp = self.main_pokemon.max_hp
+        # Keep the persisted mirror in step. to_dict() writes ``hp`` and
+        # ``current_hp`` independently and update_main_pokemon
+        # ._normalize_loaded_hp reads ``current_hp`` first, so bumping ``hp``
+        # alone makes the heal disappear the next time this record is loaded.
+        self.main_pokemon.current_hp = self.main_pokemon.hp
         self.delete_item(item_name)
         play_effect_sound(self.settings_obj, "HpHeal")
         self.logger.log_and_showinfo("info", f"{prevo_name} was healed for {heal_points}")

--- a/tests/test_main_pokemon_switch_preserves_state.py
+++ b/tests/test_main_pokemon_switch_preserves_state.py
@@ -1,0 +1,419 @@
+"""Regression tests for ``pyobj/collection_dialog.py::MainPokemon`` (switch state).
+
+Switching the main Pokemon used to rebuild the incoming Pokemon with a freshly
+computed *max* HP stat and to drop ``nature`` / ``evolution_rejected`` on the
+floor.  Because the rebuilt object is then written straight back with
+``db.save_main_pokemon(main_pokemon.to_dict())``, the silent full-heal and the
+reset nature were *persisted* -- a free full restore on every PC-box swap.
+These pin the persisted round-trip, not just the in-memory object.
+
+``collection_dialog.py`` is loaded in isolation with its module-level Qt/aqt and
+sibling-window dependencies stubbed (mirroring ``test_pc_box_cp_migration.py``),
+except that the *real* ``pokemon_obj`` is installed because ``PokemonObject``'s
+HP normalisation is exactly what is under test (mirroring that file's use of the
+real ``business`` module).  Runs Qt-free in the Tier-1 env.
+"""
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+_SRC = Path(__file__).resolve().parent.parent / "src"
+_MODULE_NAME = "Ankimon.pyobj.collection_dialog"
+
+# A Pokemon whose max HP is comfortably above the fixtures' wounded HP, so a
+# silent full-heal is unmistakable.
+_BASE_STATS = {"hp": 106, "atk": 110, "def": 90, "spa": 154, "spd": 90, "spe": 130}
+
+
+class _MockResources:
+    """Path-returning stand-in for ``Ankimon.resources`` (any attr -> /tmp/<name>)."""
+
+    pokedex_path = _SRC / "Ankimon" / "data_files" / "pokedex.json"
+
+    def __getattr__(self, name):
+        return Path("/tmp") / name
+
+
+class _FakeDB:
+    """The ``mw.ankimon_db`` seam, recording what MainPokemon persists."""
+
+    def __init__(self, existing_main=None):
+        self._main = existing_main
+        self.saved_main = []
+        self.saved_party = []
+
+    def get_main_pokemon(self):
+        return self._main
+
+    def save_main_pokemon(self, data):
+        self._main = data
+        self.saved_main.append(data)
+
+    def save_pokemon(self, data):
+        self.saved_party.append(data)
+
+
+def _make_module(name, **attrs):
+    mod = types.ModuleType(name)
+    for key, value in attrs.items():
+        setattr(mod, key, value)
+    return mod
+
+
+def _force_load(name, filepath):
+    spec = importlib.util.spec_from_file_location(name, filepath)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture
+def collection_dialog():
+    """Load ``collection_dialog.py`` with a stubbed runtime + the real PokemonObject."""
+    parent_pkgs = ("Ankimon", "Ankimon.functions", "Ankimon.pyobj")
+
+    class _Stub:
+        def __init__(self, *a, **k):
+            pass
+
+    # to_dict() lazily computes CP via ``..business``; a functional stub keeps the
+    # round-trip cheap and independent of the CP formula.
+    business = MagicMock()
+    business.pokemon_go_raw_stats.return_value = (100, 100, 100)
+    business.calculate_pokemon_go_cp.return_value = 500
+
+    singletons = _make_module(
+        "Ankimon.singletons", pokemon_pc=MagicMock(name="pokemon_pc")
+    )
+
+    to_install = {
+        # Qt/aqt runtime: MagicMock modules satisfy `from PyQt6.QtWidgets import *`
+        # and `from aqt import mw` without a real Anki or a QApplication.
+        "aqt": _make_module("aqt", mw=MagicMock(name="mw")),
+        "aqt.utils": MagicMock(),
+        "PyQt6": MagicMock(),
+        "PyQt6.QtWidgets": MagicMock(),
+        "PyQt6.QtGui": MagicMock(),
+        "PyQt6.QtCore": MagicMock(),
+        # Sibling windows/services touched only by the type hints.
+        "Ankimon.pyobj.error_handler": _make_module(
+            "Ankimon.pyobj.error_handler", show_warning_with_traceback=MagicMock()
+        ),
+        "Ankimon.pyobj.InfoLogger": _make_module(
+            "Ankimon.pyobj.InfoLogger", ShowInfoLogger=_Stub
+        ),
+        "Ankimon.pyobj.translator": _make_module(
+            "Ankimon.pyobj.translator", Translator=_Stub
+        ),
+        "Ankimon.pyobj.test_window": _make_module(
+            "Ankimon.pyobj.test_window", TestWindow=_Stub
+        ),
+        "Ankimon.pyobj.reviewer_obj": _make_module(
+            "Ankimon.pyobj.reviewer_obj", Reviewer_Manager=_Stub
+        ),
+        "Ankimon.functions.pokedex_functions": _make_module(
+            "Ankimon.functions.pokedex_functions",
+            search_pokedex_by_id=lambda pkmn_id: "mewtwo",
+            search_pokedex=lambda name, key: dict(_BASE_STATS),
+        ),
+        # Imported (unused) at the top of MainPokemon's body.
+        "Ankimon.functions.migration": _make_module(
+            "Ankimon.functions.migration", migrate_starter_individual_id=MagicMock()
+        ),
+        # Imported at the very END of MainPokemon's body.
+        "Ankimon.singletons": singletons,
+        "Ankimon.business": business,
+        "Ankimon.resources": _MockResources(),
+        _MODULE_NAME: None,
+        "Ankimon.pyobj.pokemon_obj": None,
+    }
+    saved = {name: sys.modules.get(name) for name in (*to_install, *parent_pkgs)}
+
+    for pkg in parent_pkgs:
+        mod = types.ModuleType(pkg)
+        mod.__path__ = [str(_SRC / pkg.replace(".", "/"))]
+        mod.__package__ = pkg
+        sys.modules[pkg] = mod
+    for name, mod in to_install.items():
+        if mod is not None:
+            sys.modules[name] = mod
+
+    try:
+        # The real PokemonObject -- its HP normalisation is the subject.
+        pokemon_obj = _force_load(
+            "Ankimon.pyobj.pokemon_obj", _SRC / "Ankimon" / "pyobj" / "pokemon_obj.py"
+        )
+        module = _force_load(
+            _MODULE_NAME, _SRC / "Ankimon" / "pyobj" / "collection_dialog.py"
+        )
+        module._PokemonObject = pokemon_obj.PokemonObject
+        module._singletons = singletons
+        yield module
+    finally:
+        for name, val in saved.items():
+            if val is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = val
+
+
+def _stored_pokemon(**overrides):
+    """A PC-box row for the *incoming* main, wounded and mid-evolution-refusal."""
+    row = {
+        "id": 150,
+        "name": "mewtwo",
+        "nickname": "",
+        "level": 50,
+        "ability": "Pressure",
+        "type": ["Psychic"],
+        "gender": "N",
+        "growth_rate": "slow",
+        "base_experience": 306,
+        "attacks": ["psychic"],
+        "ev": {k: 0 for k in _BASE_STATS},
+        "iv": {k: 31 for k in _BASE_STATS},
+        "nature": "adamant",
+        "hp": 7,
+        "current_hp": 7,
+        "evolution_rejected": True,
+        "everstone": False,
+        "shiny": False,
+        "individual_id": "incoming-uuid",
+        "xp": 120,
+        "friendship": 70,
+        "pokemon_defeated": 3,
+        "tier": "Legendary",
+        "captured_date": None,
+        "is_favorite": False,
+        "held_item": None,
+    }
+    row.update(overrides)
+    return row
+
+
+def _call(module, stored, db=None):
+    """Drive MainPokemon against stubbed collaborators; return (main, db)."""
+    PokemonObject = module._PokemonObject
+    outgoing = PokemonObject(
+        name="pikachu", id=25, shiny=False, level=5, ability="Static",
+        type=["Electric"], gender="M", growth_rate="medium", captured_date=None,
+        tier="Normal", individual_id="outgoing-uuid", base_stats=dict(_BASE_STATS),
+    )
+    db = db or _FakeDB(existing_main=outgoing.to_dict())
+    module.mw.ankimon_db = db
+
+    logger = MagicMock()
+    translator = MagicMock()
+    translator.translate.return_value = "picked"
+    reviewer_obj = MagicMock()
+    test_window = MagicMock()
+    test_window.isVisible.return_value = False
+
+    module.MainPokemon(stored, outgoing, logger, translator, reviewer_obj, test_window)
+    return outgoing, db
+
+
+def test_switch_preserves_wounded_hp(collection_dialog):
+    """A wounded Pokemon is not silently full-healed by being made main."""
+    main, db = _call(collection_dialog, _stored_pokemon())
+
+    assert main.hp == 7
+    assert main.hp != main.max_hp, "the incoming main was full-healed"
+    assert db.saved_main, "the new main must be persisted"
+    assert db.saved_main[-1]["hp"] == 7
+    assert db.saved_main[-1]["current_hp"] == 7
+
+
+def test_switch_preserves_nature_and_evolution_rejected(collection_dialog):
+    """``nature`` and ``evolution_rejected`` survive the rebuild."""
+    main, db = _call(collection_dialog, _stored_pokemon())
+
+    assert main.nature == "adamant"
+    assert main.evolution_rejected is True
+    assert db.saved_main[-1]["nature"] == "adamant"
+    assert db.saved_main[-1]["evolution_rejected"] is True
+
+
+def test_hp_and_current_hp_stay_consistent(collection_dialog):
+    """Both HP fields agree and stay inside the valid range."""
+    main, db = _call(collection_dialog, _stored_pokemon())
+
+    assert main.hp == main.current_hp == 7
+    assert 0 <= main.hp <= main.max_hp
+    saved = db.saved_main[-1]
+    assert saved["hp"] == saved["current_hp"]
+
+
+def test_stale_hp_key_does_not_resurrect_a_full_heal(collection_dialog):
+    """``current_hp`` wins over a stale ``hp``.
+
+    ``encounter_functions.save_main_pokemon_progress`` refreshes only
+    ``current_hp`` on the main's row after every enemy defeat, leaving ``hp`` at
+    whatever it was when the row was last written whole.  Reading ``hp`` first
+    would hand that stale full-HP value back, so re-picking the current main as
+    main straight after a win would still be a free heal.
+    """
+    stored = _stored_pokemon(hp=181, current_hp=12)  # stale full HP / fresh live HP
+    main, db = _call(collection_dialog, stored)
+
+    assert main.hp == 12, "a stale ``hp`` key full-healed the incoming main"
+    assert main.current_hp == 12
+    assert db.saved_main[-1]["hp"] == 12
+    assert db.saved_main[-1]["current_hp"] == 12
+
+
+def test_stone_evolved_record_keeps_its_post_evolution_hp(collection_dialog):
+    """``evolution_window`` writes only ``current_hp`` when a Pokemon evolves.
+
+    Its row therefore carries the pre-evolution ``hp`` alongside the correct
+    post-evolution ``current_hp``.  Preferring ``hp`` would pin the evolved
+    Pokemon at its old, much smaller HP and then persist that.
+    """
+    stored = _stored_pokemon(hp=5, current_hp=160)
+    main, db = _call(collection_dialog, stored)
+
+    assert main.hp == 160
+    assert db.saved_main[-1]["hp"] == 160
+
+
+def test_persisted_hp_keys_never_disagree(collection_dialog):
+    """Whatever the row shape, the round-trip must not write a split record.
+
+    ``to_dict()`` persists ``hp`` and ``current_hp`` independently, so a
+    disagreement here is silently resolved -- in the other direction -- by
+    ``_normalize_loaded_hp`` at the next launch.
+    """
+    for row in (
+        _stored_pokemon(hp=181, current_hp=12),
+        _stored_pokemon(hp=5, current_hp=160),
+        _stored_pokemon(hp=None, current_hp=9),
+        _stored_pokemon(hp=9, current_hp=None),
+        _stored_pokemon(hp=0, current_hp=0),
+    ):
+        main, db = _call(collection_dialog, row)
+        saved = db.saved_main[-1]
+        assert saved["hp"] == saved["current_hp"] == main.hp
+        assert 0 <= main.hp <= main.max_hp
+
+
+def test_fainted_pokemon_stays_fainted(collection_dialog):
+    """0 HP must survive the switch rather than being read as a falsy miss."""
+    main, db = _call(collection_dialog, _stored_pokemon(hp=0, current_hp=0))
+
+    assert main.hp == 0
+    assert db.saved_main[-1]["hp"] == 0
+
+
+def test_special_form_does_not_leak_from_the_outgoing_main(collection_dialog):
+    """``mega``/``special_form`` are the only fields __init__ drops.
+
+    ``__dict__.update()`` cannot clear an attribute the new object never set, so
+    assigning them only when the key is present let the outgoing Pokemon's value
+    survive onto the incoming Pokemon -- and get persisted.
+    """
+    outgoing_kwargs = dict(
+        name="pikachu", id=25, shiny=False, level=5, ability="Static",
+        type=["Electric"], gender="M", growth_rate="medium", captured_date=None,
+        tier="Normal", individual_id="outgoing-uuid", base_stats=dict(_BASE_STATS),
+    )
+    PokemonObject = collection_dialog._PokemonObject
+    outgoing = PokemonObject(**outgoing_kwargs)
+    outgoing.mega = True
+    outgoing.special_form = "gmax"
+
+    db = _FakeDB(existing_main=outgoing.to_dict())
+    collection_dialog.mw.ankimon_db = db
+    test_window = MagicMock()
+    test_window.isVisible.return_value = False
+    stored = _stored_pokemon()
+    stored.pop("mega", None)
+    stored.pop("special_form", None)
+
+    collection_dialog.MainPokemon(
+        stored, outgoing, MagicMock(), MagicMock(), MagicMock(), test_window
+    )
+
+    assert outgoing.mega is False, "mega leaked from the outgoing main"
+    assert outgoing.special_form is None
+    assert db.saved_main[-1]["mega"] is False
+    assert db.saved_main[-1]["special_form"] is None
+
+
+def test_outgoing_save_failure_is_logged_not_swallowed(collection_dialog):
+    """This save is now the only thing preserving the outgoing Pokemon's HP."""
+    class _BoomDB(_FakeDB):
+        def save_pokemon(self, data):
+            raise RuntimeError("disk on fire")
+
+    PokemonObject = collection_dialog._PokemonObject
+    outgoing = PokemonObject(
+        name="pikachu", id=25, shiny=False, level=5, ability="Static",
+        type=["Electric"], gender="M", growth_rate="medium", captured_date=None,
+        tier="Normal", individual_id="outgoing-uuid", base_stats=dict(_BASE_STATS),
+    )
+    db = _BoomDB(existing_main=outgoing.to_dict())
+    collection_dialog.mw.ankimon_db = db
+    logger = MagicMock()
+    test_window = MagicMock()
+    test_window.isVisible.return_value = False
+
+    collection_dialog.MainPokemon(
+        _stored_pokemon(), outgoing, logger, MagicMock(), MagicMock(), test_window
+    )
+
+    assert logger.log.called, "the swallowed save failure was never reported"
+    assert db.saved_main, "the switch itself must still complete"
+
+
+def test_missing_hp_falls_back_to_current_hp(collection_dialog):
+    """A partially migrated row carrying only ``current_hp`` is not healed."""
+    row = _stored_pokemon()
+    del row["hp"]
+    row["current_hp"] = 9
+
+    main, _db = _call(collection_dialog, row)
+
+    assert main.hp == main.current_hp == 9
+
+
+def test_null_nature_falls_back_to_serious(collection_dialog):
+    """An explicit null nature must not reach ``get_nature_stat_mult``."""
+    main, _db = _call(collection_dialog, _stored_pokemon(nature=None))
+
+    assert main.nature == "serious"
+    assert isinstance(main.stats, dict)  # nature maths did not blow up
+
+
+def test_outgoing_main_is_saved_before_replacement(collection_dialog):
+    """The previous main's in-memory state is written to the party first."""
+    _main, db = _call(collection_dialog, _stored_pokemon())
+
+    assert [row["individual_id"] for row in db.saved_party] == ["outgoing-uuid"]
+
+
+def test_hud_refresh_and_grid_refresh_are_triggered(collection_dialog):
+    """The HUD repaint goes through the guarded ``refresh_hud`` seam."""
+    PokemonObject = collection_dialog._PokemonObject
+    outgoing = PokemonObject(
+        name="pikachu", id=25, shiny=False, level=5, ability="Static",
+        type=["Electric"], gender="M", growth_rate="medium", captured_date=None,
+        tier="Normal", individual_id="outgoing-uuid", base_stats=dict(_BASE_STATS),
+    )
+    db = _FakeDB(existing_main=outgoing.to_dict())
+    collection_dialog.mw.ankimon_db = db
+    reviewer_obj = MagicMock()
+    test_window = MagicMock()
+    test_window.isVisible.return_value = False
+
+    collection_dialog.MainPokemon(
+        _stored_pokemon(), outgoing, MagicMock(), MagicMock(), reviewer_obj, test_window
+    )
+
+    reviewer_obj.refresh_hud.assert_called_once_with()
+    collection_dialog._singletons.pokemon_pc.refresh_pokemon_grid.assert_called_once_with()

--- a/tests/test_main_pokemon_switch_preserves_state.py
+++ b/tests/test_main_pokemon_switch_preserves_state.py
@@ -382,6 +382,63 @@ def test_missing_hp_falls_back_to_current_hp(collection_dialog):
     assert main.hp == main.current_hp == 9
 
 
+@pytest.mark.parametrize("junk", ["", "??", "12.5", {}, [], float("nan"), object()])
+def test_malformed_current_hp_falls_back_to_valid_hp(collection_dialog, junk):
+    """A corrupted ``current_hp`` must not discard a perfectly good ``hp``.
+
+    Only ``None`` used to fall through to ``hp``.  Anything else -- an empty
+    string, a leftover dict, a NaN -- went straight into the constructor, where
+    ``PokemonObject._normalize_hp`` cannot parse it either and quietly swaps in
+    max HP.  ``db.save_main_pokemon()`` then writes that free full heal over the
+    valid HP the row still held, so the corruption is not merely tolerated, it
+    is made permanent.  ``update_main_pokemon._normalize_loaded_hp``, which
+    reads the same row at the next launch, has always preferred the parseable
+    ``hp`` here.
+    """
+    main, db = _call(collection_dialog, _stored_pokemon(hp=7, current_hp=junk))
+
+    assert main.hp == main.current_hp == 7
+    assert main.hp != main.max_hp, "the malformed value triggered a full heal"
+    saved = db.saved_main[-1]
+    assert saved["hp"] == saved["current_hp"] == 7
+
+
+@pytest.mark.parametrize("junk", ["", "??", {}, float("nan")])
+def test_malformed_hp_falls_back_to_valid_current_hp(collection_dialog, junk):
+    """The fallback runs in both directions: a usable ``current_hp`` still wins."""
+    main, db = _call(collection_dialog, _stored_pokemon(hp=junk, current_hp=12))
+
+    assert main.hp == main.current_hp == 12
+    assert db.saved_main[-1]["current_hp"] == 12
+
+
+def test_both_hp_fields_malformed_restores_full_hp(collection_dialog):
+    """With no usable value anywhere, full HP is the correct last resort.
+
+    Same final fallback as ``_normalize_loaded_hp``: better a healed Pokemon
+    than a crash or a nonsense bar.
+    """
+    main, db = _call(collection_dialog, _stored_pokemon(hp="??", current_hp="??"))
+
+    assert main.hp == main.current_hp == main.max_hp
+    assert db.saved_main[-1]["hp"] == main.max_hp
+
+
+def test_malformed_current_hp_preserves_a_fainted_hp(collection_dialog):
+    """``hp`` of 0 is a real answer, not an empty one, when ``current_hp`` is junk."""
+    main, db = _call(collection_dialog, _stored_pokemon(hp=0, current_hp="??"))
+
+    assert main.hp == main.current_hp == 0
+    assert db.saved_main[-1]["hp"] == 0
+
+
+def test_string_digit_hp_is_accepted(collection_dialog):
+    """A stringified number is parseable, so it is used rather than skipped."""
+    main, _db = _call(collection_dialog, _stored_pokemon(hp=181, current_hp="9"))
+
+    assert main.hp == main.current_hp == 9
+
+
 def test_null_nature_falls_back_to_serious(collection_dialog):
     """An explicit null nature must not reach ``get_nature_stat_mult``."""
     main, _db = _call(collection_dialog, _stored_pokemon(nature=None))


### PR DESCRIPTION
Fixes a bug where switching main Pokémon in the PC box while fighting the same opponent caused the health bar to display incorrect (max) health. The issue was that the HUD's internal cache and internal reference to the `main_pokemon` were not updated. The patch invalidates the cache and updates the reference so that the HUD accurately redraws.

---
*PR created automatically by Jules for task [2908725723622743455](https://jules.google.com/task/2908725723622743455) started by @h0tp-ftw*