### PR TITLE
fix(pokedex): normalize item names before csv cache lookup

### DIFF
--- a/src/Ankimon/functions/pokedex_functions.py
+++ b/src/Ankimon/functions/pokedex_functions.py
@@ -1455,9 +1455,15 @@ def return_id_for_item_name(item_name):
         None: If no matching item is found or an error occurs.
     """
     try:
+        normalized_name = (
+            (item_name or "")
+            .lower()
+            .replace(" ", "-")
+            .replace("'", "")
+        )
         cache = _load_items_cost_cache()
         for row in cache:
-            if row["identifier"] == item_name:
+            if row["identifier"] == normalized_name:
                 return row["id"]
 
         # Log a message if the item is not found

--- a/src/Ankimon/functions/pokedex_functions.py
+++ b/src/Ankimon/functions/pokedex_functions.py
@@ -1455,12 +1455,7 @@ def return_id_for_item_name(item_name):
         None: If no matching item is found or an error occurs.
     """
     try:
-        normalized_name = (
-            (item_name or "")
-            .lower()
-            .replace(" ", "-")
-            .replace("'", "")
-        )
+        normalized_name = (item_name or "").lower().replace(" ", "-").replace("'", "")
         cache = _load_items_cost_cache()
         for row in cache:
             if row["identifier"] == normalized_name:

--- a/tests/test_item_name_normalization.py
+++ b/tests/test_item_name_normalization.py
@@ -1,0 +1,8 @@
+def test_return_id_for_item_name_normalization():
+    # Because of Anki imports in main `__init__`, we need to import pokedex_functions specifically
+    from Ankimon.functions.pokedex_functions import return_id_for_item_name
+
+    # Should resolve correctly despite casing/spacing/punctuation
+    assert return_id_for_item_name("Dubious Disc") == "301"
+    assert return_id_for_item_name("King's Rock") == "198"
+    assert return_id_for_item_name("Up-Grade") == "229"


### PR DESCRIPTION
Fixes a bug where applying an evolution item with spaces (like the Dubious Disc) would crash with a "debug error" traceback popup.

- **Root Cause:** `items.csv` uses `dubious-disc`, while the engine passes `"Dubious Disc"`. The cache lookup failed because it didn't normalize the input.
- **Fix:** Added normalization to `return_id_for_item_name` so the incoming string is lowercased, spaces are replaced with hyphens, and apostrophes are dropped.
- **Testing:** Wrote `test_item_name_normalization.py` to assert that items like `Dubious Disc` and `King's Rock` are successfully retrieved using their display names.

---
*PR created automatically by Jules for task [7749450015200260153](https://jules.google.com/task/7749450015200260153) started by @h0tp-ftw*