### PR TITLE
fix(evolution): honor data-driven move-type and gender gates across all evolution paths

### DIFF
--- a/src/Ankimon/ankimon_items_web/shop.js
+++ b/src/Ankimon/ankimon_items_web/shop.js
@@ -970,9 +970,18 @@
 
         if (matched.length === 0) {
             grid.replaceChildren();
+            // Three distinct empty states. The middle one matters because the
+            // eligibility filter above can empty the list on its own, with the
+            // search box untouched: a player whose only Kirlia is female sees
+            // zero Dawn Stone candidates, and blaming a search they never typed
+            // reads as a broken picker rather than an answer.
+            const eligibilityEmptied = !q && choices.length === 0
+                && state.picker.choices.length > 0;
             empty.textContent = state.picker.choices.length === 0
                 ? "You don't have any Pokémon yet."
-                : 'No Pokémon match that search.';
+                : eligibilityEmptied
+                    ? 'None of your Pokémon can use this item.'
+                    : 'No Pokémon match that search.';
             empty.classList.remove('hidden');
             grid.style.display = 'none';
             return;

--- a/src/Ankimon/ankimon_items_web/shop_obj.py
+++ b/src/Ankimon/ankimon_items_web/shop_obj.py
@@ -73,12 +73,10 @@ class SafeWebEnginePage(QWebEnginePage):
 from ..functions.pokedex_functions import (
     find_details_move,
     _ITEM_EVO_TRIGGERS,
-    _csv_gender_id,
-    _evolution_row_gender_id,
     _load_pokedex_cache,
     check_evolution_by_item,
+    evolution_gender_allows,
     return_id_for_item_name,
-    safe_int,
 )
 from ..business import calculate_cp_from_dict
 from ..ankimon_profile_web.profile_data import ProfileData
@@ -2075,14 +2073,15 @@ class AnkimonItemsWeb(QDialog):
 
                 # Evolution eligibility (Optimized inline to avoid file I/O)
                 if is_evo_item and item_name and p_details:
-                    # Gender gate, mirroring check_evolution_by_item: Gallade
-                    # needs a male Kirlia, Froslass a female Snorunt. Without it
-                    # this picker flags a Pokemon that Check_Evo_Item then
-                    # refuses — and shop.js filters the list to e === 1, so the
-                    # player is offered the one candidate the actual use will
-                    # turn down. The CSV lookup behind it is lru_cached, so this
-                    # keeps the picker free of per-row file I/O.
-                    caller_gender_id = _csv_gender_id(data.get("gender"))
+                    # Gender gate, through the SAME helper check_evolution_by_item
+                    # uses: Gallade needs a male Kirlia, Froslass a female
+                    # Snorunt. Without it this picker flags a Pokemon that
+                    # Check_Evo_Item then refuses — and shop.js filters the list
+                    # to e === 1, so the player is offered the one candidate the
+                    # actual use will turn down. Sharing the helper is what keeps
+                    # the two verdicts from drifting; the CSV lookup behind it is
+                    # lru_cached, so the picker stays free of per-row file I/O.
+                    pokemon_gender = data.get("gender")
                     evo_list = p_details.get("evos")
                     if evo_list:
                         for target_evo_name in evo_list:
@@ -2102,19 +2101,10 @@ class AnkimonItemsWeb(QDialog):
                                 "useItem",
                                 "trade",
                             ):
-                                if caller_gender_id is not None:
-                                    required_gender_id = _evolution_row_gender_id(
-                                        safe_int(
-                                            target_data.get("actual_id")
-                                            or target_data.get("species_id")
-                                        ),
-                                        _ITEM_EVO_TRIGGERS,
-                                    )
-                                    if (
-                                        required_gender_id is not None
-                                        and caller_gender_id != required_gender_id
-                                    ):
-                                        continue
+                                if not evolution_gender_allows(
+                                    target_data, pokemon_gender, _ITEM_EVO_TRIGGERS
+                                ):
+                                    continue
 
                                 # "trade" belongs here alongside "useItem": Ankimon has no
                                 # trading, so the trade-with-held-item species (Rhydon ->

--- a/src/Ankimon/ankimon_items_web/shop_obj.py
+++ b/src/Ankimon/ankimon_items_web/shop_obj.py
@@ -2242,7 +2242,12 @@ class AnkimonItemsWeb(QDialog):
                 pokedex_id = (pokemon_data or {}).get("id")
                 if not pokedex_id:
                     return {"ok": False, "message": "Could not look up that Pokémon."}
-                bag.Check_Evo_Item(individual_id, pokedex_id, item_name)
+                # Hand the record over rather than let Check_Evo_Item re-read it
+                # for the gender gate: one query, and the id and the gender are
+                # guaranteed to come from the same snapshot.
+                bag.Check_Evo_Item(
+                    individual_id, pokedex_id, item_name, pokemon_data=pokemon_data
+                )
                 return {"ok": True, "message": ""}
 
             # Held items (and anything else routed through the give-item

--- a/src/Ankimon/ankimon_items_web/shop_obj.py
+++ b/src/Ankimon/ankimon_items_web/shop_obj.py
@@ -34,6 +34,7 @@ except ImportError:  # dev helper not landed yet (thread-reload-and-misc-utils u
 
 from ..resources import items_path, csv_file_items_cost, csv_file_descriptions
 
+
 class SafeWebEnginePage(QWebEnginePage):
     def __init__(self, profile, screen_name, logger, parent=None):
         """Initialize a web engine page with a screen identifier and optional logger."""
@@ -44,7 +45,7 @@ class SafeWebEnginePage(QWebEnginePage):
     def javaScriptConsoleMessage(self, level, message, line, source):
         """
         Forward JavaScript console messages to the configured logger with a severity level and screen identifier.
-        
+
         Parameters:
             level: JavaScript console message severity.
             message: Text emitted by JavaScript.
@@ -53,14 +54,21 @@ class SafeWebEnginePage(QWebEnginePage):
         """
         try:
             if self.logger:
-                if level == QWebEnginePage.JavaScriptConsoleMessageLevel.InfoMessageLevel:
+                if (
+                    level
+                    == QWebEnginePage.JavaScriptConsoleMessageLevel.InfoMessageLevel
+                ):
                     self.logger.log("info", f"[JS:{self.screen_name}] {message}")
-                elif level == QWebEnginePage.JavaScriptConsoleMessageLevel.WarningMessageLevel:
+                elif (
+                    level
+                    == QWebEnginePage.JavaScriptConsoleMessageLevel.WarningMessageLevel
+                ):
                     self.logger.log("warning", f"[JS:{self.screen_name}] {message}")
                 else:
                     self.logger.log("error", f"[JS:{self.screen_name}] {message}")
         except Exception:
             pass
+
 
 from ..functions.pokedex_functions import (
     find_details_move,
@@ -141,7 +149,6 @@ class NavBridge(QObject):
         self._w.load_screen(SCREEN_HISTORY)
 
 
-
 class TrainerBridge(QObject):
     """Profile-screen data + sprite-picker actions (delegates to ProfileData)."""
 
@@ -207,7 +214,9 @@ class TeamBridge(QObject):
                 raise ValueError("team payload must be a list")
         except (TypeError, ValueError) as e:
             return {"ok": False, "message": f"Invalid team payload: {e}"}
-        return self._w.profile_data.handle_save_team(team_ids, xp_share_id or None, companion_id or None)
+        return self._w.profile_data.handle_save_team(
+            team_ids, xp_share_id or None, companion_id or None
+        )
 
 
 class SettingsBridge(QObject):
@@ -334,6 +343,7 @@ class MobileBridge(QObject):
 
             # Read settings for cards_per_round
             from ..functions import mobile_sync
+
             settings_obj = services.settings
             cards_per_round, _ = mobile_sync._parse_cards_per_round(settings_obj)
 
@@ -343,7 +353,9 @@ class MobileBridge(QObject):
             # status load.
             resolved_battles = 0
             try:
-                cursor = db.execute("SELECT value FROM metadata WHERE key = 'mobile_resolved_encounters_count'")
+                cursor = db.execute(
+                    "SELECT value FROM metadata WHERE key = 'mobile_resolved_encounters_count'"
+                )
                 row = cursor.fetchone()
                 resolved_battles = int(row[0]) if row else 0
             except Exception:
@@ -368,7 +380,7 @@ class MobileBridge(QObject):
                 0: "Manual (Auto-Resolve)",
                 1: "Auto-Catch",
                 2: "Auto-Defeat",
-                3: "Catch Uncollected"
+                3: "Catch Uncollected",
             }
             auto_battle_val = 0
             try:
@@ -398,16 +410,21 @@ class MobileBridge(QObject):
             if main_pokemon is not None:
                 main_pokemon_name = main_pokemon.name
                 main_pokemon_level = main_pokemon.level
-                
+
                 from ..functions.sprite_functions import get_relative_sprite_path
+
                 main_pokemon_sprite = get_relative_sprite_path(
-                    main_pokemon.id, bool(main_pokemon.shiny), (main_pokemon.gender or "N"), main_pokemon.name, "gif"
+                    main_pokemon.id,
+                    bool(main_pokemon.shiny),
+                    (main_pokemon.gender or "N"),
+                    main_pokemon.name,
+                    "gif",
                 )
 
             if settings_obj is not None:
                 sprite_mode = settings_obj.get(
                     "ankidex.spriteMode",
-                    settings_obj.get("pokedex_v2.spriteMode", "static")
+                    settings_obj.get("pokedex_v2.spriteMode", "static"),
                 )
 
             # Trigger async estimates calculation if there are pending reviews
@@ -445,16 +462,19 @@ class MobileBridge(QObject):
                         for r in reviews_rows_thread
                     ]
                     if pending_count > len(reviews_list_thread):
-                        reviews_list_thread.extend([{"ease": 3}] * (pending_count - len(reviews_list_thread)))
+                        reviews_list_thread.extend(
+                            [{"ease": 3}] * (pending_count - len(reviews_list_thread))
+                        )
 
                     from ..functions.mobile_sync import simulate_pending_mobile_battles
+
                     return simulate_pending_mobile_battles(
                         reviews_list_thread,
                         main_pokemon,
                         settings_obj,
                         trainer_card,
                         ankimon_tracker_obj,
-                        ankimon_db=db
+                        ankimon_db=db,
                     )
 
                 def on_sim_success(sim_res):
@@ -491,10 +511,9 @@ class MobileBridge(QObject):
                     battle_count = estimates["encounters"]
                 else:
                     from aqt.operations import QueryOp
+
                     QueryOp(
-                        parent=self._w,
-                        op=run_sim,
-                        success=on_sim_success
+                        parent=self._w, op=run_sim, success=on_sim_success
                     ).without_collection().run_in_background()
 
             return {
@@ -516,10 +535,18 @@ class MobileBridge(QObject):
             }
         except Exception as e:
             import traceback
+
             logger = services.logger
             if logger:
-                logger.log("error", f"getMobileStatus failed: {e}\n{traceback.format_exc()}")
-            return {"error": str(e), "pending_count": 0, "pending_count_at_start": 0, "cap": 10000}
+                logger.log(
+                    "error", f"getMobileStatus failed: {e}\n{traceback.format_exc()}"
+                )
+            return {
+                "error": str(e),
+                "pending_count": 0,
+                "pending_count_at_start": 0,
+                "cap": 10000,
+            }
 
     @pyqtSlot(result="QVariant")
     def getMobileHistory(self) -> list:
@@ -549,9 +576,10 @@ class MobileBridge(QObject):
             with db._get_connection() as conn:
                 conn.execute(
                     "UPDATE pending_mobile_battles SET resolved=1, resolved_at=? WHERE resolved=0",
-                    (int(time.time() * 1000),)
+                    (int(time.time() * 1000),),
                 )
             from ..menu_buttons import update_mobile_badge
+
             update_mobile_badge(0)
             return {"dismissed": count_before, "success": True}
         except Exception as e:
@@ -584,6 +612,7 @@ class MobileBridge(QObject):
             return self._run_resolve_all()
         except Exception as e:
             import traceback
+
             logger = services.logger
             if logger:
                 logger.log("error", f"resolveAll failed: {e}\n{traceback.format_exc()}")
@@ -597,7 +626,7 @@ class MobileBridge(QObject):
         try:
             res = self._run_resolve_all(limit=limit)
             if isinstance(res, dict) and res.get("success"):
-                res["done"] = (services.db.get_pending_mobile_count() == 0)
+                res["done"] = services.db.get_pending_mobile_count() == 0
             return res
         except Exception as e:
             return {"success": False, "error": str(e)}
@@ -621,7 +650,7 @@ class MobileBridge(QObject):
             "xp_gained": 0,
             "caught_list": [],
             "done": False,
-            "error": None
+            "error": None,
         }
         self._bulk_paused = False
         self._bulk_stopped = False
@@ -648,6 +677,7 @@ class MobileBridge(QObject):
                             self._bulk_progress["total"] = total
 
                     import time
+
                     # GIL yield / rate limit (Bug 2). The per-review battle
                     # simulation is CPU-bound pure Python that holds the GIL; on a
                     # plain worker thread it starves the Qt GUI thread, so the
@@ -663,7 +693,9 @@ class MobileBridge(QObject):
                         time.sleep(0.003)
                         self._bulk_last_yield = time.monotonic()
 
-                    while getattr(self, "_bulk_paused", False) and not getattr(self, "_bulk_stopped", False):
+                    while getattr(self, "_bulk_paused", False) and not getattr(
+                        self, "_bulk_stopped", False
+                    ):
                         time.sleep(0.1)
 
                     if getattr(self, "_bulk_stopped", False):
@@ -679,25 +711,32 @@ class MobileBridge(QObject):
                     logger=services.logger,
                     day_cutoff=day_cutoff,
                     limit=None,
-                    progress_callback=progress_cb
+                    progress_callback=progress_cb,
                 )
                 if res:
                     if not res.get("success", True):
-                        raise Exception(res.get("error", "Unknown error in background resolve"))
+                        raise Exception(
+                            res.get("error", "Unknown error in background resolve")
+                        )
                     self._bulk_progress["processed"] = res.get("reviews_processed", 0)
                     self._bulk_progress["resolved"] = res.get("resolved", 0)
                     self._bulk_progress["catches"] = res.get("catches", 0)
                     self._bulk_progress["cash_gained"] = res.get("cash_gained", 0)
-                    self._bulk_progress["trainer_xp_gained"] = res.get("trainer_xp_gained", 0)
+                    self._bulk_progress["trainer_xp_gained"] = res.get(
+                        "trainer_xp_gained", 0
+                    )
                     self._bulk_progress["xp_gained"] = res.get("xp_gained", 0)
                     if res.get("caught_list"):
                         self._bulk_progress["caught_list"] = res.get("caught_list")
 
             except Exception as e:
                 import traceback
+
                 logger = services.logger
                 if logger:
-                    logger.log("error", f"bg_resolve failed: {e}\n{traceback.format_exc()}")
+                    logger.log(
+                        "error", f"bg_resolve failed: {e}\n{traceback.format_exc()}"
+                    )
                 self._bulk_progress["error"] = f"{str(e)}\n{traceback.format_exc()}"
             finally:
                 self._bulk_progress["done"] = True
@@ -719,7 +758,9 @@ class MobileBridge(QObject):
 
     @pyqtSlot(result="QVariant")
     def getBulkResolveProgress(self) -> dict:
-        progress = getattr(self, "_bulk_progress", {"done": True, "processed": 0, "total": 0}).copy()
+        progress = getattr(
+            self, "_bulk_progress", {"done": True, "processed": 0, "total": 0}
+        ).copy()
         progress["paused"] = getattr(self, "_bulk_paused", False)
         # If it just finished, perform safe main-thread refreshes!
         if progress.get("done") and not getattr(self, "_bulk_refreshed", False):
@@ -731,13 +772,16 @@ class MobileBridge(QObject):
                 # Refresh active companion
                 if services.main_pokemon:
                     from ..functions.update_main_pokemon import update_main_pokemon
+
                     update_main_pokemon(services.main_pokemon)
                 # Update mobile badge safely on main thread
                 try:
                     remaining = services.db.get_pending_mobile_count()
                     from ..menu_buttons import update_mobile_badge
+
                     update_mobile_badge(remaining)
-                except Exception: pass
+                except Exception:
+                    pass
                 # Live-refresh whatever screen is showing (self._w IS the shell
                 # window) and emit the seam signal for any cross-cutting
                 # listeners — replaces exp's singletons.notify_stats_changed().
@@ -745,10 +789,15 @@ class MobileBridge(QObject):
                 events.emit("stats_changed")
             except Exception as e:
                 import traceback
+
                 logger = services.logger
                 if logger:
-                    logger.log("error", f"Error refreshing singletons after bulk resolve: {e}\n{traceback.format_exc()}")
+                    logger.log(
+                        "error",
+                        f"Error refreshing singletons after bulk resolve: {e}\n{traceback.format_exc()}",
+                    )
         return progress
+
     @pyqtSlot(str, result="QVariant")
     def resolveNext(self, companion_id: str = "") -> dict:
         try:
@@ -775,16 +824,18 @@ class MobileBridge(QObject):
                     trainer_card=trainer_card,
                     main_pokemon=main_pokemon,
                     logger=services.logger,
-                    day_cutoff=day_cutoff
+                    day_cutoff=day_cutoff,
                 )
                 if isinstance(res, dict) and "current_pending_outcome" in res:
                     outcome = res["current_pending_outcome"]
                     if outcome:
-                        outcome.update({
-                            "main_pokemon": main_pokemon,
-                            "trainer_card": trainer_card,
-                            "settings_obj": settings_obj,
-                        })
+                        outcome.update(
+                            {
+                                "main_pokemon": main_pokemon,
+                                "trainer_card": trainer_card,
+                                "settings_obj": settings_obj,
+                            }
+                        )
                     self._current_pending_outcome = outcome
                     return res["result"]
                 return res
@@ -800,39 +851,46 @@ class MobileBridge(QObject):
                         trainer_card=trainer_card,
                         main_pokemon=main_pokemon,
                         logger=services.logger,
-                        day_cutoff=day_cutoff
+                        day_cutoff=day_cutoff,
                     )
 
                 def on_sim_success(sim_res):
-                    if isinstance(sim_res, dict) and "current_pending_outcome" in sim_res:
+                    if (
+                        isinstance(sim_res, dict)
+                        and "current_pending_outcome" in sim_res
+                    ):
                         outcome = sim_res["current_pending_outcome"]
                         if outcome:
-                            outcome.update({
-                                "main_pokemon": main_pokemon,
-                                "trainer_card": trainer_card,
-                                "settings_obj": settings_obj,
-                            })
+                            outcome.update(
+                                {
+                                    "main_pokemon": main_pokemon,
+                                    "trainer_card": trainer_card,
+                                    "settings_obj": settings_obj,
+                                }
+                            )
                         self._current_pending_outcome = outcome
                         result_data = sim_res["result"]
                     else:
                         result_data = sim_res
 
                     import json
+
                     js = f"if (window.onResolveNextReady) {{ window.onResolveNextReady({json.dumps(result_data)}); }}"
                     self._w.webview_mobile.page().runJavaScript(js)
 
                 QueryOp(
-                    parent=self._w,
-                    op=run_sim,
-                    success=on_sim_success
+                    parent=self._w, op=run_sim, success=on_sim_success
                 ).without_collection().run_in_background()
 
                 return {"loading": True}
         except Exception as e:
             import traceback
+
             logger = services.logger
             if logger:
-                logger.log("error", f"resolveNext failed: {e}\n{traceback.format_exc()}")
+                logger.log(
+                    "error", f"resolveNext failed: {e}\n{traceback.format_exc()}"
+                )
             return {"success": False, "error": str(e)}
 
     @pyqtSlot(str, result="QVariant")
@@ -859,16 +917,20 @@ class MobileBridge(QObject):
                 trainer_card=trainer_card,
                 main_pokemon=main_pokemon,
                 achievements_dict=achievements_dict,
-                logger=logger
+                logger=logger,
             )
             if res.get("success"):
                 self._current_pending_outcome = None
             return res
         except Exception as e:
             import traceback
+
             logger = services.logger
             if logger:
-                logger.log("error", f"commitReplayOutcome failed: {e}\n{traceback.format_exc()}")
+                logger.log(
+                    "error",
+                    f"commitReplayOutcome failed: {e}\n{traceback.format_exc()}",
+                )
             return {"success": False, "error": str(e)}
 
     @pyqtSlot(str, result="QVariant")
@@ -896,7 +958,11 @@ class MobileBridge(QObject):
             db = services.db
             team_rows = db.get_team()
             settings_obj = services.settings
-            inactive = set(settings_obj.get("mobile.inactive_companions", [])) if settings_obj else set()
+            inactive = (
+                set(settings_obj.get("mobile.inactive_companions", []))
+                if settings_obj
+                else set()
+            )
             from ..functions.sprite_functions import get_relative_sprite_path
 
             team_list = []
@@ -906,6 +972,7 @@ class MobileBridge(QObject):
                     data = db.get_pokemon(ind_id)
                     if data:
                         from ..pyobj.pokemon_obj import PokemonObject
+
                         pkmn = PokemonObject(**data)
                         name = pkmn.display_name
                         level = data.get("level", 5)
@@ -915,18 +982,22 @@ class MobileBridge(QObject):
                         pkmn_type = data.get("type", ["Normal"])
                         if isinstance(pkmn_type, str):
                             pkmn_type = [pkmn_type]
-                        
-                        sprite_path = get_relative_sprite_path(pkmn_id, shiny, gender, pkmn.name, "gif")
+
+                        sprite_path = get_relative_sprite_path(
+                            pkmn_id, shiny, gender, pkmn.name, "gif"
+                        )
                         is_inactive = ind_id in inactive
 
-                        team_list.append({
-                            "individual_id": ind_id,
-                            "name": name,
-                            "level": level,
-                            "sprite_path": sprite_path,
-                            "type": pkmn_type,
-                            "inactive": is_inactive
-                        })
+                        team_list.append(
+                            {
+                                "individual_id": ind_id,
+                                "name": name,
+                                "level": level,
+                                "sprite_path": sprite_path,
+                                "type": pkmn_type,
+                                "inactive": is_inactive,
+                            }
+                        )
 
             return {"team": team_list, "inactive": list(inactive)}
         except Exception as e:
@@ -939,8 +1010,10 @@ class MobileBridge(QObject):
         """
         try:
             from aqt import mw
+
             if hasattr(mw, "onSync"):
                 from aqt.qt import QTimer
+
                 QTimer.singleShot(0, mw.onSync)
                 return {"success": True}
             else:
@@ -950,8 +1023,16 @@ class MobileBridge(QObject):
 
 
 class AnkimonItemsWeb(QDialog):
-    def __init__(self, addon_dir, shop_manager, item_window, ankimon_tracker,
-                 trainer_card=None, settings_obj=None, logger=None):
+    def __init__(
+        self,
+        addon_dir,
+        shop_manager,
+        item_window,
+        ankimon_tracker,
+        trainer_card=None,
+        settings_obj=None,
+        logger=None,
+    ):
         """
         Initialize the persistent web-based Ankimon interface and its data bridges.
 
@@ -1026,25 +1107,47 @@ class AnkimonItemsWeb(QDialog):
         frame.layout().addWidget(self.stack)
 
         self.webview_items = QWebEngineView()
-        self.webview_items.setPage(SafeWebEnginePage(self.profile, SCREEN_ITEMS, logger, self.webview_items))
+        self.webview_items.setPage(
+            SafeWebEnginePage(self.profile, SCREEN_ITEMS, logger, self.webview_items)
+        )
 
         self.webview_ankidex = QWebEngineView()
-        self.webview_ankidex.setPage(SafeWebEnginePage(self.profile, SCREEN_ANKIDEX, logger, self.webview_ankidex))
+        self.webview_ankidex.setPage(
+            SafeWebEnginePage(
+                self.profile, SCREEN_ANKIDEX, logger, self.webview_ankidex
+            )
+        )
 
         self.webview_settings = QWebEngineView()
-        self.webview_settings.setPage(SafeWebEnginePage(self.profile, SCREEN_SETTINGS, logger, self.webview_settings))
+        self.webview_settings.setPage(
+            SafeWebEnginePage(
+                self.profile, SCREEN_SETTINGS, logger, self.webview_settings
+            )
+        )
 
         self.webview_profile = QWebEngineView()
-        self.webview_profile.setPage(SafeWebEnginePage(self.profile, SCREEN_PROFILE, logger, self.webview_profile))
+        self.webview_profile.setPage(
+            SafeWebEnginePage(
+                self.profile, SCREEN_PROFILE, logger, self.webview_profile
+            )
+        )
 
         self.webview_team = QWebEngineView()
-        self.webview_team.setPage(SafeWebEnginePage(self.profile, SCREEN_TEAM, logger, self.webview_team))
+        self.webview_team.setPage(
+            SafeWebEnginePage(self.profile, SCREEN_TEAM, logger, self.webview_team)
+        )
 
         self.webview_mobile = QWebEngineView()
-        self.webview_mobile.setPage(SafeWebEnginePage(self.profile, SCREEN_MOBILE, logger, self.webview_mobile))
+        self.webview_mobile.setPage(
+            SafeWebEnginePage(self.profile, SCREEN_MOBILE, logger, self.webview_mobile)
+        )
 
         self.webview_history = QWebEngineView()
-        self.webview_history.setPage(SafeWebEnginePage(self.profile, SCREEN_HISTORY, logger, self.webview_history))
+        self.webview_history.setPage(
+            SafeWebEnginePage(
+                self.profile, SCREEN_HISTORY, logger, self.webview_history
+            )
+        )
         self._views = {
             SCREEN_ITEMS: self.webview_items,
             SCREEN_ANKIDEX: self.webview_ankidex,
@@ -1078,7 +1181,6 @@ class AnkimonItemsWeb(QDialog):
             if screen in (SCREEN_MOBILE, SCREEN_HISTORY):
                 channel.registerObject("mobile", self._mobile_bridge)
             view.page().setWebChannel(channel)
-
 
             view.loadFinished.connect(
                 lambda ok, s=screen: self._on_screen_load_finished(ok, s)
@@ -1157,7 +1259,9 @@ class AnkimonItemsWeb(QDialog):
         if not ok:
             return
         self.ready_screens.add(screen)
-        settings_obj = self.shop_manager.settings_obj if self.shop_manager is not None else None
+        settings_obj = (
+            self.shop_manager.settings_obj if self.shop_manager is not None else None
+        )
         if settings_obj is not None and screen in SPRITE_VISIBILITY_SCREENS:
             self._apply_sprite_visibility(
                 settings_obj.get("gui.show_sprites_across_ankimon", True),
@@ -1243,7 +1347,9 @@ class AnkimonItemsWeb(QDialog):
             self.webview_profile.page().runJavaScript(js)
         elif self.current_screen == SCREEN_TEAM:
             data = self.profile_data.get_team_data()
-            js = f"if (window.initializeTeam) window.initializeTeam({json.dumps(data)});"
+            js = (
+                f"if (window.initializeTeam) window.initializeTeam({json.dumps(data)});"
+            )
             self.webview_team.page().runJavaScript(js)
         elif self.current_screen == SCREEN_MOBILE:
             data = self._mobile_bridge.getMobileStatus()
@@ -1324,7 +1430,9 @@ class AnkimonItemsWeb(QDialog):
             try:
                 db = services.db
                 count = db.get_pending_mobile_count() if db is not None else 0
-                active_view.page().runJavaScript(f"if (window.updateNavSwitcherUnresolvedCount) window.updateNavSwitcherUnresolvedCount({count});")
+                active_view.page().runJavaScript(
+                    f"if (window.updateNavSwitcherUnresolvedCount) window.updateNavSwitcherUnresolvedCount({count});"
+                )
             except Exception:
                 pass
 
@@ -1336,7 +1444,10 @@ class AnkimonItemsWeb(QDialog):
         except Exception as e:
             logger = services.logger
             if logger:
-                logger.log("error", f"[Ankimon] live refresh failed ({self.current_screen}): {e}")
+                logger.log(
+                    "error",
+                    f"[Ankimon] live refresh failed ({self.current_screen}): {e}",
+                )
 
     def _push_profile_live(self):
         """Push a full Profile refresh (cash, caught, Pokédex, shinies, highest,
@@ -1474,7 +1585,11 @@ class AnkimonItemsWeb(QDialog):
     def handle_get_caught_pokemon(self):
         """Get the list of caught/collected Pokémon for the quick-add panel."""
         from ..utils import load_collected_pokemon_ids
-        from ..functions.pokedex_functions import _load_pokedex_cache, search_pokedex_by_id, get_pretty_name_for_id
+        from ..functions.pokedex_functions import (
+            _load_pokedex_cache,
+            search_pokedex_by_id,
+            get_pretty_name_for_id,
+        )
 
         caught_ids = load_collected_pokemon_ids()
         results = []
@@ -1484,10 +1599,12 @@ class AnkimonItemsWeb(QDialog):
             internal_name = search_pokedex_by_id(pid)
             if internal_name and internal_name != "Pokémon not found":
                 pretty_name = get_pretty_name_for_id(pid)
-                results.append({
-                    "id": int(pid),
-                    "name": pretty_name,
-                })
+                results.append(
+                    {
+                        "id": int(pid),
+                        "name": pretty_name,
+                    }
+                )
         # Sort by name alphabetically
         results.sort(key=lambda r: r["name"].lower())
         return {"results": results}
@@ -1541,14 +1658,19 @@ class AnkimonItemsWeb(QDialog):
                 if held:
                     if held not in equipped_by_map:
                         equipped_by_map[held] = []
-                    equipped_by_map[held].append({
-                        "name": pkm.get("name", "Unknown"),
-                        "individual_id": pkm.get("individual_id")
-                    })
+                    equipped_by_map[held].append(
+                        {
+                            "name": pkm.get("name", "Unknown"),
+                            "individual_id": pkm.get("individual_id"),
+                        }
+                    )
         except Exception as e:
             logger = services.logger
             if logger:
-                logger.log("error", f"[Ankimon] get_all_pokemon failed in _get_mart_and_bag_data: {e}")
+                logger.log(
+                    "error",
+                    f"[Ankimon] get_all_pokemon failed in _get_mart_and_bag_data: {e}",
+                )
 
         owned_index = {}
         for row in owned_rows:
@@ -1561,7 +1683,11 @@ class AnkimonItemsWeb(QDialog):
                 "category_id": row.get("category_id"),
             }
 
-        all_names = sorted(set(shop_index.keys()) | set(owned_index.keys()) | set(equipped_by_map.keys()))
+        all_names = sorted(
+            set(shop_index.keys())
+            | set(owned_index.keys())
+            | set(equipped_by_map.keys())
+        )
 
         items = []
         for name in all_names:
@@ -1618,7 +1744,14 @@ class AnkimonItemsWeb(QDialog):
         return {"ok": True}
 
     def _serialize_item(
-        self, name, is_tm, in_shop, shop_price, item_type, owned_quantity, equipped_instances=None
+        self,
+        name,
+        is_tm,
+        in_shop,
+        shop_price,
+        item_type,
+        owned_quantity,
+        equipped_instances=None,
     ):
         ui_name = name.replace("-", " ").title()
         entry = {
@@ -1688,7 +1821,9 @@ class AnkimonItemsWeb(QDialog):
             return None
         try:
             settings = self.shop_manager.settings_obj
-            lang = int(settings.get("misc.language") or 9) if settings is not None else 9
+            lang = (
+                int(settings.get("misc.language") or 9) if settings is not None else 9
+            )
         except (TypeError, ValueError, AttributeError):
             lang = 9
         if lang == 14:  # es_latam → fall back to es per legacy behaviour
@@ -1852,7 +1987,7 @@ class AnkimonItemsWeb(QDialog):
         is_evo_item = False
         if item_name:
             # We assume non-TM here; if it was a TM, useItemOnPokemon wouldn't be called.
-            is_evo_item = (self._categorize(item_name, False) == "evolution")
+            is_evo_item = self._categorize(item_name, False) == "evolution"
 
         cached = getattr(self, "_pokemon_choices_cache", None)
         # If not an evolution item, we can safely return the base cache (if it exists).
@@ -1865,7 +2000,10 @@ class AnkimonItemsWeb(QDialog):
         except Exception as e:
             logger = services.logger
             if logger:
-                logger.log("error", f"[Ankimon] get_pokemon_choices: get_all_pokemon failed: {e}")
+                logger.log(
+                    "error",
+                    f"[Ankimon] get_pokemon_choices: get_all_pokemon failed: {e}",
+                )
             return {"choices": []}
 
         # Active Pokémon's individual_id (so we can flag it in the UI).
@@ -1886,97 +2024,154 @@ class AnkimonItemsWeb(QDialog):
 
         choices = []
         for data in pokemons:
-          try:
-            if not isinstance(data, dict):
+            try:
+                if not isinstance(data, dict):
+                    continue
+                individual_id = data.get("individual_id")
+                pokedex_id = data.get("id")
+                name = data.get("name")
+                if not individual_id or not name:
+                    continue
+
+                nickname = (data.get("nickname") or "").strip()
+                held_item = data.get("held_item") or ""
+                level = data.get("level")
+                shiny = bool(data.get("shiny"))
+                is_main = bool(
+                    main_individual_id and individual_id == main_individual_id
+                )
+
+                # Resolve internal name using the optimized pokedex index
+                internal_name = search_pokedex_by_id(pokedex_id)
+                p_details = pokedex_data.get(internal_name)
+
+                # Sprite fallback: get base species_id
+                base_id = pokedex_id
+                if p_details:
+                    base_id = p_details.get("species_id") or pokedex_id
+
+                entry = {
+                    "id": individual_id,
+                    "p": pokedex_id or 0,
+                    "b": base_id or 0,
+                    "n": name,
+                    "l": int(level) if level is not None else None,
+                    "cp": calculate_cp_from_dict(data),
+                }
+                if shiny:
+                    entry["s"] = 1
+                if is_main:
+                    entry["m"] = 1
+                if held_item:
+                    entry["h"] = held_item
+                if nickname and nickname.lower() != (name or "").lower():
+                    entry["nk"] = nickname
+
+                # Evolution eligibility (Optimized inline to avoid file I/O)
+                if is_evo_item and item_name and p_details:
+                    evo_list = p_details.get("evos")
+                    if evo_list:
+                        for target_evo_name in evo_list:
+                            normalized_target = (
+                                target_evo_name.lower()
+                                .replace(" ", "")
+                                .replace("-", "")
+                                .replace("'", "")
+                                .replace(".", "")
+                                .replace(":", "")
+                            )
+                            target_data = pokedex_data.get(
+                                normalized_target
+                            ) or pokedex_data.get(target_evo_name.lower())
+
+                            if target_data and target_data.get("evoType") in (
+                                "useItem",
+                                "trade",
+                            ):
+                                # "trade" belongs here alongside "useItem": Ankimon has no
+                                # trading, so the trade-with-held-item species (Rhydon ->
+                                # Rhyperior via Protector, Onix -> Steelix via Metal Coat,
+                                # Seadra -> Kingdra via Dragon Scale, ...) are evolved by
+                                # applying the item directly. Omitting it hid every one of
+                                # them from this picker, which shop.js filters to e === 1.
+                                #
+                                # Normalize both sides by stripping spaces, hyphens and
+                                # apostrophes so pokedex.json display names (e.g.
+                                # "King's Rock") match items.csv identifiers (e.g.
+                                # "kings-rock"), which drop the apostrophe. Mirrors the
+                                # canonical logic in functions/pokedex_functions.py.
+                                required_item = (
+                                    (target_data.get("evoItem") or "")
+                                    .lower()
+                                    .replace(" ", "")
+                                    .replace("-", "")
+                                    .replace("'", "")
+                                )
+                                normalized_item_name = (
+                                    (item_name or "")
+                                    .lower()
+                                    .replace(" ", "")
+                                    .replace("-", "")
+                                    .replace("'", "")
+                                )
+                                if required_item == normalized_item_name:
+                                    target_region = target_data.get("evoRegion")
+
+                                    if target_region:
+                                        if (
+                                            active_region
+                                            and active_region.lower()
+                                            == target_region.lower()
+                                        ):
+                                            entry["e"] = 1
+                                            break
+                                    else:
+                                        # Standard form is only allowed if there is no regional sibling for this region/method
+                                        has_matching_regional_sibling = False
+                                        for sibling_name in evo_list:
+                                            sib_norm = (
+                                                sibling_name.lower()
+                                                .replace(" ", "")
+                                                .replace("-", "")
+                                                .replace("'", "")
+                                                .replace(".", "")
+                                                .replace(":", "")
+                                            )
+                                            sib_data = pokedex_data.get(
+                                                sib_norm
+                                            ) or pokedex_data.get(sibling_name.lower())
+                                            if (
+                                                sib_data
+                                                and sib_data.get("evoRegion")
+                                                and active_region
+                                                and sib_data.get("evoRegion").lower()
+                                                == active_region.lower()
+                                            ):
+                                                if (
+                                                    sib_data.get("evoType")
+                                                    == target_data.get("evoType")
+                                                    and (
+                                                        sib_data.get("evoItem") or ""
+                                                    ).lower()
+                                                    == (
+                                                        target_data.get("evoItem") or ""
+                                                    ).lower()
+                                                ):
+                                                    has_matching_regional_sibling = True
+                                                    break
+                                        if not has_matching_regional_sibling:
+                                            entry["e"] = 1
+                                            break
+
+                choices.append(entry)
+            except Exception as e:
+                logger = services.logger
+                if logger:
+                    logger.log(
+                        "error",
+                        f"[Ankimon] get_pokemon_choices: skipping malformed record: {e}",
+                    )
                 continue
-            individual_id = data.get("individual_id")
-            pokedex_id = data.get("id")
-            name = data.get("name")
-            if not individual_id or not name:
-                continue
-
-            nickname = (data.get("nickname") or "").strip()
-            held_item = data.get("held_item") or ""
-            level = data.get("level")
-            shiny = bool(data.get("shiny"))
-            is_main = bool(main_individual_id and individual_id == main_individual_id)
-
-            # Resolve internal name using the optimized pokedex index
-            internal_name = search_pokedex_by_id(pokedex_id)
-            p_details = pokedex_data.get(internal_name)
-
-            # Sprite fallback: get base species_id
-            base_id = pokedex_id
-            if p_details:
-                base_id = p_details.get("species_id") or pokedex_id
-
-            entry = {
-                "id": individual_id,
-                "p": pokedex_id or 0,
-                "b": base_id or 0,
-                "n": name,
-                "l": int(level) if level is not None else None,
-                "cp": calculate_cp_from_dict(data),
-            }
-            if shiny:
-                entry["s"] = 1
-            if is_main:
-                entry["m"] = 1
-            if held_item:
-                entry["h"] = held_item
-            if nickname and nickname.lower() != (name or "").lower():
-                entry["nk"] = nickname
-
-            # Evolution eligibility (Optimized inline to avoid file I/O)
-            if is_evo_item and item_name and p_details:
-                evo_list = p_details.get("evos")
-                if evo_list:
-                    for target_evo_name in evo_list:
-                        normalized_target = target_evo_name.lower().replace(" ", "").replace("-", "").replace("'", "").replace(".", "").replace(":", "")
-                        target_data = pokedex_data.get(normalized_target) or pokedex_data.get(target_evo_name.lower())
-
-                        if target_data and target_data.get("evoType") in ("useItem", "trade"):
-                            # "trade" belongs here alongside "useItem": Ankimon has no
-                            # trading, so the trade-with-held-item species (Rhydon ->
-                            # Rhyperior via Protector, Onix -> Steelix via Metal Coat,
-                            # Seadra -> Kingdra via Dragon Scale, ...) are evolved by
-                            # applying the item directly. Omitting it hid every one of
-                            # them from this picker, which shop.js filters to e === 1.
-                            #
-                            # Normalize both sides by stripping spaces, hyphens and
-                            # apostrophes so pokedex.json display names (e.g.
-                            # "King's Rock") match items.csv identifiers (e.g.
-                            # "kings-rock"), which drop the apostrophe. Mirrors the
-                            # canonical logic in functions/pokedex_functions.py.
-                            required_item = (target_data.get("evoItem") or "").lower().replace(" ", "").replace("-", "").replace("'", "")
-                            normalized_item_name = (item_name or "").lower().replace(" ", "").replace("-", "").replace("'", "")
-                            if required_item == normalized_item_name:
-                                target_region = target_data.get("evoRegion")
-
-                                if target_region:
-                                    if active_region and active_region.lower() == target_region.lower():
-                                        entry["e"] = 1
-                                        break
-                                else:
-                                    # Standard form is only allowed if there is no regional sibling for this region/method
-                                    has_matching_regional_sibling = False
-                                    for sibling_name in evo_list:
-                                        sib_norm = sibling_name.lower().replace(" ", "").replace("-", "").replace("'", "").replace(".", "").replace(":", "")
-                                        sib_data = pokedex_data.get(sib_norm) or pokedex_data.get(sibling_name.lower())
-                                        if sib_data and sib_data.get("evoRegion") and active_region and sib_data.get("evoRegion").lower() == active_region.lower():
-                                            if sib_data.get("evoType") == target_data.get("evoType") and (sib_data.get("evoItem") or "").lower() == (target_data.get("evoItem") or "").lower():
-                                                has_matching_regional_sibling = True
-                                                break
-                                    if not has_matching_regional_sibling:
-                                        entry["e"] = 1
-                                        break
-
-            choices.append(entry)
-          except Exception as e:
-            logger = services.logger
-            if logger:
-                logger.log("error", f"[Ankimon] get_pokemon_choices: skipping malformed record: {e}")
-            continue
 
         # Eligible first, then active first, then level (high → low), then alphabetical.
         choices.sort(
@@ -1992,6 +2187,7 @@ class AnkimonItemsWeb(QDialog):
         if not is_evo_item:
             self._pokemon_choices_cache = result
         return result
+
     def handle_use_with_target(self, item_name, individual_id):
         """Apply an item to a specific Pokémon (chosen via the in-shell
         picker). Bypasses dispatch_use's QInputDialog branches by calling
@@ -2021,7 +2217,10 @@ class AnkimonItemsWeb(QDialog):
                 except Exception as e:
                     logger = services.logger
                     if logger:
-                        logger.log("error", f"[Ankimon] get_pokemon({individual_id}) failed: {e}")
+                        logger.log(
+                            "error",
+                            f"[Ankimon] get_pokemon({individual_id}) failed: {e}",
+                        )
                 pokedex_id = (pokemon_data or {}).get("id")
                 if not pokedex_id:
                     return {"ok": False, "message": "Could not look up that Pokémon."}
@@ -2040,35 +2239,43 @@ class AnkimonItemsWeb(QDialog):
         """Unequip a held item from a specific Pokémon and return it to the bag."""
         if not individual_id:
             return {"ok": False, "message": "No Pokémon selected."}
-        
+
         self._invalidate_pokemon_cache()
         try:
             from ..pyobj.pokemon_obj import PokemonObject
+
             pokemon_data = services.db.get_pokemon(individual_id)
             if not pokemon_data:
                 return {"ok": False, "message": "Could not find that Pokémon."}
-            
+
             pokemon_obj = PokemonObject.from_dict(pokemon_data)
             if pokemon_obj.held_item != item_name:
-                return {"ok": False, "message": "That Pokémon is not holding this item."}
-                
+                return {
+                    "ok": False,
+                    "message": "That Pokémon is not holding this item.",
+                }
+
             pokemon_obj.remove_held_item()
-            
+
             # Refresh open legacy item bag if it exists
             if self.item_window is not None:
                 self.item_window.renewWidgets()
-                
+
             # Also refresh an already-open PC Box window. Peek the registry
             # (services.pokemon_pc) rather than importing the lazy ``pokemon_pc``
             # proxy — that proxy would CONSTRUCT a brand-new PC window (and a Test
             # window) when none is open, so is_alive() would always be True and
             # we'd force an unwanted build. Mirrors singletons.swap_ankimon_account.
             from ..utils import is_alive
+
             pc = services.pokemon_pc
             if is_alive(pc):
                 pc.refresh_gui()
-                
-            return {"ok": True, "message": f"Unequipped {item_name.replace('-', ' ').title()} from {pokemon_data.get('name')}."}
+
+            return {
+                "ok": True,
+                "message": f"Unequipped {item_name.replace('-', ' ').title()} from {pokemon_data.get('name')}.",
+            }
         except Exception as e:
             return {"ok": False, "message": f"Unequip failed: {e}"}
 
@@ -2086,7 +2293,9 @@ class AnkimonItemsWeb(QDialog):
         """Build the schema + current values payload for the Settings screen."""
         from . import settings_schema
 
-        settings_obj = self.shop_manager.settings_obj if self.shop_manager is not None else None
+        settings_obj = (
+            self.shop_manager.settings_obj if self.shop_manager is not None else None
+        )
         if settings_obj is None:
             # Reload-safe: shop_manager / settings can be unset during early boot
             # or a profile swap. Serve an empty-but-valid payload so settings.js
@@ -2133,7 +2342,9 @@ class AnkimonItemsWeb(QDialog):
                 )
                 sub_chip_def = sub.get("chip_group")
                 if sub_chip_def:
-                    sub_settings.append(self._serialize_chip_group(sub_chip_def, config))
+                    sub_settings.append(
+                        self._serialize_chip_group(sub_chip_def, config)
+                    )
                 group["subgroups"].append(
                     {
                         "label": sub["label"],
@@ -2211,6 +2422,7 @@ class AnkimonItemsWeb(QDialog):
         if key == "battle.auto_catch_wishlist":
             entry["type"] = "wishlist"
             from ..functions.pokedex_functions import get_pretty_name_for_id
+
             names_dict = {}
             if isinstance(value, list):
                 for pid in value:
@@ -2277,7 +2489,9 @@ class AnkimonItemsWeb(QDialog):
         else:
             explicit_overrides = set()
 
-        settings_obj = self.shop_manager.settings_obj if self.shop_manager is not None else None
+        settings_obj = (
+            self.shop_manager.settings_obj if self.shop_manager is not None else None
+        )
         if settings_obj is None:
             return {"ok": False, "message": "Settings service is uninitialized."}
 
@@ -2299,11 +2513,15 @@ class AnkimonItemsWeb(QDialog):
                     and settings_schema.is_unchanged_secret_placeholder(raw_val)
                 ):
                     continue
-                working_config[key] = self._coerce_incoming(working_config[key], raw_val)
+                working_config[key] = self._coerce_incoming(
+                    working_config[key], raw_val
+                )
         except ValueError as e:
             return {"ok": False, "message": f"Validation error: {e}"}
 
-        working_config, adjustments = settings_schema.validate_and_clamp(working_config, original_config)
+        working_config, adjustments = settings_schema.validate_and_clamp(
+            working_config, original_config
+        )
 
         try:
             changed = False
@@ -2379,7 +2597,11 @@ class AnkimonItemsWeb(QDialog):
         config = data.get("config") if isinstance(data, dict) else None
         if config is None:
             # If no config payload was provided, reload from disk.
-            settings_obj = self.shop_manager.settings_obj if self.shop_manager is not None else None
+            settings_obj = (
+                self.shop_manager.settings_obj
+                if self.shop_manager is not None
+                else None
+            )
             if settings_obj is not None:
                 try:
                     config = settings_obj.load_config()
@@ -2427,7 +2649,7 @@ class AnkimonItemsWeb(QDialog):
         if isinstance(existing, list):
             if isinstance(incoming, list):
                 # Accept only integer IDs; silently drop anything non-numeric.
-                return [int(x) for x in incoming if str(x).lstrip('-').isdigit()]
+                return [int(x) for x in incoming if str(x).lstrip("-").isdigit()]
             return existing  # reject non-list payloads silently
         if isinstance(existing, bool):
             return bool(incoming)

--- a/src/Ankimon/ankimon_items_web/shop_obj.py
+++ b/src/Ankimon/ankimon_items_web/shop_obj.py
@@ -1924,15 +1924,17 @@ class AnkimonItemsWeb(QDialog):
         # Compute new stock + write to DB first; only deduct cash once the
         # write succeeds. Otherwise a DB failure could swallow the reroll
         # cost with nothing to show for it.
-        from ..pyobj.ankimon_shop import DAILY_ITEMS_POOL
+        from ..pyobj.ankimon_shop import get_daily_items_pool
+
+        daily_items_pool = get_daily_items_pool()
 
         random.seed()
         # Clamp sample sizes — random.sample raises if asked for more entries
         # than the pool contains, which would crash the bridge call.
         tm_pool = sm.get_tm_pool()
-        num_items = min(sm.number_of_daily_items, len(DAILY_ITEMS_POOL))
+        num_items = min(sm.number_of_daily_items, len(daily_items_pool))
         num_tms = min(sm.number_of_daily_items, len(tm_pool))
-        new_items = random.sample(DAILY_ITEMS_POOL, num_items)
+        new_items = random.sample(daily_items_pool, num_items)
         new_tms = random.sample(tm_pool, num_tms)
 
         try:

--- a/src/Ankimon/ankimon_items_web/shop_obj.py
+++ b/src/Ankimon/ankimon_items_web/shop_obj.py
@@ -72,9 +72,13 @@ class SafeWebEnginePage(QWebEnginePage):
 
 from ..functions.pokedex_functions import (
     find_details_move,
+    _ITEM_EVO_TRIGGERS,
+    _csv_gender_id,
+    _evolution_row_gender_id,
     _load_pokedex_cache,
     check_evolution_by_item,
     return_id_for_item_name,
+    safe_int,
 )
 from ..business import calculate_cp_from_dict
 from ..ankimon_profile_web.profile_data import ProfileData
@@ -2069,6 +2073,14 @@ class AnkimonItemsWeb(QDialog):
 
                 # Evolution eligibility (Optimized inline to avoid file I/O)
                 if is_evo_item and item_name and p_details:
+                    # Gender gate, mirroring check_evolution_by_item: Gallade
+                    # needs a male Kirlia, Froslass a female Snorunt. Without it
+                    # this picker flags a Pokemon that Check_Evo_Item then
+                    # refuses — and shop.js filters the list to e === 1, so the
+                    # player is offered the one candidate the actual use will
+                    # turn down. The CSV lookup behind it is lru_cached, so this
+                    # keeps the picker free of per-row file I/O.
+                    caller_gender_id = _csv_gender_id(data.get("gender"))
                     evo_list = p_details.get("evos")
                     if evo_list:
                         for target_evo_name in evo_list:
@@ -2088,6 +2100,20 @@ class AnkimonItemsWeb(QDialog):
                                 "useItem",
                                 "trade",
                             ):
+                                if caller_gender_id is not None:
+                                    required_gender_id = _evolution_row_gender_id(
+                                        safe_int(
+                                            target_data.get("actual_id")
+                                            or target_data.get("species_id")
+                                        ),
+                                        _ITEM_EVO_TRIGGERS,
+                                    )
+                                    if (
+                                        required_gender_id is not None
+                                        and caller_gender_id != required_gender_id
+                                    ):
+                                        continue
+
                                 # "trade" belongs here alongside "useItem": Ankimon has no
                                 # trading, so the trade-with-held-item species (Rhydon ->
                                 # Rhyperior via Protector, Onix -> Steelix via Metal Coat,

--- a/src/Ankimon/functions/encounter_functions.py
+++ b/src/Ankimon/functions/encounter_functions.py
@@ -1326,6 +1326,13 @@ def save_main_pokemon_progress(
             exception=e, message="Error loading main pokemon data."
         )
         return
+
+    # Fresh-moveset holder for both evolution checks below: filled while the
+    # level-up attack merge runs, so move-based evolutions evaluate against the
+    # moves learned on THIS level (not the stale DB row). Bound at function
+    # scope because a defeat can reach the friendship check with zero level-ups
+    # (the loop body never runs) — None then means "no fresh list; use stored".
+    attacks = None
     evolution_prompted = False
     levels_gained = 0
     while int(
@@ -1368,11 +1375,6 @@ def save_main_pokemon_progress(
             if settings_obj.get("gui.pop_up_dialog_message_on_defeat") is True:
                 logger.log_and_showinfo("info", f"{msg}")
         main_pokemon.xp = int(max(0, int(main_pokemon.xp) - current_lvl_xp_cost))
-
-        # Fresh-moveset holder for the level-evolution check below: filled while
-        # the level-up attack merge runs, so move-based evolutions evaluate
-        # against the moves learned on THIS level (not the stale DB row).
-        attacks = None
 
         if main_pokemon_data:
             mainpkmndata = main_pokemon_data

--- a/src/Ankimon/functions/encounter_functions.py
+++ b/src/Ankimon/functions/encounter_functions.py
@@ -1369,40 +1369,10 @@ def save_main_pokemon_progress(
                 logger.log_and_showinfo("info", f"{msg}")
         main_pokemon.xp = int(max(0, int(main_pokemon.xp) - current_lvl_xp_cost))
 
-        # Request to open the pokemon evo window
-        evo_id = check_evolution_for_pokemon(
-            main_pokemon.individual_id,
-            main_pokemon.id,
-            main_pokemon.level,
-            evo_window,
-            main_pokemon.everstone,
-            getattr(main_pokemon, "evolution_rejected", False),
-        )
-        if evo_id is not None:
-            evolution_prompted = True
-            events.emit(
-                "evolution_offered",
-                pokemon=main_pokemon.name,
-                trigger="level",
-                evo_id=evo_id,
-            )
-            # None-safe: return_name_for_id can return None for an unknown id, so
-            # fall back to the numeric id instead of crashing on .capitalize()
-            # (mirrors the friendship-evolution path below).
-            evo_display_name = return_name_for_id(evo_id)
-            evo_display_name = (
-                evo_display_name.capitalize() if evo_display_name else str(evo_id)
-            )
-            if not _in_bulk_resolve():
-                logger.log_and_showinfo(
-                    "info",
-                    translator.translate(
-                        "pokemon_about_to_evolve",
-                        main_pokemon_name=main_pokemon.name,
-                        evo_pokemon_name=evo_display_name,
-                        main_pokemon_level=main_pokemon.level,
-                    ),
-                )
+        # Fresh-moveset holder for the level-evolution check below: filled while
+        # the level-up attack merge runs, so move-based evolutions evaluate
+        # against the moves learned on THIS level (not the stale DB row).
+        attacks = None
 
         if main_pokemon_data:
             mainpkmndata = main_pokemon_data
@@ -1472,6 +1442,45 @@ def save_main_pokemon_progress(
                                 "info", f"{new_attack} will be discarded."
                             )
                 mainpkmndata["attacks"] = attacks
+
+        # Request to open the pokemon evo window — AFTER the level-up attack
+        # merge above, so a move-based (levelMove) evolution sees moves learned
+        # on this very level and fires on that event instead of one level late.
+        evo_id = check_evolution_for_pokemon(
+            main_pokemon.individual_id,
+            main_pokemon.id,
+            main_pokemon.level,
+            evo_window,
+            main_pokemon.everstone,
+            getattr(main_pokemon, "evolution_rejected", False),
+            current_attacks=attacks,
+        )
+        if evo_id is not None:
+            evolution_prompted = True
+            events.emit(
+                "evolution_offered",
+                pokemon=main_pokemon.name,
+                trigger="level",
+                evo_id=evo_id,
+            )
+            # None-safe: return_name_for_id can return None for an unknown id, so
+            # fall back to the numeric id instead of crashing on .capitalize()
+            # (mirrors the friendship-evolution path below).
+            evo_display_name = return_name_for_id(evo_id)
+            evo_display_name = (
+                evo_display_name.capitalize() if evo_display_name else str(evo_id)
+            )
+            if not _in_bulk_resolve():
+                logger.log_and_showinfo(
+                    "info",
+                    translator.translate(
+                        "pokemon_about_to_evolve",
+                        main_pokemon_name=main_pokemon.name,
+                        evo_pokemon_name=evo_display_name,
+                        main_pokemon_level=main_pokemon.level,
+                    ),
+                )
+
     experience_till_next_level = int(
         find_experience_for_level(
             main_pokemon.growth_rate,
@@ -1571,6 +1580,7 @@ def save_main_pokemon_progress(
                 main_pokemon.everstone,
                 main_pokemon.friendship,
                 getattr(main_pokemon, "evolution_rejected", False),
+                attacks=attacks,
             )
             if friendship_evo_id is not None:
                 evolution_prompted = True

--- a/src/Ankimon/functions/encounter_functions.py
+++ b/src/Ankimon/functions/encounter_functions.py
@@ -16,6 +16,7 @@ except (ImportError, ModuleNotFoundError):
     def tooltip(msg, period=2000):
         print(f"[Ankimon Tooltip] {msg}")
 
+
 from ..services import services
 from ..events import events
 from ..functions.pokemon_functions import (
@@ -256,15 +257,15 @@ def toggle_auto_battle_override(
 ) -> Optional[Literal["catch", "defeat"]]:
     """
     Toggle the auto-battle override for the current encounter.
-    
+
     Args:
         action: "catch" or "defeat"
-    
+
     Returns:
         Current override state as a string: None, "catch", or "defeat"
     """
     global _auto_battle_override
-    
+
     # If the same action is already set, clear it (toggle off)
     if _auto_battle_override == action:
         _auto_battle_override = None
@@ -274,7 +275,7 @@ def toggle_auto_battle_override(
         _auto_battle_override = action
         action_display = "Catch" if action == "catch" else "Defeat"
         tooltip(f"Override set: Will {action_display} when fainted!")
-    
+
     return _auto_battle_override
 
 
@@ -287,6 +288,7 @@ def clear_auto_battle_override() -> None:
     """Clear the override state (called when a new encounter starts)."""
     global _auto_battle_override
     _auto_battle_override = None
+
 
 def calculate_mastery_index_ep(total_reviews, daily_average, trainer_level):
     """
@@ -1343,20 +1345,27 @@ def save_main_pokemon_progress(
         )
     ) < int(main_pokemon.xp) and (level_cap is None or main_pokemon.level < level_cap):
         if levels_gained >= 10:
-            logger.log("error", f"Level-up loop exceeded safety cap of 10 for {main_pokemon.name}")
-            next_level_cost = int(find_experience_for_level(
-                main_pokemon.growth_rate,
-                main_pokemon.level,
-                settings_obj.get("misc.remove_level_cap"),
-            ))
+            logger.log(
+                "error",
+                f"Level-up loop exceeded safety cap of 10 for {main_pokemon.name}",
+            )
+            next_level_cost = int(
+                find_experience_for_level(
+                    main_pokemon.growth_rate,
+                    main_pokemon.level,
+                    settings_obj.get("misc.remove_level_cap"),
+                )
+            )
             main_pokemon.xp = max(0, next_level_cost - 1)
             break
         levels_gained += 1
-        current_lvl_xp_cost = int(find_experience_for_level(
-            main_pokemon.growth_rate,
-            main_pokemon.level,
-            settings_obj.get("misc.remove_level_cap"),
-        ))
+        current_lvl_xp_cost = int(
+            find_experience_for_level(
+                main_pokemon.growth_rate,
+                main_pokemon.level,
+                settings_obj.get("misc.remove_level_cap"),
+            )
+        )
         main_pokemon.level += 1
         events.emit("levelup", pokemon=main_pokemon.name, level=main_pokemon.level)
         msg = ""
@@ -1456,6 +1465,7 @@ def save_main_pokemon_progress(
             main_pokemon.everstone,
             getattr(main_pokemon, "evolution_rejected", False),
             current_attacks=attacks,
+            gender=getattr(main_pokemon, "gender", None),
         )
         if evo_id is not None:
             evolution_prompted = True
@@ -1583,6 +1593,9 @@ def save_main_pokemon_progress(
                 main_pokemon.friendship,
                 getattr(main_pokemon, "evolution_rejected", False),
                 attacks=attacks,
+                # In-memory defeat count (already incremented for this battle
+                # above) keeps the victory path free of synchronous DB reads.
+                pokemon_defeated=main_pokemon.pokemon_defeated,
             )
             if friendship_evo_id is not None:
                 evolution_prompted = True
@@ -1787,6 +1800,7 @@ def save_caught_pokemon(
 
     try:
         from ..singletons import notify_stats_changed
+
         notify_stats_changed()
     except Exception:
         pass
@@ -1917,7 +1931,7 @@ def handle_enemy_faint(
         finally:
             clear_auto_battle_override()
         return
-        
+
     elif _auto_battle_override == "defeat":
         # Override: Force defeat, unless the enemy is protected by an
         # "always auto-catch" tier setting (legendary/mythical/ultra/

--- a/src/Ankimon/functions/encounter_functions.py
+++ b/src/Ankimon/functions/encounter_functions.py
@@ -1329,12 +1329,19 @@ def save_main_pokemon_progress(
         )
         return
 
-    # Fresh-moveset holder for both evolution checks below: filled while the
-    # level-up attack merge runs, so move-based evolutions evaluate against the
-    # moves learned on THIS level (not the stale DB row). Bound at function
-    # scope because a defeat can reach the friendship check with zero level-ups
-    # (the loop body never runs) — None then means "no fresh list; use stored".
-    attacks = None
+    # Moveset both evolution checks below evaluate. Seeded from the record
+    # loaded above — the SAME captured_pokemon row the checkers would re-read
+    # for themselves (get_main_pokemon() selects is_main = 1, get_pokemon()
+    # selects that row by individual_id), so the seed is identical to their
+    # fallback's result while sparing the review path one query on every
+    # no-level-up victory. The level-up merge below rebinds this to the live
+    # mainpkmndata["attacks"] list, so moves learned on THIS level are seen too.
+    # This is NOT main_pokemon.attacks — see the note at the friendship check.
+    # Stays None only when there is no stored record at all, which keeps the
+    # checkers' own lookup for that broken-save path.
+    attacks = (
+        list(main_pokemon_data.get("attacks") or []) if main_pokemon_data else None
+    )
     evolution_prompted = False
     levels_gained = 0
     while int(
@@ -1592,18 +1599,19 @@ def save_main_pokemon_progress(
                 main_pokemon.everstone,
                 main_pokemon.friendship,
                 getattr(main_pokemon, "evolution_rejected", False),
-                # The fresh post-level-up list when this defeat produced one;
-                # None otherwise, which sends the checker to the DB for the
-                # stored moveset. That read is deliberate — do NOT "optimize" it
-                # into `main_pokemon.attacks`. The level-up merge above writes
-                # the learned move to mainpkmndata (the DB dict) only, so the
-                # in-memory PokemonObject's moveset goes stale on the first
-                # level-up and never re-syncs for the rest of the session
-                # (update_main_pokemon only runs at boot / on an evolution / from
-                # the profile+shop screens). Feeding that stale list to the CSV
-                # known_move_type gate would stop offering Sylveon to an Eevee
-                # that HAS learned a Fairy move — and flip-flop, since the rarer
-                # level-up defeats still pass the fresh list.
+                # The stored moveset, refreshed by the level-up merge above
+                # when this defeat produced one. Do NOT "optimize" this into
+                # `main_pokemon.attacks` (reverted once already, 9a54562f): the
+                # merge writes the learned move to mainpkmndata (the DB dict)
+                # only, so the in-memory PokemonObject's moveset goes stale on
+                # the first level-up and never re-syncs for the rest of the
+                # session (update_main_pokemon only runs at boot / on an
+                # evolution / from the profile+shop screens). Feeding that stale
+                # list to the CSV known_move_type gate stops offering Sylveon to
+                # an Eevee that HAS learned a Fairy move — and flip-flops, since
+                # the rarer level-up defeats still pass the fresh list. The
+                # stored record is safe where the object is not: it is the very
+                # row this checker's own fallback would re-read.
                 attacks=attacks,
                 # The defeat count, unlike the moveset, IS accurate in memory —
                 # it was incremented for this battle a few lines above — so pass

--- a/src/Ankimon/functions/encounter_functions.py
+++ b/src/Ankimon/functions/encounter_functions.py
@@ -1592,9 +1592,15 @@ def save_main_pokemon_progress(
                 main_pokemon.everstone,
                 main_pokemon.friendship,
                 getattr(main_pokemon, "evolution_rejected", False),
-                attacks=attacks,
+                # Prefer the fresh post-level-up list, but never fall through to
+                # None: most defeats grant no level-up, so `attacks` is still
+                # unset there and passing it alone would send the checker back to
+                # the DB on the common path. The in-memory object always carries
+                # a moveset (PokemonObject.__init__ defaults it), so this keeps
+                # the victory path free of synchronous DB reads either way.
+                attacks=attacks if attacks is not None else main_pokemon.attacks,
                 # In-memory defeat count (already incremented for this battle
-                # above) keeps the victory path free of synchronous DB reads.
+                # above), same reason.
                 pokemon_defeated=main_pokemon.pokemon_defeated,
             )
             if friendship_evo_id is not None:

--- a/src/Ankimon/functions/encounter_functions.py
+++ b/src/Ankimon/functions/encounter_functions.py
@@ -1592,15 +1592,22 @@ def save_main_pokemon_progress(
                 main_pokemon.everstone,
                 main_pokemon.friendship,
                 getattr(main_pokemon, "evolution_rejected", False),
-                # Prefer the fresh post-level-up list, but never fall through to
-                # None: most defeats grant no level-up, so `attacks` is still
-                # unset there and passing it alone would send the checker back to
-                # the DB on the common path. The in-memory object always carries
-                # a moveset (PokemonObject.__init__ defaults it), so this keeps
-                # the victory path free of synchronous DB reads either way.
-                attacks=attacks if attacks is not None else main_pokemon.attacks,
-                # In-memory defeat count (already incremented for this battle
-                # above), same reason.
+                # The fresh post-level-up list when this defeat produced one;
+                # None otherwise, which sends the checker to the DB for the
+                # stored moveset. That read is deliberate — do NOT "optimize" it
+                # into `main_pokemon.attacks`. The level-up merge above writes
+                # the learned move to mainpkmndata (the DB dict) only, so the
+                # in-memory PokemonObject's moveset goes stale on the first
+                # level-up and never re-syncs for the rest of the session
+                # (update_main_pokemon only runs at boot / on an evolution / from
+                # the profile+shop screens). Feeding that stale list to the CSV
+                # known_move_type gate would stop offering Sylveon to an Eevee
+                # that HAS learned a Fairy move — and flip-flop, since the rarer
+                # level-up defeats still pass the fresh list.
+                attacks=attacks,
+                # The defeat count, unlike the moveset, IS accurate in memory —
+                # it was incremented for this battle a few lines above — so pass
+                # it and spare the checker that half of the lookup.
                 pokemon_defeated=main_pokemon.pokemon_defeated,
             )
             if friendship_evo_id is not None:

--- a/src/Ankimon/functions/encounter_functions.py
+++ b/src/Ankimon/functions/encounter_functions.py
@@ -1330,17 +1330,40 @@ def save_main_pokemon_progress(
         return
 
     # Moveset both evolution checks below evaluate. Seeded from the record
-    # loaded above — the SAME captured_pokemon row the checkers would re-read
-    # for themselves (get_main_pokemon() selects is_main = 1, get_pokemon()
-    # selects that row by individual_id), so the seed is identical to their
-    # fallback's result while sparing the review path one query on every
-    # no-level-up victory. The level-up merge below rebinds this to the live
-    # mainpkmndata["attacks"] list, so moves learned on THIS level are seen too.
-    # This is NOT main_pokemon.attacks — see the note at the friendship check.
-    # Stays None only when there is no stored record at all, which keeps the
-    # checkers' own lookup for that broken-save path.
+    # loaded above — normally the SAME captured_pokemon row the checkers would
+    # re-read for themselves (get_main_pokemon() selects is_main = 1,
+    # get_pokemon() selects that row by individual_id), so the seed is identical
+    # to their fallback's result while sparing the review path one query on
+    # every no-level-up victory. The level-up merge below rebinds this to the
+    # live mainpkmndata["attacks"] list, so moves learned on THIS level are seen
+    # too. This is NOT main_pokemon.attacks — see the note at the friendship
+    # check.
+    #
+    # "Normally" is why the identity is CHECKED below rather than assumed.
+    # is_main carries no uniqueness constraint (db_diagnostics.py exists to hunt
+    # for duplicate rows) and get_main_pokemon() fetchone()s whatever it finds,
+    # so the stored main row and the in-memory main_pokemon can name different
+    # Pokemon — the level-up merge below guards itself against exactly that, by
+    # name, before touching the moveset. Handing a mismatched row's moves to the
+    # checkers would evaluate a levelMove or known_move_type gate against ANOTHER
+    # Pokemon, and unlike the merge they have no guard of their own. Passing None
+    # on a mismatch costs one query and restores each checker's
+    # get_pokemon(individual_id) lookup, which is keyed correctly by
+    # construction — the same fallback a wholly missing record already takes.
     attacks = (
         list(main_pokemon_data.get("attacks") or []) if main_pokemon_data else None
+    )
+    # Compared as strings because individual_id is TEXT in the schema but has
+    # reached this code as an int from callers; a genuine match must not be
+    # declined over the type alone. Two missing ids are NOT a match — with
+    # nothing to compare the identity is unverified, which is the case this
+    # exists to refuse.
+    _main_individual_id = getattr(main_pokemon, "individual_id", None)
+    stored_row_is_main_pokemon = (
+        bool(main_pokemon_data)
+        and _main_individual_id is not None
+        and main_pokemon_data.get("individual_id") is not None
+        and str(main_pokemon_data.get("individual_id")) == str(_main_individual_id)
     )
     evolution_prompted = False
     levels_gained = 0
@@ -1471,7 +1494,7 @@ def save_main_pokemon_progress(
             evo_window,
             main_pokemon.everstone,
             getattr(main_pokemon, "evolution_rejected", False),
-            current_attacks=attacks,
+            current_attacks=attacks if stored_row_is_main_pokemon else None,
             gender=getattr(main_pokemon, "gender", None),
         )
         if evo_id is not None:
@@ -1611,8 +1634,9 @@ def save_main_pokemon_progress(
                 # an Eevee that HAS learned a Fairy move — and flip-flops, since
                 # the rarer level-up defeats still pass the fresh list. The
                 # stored record is safe where the object is not: it is the very
-                # row this checker's own fallback would re-read.
-                attacks=attacks,
+                # row this checker's own fallback would re-read — as long as it
+                # really is this Pokemon's row, which is what the flag checks.
+                attacks=attacks if stored_row_is_main_pokemon else None,
                 # The defeat count, unlike the moveset, IS accurate in memory —
                 # it was incremented for this battle a few lines above — so pass
                 # it and spare the checker that half of the lookup.

--- a/src/Ankimon/functions/friendship_evolution.py
+++ b/src/Ankimon/functions/friendship_evolution.py
@@ -23,6 +23,7 @@ from .pokedex_functions import (
     _csv_gender_id,
     _evolution_row_gender_id,
     _load_moves_cache,
+    filter_gender_split_forms,
     pokemon_evolves_from_id,
     return_name_for_id,
     rows_for_key_in_table,
@@ -942,10 +943,25 @@ def _level_readiness(
     # it back: when every target is gated to the other gender the representative
     # is kept only so the UI can say why, and ``gender_ok`` keeps it out of
     # ``ready``.
-    caller_gender_id = _csv_gender_id(_pokemon_gender(pokemon))
+    pokemon_gender = _pokemon_gender(pokemon)
+    caller_gender_id = _csv_gender_id(pokemon_gender)
     gendered = [e for e in level_evos if _level_gender_gate(e.evo_id, caller_gender_id)]
     if gendered:
         level_evos = tuple(gendered)
+
+    # Second gender source, for splits pokemon_evolution.csv cannot express as
+    # gendered rows: veekun models Espurr -> Meowstic/Meowstic-F and Lechonk ->
+    # Oinkologne/Oinkologne-F as FORMS of one species, so neither carries a
+    # gender_id and the gate above sees no split — leaving the lowest-evo_id
+    # tie-break to hand every Espurr the male Meowstic. pokedex.json does carry
+    # it, on each evolved form's own `gender`. Narrows siblings only (see
+    # filter_gender_split_forms), so it can never empty the candidate list and
+    # `gender_ok` below stays driven by the CSV gate alone.
+    split = set(
+        filter_gender_split_forms([e.evo_id for e in level_evos], pokemon_gender)
+    )
+    if split:
+        level_evos = tuple(e for e in level_evos if e.evo_id in split)
 
     # Among the surviving targets prefer one eligible right now (its time matches
     # or it has no time requirement); an explicit-time row beats a blank-time one.

--- a/src/Ankimon/functions/friendship_evolution.py
+++ b/src/Ankimon/functions/friendship_evolution.py
@@ -533,9 +533,14 @@ def _satisfies_move_gate(
     """Return whether ``evo``'s move-type requirement is satisfied.
 
     ``known_move_types is None`` means "moves unknown" — the caller had no
-    attacks data. Every gate then evaluates False so a move-gated evolution is
-    never offered on missing data (fail-closed); non-gated evolutions are
-    unaffected and stay eligible.
+    attacks data at all. Every gate then evaluates False so a move-gated
+    evolution is never offered on missing data (fail-closed); non-gated
+    evolutions are unaffected and stay eligible.
+
+    Note that :func:`evolution_readiness` always passes a concrete frozenset:
+    :func:`_known_move_types` answers a Pokémon with no readable moveset with an
+    *empty* set, which fails the same way. The ``None`` case exists for direct
+    callers (and for the parameter's own default) and behaves identically.
     """
     if evo.known_move_type is None:
         return True
@@ -565,6 +570,14 @@ def _select_evolution(
     falls back to the lowest remaining ``evo_id`` so the UI can still show e.g.
     "waiting for Night".
 
+    If *every* row is move-gated and none is satisfied there is no reachable
+    row to rank, so the lowest ``evo_id`` comes back as a representative for the
+    UI ("needs a Fairy-type move"). Callers MUST NOT read that as eligible:
+    :func:`evolution_readiness` re-checks the chosen row with
+    :func:`_satisfies_move_gate` and folds the result into ``ready``, so the
+    branch can't fail open. (No bundled species reaches it today — Eevee, the
+    only species with gated rows, also has ungated ones.)
+
     Args:
         evos: Non-empty tuple from :func:`get_friendship_evolutions_for_species`.
         time_of_day: Current time of day (``"day"`` or ``"night"``).
@@ -575,17 +588,22 @@ def _select_evolution(
         The chosen :class:`FriendshipEvolution`.
     """
     valid_evos = [e for e in evos if _satisfies_move_gate(e, known_move_types)]
-    # A species whose every friendship row is move-gated keeps a representative
-    # for UI text ("needs a Fairy-type move") instead of turning not-evolvable.
     if not valid_evos:
-        valid_evos = list(evos)
+        # Reaching here means every row carries a move gate and none is met (an
+        # ungated row would have satisfied trivially). Ranking them by "most
+        # specific requirement" is meaningless when none is reachable, so return
+        # the lowest evo_id as a stable representative for the UI and let the
+        # caller's _satisfies_move_gate re-check keep it out of `ready`.
+        return min(evos, key=lambda e: e.evo_id)
 
     eligible_now = [e for e in valid_evos if e.time_of_day in (time_of_day, None)]
     if eligible_now:
         # Sort: satisfied move gate first (a known Fairy move outranks the
         # day/night clock — Sylveon over Espeon/Umbreon), then explicit-time
         # rows over blank-time rows, then lowest evo_id. Each ``is None`` /
-        # ``==`` predicate sorts falsy-first via the bool key.
+        # ``==`` predicate sorts falsy-first via the bool key. Every row here
+        # has already passed its gate, so the first key only ever promotes a
+        # SATISFIED gate.
         return min(
             eligible_now,
             key=lambda e: (
@@ -614,8 +632,12 @@ def evolution_readiness(pokemon: Any, now: Optional[datetime] = None) -> dict:
     Returns:
         A readiness dict with keys: ``evolvable, ready, method, evo_id,
         evo_name, min_happiness, current_friendship, friendship_remaining,
-        required_time, time_ok, status_text, bar_max, rejected``. ``bar_max``
-        defaults to :data:`MAX_FRIENDSHIP` outside the friendship path.
+        required_time, time_ok, status_text, bar_max, rejected,
+        required_move_type, gated_alternatives``. ``bar_max`` defaults to
+        :data:`MAX_FRIENDSHIP` outside the friendship path;
+        ``required_move_type``/``gated_alternatives`` describe CSV
+        ``known_move_type_id`` gates (Sylveon's Fairy-move requirement) and are
+        ``None``/``()`` everywhere else.
     """
     if isinstance(pokemon, dict):
         species_id = pokemon.get("id")
@@ -646,6 +668,8 @@ def evolution_readiness(pokemon: Any, now: Optional[datetime] = None) -> dict:
         "status_text": "",
         "bar_max": MAX_FRIENDSHIP,
         "rejected": False,
+        "required_move_type": None,
+        "gated_alternatives": (),
     }
 
     if species_id is None:
@@ -674,15 +698,34 @@ def evolution_readiness(pokemon: Any, now: Optional[datetime] = None) -> dict:
             pokemon=pokemon,
         )
 
-    chosen = _select_evolution(evos, time_of_day, _known_move_types(pokemon))
+    known_move_types = _known_move_types(pokemon)
+    chosen = _select_evolution(evos, time_of_day, known_move_types)
     evo_id = chosen.evo_id
     evo_name = chosen.evo_name
     min_happiness = chosen.min_happiness
     required_time = chosen.time_of_day
 
+    # The chosen row can still carry an UNMET move gate in one case: every row
+    # for the species was gated, so _select_evolution had to hand back a
+    # representative. Folding move_ok into `ready` is what keeps that branch
+    # from failing open (the friendship/time numbers alone would say "ready").
+    move_ok = _satisfies_move_gate(chosen, known_move_types)
+    required_move_type = None if move_ok else chosen.known_move_type
+
+    # Evolutions the data offers but the current moveset hides. Without this the
+    # gate is invisible: a high-friendship Eevee simply shows Espeon/Umbreon and
+    # nothing ever tells the player Sylveon exists or what it wants.
+    gated_alternatives = tuple(
+        (e.evo_name, e.known_move_type)
+        for e in evos
+        if e.evo_id != evo_id
+        and e.known_move_type is not None
+        and not _satisfies_move_gate(e, known_move_types)
+    )
+
     friendship_remaining = max(0, min_happiness - friendship)
     time_ok = required_time is None or required_time == time_of_day
-    ready = (not everstone) and friendship >= min_happiness and time_ok
+    ready = (not everstone) and friendship >= min_happiness and time_ok and move_ok
 
     status_text = _build_status_text(
         everstone=everstone,
@@ -693,6 +736,8 @@ def evolution_readiness(pokemon: Any, now: Optional[datetime] = None) -> dict:
         time_ok=time_ok,
         time_of_day=time_of_day,
         rejected=evolution_rejected,
+        required_move_type=required_move_type,
+        gated_alternatives=gated_alternatives,
     )
 
     return {
@@ -709,6 +754,12 @@ def evolution_readiness(pokemon: Any, now: Optional[datetime] = None) -> dict:
         "status_text": status_text,
         "bar_max": min_happiness,
         "rejected": evolution_rejected,
+        # Unmet move-type gate on the CHOSEN evolution (None when satisfied or
+        # ungated), and the (name, move_type) pairs of alternatives currently
+        # hidden behind one — e.g. ``(("Sylveon", "fairy"),)`` for an Eevee that
+        # knows no Fairy move.
+        "required_move_type": required_move_type,
+        "gated_alternatives": gated_alternatives,
     }
 
 
@@ -906,6 +957,11 @@ def _level_readiness(
         "status_text": status_text,
         "bar_max": MAX_FRIENDSHIP,
         "rejected": evolution_rejected,
+        # Shape parity with the friendship path. Level evolutions gate on a
+        # specific move NAME (``evoMove``, surfaced in status_text above), not on
+        # a move TYPE from the CSV, so these are always empty here.
+        "required_move_type": None,
+        "gated_alternatives": (),
     }
 
 
@@ -919,37 +975,67 @@ def _build_status_text(
     time_ok: bool,
     time_of_day: str,
     rejected: bool = False,
+    required_move_type: Optional[str] = None,
+    gated_alternatives: tuple = (),
 ) -> str:
     """Build the human-readable readiness line shown in the UI.
+
+    ``required_move_type`` is an unmet move-type gate on the chosen evolution
+    and always wins the line, because nothing else the player does will unblock
+    it. ``gated_alternatives`` are ``(name, move_type)`` pairs for evolutions the
+    species *can* reach but whose gate the current moveset doesn't meet; they are
+    appended as a hint so the branch is discoverable at all (without it a Fairy
+    move silently redirects an Eevee to Sylveon with no prior warning).
 
     Examples:
         - ``"Everstone prevents evolution"``
         - ``"Evolution rejected — tap Evolve now to override"``
         - ``"Ready to evolve into Espeon!"``
+        - ``"Ready to evolve into Espeon! · Sylveon needs a Fairy-type move"``
         - ``"Ready — waiting for Night (now Day)"``
         - ``"40 friendship to evolve into Espeon · needs Day"``
+        - ``"Needs a Fairy-type move to evolve into Sylveon"``
     """
     if everstone:
         return "Everstone prevents evolution"
 
+    # An unmet gate on the chosen evolution outranks every other line: the
+    # friendship bar being full doesn't matter while the moveset blocks it.
+    if required_move_type:
+        return (
+            f"Needs a {required_move_type.capitalize()}-type move "
+            f"to evolve into {evo_name}"
+        )
+
+    hint = (
+        " · "
+        + " · ".join(
+            f"{name} needs a {move_type.capitalize()}-type move"
+            for name, move_type in gated_alternatives
+            if move_type
+        )
+        if gated_alternatives
+        else ""
+    )
+
     if ready and rejected:
-        return "Evolution rejected — tap Evolve now to override"
+        return "Evolution rejected — tap Evolve now to override" + hint
 
     if ready:
-        return f"Ready to evolve into {evo_name}!"
+        return f"Ready to evolve into {evo_name}!" + hint
 
     # Friendship is high enough but the time of day is wrong.
     if friendship_remaining == 0 and not time_ok and required_time is not None:
         return (
             f"Ready — waiting for {required_time.capitalize()} "
-            f"(now {time_of_day.capitalize()})"
+            f"(now {time_of_day.capitalize()})" + hint
         )
 
     # Still needs more friendship.
     text = f"{friendship_remaining} friendship to evolve into {evo_name}"
     if required_time is not None:
         text += f" · needs {required_time.capitalize()}"
-    return text
+    return text + hint
 
 
 def check_friendship_evolution_for_pokemon(

--- a/src/Ankimon/functions/friendship_evolution.py
+++ b/src/Ankimon/functions/friendship_evolution.py
@@ -987,13 +987,22 @@ def _build_status_text(
     appended as a hint so the branch is discoverable at all (without it a Fairy
     move silently redirects an Eevee to Sylveon with no prior warning).
 
+    Where the hint actually surfaces today: the only consumer of ``status_text``
+    is the details panel (``gui_classes/pokemon_details.py``), and it renders the
+    line only while ``ready`` is False — which for a friendship evolution is the
+    whole climb from 0 to ``min_happiness`` (every capture starts at friendship
+    0, Eevee needs 160), so the player sees it for the entire period they can act
+    on it. Once ``ready`` flips the panel shows an "Evolve now" button instead
+    and the line is not drawn. The hint is still appended to the ready branches
+    below so the string stays correct for any consumer that does render it —
+    just don't read those variants as something a user sees today.
+
     Examples:
         - ``"Everstone prevents evolution"``
-        - ``"Evolution rejected — tap Evolve now to override"``
         - ``"Ready to evolve into Espeon!"``
-        - ``"Ready to evolve into Espeon! · Sylveon needs a Fairy-type move"``
         - ``"Ready — waiting for Night (now Day)"``
         - ``"40 friendship to evolve into Espeon · needs Day"``
+        - ``"40 friendship to evolve into Espeon · Sylveon needs a Fairy-type move"``
         - ``"Needs a Fairy-type move to evolve into Sylveon"``
     """
     if everstone:

--- a/src/Ankimon/functions/friendship_evolution.py
+++ b/src/Ankimon/functions/friendship_evolution.py
@@ -19,7 +19,7 @@ from datetime import datetime, timedelta, timezone
 from typing import Any, NamedTuple, Optional
 
 from .pokedex_functions import (
-    find_details_move,
+    _load_moves_cache,
     pokemon_evolves_from_id,
     return_name_for_id,
     rows_for_key_in_table,
@@ -472,13 +472,46 @@ def get_level_evolutions_for_species(
     return tuple(evolutions)
 
 
+def _move_type_of(attack: Any) -> Optional[str]:
+    """Return the lower-case type of one move name, or ``None``.
+
+    A quiet lookup over the startup-loaded ``moves.json`` cache only.
+    Deliberately *not* :func:`find_details_move`, which answers unknown names
+    with the default "tackle" entry — that would misreport the type AND pop a
+    warning dialog through ``services.ui.warn`` mid-review. An unknown or junk
+    name simply carries no type evidence (None).
+    """
+    if not isinstance(attack, str):
+        return None
+    name = attack.strip()
+    if not name:
+        return None
+    try:
+        moves = _load_moves_cache() or {}
+    except Exception:
+        return None
+    # Same normalization ladder find_details_move uses, minus the fallback.
+    for candidate in (
+        name.lower(),
+        name.replace(" ", "").replace("-", "").lower(),
+        name.replace(" ", "").lower(),
+        name.replace("-", "").lower(),
+    ):
+        move_data = moves.get(candidate)
+        if isinstance(move_data, dict):
+            move_type = move_data.get("type")
+            if isinstance(move_type, str) and move_type.strip():
+                return move_type.strip().lower()
+    return None
+
+
 def _known_move_types(pokemon: Any) -> frozenset:
     """Return the set of move types the Pokémon knows, lower-cased.
 
     Accepts a dict or an object with an ``attacks`` attribute (the two shapes
-    :func:`evolution_readiness` supports). Move names are resolved through
-    ``find_details_move``; unknown moves resolve to a default entry rather than
-    raising, so the result is best-effort by construction.
+    :func:`evolution_readiness` supports). Move names resolve through the quiet
+    :func:`_move_type_of` cache lookup; unknown moves contribute nothing rather
+    than raising, so the result is best-effort by construction.
     """
     if pokemon is None:
         return frozenset()
@@ -488,14 +521,9 @@ def _known_move_types(pokemon: Any) -> frozenset:
         attacks = getattr(pokemon, "attacks", None) or []
     types: set = set()
     for attack in attacks:
-        try:
-            move_data = find_details_move(str(attack))
-        except Exception:
-            move_data = None
-        if isinstance(move_data, dict):
-            move_type = move_data.get("type")
-            if isinstance(move_type, str) and move_type.strip():
-                types.add(move_type.strip().lower())
+        move_type = _move_type_of(attack)
+        if move_type:
+            types.add(move_type)
     return frozenset(types)
 
 
@@ -646,9 +674,7 @@ def evolution_readiness(pokemon: Any, now: Optional[datetime] = None) -> dict:
             pokemon=pokemon,
         )
 
-    chosen = _select_evolution(
-        evos, time_of_day, _known_move_types(pokemon)
-    )
+    chosen = _select_evolution(evos, time_of_day, _known_move_types(pokemon))
     evo_id = chosen.evo_id
     evo_name = chosen.evo_name
     min_happiness = chosen.min_happiness
@@ -935,6 +961,7 @@ def check_friendship_evolution_for_pokemon(
     evolution_rejected: bool = False,
     now: Optional[datetime] = None,
     attacks: Optional[list] = None,
+    pokemon_defeated: Optional[int] = None,
 ) -> Optional[int]:
     """Prompt a friendship (or defeat-milestone) evolution for a Pokémon if ready.
 
@@ -945,7 +972,8 @@ def check_friendship_evolution_for_pokemon(
 
     * friendship/time evolutions (``method == "friendship"``); and
     * ``minimumDefeated`` evolutions (a subset of ``method == "level"`` — e.g.
-      Pawmo -> Pawmot after 100 defeats), whose defeat count is read from the DB.
+      Pawmo -> Pawmot after 100 defeats), whose defeat count comes from the
+      caller's in-memory state (with a guarded DB fallback for legacy callers).
 
     Plain level-up evolutions are NOT auto-prompted here (those are handled by
     ``check_evolution_for_pokemon`` on level-up; the manual PC button covers the
@@ -962,6 +990,13 @@ def check_friendship_evolution_for_pokemon(
         attacks: Optional live moveset; when given it takes precedence over the
             stored one so move-type-gated evolutions (e.g. Sylveon's Fairy-move
             requirement) evaluate against freshest-known data.
+        pokemon_defeated: Optional defeat count for ``minimumDefeated``
+            evolutions (e.g. Pawmo -> Pawmot). Supply it — together with
+            ``attacks`` — from state the caller already holds so this checker
+            performs **no synchronous disk I/O** on Anki's review path (coding
+            guideline: never do synchronous disk I/O mid-review). ``None``
+            keeps the legacy behavior of one guarded DB read for the value(s)
+            the caller didn't supply.
 
     Returns:
         The evolved species id if the evolution was triggered, else ``None``.
@@ -976,32 +1011,39 @@ def check_friendship_evolution_for_pokemon(
         return None
 
     # Defeat count and known attacks for move/defeat-gated evolutions (Sylveon
-    # needs a Fairy-type move; Pawmo/Rellor need defeat milestones): read via the
-    # DB seam, guarded so a missing/unavailable store degrades to 0 / no attacks
-    # rather than raising on the victory hot path.
-    pokemon_defeated = 0
-    stored_attacks: list = []
-    try:
-        db = services.db
-        if db is not None and hasattr(db, "get_pokemon"):
-            record = db.get_pokemon(individual_id) or {}
-            if isinstance(record, dict):
-                pokemon_defeated = record.get("pokemon_defeated", 0)
-                stored_attacks = record.get("attacks") or []
-    except Exception:
+    # needs a Fairy-type move; Pawmo/Rellor need defeat milestones). Production
+    # callers hold both in memory already and pass them in, so the victory-time
+    # path does zero synchronous disk I/O. The DB seam below runs only for the
+    # values a caller left as None (legacy/test callers), guarded so a
+    # missing/unavailable store degrades to 0 / no attacks rather than raising.
+    defeats_known = pokemon_defeated is not None
+    if pokemon_defeated is None or attacks is None:
+        try:
+            db = services.db
+            if db is not None and hasattr(db, "get_pokemon"):
+                record = db.get_pokemon(individual_id) or {}
+                if isinstance(record, dict):
+                    if not defeats_known:
+                        pokemon_defeated = record.get("pokemon_defeated", 0) or 0
+                    if attacks is None:
+                        attacks = record.get("attacks") or []
+        except Exception:
+            if not defeats_known:
+                pokemon_defeated = 0
+            if attacks is None:
+                attacks = []
+    if pokemon_defeated is None:
+        # Caller supplied an explicit None-ish count; treat as no milestone.
         pokemon_defeated = 0
-        stored_attacks = []
 
     shim = {
         "id": pokemon_id,
         "friendship": friendship,
         "everstone": everstone,
         "pokemon_defeated": pokemon_defeated,
-        # The live moveset: lets _select_evolution honor move-type gates
-        # (e.g. Sylveon) instead of offering them on unconfirmed data. The
-        # caller's just-updated list wins; otherwise fall back to the stored
-        # one read above.
-        "attacks": attacks if attacks is not None else stored_attacks,
+        # The live moveset lets _select_evolution honor move-type gates
+        # (e.g. Sylveon) instead of offering them on unconfirmed data.
+        "attacks": attacks,
     }
     readiness = evolution_readiness(shim, now)
 

--- a/src/Ankimon/functions/friendship_evolution.py
+++ b/src/Ankimon/functions/friendship_evolution.py
@@ -1007,16 +1007,14 @@ def _build_status_text(
             f"to evolve into {evo_name}"
         )
 
-    hint = (
-        " · "
-        + " · ".join(
-            f"{name} needs a {move_type.capitalize()}-type move"
-            for name, move_type in gated_alternatives
-            if move_type
-        )
-        if gated_alternatives
-        else ""
-    )
+    # Build the parts first: an entry with a blank type contributes nothing, and
+    # joining an all-blank list would otherwise leave a dangling " · ".
+    hint_parts = [
+        f"{name} needs a {move_type.capitalize()}-type move"
+        for name, move_type in gated_alternatives
+        if move_type
+    ]
+    hint = (" · " + " · ".join(hint_parts)) if hint_parts else ""
 
     if ready and rejected:
         return "Evolution rejected — tap Evolve now to override" + hint

--- a/src/Ankimon/functions/friendship_evolution.py
+++ b/src/Ankimon/functions/friendship_evolution.py
@@ -19,6 +19,9 @@ from datetime import datetime, timedelta, timezone
 from typing import Any, NamedTuple, Optional
 
 from .pokedex_functions import (
+    _LEVEL_EVO_TRIGGERS,
+    _csv_gender_id,
+    _evolution_row_gender_id,
     _load_moves_cache,
     pokemon_evolves_from_id,
     return_name_for_id,
@@ -527,6 +530,39 @@ def _known_move_types(pokemon: Any) -> frozenset:
     return frozenset(types)
 
 
+# Display names for the CSV ``gender_id`` values (veekun convention).
+_GENDER_LABELS = {1: "Female", 2: "Male"}
+
+
+def _pokemon_gender(pokemon: Any) -> Any:
+    """Return the raw ``gender`` of a Pokémon dict/object, or ``None``.
+
+    Same dual-shape handling as :func:`_known_move_types`; the value is passed
+    straight to :func:`_csv_gender_id`, which is what decides whether it is
+    recognised ("M"/"F") or degrades to "no gate".
+    """
+    if pokemon is None:
+        return None
+    if isinstance(pokemon, dict):
+        return pokemon.get("gender")
+    return getattr(pokemon, "gender", None)
+
+
+def _level_gender_gate(evo_id: int, caller_gender_id: Optional[int]) -> bool:
+    """Return whether a level-up evolution target is open to this gender.
+
+    ``caller_gender_id is None`` (no/unrecognised gender) fails **open** — the
+    same no-check-without-data convention ``check_evolution_for_pokemon`` and
+    ``check_evolution_by_item`` use for their gender gates, and deliberately the
+    opposite of the fail-closed move-type gate: a missing moveset is a fact we
+    could not read, while a missing gender is a save that never stored one.
+    """
+    if caller_gender_id is None:
+        return True
+    required = _evolution_row_gender_id(evo_id, _LEVEL_EVO_TRIGGERS)
+    return required is None or required == caller_gender_id
+
+
 def _satisfies_move_gate(
     evo: FriendshipEvolution, known_move_types: Optional[frozenset]
 ) -> bool:
@@ -841,11 +877,12 @@ def _level_readiness(
     Called by :func:`evolution_readiness` when the species has no friendship
     evolution; returns ``not_evolvable`` unchanged if it has no level-up evolution
     either. Ignores ``evolution_rejected`` (the manual button still shows) but
-    DOES enforce the region preference (``misc.active_region``), any
+    DOES enforce the region preference (``misc.active_region``), the CSV
+    ``gender_id`` gate (a male Burmy evolves into Mothim, never Wormadam), any
     ``time_of_day`` requirement, a required ``levelMove`` (e.g. Mr. Mime needs
     Mimic) and a ``minimumDefeated`` count (e.g. Pawmot needs 100 defeats):
-    ``ready = (not everstone) and level >= min_level and time_ok and knows_move
-    and defeated_ok``.
+    ``ready = (not everstone) and level >= min_level and time_ok and gender_ok
+    and knows_move and defeated_ok``.
 
     Returns:
         A readiness dict with ``method="level"`` (or ``not_evolvable``).
@@ -862,6 +899,22 @@ def _level_readiness(
     if filtered:
         level_evos = tuple(filtered)
 
+    # Gender gate from the bundled CSV (veekun ids: 1 = female, 2 = male):
+    # Vespiquen needs a female Combee, Salazzle a female Salandit, and Burmy
+    # splits into Wormadam (female) / Mothim (male). This mirrors the gate
+    # ``check_evolution_for_pokemon`` applies on the automatic level-up path —
+    # without it the PC's manual "Evolve now" button is a way around it, and a
+    # male Burmy is offered Wormadam (lowest evo_id) instead of Mothim.
+    #
+    # Unlike the region filter above this narrows the choice but never widens
+    # it back: when every target is gated to the other gender the representative
+    # is kept only so the UI can say why, and ``gender_ok`` keeps it out of
+    # ``ready``.
+    caller_gender_id = _csv_gender_id(_pokemon_gender(pokemon))
+    gendered = [e for e in level_evos if _level_gender_gate(e.evo_id, caller_gender_id)]
+    if gendered:
+        level_evos = tuple(gendered)
+
     # Among the surviving targets prefer one eligible right now (its time matches
     # or it has no time requirement); an explicit-time row beats a blank-time one.
     eligible_now = [e for e in level_evos if e.time_of_day in (time_of_day, None)]
@@ -874,8 +927,19 @@ def _level_readiness(
     min_level = chosen.min_level
     required_time = chosen.time_of_day
 
+    # Re-check the CHOSEN row rather than trusting the filter: when nothing
+    # survived it, `chosen` is a representative whose gate is unmet.
+    gender_ok = _level_gender_gate(chosen.evo_id, caller_gender_id)
+    required_gender = (
+        None
+        if gender_ok
+        else _GENDER_LABELS.get(
+            _evolution_row_gender_id(chosen.evo_id, _LEVEL_EVO_TRIGGERS)
+        )
+    )
+
     time_ok = required_time is None or required_time == time_of_day
-    ready = (not everstone) and level >= min_level and time_ok
+    ready = (not everstone) and level >= min_level and time_ok and gender_ok
 
     # Move-based (levelMove) and defeat-based (minimumDefeated) gating from the
     # evolved species' pokedex.json data.
@@ -919,6 +983,11 @@ def _level_readiness(
 
     if everstone:
         status_text = "Everstone prevents evolution"
+    elif required_gender:
+        # Nothing the player does changes a Pokémon's gender, so this outranks
+        # the level/move/defeat lines below — none of them are actionable while
+        # it holds.
+        status_text = f"Needs to be {required_gender} to evolve into {evo_name}"
     elif not knows_move and required_move:
         status_text = f"Needs to learn {required_move} to evolve"
     elif not defeated_ok and required_defeated:

--- a/src/Ankimon/functions/friendship_evolution.py
+++ b/src/Ankimon/functions/friendship_evolution.py
@@ -25,6 +25,7 @@ from .pokedex_functions import (
     _load_moves_cache,
     evolution_rows_for_evolved_species,
     filter_gender_split_forms,
+    gender_allows_evolution,
     pokemon_evolves_from_id,
     return_name_for_id,
 )
@@ -588,11 +589,12 @@ def _level_gender_gate(evo_id: int, caller_gender_id: Optional[int]) -> bool:
     ``check_evolution_by_item`` use for their gender gates, and deliberately the
     opposite of the fail-closed move-type gate: a missing moveset is a fact we
     could not read, while a missing gender is a save that never stored one.
+
+    Thin wrapper over ``pokedex_functions.gender_allows_evolution`` so the PC's
+    manual "Evolve now" readiness and the automatic level-up path can't drift
+    apart on what the gate means; only the level trigger scope is fixed here.
     """
-    if caller_gender_id is None:
-        return True
-    required = _evolution_row_gender_id(evo_id, _LEVEL_EVO_TRIGGERS)
-    return required is None or required == caller_gender_id
+    return gender_allows_evolution(evo_id, caller_gender_id, _LEVEL_EVO_TRIGGERS)
 
 
 def _satisfies_move_gate(
@@ -1030,11 +1032,21 @@ def _level_readiness(
 
     if everstone:
         status_text = "Everstone prevents evolution"
-    elif required_gender:
+    elif not gender_ok:
         # Nothing the player does changes a Pokémon's gender, so this outranks
         # the level/move/defeat lines below — none of them are actionable while
         # it holds.
-        status_text = f"Needs to be {required_gender} to evolve into {evo_name}"
+        #
+        # Branch on gender_ok, NOT on the label: an unrecognised CSV gender_id
+        # (nothing in the bundled data carries one, but the file is regenerated
+        # from upstream) leaves `required_gender` None while `ready` is already
+        # False, and keying on the label would then fall through to a cheerful
+        # "Ready to evolve into ..." line contradicting the button beside it.
+        status_text = (
+            f"Needs to be {required_gender} to evolve into {evo_name}"
+            if required_gender
+            else f"{evo_name} has a gender requirement this Pokémon doesn't meet"
+        )
     elif not knows_move and required_move:
         status_text = f"Needs to learn {required_move} to evolve"
     elif not defeated_ok and required_defeated:

--- a/src/Ankimon/functions/friendship_evolution.py
+++ b/src/Ankimon/functions/friendship_evolution.py
@@ -23,12 +23,11 @@ from .pokedex_functions import (
     _csv_gender_id,
     _evolution_row_gender_id,
     _load_moves_cache,
+    evolution_rows_for_evolved_species,
     filter_gender_split_forms,
     pokemon_evolves_from_id,
     return_name_for_id,
-    rows_for_key_in_table,
 )
-from ..resources import poke_evo_path
 from ..services import services
 
 # Reference value for friendship progress bars: the bar reads "full" at this
@@ -308,7 +307,7 @@ def get_friendship_evolutions_for_species(
         # scan them all and keep the one carrying a positive minimum_happiness.
         # check_key_in_table's first-match would miss e.g. Sylveon, whose blank
         # row precedes its friendship row in the CSV.
-        rows = rows_for_key_in_table("evolved_species_id", evo, poke_evo_path)
+        rows = evolution_rows_for_evolved_species(evo)
         # If this evolved species is also reachable by levelling up, leave it to
         # the level path instead of offering a friendship evolution. The bundled
         # CSV carries no Pokémon *form* data, so it conflates e.g. Kantonian
@@ -463,7 +462,7 @@ def get_level_evolutions_for_species(
         # plain level-up row. An evolved species may carry several method rows
         # (e.g. a level-up row *and* a friendship row), so first-match would pick
         # the wrong one when the level row isn't listed first.
-        for row in rows_for_key_in_table("evolved_species_id", evo, poke_evo_path):
+        for row in evolution_rows_for_evolved_species(evo):
             # Level-up trigger only (item/trade/etc. evolutions are out of scope).
             try:
                 trigger_id = int(row.get("evolution_trigger_id", 0))

--- a/src/Ankimon/functions/friendship_evolution.py
+++ b/src/Ankimon/functions/friendship_evolution.py
@@ -19,6 +19,7 @@ from datetime import datetime, timedelta, timezone
 from typing import Any, NamedTuple, Optional
 
 from .pokedex_functions import (
+    find_details_move,
     pokemon_evolves_from_id,
     return_name_for_id,
     rows_for_key_in_table,
@@ -41,12 +42,18 @@ class FriendshipEvolution(NamedTuple):
         evo_name: Capitalised display name of the evolved species.
         min_happiness: Friendship value required to evolve.
         time_of_day: ``"day"``, ``"night"``, or ``None`` (no time requirement).
+        known_move_type: Optional lower-case type name the Pokémon must know a
+            move of before this evolution becomes possible (e.g. ``"fairy"``).
+            Read from the CSV's ``known_move_type_id`` column via
+            :func:`_move_type_name`; only type 18 (Fairy) appears in the bundled
+            data today, but any id that resolves through the type table works.
     """
 
     evo_id: int
     evo_name: str
     min_happiness: int
     time_of_day: Optional[str]
+    known_move_type: Optional[str] = None
 
 
 class LevelEvolution(NamedTuple):
@@ -172,6 +179,47 @@ def current_time_label(now: Optional[datetime] = None) -> str:
     return label
 
 
+# Canonical Pokémon type ids, matching the ``known_move_type_id`` column of the
+# veekun-sourced ``pokemon_evolution.csv`` (standard in-game type ordering).
+# Only Fairy (18) appears in the bundled CSV today, but the full table costs
+# nothing and keeps any future move-type-gated evolution resolvable. Unknown /
+# junk ids resolve to None ("no requirement") rather than blocking evolutions.
+_MOVE_TYPE_NAMES = {
+    1: "normal",
+    2: "fighting",
+    3: "flying",
+    4: "poison",
+    5: "ground",
+    6: "rock",
+    7: "bug",
+    8: "ghost",
+    9: "steel",
+    10: "fire",
+    11: "water",
+    12: "grass",
+    13: "electric",
+    14: "psychic",
+    15: "ice",
+    16: "dragon",
+    17: "dark",
+    18: "fairy",
+}
+
+
+def _move_type_name(type_id) -> Optional[str]:
+    """Return the lower-case type name for a ``known_move_type_id``.
+
+    Maps the veekun-schema numeric type id through :data:`_MOVE_TYPE_NAMES`
+    into the lower-case keys used by ``moves.json`` entries (``move["type"]``).
+    Returns ``None`` when the id can't be resolved, so a data gap degrades to
+    "no move requirement" instead of blocking evolutions. Never raises.
+    """
+    try:
+        return _MOVE_TYPE_NAMES.get(int(type_id))
+    except (TypeError, ValueError):
+        return None
+
+
 def _is_plain_level_row(row: dict) -> bool:
     """Return ``True`` if a CSV row is a plain level-up evolution.
 
@@ -246,6 +294,17 @@ def get_friendship_evolutions_for_species(
             time_raw = (row.get("time_of_day") or "").strip().lower()
             time_of_day = time_raw if time_raw in ("day", "night") else None
 
+            # Optional move-type gate straight from the CSV (e.g. Sylveon's
+            # known_move_type_id=18 -> "fairy"). Unresolvable ids degrade to
+            # None ("no requirement") rather than blocking the evolution.
+            known_move_type = None
+            try:
+                raw_type_id = int(row.get("known_move_type_id", "") or 0)
+            except (TypeError, ValueError):
+                raw_type_id = 0
+            if raw_type_id > 0:
+                known_move_type = _move_type_name(raw_type_id)
+
             name = return_name_for_id(int(evo))
             evo_name = name.capitalize() if name else str(evo)
 
@@ -255,6 +314,7 @@ def get_friendship_evolutions_for_species(
                     evo_name=evo_name,
                     min_happiness=min_happiness,
                     time_of_day=time_of_day,
+                    known_move_type=known_move_type,
                 )
             )
             break  # one friendship row per evolved species is enough
@@ -412,30 +472,102 @@ def get_level_evolutions_for_species(
     return tuple(evolutions)
 
 
+def _known_move_types(pokemon: Any) -> frozenset:
+    """Return the set of move types the Pokémon knows, lower-cased.
+
+    Accepts a dict or an object with an ``attacks`` attribute (the two shapes
+    :func:`evolution_readiness` supports). Move names are resolved through
+    ``find_details_move``; unknown moves resolve to a default entry rather than
+    raising, so the result is best-effort by construction.
+    """
+    if pokemon is None:
+        return frozenset()
+    if isinstance(pokemon, dict):
+        attacks = pokemon.get("attacks") or []
+    else:
+        attacks = getattr(pokemon, "attacks", None) or []
+    types: set = set()
+    for attack in attacks:
+        try:
+            move_data = find_details_move(str(attack))
+        except Exception:
+            move_data = None
+        if isinstance(move_data, dict):
+            move_type = move_data.get("type")
+            if isinstance(move_type, str) and move_type.strip():
+                types.add(move_type.strip().lower())
+    return frozenset(types)
+
+
+def _satisfies_move_gate(
+    evo: FriendshipEvolution, known_move_types: Optional[frozenset]
+) -> bool:
+    """Return whether ``evo``'s move-type requirement is satisfied.
+
+    ``known_move_types is None`` means "moves unknown" — the caller had no
+    attacks data. Every gate then evaluates False so a move-gated evolution is
+    never offered on missing data (fail-closed); non-gated evolutions are
+    unaffected and stay eligible.
+    """
+    if evo.known_move_type is None:
+        return True
+    if known_move_types is None:
+        return False
+    return evo.known_move_type in known_move_types
+
+
 def _select_evolution(
-    evos: tuple[FriendshipEvolution, ...], time_of_day: str
+    evos: tuple[FriendshipEvolution, ...],
+    time_of_day: str,
+    known_move_types: Optional[frozenset] = None,
 ) -> FriendshipEvolution:
     """Pick the most appropriate friendship evolution for the current time.
 
-    Prefers an evolution eligible right now (its ``time_of_day`` matches, or it
-    has none); among those, an explicitly time-gated row beats a blank-time one,
-    then lowest ``evo_id``. If none is eligible now, falls back to the lowest
-    ``evo_id`` so the UI can still show e.g. "waiting for Night".
+    First drops evolutions whose optional move-type requirement (CSV
+    ``known_move_type_id``, e.g. Sylveon's Fairy-move gate) isn't met by the
+    Pokémon's current moveset; when the moveset is unknown (``None``), gated
+    rows are dropped too — a move-gated evolution must never be selected on
+    unconfirmed data.
+
+    Among the survivors it prefers the most specific requirement first: a
+    satisfied move-type gate (in-game, a Fairy move *forces* Sylveon over the
+    time-gated Espeon/Umbreon), then an evolution eligible right now (its
+    ``time_of_day`` matches, or it has none), an explicitly time-gated row
+    beating a blank-time one, then lowest ``evo_id``. If none is eligible now,
+    falls back to the lowest remaining ``evo_id`` so the UI can still show e.g.
+    "waiting for Night".
 
     Args:
         evos: Non-empty tuple from :func:`get_friendship_evolutions_for_species`.
         time_of_day: Current time of day (``"day"`` or ``"night"``).
+        known_move_types: Lower-case move types the Pokémon knows, or ``None``
+            when the moveset is unknown (move-gated rows then never win).
 
     Returns:
         The chosen :class:`FriendshipEvolution`.
     """
-    eligible_now = [e for e in evos if e.time_of_day in (time_of_day, None)]
+    valid_evos = [e for e in evos if _satisfies_move_gate(e, known_move_types)]
+    # A species whose every friendship row is move-gated keeps a representative
+    # for UI text ("needs a Fairy-type move") instead of turning not-evolvable.
+    if not valid_evos:
+        valid_evos = list(evos)
+
+    eligible_now = [e for e in valid_evos if e.time_of_day in (time_of_day, None)]
     if eligible_now:
-        # Prefer explicit-time rows (e.g. Espeon@day) over blank-time rows, then
-        # lowest evo_id. ``time_of_day is None`` sorts last via the bool key.
-        return min(eligible_now, key=lambda e: (e.time_of_day is None, e.evo_id))
+        # Sort: satisfied move gate first (a known Fairy move outranks the
+        # day/night clock — Sylveon over Espeon/Umbreon), then explicit-time
+        # rows over blank-time rows, then lowest evo_id. Each ``is None`` /
+        # ``==`` predicate sorts falsy-first via the bool key.
+        return min(
+            eligible_now,
+            key=lambda e: (
+                e.known_move_type is None,
+                e.time_of_day is None,
+                e.evo_id,
+            ),
+        )
     # Nothing matches the current time; still return a representative.
-    return min(evos, key=lambda e: e.evo_id)
+    return min(valid_evos, key=lambda e: e.evo_id)
 
 
 def evolution_readiness(pokemon: Any, now: Optional[datetime] = None) -> dict:
@@ -514,7 +646,9 @@ def evolution_readiness(pokemon: Any, now: Optional[datetime] = None) -> dict:
             pokemon=pokemon,
         )
 
-    chosen = _select_evolution(evos, time_of_day)
+    chosen = _select_evolution(
+        evos, time_of_day, _known_move_types(pokemon)
+    )
     evo_id = chosen.evo_id
     evo_name = chosen.evo_name
     min_happiness = chosen.min_happiness
@@ -800,6 +934,7 @@ def check_friendship_evolution_for_pokemon(
     friendship: int = 0,
     evolution_rejected: bool = False,
     now: Optional[datetime] = None,
+    attacks: Optional[list] = None,
 ) -> Optional[int]:
     """Prompt a friendship (or defeat-milestone) evolution for a Pokémon if ready.
 
@@ -816,6 +951,18 @@ def check_friendship_evolution_for_pokemon(
     ``check_evolution_for_pokemon`` on level-up; the manual PC button covers the
     rest), so a level-ready Pokémon without a defeat milestone stays silent.
 
+    Args:
+        individual_id: The individual Pokémon's DB id.
+        pokemon_id: National Pokédex id of the current species/form.
+        evo_window: The evolution window used to prompt the offer.
+        everstone: Whether an Everstone is held (suppresses prompting).
+        friendship: Current friendship value of the Pokémon.
+        evolution_rejected: Whether a prior offer was rejected (suppresses).
+        now: Optional :class:`datetime` overriding the configured day/night clock.
+        attacks: Optional live moveset; when given it takes precedence over the
+            stored one so move-type-gated evolutions (e.g. Sylveon's Fairy-move
+            requirement) evaluate against freshest-known data.
+
     Returns:
         The evolved species id if the evolution was triggered, else ``None``.
     """
@@ -828,24 +975,33 @@ def check_friendship_evolution_for_pokemon(
     ):
         return None
 
-    # Defeat count for minimumDefeated evolutions (Pawmo/Rellor): read via the DB
-    # seam, guarded so a missing/unavailable store degrades to 0 rather than
-    # raising on the victory hot path.
+    # Defeat count and known attacks for move/defeat-gated evolutions (Sylveon
+    # needs a Fairy-type move; Pawmo/Rellor need defeat milestones): read via the
+    # DB seam, guarded so a missing/unavailable store degrades to 0 / no attacks
+    # rather than raising on the victory hot path.
     pokemon_defeated = 0
+    stored_attacks: list = []
     try:
         db = services.db
         if db is not None and hasattr(db, "get_pokemon"):
-            record = db.get_pokemon(individual_id)
-            if record:
+            record = db.get_pokemon(individual_id) or {}
+            if isinstance(record, dict):
                 pokemon_defeated = record.get("pokemon_defeated", 0)
+                stored_attacks = record.get("attacks") or []
     except Exception:
         pokemon_defeated = 0
+        stored_attacks = []
 
     shim = {
         "id": pokemon_id,
         "friendship": friendship,
         "everstone": everstone,
         "pokemon_defeated": pokemon_defeated,
+        # The live moveset: lets _select_evolution honor move-type gates
+        # (e.g. Sylveon) instead of offering them on unconfirmed data. The
+        # caller's just-updated list wins; otherwise fall back to the stored
+        # one read above.
+        "attacks": attacks if attacks is not None else stored_attacks,
     }
     readiness = evolution_readiness(shim, now)
 

--- a/src/Ankimon/functions/friendship_evolution.py
+++ b/src/Ankimon/functions/friendship_evolution.py
@@ -77,6 +77,38 @@ class LevelEvolution(NamedTuple):
     time_of_day: Optional[str] = None
 
 
+class _DefaultSettings:
+    """Answers every setting with the caller's default.
+
+    Stands in for an unbound ``services.settings``.
+    """
+
+    @staticmethod
+    def get(key, default=None):
+        return default
+
+
+_DEFAULT_SETTINGS = _DefaultSettings()
+
+
+def _settings():
+    """Return the settings seam, or a defaults-only stand-in when it is unset.
+
+    ``services.settings`` is ``None`` until the registry is populated — early
+    boot, a profile swap in flight, a partially-wired headless run — and a bare
+    ``services.settings.get(...)`` then raises ``AttributeError`` from
+    ``evolution_readiness`` / ``get_time_of_day``, both of which sit on render
+    and review paths that otherwise degrade rather than raise (they already
+    coerce junk ids, junk friendship and junk hours). Every setting read in this
+    module is a preference with a sensible default, so answering with that
+    default is strictly better than raising. Mirrors the explicit ``None``
+    check the sibling clock in ``pokedex_functions.get_time_of_day`` makes, and
+    the ``try/except`` in :func:`_active_region` below.
+    """
+    settings_obj = services.settings
+    return settings_obj if settings_obj is not None else _DEFAULT_SETTINGS
+
+
 def _now_in_configured_tz() -> datetime:
     """Return the current time in the user's configured time zone.
 
@@ -84,7 +116,7 @@ def _now_in_configured_tz() -> datetime:
     when ``evolution.timezone_auto`` is off, a fixed ``evolution.timezone_offset``
     (hours, clamped to ±14) is applied instead.
     """
-    settings_obj = services.settings  # registry-backed; no singletons/aqt import
+    settings_obj = _settings()  # registry-backed; no singletons/aqt import
 
     if settings_obj.get("evolution.timezone_auto", True):
         return datetime.now()
@@ -143,7 +175,7 @@ def get_time_of_day(now: Optional[datetime] = None) -> str:
     Returns:
         ``"day"`` or ``"night"``.
     """
-    settings_obj = services.settings  # registry-backed; no singletons/aqt import
+    settings_obj = _settings()  # registry-backed; no singletons/aqt import
 
     moment = now if now is not None else _now_in_configured_tz()
     hour = moment.hour
@@ -167,7 +199,7 @@ def current_time_label(now: Optional[datetime] = None) -> str:
         A short, emoji-prefixed label including the current ``HH:MM`` time (and
         the UTC offset when a manual time zone is configured).
     """
-    settings_obj = services.settings  # registry-backed; no singletons/aqt import
+    settings_obj = _settings()  # registry-backed; no singletons/aqt import
 
     moment = now if now is not None else _now_in_configured_tz()
     time_of_day = get_time_of_day(moment)
@@ -1163,7 +1195,7 @@ def check_friendship_evolution_for_pokemon(
     Returns:
         The evolved species id if the evolution was triggered, else ``None``.
     """
-    settings_obj = services.settings  # registry-backed; no singletons/aqt import
+    settings_obj = _settings()  # registry-backed; no singletons/aqt import
 
     if (
         not settings_obj.get("evolution.friendship_time_enabled", True)

--- a/src/Ankimon/functions/pokedex_functions.py
+++ b/src/Ankimon/functions/pokedex_functions.py
@@ -17,6 +17,7 @@ try:
     from aqt import mw
 except Exception:
     mw = None
+import functools
 import json
 import math
 import random
@@ -847,7 +848,18 @@ def _csv_gender_id(gender) -> Optional[int]:
     return None
 
 
-def _evolution_row_gender_id(evolved_species_id) -> Optional[int]:
+# ``evolution_trigger_id`` values of the bundled veekun CSV, grouped by the code
+# path that consults them. Scoping the gender lookup to the trigger the caller is
+# actually evaluating keeps one method's gate from leaking onto another: today
+# every gendered species has exactly one row, but the CSV is regenerated from
+# upstream data and a second, ungendered path to the same species would
+# otherwise silently inherit the gate.
+_ITEM_EVO_TRIGGERS = (2, 3)  # 2 = trade-with-held-item, 3 = use-item
+_LEVEL_EVO_TRIGGERS = (1,)  # 1 = level-up (plain, timed, and levelMove)
+
+
+@functools.lru_cache(maxsize=None)
+def _evolution_row_gender_id(evolved_species_id, trigger_ids=None) -> Optional[int]:
     """Return the ``gender_id`` gating ``evolved_species_id``, if any.
 
     Scans the bundled ``pokemon_evolution.csv`` rows whose
@@ -857,6 +869,20 @@ def _evolution_row_gender_id(evolved_species_id) -> Optional[int]:
     e.g. Wormadam-Sandy 10004) resolve to their base species first — the CSV
     only carries base-species rows (repo tripwire: "IDs >= 10000 must be
     resolved to their base species via check_id_ok()").
+
+    ``lru_cache``d because this sits on the review path: a level-up runs it for
+    every eligible evolution candidate, and ``rows_for_key_in_table`` re-opens
+    and re-parses the whole ~500-row CSV on each call (coding guideline: no
+    synchronous disk I/O mid-review — static data is parsed once at startup).
+    The CSV is static for the process lifetime and the result is an immutable
+    ``Optional[int]``, so the cached answer is safe to share; both arguments are
+    hashable (an int and a tuple), as ``lru_cache`` requires.
+
+    Args:
+        evolved_species_id: National Pokédex id of the *evolved* species.
+        trigger_ids: Optional tuple of ``evolution_trigger_id`` values to scope
+            the scan to (:data:`_ITEM_EVO_TRIGGERS` / :data:`_LEVEL_EVO_TRIGGERS`).
+            ``None`` scans every row.
     """
     try:
         species_ref = int(evolved_species_id)
@@ -872,11 +898,18 @@ def _evolution_row_gender_id(evolved_species_id) -> Optional[int]:
         )
         if base_species > 0:
             species_ref = base_species
+    wanted_triggers = {str(t) for t in trigger_ids} if trigger_ids is not None else None
     for csv_row in rows_for_key_in_table(
         "evolved_species_id",
         species_ref,
         poke_evo_path,
     ):
+        if (
+            wanted_triggers is not None
+            and (csv_row.get("evolution_trigger_id") or "").strip()
+            not in wanted_triggers
+        ):
+            continue
         raw_gender = (csv_row.get("gender_id") or "").strip()
         if not raw_gender:
             continue
@@ -958,7 +991,8 @@ def check_evolution_by_item(pokemon_id, item_id, gender=None):
                                     safe_int(
                                         target_data.get("actual_id")
                                         or target_data.get("species_id")
-                                    )
+                                    ),
+                                    _ITEM_EVO_TRIGGERS,
                                 )
                                 if (
                                     required_gender_id is not None
@@ -1283,12 +1317,8 @@ def check_evolution_for_pokemon(
                                     safe_int(
                                         target_data.get("actual_id")
                                         or target_data.get("species_id")
-                                        # Smogon-schema base forms (Wormadam,
-                                        # Mothim, Vespiquen, Salazzle, ...) carry
-                                        # only ``num``; without this fallback the
-                                        # CSV gate could never match them.
-                                        or target_data.get("num")
-                                    )
+                                    ),
+                                    _LEVEL_EVO_TRIGGERS,
                                 )
                                 if (
                                     required_gender_id is not None

--- a/src/Ankimon/functions/pokedex_functions.py
+++ b/src/Ankimon/functions/pokedex_functions.py
@@ -1,9 +1,8 @@
-from typing import Literal, Optional
+from typing import Optional
 from ..resources import (
     pokedex_path,
     pokedesc_lang_path,
     pokenames_lang_path,
-    learnset_path,
     moves_file_path,
     poke_evo_path,
     poke_species_path,
@@ -591,9 +590,6 @@ def get_pretty_name_for_name(pokemon_name):
             if suffix in pokemon_name.lower():
                 base_name = pokemon_name.lower().replace(suffix, "").replace("-", "")
                 if base_name in pokedex_data:
-                    raw_base = pokedex_data[base_name].get(
-                        "name", base_name.capitalize()
-                    )
                     return format_lore_name(pokemon_name.title())
     except:
         pass

--- a/src/Ankimon/functions/pokedex_functions.py
+++ b/src/Ankimon/functions/pokedex_functions.py
@@ -255,6 +255,48 @@ def _load_poke_evo_cache():
     return _poke_evo_cache
 
 
+_poke_evo_index = None
+
+
+def _load_poke_evo_index():
+    """Index the evolution rows by ``evolved_species_id`` for O(1) lookup.
+
+    Same lazy-module-global shape as :func:`_load_pokedex_id_index`, and built
+    FROM :func:`_load_poke_evo_cache`, so the CSV is parsed once and the rows
+    exist once — the index holds references, not copies.
+
+    Keys are ``str`` and lookups stringify, reproducing
+    :func:`rows_for_key_in_table`'s ``str(row[col]) == str(value)`` exactly.
+    Callers pass both ints (:func:`_evolution_row_gender_id_cached`) and the
+    strings :func:`pokemon_evolves_from_id` returns, and a zero-padded
+    ``"0700"`` must keep matching nothing — so do NOT ``safe_int`` the key.
+    """
+    global _poke_evo_index
+    if _poke_evo_index is None:
+        buckets = {}
+        for row in _load_poke_evo_cache():
+            # `"col" in row` mirrors rows_for_key_in_table's guard exactly.
+            if "evolved_species_id" not in row:
+                continue
+            buckets.setdefault(str(row["evolved_species_id"]), []).append(row)
+        _poke_evo_index = {key: tuple(rows) for key, rows in buckets.items()}
+    return _poke_evo_index
+
+
+def evolution_rows_for_evolved_species(evolved_species_id):
+    """Every ``pokemon_evolution.csv`` row for one evolved species.
+
+    In-memory equivalent of ``rows_for_key_in_table("evolved_species_id", ...,
+    poke_evo_path)`` — same rows, same order, same string comparison — without
+    the synchronous re-parse. Use this on the review path (repo rule: no
+    synchronous disk I/O mid-review; static data is parsed once at startup).
+
+    Returns a tuple of the SHARED row dicts; treat them as read-only, the same
+    contract :func:`_load_poke_evo_cache` already has.
+    """
+    return _load_poke_evo_index().get(str(evolved_species_id), ())
+
+
 def _load_moves_cache():
     """Cache moves.json to avoid repeated file I/O"""
     global _moves_cache
@@ -336,6 +378,7 @@ def clear_pokedex_caches():
         _pokemon_csv_cache, \
         _stats_csv_cache, \
         _poke_evo_cache, \
+        _poke_evo_index, \
         _moves_cache, \
         _pokedex_id_index, \
         _pokemon_names_cache, \
@@ -345,6 +388,10 @@ def clear_pokedex_caches():
     _pokemon_csv_cache = None
     _stats_csv_cache = None
     _poke_evo_cache = None
+    # Reset with its source cache: the index holds references into the rows
+    # _load_poke_evo_cache built, so leaving it warm past a clear would keep
+    # the pre-clear rows alive (parity with _pokedex_id_index above).
+    _poke_evo_index = None
     _moves_cache = None
     _pokedex_id_index = None
     _pokemon_names_cache = {}
@@ -894,9 +941,11 @@ def _evolution_row_gender_id_cached(species_ref: int, trigger_ids) -> Optional[i
     >= 10000 must be resolved to their base species via check_id_ok()").
 
     ``lru_cache``d because this sits on the review path: a level-up runs it for
-    every eligible evolution candidate, and ``rows_for_key_in_table`` re-opens
-    and re-parses the whole ~500-row CSV on each call (coding guideline: no
-    synchronous disk I/O mid-review — static data is parsed once at startup).
+    every eligible evolution candidate. The rows now come from the startup-built
+    in-memory index (:func:`evolution_rows_for_evolved_species`) rather than a
+    fresh ~500-row CSV parse per cache miss, so the cache saves the scan rather
+    than the file I/O (coding guideline: no synchronous disk I/O mid-review —
+    static data is parsed once at startup).
     ``poke_evo_path`` points into the shipped, read-only ``data_files`` dir, so
     the CSV really is immutable for the process and the memoized
     ``Optional[int]`` is safe to share. The key space is bounded by
@@ -915,11 +964,7 @@ def _evolution_row_gender_id_cached(species_ref: int, trigger_ids) -> Optional[i
         if base_species > 0:
             species_ref = base_species
     wanted_triggers = {str(t) for t in trigger_ids} if trigger_ids is not None else None
-    for csv_row in rows_for_key_in_table(
-        "evolved_species_id",
-        species_ref,
-        poke_evo_path,
-    ):
+    for csv_row in evolution_rows_for_evolved_species(species_ref):
         if (
             wanted_triggers is not None
             and (csv_row.get("evolution_trigger_id") or "").strip()

--- a/src/Ankimon/functions/pokedex_functions.py
+++ b/src/Ankimon/functions/pokedex_functions.py
@@ -858,25 +858,19 @@ _ITEM_EVO_TRIGGERS = (2, 3)  # 2 = trade-with-held-item, 3 = use-item
 _LEVEL_EVO_TRIGGERS = (1,)  # 1 = level-up (plain, timed, and levelMove)
 
 
-@functools.lru_cache(maxsize=None)
 def _evolution_row_gender_id(evolved_species_id, trigger_ids=None) -> Optional[int]:
     """Return the ``gender_id`` gating ``evolved_species_id``, if any.
 
     Scans the bundled ``pokemon_evolution.csv`` rows whose
     ``evolved_species_id`` matches and returns the first parseable non-blank
     ``gender_id`` (veekun convention: 1 = female, 2 = male). ``None`` means the
-    species' evolution rows carry no gender gate. Form-variant ids (>= 10000,
-    e.g. Wormadam-Sandy 10004) resolve to their base species first — the CSV
-    only carries base-species rows (repo tripwire: "IDs >= 10000 must be
-    resolved to their base species via check_id_ok()").
+    species' evolution rows carry no gender gate. Anything that isn't an integer
+    id degrades to ``None`` ("no gate") rather than raising.
 
-    ``lru_cache``d because this sits on the review path: a level-up runs it for
-    every eligible evolution candidate, and ``rows_for_key_in_table`` re-opens
-    and re-parses the whole ~500-row CSV on each call (coding guideline: no
-    synchronous disk I/O mid-review — static data is parsed once at startup).
-    The CSV is static for the process lifetime and the result is an immutable
-    ``Optional[int]``, so the cached answer is safe to share; both arguments are
-    hashable (an int and a tuple), as ``lru_cache`` requires.
+    The coercion happens HERE rather than inside the cached helper so that an
+    unhashable argument still returns ``None`` instead of dying in
+    ``lru_cache``'s key lookup, and so the cache keys on the normalized int
+    (``475`` and ``"475"`` share one entry).
 
     Args:
         evolved_species_id: National Pokédex id of the *evolved* species.
@@ -888,6 +882,28 @@ def _evolution_row_gender_id(evolved_species_id, trigger_ids=None) -> Optional[i
         species_ref = int(evolved_species_id)
     except (TypeError, ValueError):
         return None
+    return _evolution_row_gender_id_cached(species_ref, trigger_ids)
+
+
+@functools.lru_cache(maxsize=None)
+def _evolution_row_gender_id_cached(species_ref: int, trigger_ids) -> Optional[int]:
+    """CSV-backed body of :func:`_evolution_row_gender_id` (see it for semantics).
+
+    Form-variant ids (>= 10000, e.g. Wormadam-Sandy 10004) resolve to their base
+    species first — the CSV only carries base-species rows (repo tripwire: "IDs
+    >= 10000 must be resolved to their base species via check_id_ok()").
+
+    ``lru_cache``d because this sits on the review path: a level-up runs it for
+    every eligible evolution candidate, and ``rows_for_key_in_table`` re-opens
+    and re-parses the whole ~500-row CSV on each call (coding guideline: no
+    synchronous disk I/O mid-review — static data is parsed once at startup).
+    ``poke_evo_path`` points into the shipped, read-only ``data_files`` dir, so
+    the CSV really is immutable for the process and the memoized
+    ``Optional[int]`` is safe to share. The key space is bounded by
+    species x trigger-scope (a few thousand small ints at most), so ``maxsize=None``
+    can't grow without bound. Same caveat as the other CSV caches here: a
+    transient read failure would be memoized for the session.
+    """
     if species_ref >= 10000:
         # Form variant: the CSV keys on the base species id only.
         form_name = search_pokedex_by_id(species_ref)

--- a/src/Ankimon/functions/pokedex_functions.py
+++ b/src/Ankimon/functions/pokedex_functions.py
@@ -289,12 +289,51 @@ def evolution_rows_for_evolved_species(evolved_species_id):
     In-memory equivalent of ``rows_for_key_in_table("evolved_species_id", ...,
     poke_evo_path)`` — same rows, same order, same string comparison — without
     the synchronous re-parse. Use this on the review path (repo rule: no
-    synchronous disk I/O mid-review; static data is parsed once at startup).
+    synchronous disk I/O mid-review; static data is parsed once at startup) —
+    :func:`warm_evolution_caches` is what does that parsing at startup, so this
+    only ever reads memory once the boot has run.
 
     Returns a tuple of the SHARED row dicts; treat them as read-only, the same
     contract :func:`_load_poke_evo_cache` already has.
     """
     return _load_poke_evo_index().get(str(evolved_species_id), ())
+
+
+def warm_evolution_caches():
+    """Parse ``pokemon_evolution.csv`` and build its index, off the review path.
+
+    The loaders above are lazy, which leaves their FIRST caller deciding when
+    the ~500-row parse happens — and every production caller of these rows sits
+    on the review path: :func:`_evolution_row_gender_id_cached` for the gender
+    gate, ``friendship_evolution``'s level and friendship lookups, all reached
+    from ``on_review_card``. Left cold, the first level-up of a session opened
+    and parsed the CSV mid-review, which is the synchronous disk I/O the repo
+    rule forbids ("static data is parsed once at startup").
+
+    Two callers make that rule true. ``startup.run_startup_background_checks``
+    warms on the boot thread, before ``services.startup_finished`` opens the
+    review gate; ``profile_hooks``' did-open handler warms again, because a
+    profile switch runs :func:`clear_pokedex_caches` while the once-per-process
+    boot does not run a second time.
+
+    Purely an optimization, so it must not add a failure mode. Moving the first
+    read earlier means a file that is momentarily unreadable at boot (an add-on
+    update mid-write, a cold network drive) would otherwise let
+    :func:`_load_poke_evo_cache` memoize its empty fallback for the whole
+    session, silently answering "this species has no evolution rows" to every
+    gate. So an empty result puts both globals back to ``None`` and the lazy
+    path simply retries on first use, exactly as it does today.
+
+    Returns the number of rows indexed (0 if the CSV could not be read).
+    """
+    global _poke_evo_cache, _poke_evo_index
+    rows = _load_poke_evo_cache()
+    if rows:
+        _load_poke_evo_index()
+        return len(rows)
+    _poke_evo_cache = None
+    _poke_evo_index = None
+    return 0
 
 
 def _load_moves_cache():

--- a/src/Ankimon/functions/pokedex_functions.py
+++ b/src/Ankimon/functions/pokedex_functions.py
@@ -392,6 +392,12 @@ def clear_pokedex_caches():
     # _load_poke_evo_cache built, so leaving it warm past a clear would keep
     # the pre-clear rows alive (parity with _pokedex_id_index above).
     _poke_evo_index = None
+    # ...and so does the memo built ON TOP of that index. _evolution_row_gender_id_cached
+    # answers from _poke_evo_index (and, for form ids >= 10000, from
+    # _pokedex_cache via search_pokedex_by_id), so a clear that leaves it warm
+    # keeps serving pre-clear verdicts for the rest of the session — the gender
+    # gate would then contradict the reloaded data it is supposed to read.
+    _evolution_row_gender_id_cached.cache_clear()
     _moves_cache = None
     _pokedex_id_index = None
     _pokemon_names_cache = {}
@@ -981,6 +987,60 @@ def _evolution_row_gender_id_cached(species_ref: int, trigger_ids) -> Optional[i
     return None
 
 
+def gender_allows_evolution(evolved_species_id, caller_gender_id, trigger_ids) -> bool:
+    """Return whether a gender may take one evolution, per the CSV gate.
+
+    The single place the gate's semantics live, so the three call sites that
+    apply it to a ``pokedex.json`` entry (:func:`check_evolution_by_item`,
+    :func:`check_evolution_for_pokemon` and the web bag's inline eligibility
+    loop) and the one that applies it to a bare id
+    (``friendship_evolution._level_gender_gate``) cannot drift apart.
+
+    ``caller_gender_id is None`` — no gender, or one :func:`_csv_gender_id`
+    doesn't recognise, "Genderless" included — fails **open**, keeping the
+    historical no-check behavior for callers and saves without gender data. A
+    species whose rows carry no ``gender_id`` is likewise unrestricted.
+
+    Args:
+        evolved_species_id: National Pokédex id of the *evolved* species.
+        caller_gender_id: The Pokémon's gender as a CSV id (1 = female,
+            2 = male), or ``None`` for "unknown — don't gate".
+        trigger_ids: Trigger scope to consult (:data:`_ITEM_EVO_TRIGGERS` /
+            :data:`_LEVEL_EVO_TRIGGERS`), so one method's gate never leaks
+            onto another.
+    """
+    if caller_gender_id is None:
+        return True
+    required_gender_id = _evolution_row_gender_id(evolved_species_id, trigger_ids)
+    return required_gender_id is None or required_gender_id == caller_gender_id
+
+
+def evolution_target_species_id(target_data) -> int:
+    """National id of the evolved species a ``pokedex.json`` entry describes.
+
+    ``actual_id`` carries it for base species and forms alike; ``species_id``
+    is the fallback for entries that predate it. ``0`` when neither resolves.
+    """
+    if not isinstance(target_data, dict):
+        return 0
+    return safe_int(target_data.get("actual_id") or target_data.get("species_id"))
+
+
+def evolution_gender_allows(target_data, gender, trigger_ids) -> bool:
+    """:func:`gender_allows_evolution` for a ``pokedex.json`` evolution entry.
+
+    Takes the raw Ankimon gender string (``"M"``/``"F"``/``"Genderless"``/
+    ``None``) and the evolved species' own pokedex entry, so callers holding a
+    ``target_data`` dict apply the gate identically without restating the
+    id-extraction and the comparison.
+    """
+    return gender_allows_evolution(
+        evolution_target_species_id(target_data),
+        _csv_gender_id(gender),
+        trigger_ids,
+    )
+
+
 def _pokedex_form_gender(species_ref) -> Optional[str]:
     """Return ``"M"``/``"F"`` when pokedex.json marks a species/form single-gender.
 
@@ -1107,20 +1167,10 @@ def check_evolution_by_item(pokemon_id, item_id, gender=None):
                             # RECOGNISED gender ("M"/"F"); None/unrecognised
                             # keeps the historical no-check behavior so
                             # callers without gender data are unaffected.
-                            caller_gender_id = _csv_gender_id(gender)
-                            if caller_gender_id is not None:
-                                required_gender_id = _evolution_row_gender_id(
-                                    safe_int(
-                                        target_data.get("actual_id")
-                                        or target_data.get("species_id")
-                                    ),
-                                    _ITEM_EVO_TRIGGERS,
-                                )
-                                if (
-                                    required_gender_id is not None
-                                    and caller_gender_id != required_gender_id
-                                ):
-                                    continue
+                            if not evolution_gender_allows(
+                                target_data, gender, _ITEM_EVO_TRIGGERS
+                            ):
+                                continue
 
                             # Normalize both sides by stripping spaces, hyphens and
                             # apostrophes so pokedex.json display names (e.g.
@@ -1433,20 +1483,10 @@ def check_evolution_for_pokemon(
                             # RECOGNISED gender ("M"/"F"); None/unrecognised
                             # keeps the historical no-check behavior so
                             # callers without gender data are unaffected.
-                            caller_gender_id = _csv_gender_id(gender)
-                            if caller_gender_id is not None:
-                                required_gender_id = _evolution_row_gender_id(
-                                    safe_int(
-                                        target_data.get("actual_id")
-                                        or target_data.get("species_id")
-                                    ),
-                                    _LEVEL_EVO_TRIGGERS,
-                                )
-                                if (
-                                    required_gender_id is not None
-                                    and caller_gender_id != required_gender_id
-                                ):
-                                    continue
+                            if not evolution_gender_allows(
+                                target_data, gender, _LEVEL_EVO_TRIGGERS
+                            ):
+                                continue
 
                             time_of_day = None
                             if "day" in condition:
@@ -1503,22 +1543,14 @@ def check_evolution_for_pokemon(
                     by_id = {}
                     for candidate in eligible_evos:
                         by_id.setdefault(
-                            safe_int(
-                                candidate.get("actual_id")
-                                or candidate.get("species_id")
-                            ),
-                            candidate,
+                            evolution_target_species_id(candidate), candidate
                         )
                     kept = set(filter_gender_split_forms(list(by_id), gender))
                     if kept:
                         eligible_evos = [
                             candidate
                             for candidate in eligible_evos
-                            if safe_int(
-                                candidate.get("actual_id")
-                                or candidate.get("species_id")
-                            )
-                            in kept
+                            if evolution_target_species_id(candidate) in kept
                         ]
 
                     eligible_evos.sort(key=lambda x: 0 if x.get("evoRegion") else 1)

--- a/src/Ankimon/functions/pokedex_functions.py
+++ b/src/Ankimon/functions/pokedex_functions.py
@@ -1,4 +1,4 @@
-from typing import Literal
+from typing import Literal, Optional
 from ..resources import (
     pokedex_path,
     pokedesc_lang_path,
@@ -833,7 +833,26 @@ def return_identifier_for_item_id(item_id):
     return None
 
 
-def check_evolution_by_item(pokemon_id, item_id):
+def _csv_gender_id(gender) -> Optional[int]:
+    """Normalize Ankimon's ``"M"/"F"/"Genderless"`` values to CSV gender ids.
+
+    ``pokemon_evolution.csv`` follows the veekun convention: 1 = female,
+    2 = male. Returns ``None`` for anything unrecognised (including
+    "Genderless") so a gate never matches on junk data.
+    """
+    if isinstance(gender, str):
+        gender = gender.strip().upper()
+        # Accept both the internal short form ("M"/"F", what
+        # pick_random_gender stores) and long-form variants seen in legacy
+        # saves. Anything else (incl. "Genderless") -> None -> no gate.
+        if gender in ("M", "MALE"):
+            return 2
+        if gender in ("F", "FEMALE"):
+            return 1
+    return None
+
+
+def check_evolution_by_item(pokemon_id, item_id, gender=None):
     """
     Check if a Pokémon evolves using a specific item.
 
@@ -850,6 +869,11 @@ def check_evolution_by_item(pokemon_id, item_id):
     Args:
         pokemon_id (int): The ID of the (pre-evolution) Pokémon.
         item_id (int): The ID of the item.
+        gender (str | None): The Pokémon's gender ("M"/"F"/"Genderless"). When
+            given, gender-gated evolutions from ``pokemon_evolution.csv``
+            (Gallade needs a male Kirlia, Froslass a female Snorunt/Kirlia)
+            only match when the gender agrees; ``None`` keeps the historical
+            no-gender-check behavior for callers without gender data.
 
     Returns:
         int | None: The evolved species id if the Pokémon evolves with the given
@@ -886,6 +910,38 @@ def check_evolution_by_item(pokemon_id, item_id):
                             "useItem",
                             "trade",
                         ):
+                            # Gender gate from the bundled CSV (veekun ids:
+                            # 1 = female, 2 = male). Gallade (475) requires a
+                            # male Kirlia, Froslass (478) a female Snorunt.
+                            # Only enforced when the caller supplies a
+                            # RECOGNISED gender ("M"/"F"); None/unrecognised
+                            # keeps the historical no-check behavior so
+                            # callers without gender data are unaffected.
+                            caller_gender_id = _csv_gender_id(gender)
+                            if caller_gender_id is not None:
+                                required_gender_id = None
+                                for csv_row in rows_for_key_in_table(
+                                    "evolved_species_id",
+                                    safe_int(
+                                        target_data.get("actual_id")
+                                        or target_data.get("species_id")
+                                    ),
+                                    poke_evo_path,
+                                ):
+                                    raw_gender = (csv_row.get("gender_id") or "").strip()
+                                    if not raw_gender:
+                                        continue
+                                    try:
+                                        required_gender_id = int(raw_gender)
+                                        break
+                                    except (TypeError, ValueError):
+                                        continue
+                                if (
+                                    required_gender_id is not None
+                                    and caller_gender_id != required_gender_id
+                                ):
+                                    continue
+
                             # Normalize both sides by stripping spaces, hyphens and
                             # apostrophes so pokedex.json display names (e.g.
                             # "King's Rock") match items.csv identifiers (e.g.
@@ -1036,6 +1092,7 @@ def check_evolution_for_pokemon(
     evo_window,
     everstone=False,
     evolution_rejected=False,
+    current_attacks=None,
 ):
     """
     Check if a Pokémon evolves by a level (or move-based level-up) condition.
@@ -1055,6 +1112,12 @@ def check_evolution_for_pokemon(
         everstone (bool): Whether the Pokémon is holding an Everstone.
         evolution_rejected (bool): Whether the user previously rejected this
             evolution. When True the automatic prompt is suppressed.
+        current_attacks (list | None): The Pokémon's just-updated moveset, when
+            the caller has fresher data than the database (e.g. immediately
+            after new level-up moves were learned). ``None`` falls back to the
+            stored moveset from the DB seam. Move-based evolutions evaluate
+            against this list so learning the required move on this very level
+            triggers the offer on that same event instead of one level late.
 
     Returns:
         int | None: The evolution ID if an evolution is found, or None otherwise.
@@ -1139,29 +1202,36 @@ def check_evolution_for_pokemon(
                             required_move = target_data.get("evoMove")
                             knows_move = False
 
-                            pkmn_data = None
-                            try:
-                                pkmn_data = services.db.get_pokemon(individual_id)
-                            except Exception:
-                                pkmn_data = None
-                            if pkmn_data and "attacks" in pkmn_data:
-                                p_attacks = pkmn_data["attacks"]
-                                if required_move and any(
-                                    isinstance(a, str)
-                                    and a.lower().replace(" ", "").replace("-", "")
-                                    == required_move.lower()
-                                    .replace(" ", "")
-                                    .replace("-", "")
-                                    for a in p_attacks
-                                ):
-                                    knows_move = True
+                            # Prefer the caller's just-updated moveset when
+                            # provided (the DB may still hold the pre-level-up
+                            # moveset at this point); fall back to the stored
+                            # one otherwise.
+                            if current_attacks is not None:
+                                p_attacks = current_attacks
                             else:
-                                # Fail closed when the moveset can't be fetched:
-                                # a move-gated evolution must never fire on
-                                # unconfirmed data (mirrors friendship_evolution.py's
-                                # conservative levelMove handling). knows_move stays
-                                # False so the evolution simply doesn't trigger.
-                                knows_move = False
+                                p_attacks = None
+                                try:
+                                    pkmn_data = services.db.get_pokemon(
+                                        individual_id
+                                    )
+                                except Exception:
+                                    pkmn_data = None
+                                if pkmn_data and "attacks" in pkmn_data:
+                                    p_attacks = pkmn_data["attacks"]
+                            if required_move and p_attacks and any(
+                                isinstance(a, str)
+                                and a.lower().replace(" ", "").replace("-", "")
+                                == required_move.lower()
+                                .replace(" ", "")
+                                .replace("-", "")
+                                for a in p_attacks
+                            ):
+                                knows_move = True
+                            # Fail closed when the moveset can't be fetched:
+                            # a move-gated evolution must never fire on
+                            # unconfirmed data (mirrors friendship_evolution.py's
+                            # conservative levelMove handling). knows_move stays
+                            # False so the evolution simply doesn't trigger.
 
                             if knows_move:
                                 is_level_evo = True
@@ -1337,42 +1407,6 @@ def check_key_in_table(column_name, value, file_path):
 
     # Return the matching row or None if no match is found
     return matching_row
-
-
-def rows_for_key_in_table(column_name, value, file_path):
-    """Return *all* rows where ``column_name`` equals ``value`` (as a list).
-
-    Unlike :func:`check_key_in_table`, which stops at the first hit, this returns
-    every matching row. The bundled ``pokemon_evolution.csv`` stores one row per
-    evolution *method*, so a single evolved species can appear on several rows —
-    e.g. Sylveon has a blank row and a separate ``minimum_happiness`` row, and
-    Persian has both a level-up row and a friendship row. Callers that need to
-    pick the row matching a specific method (level vs. friendship) must see them
-    all rather than just whichever comes first in the file.
-
-    Args:
-        column_name: The column to match on.
-        value: The value to match (compared as a string, like
-            :func:`check_key_in_table`).
-        file_path: Path to the CSV file to scan.
-
-    Returns:
-        A list of matching rows (each a ``dict``); empty on no match or error.
-    """
-    matching_rows = []
-    try:
-        with open(file_path, mode="r", encoding="utf-8") as file:
-            reader = csv.DictReader(file)
-            for row in reader:
-                # Use .get() to prevent KeyError if the column doesn't exist.
-                if row.get(column_name) and str(row[column_name]) == str(value):
-                    matching_rows.append(row)
-    except FileNotFoundError:
-        print(f"Error: The file {file_path} does not exist.")
-    except Exception as e:
-        print(f"Error: {e}")
-
-    return matching_rows
 
 
 def rows_for_key_in_table(column_name, value, file_path):

--- a/src/Ankimon/functions/pokedex_functions.py
+++ b/src/Ankimon/functions/pokedex_functions.py
@@ -81,7 +81,6 @@ def is_valid_base_stats(base_stats) -> bool:
     return True
 
 
-
 def _load_pokedex_cache():
     """Load pokedex JSON once and cache it in memory"""
     global _pokedex_cache
@@ -852,6 +851,46 @@ def _csv_gender_id(gender) -> Optional[int]:
     return None
 
 
+def _evolution_row_gender_id(evolved_species_id) -> Optional[int]:
+    """Return the ``gender_id`` gating ``evolved_species_id``, if any.
+
+    Scans the bundled ``pokemon_evolution.csv`` rows whose
+    ``evolved_species_id`` matches and returns the first parseable non-blank
+    ``gender_id`` (veekun convention: 1 = female, 2 = male). ``None`` means the
+    species' evolution rows carry no gender gate. Form-variant ids (>= 10000,
+    e.g. Wormadam-Sandy 10004) resolve to their base species first — the CSV
+    only carries base-species rows (repo tripwire: "IDs >= 10000 must be
+    resolved to their base species via check_id_ok()").
+    """
+    try:
+        species_ref = int(evolved_species_id)
+    except (TypeError, ValueError):
+        return None
+    if species_ref >= 10000:
+        # Form variant: the CSV keys on the base species id only.
+        form_name = search_pokedex_by_id(species_ref)
+        base_species = (
+            safe_int(search_pokedex(form_name, "species_id"))
+            if (form_name and form_name != "Pokémon not found")
+            else 0
+        )
+        if base_species > 0:
+            species_ref = base_species
+    for csv_row in rows_for_key_in_table(
+        "evolved_species_id",
+        species_ref,
+        poke_evo_path,
+    ):
+        raw_gender = (csv_row.get("gender_id") or "").strip()
+        if not raw_gender:
+            continue
+        try:
+            return int(raw_gender)
+        except (TypeError, ValueError):
+            continue
+    return None
+
+
 def check_evolution_by_item(pokemon_id, item_id, gender=None):
     """
     Check if a Pokémon evolves using a specific item.
@@ -919,23 +958,12 @@ def check_evolution_by_item(pokemon_id, item_id, gender=None):
                             # callers without gender data are unaffected.
                             caller_gender_id = _csv_gender_id(gender)
                             if caller_gender_id is not None:
-                                required_gender_id = None
-                                for csv_row in rows_for_key_in_table(
-                                    "evolved_species_id",
+                                required_gender_id = _evolution_row_gender_id(
                                     safe_int(
                                         target_data.get("actual_id")
                                         or target_data.get("species_id")
-                                    ),
-                                    poke_evo_path,
-                                ):
-                                    raw_gender = (csv_row.get("gender_id") or "").strip()
-                                    if not raw_gender:
-                                        continue
-                                    try:
-                                        required_gender_id = int(raw_gender)
-                                        break
-                                    except (TypeError, ValueError):
-                                        continue
+                                    )
+                                )
                                 if (
                                     required_gender_id is not None
                                     and caller_gender_id != required_gender_id
@@ -1093,6 +1121,7 @@ def check_evolution_for_pokemon(
     everstone=False,
     evolution_rejected=False,
     current_attacks=None,
+    gender=None,
 ):
     """
     Check if a Pokémon evolves by a level (or move-based level-up) condition.
@@ -1118,6 +1147,11 @@ def check_evolution_for_pokemon(
             stored moveset from the DB seam. Move-based evolutions evaluate
             against this list so learning the required move on this very level
             triggers the offer on that same event instead of one level late.
+        gender (str | None): The Pokémon's gender (``"M"``/``"F"``/...). When a
+            recognised gender is supplied, CSV ``gender_id`` gates are enforced:
+            Vespiquen needs a female Combee, Salazzle a female Salandit,
+            Wormadam a female Burmy and Mothim a male one. ``None`` keeps the
+            historical no-check behavior for callers without gender data.
 
     Returns:
         int | None: The evolution ID if an evolution is found, or None otherwise.
@@ -1211,20 +1245,22 @@ def check_evolution_for_pokemon(
                             else:
                                 p_attacks = None
                                 try:
-                                    pkmn_data = services.db.get_pokemon(
-                                        individual_id
-                                    )
+                                    pkmn_data = services.db.get_pokemon(individual_id)
                                 except Exception:
                                     pkmn_data = None
                                 if pkmn_data and "attacks" in pkmn_data:
                                     p_attacks = pkmn_data["attacks"]
-                            if required_move and p_attacks and any(
-                                isinstance(a, str)
-                                and a.lower().replace(" ", "").replace("-", "")
-                                == required_move.lower()
-                                .replace(" ", "")
-                                .replace("-", "")
-                                for a in p_attacks
+                            if (
+                                required_move
+                                and p_attacks
+                                and any(
+                                    isinstance(a, str)
+                                    and a.lower().replace(" ", "").replace("-", "")
+                                    == required_move.lower()
+                                    .replace(" ", "")
+                                    .replace("-", "")
+                                    for a in p_attacks
+                                )
                             ):
                                 knows_move = True
                             # Fail closed when the moveset can't be fetched:
@@ -1237,6 +1273,33 @@ def check_evolution_for_pokemon(
                                 is_level_evo = True
 
                         if is_level_evo:
+                            # Gender gate from the bundled CSV (veekun ids:
+                            # 1 = female, 2 = male): Vespiquen needs a female
+                            # Combee, Salazzle a female Salandit, and Burmy
+                            # splits into Wormadam (female) / Mothim (male).
+                            # Only enforced when the caller supplies a
+                            # RECOGNISED gender ("M"/"F"); None/unrecognised
+                            # keeps the historical no-check behavior so
+                            # callers without gender data are unaffected.
+                            caller_gender_id = _csv_gender_id(gender)
+                            if caller_gender_id is not None:
+                                required_gender_id = _evolution_row_gender_id(
+                                    safe_int(
+                                        target_data.get("actual_id")
+                                        or target_data.get("species_id")
+                                        # Smogon-schema base forms (Wormadam,
+                                        # Mothim, Vespiquen, Salazzle, ...) carry
+                                        # only ``num``; without this fallback the
+                                        # CSV gate could never match them.
+                                        or target_data.get("num")
+                                    )
+                                )
+                                if (
+                                    required_gender_id is not None
+                                    and caller_gender_id != required_gender_id
+                                ):
+                                    continue
+
                             time_of_day = None
                             if "day" in condition:
                                 time_of_day = "day"

--- a/src/Ankimon/functions/pokedex_functions.py
+++ b/src/Ankimon/functions/pokedex_functions.py
@@ -936,6 +936,67 @@ def _evolution_row_gender_id_cached(species_ref: int, trigger_ids) -> Optional[i
     return None
 
 
+def _pokedex_form_gender(species_ref) -> Optional[str]:
+    """Return ``"M"``/``"F"`` when pokedex.json marks a species/form single-gender.
+
+    This is the ``gender`` field on the *evolved* entry (e.g. ``meowstic`` -> M,
+    ``meowsticf`` -> F). ``None`` for anything unlabelled or unresolvable.
+    """
+    try:
+        name = search_pokedex_by_id(species_ref)
+    except Exception:
+        return None
+    if not name or name == "Pokémon not found":
+        return None
+    entry = (_load_pokedex_cache() or {}).get(name)
+    if not isinstance(entry, dict):
+        return None
+    form_gender = entry.get("gender")
+    return form_gender if form_gender in ("M", "F") else None
+
+
+def filter_gender_split_forms(evo_ids, gender):
+    """Narrow sibling evolution targets to the ones this gender can reach.
+
+    A SECOND gender source, needed because ``pokemon_evolution.csv`` cannot see
+    every split. veekun models Espurr -> Meowstic and Lechonk -> Oinkologne as
+    two *forms of one species* rather than as two gendered evolutions, so those
+    rows carry no ``gender_id`` and :func:`_evolution_row_gender_id` answers
+    "no gate" for both candidates — leaving the lowest-``evo_id`` tie-break to
+    hand every Espurr the MALE Meowstic and every Lechonk the MALE Oinkologne,
+    which is the exact failure the CSV gate fixes for Burmy. pokedex.json does
+    carry the split, on the evolved forms' own ``gender`` field.
+
+    Deliberately applied ONLY as a tie-break between siblings whose labels
+    disagree. A lone target carrying a ``gender`` (Bounsweet -> Steenee, both
+    female-only) is stating a species property, not an evolution requirement,
+    and must never block an evolution — every such line in the bundled data has
+    a single-gender pre-evolution anyway, so gating on it could only ever hurt a
+    save whose stored gender disagrees with its own species. Unlabelled siblings
+    are kept, and a gender matching no sibling falls back to the full set, so
+    this can never empty the candidate list.
+
+    Args:
+        evo_ids: Candidate evolved-species ids (form ids >= 10000 included).
+        gender: The Pokémon's gender (``"M"``/``"F"``/...); unrecognised values
+            disable the filter.
+
+    Returns:
+        The surviving ids, in the order given.
+    """
+    ids = list(evo_ids)
+    caller_gender_id = _csv_gender_id(gender)
+    if caller_gender_id is None or len(ids) < 2:
+        return ids
+    labels = {evo_id: _pokedex_form_gender(evo_id) for evo_id in ids}
+    if len({label for label in labels.values() if label}) < 2:
+        # Siblings agree (or none is labelled): a species property, not a split.
+        return ids
+    wanted = "M" if caller_gender_id == 2 else "F"
+    matching = [evo_id for evo_id in ids if labels.get(evo_id) in (wanted, None)]
+    return matching or ids
+
+
 def check_evolution_by_item(pokemon_id, item_id, gender=None):
     """
     Check if a Pokémon evolves using a specific item.
@@ -1390,6 +1451,31 @@ def check_evolution_for_pokemon(
                                         eligible_evos.append(target_data)
 
                 if eligible_evos:
+                    # Second gender source for splits the CSV cannot express as
+                    # gendered rows (Espurr -> Meowstic/Meowstic-F, Lechonk ->
+                    # Oinkologne/Oinkologne-F are FORMS in the veekun schema).
+                    # Narrows siblings only; never empties the list.
+                    by_id = {}
+                    for candidate in eligible_evos:
+                        by_id.setdefault(
+                            safe_int(
+                                candidate.get("actual_id")
+                                or candidate.get("species_id")
+                            ),
+                            candidate,
+                        )
+                    kept = set(filter_gender_split_forms(list(by_id), gender))
+                    if kept:
+                        eligible_evos = [
+                            candidate
+                            for candidate in eligible_evos
+                            if safe_int(
+                                candidate.get("actual_id")
+                                or candidate.get("species_id")
+                            )
+                            in kept
+                        ]
+
                     eligible_evos.sort(key=lambda x: 0 if x.get("evoRegion") else 1)
                     target_data = eligible_evos[0]
                     evo_id = safe_int(

--- a/src/Ankimon/functions/trainer_functions.py
+++ b/src/Ankimon/functions/trainer_functions.py
@@ -129,7 +129,8 @@ def xp_share_gain_exp(logger, settings_obj, evo_window, main_pokemon_id, exp, xp
         pokemon['level'],
         evo_window,
         pokemon.get('everstone', False),
-        pokemon.get('evolution_rejected', False)
+        pokemon.get('evolution_rejected', False),
+        current_attacks=pokemon.get('attacks'),
     )
 
     if evo_id is not None:
@@ -158,6 +159,7 @@ def xp_share_gain_exp(logger, settings_obj, evo_window, main_pokemon_id, exp, xp
             pokemon.get("everstone", False),
             pokemon.get("friendship", 0),
             pokemon.get("evolution_rejected", False),
+            attacks=pokemon.get("attacks"),
         )
         if friendship_evo_id is not None:
             # return_name_for_id can return None if the evolved id is missing

--- a/src/Ankimon/functions/trainer_functions.py
+++ b/src/Ankimon/functions/trainer_functions.py
@@ -1,7 +1,4 @@
-import json
-
 from .badges_functions import get_achieved_badges
-from .pokedex_functions import extract_ids_from_file
 from .pokemon_functions import find_experience_for_level
 from .pokedex_functions import check_evolution_for_pokemon, return_name_for_id
 from .friendship_evolution import check_friendship_evolution_for_pokemon

--- a/src/Ankimon/functions/trainer_functions.py
+++ b/src/Ankimon/functions/trainer_functions.py
@@ -7,6 +7,7 @@ from .pokedex_functions import check_evolution_for_pokemon, return_name_for_id
 from .friendship_evolution import check_friendship_evolution_for_pokemon
 from ..services import services
 
+
 def find_trainer_rank(highest_level, trainer_level):
     """
     Determines the Pokémon rank based on the player's achievements like Pokémon caught (from Pokedex),
@@ -21,7 +22,9 @@ def find_trainer_rank(highest_level, trainer_level):
     """
     try:
         # Count the amount of Pokémon caught based on the Pokedex
-        caught_pokemon = services.db.execute("SELECT COUNT(DISTINCT pokedex_id) FROM captured_pokemon").fetchone()[0]
+        caught_pokemon = services.db.execute(
+            "SELECT COUNT(DISTINCT pokedex_id) FROM captured_pokemon"
+        ).fetchone()[0]
 
         # Count the number of shiny Pokémon
         shiny_pokemon_count = services.db.get_shiny_count()
@@ -30,23 +33,73 @@ def find_trainer_rank(highest_level, trainer_level):
         badge_count = len(get_achieved_badges())
 
         # Determine rank based on achievements
-        if caught_pokemon >= 900 and highest_level >= 99 and trainer_level >= 100 and shiny_pokemon_count >= 50:
+        if (
+            caught_pokemon >= 900
+            and highest_level >= 99
+            and trainer_level >= 100
+            and shiny_pokemon_count >= 50
+        ):
             rank = "Legendary Trainer"
-        elif caught_pokemon >= 800 and highest_level >= 95 and trainer_level >= 80 and shiny_pokemon_count >= 25:
+        elif (
+            caught_pokemon >= 800
+            and highest_level >= 95
+            and trainer_level >= 80
+            and shiny_pokemon_count >= 25
+        ):
             rank = "Grand Champion"
-        elif caught_pokemon >= 700 and highest_level >= 90 and trainer_level >= 70 and shiny_pokemon_count >= 20:
+        elif (
+            caught_pokemon >= 700
+            and highest_level >= 90
+            and trainer_level >= 70
+            and shiny_pokemon_count >= 20
+        ):
             rank = "Champion"
-        elif caught_pokemon >= 600 and highest_level >= 80 and trainer_level >= 60 and shiny_pokemon_count >= 10 and badge_count >= 8:
+        elif (
+            caught_pokemon >= 600
+            and highest_level >= 80
+            and trainer_level >= 60
+            and shiny_pokemon_count >= 10
+            and badge_count >= 8
+        ):
             rank = "Master Trainer"
-        elif caught_pokemon >= 500 and highest_level >= 75 and trainer_level >= 50 and shiny_pokemon_count >= 5 and badge_count > 6:
+        elif (
+            caught_pokemon >= 500
+            and highest_level >= 75
+            and trainer_level >= 50
+            and shiny_pokemon_count >= 5
+            and badge_count > 6
+        ):
             rank = "Elite"
-        elif caught_pokemon >= 400 and highest_level >= 70 and trainer_level >= 45 and shiny_pokemon_count >= 3 and badge_count > 5:
+        elif (
+            caught_pokemon >= 400
+            and highest_level >= 70
+            and trainer_level >= 45
+            and shiny_pokemon_count >= 3
+            and badge_count > 5
+        ):
             rank = "Elite Trainer"
-        elif caught_pokemon >= 350 and highest_level >= 60 and trainer_level >= 40 and shiny_pokemon_count >= 2 and badge_count > 4:
+        elif (
+            caught_pokemon >= 350
+            and highest_level >= 60
+            and trainer_level >= 40
+            and shiny_pokemon_count >= 2
+            and badge_count > 4
+        ):
             rank = "Advanced Trainer"
-        elif caught_pokemon >= 300 and highest_level >= 50 and trainer_level >= 30 and shiny_pokemon_count > 0 and badge_count > 3:
+        elif (
+            caught_pokemon >= 300
+            and highest_level >= 50
+            and trainer_level >= 30
+            and shiny_pokemon_count > 0
+            and badge_count > 3
+        ):
             rank = "Veteran"
-        elif caught_pokemon >= 250 and highest_level >= 40 and trainer_level >= 20 and shiny_pokemon_count > 0:
+        elif (
+            caught_pokemon >= 250
+            and highest_level >= 40
+            and trainer_level >= 20
+            and shiny_pokemon_count > 0
+        ):
             rank = "Skilled Trainer"
         elif caught_pokemon >= 150 and highest_level >= 30 and trainer_level >= 10:
             rank = "Rookie"
@@ -59,7 +112,10 @@ def find_trainer_rank(highest_level, trainer_level):
         print("Error: One of the files (Pokedex or MyPokemon) could not be found.")
         return "Unknown Rank"
 
-def xp_share_gain_exp(logger, settings_obj, evo_window, main_pokemon_id, exp, xp_share_individual_id):
+
+def xp_share_gain_exp(
+    logger, settings_obj, evo_window, main_pokemon_id, exp, xp_share_individual_id
+):
     # Ensure that the XP Share Pokémon is set and different from the main Pokémon
     if not xp_share_individual_id:
         return exp
@@ -89,15 +145,17 @@ def xp_share_gain_exp(logger, settings_obj, evo_window, main_pokemon_id, exp, xp
         logger.log("info", "XP Share target no longer exists; cleared the setting.")
         return original_exp
 
-    current_level = int(pokemon['level'])  # MODIFIED: Use local variable for level
-    if pokemon.get('held_item') == "lucky-egg":
-        exp = int(exp * 1.5) # Multiply by 1.5 if pokemon holds lucky egg
+    current_level = int(pokemon["level"])  # MODIFIED: Use local variable for level
+    if pokemon.get("held_item") == "lucky-egg":
+        exp = int(exp * 1.5)  # Multiply by 1.5 if pokemon holds lucky egg
         msg += f"{pokemon['name']}'s Lucky Egg boosts its XP gained!\n"
     # Increase the xp of the matched Pokémon
     current_xp = pokemon.get("xp") or pokemon.get("stats", {}).get("xp", 0)
-    growth_rate = pokemon['growth_rate']  # MODIFIED: Use local variable for growth rate
-    experience_needed = int(find_experience_for_level(growth_rate, current_level, remove_level_cap))  # MODIFIED: Pre-calculate needed XP
-    evo_id = None # Initialize variable
+    growth_rate = pokemon["growth_rate"]  # MODIFIED: Use local variable for growth rate
+    experience_needed = int(
+        find_experience_for_level(growth_rate, current_level, remove_level_cap)
+    )  # MODIFIED: Pre-calculate needed XP
+    evo_id = None  # Initialize variable
 
     levels_gained = 0
     logger.log("info", "Running XP share function")
@@ -105,9 +163,12 @@ def xp_share_gain_exp(logger, settings_obj, evo_window, main_pokemon_id, exp, xp
         pokemon["xp"] = current_xp + exp
     else:
         while exp + current_xp > experience_needed:
-            if (remove_level_cap or current_level < 100):
+            if remove_level_cap or current_level < 100:
                 if levels_gained >= 10:
-                    logger.log("error", f"XP Share level-up loop exceeded safety cap of 10 for {pokemon['name']}")
+                    logger.log(
+                        "error",
+                        f"XP Share level-up loop exceeded safety cap of 10 for {pokemon['name']}",
+                    )
                     exp = max(0, experience_needed - 1)
                     current_xp = 0
                     break
@@ -115,22 +176,27 @@ def xp_share_gain_exp(logger, settings_obj, evo_window, main_pokemon_id, exp, xp
                 current_level += 1
                 exp = exp + current_xp - experience_needed
                 current_xp = 0
-                experience_needed = int(find_experience_for_level(growth_rate, current_level, remove_level_cap))  # MODIFIED: Recalculate needed XP
+                experience_needed = int(
+                    find_experience_for_level(
+                        growth_rate, current_level, remove_level_cap
+                    )
+                )  # MODIFIED: Recalculate needed XP
                 msg += f"XP increased for {pokemon['name']} with level {current_level} and XP {exp}\n"
             else:
                 break
-        pokemon['level'] = current_level
-        pokemon['xp'] = 0 if exp < 0 else exp
+        pokemon["level"] = current_level
+        pokemon["xp"] = 0 if exp < 0 else exp
 
     # Check for evolution
     evo_id = check_evolution_for_pokemon(
-        pokemon['individual_id'],
-        pokemon['id'],
-        pokemon['level'],
+        pokemon["individual_id"],
+        pokemon["id"],
+        pokemon["level"],
         evo_window,
-        pokemon.get('everstone', False),
-        pokemon.get('evolution_rejected', False),
-        current_attacks=pokemon.get('attacks'),
+        pokemon.get("everstone", False),
+        pokemon.get("evolution_rejected", False),
+        current_attacks=pokemon.get("attacks"),
+        gender=pokemon.get("gender"),
     )
 
     if evo_id is not None:
@@ -159,14 +225,21 @@ def xp_share_gain_exp(logger, settings_obj, evo_window, main_pokemon_id, exp, xp
             pokemon.get("everstone", False),
             pokemon.get("friendship", 0),
             pokemon.get("evolution_rejected", False),
+            # Both values are already loaded in `pokemon`; passing them avoids a
+            # synchronous DB read on the XP-share (review-path) flow.
             attacks=pokemon.get("attacks"),
+            pokemon_defeated=pokemon.get("pokemon_defeated", 0),
         )
         if friendship_evo_id is not None:
             # return_name_for_id can return None if the evolved id is missing
             # from the name CSV; guard the .capitalize() so a data gap can't
             # crash the XP-share flow.
             friendship_evo_name = return_name_for_id(friendship_evo_id)
-            friendship_evo_name = friendship_evo_name.capitalize() if friendship_evo_name else str(friendship_evo_id)
+            friendship_evo_name = (
+                friendship_evo_name.capitalize()
+                if friendship_evo_name
+                else str(friendship_evo_id)
+            )
             msg += evo_window.translator.translate(
                 "pokemon_about_to_evolve_friendship",
                 main_pokemon_name=pokemon["name"],

--- a/src/Ankimon/gui_classes/pokemon_details.py
+++ b/src/Ankimon/gui_classes/pokemon_details.py
@@ -143,6 +143,10 @@ def PokemonCollectionDetailsSplit(
             "everstone": everstone,
             "attacks": attacks,
             "pokemon_defeated": pokemon_defeated,
+            # Needed for the CSV gender_id gate (Wormadam/Mothim, Vespiquen,
+            # Salazzle): without it this panel's status line would silently skip
+            # a gate the PC grid and the automatic level-up path both enforce.
+            "gender": gender,
         }
         readiness = evolution_readiness(pkmn_data_stub)
 

--- a/src/Ankimon/profile_hooks.py
+++ b/src/Ankimon/profile_hooks.py
@@ -12,7 +12,7 @@ from .pyobj.ankimon_sync import setup_ankimon_sync_hooks, check_and_sync_pokemon
 from .pyobj.tip_of_the_day import show_tip_of_the_day
 from .pyobj.pokemon_trade import check_and_award_monthly_pokemon
 from .pyobj.error_handler import show_warning_with_traceback
-from .functions.pokedex_functions import clear_pokedex_caches
+from .functions.pokedex_functions import clear_pokedex_caches, warm_evolution_caches
 from .functions.learnset_retrieval import clear_learnset_cache
 from .functions.encounter_functions import clear_encounter_cache, clear_auto_battle_override
 
@@ -53,6 +53,20 @@ def _on_profile_close():
 
 def _on_profile_did_open(online_connectivity):
     def handler():
+        # Re-warm the static evolution table _on_profile_close just dropped.
+        # The boot warm (startup.run_startup_background_checks) runs once per
+        # Anki PROCESS, so a profile SWITCH leaves pokemon_evolution.csv
+        # unparsed with the review gate already open — the next level-up would
+        # then parse it inside on_review_card, the synchronous review-path I/O
+        # the boot warm exists to prevent. Cheap enough for the main thread
+        # (one ~500-row CSV) and guarded like everything else here: the warm is
+        # an optimization and runs first, so a raise would take the sync-hook
+        # registration and the tip of the day down with it.
+        try:
+            warm_evolution_caches()
+        except Exception as e:
+            logger.log("error", f"Error warming evolution caches on profile open: {e}")
+
         # Mobile-review sync bootstrap (F20 deferred half): initialise the revlog
         # watermark on first run, clear the desktop session set for a fresh
         # inter-sync interval, run a startup detection pass to catch reviews pulled

--- a/src/Ankimon/profile_hooks.py
+++ b/src/Ankimon/profile_hooks.py
@@ -1,4 +1,5 @@
 from anki.hooks import addHook
+
 try:
     from anki.hooks import remHook
 except ImportError:
@@ -14,7 +15,10 @@ from .pyobj.pokemon_trade import check_and_award_monthly_pokemon
 from .pyobj.error_handler import show_warning_with_traceback
 from .functions.pokedex_functions import clear_pokedex_caches, warm_evolution_caches
 from .functions.learnset_retrieval import clear_learnset_cache
-from .functions.encounter_functions import clear_encounter_cache, clear_auto_battle_override
+from .functions.encounter_functions import (
+    clear_encounter_cache,
+    clear_auto_battle_override,
+)
 
 sync_dialog = None
 
@@ -90,7 +94,10 @@ def _on_profile_did_open(online_connectivity):
                 # Run detection immediately to catch reviews pulled in by startup sync
                 if settings_obj.get("mobile.enabled", True):
                     try:
-                        from .functions.mobile_sync import process_mobile_reviews_after_sync
+                        from .functions.mobile_sync import (
+                            process_mobile_reviews_after_sync,
+                        )
+
                         process_mobile_reviews_after_sync(
                             col=col,
                             ankimon_db=db,
@@ -98,7 +105,10 @@ def _on_profile_did_open(online_connectivity):
                             logger=logger,
                         )
                     except Exception as sync_err:
-                        logger.log("error", f"Failed to run startup mobile reviews sync: {sync_err}")
+                        logger.log(
+                            "error",
+                            f"Failed to run startup mobile reviews sync: {sync_err}",
+                        )
 
                 # Restore badge — show pending count from previous session
                 pending = db.get_pending_mobile_count()
@@ -132,6 +142,7 @@ def _on_profile_did_open(online_connectivity):
         # and adds them to the candidates list for later review
         try:
             from .functions.badges_functions import check_unleeched_cards
+
             check_unleeched_cards(
                 services.col if services.col is not None else mw.col,
                 services.db,
@@ -176,12 +187,15 @@ def _on_profile_did_open(online_connectivity):
                     )
                 elif not is_online:
                     logger.log(
-                        "info", "No connection - AnkiWeb file-sync disabled for this session"
+                        "info",
+                        "No connection - AnkiWeb file-sync disabled for this session",
                     )
                 else:
                     global sync_dialog
                     sync_dialog = check_and_sync_pokemon_data(settings_obj, logger)
-                    logger.log("info", "Ankimon file-sync system initialized successfully")
+                    logger.log(
+                        "info", "Ankimon file-sync system initialized successfully"
+                    )
             except Exception as e:
                 show_warning_with_traceback(
                     parent=mw, exception=e, message="Error setting up sync system:"

--- a/src/Ankimon/pyobj/InfoLogger.py
+++ b/src/Ankimon/pyobj/InfoLogger.py
@@ -12,25 +12,29 @@ class ShowInfoLogger:
 
         # Check if log file exists, and create it if it doesn't
         if not os.path.exists(self.log_file):
-            with open(self.log_file, 'w') as f:
-                f.write('')  # Create an empty file
+            with open(self.log_file, "w") as f:
+                f.write("")  # Create an empty file
 
         # Set up logging
         self.logger = logging.getLogger(name)
         if not self.logger.handlers:
             self.logger.setLevel(logging.DEBUG)
-            file_handler = logging.FileHandler(self.log_file, encoding='utf-8')  # Explicit UTF-8 encoding
+            file_handler = logging.FileHandler(
+                self.log_file, encoding="utf-8"
+            )  # Explicit UTF-8 encoding
             file_handler.setLevel(logging.DEBUG)
-            formatter = logging.Formatter('%(asctime)s - %(levelname)s - %(message)s')
+            formatter = logging.Formatter("%(asctime)s - %(levelname)s - %(message)s")
             file_handler.setFormatter(formatter)
             self.logger.addHandler(file_handler)
 
         # Create a separate handler for the game log messages
         self.game_logger = logging.getLogger("GameLogger")
         if not self.game_logger.handlers:
-            game_file_handler = logging.FileHandler(self.log_file,encoding="utf-8")
+            game_file_handler = logging.FileHandler(self.log_file, encoding="utf-8")
             game_file_handler.setLevel(logging.DEBUG)
-            game_formatter = logging.Formatter('%(asctime)s - GAME - %(message)s')  # Custom format for game messages
+            game_formatter = logging.Formatter(
+                "%(asctime)s - GAME - %(message)s"
+            )  # Custom format for game messages
             game_file_handler.setFormatter(game_formatter)
             self.game_logger.addHandler(game_file_handler)
 
@@ -51,25 +55,36 @@ class ShowInfoLogger:
         except Exception:
             pass
 
-        if level == 'info':
+        if level == "info":
             self.logger.info(message)
-        elif level == 'warning':
+        elif level == "warning":
             self.logger.warning(message)
-        elif level == 'error':
+        elif level == "error":
             self.logger.error(message)
-        elif level == 'game':
+        elif level == "game":
             self.game_logger.info(message)
 
     def log_and_showinfo(self, level, message):
         # Log + emit always; show a blocking dialog only under a Qt GUI.
         self._record(level, message)
 
-        if level in ['info', 'warning', 'error']:
+        if level in ["info", "warning", "error"]:
             # Lazy, guarded import keeps this module loadable headless. When
             # there is no Qt runtime (the agent harness / tests), the structured
             # event above is the observable record instead of a popup.
             try:
-                from PyQt6.QtWidgets import QMessageBox
+                from PyQt6.QtWidgets import QApplication, QMessageBox
+
+                # The try/except alone is NOT enough, and this is the seam where
+                # that matters: PyQt6 being importable is not the same as an
+                # application running. Constructing a QWidget without a
+                # QApplication makes Qt call abort() — a process death, not an
+                # exception — so a dev box that happens to have PyQt6 installed
+                # would kill the harness here rather than fall through to the
+                # event-only path this comment promises.
+                if QApplication.instance() is None:
+                    return
+
                 msg_box = QMessageBox()
                 msg_box.setWindowTitle("Log Message")
                 msg_box.setText(message)
@@ -83,7 +98,7 @@ class ShowInfoLogger:
 
     def game_log(self, message):
         # Log a game-specific message with the GAME- prefix
-        self._record('game', message)
+        self._record("game", message)
 
     def toggle_log_window(self):
         # Imported lazily so the logger module never hard-depends on Qt.
@@ -114,7 +129,9 @@ class ShowInfoLogger:
 
             # Add a refresh button to reload the log content
             refresh_button = QPushButton("Refresh")
-            refresh_button.clicked.connect(lambda: text_edit.setPlainText(open(self.log_file).read()))
+            refresh_button.clicked.connect(
+                lambda: text_edit.setPlainText(open(self.log_file).read())
+            )
 
             # Add a clear button to clear the log file content
             clear_button = QPushButton("Clear")
@@ -132,12 +149,13 @@ class ShowInfoLogger:
 
     def clear_log_file(self):
         # Clear the log file
-        with open(self.log_file, 'w') as f:
-            f.write('')  # Empty the log file
+        with open(self.log_file, "w") as f:
+            f.write("")  # Empty the log file
 
         # Update the log viewer with the cleared content
         if self.log_dialog:
             from PyQt6.QtWidgets import QTextEdit
+
             text_edit = self.log_dialog.findChild(QTextEdit)
             if text_edit:
-                text_edit.setPlainText('')  # Clear the displayed content in the viewer
+                text_edit.setPlainText("")  # Clear the displayed content in the viewer

--- a/src/Ankimon/pyobj/InfoLogger.py
+++ b/src/Ankimon/pyobj/InfoLogger.py
@@ -78,11 +78,16 @@ class ShowInfoLogger:
                 # The try/except alone is NOT enough, and this is the seam where
                 # that matters: PyQt6 being importable is not the same as an
                 # application running. Constructing a QWidget without a
-                # QApplication makes Qt call abort() — a process death, not an
-                # exception — so a dev box that happens to have PyQt6 installed
-                # would kill the harness here rather than fall through to the
-                # event-only path this comment promises.
-                if QApplication.instance() is None:
+                # widget-capable QApplication makes Qt call abort() — a process
+                # death, not an exception — so a dev box that happens to have
+                # PyQt6 installed would kill the harness here rather than fall
+                # through to the event-only path this comment promises.
+                #
+                # isinstance, not `is None`: QApplication.instance() is inherited
+                # from QCoreApplication and hands back whatever application
+                # exists, so a console-only QCoreApplication reads as non-None
+                # and a QWidget built after it aborts just the same.
+                if not isinstance(QApplication.instance(), QApplication):
                     return
 
                 msg_box = QMessageBox()

--- a/src/Ankimon/pyobj/ankimon_shop.py
+++ b/src/Ankimon/pyobj/ankimon_shop.py
@@ -6,8 +6,24 @@ from ..services import services
 from ..utils import daily_item_list
 from ..resources import pokemon_tm_learnset_path
 
-# Daily Rotating Items Pool
-DAILY_ITEMS_POOL = daily_item_list()
+# Daily Rotating Items Pool, built on first use rather than at import time.
+#
+# `daily_item_list()` scans the sprites directory and, when it is missing, opens
+# the sprite-download agreement dialog. Doing that at module scope made merely
+# importing this module scan the disk and potentially pop a modal — and this
+# module is imported by `singletons`, which `battle_loop` imports lazily from
+# inside `on_review_card`. So the first card review of a fresh profile could
+# surface a download dialog from inside a stats notification, and a headless
+# run (the agent harness) aborted outright on the QWidget construction.
+_DAILY_ITEMS_POOL = None
+
+
+def get_daily_items_pool():
+    """Return the daily-shop item pool, building it once on first call."""
+    global _DAILY_ITEMS_POOL
+    if _DAILY_ITEMS_POOL is None:
+        _DAILY_ITEMS_POOL = daily_item_list() or []
+    return _DAILY_ITEMS_POOL
 
 
 class PokemonShopManager:
@@ -38,20 +54,25 @@ class PokemonShopManager:
         db = services.db
         shop_data = db.get_user_data("todays_shop")
         if shop_data:
-            if shop_data.get("items") and shop_data.get("date") == datetime.now().strftime("%Y-%m-%d"):
+            if shop_data.get("items") and shop_data.get(
+                "date"
+            ) == datetime.now().strftime("%Y-%m-%d"):
                 return shop_data.get("items")
 
         seed = datetime.now().strftime("%Y-%m-%d")
         rng = random.Random(seed)
-        num_items = min(self.number_of_daily_items, len(DAILY_ITEMS_POOL))
-        return rng.sample(DAILY_ITEMS_POOL, num_items)
+        pool = get_daily_items_pool()
+        num_items = min(self.number_of_daily_items, len(pool))
+        return rng.sample(pool, num_items)
 
     def get_daily_tms(self):
         """Works like get_daily_items, but for TMs"""
         db = services.db
         shop_data = db.get_user_data("todays_shop")
         if shop_data:
-            if shop_data.get("technical_machines") and shop_data.get("date") == datetime.now().strftime("%Y-%m-%d"):
+            if shop_data.get("technical_machines") and shop_data.get(
+                "date"
+            ) == datetime.now().strftime("%Y-%m-%d"):
                 return shop_data.get("technical_machines")
 
         tm_pool = self.get_tm_pool()

--- a/src/Ankimon/pyobj/download_sprites.py
+++ b/src/Ankimon/pyobj/download_sprites.py
@@ -546,7 +546,10 @@ def show_agreement_and_download_dialog(force_download=False):
     # agent harness imports these modules directly, and PyQt6 being importable
     # is not the same as a running application. Degrade to "no download
     # offered" instead of killing the interpreter.
-    if QApplication.instance() is None:
+    # isinstance, not `is None`: QApplication.instance() is inherited from
+    # QCoreApplication and returns whatever application exists, so a console-only
+    # QCoreApplication reads as non-None and the dialog below would still abort.
+    if not isinstance(QApplication.instance(), QApplication):
         try:
             logger = services.logger
             if logger is not None:

--- a/src/Ankimon/pyobj/download_sprites.py
+++ b/src/Ankimon/pyobj/download_sprites.py
@@ -2,14 +2,23 @@ import os
 import zipfile
 import requests
 import time
-import hashlib # Point 4: Add import for hashlib
+import hashlib  # Point 4: Add import for hashlib
 from pathlib import Path
 from typing import Optional
 
 from ..resources import user_path_sprites
+from ..services import services
 from ..gui_entities import AgreementDialog
 from PyQt6.QtCore import Qt, QThread, pyqtSignal
-from PyQt6.QtWidgets import QDialog, QVBoxLayout, QProgressBar, QLabel, QPushButton, QMessageBox
+from PyQt6.QtWidgets import (
+    QApplication,
+    QDialog,
+    QVBoxLayout,
+    QProgressBar,
+    QLabel,
+    QPushButton,
+    QMessageBox,
+)
 
 
 class DownloadThread(QThread):
@@ -18,16 +27,17 @@ class DownloadThread(QThread):
     This class handles network retries, SHA256 integrity checks, download cancellation,
     and provides detailed progress updates through Qt signals. It uses Path objects for
     robust file system operations.
-    
+
     Signals:
         progress_signal(int): Emitted during download/extraction with progress percentage (0-100).
         status_signal(str): Emitted with status updates throughout the process.
         download_finished_signal(bool, str): Emitted upon completion (success, message).
     """
+
     # Define custom signals for progress and completion
     progress_signal = pyqtSignal(int)
     status_signal = pyqtSignal(str)
-    download_finished_signal = pyqtSignal(bool, str) # success, message
+    download_finished_signal = pyqtSignal(bool, str)  # success, message
 
     def __init__(self, urls: list[str], dest_dir_path: Path, force_download=False):
         super().__init__()
@@ -40,7 +50,7 @@ class DownloadThread(QThread):
         self._flag_file_path = self.dest_dir_path / "download_complete.flag"
         self._last_progress_percent_emit = -1
         self._last_progress_time_emit = 0.0
-        self.download_timeout = 30 # seconds
+        self.download_timeout = 30  # seconds
 
     def cancel(self):
         self._is_cancelled = True
@@ -58,36 +68,52 @@ class DownloadThread(QThread):
     # Point 1: Add method _fetch_expected_hash(self)
     def _fetch_expected_hash(self) -> Optional[str]:
         """Fetches the expected SHA256 hash from GitHub Releases API."""
-        api_url = "https://api.github.com/repos/h0tp-ftw/ankimon-sprites/releases/latest"
+        api_url = (
+            "https://api.github.com/repos/h0tp-ftw/ankimon-sprites/releases/latest"
+        )
         try:
             # Add 10-second timeout to API request
             response = requests.get(api_url, timeout=10)
             response.raise_for_status()
             release_data = response.json()
-            
+
             # Parse JSON to find asset matching "sprites.zip"
             # Note: The provided example JSON does not contain 'sprites.zip'
             # directly but 'ankimon-1.288-anki21-ankiweb.ankiaddon'.
             # Assuming 'sprites.zip' will eventually be an asset with 'sha256' field.
-            for asset in release_data.get('assets', []):
-                if asset.get('name') == "sprites.zip":
-                    sha256_hash = asset.get('sha256') # Extract and return the "sha256" field
+            for asset in release_data.get("assets", []):
+                if asset.get("name") == "sprites.zip":
+                    sha256_hash = asset.get(
+                        "sha256"
+                    )  # Extract and return the "sha256" field
                     if sha256_hash:
-                        return sha256_hash.lower() # Return in lowercase for case-insensitive comparison later
-            
-            self.status_signal.emit("Warning: 'sprites.zip' asset not found in GitHub release assets or missing 'sha256'.")
+                        return (
+                            sha256_hash.lower()
+                        )  # Return in lowercase for case-insensitive comparison later
+
+            self.status_signal.emit(
+                "Warning: 'sprites.zip' asset not found in GitHub release assets or missing 'sha256'."
+            )
             return None
         except requests.exceptions.Timeout:
-            self.status_signal.emit("Warning: GitHub API request timed out when fetching checksum.")
+            self.status_signal.emit(
+                "Warning: GitHub API request timed out when fetching checksum."
+            )
             return None
         except requests.exceptions.RequestException as e:
-            self.status_signal.emit(f"Warning: Failed to fetch checksum from GitHub API: {e}")
+            self.status_signal.emit(
+                f"Warning: Failed to fetch checksum from GitHub API: {e}"
+            )
             return None
-        except ValueError: # For JSON decoding errors
-            self.status_signal.emit("Warning: Failed to decode GitHub API response as JSON.")
+        except ValueError:  # For JSON decoding errors
+            self.status_signal.emit(
+                "Warning: Failed to decode GitHub API response as JSON."
+            )
             return None
         except Exception as e:
-            self.status_signal.emit(f"Warning: An unexpected error occurred while fetching checksum: {e}")
+            self.status_signal.emit(
+                f"Warning: An unexpected error occurred while fetching checksum: {e}"
+            )
             return None
 
     # Point 2: Add method _calculate_file_hash(self, file_path: Path) -> str:
@@ -95,10 +121,12 @@ class DownloadThread(QThread):
         """Calculates the SHA256 hash of a file, reading in chunks."""
         hasher = hashlib.sha256()
         try:
-            with open(file_path, 'rb') as f:
+            with open(file_path, "rb") as f:
                 while chunk := f.read(1024 * 1024):  # Read file in 1MB chunks
                     hasher.update(chunk)
-            return hasher.hexdigest().lower() # Return in lowercase for case-insensitive comparison
+            return (
+                hasher.hexdigest().lower()
+            )  # Return in lowercase for case-insensitive comparison
         except IOError as e:
             self.status_signal.emit(f"Error calculating hash for {file_path.name}: {e}")
             return ""
@@ -113,18 +141,26 @@ class DownloadThread(QThread):
                 self.dest_dir_path.mkdir(parents=True, exist_ok=True)
                 self.status_signal.emit(f"Created directory: {self.dest_dir_path}")
             except OSError as e:
-                self.status_signal.emit(f"Error creating directory {self.dest_dir_path}: {e}")
-                self.download_finished_signal.emit(False, f"Failed to create directory: {e}")
+                self.status_signal.emit(
+                    f"Error creating directory {self.dest_dir_path}: {e}"
+                )
+                self.download_finished_signal.emit(
+                    False, f"Failed to create directory: {e}"
+                )
                 return
-        
+
         if not os.access(self.dest_dir_path, os.W_OK):
-            self.status_signal.emit(f"Destination directory not writable: {self.dest_dir_path}")
-            self.download_finished_signal.emit(False, "Destination directory not writable.")
+            self.status_signal.emit(
+                f"Destination directory not writable: {self.dest_dir_path}"
+            )
+            self.download_finished_signal.emit(
+                False, "Destination directory not writable."
+            )
             return
 
         # Point 3: Check for existing partial downloads and clean them up
         self._cleanup_temp_files()
-        
+
         # Point 10: Check if already completed
         if self._flag_file_path.exists() and not self.force_download:
             self.status_signal.emit("Sprites already downloaded and verified.")
@@ -134,9 +170,11 @@ class DownloadThread(QThread):
         # Point 8: Add retry logic (3 attempts) with exponential backoff for network failures
         max_attempts = 3
         download_successful = False
-        
+
         for url_index, url in enumerate(self.urls):
-            self.status_signal.emit(f"Trying download mirror {url_index + 1}/{len(self.urls)}: {url}")
+            self.status_signal.emit(
+                f"Trying download mirror {url_index + 1}/{len(self.urls)}: {url}"
+            )
             for attempt in range(max_attempts):
                 if self._is_cancelled:
                     self.status_signal.emit("Download cancelled during retry setup.")
@@ -145,62 +183,93 @@ class DownloadThread(QThread):
                     return
 
                 try:
-                    self.status_signal.emit(f"Attempt {attempt + 1}/{max_attempts} for current mirror: Downloading ZIP file...")
+                    self.status_signal.emit(
+                        f"Attempt {attempt + 1}/{max_attempts} for current mirror: Downloading ZIP file..."
+                    )
                     # Point 1 & 2: Add comprehensive error handling & timeout
-                    response = requests.get(url, stream=True, timeout=self.download_timeout)
-                    response.raise_for_status() # Raise an exception for bad status codes (4xx or 5xx)
+                    response = requests.get(
+                        url, stream=True, timeout=self.download_timeout
+                    )
+                    response.raise_for_status()  # Raise an exception for bad status codes (4xx or 5xx)
 
-                    total_size = int(response.headers.get('content-length', 0))
+                    total_size = int(response.headers.get("content-length", 0))
                     downloaded_size = 0
 
                     with open(self._temp_zip_path, "wb") as f:
-                        for data in response.iter_content(chunk_size=(1024*1024)): # Point 2: Increased chunk size for better throughput
+                        for data in response.iter_content(
+                            chunk_size=(1024 * 1024)
+                        ):  # Point 2: Increased chunk size for better throughput
                             if self._is_cancelled:
                                 self.status_signal.emit("Download cancelled.")
                                 self._cleanup_temp_files()
-                                self.download_finished_signal.emit(False, "Download cancelled.")
+                                self.download_finished_signal.emit(
+                                    False, "Download cancelled."
+                                )
                                 return
 
                             downloaded_size += len(data)
                             f.write(data)
 
                             # Point 5: Throttle progress updates to max 10Hz (every 10%)
-                            current_progress_percent = int((downloaded_size / total_size) * 100) if total_size > 0 else 0
+                            current_progress_percent = (
+                                int((downloaded_size / total_size) * 100)
+                                if total_size > 0
+                                else 0
+                            )
                             current_time = time.time()
 
-                            if (current_progress_percent >= self._last_progress_percent_emit + 10 or current_progress_percent == 100) and \
-                               (current_time - self._last_progress_time_emit >= 0.1): # Max 10Hz
+                            if (
+                                current_progress_percent
+                                >= self._last_progress_percent_emit + 10
+                                or current_progress_percent == 100
+                            ) and (
+                                current_time - self._last_progress_time_emit >= 0.1
+                            ):  # Max 10Hz
                                 self.progress_signal.emit(current_progress_percent)
-                                self._last_progress_percent_emit = current_progress_percent
+                                self._last_progress_percent_emit = (
+                                    current_progress_percent
+                                )
                                 self._last_progress_time_emit = current_time
 
                     # Emit final progress
                     self.progress_signal.emit(100)
-                    self.status_signal.emit(f"Downloaded {self._temp_zip_path.name} from mirror {url_index + 1}.")
+                    self.status_signal.emit(
+                        f"Downloaded {self._temp_zip_path.name} from mirror {url_index + 1}."
+                    )
                     download_successful = True
-                    break # Download successful, break out of retry loop
-                
+                    break  # Download successful, break out of retry loop
+
                 except requests.exceptions.Timeout:
-                    self.status_signal.emit(f"Download timed out (attempt {attempt + 1}). Retrying...")
+                    self.status_signal.emit(
+                        f"Download timed out (attempt {attempt + 1}). Retrying..."
+                    )
                 except requests.exceptions.RequestException as e:
-                    self.status_signal.emit(f"Network error (attempt {attempt + 1}): {e}. Retrying...")
+                    self.status_signal.emit(
+                        f"Network error (attempt {attempt + 1}): {e}. Retrying..."
+                    )
                 except IOError as e:
-                    self.status_signal.emit(f"File system error during download (attempt {attempt + 1}): {e}. Retrying...")
-                
+                    self.status_signal.emit(
+                        f"File system error during download (attempt {attempt + 1}): {e}. Retrying..."
+                    )
+
                 if attempt < max_attempts - 1:
-                    time.sleep(2 ** attempt) # Exponential backoff
+                    time.sleep(2**attempt)  # Exponential backoff
                 else:
-                    self.status_signal.emit(f"Failed to download from mirror {url_index + 1} after {max_attempts} attempts.")
-            
+                    self.status_signal.emit(
+                        f"Failed to download from mirror {url_index + 1} after {max_attempts} attempts."
+                    )
+
             if download_successful:
-                break # Break out of the URL loop if download was successful
+                break  # Break out of the URL loop if download was successful
 
         if not download_successful:
-            self.status_signal.emit(f"Failed to download after trying all {len(self.urls)} mirrors.")
+            self.status_signal.emit(
+                f"Failed to download after trying all {len(self.urls)} mirrors."
+            )
             self._cleanup_temp_files()
             self.download_finished_signal.emit(False, "Failed to download sprites.")
             return
-        
+
         # Point 4: The previous 'return' here was incorrect, preventing successful paths from proceeding.
         # The 'else' clause after the for loop is now implicitly handled if the loop completes without a 'break'.
 
@@ -212,38 +281,53 @@ class DownloadThread(QThread):
             self.status_signal.emit("Verifying file integrity with SHA256...")
             actual_hash = self._calculate_file_hash(self._temp_zip_path)
 
-            if not actual_hash: # Error during hash calculation
-                self.download_finished_signal.emit(False, "Failed to calculate download file checksum.")
+            if not actual_hash:  # Error during hash calculation
+                self.download_finished_signal.emit(
+                    False, "Failed to calculate download file checksum."
+                )
                 self._cleanup_temp_files()
                 return
 
-            if actual_hash != expected_hash: # Compare hashes (case-insensitive done in methods)
-                self.status_signal.emit(f"Checksum mismatch! Expected: {expected_hash}, Actual: {actual_hash[:10]}...")
+            if (
+                actual_hash != expected_hash
+            ):  # Compare hashes (case-insensitive done in methods)
+                self.status_signal.emit(
+                    f"Checksum mismatch! Expected: {expected_hash}, Actual: {actual_hash[:10]}..."
+                )
                 self._cleanup_temp_files()
-                self.download_finished_signal.emit(False, "Downloaded file checksum mismatch. It might be corrupted.")
+                self.download_finished_signal.emit(
+                    False, "Downloaded file checksum mismatch. It might be corrupted."
+                )
                 return
             self.status_signal.emit("Checksum verified (SHA256).")
         else:
-            self.status_signal.emit("Could not fetch checksum, proceeding with ZIP validation only.")
-
+            self.status_signal.emit(
+                "Could not fetch checksum, proceeding with ZIP validation only."
+            )
 
         # Point 5: Keep all existing ZIP validation as secondary check
         self.status_signal.emit("Verifying ZIP file integrity...")
         try:
             if not zipfile.is_zipfile(self._temp_zip_path):
                 raise zipfile.BadZipFile("File is not a valid ZIP archive.")
-            with zipfile.ZipFile(self._temp_zip_path, 'r') as _: # Try to open to ensure it's readable
+            with zipfile.ZipFile(
+                self._temp_zip_path, "r"
+            ) as _:  # Try to open to ensure it's readable
                 pass
             self.status_signal.emit("ZIP file integrity verified.")
             # Point 3 (from original request): Only rename to sprites.zip after validation
             os.rename(self._temp_zip_path, self._final_zip_path)
-            self.status_signal.emit(f"Renamed {self._temp_zip_path.name} to {self._final_zip_path.name}.")
+            self.status_signal.emit(
+                f"Renamed {self._temp_zip_path.name} to {self._final_zip_path.name}."
+            )
         except (zipfile.BadZipFile, IOError) as e:
             self.status_signal.emit(f"ZIP file verification failed: {e}")
             self._cleanup_temp_files()
-            self.download_finished_signal.emit(False, "ZIP file format verification failed.")
+            self.download_finished_signal.emit(
+                False, "ZIP file format verification failed."
+            )
             return
-        
+
         self.status_signal.emit("Extracting files...")
         extracted_count = 0
         total_files = 0
@@ -254,29 +338,37 @@ class DownloadThread(QThread):
                     if self._is_cancelled:
                         self.status_signal.emit("Extraction cancelled.")
                         self._cleanup_temp_files()
-                        self.download_finished_signal.emit(False, "Extraction cancelled.")
+                        self.download_finished_signal.emit(
+                            False, "Extraction cancelled."
+                        )
                         return
 
                     dest_file = self.dest_dir_path / file_name
 
                     # Point 6: Add extraction progress tracking and status updates
-                    extraction_progress = int((i / total_files) * 100) if total_files > 0 else 0
+                    extraction_progress = (
+                        int((i / total_files) * 100) if total_files > 0 else 0
+                    )
                     self.progress_signal.emit(extraction_progress)
-                    
+
                     # Check if file already exists to avoid overwriting
                     if dest_file.exists():
-                        self.status_signal.emit(f"Skipped ({extraction_progress}%): {file_name} (File exists)")
-                        continue # Skip to the next file
-                        
+                        self.status_signal.emit(
+                            f"Skipped ({extraction_progress}%): {file_name} (File exists)"
+                        )
+                        continue  # Skip to the next file
+
                     try:
                         zip_ref.extract(file_name, self.dest_dir_path)
-                        self.status_signal.emit(f"Extracted ({extraction_progress}%): {file_name}")
+                        self.status_signal.emit(
+                            f"Extracted ({extraction_progress}%): {file_name}"
+                        )
                         extracted_count += 1
                     except OSError as e:
                         self.status_signal.emit(f"Error extracting {file_name}: {e}")
                         # Continue with other files, but mark as failure later? Or stop?
                         # For now, continue and report overall success/failure.
-                self.progress_signal.emit(100) # Final extraction progress
+                self.progress_signal.emit(100)  # Final extraction progress
         except (zipfile.BadZipFile, IOError) as e:
             self.status_signal.emit(f"Error during extraction: {e}")
             self._cleanup_temp_files()
@@ -284,17 +376,21 @@ class DownloadThread(QThread):
             return
 
         # Final Cleanup: Remove the ZIP file after extraction and verification
-        self.status_signal.emit(f"Removing temporary ZIP file: {self._final_zip_path.name}")
+        self.status_signal.emit(
+            f"Removing temporary ZIP file: {self._final_zip_path.name}"
+        )
         try:
             os.remove(self._final_zip_path)
         except OSError as e:
             self.status_signal.emit(f"Error removing {self._final_zip_path.name}: {e}")
             # Non-critical, download considered successful if extraction is done.
-        
+
         # Point 10: Add completion state file
         try:
             self._flag_file_path.touch()
-            self.status_signal.emit("Download verification complete. Sprites installed.")
+            self.status_signal.emit(
+                "Download verification complete. Sprites installed."
+            )
         except OSError as e:
             self.status_signal.emit(f"Error creating completion flag file: {e}")
             # Non-critical, but report issue.
@@ -308,7 +404,9 @@ class DownloadThread(QThread):
         except OSError:
             pass
 
-        self.download_finished_signal.emit(True, "Sprites download and extraction complete!")
+        self.download_finished_signal.emit(
+            True, "Sprites download and extraction complete!"
+        )
 
 
 class DownloadDialog(QDialog):
@@ -316,7 +414,7 @@ class DownloadDialog(QDialog):
         super().__init__(parent)
 
         self.force_download = force_download
-        self.setWindowTitle('Ankimon Sprites Download')
+        self.setWindowTitle("Ankimon Sprites Download")
         self.setGeometry(300, 300, 400, 200)
 
         self.urls = [
@@ -325,7 +423,6 @@ class DownloadDialog(QDialog):
         ]
         self.dest_dir_path = Path(user_path_sprites)
         self._flag_file_path = self.dest_dir_path / "download_complete.flag"
-
 
         self.init_ui()
         self._check_initial_state()
@@ -347,7 +444,7 @@ class DownloadDialog(QDialog):
         # Point 4: Add cancel button to DownloadDialog
         self.cancel_button = QPushButton("Cancel Download", self)
         self.cancel_button.clicked.connect(self.cancel_download)
-        self.cancel_button.setEnabled(False) # Disabled until download starts
+        self.cancel_button.setEnabled(False)  # Disabled until download starts
         layout.addWidget(self.cancel_button)
 
         self.setLayout(layout)
@@ -357,8 +454,8 @@ class DownloadDialog(QDialog):
         if self._flag_file_path.exists():
             if self.force_download:
                 self.status_label.setText("Forcing download despite existing flag.")
-                return # Do not disable button, allow download to start
-                
+                return  # Do not disable button, allow download to start
+
             self.status_label.setText("Sprites already downloaded and verified.")
             self.start_button.setEnabled(False)
             self.cancel_button.setEnabled(False)
@@ -370,18 +467,30 @@ class DownloadDialog(QDialog):
             try:
                 self.dest_dir_path.mkdir(parents=True, exist_ok=True)
             except OSError as e:
-                QMessageBox.critical(self, "Download Error", f"Failed to create directory {self.dest_dir_path}: {e}")
+                QMessageBox.critical(
+                    self,
+                    "Download Error",
+                    f"Failed to create directory {self.dest_dir_path}: {e}",
+                )
                 self.status_label.setText("Error: Destination directory not writable.")
                 return
-        
+
         if not os.access(self.dest_dir_path, os.W_OK):
-            QMessageBox.critical(self, "Download Error", f"Destination directory is not writable: {self.dest_dir_path}")
+            QMessageBox.critical(
+                self,
+                "Download Error",
+                f"Destination directory is not writable: {self.dest_dir_path}",
+            )
             self.status_label.setText("Error: Destination directory not writable.")
             return
 
         # Point 10: Check if download is already complete
         if self._flag_file_path.exists() and not self.force_download:
-            QMessageBox.information(self, "Download Complete", "Ankimon sprites are already downloaded and verified.")
+            QMessageBox.information(
+                self,
+                "Download Complete",
+                "Ankimon sprites are already downloaded and verified.",
+            )
             self.status_label.setText("Sprites already downloaded and verified.")
             self.start_button.setEnabled(False)
             self.cancel_button.setEnabled(False)
@@ -389,22 +498,24 @@ class DownloadDialog(QDialog):
             return
 
         # Start the download thread
-        self.download_thread = DownloadThread(self.urls, self.dest_dir_path, force_download=self.force_download)
+        self.download_thread = DownloadThread(
+            self.urls, self.dest_dir_path, force_download=self.force_download
+        )
         self.download_thread.progress_signal.connect(self.update_progress)
         self.download_thread.status_signal.connect(self.update_status)
         self.download_thread.download_finished_signal.connect(self.on_download_finished)
         self.download_thread.start()
-        
+
         self.status_label.setText("Download starting...")
         self.start_button.setEnabled(False)
         self.cancel_button.setEnabled(True)
         self.progress_bar.setValue(0)
 
     def cancel_download(self):
-        if hasattr(self, 'download_thread') and self.download_thread.isRunning():
+        if hasattr(self, "download_thread") and self.download_thread.isRunning():
             self.download_thread.cancel()
             self.status_label.setText("Cancellation requested...")
-            self.cancel_button.setEnabled(False) # Disable cancel button immediately
+            self.cancel_button.setEnabled(False)  # Disable cancel button immediately
 
     def update_progress(self, value):
         self.progress_bar.setValue(value)
@@ -424,10 +535,29 @@ class DownloadDialog(QDialog):
             self.start_button.setText("Retry Download")
             self.start_button.setEnabled(True)
             QMessageBox.warning(self, "Download Failed", message)
-            self.progress_bar.setValue(0) # Reset progress on failure
+            self.progress_bar.setValue(0)  # Reset progress on failure
 
 
 def show_agreement_and_download_dialog(force_download=False):
+    # Constructing a QWidget before a QApplication exists aborts the PROCESS
+    # (Qt calls abort(); "QWidget: Must construct a QApplication before a
+    # QWidget"), which no try/except can catch — so this has to be checked, not
+    # caught. It is reachable from contexts that have no Qt app: the headless
+    # agent harness imports these modules directly, and PyQt6 being importable
+    # is not the same as a running application. Degrade to "no download
+    # offered" instead of killing the interpreter.
+    if QApplication.instance() is None:
+        try:
+            logger = services.logger
+            if logger is not None:
+                logger.log(
+                    "warning",
+                    "Sprite download skipped: no QApplication (headless run).",
+                )
+        except Exception:
+            pass
+        return
+
     # Show the agreement dialog
     dialog = AgreementDialog()
     if dialog.exec() == QDialog.DialogCode.Accepted:
@@ -435,4 +565,4 @@ def show_agreement_and_download_dialog(force_download=False):
         # Point 1: Memory leak fix - Ensure dialog is deleted when closed.
         download_dialog.setAttribute(Qt.WidgetAttribute.WA_DeleteOnClose)
         # Ensure the dialog is modal and blocks execution until download is complete or cancelled.
-        download_dialog.exec() # Show the dialog modally
+        download_dialog.exec()  # Show the dialog modally

--- a/src/Ankimon/pyobj/error_handler.py
+++ b/src/Ankimon/pyobj/error_handler.py
@@ -308,7 +308,10 @@ def show_warning_with_traceback(
     # Tier-1 harness that turned any recoverable error into a force-close —
     # exactly inverting this module's purpose, which is to make errors
     # observable. Headless we stop after the log + error event above.
-    if QApplication.instance() is None:
+    # isinstance, not `is None`: QApplication.instance() is inherited from
+    # QCoreApplication and returns whatever application exists, so a console-only
+    # QCoreApplication reads as non-None and the QDialog below aborts anyway.
+    if not isinstance(QApplication.instance(), QApplication):
         return
 
     # Constructing a QWidget/QDialog off the Qt GUI thread is a hard Qt violation

--- a/src/Ankimon/pyobj/error_handler.py
+++ b/src/Ankimon/pyobj/error_handler.py
@@ -24,10 +24,17 @@ from typing import Optional, Dict
 # headless harness they fail and we fall back to log + structured event only.
 try:
     from PyQt6.QtWidgets import (
-        QDialog, QVBoxLayout, QHBoxLayout, QLabel, QPushButton, QSizePolicy
+        QApplication,
+        QDialog,
+        QVBoxLayout,
+        QHBoxLayout,
+        QLabel,
+        QPushButton,
+        QSizePolicy,
     )
     from PyQt6.QtGui import QPixmap, QImage
     from PyQt6.QtCore import Qt
+
     _HAVE_QT = True
 except Exception:  # pragma: no cover - exercised only headless
     _HAVE_QT = False
@@ -42,6 +49,7 @@ def _logger():
     """Best-effort access to the shared logger without importing aqt."""
     try:
         from ..services import services
+
         return services.logger
     except Exception:
         return None
@@ -74,7 +82,9 @@ def set_image_from_url(label: "QLabel", url: str, width: int = 140) -> None:
         image.loadFromData(response.content)
         pixmap = QPixmap.fromImage(image)
         if not pixmap.isNull():
-            pixmap = pixmap.scaledToWidth(width, Qt.TransformationMode.SmoothTransformation)
+            pixmap = pixmap.scaledToWidth(
+                width, Qt.TransformationMode.SmoothTransformation
+            )
             label.setPixmap(pixmap)
             label.setAlignment(Qt.AlignmentFlag.AlignRight | Qt.AlignmentFlag.AlignTop)
         else:
@@ -103,7 +113,7 @@ def load_error_images(json_path: Path) -> Dict[str, str]:
     """Load and select random error image metadata."""
     default_image = {"path": "", "credit": "", "url": ""}
     try:
-        with open(json_path, 'r', encoding='utf-8') as f:
+        with open(json_path, "r", encoding="utf-8") as f:
             error_images = json.load(f)
         return random.choice(error_images)
     except Exception as e:
@@ -140,12 +150,15 @@ def create_credit_label(chosen_image: Dict[str, str]) -> "Optional[QLabel]":
     label.setStyleSheet("font-size:10px; color:#aaa;")
     label.setWordWrap(True)
     label.setFixedWidth(140)
-    label.setSizePolicy(QSizePolicy.Policy.Preferred, QSizePolicy.Policy.MinimumExpanding)
+    label.setSizePolicy(
+        QSizePolicy.Policy.Preferred, QSizePolicy.Policy.MinimumExpanding
+    )
     return label
 
 
-def build_dialog_ui(dialog: "QDialog", message: str, exception: Exception,
-                   chosen_image: Dict[str, str]) -> None:
+def build_dialog_ui(
+    dialog: "QDialog", message: str, exception: Exception, chosen_image: Dict[str, str]
+) -> None:
     """Construct dialog UI layout without environment info display."""
     main_layout = QHBoxLayout(dialog)
     main_layout.setContentsMargins(24, 18, 24, 18)
@@ -197,9 +210,13 @@ def build_dialog_ui(dialog: "QDialog", message: str, exception: Exception,
         if local_path.exists():
             pixmap = QPixmap(str(local_path))
             if not pixmap.isNull():
-                pixmap = pixmap.scaledToWidth(140, Qt.TransformationMode.SmoothTransformation)
+                pixmap = pixmap.scaledToWidth(
+                    140, Qt.TransformationMode.SmoothTransformation
+                )
                 image_label.setPixmap(pixmap)
-                image_label.setAlignment(Qt.AlignmentFlag.AlignRight | Qt.AlignmentFlag.AlignTop)
+                image_label.setAlignment(
+                    Qt.AlignmentFlag.AlignRight | Qt.AlignmentFlag.AlignTop
+                )
             else:
                 image_label.setText("Image failed to load")
     right_layout.addWidget(image_label, alignment=Qt.AlignmentFlag.AlignRight)
@@ -251,7 +268,7 @@ def setup_dialog_style(dialog: "QDialog") -> None:
 def show_warning_with_traceback(
     parent=None,
     exception: Optional[Exception] = None,
-    message: str = "An error occurred during execution."
+    message: str = "An error occurred during execution.",
 ) -> None:
     """Report an error: always log + emit an ``error`` event; show the rich Qt
     dialog only when a Qt runtime is available.
@@ -272,12 +289,26 @@ def show_warning_with_traceback(
         logger.log("error", f"{message}: {exception}\n{env_info}\n{tb_text}")
     try:
         from ..events import events
-        events.emit("error", message=message, exception=str(exception), traceback=tb_text)
+
+        events.emit(
+            "error", message=message, exception=str(exception), traceback=tb_text
+        )
     except Exception:
         pass
 
     # No GUI → done.
     if not _HAVE_QT:
+        return
+
+    # Same hard Qt violation as the thread check below, for the other reason a
+    # QWidget can be unbuildable: PyQt6 being IMPORTABLE (_HAVE_QT above) is not
+    # the same as an application existing. Without a QApplication, constructing
+    # the dialog aborts the process at the C++ level. This function is the funnel
+    # every `except Exception` in the add-on reaches, so on a dev box running the
+    # Tier-1 harness that turned any recoverable error into a force-close —
+    # exactly inverting this module's purpose, which is to make errors
+    # observable. Headless we stop after the log + error event above.
+    if QApplication.instance() is None:
         return
 
     # Constructing a QWidget/QDialog off the Qt GUI thread is a hard Qt violation
@@ -288,6 +319,7 @@ def show_warning_with_traceback(
     # log + error-event above (the durable record) rather than building a dialog.
     try:
         from ..utils import is_main_thread
+
         if not is_main_thread():
             return
     except Exception:
@@ -301,7 +333,7 @@ def show_warning_with_traceback(
         parent = _mw
 
     # Load error images
-    error_json_path = pyobj_path / 'error_images.json'
+    error_json_path = pyobj_path / "error_images.json"
     chosen_image = load_error_images(error_json_path)
 
     # Create and configure dialog

--- a/src/Ankimon/pyobj/item_window.py
+++ b/src/Ankimon/pyobj/item_window.py
@@ -692,22 +692,49 @@ class ItemWindow(QWidget):
             "info", f"{prevo_name} was healed for {heal_points}"
         )
 
-    def Check_Evo_Item(self, individual_id: str, prevo_id: str, item_name: str):
+    def Check_Evo_Item(
+        self,
+        individual_id: str,
+        prevo_id: str,
+        item_name: str,
+        pokemon_data: Optional[dict] = None,
+    ):
+        """Offer the item evolution for ``individual_id``, gender gate included.
+
+        ``pokemon_data`` is the stored record for ``individual_id`` when the
+        caller already holds one (the web bag loads it to resolve ``prevo_id``);
+        it is read here only when omitted, so that path costs one query, not two.
+        """
         try:
             item_id = return_id_for_item_name(item_name)
             # Gate on the SELECTED Pokémon's gender, not the active battle one:
             # the user can pick any Pokémon from their collection here, and
             # gender-gated evolutions from pokemon_evolution.csv (Gallade =
             # male Kirlia, Froslass = female Snorunt) would otherwise evaluate
-            # unrelated state. A missing/unknown gender degrades to the
-            # historical no-check behavior.
-            gender = None
-            try:
-                target_data = services.db.get_pokemon(individual_id)
-            except Exception:
-                target_data = None
-            if isinstance(target_data, dict):
-                gender = target_data.get("gender")
+            # unrelated state.
+            #
+            # A record that simply carries no gender still degrades to the
+            # historical no-check behavior (legacy saves predate the column) —
+            # but a record we could not READ must not: check_evolution_by_item
+            # treats gender=None as "unrestricted", so reporting a failed lookup
+            # that way would hand a female Kirlia the male-only Gallade the one
+            # time the database is busy. Refuse instead; the player can retry.
+            if pokemon_data is None:
+                try:
+                    pokemon_data = services.db.get_pokemon(individual_id)
+                except Exception as e:
+                    self.logger.log_and_showinfo(
+                        "error",
+                        f"Could not look up that Pokemon, so the item was not "
+                        f"used: {e}",
+                    )
+                    return
+            if not isinstance(pokemon_data, dict):
+                self.logger.log_and_showinfo(
+                    "error", "Could not find that Pokemon; the item was not used."
+                )
+                return
+            gender = pokemon_data.get("gender")
             evo_id = check_evolution_by_item(prevo_id, item_id, gender=gender)
             if evo_id:
                 # Perform your action when the item matches the Pokémon's evolution item

--- a/src/Ankimon/pyobj/item_window.py
+++ b/src/Ankimon/pyobj/item_window.py
@@ -614,7 +614,12 @@ class ItemWindow(QWidget):
     def Check_Evo_Item(self, individual_id: str, prevo_id: str, item_name: str):
         try:
             item_id = return_id_for_item_name(item_name)
-            evo_id = check_evolution_by_item(prevo_id, item_id)
+            # Pass the main Pokémon's gender so gender-gated evolutions from
+            # pokemon_evolution.csv (Gallade = male Kirlia, Froslass = female
+            # Snorunt) can't fire on the wrong sex. A missing/unknown
+            # gender degrades to the historical no-check behavior.
+            gender = getattr(self.main_pokemon, "gender", None)
+            evo_id = check_evolution_by_item(prevo_id, item_id, gender=gender)
             if evo_id:
                 # Perform your action when the item matches the Pokémon's evolution item
                 self.logger.log_and_showinfo("info", "Pokemon Evolution is fitting !")

--- a/src/Ankimon/pyobj/item_window.py
+++ b/src/Ankimon/pyobj/item_window.py
@@ -1,6 +1,4 @@
-from pathlib import Path
 import random
-import json
 import csv
 from typing import Any, Optional
 

--- a/src/Ankimon/pyobj/item_window.py
+++ b/src/Ankimon/pyobj/item_window.py
@@ -30,14 +30,12 @@ from ..pyobj.pokemon_obj import PokemonObject
 from ..pyobj.settings import Settings
 from ..pyobj.starter_window import StarterWindow
 
-from ..business import (
-    get_id_and_description_by_item_name
-)
+from ..business import get_id_and_description_by_item_name
 from ..functions.pokedex_functions import (
     search_pokedex_by_id,
     return_id_for_item_name,
     check_evolution_by_item,
-    find_details_move
+    find_details_move,
 )
 
 from ..resources import icon_path, items_path, csv_file_items_cost, poke_evo_path
@@ -50,17 +48,18 @@ from .error_handler import show_warning_with_traceback
 # At the moment when I write this line, "UserRole" is defined as UserRole 1000 in the Ankimon __init__.py file. IDK what it's about.
 UserRole = 1000
 
+
 class ItemWindow(QWidget):
     def __init__(
-            self,
-            logger: ShowInfoLogger,
-            settings_obj: Settings,
-            main_pokemon: PokemonObject,
-            enemy_pokemon: PokemonObject,
-            achievements: dict[str, bool],
-            starter_window: StarterWindow,
-            evo_window: EvoWindow,
-            ):
+        self,
+        logger: ShowInfoLogger,
+        settings_obj: Settings,
+        main_pokemon: PokemonObject,
+        enemy_pokemon: PokemonObject,
+        achievements: dict[str, bool],
+        starter_window: StarterWindow,
+        evo_window: EvoWindow,
+    ):
         super().__init__()
         self.logger: ShowInfoLogger = logger
         self.settings_obj: Settings = settings_obj
@@ -75,19 +74,19 @@ class ItemWindow(QWidget):
 
     def initUI(self):
         self.hp_heal_items = {
-            'potion': 20,
-            'sweet-heart': 20,
-            'berry-juice': 20,
-            'fresh-water': 30,
-            'soda-pop': 50,
-            'super-potion': 60,
-            'energy-powder': 60,
-            'lemonade': 70,
-            'moomoo-milk': 100,
-            'hyper-potion': 120,
-            'energy-root': 120,
-            'full-restore': 1000,
-            'max-potion': 1000
+            "potion": 20,
+            "sweet-heart": 20,
+            "berry-juice": 20,
+            "fresh-water": 30,
+            "soda-pop": 50,
+            "super-potion": 60,
+            "energy-powder": 60,
+            "lemonade": 70,
+            "moomoo-milk": 100,
+            "hyper-potion": 120,
+            "energy-root": 120,
+            "full-restore": 1000,
+            "max-potion": 1000,
         }
 
         self.fossil_pokemon = {
@@ -99,28 +98,28 @@ class ItemWindow(QWidget):
             "skull-fossil": 408,
             "armor-fossil": 410,
             "cover-fossil": 564,
-            "plume-fossil": 566
+            "plume-fossil": 566,
         }
 
         self.pokeball_chances = {
-            'dive-ball': 11,      # Increased chance when fishing or underwater
-            'dusk-ball': 11,      # Increased chance at night or in caves
-            'great-ball': 12,     # Increased catch rate (original was 9, now 12)
-            'heal-ball': 12,      # Same as a Poké Ball but heals the Pokémon
-            'iron-ball': 12,      # Used for Steel-type Pokémon, 1.5x chance
-            'light-ball': 1,      # Not actually used for catching Pokémon; it's an item
-            'luxury-ball': 12,    # Same as a Poké Ball but increases happiness
-            'master-ball': 100,   # Guarantees a successful catch (100% chance)
-            'nest-ball': 12,      # Works better on lower-level Pokémon
-            'net-ball': 12,       # Higher chance for Water- and Bug-type Pokémon
-            'poke-ball': 8,       # Increased chance from 5 to 8
-            'premier-ball': 8,    # Same as Poké Ball, but it's a special ball
-            'quick-ball': 13,     # High chance if used at the start of battle
-            'repeat-ball': 12,    # Higher chance on Pokémon that have been caught before
-            'safari-ball': 8,     # Used in Safari Zone, with a fixed catch rate
-            'smoke-ball': 1,      # Used to flee from wild battles, no catch chance
-            'timer-ball': 13,     # Higher chance the longer the battle goes
-            'ultra-ball': 13      # Increased catch rate (original was 10, now 13)
+            "dive-ball": 11,  # Increased chance when fishing or underwater
+            "dusk-ball": 11,  # Increased chance at night or in caves
+            "great-ball": 12,  # Increased catch rate (original was 9, now 12)
+            "heal-ball": 12,  # Same as a Poké Ball but heals the Pokémon
+            "iron-ball": 12,  # Used for Steel-type Pokémon, 1.5x chance
+            "light-ball": 1,  # Not actually used for catching Pokémon; it's an item
+            "luxury-ball": 12,  # Same as a Poké Ball but increases happiness
+            "master-ball": 100,  # Guarantees a successful catch (100% chance)
+            "nest-ball": 12,  # Works better on lower-level Pokémon
+            "net-ball": 12,  # Higher chance for Water- and Bug-type Pokémon
+            "poke-ball": 8,  # Increased chance from 5 to 8
+            "premier-ball": 8,  # Same as Poké Ball, but it's a special ball
+            "quick-ball": 13,  # High chance if used at the start of battle
+            "repeat-ball": 12,  # Higher chance on Pokémon that have been caught before
+            "safari-ball": 8,  # Used in Safari Zone, with a fixed catch rate
+            "smoke-ball": 1,  # Used to flee from wild battles, no catch chance
+            "timer-ball": 13,  # Higher chance the longer the battle goes
+            "ultra-ball": 13,  # Increased catch rate (original was 10, now 13)
         }
 
         self.evolution_items = set()
@@ -184,7 +183,9 @@ class ItemWindow(QWidget):
 
         # FIX 3: Increase initial window size to better accommodate 3 columns
         # Calculate appropriate width: 3 columns * min_width + spacing + margins
-        initial_width = 3 * min_column_width + 2 * 10 + 40  # 3 cols + 2 spacings + margins
+        initial_width = (
+            3 * min_column_width + 2 * 10 + 40
+        )  # 3 cols + 2 spacings + margins
         initial_height = 600  # Increased from 500
         self.resize(initial_width, initial_height)
 
@@ -206,7 +207,9 @@ class ItemWindow(QWidget):
         else:
             for item in itembag_list:
                 try:
-                    item_widget = self.ItemLabel(item["item"], item["quantity"], item.get("type"))
+                    item_widget = self.ItemLabel(
+                        item["item"], item["quantity"], item.get("type")
+                    )
                     item_widget.setMinimumWidth(180)
                     self.contentLayout.addWidget(item_widget, row, col)
                     col += 1
@@ -242,29 +245,45 @@ class ItemWindow(QWidget):
             # Filter items based on category index
             if category_index == 1:  # Fossils
                 filtered_items = [
-                    item for item in filtered_items
-                    if isinstance(item, dict) and "item" in item and item["item"] in self.fossil_pokemon
+                    item
+                    for item in filtered_items
+                    if isinstance(item, dict)
+                    and "item" in item
+                    and item["item"] in self.fossil_pokemon
                 ]
             elif category_index == 2:  # TMs and HMs
-                filtered_items = list(filter(lambda item: item.get("type") == "TM", filtered_items))
+                filtered_items = list(
+                    filter(lambda item: item.get("type") == "TM", filtered_items)
+                )
             elif category_index == 3:  # Heal items
                 filtered_items = [
-                    item for item in filtered_items
-                    if isinstance(item, dict) and "item" in item and item["item"] in self.hp_heal_items
+                    item
+                    for item in filtered_items
+                    if isinstance(item, dict)
+                    and "item" in item
+                    and item["item"] in self.hp_heal_items
                 ]
             elif category_index == 4:  # Evolution items
                 filtered_items = [
-                    item for item in filtered_items
-                    if isinstance(item, dict) and "item" in item and item["item"] in self.evolution_items
+                    item
+                    for item in filtered_items
+                    if isinstance(item, dict)
+                    and "item" in item
+                    and item["item"] in self.evolution_items
                 ]
-            elif category_index == 5: # Pokeballs
+            elif category_index == 5:  # Pokeballs
                 filtered_items = [
-                    item for item in filtered_items
-                    if isinstance(item, dict) and "item" in item and item["item"] in self.pokeball_chances
+                    item
+                    for item in filtered_items
+                    if isinstance(item, dict)
+                    and "item" in item
+                    and item["item"] in self.pokeball_chances
                 ]
 
             # Now filter by search
-            filtered_items = list(filter(lambda item: search_text in item["item"].lower(), filtered_items))
+            filtered_items = list(
+                filter(lambda item: search_text in item["item"].lower(), filtered_items)
+            )
         except Exception as e:
             filtered_items = []
             self.logger.log_and_showinfo("error", f"Error filtering items: {e}")
@@ -276,7 +295,9 @@ class ItemWindow(QWidget):
 
         for item in filtered_items:
             try:
-                item_widget = self.ItemLabel(item["item"], item["quantity"], item.get("type"))
+                item_widget = self.ItemLabel(
+                    item["item"], item["quantity"], item.get("type")
+                )
                 item_widget.setMinimumWidth(180)
                 self.contentLayout.addWidget(item_widget, row, col)
                 col += 1
@@ -303,10 +324,16 @@ class ItemWindow(QWidget):
                 pokemon_obj.give_held_item(item_name)
 
                 # Sync the main_pokemon singleton if it's the target
-                if self.main_pokemon and self.main_pokemon.individual_id == individual_id:
+                if (
+                    self.main_pokemon
+                    and self.main_pokemon.individual_id == individual_id
+                ):
                     self.main_pokemon.held_item = item_name
 
-                self.logger.log_and_showinfo("info", f"{item_name} was given to {target_pokemon_data.get('name')}.")
+                self.logger.log_and_showinfo(
+                    "info",
+                    f"{item_name} was given to {target_pokemon_data.get('name')}.",
+                )
                 self.renewWidgets()
 
                 # Refresh open PC Box window. Read services.pokemon_pc directly:
@@ -324,9 +351,13 @@ class ItemWindow(QWidget):
         item_frame = QVBoxLayout()  # itemframe
         info_item_button = QPushButton("More Info")
         info_item_button.clicked.connect(lambda: self.more_info_button_act(item_name))
-        
-        item_name_for_label = item_name.replace("-", " ")  # Remove hyphens from item_name
-        item_name_for_label = f"{item_name_for_label.capitalize()} x{quantity}"  # Display quantity
+
+        item_name_for_label = item_name.replace(
+            "-", " "
+        )  # Remove hyphens from item_name
+        item_name_for_label = (
+            f"{item_name_for_label.capitalize()} x{quantity}"  # Display quantity
+        )
         if item_type == "TM":
             item_name_for_label = f"TM: {item_name_for_label}"
         item_name_label = QLabel(item_name_for_label)
@@ -335,7 +366,10 @@ class ItemWindow(QWidget):
         if item_type == "TM":
             details = find_details_move(item_name)
             if not details or "type" not in details:
-                self.logger.log_and_showinfo("error", f"Report the following: Missing details for item: {item_name!r}")
+                self.logger.log_and_showinfo(
+                    "error",
+                    f"Report the following: Missing details for item: {item_name!r}",
+                )
                 tm_type = "normal"
             else:
                 tm_type = details["type"].lower()
@@ -345,8 +379,9 @@ class ItemWindow(QWidget):
             item_file_path = items_path / f"{item_name}.png"
         item_picture_pixmap = QPixmap(str(item_file_path))
         item_picture_pixmap_scaled = item_picture_pixmap.scaled(
-            96, 96,
-            Qt.AspectRatioMode.KeepAspectRatio, # Important: Keeps the image from stretching
+            96,
+            96,
+            Qt.AspectRatioMode.KeepAspectRatio,  # Important: Keeps the image from stretching
         )
         item_picture_label = QLabel()
         item_picture_label.setPixmap(item_picture_pixmap_scaled)
@@ -359,12 +394,20 @@ class ItemWindow(QWidget):
         if item_name in self.hp_heal_items:
             use_item_button = QPushButton("Heal Mainpokemon")
             hp_heal = self.hp_heal_items[item_name]
-            use_item_button.clicked.connect(lambda: self.Check_Heal_Item(self.main_pokemon.name, hp_heal, item_name, self.achievements))
+            use_item_button.clicked.connect(
+                lambda: self.Check_Heal_Item(
+                    self.main_pokemon.name, hp_heal, item_name, self.achievements
+                )
+            )
         elif item_name in self.fossil_pokemon:
             fossil_id = self.fossil_pokemon[item_name]
             fossil_pokemon_name = search_pokedex_by_id(fossil_id)
-            use_item_button = QPushButton(f"Evolve Fossil to {fossil_pokemon_name.capitalize()}")
-            use_item_button.clicked.connect(lambda: self.Evolve_Fossil(item_name, fossil_id, fossil_pokemon_name))
+            use_item_button = QPushButton(
+                f"Evolve Fossil to {fossil_pokemon_name.capitalize()}"
+            )
+            use_item_button.clicked.connect(
+                lambda: self.Evolve_Fossil(item_name, fossil_id, fossil_pokemon_name)
+            )
         elif item_name in self.pokeball_chances:
             use_item_button = QPushButton("Try catching wild Pokemon")
             use_item_button.clicked.connect(lambda: self.Handle_Pokeball(item_name))
@@ -374,7 +417,7 @@ class ItemWindow(QWidget):
             # FIX: Remove indentation by using textwrap.dedent() or reformatting the string
             import textwrap
 
-            description_text = f"""Allows the user to teach {item_name.replace('-', ' ').title()} to Pokémon that can learn this move.\n\nTeaching the move doesn't consume the TM."""
+            description_text = f"""Allows the user to teach {item_name.replace("-", " ").title()} to Pokémon that can learn this move.\n\nTeaching the move doesn't consume the TM."""
 
             info_item_button = QLabel(textwrap.dedent(description_text).strip())
 
@@ -388,7 +431,11 @@ class ItemWindow(QWidget):
             use_item_button.clicked.connect(
                 lambda: self._prompt_and_check_evo_item(item_name)
             )
-        elif item_name in GiveItemWindow.NOT_YET_IMPLEMENTED_ITEMS or item_name.endswith("-berry") or item_name.endswith("-gem"):
+        elif (
+            item_name in GiveItemWindow.NOT_YET_IMPLEMENTED_ITEMS
+            or item_name.endswith("-berry")
+            or item_name.endswith("-gem")
+        ):
             use_item_button = QLabel("Not implemented yet")
             use_item_button.setAlignment(Qt.AlignmentFlag.AlignCenter)
         else:
@@ -467,7 +514,9 @@ class ItemWindow(QWidget):
     def PokemonList(self, comboBox):
         try:
             db = services.db
-            pokemon_list = db.execute("SELECT name, individual_id, pokedex_id FROM captured_pokemon").fetchall()
+            pokemon_list = db.execute(
+                "SELECT name, individual_id, pokedex_id FROM captured_pokemon"
+            ).fetchall()
             if pokemon_list:
                 for pokemon in pokemon_list:
                     pokemon_name = pokemon[0]
@@ -477,8 +526,12 @@ class ItemWindow(QWidget):
                         # Add Pokémon name to comboBox
                         comboBox.addItem(pokemon_name)
                         # Store both individual_id and id as separate data using roles
-                        comboBox.setItemData(comboBox.count() - 1, individual_id, role=UserRole)
-                        comboBox.setItemData(comboBox.count() - 1, id_, role=UserRole + 1)
+                        comboBox.setItemData(
+                            comboBox.count() - 1, individual_id, role=UserRole
+                        )
+                        comboBox.setItemData(
+                            comboBox.count() - 1, id_, role=UserRole + 1
+                        )
         except Exception as e:
             self.logger.log_and_showinfo("error", f"Error loading Pokémon list: {e}")
 
@@ -488,11 +541,15 @@ class ItemWindow(QWidget):
         choices = []
         try:
             db = services.db
-            rows = db.execute("SELECT name, individual_id, pokedex_id FROM captured_pokemon").fetchall()
+            rows = db.execute(
+                "SELECT name, individual_id, pokedex_id FROM captured_pokemon"
+            ).fetchall()
             for row in rows:
                 name, individual_id, poke_id = row[0], row[1], row[2]
                 if name and individual_id and poke_id:
-                    choices.append((f"{name} ({individual_id[:8]})", individual_id, poke_id))
+                    choices.append(
+                        (f"{name} ({individual_id[:8]})", individual_id, poke_id)
+                    )
         except Exception as e:
             self.logger.log("error", f"Error loading Pokemon list: {e}")
         self._pokemon_choices_cache = choices
@@ -504,7 +561,9 @@ class ItemWindow(QWidget):
             self.logger.log_and_showinfo("error", "No Pokemon available.")
             return None
         labels = [c[0] for c in choices]
-        selected_label, ok = QInputDialog.getItem(self, title, "Select Pokemon:", labels, 0, False)
+        selected_label, ok = QInputDialog.getItem(
+            self, title, "Select Pokemon:", labels, 0, False
+        )
         if not ok:
             return None
         for label, individual_id, poke_id in choices:
@@ -546,6 +605,7 @@ class ItemWindow(QWidget):
             # raise RuntimeError inside display_fossil_pokemon.
             if not is_alive(self.starter_window):
                 from ..singletons import get_starter_window
+
                 self.starter_window = get_starter_window()
             self.starter_window.display_fossil_pokemon(fossil_id, fossil_poke_name)
             # Read services.pokemon_pc directly rather than importing pokemon_pc from
@@ -554,22 +614,30 @@ class ItemWindow(QWidget):
                 services.pokemon_pc.refresh_pokemon_grid()
             return True
         except Exception as e:
-            show_warning_with_traceback(parent=self, exception=e, message=f"Error using fossil item '{item_name}'")
+            show_warning_with_traceback(
+                parent=self,
+                exception=e,
+                message=f"Error using fossil item '{item_name}'",
+            )
             return False
         finally:
             self._item_action_in_progress = False
 
     def modified_pokeball_chances(self, item_name: str, catch_chance: int):
         # Adjust catch chance based on Pokémon type and Poké Ball
-        if item_name == 'net-ball' and ('water' in self.enemy_pokemon.type or 'bug' in self.enemy_pokemon.type):
+        if item_name == "net-ball" and (
+            "water" in self.enemy_pokemon.type or "bug" in self.enemy_pokemon.type
+        ):
             catch_chance += 10  # Additional 10% for Water or Bug-type Pokémon
-            self.logger.log("game", f"{item_name} gets a bonus for Water/Bug-type Pokémon!")
+            self.logger.log(
+                "game", f"{item_name} gets a bonus for Water/Bug-type Pokémon!"
+            )
 
-        elif item_name == 'iron-ball' and 'steel' in self.enemy_pokemon.type:
+        elif item_name == "iron-ball" and "steel" in self.enemy_pokemon.type:
             catch_chance += 10  # Additional 10% for Steel-type Pokémon
             self.logger.log("game", f"{item_name} gets a bonus for Steel-type Pokémon!")
 
-        elif item_name == 'dive-ball' and 'water' in self.enemy_pokemon.type:
+        elif item_name == "dive-ball" and "water" in self.enemy_pokemon.type:
             catch_chance += 10  # Additional 10% for Water-type Pokémon
             self.logger.log("game", f"{item_name} gets a bonus for Water-type Pokémon!")
 
@@ -584,21 +652,29 @@ class ItemWindow(QWidget):
             # Simulate catching the Pokémon based on the catch chance
             if random.randint(1, 100) <= catch_chance:
                 # Pokémon caught successfully
-                self.logger.log_and_showinfo("info", f"{item_name} successfully caught the Pokémon!")
+                self.logger.log_and_showinfo(
+                    "info", f"{item_name} successfully caught the Pokémon!"
+                )
                 self.delete_item(item_name)  # Delete the Poké Ball after use
             else:
                 # Pokémon was not caught
-                self.logger.log_and_showinfo("info", f"{item_name} failed to catch the Pokémon.")
+                self.logger.log_and_showinfo(
+                    "info", f"{item_name} failed to catch the Pokémon."
+                )
                 self.delete_item(item_name)  # Still delete the Poké Ball after use
         else:
-            self.logger.log_and_showinfo("error", f"{item_name} is not a valid Poké Ball!")
+            self.logger.log_and_showinfo(
+                "error", f"{item_name} is not a valid Poké Ball!"
+            )
 
     def delete_item(self, item_name: str):
         # Update database directly for performance
         services.db.update_item_quantity(item_name, -1)
         self.renewWidgets()
 
-    def Check_Heal_Item(self, prevo_name: str, heal_points: int, item_name: str, achievements):
+    def Check_Heal_Item(
+        self, prevo_name: str, heal_points: int, item_name: str, achievements
+    ):
         check = check_for_badge(achievements, 20)
         if check is False:
             receive_badge(20, achievements)
@@ -609,38 +685,55 @@ class ItemWindow(QWidget):
             self.main_pokemon.hp = self.main_pokemon.max_hp
         self.delete_item(item_name)
         play_effect_sound(self.settings_obj, "HpHeal")
-        self.logger.log_and_showinfo("info", f"{prevo_name} was healed for {heal_points}")
+        self.logger.log_and_showinfo(
+            "info", f"{prevo_name} was healed for {heal_points}"
+        )
 
     def Check_Evo_Item(self, individual_id: str, prevo_id: str, item_name: str):
         try:
             item_id = return_id_for_item_name(item_name)
-            # Pass the main Pokémon's gender so gender-gated evolutions from
-            # pokemon_evolution.csv (Gallade = male Kirlia, Froslass = female
-            # Snorunt) can't fire on the wrong sex. A missing/unknown
-            # gender degrades to the historical no-check behavior.
-            gender = getattr(self.main_pokemon, "gender", None)
+            # Gate on the SELECTED Pokémon's gender, not the active battle one:
+            # the user can pick any Pokémon from their collection here, and
+            # gender-gated evolutions from pokemon_evolution.csv (Gallade =
+            # male Kirlia, Froslass = female Snorunt) would otherwise evaluate
+            # unrelated state. A missing/unknown gender degrades to the
+            # historical no-check behavior.
+            gender = None
+            try:
+                target_data = services.db.get_pokemon(individual_id)
+            except Exception:
+                target_data = None
+            if isinstance(target_data, dict):
+                gender = target_data.get("gender")
             evo_id = check_evolution_by_item(prevo_id, item_id, gender=gender)
             if evo_id:
                 # Perform your action when the item matches the Pokémon's evolution item
                 self.logger.log_and_showinfo("info", "Pokemon Evolution is fitting !")
                 if not is_alive(self.evo_window):
                     from ..singletons import get_evo_window
+
                     self.evo_window = get_evo_window()
-                self.evo_window.ask_pokemon_evo(individual_id, prevo_id, evo_id, item_name=item_name)
+                self.evo_window.ask_pokemon_evo(
+                    individual_id, prevo_id, evo_id, item_name=item_name
+                )
             else:
-                self.logger.log_and_showinfo("info", "This Pokemon does not need this item.")
+                self.logger.log_and_showinfo(
+                    "info", "This Pokemon does not need this item."
+                )
         except Exception as e:
             show_warning_with_traceback(parent=self, exception=e, message=f"{e}")
 
     def load_evolution_items(self):
         try:
             evolution_item_ids = set()
-            with open(poke_evo_path, mode='r', newline='', encoding='utf-8') as evo_file:
+            with open(
+                poke_evo_path, mode="r", newline="", encoding="utf-8"
+            ) as evo_file:
                 reader = csv.DictReader(evo_file)
                 for row in reader:
                     # Use-item evolutions (trigger 3) consume trigger_item_id.
-                    if row.get('evolution_trigger_id') == '3':
-                        item_id = row.get('trigger_item_id')
+                    if row.get("evolution_trigger_id") == "3":
+                        item_id = row.get("trigger_item_id")
                         if item_id:
                             evolution_item_ids.add(item_id)
                     # Trade-with-held-item evolutions (trigger 2) need held_item_id.
@@ -648,17 +741,19 @@ class ItemWindow(QWidget):
                     # (e.g. Metal Coat -> Steelix/Scizor, Deep Sea Tooth/Scale ->
                     # Huntail/Gorebyss, Dragon Scale -> Kingdra, King's Rock ->
                     # Politoed/Slowking).
-                    elif row.get('evolution_trigger_id') == '2':
-                        item_id = row.get('held_item_id')
+                    elif row.get("evolution_trigger_id") == "2":
+                        item_id = row.get("held_item_id")
                         if item_id:
                             evolution_item_ids.add(item_id)
 
-            with open(csv_file_items_cost, mode='r', newline='', encoding='utf-8') as items_file:
+            with open(
+                csv_file_items_cost, mode="r", newline="", encoding="utf-8"
+            ) as items_file:
                 reader = csv.DictReader(items_file)
                 for row in reader:
-                    if row['id'] in evolution_item_ids:
-                        self.evolution_items.add(row['identifier'])
-            
+                    if row["id"] in evolution_item_ids:
+                        self.evolution_items.add(row["identifier"])
+
         except Exception as e:
             self.logger.log_and_showinfo("error", f"Error loading evolution items: {e}")
 
@@ -671,14 +766,14 @@ class ItemWindow(QWidget):
             quantity = item.get("quantity", 1)
             # Pass cached metadata back to database
             db.save_item(
-                item_id, 
-                item_name, 
-                quantity, 
-                extra_data=item, 
+                item_id,
+                item_name,
+                quantity,
+                extra_data=item,
                 category_id=item.get("category_id"),
                 cost=item.get("cost"),
                 fling_power=item.get("fling_power"),
-                fling_effect_id=item.get("fling_effect_id")
+                fling_effect_id=item.get("fling_effect_id"),
             )
 
     def read_items_file(self):
@@ -695,7 +790,7 @@ class ItemWindow(QWidget):
                 # Prioritize SQL columns over JSON blob
                 cat_id = item.get("category_id")
                 item_type = "TM" if cat_id == 37 else None
-                
+
                 # Combine database columns into the UI dictionary (preserving extra_data for legacy)
                 item_dict = {
                     "id": item.get("id"),
@@ -705,15 +800,15 @@ class ItemWindow(QWidget):
                     "category_id": cat_id,
                     "cost": item.get("cost"),
                     "fling_power": item.get("fling_power"),
-                    "fling_effect_id": item.get("fling_effect_id")
+                    "fling_effect_id": item.get("fling_effect_id"),
                 }
-                
+
                 # Merge with any existing extra_data for backward compatibility
                 if item.get("extra_data"):
                     for k, v in item["extra_data"].items():
                         if k not in item_dict:
                             item_dict[k] = v
-                            
+
                 result.append(item_dict)
             return result
         except Exception as e:
@@ -737,11 +832,13 @@ class ItemWindow(QWidget):
                 quantity = 1
             if quantity < 1:
                 continue
-            normalized.append({
-                **raw,
-                "item": name.strip(),
-                "quantity": quantity,
-            })
+            normalized.append(
+                {
+                    **raw,
+                    "item": name.strip(),
+                    "quantity": quantity,
+                }
+            )
         return normalized
 
     def clear_layout(self, layout):

--- a/src/Ankimon/startup.py
+++ b/src/Ankimon/startup.py
@@ -28,6 +28,7 @@ from .utils import (
     count_items_and_rewrite,
 )
 from .functions.encounter_functions import generate_random_pokemon
+from .functions.pokedex_functions import warm_evolution_caches
 from .functions.badges_functions import get_achieved_badges
 from .functions.rate_addon_functions import rate_this_addon
 from .gui_entities import CheckFiles
@@ -112,7 +113,24 @@ def run_startup_background_checks(backup_manager=None):
     # 4. Sprite/asset folder checks (disk).
     database_complete = _check_assets_background()
 
-    # 5. First enemy + starter/rating preconditions (DB/CPU); the Qt side of
+    # 5. Warm the static evolution table (disk parse) HERE rather than letting
+    #    the first level-up pay for it. Every reader of pokemon_evolution.csv
+    #    — the gender gate, the friendship and level-up evolution lookups —
+    #    runs inside on_review_card, and reviews are gated on
+    #    services.startup_finished, which flips only once this function has
+    #    returned: warming here is what keeps the parse off the review path for
+    #    the whole session. Unconditional (unlike step 6 below) because the CSV
+    #    ships inside the add-on, so it is readable whether or not the player's
+    #    downloaded assets are complete. Guarded because a QueryOp failure has
+    #    no recovery — see on_startup_failed: it would leave startup_finished
+    #    False and silently drop every answered card. An unparsed CSV must
+    #    never cost the player the add-on.
+    try:
+        warm_evolution_caches()
+    except Exception as e:
+        logger.log("error", f"Error warming evolution caches: {e}")
+
+    # 6. First enemy + starter/rating preconditions (DB/CPU); the Qt side of
     #    each (stat application, starter window, rate dialog) runs in
     #    run_startup_ui_callbacks.
     enemy_info = None
@@ -129,7 +147,7 @@ def run_startup_background_checks(backup_manager=None):
         if len(badge_list) > 1 and ankimon_db.get_user_data("rate_this") is not True:
             needs_rating = True
 
-    # 6. Item-count consolidation (DB write; thread-safe layer).
+    # 7. Item-count consolidation (DB write; thread-safe layer).
     try:
         count_items_and_rewrite()
     except Exception as e:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -134,6 +134,10 @@ def restore_package_stubs():
     do_restore()
 
 
+# Sentinel for "this parent package had no such attribute before the block".
+_MISSING = object()
+
+
 @contextlib.contextmanager
 def isolated_modules(*prefixes, extra=()):
     """Clear the named module namespaces, then restore ``sys.modules`` EXACTLY.
@@ -153,9 +157,12 @@ def isolated_modules(*prefixes, extra=()):
 
     So: on entry every module whose top-level name is in ``prefixes`` (plus any
     exact name in ``extra``) is removed; on exit everything added under those
-    same names is removed and the original entries are put back. Untracked
-    namespaces are left alone. Exceptions still restore, so an import failure
-    inside the block cannot leak state either.
+    same names is removed and the original entries are put back, along with the
+    parent-package ATTRIBUTE for any tracked module whose parent outlives the
+    block (see the comment on ``saved_attrs`` — ``sys.modules`` alone leaves
+    ``Ankimon.pyobj.InfoLogger`` and ``sys.modules[...]`` disagreeing).
+    Untracked namespaces are left alone. Exceptions still restore, so an import
+    failure inside the block cannot leak state either.
 
     Args:
         *prefixes: Top-level package names to isolate (e.g. ``"PyQt6"``).
@@ -168,6 +175,37 @@ def isolated_modules(*prefixes, extra=()):
         return name.split(".")[0] in prefixes or name in tracked
 
     saved = {name: mod for name, mod in sys.modules.items() if _is_tracked(name)}
+
+    # ``sys.modules`` is not the whole story: importing ``a.b`` also binds ``b``
+    # as an attribute of package ``a``. Restoring only ``sys.modules`` therefore
+    # leaves the two identities disagreeing whenever a tracked module's parent
+    # SURVIVES the block — ``Ankimon.pyobj.InfoLogger`` the attribute would keep
+    # pointing at the module re-imported in here while
+    # ``sys.modules["Ankimon.pyobj.InfoLogger"]`` points at the original. Which
+    # one a later test sees depends on whether it writes ``from ..pyobj import
+    # InfoLogger`` (attribute) or ``import Ankimon.pyobj.InfoLogger``
+    # (sys.modules), and that is precisely the order-dependent breakage this
+    # helper exists to prevent.
+    #
+    # A tracked parent needs none of this: it is restored as a whole object and
+    # brings its own attributes back with it. Parents are re-resolved by name on
+    # the way out so a parent that was itself swapped mid-block (conftest's
+    # ``restore_package_stubs`` rebuilds the Ankimon stubs) is not written to
+    # through a stale reference.
+    saved_attrs = []
+    for name in set(saved) | tracked:
+        parent_name, _, attr = name.rpartition(".")
+        if not parent_name or _is_tracked(parent_name):
+            continue
+        parent = sys.modules.get(parent_name)
+        # A parent that isn't imported yet still gets an entry: importing the
+        # child in here imports the parent too and binds the attribute, and the
+        # parent — being untracked — then survives the block carrying a name
+        # bound to a module that is no longer in sys.modules. Recording
+        # _MISSING makes the exit path delete it.
+        previous = _MISSING if parent is None else getattr(parent, attr, _MISSING)
+        saved_attrs.append((parent_name, attr, previous))
+
     for name in saved:
         del sys.modules[name]
     try:
@@ -176,3 +214,16 @@ def isolated_modules(*prefixes, extra=()):
         for name in [n for n in list(sys.modules) if _is_tracked(n) and n not in saved]:
             del sys.modules[name]
         sys.modules.update(saved)
+        for parent_name, attr, previous in saved_attrs:
+            parent = sys.modules.get(parent_name)
+            if parent is None:
+                continue
+            if previous is _MISSING:
+                # The attribute did not exist before; an import in here created
+                # it. Leaving it behind is the same leak in reverse.
+                try:
+                    delattr(parent, attr)
+                except AttributeError:
+                    pass
+            else:
+                setattr(parent, attr, previous)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,7 @@ Stub the Ankimon package in sys.modules so that individual submodules can be
 imported without triggering Ankimon/__init__.py, which depends on Anki internals.
 """
 
+import contextlib
 import sys
 import types
 from pathlib import Path
@@ -131,3 +132,47 @@ def restore_package_stubs():
     do_restore()
     yield
     do_restore()
+
+
+@contextlib.contextmanager
+def isolated_modules(*prefixes, extra=()):
+    """Clear the named module namespaces, then restore ``sys.modules`` EXACTLY.
+
+    Several tests have to import a module against the *genuine* PyQt6 (and a
+    synthetic ``aqt``) even though earlier suite modules have replaced those
+    entries with ``MagicMock``s. Dropping the mocks is the easy half; putting
+    things back is the half that is easy to get wrong.
+
+    Restoring only the saved keys is not enough. A block that drops ``PyQt6.*``
+    so the real package can load leaves the freshly imported submodules behind,
+    so a later test that installs a mocked ``PyQt6`` parent ends up with that
+    mock and genuine children such as ``PyQt6.QtWebChannel`` hanging off it —
+    order-dependent, and dependent on which test ran first. Likewise a fixture
+    that installs synthetic ``aqt``/``aqt.qt``/``aqt.utils`` modules must take
+    them away again.
+
+    So: on entry every module whose top-level name is in ``prefixes`` (plus any
+    exact name in ``extra``) is removed; on exit everything added under those
+    same names is removed and the original entries are put back. Untracked
+    namespaces are left alone. Exceptions still restore, so an import failure
+    inside the block cannot leak state either.
+
+    Args:
+        *prefixes: Top-level package names to isolate (e.g. ``"PyQt6"``).
+        extra: Exact module names to isolate as well (e.g. a single submodule
+            that must be re-executed against the swapped-in dependencies).
+    """
+    tracked = set(extra)
+
+    def _is_tracked(name):
+        return name.split(".")[0] in prefixes or name in tracked
+
+    saved = {name: mod for name, mod in sys.modules.items() if _is_tracked(name)}
+    for name in saved:
+        del sys.modules[name]
+    try:
+        yield
+    finally:
+        for name in [n for n in list(sys.modules) if _is_tracked(n) and n not in saved]:
+            del sys.modules[name]
+        sys.modules.update(saved)

--- a/tests/test_async_startup_boot.py
+++ b/tests/test_async_startup_boot.py
@@ -259,6 +259,14 @@ def startup_env(monkeypatch, tmp_path):
     )
     monkeypatch.setitem(
         sys.modules,
+        "Ankimon.functions.pokedex_functions",
+        _stub_module(
+            "Ankimon.functions.pokedex_functions",
+            warm_evolution_caches=rec("warm_evolution_caches", 507),
+        ),
+    )
+    monkeypatch.setitem(
+        sys.modules,
         "Ankimon.functions.badges_functions",
         _stub_module(
             "Ankimon.functions.badges_functions",
@@ -377,6 +385,61 @@ def test_background_checks_do_no_ui_work_and_return_contract(startup_env):
     assert _called(env, "run_backup")
     assert _called(env, "generate_random_pokemon")
     assert _called(env, "count_items_and_rewrite")
+    assert _called(env, "warm_evolution_caches")
+
+
+def test_background_checks_warm_the_evolution_table(startup_env):
+    """``pokemon_evolution.csv`` must be parsed HERE, not by the first level-up.
+
+    Every consumer of the evolution rows (the gender gate, the friendship and
+    level-up lookups) runs inside ``on_review_card``, and the lazy loaders let
+    whichever caller arrives first pay the ~500-row parse — synchronous disk
+    I/O mid-review, which AGENTS.md forbids. Warming on the boot thread is what
+    makes that impossible for the session: reviews are gated on
+    ``services.startup_finished``, which flips only once this half has
+    returned, so no review can precede the warm.
+    """
+    env = startup_env
+    env.mod.run_startup_background_checks()
+
+    assert len(_called(env, "warm_evolution_caches")) == 1
+
+
+def test_evolution_table_is_warmed_even_when_assets_are_missing(startup_env):
+    """The evolution CSV ships inside the add-on, so it is warmable whether or
+    not the player's sprite folders are complete. Hanging the warm off
+    ``database_complete`` (as the first-enemy step is) would leave the table
+    cold for exactly the players whose next boot step is a download dialog."""
+    env = startup_env
+    env.folders_exist = False
+
+    results = env.mod.run_startup_background_checks()
+
+    assert results["database_complete"] is False
+    assert len(_called(env, "warm_evolution_caches")) == 1
+
+
+def test_a_failing_warm_cannot_fail_the_boot(startup_env, monkeypatch):
+    """The warm rides on a QueryOp with no recovery: a raise here skips
+    ``on_startup_complete`` entirely, so ``services.startup_finished`` stays
+    False and every answered card is silently dropped for the session. Failing
+    to pre-parse a CSV must never cost the player the whole add-on."""
+    env = startup_env
+
+    def boom():
+        raise OSError("data_files unreadable")
+
+    monkeypatch.setattr(env.mod, "warm_evolution_caches", boom)
+
+    results = env.mod.run_startup_background_checks()
+
+    # The boot completed and the rest of the background work still ran.
+    assert results["database_complete"] is True
+    assert _called(env, "count_items_and_rewrite")
+    assert any(
+        call[0] == "log" and call[1] == "error" and "data_files unreadable" in call[2]
+        for call in env.calls
+    )
 
 
 def test_background_checks_flag_starter_and_rating(startup_env):

--- a/tests/test_async_startup_boot.py
+++ b/tests/test_async_startup_boot.py
@@ -807,9 +807,7 @@ def boot_env(monkeypatch):
             "PyQt6.QtGui",
             QKeySequence=lambda *args: None,
             QShortcut=lambda *args, **kwargs: SimpleNamespace(
-                activated=SimpleNamespace(
-                    connect=rec("QShortcut.activated.connect")
-                ),
+                activated=SimpleNamespace(connect=rec("QShortcut.activated.connect")),
                 setEnabled=rec("QShortcut.setEnabled"),
             ),
         ),

--- a/tests/test_encounter_functions.py
+++ b/tests/test_encounter_functions.py
@@ -549,3 +549,131 @@ def test_tier_fallback_degrades_straight_to_normal(monkeypatch):
 
     assert queried == ["Mega", "Normal"]
     assert "Legendary" not in queried  # no sideways cascade into other rare tiers
+
+
+def _run_victory_with_stored_row(stored_individual_id, main_individual_id):
+    """Drive one no-level-up victory and report what the checkers were handed.
+
+    Returns the ``attacks=`` kwarg ``check_friendship_evolution_for_pokemon``
+    received. ``None`` means the seed was declined and the checker falls back to
+    its own ``get_pokemon(individual_id)`` lookup.
+    """
+    import types
+
+    names = (
+        "settings_obj",
+        "translator",
+        "services",
+        "ankimon_db",
+        "find_experience_for_level",
+        "limit_ev_yield",
+        "check_friendship_evolution_for_pokemon",
+        "check_evolution_for_pokemon",
+    )
+    orig = {n: getattr(ef, n) for n in names}
+    try:
+        main_data = {
+            "individual_id": stored_individual_id,
+            "name": "Pikachu",
+            "attacks": ["Tackle", "Charm"],
+            "ev": {"hp": 0, "atk": 0, "def": 0, "spa": 0, "spd": 0, "spe": 0},
+            "held_item": None,
+            "pokemon_defeated": 0,
+            "stats": {},
+            "level": 50,
+            "xp": 0,
+            "friendship": 300,
+        }
+        settings = mock.MagicMock()
+        settings.get = lambda k, d=None: {
+            "misc.remove_level_cap": False,
+            "gui.pop_up_dialog_message_on_defeat": False,
+        }.get(k, d)
+        ef.settings_obj = settings
+        ef.translator = mock.MagicMock()
+        ef.translator.translate = lambda *a, **k: "msg"
+        ef.services = mock.MagicMock()
+        ef.services.db.get_main_pokemon.return_value = main_data
+        ef.ankimon_db = mock.MagicMock()
+        # Never level up: this is the no-level-up victory the seed exists for.
+        ef.find_experience_for_level = lambda *a, **k: 10**9
+        ef.limit_ev_yield = lambda have, add: {
+            "hp": 0,
+            "attack": 0,
+            "defense": 0,
+            "special-attack": 0,
+            "special-defense": 0,
+            "speed": 0,
+        }
+        ef.check_friendship_evolution_for_pokemon = mock.MagicMock(return_value=None)
+        ef.check_evolution_for_pokemon = mock.MagicMock(return_value=None)
+
+        main = types.SimpleNamespace(
+            name="Pikachu",
+            growth_rate="medium",
+            level=50,
+            xp=0,
+            individual_id=main_individual_id,
+            id=25,
+            everstone=False,
+            friendship=300,
+            gender="F",
+            stats={},
+            ev={"hp": 0, "atk": 0, "def": 0, "spa": 0, "spd": 0, "spe": 0},
+            hp=100,
+            held_item=None,
+            pokemon_defeated=0,
+            tier="Normal",
+            is_favorite=False,
+            evolution_rejected=False,
+            invalidate_cp_cache=lambda: None,
+        )
+        enemy = types.SimpleNamespace(ev_yield={})
+
+        ef.save_main_pokemon_progress(
+            main, enemy, 5, {}, mock.MagicMock(), mock.MagicMock()
+        )
+
+        ef.check_friendship_evolution_for_pokemon.assert_called_once()
+        return ef.check_friendship_evolution_for_pokemon.call_args.kwargs.get("attacks")
+    finally:
+        for n, v in orig.items():
+            setattr(ef, n, v)
+
+
+def test_victory_seeds_the_moveset_when_the_stored_row_is_this_pokemon():
+    # The happy path the seed exists for: one fewer DB query per no-level-up
+    # victory, with the exact list the checker's own fallback would have read.
+    assert _run_victory_with_stored_row("iid", "iid") == ["Tackle", "Charm"]
+
+
+def test_victory_declines_the_seed_when_the_stored_row_is_another_pokemon():
+    """A mismatched is_main row must not feed its moveset to the checkers.
+
+    ``is_main`` has no uniqueness constraint and ``get_main_pokemon()``
+    ``fetchone()``s whatever it finds, so the stored row and the in-memory
+    ``main_pokemon`` can name different Pokemon — the level-up merge below the
+    seed guards itself against exactly that before touching the moveset. Seeding
+    past the same mismatch evaluates a ``levelMove`` / ``known_move_type`` gate
+    against ANOTHER Pokemon's moves (a Charm here would offer Sylveon to an Eevee
+    that knows no Fairy move). ``None`` restores the checker's own
+    ``get_pokemon(individual_id)`` lookup, which is keyed correctly.
+    """
+    assert _run_victory_with_stored_row("someone-else", "iid") is None
+
+
+def test_victory_declines_the_seed_when_the_stored_row_has_no_id():
+    # A row that cannot prove its identity is treated as a mismatch, not a match.
+    assert _run_victory_with_stored_row(None, "iid") is None
+
+
+def test_victory_declines_the_seed_when_neither_side_has_an_id():
+    # Two missing ids must not compare equal into a match: there is nothing to
+    # verify, which is precisely the case the check exists to refuse.
+    assert _run_victory_with_stored_row(None, None) is None
+
+
+def test_victory_seed_tolerates_int_vs_str_id_drift():
+    # individual_id is TEXT in the schema but callers have passed ints; the
+    # guard must not decline a genuine match over the type alone.
+    assert _run_victory_with_stored_row(7, "7") == ["Tackle", "Charm"]

--- a/tests/test_evolution_gender_gate.py
+++ b/tests/test_evolution_gender_gate.py
@@ -499,3 +499,107 @@ def test_pokedex_form_gender_reads_the_bundled_data():
     assert pf._pokedex_form_gender(1) is None  # Bulbasaur: no gender field
     for junk in (None, "x", 0, -1, 99999):
         assert pf._pokedex_form_gender(junk) is None
+
+
+# --------------------------------------------------------------------------- #
+# Cache invalidation: the memo built ON TOP of the evolution index.
+# --------------------------------------------------------------------------- #
+def test_clearing_the_pokedex_caches_also_clears_the_gender_memo():
+    """``clear_pokedex_caches`` must invalidate every layer, not just the data.
+
+    ``_evolution_row_gender_id_cached`` answers from ``_poke_evo_index`` (and,
+    for form ids >= 10000, from ``_pokedex_cache`` via ``search_pokedex_by_id``).
+    Clearing those two while leaving the memo warm keeps serving pre-clear
+    verdicts for the rest of the session, so the gate contradicts the very data
+    it is supposed to read. ``clear_pokedex_caches`` is the registered
+    profile-close hook, so "the rest of the session" spans a profile swap.
+    """
+    pf._evolution_row_gender_id_cached.cache_clear()
+    assert pf._evolution_row_gender_id(416, pf._LEVEL_EVO_TRIGGERS) == 1
+    assert pf._evolution_row_gender_id_cached.cache_info().currsize > 0
+
+    pf.clear_pokedex_caches()
+    assert pf._evolution_row_gender_id_cached.cache_info().currsize == 0
+
+    # Still correct once rebuilt from the reloaded data.
+    assert pf._evolution_row_gender_id(416, pf._LEVEL_EVO_TRIGGERS) == 1
+    assert pf._evolution_row_gender_id(475, pf._ITEM_EVO_TRIGGERS) == 2
+
+
+def test_a_reloaded_csv_changes_the_gender_verdict():
+    """The observable consequence of the memo surviving a clear.
+
+    Swap the parsed rows for ones that gate Vespiquen on MALE, clear, and the
+    gate must follow the new data. Before the fix the stale ``1`` came straight
+    back out of the memo and a female Combee stayed the only one that could
+    evolve, whatever the reloaded file said.
+    """
+    pf.clear_pokedex_caches()
+    assert pf._evolution_row_gender_id(416, pf._LEVEL_EVO_TRIGGERS) == 1
+
+    swapped = [
+        dict(row, gender_id="2") if row.get("evolved_species_id") == "416" else row
+        for row in pf._load_poke_evo_cache()
+    ]
+    try:
+        pf.clear_pokedex_caches()
+        pf._poke_evo_cache = swapped
+        assert pf._evolution_row_gender_id(416, pf._LEVEL_EVO_TRIGGERS) == 2
+    finally:
+        pf.clear_pokedex_caches()
+
+    assert pf._evolution_row_gender_id(416, pf._LEVEL_EVO_TRIGGERS) == 1
+
+
+# --------------------------------------------------------------------------- #
+# One gate, one implementation.
+# --------------------------------------------------------------------------- #
+def test_gender_allows_evolution_semantics():
+    # Unknown gender fails open; an ungated species is unrestricted; a gated one
+    # matches only its own id, and only within the calling trigger scope.
+    assert pf.gender_allows_evolution(416, None, pf._LEVEL_EVO_TRIGGERS) is True
+    assert pf.gender_allows_evolution(1, 2, pf._LEVEL_EVO_TRIGGERS) is True
+    assert pf.gender_allows_evolution(416, 1, pf._LEVEL_EVO_TRIGGERS) is True
+    assert pf.gender_allows_evolution(416, 2, pf._LEVEL_EVO_TRIGGERS) is False
+    # Vespiquen's gate lives on a level row, so the item scope must not see it.
+    assert pf.gender_allows_evolution(416, 2, pf._ITEM_EVO_TRIGGERS) is True
+
+
+def test_evolution_target_species_id_prefers_actual_id():
+    assert pf.evolution_target_species_id({"actual_id": 10004}) == 10004
+    assert pf.evolution_target_species_id({"species_id": 413}) == 413
+    assert pf.evolution_target_species_id({"actual_id": 0, "species_id": 413}) == 413
+    for junk in (None, {}, [], "nope", {"actual_id": "x"}):
+        assert pf.evolution_target_species_id(junk) == 0
+
+
+def test_evolution_gender_allows_wraps_the_raw_ankimon_gender_string():
+    gallade = pf._load_pokedex_cache()["gallade"]
+    assert pf.evolution_gender_allows(gallade, "M", pf._ITEM_EVO_TRIGGERS) is True
+    assert pf.evolution_gender_allows(gallade, "F", pf._ITEM_EVO_TRIGGERS) is False
+    for junk in (None, "Genderless", "", "x"):
+        assert pf.evolution_gender_allows(gallade, junk, pf._ITEM_EVO_TRIGGERS) is True
+
+
+def test_item_and_level_paths_route_through_the_shared_gate(monkeypatch):
+    """Both in-module gate sites must call the helper, not a private copy.
+
+    The gate was hand-copied into three places (both paths here and the web
+    bag's inline eligibility loop). Copies drift; a test that only checks the
+    verdicts agree today cannot see a copy that stops matching tomorrow. Force
+    the shared helper to refuse everything and require both call sites to go
+    quiet — a surviving copy keeps answering and fails this.
+    """
+    monkeypatch.setattr(pf, "evolution_gender_allows", lambda *a, **k: False)
+
+    # Item path: Dawn Stone on a male Kirlia is the canonical accept.
+    assert pf.check_evolution_by_item(281, _DAWN_STONE_ID, gender="M") is None
+
+    # Level path: a female Combee at 21 is the canonical accept.
+    evo_window = mock.MagicMock()
+    with mock.patch.object(pf.services, "db", mock.MagicMock()):
+        assert (
+            pf.check_evolution_for_pokemon("combee-1", 415, 21, evo_window, gender="F")
+            is None
+        )
+    evo_window.ask_pokemon_evo.assert_not_called()

--- a/tests/test_evolution_gender_gate.py
+++ b/tests/test_evolution_gender_gate.py
@@ -77,9 +77,7 @@ _DAWN_STONE_ID = 109
 @pytest.fixture(autouse=True)
 def _reset_env():
     sys.modules["Ankimon.singletons"] = _SINGLETONS_STUB
-    sys.modules["Ankimon.functions.pokedex_functions"] = (
-        _POKEDEX_FUNCTIONS_STUB
-    )
+    sys.modules["Ankimon.functions.pokedex_functions"] = _POKEDEX_FUNCTIONS_STUB
     yield
 
 
@@ -87,9 +85,7 @@ def _reset_env():
 # Gender-gated useItem evolutions (Kirlia 281 -> Gallade 475 / Froslass 478)
 # --------------------------------------------------------------------------- #
 def test_dawn_stone_on_male_kirlia_gives_gallade():
-    assert (
-        pf.check_evolution_by_item(281, _DAWN_STONE_ID, gender="Male") == 475
-    )
+    assert pf.check_evolution_by_item(281, _DAWN_STONE_ID, gender="Male") == 475
 
 
 def test_dawn_stone_on_female_snorunt_gives_froslass():
@@ -131,7 +127,9 @@ def test_non_gendered_items_unaffected_by_gender_argument():
     thunder_stone_id = 82
     without = pf.check_evolution_by_item(25, thunder_stone_id)
     for gender in ("M", "F", None):
-        assert pf.check_evolution_by_item(25, thunder_stone_id, gender=gender) == without
+        assert (
+            pf.check_evolution_by_item(25, thunder_stone_id, gender=gender) == without
+        )
 
 
 def test_csv_gender_id_normalization():
@@ -152,3 +150,93 @@ def test_rows_for_key_in_table_defined_exactly_once():
     source = inspect.getsource(pf)
     count = source.count("def rows_for_key_in_table(")
     assert count == 1
+
+
+# --------------------------------------------------------------------------- #
+# Gender-gated LEVEL evolutions (CSV gender_id on trigger-1 rows).
+#
+# pokedex.json lists only the female target for Combee/Salandit and both
+# Burmy targets with no gender data, so without the CSV gate a male Combee
+# could evolve into Vespiquen. The level path must honor the same
+# pokemon_evolution.csv gender gate as the item path.
+# --------------------------------------------------------------------------- #
+class _FakeEvoWindow:
+    def __init__(self):
+        self.calls = []
+
+    def ask_pokemon_evo(self, individual_id, pokemon_id, evo_id):
+        self.calls.append((individual_id, pokemon_id, evo_id))
+
+
+def test_female_combee_level_evolves_to_vespiquen():
+    win = _FakeEvoWindow()
+    assert pf.check_evolution_for_pokemon("ind-f", 415, 21, win, gender="F") == 416
+    assert win.calls == [("ind-f", 415, 416)]
+
+
+def test_male_combee_cannot_become_vespiquen():
+    win = _FakeEvoWindow()
+    assert pf.check_evolution_for_pokemon("ind-m", 415, 21, win, gender="M") is None
+    assert win.calls == []
+
+
+def test_male_burmy_becomes_mothim_not_wormadam():
+    win = _FakeEvoWindow()
+    assert pf.check_evolution_for_pokemon("ind-m", 412, 20, win, gender="M") == 414
+
+
+def test_burmy_gender_gate_blocks_cross_sex_targets():
+    assert (
+        pf.check_evolution_for_pokemon("ind-m", 412, 20, _FakeEvoWindow(), gender="M")
+        != 413
+    )
+    assert (
+        pf.check_evolution_for_pokemon("ind-f", 412, 20, _FakeEvoWindow(), gender="F")
+        != 414
+    )
+
+
+def test_salandit_gender_gate_on_level_path():
+    assert (
+        pf.check_evolution_for_pokemon(
+            "ind-f", 757, 33, _FakeEvoWindow(), gender="Female"
+        )
+        == 758
+    )
+    assert (
+        pf.check_evolution_for_pokemon(
+            "ind-m", 757, 33, _FakeEvoWindow(), gender="Male"
+        )
+        is None
+    )
+
+
+def test_unknown_gender_keeps_historical_level_behavior():
+    # None/unrecognised gender keeps the no-check behavior so callers (and any
+    # legacy saves) without gender data are unaffected.
+    result_none = pf.check_evolution_for_pokemon(
+        "ind-x", 415, 21, _FakeEvoWindow(), gender=None
+    )
+    assert result_none == 416
+
+
+def test_everstone_still_blocks_gated_level_evolutions():
+    win = _FakeEvoWindow()
+    assert (
+        pf.check_evolution_for_pokemon(
+            "ind-f", 415, 21, win, everstone=True, gender="F"
+        )
+        is None
+    )
+    assert win.calls == []
+
+
+def test_plain_level_evolvers_unaffected_by_gender_argument():
+    win = _FakeEvoWindow()
+    for gender in ("M", "F", None, "junk"):
+        assert (
+            pf.check_evolution_for_pokemon(
+                "ind-p", 4, 20, win, everstone=False, gender=gender
+            )
+            == 5
+        )

--- a/tests/test_evolution_gender_gate.py
+++ b/tests/test_evolution_gender_gate.py
@@ -240,3 +240,85 @@ def test_plain_level_evolvers_unaffected_by_gender_argument():
             )
             == 5
         )
+
+
+# --------------------------------------------------------------------------- #
+# The gender lookup sits on the review path (a level-up runs it per candidate)
+# and rows_for_key_in_table re-opens + re-parses the whole ~500-row CSV on every
+# call. Pin the lru_cache that keeps that off the hot path, and the trigger
+# scoping that keeps one evolution method's gate from leaking onto another.
+# --------------------------------------------------------------------------- #
+def test_evolution_row_gender_id_reads_the_csv_only_once_per_key():
+    # Repo rule: "No synchronous disk I/O in the review path — static data is
+    # parsed once at startup." Without the cache this was one full CSV parse per
+    # level-up per candidate (~0.5 ms each, measured 175x slower than cached).
+    pf._evolution_row_gender_id.cache_clear()
+    opens = []
+    real_open = pf.open if hasattr(pf, "open") else open
+
+    import builtins
+
+    def counting_open(file, *args, **kwargs):
+        if str(file).endswith("pokemon_evolution.csv"):
+            opens.append(str(file))
+        return real_open(file, *args, **kwargs)
+
+    original = builtins.open
+    builtins.open = counting_open
+    try:
+        first = pf._evolution_row_gender_id(416, pf._LEVEL_EVO_TRIGGERS)
+        for _ in range(24):
+            assert pf._evolution_row_gender_id(416, pf._LEVEL_EVO_TRIGGERS) == first
+    finally:
+        builtins.open = original
+
+    assert first == 1  # Vespiquen is female-only
+    assert len(opens) == 1, f"expected 1 CSV parse for 25 calls, got {len(opens)}"
+
+
+def test_evolution_row_gender_id_is_scoped_to_the_calling_trigger():
+    # Gallade/Froslass are gated on use-item rows (trigger 3); Vespiquen and the
+    # Burmy pair on level-up rows (trigger 1). Asking with the wrong trigger must
+    # find no gate rather than borrowing another method's.
+    assert pf._evolution_row_gender_id(475, pf._ITEM_EVO_TRIGGERS) == 2  # Gallade
+    assert pf._evolution_row_gender_id(475, pf._LEVEL_EVO_TRIGGERS) is None
+    assert pf._evolution_row_gender_id(478, pf._ITEM_EVO_TRIGGERS) == 1  # Froslass
+    assert pf._evolution_row_gender_id(478, pf._LEVEL_EVO_TRIGGERS) is None
+
+    assert pf._evolution_row_gender_id(416, pf._LEVEL_EVO_TRIGGERS) == 1  # Vespiquen
+    assert pf._evolution_row_gender_id(416, pf._ITEM_EVO_TRIGGERS) is None
+    assert pf._evolution_row_gender_id(413, pf._LEVEL_EVO_TRIGGERS) == 1  # Wormadam
+    assert pf._evolution_row_gender_id(414, pf._LEVEL_EVO_TRIGGERS) == 2  # Mothim
+    assert pf._evolution_row_gender_id(758, pf._LEVEL_EVO_TRIGGERS) == 1  # Salazzle
+
+    # No trigger scope keeps the historical "any row" behavior.
+    assert pf._evolution_row_gender_id(475) == 2
+    # An ungated species stays ungated under every scope.
+    assert pf._evolution_row_gender_id(2, pf._LEVEL_EVO_TRIGGERS) is None
+
+
+def test_evolution_row_gender_id_resolves_form_ids_and_survives_junk():
+    # Cloak forms (>= 10000) must resolve to their base species before the CSV
+    # lookup, per the repo tripwire; junk degrades to "no gate", never raises.
+    assert pf._evolution_row_gender_id(10004, pf._LEVEL_EVO_TRIGGERS) == 1
+    for junk in (99999, 0, -1, None, "x", object()):
+        assert pf._evolution_row_gender_id(junk, pf._LEVEL_EVO_TRIGGERS) is None
+
+
+def test_evolved_species_id_is_resolved_without_a_num_fallback():
+    # pokedex.json carries actual_id/species_id on every one of its entries and
+    # `num` on none of them, so the gate never needs a `num` fallback. Pin that
+    # so the dead branch can't creep back in.
+    pokedex = pf._load_pokedex_cache()
+    assert pokedex, "pokedex cache is empty"
+    assert not [k for k, v in pokedex.items() if v.get("num") is not None]
+    for species in (
+        "gallade",
+        "froslass",
+        "wormadam",
+        "mothim",
+        "vespiquen",
+        "salazzle",
+    ):
+        entry = pokedex[species]
+        assert entry.get("actual_id") or entry.get("species_id")

--- a/tests/test_evolution_gender_gate.py
+++ b/tests/test_evolution_gender_gate.py
@@ -333,3 +333,108 @@ def test_pokedex_entries_carry_an_id_the_gender_gate_can_resolve():
     ):
         entry = pokedex[species]
         assert entry.get("actual_id") or entry.get("species_id")
+
+
+# --------------------------------------------------------------------------- #
+# Gender SPLITS the CSV cannot express (pokedex.json `gender` on the forms).
+#
+# veekun models Espurr -> Meowstic/Meowstic-F and Lechonk -> Oinkologne/
+# Oinkologne-F as two FORMS of one species rather than as two gendered
+# evolutions, so pokemon_evolution.csv carries no gender_id row for evolved
+# species 678 or 916 and the CSV gate sees no split at all. The lowest-evo_id
+# tie-break then handed EVERY Espurr the male Meowstic and every Lechonk the
+# male Oinkologne — the same failure the CSV gate fixes for Burmy, and
+# irreversible once accepted. pokedex.json does carry the split.
+#
+# pick_random_gender falls through to random.choice(["M", "F"]) for both
+# species (neither has a genderRatio or a fixed gender), so ~half of all
+# captures hit it.
+# --------------------------------------------------------------------------- #
+def test_female_espurr_evolves_into_the_female_meowstic_form():
+    win = _FakeEvoWindow()
+    assert pf.check_evolution_for_pokemon("ind-f", 677, 25, win, gender="F") == 10025
+    assert win.calls == [("ind-f", 677, 10025)]
+
+
+def test_male_espurr_evolves_into_the_male_meowstic_form():
+    win = _FakeEvoWindow()
+    assert pf.check_evolution_for_pokemon("ind-m", 677, 25, win, gender="M") == 678
+
+
+def test_female_lechonk_evolves_into_the_female_oinkologne_form():
+    win = _FakeEvoWindow()
+    assert pf.check_evolution_for_pokemon("ind-f", 915, 18, win, gender="F") == 10254
+
+
+def test_male_lechonk_evolves_into_the_male_oinkologne_form():
+    win = _FakeEvoWindow()
+    assert pf.check_evolution_for_pokemon("ind-m", 915, 18, win, gender="M") == 916
+
+
+def test_split_forms_without_a_gender_keep_historical_behavior():
+    # No gender on the record -> no narrowing, lowest evo_id as before.
+    win = _FakeEvoWindow()
+    assert pf.check_evolution_for_pokemon("ind", 677, 25, win, gender=None) == 678
+
+
+def test_lone_gendered_target_never_blocks_an_evolution():
+    # Bounsweet (761) -> Steenee (762) is a SINGLE target that pokedex.json
+    # labels female-only. That is a species property, not an evolution gate:
+    # narrowing on it would strand any save whose stored gender disagrees with
+    # its own species. Both sexes must still evolve.
+    for gender in ("M", "F", None):
+        win = _FakeEvoWindow()
+        assert pf.check_evolution_for_pokemon("ind", 761, 20, win, gender=gender) == 762
+
+
+def test_same_gender_siblings_are_not_treated_as_a_split():
+    # Tyrogue (236) has three targets, all labelled male-only in pokedex.json.
+    # No disagreement -> no narrowing -> the pre-existing choice is preserved.
+    without = pf.check_evolution_for_pokemon("ind", 236, 25, _FakeEvoWindow())
+    for gender in ("M", "F"):
+        assert (
+            pf.check_evolution_for_pokemon(
+                "ind", 236, 25, _FakeEvoWindow(), gender=gender
+            )
+            == without
+        )
+
+
+def test_burmy_split_still_resolved_by_the_csv_gate():
+    # The CSV gate runs first and already resolves Burmy; the form filter must
+    # not disturb it.
+    assert (
+        pf.check_evolution_for_pokemon("i", 412, 20, _FakeEvoWindow(), gender="M")
+        == 414
+    )
+    assert (
+        pf.check_evolution_for_pokemon("i", 412, 20, _FakeEvoWindow(), gender="F")
+        == 413
+    )
+
+
+def test_filter_gender_split_forms_semantics():
+    # Espurr's pair disagrees -> narrows.
+    assert pf.filter_gender_split_forms([678, 10025], "F") == [10025]
+    assert pf.filter_gender_split_forms([678, 10025], "M") == [678]
+    # Unrecognised / missing gender -> untouched.
+    for junk in (None, "Genderless", "N", "", "x"):
+        assert pf.filter_gender_split_forms([678, 10025], junk) == [678, 10025]
+    # Fewer than two candidates -> untouched, whatever the label says.
+    assert pf.filter_gender_split_forms([762], "M") == [762]
+    # Siblings that agree -> untouched.
+    assert pf.filter_gender_split_forms([106, 107, 237], "F") == [106, 107, 237]
+    # Unlabelled siblings survive alongside the matching label.
+    assert pf.filter_gender_split_forms([678, 10025, 1], "M") == [678, 1]
+    # Never empties the list.
+    assert pf.filter_gender_split_forms([678, 10025], "F") != []
+
+
+def test_pokedex_form_gender_reads_the_bundled_data():
+    assert pf._pokedex_form_gender(678) == "M"  # Meowstic
+    assert pf._pokedex_form_gender(10025) == "F"  # Meowstic-F
+    assert pf._pokedex_form_gender(916) == "M"  # Oinkologne
+    assert pf._pokedex_form_gender(10254) == "F"  # Oinkologne-F
+    assert pf._pokedex_form_gender(1) is None  # Bulbasaur: no gender field
+    for junk in (None, "x", 0, -1, 99999):
+        assert pf._pokedex_form_gender(junk) is None

--- a/tests/test_evolution_gender_gate.py
+++ b/tests/test_evolution_gender_gate.py
@@ -1,0 +1,154 @@
+"""Tests for gender-gated item evolutions and CSV helper hygiene.
+
+Covers two same-class findings discovered while reviewing PRs #785/#744/#706
+(evolution requirements carried by the bundled data but ignored by the code):
+
+* ``check_evolution_by_item`` now honors the ``gender_id`` column of
+  ``pokemon_evolution.csv`` when the caller supplies a gender: Gallade (475)
+  requires a male Kirlia, Froslass (478) a female Snorunt/Kirlia. Without a
+  gender argument the historical no-check behavior is preserved.
+* ``rows_for_key_in_table`` was defined twice in pokedex_functions.py; the
+  second definition shadowed the first, so only one may exist.
+
+Loading strategy mirrors ``tests/test_move_evo_timing.py``: stub Anki/aqt,
+load ``resources`` + ``pokedex_functions`` FOR REAL so the bundled data drives
+every lookup.
+"""
+
+import importlib.util
+import sys
+import unittest.mock as mock
+from pathlib import Path
+
+import pytest
+
+_SRC = Path(__file__).parent.parent / "src"
+
+
+class _FakeSettings:
+    """Minimal stand-in for ``settings_obj`` backed by a mutable dict."""
+
+    def __init__(self):
+        self.values = {"misc.active_region": None}
+
+    def get(self, key, default=None):
+        return self.values.get(key, default)
+
+
+def _load_pf():
+    sys.modules["aqt"] = mock.MagicMock()
+    sys.modules["aqt.qt"] = mock.MagicMock()
+    sys.modules["aqt.utils"] = mock.MagicMock()
+    sys.modules["Ankimon.pyobj.error_handler"] = mock.MagicMock()
+
+    fake_settings = _FakeSettings()
+    singletons_stub = importlib.util.module_from_spec(
+        importlib.util.spec_from_loader("Ankimon.singletons", loader=None)
+    )
+    singletons_stub.settings_obj = fake_settings
+    sys.modules["Ankimon.singletons"] = singletons_stub
+
+    res_spec = importlib.util.spec_from_file_location(
+        "Ankimon.resources", _SRC / "Ankimon" / "resources.py"
+    )
+    resources = importlib.util.module_from_spec(res_spec)
+    sys.modules["Ankimon.resources"] = resources
+    res_spec.loader.exec_module(resources)
+
+    pf_spec = importlib.util.spec_from_file_location(
+        "Ankimon.functions.pokedex_functions",
+        _SRC / "Ankimon" / "functions" / "pokedex_functions.py",
+    )
+    pokedex_functions = importlib.util.module_from_spec(pf_spec)
+    sys.modules["Ankimon.functions.pokedex_functions"] = pokedex_functions
+    pf_spec.loader.exec_module(pokedex_functions)
+    return pokedex_functions
+
+
+pf = _load_pf()
+
+_SINGLETONS_STUB = sys.modules["Ankimon.singletons"]
+_POKEDEX_FUNCTIONS_STUB = sys.modules["Ankimon.functions.pokedex_functions"]
+
+# Dawn Stone item id from items.csv (Kirlia -> Gallade/Froslass).
+_DAWN_STONE_ID = 109
+
+
+@pytest.fixture(autouse=True)
+def _reset_env():
+    sys.modules["Ankimon.singletons"] = _SINGLETONS_STUB
+    sys.modules["Ankimon.functions.pokedex_functions"] = (
+        _POKEDEX_FUNCTIONS_STUB
+    )
+    yield
+
+
+# --------------------------------------------------------------------------- #
+# Gender-gated useItem evolutions (Kirlia 281 -> Gallade 475 / Froslass 478)
+# --------------------------------------------------------------------------- #
+def test_dawn_stone_on_male_kirlia_gives_gallade():
+    assert (
+        pf.check_evolution_by_item(281, _DAWN_STONE_ID, gender="Male") == 475
+    )
+
+
+def test_dawn_stone_on_female_snorunt_gives_froslass():
+    # Froslass (478) evolves only from a FEMALE Snorunt (361) with a Dawn
+    # Stone; the CSV gender gate must make this exact and not leak to males.
+    assert pf.check_evolution_by_item(361, _DAWN_STONE_ID, gender="F") == 478
+
+
+def test_dawn_stone_gender_mismatch_does_not_evolve_to_wrong_species():
+    # The core bug: without a gender gate either sex could become Gallade.
+    assert pf.check_evolution_by_item(281, _DAWN_STONE_ID, gender="F") != 475
+    assert pf.check_evolution_by_item(281, _DAWN_STONE_ID, gender="M") != 478
+
+
+def test_female_snorunt_with_dawn_stone_gives_froslass():
+    # Snorunt (361) has both Glalie (plain level) and Froslass (female +
+    # Dawn Stone); only the female form is item-reachable.
+    assert pf.check_evolution_by_item(361, _DAWN_STONE_ID, gender="Female") == 478
+
+
+def test_male_snorunt_with_dawn_stone_gets_no_female_locked_evo():
+    assert pf.check_evolution_by_item(361, _DAWN_STONE_ID, gender="M") is None
+
+
+def test_unknown_gender_preserves_historical_no_check_behavior():
+    # Callers without gender data keep working exactly as before.
+    result = pf.check_evolution_by_item(281, _DAWN_STONE_ID, gender=None)
+    assert result in (475, 478)
+
+
+def test_junk_gender_values_degrade_to_no_check():
+    for junk in ("Genderless", "", "x"):
+        result = pf.check_evolution_by_item(281, _DAWN_STONE_ID, gender=junk)
+        assert result in (475, 478)
+
+
+def test_non_gendered_items_unaffected_by_gender_argument():
+    # A Thunder Stone on Pikachu must behave identically with or without gender.
+    thunder_stone_id = 82
+    without = pf.check_evolution_by_item(25, thunder_stone_id)
+    for gender in ("M", "F", None):
+        assert pf.check_evolution_by_item(25, thunder_stone_id, gender=gender) == without
+
+
+def test_csv_gender_id_normalization():
+    assert pf._csv_gender_id("M") == 2
+    assert pf._csv_gender_id("male") == 2
+    assert pf._csv_gender_id("F") == 1
+    assert pf._csv_gender_id("Female") == 1
+    assert pf._csv_gender_id("Genderless") is None
+    assert pf._csv_gender_id(None) is None
+    assert pf._csv_gender_id(7) is None
+
+
+def test_rows_for_key_in_table_defined_exactly_once():
+    # The helper used to be defined twice (the second shadowing the first);
+    # pin the de-duplicated state.
+    import inspect
+
+    source = inspect.getsource(pf)
+    count = source.count("def rows_for_key_in_table(")
+    assert count == 1

--- a/tests/test_evolution_gender_gate.py
+++ b/tests/test_evolution_gender_gate.py
@@ -252,7 +252,7 @@ def test_evolution_row_gender_id_reads_the_csv_only_once_per_key():
     # Repo rule: "No synchronous disk I/O in the review path — static data is
     # parsed once at startup." Without the cache this was one full CSV parse per
     # level-up per candidate (~0.5 ms each, measured 175x slower than cached).
-    pf._evolution_row_gender_id.cache_clear()
+    pf._evolution_row_gender_id_cached.cache_clear()
     opens = []
     real_open = pf.open if hasattr(pf, "open") else open
 
@@ -298,17 +298,28 @@ def test_evolution_row_gender_id_is_scoped_to_the_calling_trigger():
 
 
 def test_evolution_row_gender_id_resolves_form_ids_and_survives_junk():
-    # Cloak forms (>= 10000) must resolve to their base species before the CSV
-    # lookup, per the repo tripwire; junk degrades to "no gate", never raises.
+    # Characterization pin, not a regression test: cloak forms (>= 10000) must
+    # resolve to their base species before the CSV lookup, per the repo tripwire,
+    # and junk must degrade to "no gate" rather than raising. Both held before
+    # the cache was added; this pins that CACHING DID NOT BREAK THEM — the
+    # unhashable cases below would die inside lru_cache's key lookup if the
+    # coercion were not in the uncached wrapper.
     assert pf._evolution_row_gender_id(10004, pf._LEVEL_EVO_TRIGGERS) == 1
     for junk in (99999, 0, -1, None, "x", object()):
         assert pf._evolution_row_gender_id(junk, pf._LEVEL_EVO_TRIGGERS) is None
+    for unhashable in ([1, 2], {"a": 1}, {1, 2}, bytearray(b"x")):
+        assert pf._evolution_row_gender_id(unhashable, pf._LEVEL_EVO_TRIGGERS) is None
+    # Numeric strings must not open a second cache entry for the same species.
+    assert pf._evolution_row_gender_id("416", pf._LEVEL_EVO_TRIGGERS) == 1
 
 
-def test_evolved_species_id_is_resolved_without_a_num_fallback():
-    # pokedex.json carries actual_id/species_id on every one of its entries and
-    # `num` on none of them, so the gate never needs a `num` fallback. Pin that
-    # so the dead branch can't creep back in.
+def test_pokedex_entries_carry_an_id_the_gender_gate_can_resolve():
+    # Data invariant, not a behavioural regression test: the removed
+    # `or target_data.get("num")` fallback was unreachable because pokedex.json
+    # carries actual_id/species_id on every entry and `num` on none. Removing it
+    # is behaviour-neutral BY CONSTRUCTION, so no test can observe the removal —
+    # what is worth pinning is the premise, which would silently stop holding if
+    # the bundled pokedex were regenerated in the Smogon `num` schema.
     pokedex = pf._load_pokedex_cache()
     assert pokedex, "pokedex cache is empty"
     assert not [k for k, v in pokedex.items() if v.get("num") is not None]

--- a/tests/test_evolution_gender_gate.py
+++ b/tests/test_evolution_gender_gate.py
@@ -243,37 +243,98 @@ def test_plain_level_evolvers_unaffected_by_gender_argument():
 
 
 # --------------------------------------------------------------------------- #
-# The gender lookup sits on the review path (a level-up runs it per candidate)
-# and rows_for_key_in_table re-opens + re-parses the whole ~500-row CSV on every
-# call. Pin the lru_cache that keeps that off the hot path, and the trigger
+# The gender lookup sits on the review path (a level-up runs it per candidate).
+# Repo rule: "No synchronous disk I/O in the review path — static data is parsed
+# once at startup." The rows now come from an in-memory index built once from
+# _load_poke_evo_cache, so eligibility checks must open NO file at all; the
+# lru_cache on top saves the scan rather than the parse. Also pin the trigger
 # scoping that keeps one evolution method's gate from leaking onto another.
 # --------------------------------------------------------------------------- #
-def test_evolution_row_gender_id_reads_the_csv_only_once_per_key():
-    # Repo rule: "No synchronous disk I/O in the review path — static data is
-    # parsed once at startup." Without the cache this was one full CSV parse per
-    # level-up per candidate (~0.5 ms each, measured 175x slower than cached).
-    pf._evolution_row_gender_id_cached.cache_clear()
-    opens = []
-    real_open = pf.open if hasattr(pf, "open") else open
-
+def _count_evolution_csv_opens(fn):
+    """Run ``fn`` and return how many times pokemon_evolution.csv was opened."""
     import builtins
+
+    opens = []
+    original = builtins.open
 
     def counting_open(file, *args, **kwargs):
         if str(file).endswith("pokemon_evolution.csv"):
             opens.append(str(file))
-        return real_open(file, *args, **kwargs)
+        return original(file, *args, **kwargs)
 
-    original = builtins.open
     builtins.open = counting_open
     try:
-        first = pf._evolution_row_gender_id(416, pf._LEVEL_EVO_TRIGGERS)
-        for _ in range(24):
-            assert pf._evolution_row_gender_id(416, pf._LEVEL_EVO_TRIGGERS) == first
+        result = fn()
     finally:
         builtins.open = original
+    return result, opens
+
+
+def test_evolution_row_gender_id_opens_no_file_once_initialised():
+    # This used to be "one parse per cache miss" — the lru_cache suppressed
+    # repeats of the same key but every NEW (species, trigger) pair still
+    # re-opened and re-parsed the whole ~500-row CSV mid-review. Measured across
+    # the dex that was 372 parses for 966 level-evolution checks.
+    pf._evolution_row_gender_id_cached.cache_clear()
+    pf._load_poke_evo_index()  # what startup does
+
+    def _probe():
+        first = pf._evolution_row_gender_id(416, pf._LEVEL_EVO_TRIGGERS)
+        # 24 repeats of the same key, then a spread of DISTINCT keys — the case
+        # the lru_cache alone could never cover.
+        for _ in range(24):
+            assert pf._evolution_row_gender_id(416, pf._LEVEL_EVO_TRIGGERS) == first
+        for species_id in (413, 414, 758, 475, 478, 1, 25, 133, 700, 10004):
+            for triggers in (pf._LEVEL_EVO_TRIGGERS, pf._ITEM_EVO_TRIGGERS):
+                pf._evolution_row_gender_id(species_id, triggers)
+        return first
+
+    first, opens = _count_evolution_csv_opens(_probe)
 
     assert first == 1  # Vespiquen is female-only
-    assert len(opens) == 1, f"expected 1 CSV parse for 25 calls, got {len(opens)}"
+    assert opens == [], f"eligibility checks re-parsed the CSV {len(opens)}x"
+
+
+def test_evolution_index_matches_the_csv_scan_for_every_species_and_key_type():
+    """The index must be a drop-in for rows_for_key_in_table on this column.
+
+    A silent str/int key mismatch would return () and quietly stop offering
+    evolutions with no error — the same shape of failure as the reverted
+    stale-moveset optimisation (9a54562f). The two caller families genuinely
+    pass different types: ``_evolution_row_gender_id_cached`` passes an int,
+    while ``get_friendship_evolutions_for_species`` passes the strings
+    ``pokemon_evolves_from_id`` returns. Sweep every id, both key types.
+    """
+    rows = pf._load_poke_evo_cache()
+    ids = {r["evolved_species_id"] for r in rows if r.get("evolved_species_id")}
+    assert len(ids) > 400, "sanity: the bundled CSV should carry ~479 species"
+
+    for raw in ids:
+        scanned = tuple(
+            pf.rows_for_key_in_table("evolved_species_id", raw, pf.poke_evo_path)
+        )
+        assert pf.evolution_rows_for_evolved_species(raw) == scanned
+        assert pf.evolution_rows_for_evolved_species(int(raw)) == scanned
+
+    # Sylveon carries two rows; both must survive (the first-match bug).
+    assert len(pf.evolution_rows_for_evolved_species(700)) == 2
+    # Misses and malformed keys stay empty, exactly as the scan does. "0700"
+    # matters: int-normalising the key would silently make it match Sylveon.
+    for miss in (0, -1, 99999, "0700", "", "junk", None):
+        assert pf.evolution_rows_for_evolved_species(miss) == ()
+
+
+def test_clearing_the_pokedex_caches_also_clears_the_evolution_index():
+    # The index holds references into the rows _load_poke_evo_cache built, so
+    # leaving it warm past a clear would keep the pre-clear rows alive. Parity
+    # with _pokedex_id_index, which is already in the clear list.
+    pf._load_poke_evo_index()
+    assert pf._poke_evo_index is not None
+    pf.clear_pokedex_caches()
+    assert pf._poke_evo_cache is None
+    assert pf._poke_evo_index is None
+    # And it rebuilds correctly afterwards.
+    assert len(pf.evolution_rows_for_evolved_species(700)) == 2
 
 
 def test_evolution_row_gender_id_is_scoped_to_the_calling_trigger():

--- a/tests/test_evolution_gender_gate.py
+++ b/tests/test_evolution_gender_gate.py
@@ -276,7 +276,7 @@ def test_evolution_row_gender_id_opens_no_file_once_initialised():
     # re-opened and re-parsed the whole ~500-row CSV mid-review. Measured across
     # the dex that was 372 parses for 966 level-evolution checks.
     pf._evolution_row_gender_id_cached.cache_clear()
-    pf._load_poke_evo_index()  # what startup does
+    pf.warm_evolution_caches()  # what startup does
 
     def _probe():
         first = pf._evolution_row_gender_id(416, pf._LEVEL_EVO_TRIGGERS)
@@ -335,6 +335,92 @@ def test_clearing_the_pokedex_caches_also_clears_the_evolution_index():
     assert pf._poke_evo_index is None
     # And it rebuilds correctly afterwards.
     assert len(pf.evolution_rows_for_evolved_species(700)) == 2
+
+
+def _fail_to_open_the_evolution_csv(fn):
+    """Run ``fn`` with every open of pokemon_evolution.csv raising."""
+    import builtins
+
+    original = builtins.open
+
+    def failing_open(file, *args, **kwargs):
+        if str(file).endswith("pokemon_evolution.csv"):
+            raise OSError("simulated read failure")
+        return original(file, *args, **kwargs)
+
+    builtins.open = failing_open
+    try:
+        return fn()
+    finally:
+        builtins.open = original
+
+
+def test_warming_the_evolution_caches_takes_the_parse_off_the_review_path():
+    """The index has to be built by STARTUP, not by the first level-up.
+
+    The lazy loaders are correct, but their first CALLER decides when the parse
+    happens — and every production caller of these rows (the gender gate here,
+    friendship_evolution's level and friendship lookups) runs inside
+    ``on_review_card``. Nothing outside the lookup itself ever built the index,
+    so the ~500-row parse landed mid-review the first time a Pokemon levelled
+    up: exactly the synchronous review-path I/O the docstrings on this path
+    already claimed was gone, and that AGENTS.md forbids.
+    """
+    pf.clear_pokedex_caches()
+    assert pf._poke_evo_index is None
+
+    indexed = pf.warm_evolution_caches()
+
+    assert indexed > 400, "the bundled CSV carries ~507 rows"
+    assert pf._poke_evo_cache is not None
+    assert pf._poke_evo_index is not None
+
+    # With the warm done, the review path's own lookups open nothing at all.
+    _, opens = _count_evolution_csv_opens(
+        lambda: [
+            pf._evolution_row_gender_id(species_id, pf._LEVEL_EVO_TRIGGERS)
+            for species_id in (416, 413, 758, 475, 478)
+        ]
+    )
+    assert opens == [], f"a warmed review path still parsed the CSV {len(opens)}x"
+
+
+def test_a_failed_warm_leaves_the_lazy_path_to_retry_instead_of_memoizing_empty():
+    """The warm is an optimization; it must not add a failure mode.
+
+    ``_load_poke_evo_cache`` swallows a read error and memoizes ``[]`` for the
+    session. Lazily that is survivable — the first read happens whenever the
+    game needs the data. Moving the first read to boot means a file that is
+    momentarily unavailable *then* (an add-on update mid-write, a cold network
+    drive) would freeze "this species has no evolution rows" in for the whole
+    session, silently disabling every gender gate and friendship lookup. So a
+    warm that comes back empty puts the globals back rather than keeping it.
+    """
+    pf.clear_pokedex_caches()
+
+    assert _fail_to_open_the_evolution_csv(pf.warm_evolution_caches) == 0
+    assert pf._poke_evo_cache is None
+    assert pf._poke_evo_index is None
+
+    # Nothing was memoized: the ordinary lazy path still reads real data.
+    assert len(pf.evolution_rows_for_evolved_species(700)) == 2
+
+
+def test_warming_twice_is_a_no_op_that_keeps_the_same_rows():
+    """Boot warms once per process and the profile-open hook warms again after
+    a profile switch cleared the caches, so back-to-back warms are normal. The
+    second must not re-parse or hand back different row objects — the index
+    holds references into the cached rows, and callers memoize verdicts from
+    them (``_evolution_row_gender_id_cached``)."""
+    pf.clear_pokedex_caches()
+    first_count = pf.warm_evolution_caches()
+    first_rows = pf.evolution_rows_for_evolved_species(700)
+
+    second_count, opens = _count_evolution_csv_opens(pf.warm_evolution_caches)
+
+    assert second_count == first_count
+    assert opens == []
+    assert pf.evolution_rows_for_evolved_species(700) is first_rows
 
 
 def test_evolution_row_gender_id_is_scoped_to_the_calling_trigger():

--- a/tests/test_evolution_item_gender_lookup.py
+++ b/tests/test_evolution_item_gender_lookup.py
@@ -1,0 +1,287 @@
+"""Regression: a failed Pokemon lookup must not disable the gender gate.
+
+``ItemWindow.Check_Evo_Item`` reads the SELECTED Pokemon's record so the
+``pokemon_evolution.csv`` gender gate can be applied to the right Pokemon
+(Gallade needs a male Kirlia, Froslass a female Snorunt). The trap is that
+``check_evolution_by_item`` treats ``gender=None`` as *unrestricted* — a
+deliberate fail-open for legacy saves whose records predate the column.
+
+So swallowing a lookup failure into ``gender = None`` silently reports "this
+Pokemon has no gender" when the truth is "I could not read this Pokemon". A
+busy database — a lock, a transient sqlite error — was therefore enough to
+hand a **female** Kirlia the male-only Gallade, which is precisely the class of
+bug this branch exists to close.
+
+The two states must stay distinguishable:
+
+* record read, no recognised gender -> fail open (legacy behavior preserved);
+* record NOT read (raised, or came back as a non-dict) -> refuse the item.
+
+Everything below the ``aqt`` line is the genuine module: the real
+``check_evolution_by_item``, the real ``pokemon_evolution.csv`` and the real
+``pokedex.json`` decide the verdicts, so a data or gate change is visible here
+rather than mocked away.
+"""
+
+import importlib
+import importlib.util
+import sys
+import types
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+from conftest import isolated_modules
+
+_SRC = Path(__file__).parent.parent / "src"
+
+# Kirlia + Dawn Stone is the canonical gender split: Gallade (475) is the only
+# Dawn Stone target Kirlia has, and it is male-only.
+_KIRLIA_ID = 281
+_GALLADE_ID = 475
+_DAWN_STONE = "dawn-stone"
+
+
+def _synthetic_aqt_finder():
+    """A meta-path finder that answers any ``aqt``/``aqt.*`` import.
+
+    Anki is absent from the documented dev env (AGENTS.md installs only
+    pytest/pytest-qt/PyQt6/markdown), but ``item_window`` reaches it through a
+    chain — ``evolution_window``, ``pc_box``, ``starter_window`` — that imports
+    a moving set of ``aqt`` submodules (``aqt.qt``, ``aqt.theme``, ...) and
+    pulls a moving set of Qt names out of them.
+
+    Enumerating that set is what rots: the previous generation of these tests
+    ``pytest.skip``-ped when a stub fell behind, and so never ran anywhere but a
+    developer box with Anki installed. A finder cannot fall behind. Real
+    ``aqt.qt`` re-exports PyQt6, so each attribute resolves against the genuine
+    PyQt6 modules first and only falls back to a MagicMock for the handful of
+    Anki-only names (``theme_manager`` and friends) that nothing here calls.
+    """
+    import PyQt6.QtCore
+    import PyQt6.QtGui
+    import PyQt6.QtWidgets
+
+    qt_modules = (PyQt6.QtWidgets, PyQt6.QtGui, PyQt6.QtCore)
+
+    def build(name):
+        module = types.ModuleType(name)
+        module.__path__ = []  # every aqt.* name must remain importable
+
+        def __getattr__(attr, _name=name):
+            for qt_module in qt_modules:
+                if hasattr(qt_module, attr):
+                    return getattr(qt_module, attr)
+            return mock.MagicMock(name=f"{_name}.{attr}")
+
+        module.__getattr__ = __getattr__
+        return module
+
+    class Loader:
+        def create_module(self, spec):
+            return build(spec.name)
+
+        def exec_module(self, module):
+            pass
+
+    class Finder:
+        def find_spec(self, fullname, path=None, target=None):
+            if fullname == "aqt" or fullname.startswith("aqt."):
+                return importlib.util.spec_from_loader(
+                    fullname, Loader(), is_package=True
+                )
+            return None
+
+    return Finder()
+
+
+@pytest.fixture(scope="module")
+def item_window():
+    """Import the real ``pyobj/item_window.py`` headlessly, once."""
+    with isolated_modules("PyQt6", "aqt", "Ankimon"):
+        for pkg in ("Ankimon", "Ankimon.functions", "Ankimon.pyobj"):
+            module = types.ModuleType(pkg)
+            module.__path__ = [str(_SRC / pkg.replace(".", "/"))]
+            module.__package__ = pkg
+            sys.modules[pkg] = module
+
+        finder = _synthetic_aqt_finder()
+        sys.meta_path.insert(0, finder)
+        try:
+            import aqt
+
+            aqt.mw = mock.MagicMock()
+            try:
+                module = importlib.import_module("Ankimon.pyobj.item_window")
+            except Exception as e:
+                # Deliberately NOT pytest.skip: a skip here reports green while
+                # every test in this file silently stops running. PyQt6 is a
+                # documented test dependency and aqt is supplied above, so an
+                # import failure means something real broke.
+                raise AssertionError(
+                    f"item_window is no longer importable headlessly: {e!r}"
+                ) from e
+            yield module
+        finally:
+            sys.meta_path.remove(finder)
+
+
+class _Logger:
+    """Records what the player would have been shown."""
+
+    def __init__(self):
+        self.messages = []
+
+    def log_and_showinfo(self, level, message):
+        self.messages.append((level, message))
+
+    def log(self, level, message):
+        self.messages.append((level, message))
+
+
+class _EvoWindow:
+    """Stands in for ``EvoWindow`` — ``objectName`` keeps ``is_alive`` true.
+
+    Answering ``is_alive`` for real matters: a dead window sends
+    ``Check_Evo_Item`` into ``singletons.get_evo_window()``, which would build a
+    genuine Qt window mid-test.
+    """
+
+    def __init__(self):
+        self.offers = []
+
+    def objectName(self):
+        return "evo_window"
+
+    def ask_pokemon_evo(self, individual_id, prevo_id, evo_id, item_name=None):
+        self.offers.append((individual_id, prevo_id, evo_id, item_name))
+
+
+class _Bag:
+    """The slice of ``ItemWindow`` that ``Check_Evo_Item`` actually reads.
+
+    Called unbound against this, so no QWidget is constructed for what is a
+    lookup plus a gate.
+    """
+
+    def __init__(self):
+        self.logger = _Logger()
+        self.evo_window = _EvoWindow()
+
+
+def _use_dawn_stone(item_window, get_pokemon, **kwargs):
+    """Run the item on a Kirlia; ``get_pokemon`` drives the database seam."""
+    bag = _Bag()
+    db = mock.MagicMock()
+    db.get_pokemon.side_effect = get_pokemon
+    with (
+        mock.patch.object(item_window, "services", mock.MagicMock(db=db)),
+        mock.patch.object(
+            item_window, "show_warning_with_traceback", mock.MagicMock()
+        ) as warned,
+    ):
+        item_window.ItemWindow.Check_Evo_Item(
+            bag, "kirlia-1", _KIRLIA_ID, _DAWN_STONE, **kwargs
+        )
+    # Nothing here should reach the crash dialog; if it does, the assertion the
+    # caller is about to make would be true for the wrong reason.
+    assert not warned.called, f"unexpected traceback dialog: {warned.call_args}"
+    return bag, db
+
+
+def _raises(_individual_id):
+    raise RuntimeError("database is locked")
+
+
+# --------------------------------------------------------------------------- #
+# The regression itself.
+# --------------------------------------------------------------------------- #
+def test_a_failed_lookup_does_not_offer_a_gender_gated_evolution(item_window):
+    """The bug: a raising ``get_pokemon`` used to read as "no gender".
+
+    With the gender unknown the gate falls open, so the Dawn Stone offered
+    Gallade to whatever Kirlia was selected — female ones included — and
+    accepting it persisted the wrong species.
+    """
+    bag, _ = _use_dawn_stone(item_window, _raises)
+
+    assert bag.evo_window.offers == []
+    level, message = bag.logger.messages[-1]
+    assert level == "error"
+    assert "database is locked" in message
+
+
+def test_a_missing_record_does_not_offer_a_gender_gated_evolution(item_window):
+    """``get_pokemon`` returning nothing is the same unknown, without an exception."""
+    for absent in (None, [], "", 0):
+        bag, _ = _use_dawn_stone(item_window, lambda _id, r=absent: r)
+
+        assert bag.evo_window.offers == [], absent
+        assert bag.logger.messages[-1][0] == "error", absent
+
+
+def test_a_record_without_a_gender_still_evolves(item_window):
+    """The fail-open the fix must NOT take away.
+
+    Saves that predate the gender column carry no ``gender`` key. Refusing them
+    would strip working evolutions from every legacy collection, so a record we
+    *did* read stays unrestricted.
+    """
+    bag, _ = _use_dawn_stone(item_window, lambda _id: {"name": "Kirlia"})
+
+    assert bag.evo_window.offers == [("kirlia-1", _KIRLIA_ID, _GALLADE_ID, _DAWN_STONE)]
+
+
+@pytest.mark.parametrize("junk", ["Genderless", "N", "", "x"])
+def test_an_unrecognised_gender_still_evolves(item_window, junk):
+    bag, _ = _use_dawn_stone(item_window, lambda _id, g=junk: {"gender": g})
+
+    assert bag.evo_window.offers[0][2] == _GALLADE_ID
+
+
+# --------------------------------------------------------------------------- #
+# ...while the gate the branch added keeps working.
+# --------------------------------------------------------------------------- #
+def test_a_male_kirlia_is_offered_gallade(item_window):
+    bag, _ = _use_dawn_stone(item_window, lambda _id: {"gender": "M"})
+
+    assert bag.evo_window.offers == [("kirlia-1", _KIRLIA_ID, _GALLADE_ID, _DAWN_STONE)]
+
+
+def test_a_female_kirlia_is_refused_gallade(item_window):
+    bag, _ = _use_dawn_stone(item_window, lambda _id: {"gender": "F"})
+
+    assert bag.evo_window.offers == []
+    # Refused by the gate, not by a failed read — the player is told the item
+    # does not apply rather than that something went wrong.
+    assert bag.logger.messages[-1] == (
+        "info",
+        "This Pokemon does not need this item.",
+    )
+
+
+# --------------------------------------------------------------------------- #
+# The caller-supplied record.
+# --------------------------------------------------------------------------- #
+def test_a_supplied_record_is_used_without_a_second_read(item_window):
+    """The web bag already holds the record; passing it must skip the re-read.
+
+    Two reads are not merely wasteful — the id and the gender would come from
+    different snapshots.
+    """
+    bag, db = _use_dawn_stone(
+        item_window, _raises, pokemon_data={"id": _KIRLIA_ID, "gender": "M"}
+    )
+
+    db.get_pokemon.assert_not_called()
+    assert bag.evo_window.offers[0][2] == _GALLADE_ID
+
+
+def test_a_supplied_record_is_gated_like_a_read_one(item_window):
+    bag, db = _use_dawn_stone(
+        item_window, _raises, pokemon_data={"id": _KIRLIA_ID, "gender": "F"}
+    )
+
+    db.get_pokemon.assert_not_called()
+    assert bag.evo_window.offers == []

--- a/tests/test_friendship_evolution.py
+++ b/tests/test_friendship_evolution.py
@@ -735,3 +735,165 @@ def test_check_friendship_evolution_auto_prompts_pawmo():
         assert evo_window.calls == [("some_id", 922, 923)]
     finally:
         services.db = None
+
+
+# --------------------------------------------------------------------------- #
+# Move-type-gated friendship evolutions (Sylveon's Fairy-move requirement).
+#
+# The bundled pokemon_evolution.csv carries known_move_type_id=18 ("fairy") on
+# both of Sylveon's rows; _select_evolution must honor that gate: Sylveon only
+# when the Pokémon knows a Fairy move (and then it outranks Espeon/Umbreon),
+# never on missing/unconfirmed movesets.
+# --------------------------------------------------------------------------- #
+def test_sylveon_row_carries_fairy_move_gate_from_csv():
+    by_id = {e.evo_id: e for e in fe.get_friendship_evolutions_for_species(133)}
+    assert by_id[700].known_move_type == "fairy"
+    assert by_id[196].known_move_type is None
+    assert by_id[197].known_move_type is None
+
+
+def test_sylveon_needs_fairy_move_day_stays_espeon():
+    # No Fairy move -> Sylveon is gated out; day still offers Espeon.
+    pokemon = {
+        "id": 133,
+        "friendship": 200,
+        "everstone": False,
+        "attacks": ["tackle", "growl", "tailwhip"],
+    }
+    result = fe.evolution_readiness(pokemon, now=datetime(2024, 1, 1, 9, 0))
+    assert result["evo_name"] == "Espeon"
+    assert result["ready"] is True
+
+
+def test_sylveon_with_fairy_move_wins_over_espeon():
+    # A Fairy move forces Sylveon in-game, so it outranks the time-gated rows.
+    pokemon = {
+        "id": 133,
+        "friendship": 200,
+        "everstone": False,
+        "attacks": ["moonblast", "tackle"],
+    }
+    result = fe.evolution_readiness(pokemon, now=datetime(2024, 1, 1, 9, 0))
+    assert result["evo_name"] == "Sylveon"
+    assert result["evo_id"] == 700
+    assert result["ready"] is True
+
+
+def test_sylveon_with_fairy_move_also_ready_at_night():
+    pokemon = {
+        "id": 133,
+        "friendship": 200,
+        "everstone": False,
+        "attacks": ["moonblast"],
+    }
+    result = fe.evolution_readiness(pokemon, now=datetime(2024, 1, 1, 23, 0))
+    assert result["evo_name"] == "Sylveon"
+    assert result["ready"] is True
+
+
+def test_no_fairy_move_night_stays_umbreon():
+    pokemon = {
+        "id": 133,
+        "friendship": 200,
+        "everstone": False,
+        "attacks": ["bite", "tackle"],
+    }
+    result = fe.evolution_readiness(pokemon, now=datetime(2024, 1, 1, 23, 0))
+    assert result["evo_name"] == "Umbreon"
+
+
+def test_missing_attacks_key_never_offers_sylveon():
+    # Unknown moveset (no "attacks" key at all) must fail closed: Sylveon is
+    # not offered even though its blank-time row would otherwise be eligible.
+    for now, expected in (
+        (datetime(2024, 1, 1, 9, 0), "Espeon"),
+        (datetime(2024, 1, 1, 23, 0), "Umbreon"),
+    ):
+        result = fe.evolution_readiness(
+            {"id": 133, "friendship": 200, "everstone": False}, now=now
+        )
+        assert result["evo_name"] == expected
+
+
+def test_auto_prompt_uses_stored_moveset_for_move_gates():
+    # The victory-time checker reads the stored attacks through the DB seam;
+    # with a Fairy move stored, Sylveon is prompted instead of Espeon.
+    from Ankimon.services import services
+
+    fake_db = mock.MagicMock()
+    fake_db.get_pokemon = mock.MagicMock(
+        return_value={"pokemon_defeated": 0, "attacks": ["Moonblast"]}
+    )
+    services.db = fake_db
+    try:
+        evo_window = _FakeEvoWindow()
+        res = fe.check_friendship_evolution_for_pokemon(
+            individual_id=7,
+            pokemon_id=133,
+            evo_window=evo_window,
+            everstone=False,
+            friendship=200,
+            now=datetime(2024, 1, 1, 9, 0),
+        )
+        assert res == 700
+        assert evo_window.calls == [(7, 133, 700)]
+    finally:
+        services.db = None
+
+
+def test_auto_prompt_without_fairy_move_prompts_time_gated_evo():
+    from Ankimon.services import services
+
+    fake_db = mock.MagicMock()
+    fake_db.get_pokemon = mock.MagicMock(
+        return_value={"pokemon_defeated": 0, "attacks": ["Tackle"]}
+    )
+    services.db = fake_db
+    try:
+        evo_window = _FakeEvoWindow()
+        res = fe.check_friendship_evolution_for_pokemon(
+            individual_id=7,
+            pokemon_id=133,
+            evo_window=evo_window,
+            everstone=False,
+            friendship=200,
+            now=datetime(2024, 1, 1, 9, 0),
+        )
+        assert res == 196
+        assert evo_window.calls == [(7, 133, 196)]
+    finally:
+        services.db = None
+
+
+def test_auto_prompt_caller_attacks_override_stored_moveset():
+    # A caller-supplied live moveset wins over the stale DB row.
+    from Ankimon.services import services
+
+    fake_db = mock.MagicMock()
+    fake_db.get_pokemon = mock.MagicMock(
+        return_value={"pokemon_defeated": 0, "attacks": ["Tackle"]}
+    )
+    services.db = fake_db
+    try:
+        evo_window = _FakeEvoWindow()
+        res = fe.check_friendship_evolution_for_pokemon(
+            individual_id=7,
+            pokemon_id=133,
+            evo_window=evo_window,
+            everstone=False,
+            friendship=200,
+            now=datetime(2024, 1, 1, 9, 0),
+            attacks=["Moonblast"],  # just learned this battle/level
+        )
+        assert res == 700
+        assert evo_window.calls == [(7, 133, 700)]
+    finally:
+        services.db = None
+
+
+def test_move_type_name_resolves_known_ids_and_degrades_on_junk():
+    assert fe._move_type_name(18) == "fairy"
+    assert fe._move_type_name("18") == "fairy"  # CSV cells arrive as strings
+    assert fe._move_type_name(None) is None
+    assert fe._move_type_name("junk") is None
+    assert fe._move_type_name(9999) is None

--- a/tests/test_friendship_evolution.py
+++ b/tests/test_friendship_evolution.py
@@ -1127,3 +1127,102 @@ def test_all_gated_fallback_becomes_ready_once_the_move_is_known(monkeypatch):
     assert result["ready"] is True
     assert result["required_move_type"] is None
     assert result["status_text"] == "Ready to evolve into Sylveon!"
+
+
+# --------------------------------------------------------------------------- #
+# CSV gender_id gates on the MANUAL level path (_level_readiness)
+#
+# check_evolution_for_pokemon gained the gate on the automatic level-up path,
+# but evolution_readiness feeds the PC box's "Evolve now" button, its ✨ badge
+# and the details-panel status line. Without the same gate there, the manual
+# path is a way around it: a male Combee could still be evolved into Vespiquen,
+# and a male Burmy was offered Wormadam (lowest evo_id) rather than Mothim.
+# Real bundled data throughout — Burmy 412 -> Wormadam 413 (F) / Mothim 414 (M),
+# Combee 415 -> Vespiquen 416 (F), Salandit 757 -> Salazzle 758 (F).
+# --------------------------------------------------------------------------- #
+_NOON = datetime(2024, 1, 1, 12, 0)
+
+
+def _lvl(species_id, level, gender=None):
+    pkmn = {"id": species_id, "level": level, "attacks": []}
+    if gender is not None:
+        pkmn["gender"] = gender
+    return pkmn
+
+
+def test_male_burmy_is_offered_mothim_not_wormadam():
+    result = fe.evolution_readiness(_lvl(412, 25, "M"), now=_NOON)
+    assert result["evo_id"] == 414
+    assert result["ready"] is True
+    assert result["status_text"] == "Ready to evolve into Mothim!"
+
+
+def test_female_burmy_is_offered_wormadam():
+    result = fe.evolution_readiness(_lvl(412, 25, "F"), now=_NOON)
+    assert result["evo_id"] == 413
+    assert result["ready"] is True
+
+
+def test_burmy_without_gender_keeps_historical_behavior():
+    # No gender on the record -> no gate (fail open, matching the item and
+    # automatic level paths), so the lowest-id target is still chosen.
+    result = fe.evolution_readiness(_lvl(412, 25), now=_NOON)
+    assert result["evo_id"] == 413
+    assert result["ready"] is True
+
+
+def test_male_combee_is_never_ready_for_vespiquen():
+    result = fe.evolution_readiness(_lvl(415, 25, "M"), now=_NOON)
+    assert result["evolvable"] is True
+    assert result["ready"] is False, "manual path bypassed the gender gate"
+    assert result["status_text"] == "Needs to be Female to evolve into Vespiquen"
+
+
+def test_female_combee_is_ready_for_vespiquen():
+    result = fe.evolution_readiness(_lvl(415, 25, "F"), now=_NOON)
+    assert result["evo_id"] == 416
+    assert result["ready"] is True
+
+
+def test_male_salandit_is_never_ready_for_salazzle():
+    result = fe.evolution_readiness(_lvl(757, 40, "M"), now=_NOON)
+    assert result["ready"] is False
+    assert result["status_text"] == "Needs to be Female to evolve into Salazzle"
+
+
+def test_gender_gate_outranks_the_level_line():
+    # Below the evolve level AND the wrong gender: the immutable requirement is
+    # the one worth showing, since no amount of levelling unblocks it.
+    result = fe.evolution_readiness(_lvl(415, 5, "M"), now=_NOON)
+    assert result["ready"] is False
+    assert result["status_text"] == "Needs to be Female to evolve into Vespiquen"
+
+
+def test_ungendered_species_unaffected_by_the_gate():
+    # A plain level evolution must behave identically for either gender.
+    baseline = fe.evolution_readiness(_lvl(1, 20), now=_NOON)
+    for gender in ("M", "F", "N", "Genderless", ""):
+        result = fe.evolution_readiness(_lvl(1, 20, gender), now=_NOON)
+        assert result["evo_id"] == baseline["evo_id"]
+        assert result["ready"] == baseline["ready"]
+        assert result["status_text"] == baseline["status_text"]
+
+
+def test_level_gender_gate_helper_fails_open_without_a_gender():
+    # Vespiquen (416) is female-gated in the CSV.
+    assert fe._level_gender_gate(416, None) is True
+    assert fe._level_gender_gate(416, 1) is True
+    assert fe._level_gender_gate(416, 2) is False
+    # Ivysaur (2) carries no gate at all.
+    assert fe._level_gender_gate(2, 2) is True
+
+
+def test_pokemon_gender_reads_dicts_and_objects():
+    assert fe._pokemon_gender({"gender": "F"}) == "F"
+    assert fe._pokemon_gender({}) is None
+    assert fe._pokemon_gender(None) is None
+
+    class _Obj:
+        gender = "M"
+
+    assert fe._pokemon_gender(_Obj()) == "M"

--- a/tests/test_friendship_evolution.py
+++ b/tests/test_friendship_evolution.py
@@ -992,3 +992,130 @@ def test_move_type_of_is_quiet_and_accurate():
         assert "tackle" not in types and types == frozenset()
     finally:
         services.ui = real_ui
+
+
+# --------------------------------------------------------------------------- #
+# Move-type gates must be VISIBLE, not just enforced.
+#
+# Filtering Sylveon out of the candidate list makes it correct but invisible: a
+# high-friendship Eevee just shows Espeon/Umbreon and nothing ever tells the
+# player the third branch exists or what it wants. evolution_readiness now
+# reports the gate alongside the choice.
+# --------------------------------------------------------------------------- #
+def _eevee(friendship, attacks):
+    return {
+        "id": 133,
+        "friendship": friendship,
+        "everstone": False,
+        "pokemon_defeated": 0,
+        "attacks": attacks,
+    }
+
+
+def test_readiness_reports_the_hidden_sylveon_gate():
+    result = fe.evolution_readiness(
+        _eevee(220, ["Tackle", "Swift"]), now=datetime(2024, 1, 1, 9, 0)
+    )
+    assert result["evo_name"] == "Espeon"
+    assert result["ready"] is True
+    # The chosen evolution has no unmet gate of its own...
+    assert result["required_move_type"] is None
+    # ...but the branch the moveset is hiding is named, with its requirement.
+    assert result["gated_alternatives"] == (("Sylveon", "fairy"),)
+    assert "Sylveon needs a Fairy-type move" in result["status_text"]
+
+
+def test_readiness_hint_also_shows_while_still_gaining_friendship():
+    result = fe.evolution_readiness(
+        _eevee(100, ["Tackle"]), now=datetime(2024, 1, 1, 9, 0)
+    )
+    assert result["ready"] is False
+    assert "60 friendship to evolve into Espeon" in result["status_text"]
+    assert "Sylveon needs a Fairy-type move" in result["status_text"]
+
+
+def test_readiness_hint_disappears_once_the_gate_is_met():
+    result = fe.evolution_readiness(
+        _eevee(220, ["Baby-Doll Eyes"]), now=datetime(2024, 1, 1, 9, 0)
+    )
+    assert result["evo_name"] == "Sylveon"
+    assert result["gated_alternatives"] == ()
+    assert result["required_move_type"] is None
+    assert result["status_text"] == "Ready to evolve into Sylveon!"
+
+
+def test_readiness_keys_exist_on_every_path():
+    # Consumers (PC box overlays, the details panel) read the dict positionally
+    # by key; every return path must carry the same shape.
+    for pokemon in (
+        _eevee(220, ["Tackle"]),  # friendship path
+        {"id": 1, "level": 20, "friendship": 0, "everstone": False},  # level path
+        {"id": 999999, "level": 5},  # not evolvable
+        {"id": None},  # missing id
+    ):
+        result = fe.evolution_readiness(pokemon, now=datetime(2024, 1, 1, 9, 0))
+        assert "required_move_type" in result
+        assert "gated_alternatives" in result
+
+
+# --------------------------------------------------------------------------- #
+# The all-rows-gated fallback in _select_evolution.
+#
+# No bundled species reaches it (Eevee, the only species with gated rows, also
+# has ungated ones), so these drive it directly. The property that matters is
+# fail-closed: the branch hands back a representative purely so the UI has
+# something to name, and that representative must never be reported as ready.
+# The first two tests pin its identity so selection stays predictable.
+# --------------------------------------------------------------------------- #
+def _gated(evo_id, name, move_type, time_of_day=None):
+    return fe.FriendshipEvolution(
+        evo_id=evo_id,
+        evo_name=name,
+        min_happiness=160,
+        time_of_day=time_of_day,
+        known_move_type=move_type,
+    )
+
+
+def test_all_gated_fallback_returns_the_lowest_id_representative():
+    evos = (_gated(700, "Sylveon", "fairy"), _gated(701, "Ghosteon", "ghost"))
+    chosen = fe._select_evolution(evos, "day", frozenset())
+    assert chosen.evo_name == "Sylveon"  # lowest evo_id; nothing here is reachable
+
+
+def test_satisfied_gate_still_wins_when_one_is_met():
+    evos = (_gated(700, "Sylveon", "fairy"), _gated(701, "Ghosteon", "ghost"))
+    chosen = fe._select_evolution(evos, "day", frozenset({"ghost"}))
+    assert chosen.evo_name == "Ghosteon"
+
+
+def test_all_gated_fallback_is_never_reported_ready(monkeypatch):
+    # Friendship and time both satisfied — only the move gate is unmet. Without
+    # folding move_ok into `ready` this path would fail OPEN and offer a
+    # gate-locked evolution.
+    monkeypatch.setattr(
+        fe,
+        "get_friendship_evolutions_for_species",
+        lambda species_id: (_gated(700, "Sylveon", "fairy"),),
+    )
+    result = fe.evolution_readiness(
+        _eevee(400, ["Tackle"]), now=datetime(2024, 1, 1, 9, 0)
+    )
+    assert result["evolvable"] is True
+    assert result["ready"] is False, "gate-locked evolution reported as ready"
+    assert result["required_move_type"] == "fairy"
+    assert result["status_text"] == ("Needs a Fairy-type move to evolve into Sylveon")
+
+
+def test_all_gated_fallback_becomes_ready_once_the_move_is_known(monkeypatch):
+    monkeypatch.setattr(
+        fe,
+        "get_friendship_evolutions_for_species",
+        lambda species_id: (_gated(700, "Sylveon", "fairy"),),
+    )
+    result = fe.evolution_readiness(
+        _eevee(400, ["Moonblast"]), now=datetime(2024, 1, 1, 9, 0)
+    )
+    assert result["ready"] is True
+    assert result["required_move_type"] is None
+    assert result["status_text"] == "Ready to evolve into Sylveon!"

--- a/tests/test_friendship_evolution.py
+++ b/tests/test_friendship_evolution.py
@@ -1013,6 +1013,10 @@ def _eevee(friendship, attacks):
 
 
 def test_readiness_reports_the_hidden_sylveon_gate():
+    # The structured keys are the contract; status_text is one rendering of them.
+    # (Note the details panel only draws status_text while ready is False — see
+    # test_readiness_hint_also_shows_while_still_gaining_friendship for the
+    # variant a user actually reads.)
     result = fe.evolution_readiness(
         _eevee(220, ["Tackle", "Swift"]), now=datetime(2024, 1, 1, 9, 0)
     )
@@ -1026,6 +1030,10 @@ def test_readiness_reports_the_hidden_sylveon_gate():
 
 
 def test_readiness_hint_also_shows_while_still_gaining_friendship():
+    # This is the branch the details panel actually renders (it draws
+    # status_text only when ready is False), and it covers the whole 0..159
+    # friendship climb — i.e. the entire window in which the player can still
+    # choose to teach a Fairy move.
     result = fe.evolution_readiness(
         _eevee(100, ["Tackle"]), now=datetime(2024, 1, 1, 9, 0)
     )

--- a/tests/test_friendship_evolution.py
+++ b/tests/test_friendship_evolution.py
@@ -1226,3 +1226,68 @@ def test_pokemon_gender_reads_dicts_and_objects():
         gender = "M"
 
     assert fe._pokemon_gender(_Obj()) == "M"
+
+
+# --------------------------------------------------------------------------- #
+# The settings seam may be unbound (early boot, profile swap in flight, a
+# partially-wired headless run). Every read in this module is a preference with
+# a default, and both entry points sit on paths that otherwise degrade rather
+# than raise — so `services.settings is None` must not turn into AttributeError.
+# `pokedex_functions.get_time_of_day` already makes this exact check; this
+# module did not.
+# --------------------------------------------------------------------------- #
+@pytest.fixture
+def no_settings():
+    from Ankimon.services import services
+
+    previous = services.settings
+    services.settings = None
+    yield
+    services.settings = previous
+
+
+def test_get_time_of_day_survives_an_unbound_settings_seam(no_settings):
+    # Defaults are day_start=6 / night_start=18.
+    assert fe.get_time_of_day(datetime(2024, 1, 1, 9, 0)) == "day"
+    assert fe.get_time_of_day(datetime(2024, 1, 1, 23, 0)) == "night"
+
+
+def test_evolution_readiness_survives_an_unbound_settings_seam(no_settings):
+    result = fe.evolution_readiness(
+        {"id": 133, "level": 20, "friendship": 200, "attacks": ["Tackle"]},
+        now=datetime(2024, 1, 1, 9, 0),
+    )
+    assert result["evolvable"] is True
+    assert result["evo_name"] == "Espeon"
+
+
+def test_current_time_label_survives_an_unbound_settings_seam(no_settings):
+    assert "Day" in fe.current_time_label(datetime(2024, 1, 1, 9, 0))
+
+
+def test_check_friendship_evolution_survives_an_unbound_settings_seam(no_settings):
+    # The toggle defaults to True, so the checker proceeds instead of raising.
+    class _Win:
+        def __init__(self):
+            self.calls = []
+
+        def ask_pokemon_evo(self, *args):
+            self.calls.append(args)
+
+    win = _Win()
+    result = fe.check_friendship_evolution_for_pokemon(
+        "iid",
+        133,
+        win,
+        friendship=200,
+        attacks=["Tackle"],
+        pokemon_defeated=0,
+        now=datetime(2024, 1, 1, 9, 0),
+    )
+    assert result == 196  # Espeon
+    assert win.calls == [("iid", 133, 196)]
+
+
+def test_settings_helper_falls_back_to_defaults(no_settings):
+    assert fe._settings().get("evolution.day_start_hour", 6) == 6
+    assert fe._settings().get("anything.at.all") is None

--- a/tests/test_friendship_evolution.py
+++ b/tests/test_friendship_evolution.py
@@ -614,11 +614,11 @@ def test_meowth_readiness_uses_level_route():
 def test_rows_for_key_in_table_returns_all_matching_rows():
     # The underlying helper must return *every* row for an evolved species, not
     # just the first (this is what fixes the Sylveon/Persian first-match bug).
-    # Use the real function/path captured by the module under test at load time
-    # (`fe.rows_for_key_in_table` / `fe.poke_evo_path`) rather than re-importing
-    # from the package, whose sys.modules entries other test modules replace with
+    # Use the real helper captured by the module under test at load time
+    # (`fe.evolution_rows_for_evolved_species`) rather than re-importing from
+    # the package, whose sys.modules entries other test modules replace with
     # mocks when the whole suite runs.
-    rows = fe.rows_for_key_in_table("evolved_species_id", 700, fe.poke_evo_path)
+    rows = fe.evolution_rows_for_evolved_species(700)
     assert len(rows) >= 2
     # Exactly one of Sylveon's rows carries the friendship requirement.
     happiness = [r.get("minimum_happiness") for r in rows]

--- a/tests/test_friendship_evolution.py
+++ b/tests/test_friendship_evolution.py
@@ -897,3 +897,98 @@ def test_move_type_name_resolves_known_ids_and_degrades_on_junk():
     assert fe._move_type_name(None) is None
     assert fe._move_type_name("junk") is None
     assert fe._move_type_name(9999) is None
+
+
+# --------------------------------------------------------------------------- #
+# Victory-path I/O discipline + quiet move-type resolution.
+#
+# Coding guideline: "No synchronous disk I/O in the review path." The
+# victory-time checker must therefore run entirely on caller-supplied state
+# (pokemon_defeated / attacks) — no services.db.get_pokemon call at all — and
+# its move-type lookups must never route through find_details_move, whose
+# unknown-move fallback returns "tackle" data and pops a warning dialog via
+# services.ui.warn (a modal showWarning under QtPresenter) mid-review.
+# --------------------------------------------------------------------------- #
+def test_auto_prompt_with_full_caller_state_never_touches_db():
+    from Ankimon.services import services
+
+    fake_db = mock.MagicMock()
+    fake_db.get_pokemon = mock.MagicMock(
+        side_effect=AssertionError("victory path performed a DB read")
+    )
+    services.db = fake_db
+    try:
+        evo_window = _FakeEvoWindow()
+        res = fe.check_friendship_evolution_for_pokemon(
+            individual_id="some_id",
+            pokemon_id=922,
+            evo_window=evo_window,
+            everstone=False,
+            friendship=50,
+            evolution_rejected=False,
+            attacks=["Tackle"],
+            pokemon_defeated=100,  # Pawmot milestone reached this battle
+        )
+        assert res == 923
+        assert evo_window.calls == [("some_id", 922, 923)]
+        fake_db.get_pokemon.assert_not_called()
+    finally:
+        services.db = None
+
+
+def test_auto_prompt_no_level_up_victory_does_not_raise():
+    # Regression for the unbound-`attacks` crash class: a friendship-ready
+    # Pokémon winning a battle that grants NO level-up reaches the checker with
+    # attacks=None; it must fall back to the stored moveset instead of raising
+    # UnboundLocalError (which used to abort the final save).
+    from Ankimon.services import services
+
+    fake_db = mock.MagicMock()
+    fake_db.get_pokemon = mock.MagicMock(
+        return_value={"pokemon_defeated": 0, "attacks": ["Moonblast"]}
+    )
+    services.db = fake_db
+    try:
+        evo_window = _FakeEvoWindow()
+        res = fe.check_friendship_evolution_for_pokemon(
+            individual_id=7,
+            pokemon_id=133,
+            evo_window=evo_window,
+            everstone=False,
+            friendship=200,
+            now=datetime(2024, 1, 1, 9, 0),
+            # attacks omitted entirely: zero level-ups => caller has no fresh list
+        )
+        assert res == 700
+        assert evo_window.calls == [(7, 133, 700)]
+    finally:
+        services.db = None
+
+
+def test_move_type_of_is_quiet_and_accurate():
+    # Known move resolves to its real type from the moves.json cache...
+    assert fe._move_type_of("Moonblast") == "fairy"
+    assert fe._move_type_of("moonblast") == "fairy"
+    assert fe._move_type_of("Leaf Blade") == "grass"
+
+    # ...unknown/junk names resolve to None WITHOUT touching services.ui
+    # (no tackle fallback, no warning popup)...
+    class _BoomUI:
+        def warn(self, message):
+            raise AssertionError(f"ui.warn called with {message!r}")
+
+    from Ankimon.services import services
+
+    real_ui = services.ui
+    services.ui = _BoomUI()
+    try:
+        assert fe._move_type_of("Not A Real Move") is None
+        assert fe._move_type_of("") is None
+        assert fe._move_type_of(None) is None
+        assert fe._move_type_of(12345) is None
+        # ...and an unknown move contributes NO type evidence, so Sylveon's
+        # gate stays unmet instead of being satisfied by phantom "tackle".
+        types = fe._known_move_types({"attacks": ["Not A Real Move"]})
+        assert "tackle" not in types and types == frozenset()
+    finally:
+        services.ui = real_ui

--- a/tests/test_friendship_evolution.py
+++ b/tests/test_friendship_evolution.py
@@ -1291,3 +1291,70 @@ def test_check_friendship_evolution_survives_an_unbound_settings_seam(no_setting
 def test_settings_helper_falls_back_to_defaults(no_settings):
     assert fe._settings().get("evolution.day_start_hour", 6) == 6
     assert fe._settings().get("anything.at.all") is None
+
+
+# --------------------------------------------------------------------------- #
+# The same gender split, on the MANUAL readiness path. The two paths must agree:
+# a female Espurr the automatic level-up offers Meowstic-F must not be offered
+# the male Meowstic by the PC box's "Evolve now" button.
+# --------------------------------------------------------------------------- #
+def test_female_espurr_readiness_offers_the_female_meowstic_form():
+    result = fe.evolution_readiness(_lvl(677, 30, "F"), now=_NOON)
+    assert result["evo_id"] == 10025
+    assert result["ready"] is True
+    assert result["status_text"] == "Ready to evolve into Meowstic-F!"
+
+
+def test_male_espurr_readiness_offers_the_male_meowstic_form():
+    assert fe.evolution_readiness(_lvl(677, 30, "M"), now=_NOON)["evo_id"] == 678
+
+
+def test_female_lechonk_readiness_offers_the_female_oinkologne_form():
+    assert fe.evolution_readiness(_lvl(915, 25, "F"), now=_NOON)["evo_id"] == 10254
+
+
+def test_male_lechonk_readiness_offers_the_male_oinkologne_form():
+    assert fe.evolution_readiness(_lvl(915, 25, "M"), now=_NOON)["evo_id"] == 916
+
+
+def test_split_forms_without_a_gender_keep_the_lowest_id():
+    assert fe.evolution_readiness(_lvl(677, 30), now=_NOON)["evo_id"] == 678
+
+
+def test_lone_gendered_target_stays_ready_for_either_gender():
+    # Bounsweet -> Steenee: a single female-labelled target is a species
+    # property, not a gate. Narrowing on it would strand a save whose stored
+    # gender disagrees with its own species.
+    for gender in ("M", "F", None):
+        result = fe.evolution_readiness(_lvl(761, 25, gender), now=_NOON)
+        assert result["evo_id"] == 762
+        assert result["ready"] is True, gender
+
+
+def test_form_split_never_flips_gender_ok_or_the_status_line():
+    # The form filter narrows the choice; it must not feed `ready`/`required_
+    # gender`, which stay driven by the CSV gate alone.
+    for species_id, level in ((677, 30), (915, 25)):
+        for gender in ("M", "F"):
+            result = fe.evolution_readiness(_lvl(species_id, level, gender), now=_NOON)
+            assert result["ready"] is True
+            assert "Needs to be" not in result["status_text"]
+
+
+def test_manual_and_automatic_paths_agree_on_the_split():
+    """The regression this whole gate exists to prevent: two paths, one answer."""
+    from Ankimon.functions import pokedex_functions as _pf
+
+    class _Win:
+        def ask_pokemon_evo(self, *args):
+            pass
+
+    for species_id, level in ((677, 25), (915, 18), (412, 20)):
+        for gender in ("M", "F"):
+            manual = fe.evolution_readiness(_lvl(species_id, level, gender), now=_NOON)[
+                "evo_id"
+            ]
+            auto = _pf.check_evolution_for_pokemon(
+                "iid", species_id, level, _Win(), gender=gender, current_attacks=[]
+            )
+            assert manual == auto, (species_id, gender, manual, auto)

--- a/tests/test_friendship_evolution.py
+++ b/tests/test_friendship_evolution.py
@@ -1358,3 +1358,50 @@ def test_manual_and_automatic_paths_agree_on_the_split():
                 "iid", species_id, level, _Win(), gender=gender, current_attacks=[]
             )
             assert manual == auto, (species_id, gender, manual, auto)
+
+
+def test_unlabelled_gender_gate_never_reads_as_ready(monkeypatch):
+    """``status_text`` must follow ``gender_ok``, not the label lookup.
+
+    ``_GENDER_LABELS`` only knows the veekun ids 1 and 2. Nothing in the bundled
+    CSV carries anything else, but the file is regenerated from upstream, and a
+    gender_id the labels don't cover used to leave ``ready`` False while the
+    branch below cheerfully rendered "Ready to evolve into ..." — a status line
+    contradicting the disabled button beside it. Simulate that by making both the
+    gate and the label lookup answer from an unlabelled id.
+    """
+    from Ankimon.functions import pokedex_functions as _pf
+
+    monkeypatch.setattr(_pf, "_evolution_row_gender_id", lambda *a, **k: 3)
+    monkeypatch.setattr(fe, "_evolution_row_gender_id", lambda *a, **k: 3)
+
+    result = fe.evolution_readiness(_lvl(1, 20, "M"), now=_NOON)
+
+    assert result["ready"] is False
+    assert "Ready to evolve" not in result["status_text"]
+    assert "gender requirement" in result["status_text"]
+    assert "Ivysaur" in result["status_text"]
+
+
+def test_labelled_gender_gate_still_names_the_gender(monkeypatch):
+    # The unlabelled fallback must not swallow the informative line.
+    result = fe.evolution_readiness(_lvl(415, 21, "M"), now=_NOON)
+    assert result["ready"] is False
+    assert result["status_text"] == "Needs to be Female to evolve into Vespiquen"
+
+
+def test_level_gender_gate_delegates_to_the_shared_helper(monkeypatch):
+    """One gate, one implementation — the PC path must not keep a private copy.
+
+    ``check_evolution_for_pokemon`` (automatic) and ``_level_readiness`` (the
+    PC's manual "Evolve now") have to answer identically or the button becomes a
+    way around the gate. Force the shared helper to refuse and require the manual
+    path to follow; a re-inlined copy would keep saying yes.
+    """
+    from Ankimon.functions import pokedex_functions as _pf
+
+    monkeypatch.setattr(_pf, "gender_allows_evolution", lambda *a, **k: False)
+    monkeypatch.setattr(fe, "gender_allows_evolution", lambda *a, **k: False)
+
+    assert fe._level_gender_gate(416, 1) is False
+    assert fe.evolution_readiness(_lvl(1, 20, "M"), now=_NOON)["ready"] is False

--- a/tests/test_headless_harness.py
+++ b/tests/test_headless_harness.py
@@ -263,3 +263,98 @@ if __name__ == "__main__":
     test_battle_loop_survives_dead_windows()
     test_victory_path_move_gate_sees_moves_learned_at_level_up()
     print("headless harness tests: OK")
+
+
+def test_victory_path_seeds_the_moveset_from_the_stored_record():
+    """The victory-time gate should not need its own DB read on a healthy save.
+
+    `save_main_pokemon_progress` already loads the main Pokemon's record at the
+    top. Seeding `attacks` from it means the friendship checker never falls back
+    to `services.db.get_pokemon()` mid-review — the repo rule is no synchronous
+    I/O on the review path.
+
+    Safe where the reverted 9a54562f change was not: the seed is the stored
+    RECORD (the same captured_pokemon row the fallback would re-read), not the
+    in-memory PokemonObject, whose moveset goes stale on the first level-up.
+    `test_victory_path_move_gate_sees_moves_learned_at_level_up` above is what
+    pins that distinction; this test pins that the read is actually gone.
+    """
+    result = _subrun(
+        "from harness.driver import Driver\n"
+        "import random\n"
+        "random.seed(0)\n"
+        "d = Driver(seed={'main': {'species': 'Eevee', 'level': 14, 'gender': 'M',\n"
+        "                          'friendship': 300,\n"
+        "                          'attacks': ['Tackle', 'Growl']}},\n"
+        "           settings_overrides={'battle.cards_per_round': 1},\n"
+        "           evolution_policy='ignore')\n"
+        "import Ankimon.functions.encounter_functions as ef\n"
+        "import Ankimon.functions.friendship_evolution as fe\n"
+        "passed_none = []\n"
+        "_real = fe.check_friendship_evolution_for_pokemon\n"
+        "def spy(*a, **kw):\n"
+        "    passed_none.append(kw.get('attacks') is None)\n"
+        "    return _real(*a, **kw)\n"
+        "ef.check_friendship_evolution_for_pokemon = spy\n"
+        "for _ in range(400):\n"
+        "    d.answer('good')\n"
+        "    if d.services.enemy_pokemon.hp <= 0:\n"
+        "        d.defeat()\n"
+        "print(%r + json.dumps({\n"
+        "    'checks': len(passed_none),\n"
+        "    'fell_back_to_db': sum(passed_none),\n"
+        "}))" % _MARKER
+    )
+    assert result["checks"] > 0, "no victory-time friendship checks ran"
+    assert result["fell_back_to_db"] == 0, (
+        f"{result['fell_back_to_db']} of {result['checks']} victory checks still "
+        "sent the checker to the DB for a moveset the caller already had"
+    )
+
+
+def test_victory_path_still_consults_the_store_when_there_is_no_main_record():
+    """With no is_main row there is nothing to seed from — keep the lookup.
+
+    The obvious one-liner (`(main_pokemon_data or {}).get("attacks") or []`)
+    passes an EMPTY LIST here instead of None. `check_evolution_for_pokemon`
+    treats a non-None `current_attacks` as authoritative and skips its own
+    `db.get_pokemon()` fallback entirely, so a `levelMove` evolution that is
+    currently still offered on such a save would be silently suppressed. That
+    call site sits outside the `if main_pokemon_data:` guard, so it really is
+    reachable. `None` is the only value that reaches the fallback.
+    """
+    result = _subrun(
+        "from harness.driver import Driver\n"
+        "import random\n"
+        "random.seed(0)\n"
+        "d = Driver(seed={'main': {'species': 'Eevee', 'level': 14, 'gender': 'M',\n"
+        "                          'friendship': 300,\n"
+        "                          'attacks': ['Tackle', 'Growl']}},\n"
+        "           settings_overrides={'battle.cards_per_round': 1},\n"
+        "           evolution_policy='ignore')\n"
+        "import Ankimon.functions.encounter_functions as ef\n"
+        "seen = []\n"
+        "_real = ef.check_evolution_for_pokemon\n"
+        "def spy(*a, **kw):\n"
+        "    seen.append(kw.get('current_attacks'))\n"
+        "    return _real(*a, **kw)\n"
+        "ef.check_evolution_for_pokemon = spy\n"
+        # Break the save the way a missing is_main row would.
+        "ef.services.db.execute('UPDATE captured_pokemon SET is_main = 0')\n"
+        "ef.services.db._get_connection().commit()\n"
+        "for _ in range(400):\n"
+        "    d.answer('good')\n"
+        "    if d.services.enemy_pokemon.hp <= 0:\n"
+        "        d.defeat()\n"
+        "print(%r + json.dumps({\n"
+        "    'level_checks': len(seen),\n"
+        "    'none_passed': sum(1 for v in seen if v is None),\n"
+        "    'empty_list_passed': sum(1 for v in seen if v == []),\n"
+        "}))" % _MARKER
+    )
+    assert result["level_checks"] > 0, "no level-up evolution checks ran"
+    assert result["empty_list_passed"] == 0, (
+        "an empty list was passed where the store should have been consulted — "
+        "this fails the levelMove gate closed instead of letting it look"
+    )
+    assert result["none_passed"] == result["level_checks"]

--- a/tests/test_headless_harness.py
+++ b/tests/test_headless_harness.py
@@ -161,71 +161,98 @@ def test_battle_loop_survives_dead_windows():
     )
 
 
-def test_victory_path_friendship_check_does_no_db_reads():
-    """The friendship/defeat-milestone checker must run on real in-memory state.
+def test_victory_path_move_gate_sees_moves_learned_at_level_up():
+    """The victory-time move-type gate must evaluate the CURRENT moveset.
 
-    Repo rule: no synchronous disk I/O in the review path. Every defeat calls
-    check_friendship_evolution_for_pokemon, and it falls back to a
-    services.db.get_pokemon() read for whichever of `attacks` /
-    `pokemon_defeated` the caller leaves as None. Most defeats grant no
-    level-up, so the encounter path's fresh-moveset holder is still None there —
-    it must fall back to the in-memory PokemonObject moveset, not to the DB.
+    Regression for a tempting but wrong optimization. The friendship checker
+    falls back to a services.db.get_pokemon() read for whichever of `attacks` /
+    `pokemon_defeated` the caller leaves as None, and most defeats grant no
+    level-up, so `attacks` is None on the common path. Replacing that read with
+    the in-memory `main_pokemon.attacks` looks free but is not: the level-up
+    merge writes the learned move to the DB dict only, so the PokemonObject's
+    moveset goes stale on the first level-up and never re-syncs (verified: still
+    ['tackle','growl'] 1200 answers after the DB reached
+    ['tackle','growl','babydolleyes','swift']).
 
-    Drives real defeats with a spy around the checker that (a) records the
-    kwargs it was called with and (b) counts get_pokemon calls made INSIDE it.
+    Concretely: an Eevee that learns Baby-Doll Eyes at Lv15 must be offered
+    Sylveon (700) on a later defeat, not Espeon/Umbreon. Reading the stale
+    in-memory list breaks exactly that, and flip-flops, because the rarer
+    level-up defeats still pass a fresh list.
     """
     result = _subrun(
         "from harness.driver import Driver\n"
-        # Deterministic RNG: enemy faints are stochastic, and a run with zero
-        # defeats would vacuously pass.
         "import random\n"
         "random.seed(0)\n"
-        "d = Driver(seed={'main': {'species': 'Eevee', 'level': 30, 'gender': 'M',\n"
-        "                          'friendship': 100,\n"
-        "                          'attacks': ['Tackle', 'Swift', 'Bite', 'Baby-Doll Eyes']}},\n"
+        # Starts below Lv15 knowing no Fairy move, with room in the moveset for
+        # Baby-Doll Eyes, and enough friendship that Sylveon is offerable as
+        # soon as the gate is met.
+        "d = Driver(seed={'main': {'species': 'Eevee', 'level': 14, 'gender': 'M',\n"
+        "                          'friendship': 300,\n"
+        "                          'attacks': ['Tackle', 'Growl']}},\n"
         "           settings_overrides={'battle.cards_per_round': 1},\n"
         "           evolution_policy='ignore')\n"
         "import Ankimon.functions.encounter_functions as ef\n"
         "import Ankimon.functions.friendship_evolution as fe\n"
-        "from Ankimon.services import services\n"
-        "calls = []\n"
+        "s = d.services\n"
+        "offers = []\n"
         "_real = fe.check_friendship_evolution_for_pokemon\n"
+        # The moveset the gate actually evaluates: what the caller passed, or —
+        # when it passes None — the stored one the checker falls back to.
         "def spy(*a, **kw):\n"
-        "    real_get = services.db.get_pokemon\n"
-        "    n = [0]\n"
-        "    def counting(iid):\n"
-        "        n[0] += 1\n"
-        "        return real_get(iid)\n"
-        "    services.db.get_pokemon = counting\n"
-        "    try:\n"
-        "        r = _real(*a, **kw)\n"
-        "    finally:\n"
-        "        services.db.get_pokemon = real_get\n"
-        "    calls.append({'attacks_none': kw.get('attacks') is None,\n"
-        "                  'defeated_none': kw.get('pokemon_defeated') is None,\n"
-        "                  'db_reads': n[0]})\n"
+        "    stored = (s.db.get_main_pokemon() or {}).get('attacks') or []\n"
+        "    passed = kw.get('attacks')\n"
+        "    effective = stored if passed is None else passed\n"
+        "    norm = lambda ms: [str(m).lower().replace(' ', '').replace('-', '')\n"
+        "                       for m in (ms or [])]\n"
+        "    r = _real(*a, **kw)\n"
+        "    offers.append({'evo': r,\n"
+        "                   'learned': 'babydolleyes' in norm(stored),\n"
+        "                   'gate_saw_it': 'babydolleyes' in norm(effective)})\n"
         "    return r\n"
         "ef.check_friendship_evolution_for_pokemon = spy\n"
-        "for _ in range(400):\n"
+        "for _ in range(700):\n"
         "    d.answer('good')\n"
-        "    if d.services.enemy_pokemon.hp <= 0:\n"
+        "    if s.enemy_pokemon.hp <= 0:\n"
         "        d.defeat()\n"
+        "after = [o for o in offers if o['learned']]\n"
         "print(%r + json.dumps({\n"
-        "    'checks': len(calls),\n"
-        "    'attacks_none': sum(1 for c in calls if c['attacks_none']),\n"
-        "    'defeated_none': sum(1 for c in calls if c['defeated_none']),\n"
-        "    'db_reads': sum(c['db_reads'] for c in calls),\n"
+        "    'checks': len(offers),\n"
+        "    'after_learning': len(after),\n"
+        "    'gate_blind_to_learned_move': sum(1 for o in after if not o['gate_saw_it']),\n"
+        "    'sylveon': sum(1 for o in after if o['evo'] == 700),\n"
+        "    'wrong_eeveelution': sorted({o['evo'] for o in after\n"
+        "                                 if o['evo'] not in (None, 700)}),\n"
+        "    'db_attacks': (d.services.db.get_main_pokemon() or {}).get('attacks'),\n"
+        "    'obj_attacks': list(s.main_pokemon.attacks),\n"
         "}))" % _MARKER
     )
     assert result["checks"] > 0, "no defeats occurred; the check never ran"
-    assert result["attacks_none"] == 0, (
-        "%d/%d victory-path checks arrived with attacks=None and fell back to the DB"
-        % (result["attacks_none"], result["checks"])
+    assert "babydolleyes" in (result["db_attacks"] or []), (
+        "Eevee never learned Baby-Doll Eyes; the scenario did not exercise the gate"
     )
-    assert result["defeated_none"] == 0
-    assert result["db_reads"] == 0, (
-        "victory-path friendship check performed %d synchronous DB reads"
-        % result["db_reads"]
+    assert result["after_learning"] > 0, (
+        "no victory check ran after the move was learned"
+    )
+    # The invariant: once the move is in the save, every victory-time check must
+    # evaluate a moveset that contains it.
+    assert result["gate_blind_to_learned_move"] == 0, (
+        "%d/%d victory checks evaluated a moveset missing the learned Fairy move "
+        "(db=%s, in-memory=%s)"
+        % (
+            result["gate_blind_to_learned_move"],
+            result["after_learning"],
+            result["db_attacks"],
+            result["obj_attacks"],
+        )
+    )
+    assert not result["wrong_eeveelution"], (
+        "move gate evaluated a stale moveset: offered %s instead of Sylveon after "
+        "the Fairy move was learned (db=%s, in-memory=%s)"
+        % (result["wrong_eeveelution"], result["db_attacks"], result["obj_attacks"])
+    )
+    assert result["sylveon"] > 0, (
+        "Sylveon was never offered after the Fairy move was learned (db=%s)"
+        % (result["db_attacks"],)
     )
 
 
@@ -234,5 +261,5 @@ if __name__ == "__main__":
     test_state_snapshot_and_single_answer()
     test_auto_battle_mode_cycles()
     test_battle_loop_survives_dead_windows()
-    test_victory_path_friendship_check_does_no_db_reads()
+    test_victory_path_move_gate_sees_moves_learned_at_level_up()
     print("headless harness tests: OK")

--- a/tests/test_headless_harness.py
+++ b/tests/test_headless_harness.py
@@ -51,15 +51,19 @@ def _subrun(snippet):
     break the real Ankimon boot (the same reason check.py shells out per probe),
     and we block Qt so the child runs the genuine Tier-1 (no-Anki/no-Qt) path."""
     code = _BLOCK_QT + "import json\nsys.path.insert(0, %r)\n%s" % (str(_repo), snippet)
-    proc = subprocess.run([sys.executable, "-c", code], capture_output=True, text=True, timeout=300)
+    proc = subprocess.run(
+        [sys.executable, "-c", code], capture_output=True, text=True, timeout=300
+    )
     assert proc.returncode == 0, (
         "harness subprocess failed (rc=%d):\n--- stdout ---\n%s\n--- stderr ---\n%s"
         % (proc.returncode, proc.stdout, proc.stderr)
     )
     for line in reversed(proc.stdout.splitlines()):
         if line.startswith(_MARKER):
-            return json.loads(line[len(_MARKER):])
-    raise AssertionError("no %s in harness output:\n%s\n%s" % (_MARKER, proc.stdout, proc.stderr))
+            return json.loads(line[len(_MARKER) :])
+    raise AssertionError(
+        "no %s in harness output:\n%s\n%s" % (_MARKER, proc.stdout, proc.stderr)
+    )
 
 
 def test_play_session_runs_without_errors():
@@ -157,9 +161,78 @@ def test_battle_loop_survives_dead_windows():
     )
 
 
+def test_victory_path_friendship_check_does_no_db_reads():
+    """The friendship/defeat-milestone checker must run on real in-memory state.
+
+    Repo rule: no synchronous disk I/O in the review path. Every defeat calls
+    check_friendship_evolution_for_pokemon, and it falls back to a
+    services.db.get_pokemon() read for whichever of `attacks` /
+    `pokemon_defeated` the caller leaves as None. Most defeats grant no
+    level-up, so the encounter path's fresh-moveset holder is still None there —
+    it must fall back to the in-memory PokemonObject moveset, not to the DB.
+
+    Drives real defeats with a spy around the checker that (a) records the
+    kwargs it was called with and (b) counts get_pokemon calls made INSIDE it.
+    """
+    result = _subrun(
+        "from harness.driver import Driver\n"
+        # Deterministic RNG: enemy faints are stochastic, and a run with zero
+        # defeats would vacuously pass.
+        "import random\n"
+        "random.seed(0)\n"
+        "d = Driver(seed={'main': {'species': 'Eevee', 'level': 30, 'gender': 'M',\n"
+        "                          'friendship': 100,\n"
+        "                          'attacks': ['Tackle', 'Swift', 'Bite', 'Baby-Doll Eyes']}},\n"
+        "           settings_overrides={'battle.cards_per_round': 1},\n"
+        "           evolution_policy='ignore')\n"
+        "import Ankimon.functions.encounter_functions as ef\n"
+        "import Ankimon.functions.friendship_evolution as fe\n"
+        "from Ankimon.services import services\n"
+        "calls = []\n"
+        "_real = fe.check_friendship_evolution_for_pokemon\n"
+        "def spy(*a, **kw):\n"
+        "    real_get = services.db.get_pokemon\n"
+        "    n = [0]\n"
+        "    def counting(iid):\n"
+        "        n[0] += 1\n"
+        "        return real_get(iid)\n"
+        "    services.db.get_pokemon = counting\n"
+        "    try:\n"
+        "        r = _real(*a, **kw)\n"
+        "    finally:\n"
+        "        services.db.get_pokemon = real_get\n"
+        "    calls.append({'attacks_none': kw.get('attacks') is None,\n"
+        "                  'defeated_none': kw.get('pokemon_defeated') is None,\n"
+        "                  'db_reads': n[0]})\n"
+        "    return r\n"
+        "ef.check_friendship_evolution_for_pokemon = spy\n"
+        "for _ in range(400):\n"
+        "    d.answer('good')\n"
+        "    if d.services.enemy_pokemon.hp <= 0:\n"
+        "        d.defeat()\n"
+        "print(%r + json.dumps({\n"
+        "    'checks': len(calls),\n"
+        "    'attacks_none': sum(1 for c in calls if c['attacks_none']),\n"
+        "    'defeated_none': sum(1 for c in calls if c['defeated_none']),\n"
+        "    'db_reads': sum(c['db_reads'] for c in calls),\n"
+        "}))" % _MARKER
+    )
+    assert result["checks"] > 0, "no defeats occurred; the check never ran"
+    assert result["attacks_none"] == 0, (
+        "%d/%d victory-path checks arrived with attacks=None and fell back to the DB"
+        % (result["attacks_none"], result["checks"])
+    )
+    assert result["defeated_none"] == 0
+    assert result["db_reads"] == 0, (
+        "victory-path friendship check performed %d synchronous DB reads"
+        % result["db_reads"]
+    )
+
+
 if __name__ == "__main__":
     test_play_session_runs_without_errors()
     test_state_snapshot_and_single_answer()
     test_auto_battle_mode_cycles()
     test_battle_loop_survives_dead_windows()
+    test_victory_path_friendship_check_does_no_db_reads()
     print("headless harness tests: OK")

--- a/tests/test_headless_qt_guards.py
+++ b/tests/test_headless_qt_guards.py
@@ -40,9 +40,15 @@ def logger_env(tmp_path):
     try:
         widgets = importlib.import_module("PyQt6.QtWidgets")
         module = importlib.import_module("Ankimon.pyobj.InfoLogger")
-    except Exception as e:  # pragma: no cover - environment guard
+    except Exception as e:
         sys.modules.update(saved)
-        pytest.skip(f"headless Qt guard env not importable: {e}")
+        # Deliberately NOT pytest.skip — see tests/test_web_bag_trade_evolutions
+        # .py's fixture docstring. PyQt6 is a documented test dependency, so an
+        # import failure here is drift to fix, not an environment to tolerate.
+        raise AssertionError(
+            "InfoLogger / PyQt6.QtWidgets no longer importable for this guard "
+            f"test — fix the fixture rather than skipping. Original error: {e!r}"
+        ) from e
 
     logger = module.ShowInfoLogger(
         name=f"test-{tmp_path.name}", log_filename=str(tmp_path / "app.log")
@@ -123,3 +129,97 @@ def test_log_and_showinfo_shows_the_dialog_when_an_application_exists(
 
     logger_env.logger.log_and_showinfo("info", "gui mode")
     assert built == [1], "the guard swallowed a legitimate GUI-mode popup"
+
+
+# --------------------------------------------------------------------------- #
+# error_handler.show_warning_with_traceback is the funnel EVERY `except
+# Exception:` in the add-on reaches. It already guards two ways a QWidget can be
+# unbuildable (PyQt6 missing -> _HAVE_QT; wrong thread -> is_main_thread) but
+# not the third: PyQt6 importable with no QApplication. Headless that inverted
+# the module's whole purpose — a recoverable error, the thing it exists to make
+# observable, became a force-close instead.
+# --------------------------------------------------------------------------- #
+@pytest.fixture
+def error_handler():
+    """`error_handler` re-imported on a genuine PyQt6 (see `logger_env`)."""
+    saved = {
+        name: mod for name, mod in sys.modules.items() if name.split(".")[0] == "PyQt6"
+    }
+    for name in saved:
+        del sys.modules[name]
+    sys.modules.pop("Ankimon.pyobj.error_handler", None)
+    try:
+        module = importlib.import_module("Ankimon.pyobj.error_handler")
+    except Exception as e:
+        sys.modules.update(saved)
+        raise AssertionError(f"error_handler no longer importable: {e!r}") from e
+    yield module
+    sys.modules.update(saved)
+
+
+def test_error_dialog_is_not_built_without_a_qapplication(monkeypatch, error_handler):
+    assert error_handler._HAVE_QT, "fixture must supply a real PyQt6"
+
+    def _explode(*args, **kwargs):
+        raise AssertionError("constructed a QDialog with no QApplication")
+
+    monkeypatch.setattr(error_handler, "QDialog", _explode)
+    monkeypatch.setattr(error_handler, "load_error_images", _explode)
+    monkeypatch.setattr(
+        error_handler.QApplication, "instance", staticmethod(lambda: None)
+    )
+
+    # Must return quietly — the log line and the `error` event are the record.
+    error_handler.show_warning_with_traceback(
+        exception=ValueError("boom"), message="headless error"
+    )
+
+
+def test_error_event_is_still_emitted_when_the_dialog_is_skipped(
+    monkeypatch, error_handler
+):
+    from Ankimon.events import events
+
+    monkeypatch.setattr(
+        error_handler.QApplication, "instance", staticmethod(lambda: None)
+    )
+
+    seen = []
+    events.enable(sink=seen.append)
+    try:
+        error_handler.show_warning_with_traceback(
+            exception=ValueError("boom"), message="still observable"
+        )
+    finally:
+        events.disable()
+
+    assert any(
+        ev.get("type") == "error" and ev.get("message") == "still observable"
+        for ev in seen
+    ), "the structured error event is the headless substitute for the dialog"
+
+
+def test_error_dialog_is_still_built_when_an_application_exists(
+    monkeypatch, error_handler
+):
+    reached = []
+
+    class _App:
+        def processEvents(self, *args, **kwargs):
+            pass
+
+    def _record(*args, **kwargs):
+        reached.append(1)
+        raise RuntimeError("stop here — past the guard is all we need to prove")
+
+    fake_app = _App()
+    monkeypatch.setattr(
+        error_handler.QApplication, "instance", staticmethod(lambda: fake_app)
+    )
+    monkeypatch.setattr(error_handler, "load_error_images", _record)
+
+    with pytest.raises(RuntimeError):
+        error_handler.show_warning_with_traceback(
+            exception=ValueError("boom"), message="gui mode"
+        )
+    assert reached == [1], "the guard swallowed a legitimate GUI-mode error dialog"

--- a/tests/test_headless_qt_guards.py
+++ b/tests/test_headless_qt_guards.py
@@ -327,3 +327,101 @@ def test_sprite_download_survives_a_qcoreapplication_only_process():
         "from Ankimon.pyobj.download_sprites import show_agreement_and_download_dialog",
         "show_agreement_and_download_dialog()\nprint('OK')\n",
     )
+
+
+# --------------------------------------------------------------------------- #
+# isolated_modules itself: sys.modules is not the whole of a module's identity.
+#
+# These use a throwaway package written to tmp_path rather than a real Ankimon
+# submodule. Not squeamishness: the suite's other modules register MagicMocks
+# straight into ``sys.modules["Ankimon.pyobj.*"]``, so ``import_module`` on a
+# real name can hand back a mock without ever binding the parent attribute, and
+# the assertions below would then be measuring test-order rather than the helper.
+# A package on disk gives a genuine import with a starting state this test owns.
+# --------------------------------------------------------------------------- #
+@pytest.fixture
+def probe_package(tmp_path, monkeypatch):
+    """A real, importable ``iso_probe_pkg.child`` that leaves nothing behind."""
+    pkg_dir = tmp_path / "iso_probe_pkg"
+    pkg_dir.mkdir()
+    (pkg_dir / "__init__.py").write_text("")
+    (pkg_dir / "child.py").write_text("VALUE = 1\n")
+    monkeypatch.syspath_prepend(str(tmp_path))
+    importlib.invalidate_caches()
+    try:
+        yield SimpleNamespace(parent="iso_probe_pkg", child="iso_probe_pkg.child")
+    finally:
+        for name in [n for n in list(sys.modules) if n.startswith("iso_probe_pkg")]:
+            del sys.modules[name]
+
+
+def test_isolated_modules_restores_the_parent_package_attribute(probe_package):
+    """Both identities of a re-imported submodule must come back together.
+
+    Importing ``a.b`` binds ``b`` onto package ``a`` as well as into
+    ``sys.modules``. Restoring only ``sys.modules`` leaves the attribute pointing
+    at the module imported inside the block while ``sys.modules[...]`` points at
+    the original — and which one a later test sees depends on whether it writes
+    ``from a import b`` or ``import a.b``. That is exactly the order-dependent
+    breakage this helper exists to prevent.
+    """
+    parent = importlib.import_module(probe_package.parent)
+    before = importlib.import_module(probe_package.child)
+    assert parent.child is before  # what a real import binds
+
+    with isolated_modules(extra=(probe_package.child,)):
+        reimported = importlib.import_module(probe_package.child)
+        assert reimported is not before  # the block really did re-execute it
+        assert parent.child is reimported  # ...and rebound the parent attribute
+
+    assert sys.modules[probe_package.child] is before
+    assert parent.child is before
+
+
+def test_isolated_modules_removes_an_attribute_it_created(probe_package):
+    """A submodule absent beforehand must leave no attribute behind either.
+
+    The same leak in reverse: nothing to restore, so the binding the block's
+    import created has to be deleted rather than left on the parent.
+    """
+    parent = importlib.import_module(probe_package.parent)
+    assert not hasattr(parent, "child")
+
+    with isolated_modules(extra=(probe_package.child,)):
+        importlib.import_module(probe_package.child)
+        assert hasattr(parent, "child")
+
+    assert probe_package.child not in sys.modules
+    assert not hasattr(parent, "child")
+
+
+def test_isolated_modules_restores_on_an_exception(probe_package):
+    parent = importlib.import_module(probe_package.parent)
+    before = importlib.import_module(probe_package.child)
+
+    with pytest.raises(RuntimeError):
+        with isolated_modules(extra=(probe_package.child,)):
+            importlib.import_module(probe_package.child)
+            raise RuntimeError("boom")
+
+    assert sys.modules[probe_package.child] is before
+    assert parent.child is before
+
+
+def test_isolated_modules_cleans_up_when_the_parent_is_imported_inside(probe_package):
+    """The parent itself arriving mid-block must not leave a dangling name.
+
+    Importing the child imports the parent too; the parent is untracked, so it
+    survives the block. Without an entry for it, it survives holding a ``child``
+    attribute bound to a module that is no longer in ``sys.modules`` — the same
+    split identity, just created rather than overwritten.
+    """
+    assert probe_package.parent not in sys.modules
+
+    with isolated_modules(extra=(probe_package.child,)):
+        importlib.import_module(probe_package.child)
+
+    assert probe_package.child not in sys.modules
+    parent = sys.modules.get(probe_package.parent)
+    if parent is not None:
+        assert not hasattr(parent, "child")

--- a/tests/test_headless_qt_guards.py
+++ b/tests/test_headless_qt_guards.py
@@ -1,0 +1,125 @@
+"""A QWidget must never be constructed without a QApplication.
+
+Qt answers that by calling ``abort()`` — the process dies with SIGABRT and
+"QWidget: Must construct a QApplication before a QWidget". That is not a Python
+exception, so the ``try/except Exception`` wrappers the add-on uses as its
+"headless is fine" guard cannot contain it. Those wrappers were written against
+"PyQt6 is not installed"; they do not cover "PyQt6 is installed but nothing has
+created an application", which is exactly the shape of a dev box running the
+Tier-1 agent harness (AGENTS.md makes `python3 harness/check.py` the standard
+pre-review check, and CI runs it on every PR).
+
+`ShowInfoLogger.log_and_showinfo` is on the review path — `save_main_pokemon_
+progress` calls it whenever a level-up move has to be replaced — so this took
+out any headless play-through that got that far.
+"""
+
+import importlib
+import sys
+from types import SimpleNamespace
+
+import pytest
+
+
+@pytest.fixture
+def logger_env(tmp_path):
+    """A freshly imported ``InfoLogger`` sitting on a genuine ``PyQt6.QtWidgets``.
+
+    Both halves matter, and both are about test isolation rather than the code
+    under test: earlier suite modules replace ``PyQt6`` with a ``MagicMock``
+    (so ``QApplication.instance()`` answers with a mock instead of ``None``,
+    and the dialog class is a mock too) and may leave a stale ``InfoLogger``
+    bound to it. Without this the tests silently pass or silently miss.
+    """
+    saved = {
+        name: mod for name, mod in sys.modules.items() if name.split(".")[0] == "PyQt6"
+    }
+    for name in saved:
+        del sys.modules[name]
+    sys.modules.pop("Ankimon.pyobj.InfoLogger", None)
+    try:
+        widgets = importlib.import_module("PyQt6.QtWidgets")
+        module = importlib.import_module("Ankimon.pyobj.InfoLogger")
+    except Exception as e:  # pragma: no cover - environment guard
+        sys.modules.update(saved)
+        pytest.skip(f"headless Qt guard env not importable: {e}")
+
+    logger = module.ShowInfoLogger(
+        name=f"test-{tmp_path.name}", log_filename=str(tmp_path / "app.log")
+    )
+    # `module.events` is the bus the logger actually emits on — importing
+    # `Ankimon.events` separately can hand back a different (mocked) object.
+    yield SimpleNamespace(
+        module=module, logger=logger, widgets=widgets, events=module.events
+    )
+    sys.modules.update(saved)
+
+
+def test_log_and_showinfo_builds_no_dialog_without_an_application(
+    monkeypatch, logger_env
+):
+    def _explode(*args, **kwargs):
+        raise AssertionError("constructed a QMessageBox with no QApplication")
+
+    monkeypatch.setattr(logger_env.widgets, "QMessageBox", _explode)
+    monkeypatch.setattr(
+        logger_env.widgets.QApplication, "instance", staticmethod(lambda: None)
+    )
+
+    # Must not raise, and must still record the message.
+    logger_env.logger.log_and_showinfo("info", "hello from a headless run")
+
+
+def test_log_and_showinfo_still_records_the_event_when_it_skips_the_dialog(
+    monkeypatch, logger_env
+):
+    monkeypatch.setattr(
+        logger_env.widgets.QApplication, "instance", staticmethod(lambda: None)
+    )
+
+    seen = []
+    logger_env.events.enable(sink=seen.append)
+    try:
+        logger_env.logger.log_and_showinfo("warning", "still observable")
+    finally:
+        logger_env.events.disable()
+
+    assert any(
+        ev.get("type") == "log" and ev.get("message") == "still observable"
+        for ev in seen
+    ), "the structured event is the headless substitute for the popup"
+
+
+def test_log_and_showinfo_shows_the_dialog_when_an_application_exists(
+    monkeypatch, logger_env
+):
+    built = []
+
+    class _MessageBox:
+        Icon = logger_env.widgets.QMessageBox.Icon
+
+        def setWindowTitle(self, *a):
+            pass
+
+        def setText(self, *a):
+            pass
+
+        def setIcon(self, *a):
+            pass
+
+        def exec(self):
+            built.append(1)
+
+    class _App:
+        # pytest-qt's teardown hook calls processEvents() on the instance.
+        def processEvents(self, *args, **kwargs):
+            pass
+
+    fake_app = _App()
+    monkeypatch.setattr(logger_env.widgets, "QMessageBox", _MessageBox)
+    monkeypatch.setattr(
+        logger_env.widgets.QApplication, "instance", staticmethod(lambda: fake_app)
+    )
+
+    logger_env.logger.log_and_showinfo("info", "gui mode")
+    assert built == [1], "the guard swallowed a legitimate GUI-mode popup"

--- a/tests/test_headless_qt_guards.py
+++ b/tests/test_headless_qt_guards.py
@@ -15,10 +15,16 @@ out any headless play-through that got that far.
 """
 
 import importlib
+import subprocess
 import sys
+from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
+
+from conftest import isolated_modules
+
+_SRC = Path(__file__).parent.parent / "src"
 
 
 @pytest.fixture
@@ -30,35 +36,34 @@ def logger_env(tmp_path):
     (so ``QApplication.instance()`` answers with a mock instead of ``None``,
     and the dialog class is a mock too) and may leave a stale ``InfoLogger``
     bound to it. Without this the tests silently pass or silently miss.
-    """
-    saved = {
-        name: mod for name, mod in sys.modules.items() if name.split(".")[0] == "PyQt6"
-    }
-    for name in saved:
-        del sys.modules[name]
-    sys.modules.pop("Ankimon.pyobj.InfoLogger", None)
-    try:
-        widgets = importlib.import_module("PyQt6.QtWidgets")
-        module = importlib.import_module("Ankimon.pyobj.InfoLogger")
-    except Exception as e:
-        sys.modules.update(saved)
-        # Deliberately NOT pytest.skip — see tests/test_web_bag_trade_evolutions
-        # .py's fixture docstring. PyQt6 is a documented test dependency, so an
-        # import failure here is drift to fix, not an environment to tolerate.
-        raise AssertionError(
-            "InfoLogger / PyQt6.QtWidgets no longer importable for this guard "
-            f"test — fix the fixture rather than skipping. Original error: {e!r}"
-        ) from e
 
-    logger = module.ShowInfoLogger(
-        name=f"test-{tmp_path.name}", log_filename=str(tmp_path / "app.log")
-    )
-    # `module.events` is the bus the logger actually emits on — importing
-    # `Ankimon.events` separately can hand back a different (mocked) object.
-    yield SimpleNamespace(
-        module=module, logger=logger, widgets=widgets, events=module.events
-    )
-    sys.modules.update(saved)
+    ``isolated_modules`` puts ``sys.modules`` back exactly, including removing
+    the submodules imported inside the block, so nothing here can make a later
+    test order-dependent.
+    """
+    with isolated_modules("PyQt6", extra=("Ankimon.pyobj.InfoLogger",)):
+        try:
+            widgets = importlib.import_module("PyQt6.QtWidgets")
+            module = importlib.import_module("Ankimon.pyobj.InfoLogger")
+        except Exception as e:
+            # Deliberately NOT pytest.skip — see the fixture docstring in
+            # tests/test_web_bag_trade_evolutions.py. PyQt6 is a documented test
+            # dependency, so an import failure here is drift to fix, not an
+            # environment to tolerate.
+            raise AssertionError(
+                "InfoLogger / PyQt6.QtWidgets no longer importable for this "
+                f"guard test — fix the fixture rather than skipping. Original "
+                f"error: {e!r}"
+            ) from e
+
+        logger = module.ShowInfoLogger(
+            name=f"test-{tmp_path.name}", log_filename=str(tmp_path / "app.log")
+        )
+        # `module.events` is the bus the logger actually emits on — importing
+        # `Ankimon.events` separately can hand back a different (mocked) object.
+        yield SimpleNamespace(
+            module=module, logger=logger, widgets=widgets, events=module.events
+        )
 
 
 def test_log_and_showinfo_builds_no_dialog_without_an_application(
@@ -100,9 +105,10 @@ def test_log_and_showinfo_shows_the_dialog_when_an_application_exists(
     monkeypatch, logger_env
 ):
     built = []
+    widgets = logger_env.widgets
 
     class _MessageBox:
-        Icon = logger_env.widgets.QMessageBox.Icon
+        Icon = widgets.QMessageBox.Icon
 
         def setWindowTitle(self, *a):
             pass
@@ -116,16 +122,17 @@ def test_log_and_showinfo_shows_the_dialog_when_an_application_exists(
         def exec(self):
             built.append(1)
 
+    # A stand-in for QApplication that satisfies the guard's isinstance check:
+    # patch the class the module looks up AND make instance() return one of it.
     class _App:
-        # pytest-qt's teardown hook calls processEvents() on the instance.
-        def processEvents(self, *args, **kwargs):
-            pass
+        @staticmethod
+        def instance():
+            return _app
 
-    fake_app = _App()
-    monkeypatch.setattr(logger_env.widgets, "QMessageBox", _MessageBox)
-    monkeypatch.setattr(
-        logger_env.widgets.QApplication, "instance", staticmethod(lambda: fake_app)
-    )
+    _app = _App()
+
+    monkeypatch.setattr(widgets, "QMessageBox", _MessageBox)
+    monkeypatch.setattr(widgets, "QApplication", _App)
 
     logger_env.logger.log_and_showinfo("info", "gui mode")
     assert built == [1], "the guard swallowed a legitimate GUI-mode popup"
@@ -142,19 +149,12 @@ def test_log_and_showinfo_shows_the_dialog_when_an_application_exists(
 @pytest.fixture
 def error_handler():
     """`error_handler` re-imported on a genuine PyQt6 (see `logger_env`)."""
-    saved = {
-        name: mod for name, mod in sys.modules.items() if name.split(".")[0] == "PyQt6"
-    }
-    for name in saved:
-        del sys.modules[name]
-    sys.modules.pop("Ankimon.pyobj.error_handler", None)
-    try:
-        module = importlib.import_module("Ankimon.pyobj.error_handler")
-    except Exception as e:
-        sys.modules.update(saved)
-        raise AssertionError(f"error_handler no longer importable: {e!r}") from e
-    yield module
-    sys.modules.update(saved)
+    with isolated_modules("PyQt6", extra=("Ankimon.pyobj.error_handler",)):
+        try:
+            module = importlib.import_module("Ankimon.pyobj.error_handler")
+        except Exception as e:
+            raise AssertionError(f"error_handler no longer importable: {e!r}") from e
+        yield module
 
 
 def test_error_dialog_is_not_built_without_a_qapplication(monkeypatch, error_handler):
@@ -205,17 +205,17 @@ def test_error_dialog_is_still_built_when_an_application_exists(
     reached = []
 
     class _App:
-        def processEvents(self, *args, **kwargs):
-            pass
+        @staticmethod
+        def instance():
+            return _app
+
+    _app = _App()
 
     def _record(*args, **kwargs):
         reached.append(1)
         raise RuntimeError("stop here — past the guard is all we need to prove")
 
-    fake_app = _App()
-    monkeypatch.setattr(
-        error_handler.QApplication, "instance", staticmethod(lambda: fake_app)
-    )
+    monkeypatch.setattr(error_handler, "QApplication", _App)
     monkeypatch.setattr(error_handler, "load_error_images", _record)
 
     with pytest.raises(RuntimeError):
@@ -223,3 +223,107 @@ def test_error_dialog_is_still_built_when_an_application_exists(
             exception=ValueError("boom"), message="gui mode"
         )
     assert reached == [1], "the guard swallowed a legitimate GUI-mode error dialog"
+
+
+# --------------------------------------------------------------------------- #
+# The other half of the guard: QApplication.instance() is inherited from
+# QCoreApplication and returns whatever application exists, so a console-only
+# QCoreApplication comes back NON-None. A guard written as `instance() is None`
+# therefore passes and the QWidget built after it aborts anyway.
+#
+# Run in subprocesses: the failure mode is SIGABRT, which cannot be caught
+# in-process, and only a fresh interpreter can create a QCoreApplication (Qt
+# permits one application object per process, and the suite may already have a
+# QApplication from pytest-qt). A non-zero exit IS the regression.
+# --------------------------------------------------------------------------- #
+_QCORE_STUBS = """
+import sys, types
+sys.path.insert(0, {src!r})
+from unittest.mock import MagicMock
+
+# Package stubs so relative imports resolve without running Ankimon/__init__.py.
+for pkg in ("Ankimon", "Ankimon.pyobj", "Ankimon.functions"):
+    m = types.ModuleType(pkg)
+    m.__path__ = [{src!r} + "/Ankimon" + pkg[len("Ankimon"):].replace(".", "/")]
+    m.__package__ = pkg
+    sys.modules[pkg] = m
+
+# `aqt` stub forwarding to the real PyQt6, so this matches CI (no Anki) and does
+# not drag in QtWebEngineWidgets, which Qt requires to be imported before any
+# application object exists.
+import PyQt6.QtCore, PyQt6.QtGui, PyQt6.QtWidgets
+aqt = types.ModuleType("aqt"); aqt.__path__ = []; aqt.mw = None
+aqt_qt = types.ModuleType("aqt.qt")
+for _src in (PyQt6.QtCore, PyQt6.QtGui, PyQt6.QtWidgets):
+    for _n in dir(_src):
+        if not _n.startswith("_"):
+            setattr(aqt_qt, _n, getattr(_src, _n))
+aqt_qt.qconnect = lambda sig, slot: sig.connect(slot)
+aqt_utils = types.ModuleType("aqt.utils")
+aqt_utils.showWarning = aqt_utils.showInfo = aqt_utils.tooltip = lambda *a, **k: None
+sys.modules["aqt"] = aqt
+sys.modules["aqt.qt"] = aqt_qt
+sys.modules["aqt.utils"] = aqt_utils
+"""
+
+_QCORE_APP = """
+# Import the module under test BEFORE the application exists — that is the real
+# load order, and Qt forbids importing some modules after an app is created.
+{imports}
+
+from PyQt6.QtCore import QCoreApplication
+from PyQt6.QtWidgets import QApplication
+_app = QCoreApplication([])
+assert QApplication.instance() is not None, (
+    "premise: a QCoreApplication reads as non-None"
+)
+assert not isinstance(QApplication.instance(), QApplication), (
+    "premise: a QCoreApplication is not widget-capable"
+)
+"""
+
+
+def _run_under_qcoreapplication(imports, body):
+    """Run ``body`` in a fresh interpreter that owns only a QCoreApplication.
+
+    A non-zero exit IS the regression: the failure mode is Qt calling abort(),
+    which no in-process assertion could observe.
+    """
+    code = (
+        _QCORE_STUBS.format(src=str(_SRC)) + _QCORE_APP.format(imports=imports) + body
+    )
+    proc = subprocess.run(
+        [sys.executable, "-c", code], capture_output=True, text=True, timeout=300
+    )
+    assert proc.returncode == 0, (
+        f"guard failed under a QCoreApplication (exit {proc.returncode}; "
+        "-6 is SIGABRT / 'Must construct a QApplication before a QWidget')\n"
+        f"stdout: {proc.stdout}\nstderr: {proc.stderr}"
+    )
+    assert "OK" in proc.stdout, f"body did not complete: {proc.stdout}{proc.stderr}"
+    return proc
+
+
+def test_log_and_showinfo_survives_a_qcoreapplication_only_process(tmp_path):
+    _run_under_qcoreapplication(
+        "from Ankimon.pyobj.InfoLogger import ShowInfoLogger",
+        "log = ShowInfoLogger(name='qcore', "
+        f"log_filename={str(tmp_path / 'a.log')!r})\n"
+        "log.log_and_showinfo('info', 'no widgets available here')\n"
+        "print('OK')\n",
+    )
+
+
+def test_error_dialog_survives_a_qcoreapplication_only_process():
+    _run_under_qcoreapplication(
+        "from Ankimon.pyobj.error_handler import show_warning_with_traceback",
+        "show_warning_with_traceback(exception=ValueError('boom'), message='qcore')\n"
+        "print('OK')\n",
+    )
+
+
+def test_sprite_download_survives_a_qcoreapplication_only_process():
+    _run_under_qcoreapplication(
+        "from Ankimon.pyobj.download_sprites import show_agreement_and_download_dialog",
+        "show_agreement_and_download_dialog()\nprint('OK')\n",
+    )

--- a/tests/test_move_evo_timing.py
+++ b/tests/test_move_evo_timing.py
@@ -107,7 +107,10 @@ def _reset_env(monkeypatch):
 
     sys.modules["Ankimon.singletons"] = _SINGLETONS_STUB
     sys.modules["Ankimon.functions.pokedex_functions"] = _POKEDEX_FUNCTIONS_STUB
-    services.settings = settings
+    # monkeypatch restores the real registry attributes after each test, so
+    # later tests can never inherit this module's fake settings/db (the direct
+    # assignments used before leaked across the suite and made it order-bound).
+    monkeypatch.setattr(services, "settings", settings)
     settings.values.update(
         {
             "misc.active_region": None,
@@ -119,7 +122,7 @@ def _reset_env(monkeypatch):
 
     fake_db = mock.MagicMock()
     fake_db.get_pokemon = mock.MagicMock(return_value={"attacks": list(STORED_ATTACKS)})
-    services.db = fake_db
+    monkeypatch.setattr(services, "db", fake_db)
 
     # Freeze pokedex_functions' clock: 09:00 local == "day" deterministically.
     frozen_now = datetime(2024, 1, 1, 9, 0)

--- a/tests/test_move_evo_timing.py
+++ b/tests/test_move_evo_timing.py
@@ -1,0 +1,240 @@
+"""Tests for move-based (levelMove) evolution timing in ``check_evolution_for_pokemon``.
+
+Regression coverage for the "evolution checked before new moves are learned" bug
+(fixed alongside PRs #706/#744/#785): a Pokémon that learns its required move on
+a level-up must be offered the evolution on that very event, and the check must
+prefer the caller's fresh moveset over the stale DB row.
+
+Loading strategy mirrors ``tests/test_friendship_evolution.py``:
+
+* conftest.py registers lightweight stub packages so relative imports resolve.
+* Anki/aqt modules and the error handler are stubbed with MagicMocks.
+* ``resources`` + ``pokedex_functions`` are loaded FOR REAL so the bundled
+  pokedex.json / CSV data drive every lookup (real Bonsly -> Sudowoodo chain).
+* ``services.db`` is a fake returning a controllable stored-moveset, so tests can
+  prove the fresh ``current_attacks`` argument wins over stale stored data.
+
+Time of day is pinned by freezing ``services.settings`` with an explicit offset
+clock (``timezone_auto=False``), which ``pokedex_functions.get_time_of_day``
+reads through the services seam.
+"""
+
+import importlib.util
+import sys
+import unittest.mock as mock
+from datetime import datetime
+from pathlib import Path
+
+import pytest
+
+_SRC = Path(__file__).parent.parent / "src"
+
+
+class _FakeSettings:
+    """Minimal stand-in for ``settings_obj`` backed by a mutable dict."""
+
+    def __init__(self):
+        self.values = {
+            "misc.active_region": None,
+            "evolution.day_start_hour": 6,
+            "evolution.night_start_hour": 18,
+            "evolution.timezone_auto": False,
+            # Fixed-offset clock: get_time_of_day() reads datetime.now(tz) with
+            # offset 0, so tests pin "day"/"night" by passing now= explicitly —
+            # but check_evolution_for_pokemon reads the clock itself. The fixed
+            # offset keeps it deterministic for the test run's wall time only
+            # via the _freeze_clock helper below.
+            "evolution.timezone_offset": 0.0,
+        }
+
+    def get(self, key, default=None):
+        return self.values.get(key, default)
+
+
+class _FakeEvoWindow:
+    """Records ``ask_pokemon_evo`` invocations for assertions."""
+
+    def __init__(self):
+        self.calls = []
+
+    def ask_pokemon_evo(self, individual_id, pokemon_id, evo_id):
+        self.calls.append((individual_id, pokemon_id, evo_id))
+
+
+def _load_pf():
+    sys.modules["aqt"] = mock.MagicMock()
+    sys.modules["aqt.qt"] = mock.MagicMock()
+    sys.modules["aqt.utils"] = mock.MagicMock()
+    sys.modules["Ankimon.pyobj.error_handler"] = mock.MagicMock()
+
+    fake_settings = _FakeSettings()
+    singletons_stub = importlib.util.module_from_spec(
+        importlib.util.spec_from_loader("Ankimon.singletons", loader=None)
+    )
+    singletons_stub.settings_obj = fake_settings
+    sys.modules["Ankimon.singletons"] = singletons_stub
+
+    res_spec = importlib.util.spec_from_file_location(
+        "Ankimon.resources", _SRC / "Ankimon" / "resources.py"
+    )
+    resources = importlib.util.module_from_spec(res_spec)
+    sys.modules["Ankimon.resources"] = resources
+    res_spec.loader.exec_module(resources)
+
+    pf_spec = importlib.util.spec_from_file_location(
+        "Ankimon.functions.pokedex_functions",
+        _SRC / "Ankimon" / "functions" / "pokedex_functions.py",
+    )
+    pokedex_functions = importlib.util.module_from_spec(pf_spec)
+    sys.modules["Ankimon.functions.pokedex_functions"] = pokedex_functions
+    pf_spec.loader.exec_module(pokedex_functions)
+    return pokedex_functions, fake_settings
+
+
+pf, settings = _load_pf()
+
+_SINGLETONS_STUB = sys.modules["Ankimon.singletons"]
+_POKEDEX_FUNCTIONS_STUB = sys.modules["Ankimon.functions.pokedex_functions"]
+
+# A fake DB whose get_pokemon returns the "stale stored moveset".
+STORED_ATTACKS = ["Tackle"]
+
+
+@pytest.fixture(autouse=True)
+def _reset_env(monkeypatch):
+    """Restore stubs, pin the clock to day, and wire the fake DB seam."""
+    from Ankimon.services import services
+
+    sys.modules["Ankimon.singletons"] = _SINGLETONS_STUB
+    sys.modules["Ankimon.functions.pokedex_functions"] = _POKEDEX_FUNCTIONS_STUB
+    services.settings = settings
+    settings.values.update(
+        {
+            "misc.active_region": None,
+            "evolution.day_start_hour": 6,
+            "evolution.night_start_hour": 18,
+            "evolution.friendship_time_enabled": True,
+        }
+    )
+
+    fake_db = mock.MagicMock()
+    fake_db.get_pokemon = mock.MagicMock(return_value={"attacks": list(STORED_ATTACKS)})
+    services.db = fake_db
+
+    # Freeze pokedex_functions' clock: 09:00 local == "day" deterministically.
+    frozen_now = datetime(2024, 1, 1, 9, 0)
+
+    class _FrozenDatetime(datetime):
+        @classmethod
+        def now(cls, tz=None):
+            if tz is not None:
+                return tz.fromtimestamp(frozen_now.timestamp())
+            return frozen_now
+
+    monkeypatch.setattr(pf, "datetime", _FrozenDatetime, raising=False)
+    yield
+
+
+# --------------------------------------------------------------------------- #
+# Real data chain: Bonsly (438) -> Sudowoodo (185) requires levelMove Mimic.
+# --------------------------------------------------------------------------- #
+def test_level_move_evo_fires_on_fresh_attacks_same_level():
+    """Learning Mimic THIS level must trigger the offer immediately (#706 bug).
+
+    The stored DB moveset is stale (no Mimic); the fresh current_attacks carry
+    it. Before the fix the level-evo check ran before attack learning and read
+    only the DB, so the offer came one level late or never.
+    """
+    evo_window = _FakeEvoWindow()
+    result = pf.check_evolution_for_pokemon(
+        individual_id="ind-1",
+        pokemon_id=438,  # Bonsly
+        level=17,
+        evo_window=evo_window,
+        everstone=False,
+        evolution_rejected=False,
+        current_attacks=["Tackle", "Mimic"],  # just learned this level
+    )
+    assert result == 185  # Sudowoodo
+    assert evo_window.calls == [("ind-1", 438, 185)]
+
+
+def test_level_move_evo_uses_stored_attacks_when_no_fresh_list():
+    """Without a fresh list the check falls back to the stored moveset."""
+    evo_window = _FakeEvoWindow()
+    result = pf.check_evolution_for_pokemon(
+        individual_id="ind-1",
+        pokemon_id=438,
+        level=17,
+        evo_window=evo_window,
+        everstone=False,
+        evolution_rejected=False,
+        current_attacks=None,
+    )
+    # Stored moveset is ["Tackle"] -> no Mimic -> fail closed, no offer.
+    assert result is None
+    assert evo_window.calls == []
+    # And the DB seam was actually consulted.
+    from Ankimon.services import services
+
+    services.db.get_pokemon.assert_called_with("ind-1")
+
+
+def test_level_move_evo_empty_fresh_list_beats_stored_data():
+    """An empty fresh list must NOT silently fall back to stored data.
+
+    The caller said "this is the current moveset"; treating [] as unknown would
+    let a stale DB row (that may already contain the move) fire the evolution
+    on unconfirmed data.
+    """
+    from Ankimon.services import services
+
+    # Stored row KNOWS Mimic; the fresh list says it was replaced away.
+    services.db.get_pokemon = mock.MagicMock(return_value={"attacks": ["Mimic"]})
+    evo_window = _FakeEvoWindow()
+    result = pf.check_evolution_for_pokemon(
+        individual_id="ind-1",
+        pokemon_id=438,
+        level=17,
+        evo_window=evo_window,
+        everstone=False,
+        evolution_rejected=False,
+        current_attacks=["Tackle", "Rock Throw"],
+    )
+    assert result is None
+    assert evo_window.calls == []
+
+
+def test_level_move_evo_still_blocked_by_everstone_and_rejection():
+    """The new parameter must not bypass existing suppressors."""
+    for kwargs in (
+        {"everstone": True},
+        {"evolution_rejected": True},
+    ):
+        evo_window = _FakeEvoWindow()
+        result = pf.check_evolution_for_pokemon(
+            individual_id="ind-1",
+            pokemon_id=438,
+            level=17,
+            evo_window=evo_window,
+            current_attacks=["Tackle", "Mimic"],
+            **kwargs,
+        )
+        assert result is None
+        assert evo_window.calls == []
+
+
+def test_plain_level_evo_unaffected_by_moveset():
+    """A plain level-up evolver still evolves regardless of attacks."""
+    evo_window = _FakeEvoWindow()
+    result = pf.check_evolution_for_pokemon(
+        individual_id="ind-2",
+        pokemon_id=4,  # Charmander -> Charmeleon at Lv16 (plain level)
+        level=20,
+        evo_window=evo_window,
+        everstone=False,
+        evolution_rejected=False,
+        current_attacks=["Scratch"],
+    )
+    assert result == 5
+    assert evo_window.calls == [("ind-2", 4, 5)]

--- a/tests/test_profile_hooks.py
+++ b/tests/test_profile_hooks.py
@@ -68,6 +68,7 @@ def _exec_profile_hooks(monkeypatch, gui_hooks):
     clear_learnset = MagicMock(name="clear_learnset_cache")
     clear_encounter = MagicMock(name="clear_encounter_cache")
     clear_auto_battle = MagicMock(name="clear_auto_battle_override")
+    warm_evolution = MagicMock(name="warm_evolution_caches", return_value=507)
 
     monkeypatch.setitem(
         sys.modules,
@@ -125,7 +126,9 @@ def _exec_profile_hooks(monkeypatch, gui_hooks):
         sys.modules,
         "Ankimon.functions.pokedex_functions",
         _stub_module(
-            "Ankimon.functions.pokedex_functions", clear_pokedex_caches=clear_pokedex
+            "Ankimon.functions.pokedex_functions",
+            clear_pokedex_caches=clear_pokedex,
+            warm_evolution_caches=warm_evolution,
         ),
     )
     monkeypatch.setitem(
@@ -157,6 +160,7 @@ def _exec_profile_hooks(monkeypatch, gui_hooks):
         clear_encounter,
         clear_auto_battle,
     )
+    profile_hooks._warm = warm_evolution
     return profile_hooks
 
 
@@ -250,12 +254,16 @@ class _Future:
         return self._value
 
 
-def _fire_profile_did_open(monkeypatch, *, ankiweb_sync, mobile_enabled=True):
+def _fire_profile_did_open(
+    monkeypatch, *, ankiweb_sync, mobile_enabled=True, warm_error=None
+):
     """Register hooks, then fire the profile_did_open handler with the given
     settings and return (profile_hooks, its stubbed ankimon_sync module)."""
     _fresh_services(monkeypatch)
     gui_hooks = _fresh_gui_hooks()
     profile_hooks = _exec_profile_hooks(monkeypatch, gui_hooks)
+    if warm_error is not None:
+        profile_hooks._warm.side_effect = warm_error
 
     def _get(key, default=None):
         return {
@@ -298,3 +306,33 @@ def test_sync_hooks_registered_when_ankiweb_sync_enabled(monkeypatch):
     _, sync_mod = _fire_profile_did_open(monkeypatch, ankiweb_sync=True)
 
     sync_mod.setup_ankimon_sync_hooks.assert_called_once()
+
+
+# --- Static-data re-warm on profile open ------------------------------------
+# _on_profile_close drops the pokedex caches, the evolution table among them.
+# The boot warm (startup.run_startup_background_checks) runs once per Anki
+# PROCESS — a profile switch never re-runs it — so without a re-warm here the
+# first level-up after a switch parses pokemon_evolution.csv inside
+# on_review_card, which is the review-path I/O AGENTS.md forbids.
+
+
+def test_profile_open_rewarms_the_evolution_table(monkeypatch):
+    profile_hooks, _ = _fire_profile_did_open(monkeypatch, ankiweb_sync=False)
+
+    profile_hooks._warm.assert_called_once_with()
+
+
+def test_profile_open_warm_failure_does_not_break_the_rest_of_the_handler(monkeypatch):
+    """The warm is an optimization, and it runs first in the handler — a raise
+    would take the mobile-sync hook registration and the tip of the day down
+    with it, which costs far more than an unparsed CSV."""
+    profile_hooks, sync_mod = _fire_profile_did_open(
+        monkeypatch, ankiweb_sync=False, warm_error=OSError("data_files unreadable")
+    )
+
+    profile_hooks._warm.assert_called_once_with()
+    sync_mod.setup_ankimon_sync_hooks.assert_called_once()
+    profile_hooks.logger.log.assert_any_call(
+        "error",
+        "Error warming evolution caches on profile open: data_files unreadable",
+    )

--- a/tests/test_profile_hooks.py
+++ b/tests/test_profile_hooks.py
@@ -90,7 +90,8 @@ def _exec_profile_hooks(monkeypatch, gui_hooks):
         ),
     )
     monkeypatch.setitem(
-        sys.modules, "Ankimon.utils",
+        sys.modules,
+        "Ankimon.utils",
         _stub_module("Ankimon.utils", test_online_connectivity=lambda: False),
     )
     monkeypatch.setitem(

--- a/tests/test_shop_pool_lazy.py
+++ b/tests/test_shop_pool_lazy.py
@@ -23,6 +23,8 @@ import types
 
 import pytest
 
+from conftest import isolated_modules
+
 
 @pytest.fixture
 def download_sprites():
@@ -30,60 +32,56 @@ def download_sprites():
 
     Earlier modules in the suite replace ``PyQt6`` with a ``MagicMock``, which
     turns ``from PyQt6.QtWidgets import QTextEdit`` (via ``gui_entities``) into
-    an ImportError and would silently skip these tests. Drop those entries for
-    the duration so the real package — a documented test dependency — loads,
-    then hand them back.
+    an ImportError. ``isolated_modules`` drops those entries for the duration so
+    the real package — a documented test dependency — loads, and restores
+    ``sys.modules`` EXACTLY afterwards: the submodules imported inside the block
+    and the synthetic ``aqt`` modules installed below are removed again, so a
+    later test that installs a mocked ``PyQt6`` parent cannot end up with
+    genuine children hanging off it.
     """
-    saved = {
-        name: mod
-        for name, mod in sys.modules.items()
-        if name.split(".")[0] in ("PyQt6", "aqt")
-    }
-    for name in saved:
-        del sys.modules[name]
+    with isolated_modules(
+        "PyQt6",
+        "aqt",
+        extra=("Ankimon.pyobj.download_sprites", "Ankimon.gui_entities"),
+    ):
+        # `gui_entities` (imported transitively) wants `aqt.qt.QDialog/qconnect`
+        # and `aqt.utils`; Anki is absent from CI, so forward to the real PyQt6
+        # the way Anki's own `aqt.qt` does.
+        import PyQt6.QtCore
+        import PyQt6.QtGui
+        import PyQt6.QtWidgets
 
-    # `gui_entities` (imported transitively) wants `aqt.qt.QDialog/qconnect` and
-    # `aqt.utils`; Anki is absent from CI, so forward to the real PyQt6 the way
-    # Anki's own `aqt.qt` does.
-    import PyQt6.QtCore
-    import PyQt6.QtGui
-    import PyQt6.QtWidgets
+        aqt = types.ModuleType("aqt")
+        aqt.__path__ = []
+        aqt.mw = None
+        aqt_qt = types.ModuleType("aqt.qt")
+        for source in (PyQt6.QtCore, PyQt6.QtGui, PyQt6.QtWidgets):
+            for name in dir(source):
+                if not name.startswith("_"):
+                    setattr(aqt_qt, name, getattr(source, name))
+        aqt_qt.qconnect = lambda signal, slot: signal.connect(slot)
+        aqt_utils = types.ModuleType("aqt.utils")
+        aqt_utils.showWarning = lambda *a, **k: None
+        aqt_utils.showInfo = lambda *a, **k: None
+        aqt_utils.tooltip = lambda *a, **k: None
+        sys.modules["aqt"] = aqt
+        sys.modules["aqt.qt"] = aqt_qt
+        sys.modules["aqt.utils"] = aqt_utils
 
-    aqt = types.ModuleType("aqt")
-    aqt.__path__ = []
-    aqt.mw = None
-    aqt_qt = types.ModuleType("aqt.qt")
-    for source in (PyQt6.QtCore, PyQt6.QtGui, PyQt6.QtWidgets):
-        for name in dir(source):
-            if not name.startswith("_"):
-                setattr(aqt_qt, name, getattr(source, name))
-    aqt_qt.qconnect = lambda signal, slot: signal.connect(slot)
-    aqt_utils = types.ModuleType("aqt.utils")
-    aqt_utils.showWarning = lambda *a, **k: None
-    aqt_utils.showInfo = lambda *a, **k: None
-    aqt_utils.tooltip = lambda *a, **k: None
-    sys.modules["aqt"] = aqt
-    sys.modules["aqt.qt"] = aqt_qt
-    sys.modules["aqt.utils"] = aqt_utils
-
-    sys.modules.pop("Ankimon.pyobj.download_sprites", None)
-    sys.modules.pop("Ankimon.gui_entities", None)
-    try:
-        module = importlib.import_module("Ankimon.pyobj.download_sprites")
-    except Exception as e:
-        sys.modules.update(saved)
-        # Deliberately NOT pytest.skip. PyQt6 is a documented test dependency
-        # and `aqt` is supplied by this fixture, so an import failure means the
-        # stub set has drifted from what the module imports — and a skip would
-        # report that as green with every test here silently disabled, which is
-        # the exact failure mode this file's own subject matter is about.
-        raise AssertionError(
-            "download_sprites is no longer importable with this fixture's Qt "
-            "stubs — extend them to cover its new imports rather than letting "
-            f"these tests silently skip. Original error: {e!r}"
-        ) from e
-    yield module
-    sys.modules.update(saved)
+        try:
+            module = importlib.import_module("Ankimon.pyobj.download_sprites")
+        except Exception as e:
+            # Deliberately NOT pytest.skip. PyQt6 is a documented test
+            # dependency and `aqt` is supplied right here, so an import failure
+            # means the stub set has drifted from what the module imports — and
+            # a skip would report that as green with every test in this file
+            # silently disabled, which is this file's own subject matter.
+            raise AssertionError(
+                "download_sprites is no longer importable with this fixture's "
+                "Qt stubs — extend them to cover its new imports rather than "
+                f"letting these tests silently skip. Original error: {e!r}"
+            ) from e
+        yield module
 
 
 def _fresh_import(monkeypatch, calls):
@@ -152,17 +150,17 @@ def test_download_dialog_still_runs_when_a_qapplication_exists(
             built.append(1)
             return object()  # never equals QDialog.DialogCode.Accepted
 
+    # A stand-in that satisfies the guard's isinstance check: patch the class
+    # the module looks up AND make instance() hand back one of it.
     class _App:
-        # pytest-qt's teardown hook calls processEvents() on whatever
-        # QApplication.instance() hands back, so the stand-in needs it.
-        def processEvents(self, *args, **kwargs):
-            pass
+        @staticmethod
+        def instance():
+            return _app
 
-    fake_app = _App()
+    _app = _App()
+
     monkeypatch.setattr(download_sprites, "AgreementDialog", _Dialog)
-    monkeypatch.setattr(
-        download_sprites.QApplication, "instance", staticmethod(lambda: fake_app)
-    )
+    monkeypatch.setattr(download_sprites, "QApplication", _App)
 
     download_sprites.show_agreement_and_download_dialog()
     assert built == [1], "the guard swallowed a legitimate GUI-mode call"

--- a/tests/test_shop_pool_lazy.py
+++ b/tests/test_shop_pool_lazy.py
@@ -1,0 +1,159 @@
+"""The daily-shop item pool must not be built while importing its module.
+
+``utils.daily_item_list()`` scans the sprites directory and, when it is absent,
+opens the sprite-download agreement dialog. ``ankimon_shop`` used to call it at
+module scope (``DAILY_ITEMS_POOL = daily_item_list()``), which made two things
+true that should not have been:
+
+* ``singletons`` imports ``ankimon_shop``, and ``battle_loop.on_review_card``
+  lazily imports ``singletons`` — so on a profile whose sprites had not been
+  downloaded, the first card review could surface a modal download dialog from
+  inside a stats notification.
+* Building a ``QWidget`` before a ``QApplication`` exists makes Qt call
+  ``abort()``. That is a process death, not an exception, so the ``try/except
+  Exception`` around that lazy import could not contain it: the Tier-1 harness
+  gate died with SIGABRT on any machine where PyQt6 was importable.
+
+These tests pin the lazy accessor and the no-QApplication guard.
+"""
+
+import importlib
+import sys
+import types
+
+import pytest
+
+
+@pytest.fixture
+def download_sprites():
+    """Import ``download_sprites`` with a genuine PyQt6 underneath it.
+
+    Earlier modules in the suite replace ``PyQt6`` with a ``MagicMock``, which
+    turns ``from PyQt6.QtWidgets import QTextEdit`` (via ``gui_entities``) into
+    an ImportError and would silently skip these tests. Drop those entries for
+    the duration so the real package — a documented test dependency — loads,
+    then hand them back.
+    """
+    saved = {
+        name: mod
+        for name, mod in sys.modules.items()
+        if name.split(".")[0] in ("PyQt6", "aqt")
+    }
+    for name in saved:
+        del sys.modules[name]
+
+    # `gui_entities` (imported transitively) wants `aqt.qt.QDialog/qconnect` and
+    # `aqt.utils`; Anki is absent from CI, so forward to the real PyQt6 the way
+    # Anki's own `aqt.qt` does.
+    import PyQt6.QtCore
+    import PyQt6.QtGui
+    import PyQt6.QtWidgets
+
+    aqt = types.ModuleType("aqt")
+    aqt.__path__ = []
+    aqt.mw = None
+    aqt_qt = types.ModuleType("aqt.qt")
+    for source in (PyQt6.QtCore, PyQt6.QtGui, PyQt6.QtWidgets):
+        for name in dir(source):
+            if not name.startswith("_"):
+                setattr(aqt_qt, name, getattr(source, name))
+    aqt_qt.qconnect = lambda signal, slot: signal.connect(slot)
+    aqt_utils = types.ModuleType("aqt.utils")
+    aqt_utils.showWarning = lambda *a, **k: None
+    aqt_utils.showInfo = lambda *a, **k: None
+    aqt_utils.tooltip = lambda *a, **k: None
+    sys.modules["aqt"] = aqt
+    sys.modules["aqt.qt"] = aqt_qt
+    sys.modules["aqt.utils"] = aqt_utils
+
+    sys.modules.pop("Ankimon.pyobj.download_sprites", None)
+    sys.modules.pop("Ankimon.gui_entities", None)
+    try:
+        module = importlib.import_module("Ankimon.pyobj.download_sprites")
+    except Exception as e:  # pragma: no cover - environment guard
+        sys.modules.update(saved)
+        pytest.skip(f"download_sprites not importable: {e}")
+    yield module
+    sys.modules.update(saved)
+
+
+def _fresh_import(monkeypatch, calls):
+    """Import ``ankimon_shop`` fresh with ``daily_item_list`` recording calls."""
+    utils = importlib.import_module("Ankimon.utils")
+    monkeypatch.setattr(
+        utils,
+        "daily_item_list",
+        lambda: calls.append(1) or [{"name": "potion", "price": 10}],
+    )
+    sys.modules.pop("Ankimon.pyobj.ankimon_shop", None)
+    return importlib.import_module("Ankimon.pyobj.ankimon_shop")
+
+
+def test_importing_ankimon_shop_does_not_build_the_pool(monkeypatch):
+    calls = []
+    _fresh_import(monkeypatch, calls)
+    assert calls == [], "importing ankimon_shop scanned the sprites directory"
+
+
+def test_pool_is_built_on_first_use_and_memoized(monkeypatch):
+    calls = []
+    shop = _fresh_import(monkeypatch, calls)
+
+    assert shop.get_daily_items_pool() == [{"name": "potion", "price": 10}]
+    assert calls == [1]
+    # Second call must reuse the cached pool, not re-scan.
+    assert shop.get_daily_items_pool() == [{"name": "potion", "price": 10}]
+    assert calls == [1]
+
+
+def test_pool_degrades_to_a_list_when_the_scan_returns_nothing(monkeypatch):
+    # daily_item_list() returns None on some failure paths; len()/random.sample()
+    # in the callers must still get a sequence.
+    utils = importlib.import_module("Ankimon.utils")
+    monkeypatch.setattr(utils, "daily_item_list", lambda: None)
+    sys.modules.pop("Ankimon.pyobj.ankimon_shop", None)
+    shop = importlib.import_module("Ankimon.pyobj.ankimon_shop")
+
+    assert shop.get_daily_items_pool() == []
+
+
+def test_download_dialog_is_skipped_without_a_qapplication(
+    monkeypatch, download_sprites
+):
+    """The guard has to be a check, not a try/except — Qt aborts the process."""
+
+    def _explode(*args, **kwargs):
+        raise AssertionError("built a QWidget with no QApplication")
+
+    monkeypatch.setattr(download_sprites, "AgreementDialog", _explode)
+    monkeypatch.setattr(
+        download_sprites.QApplication, "instance", staticmethod(lambda: None)
+    )
+
+    assert download_sprites.show_agreement_and_download_dialog() is None
+
+
+def test_download_dialog_still_runs_when_a_qapplication_exists(
+    monkeypatch, download_sprites
+):
+    built = []
+
+    class _Dialog:
+        def exec(self):
+            built.append(1)
+            return object()  # never equals QDialog.DialogCode.Accepted
+
+    class _App:
+        # pytest-qt's teardown hook calls processEvents() on whatever
+        # QApplication.instance() hands back, so the stand-in needs it.
+        def processEvents(self, *args, **kwargs):
+            pass
+
+    fake_app = _App()
+    monkeypatch.setattr(download_sprites, "AgreementDialog", _Dialog)
+    monkeypatch.setattr(
+        download_sprites.QApplication, "instance", staticmethod(lambda: fake_app)
+    )
+
+    download_sprites.show_agreement_and_download_dialog()
+    assert built == [1], "the guard swallowed a legitimate GUI-mode call"

--- a/tests/test_shop_pool_lazy.py
+++ b/tests/test_shop_pool_lazy.py
@@ -70,9 +70,18 @@ def download_sprites():
     sys.modules.pop("Ankimon.gui_entities", None)
     try:
         module = importlib.import_module("Ankimon.pyobj.download_sprites")
-    except Exception as e:  # pragma: no cover - environment guard
+    except Exception as e:
         sys.modules.update(saved)
-        pytest.skip(f"download_sprites not importable: {e}")
+        # Deliberately NOT pytest.skip. PyQt6 is a documented test dependency
+        # and `aqt` is supplied by this fixture, so an import failure means the
+        # stub set has drifted from what the module imports — and a skip would
+        # report that as green with every test here silently disabled, which is
+        # the exact failure mode this file's own subject matter is about.
+        raise AssertionError(
+            "download_sprites is no longer importable with this fixture's Qt "
+            "stubs — extend them to cover its new imports rather than letting "
+            f"these tests silently skip. Original error: {e!r}"
+        ) from e
     yield module
     sys.modules.update(saved)
 

--- a/tests/test_web_bag_trade_evolutions.py
+++ b/tests/test_web_bag_trade_evolutions.py
@@ -135,11 +135,25 @@ def _install_qt_stubs():
 def shop_obj():
     """Import the real web-shell host once, headlessly.
 
-    Only the package stubs conftest already installs are needed; everything else
-    (pokedex cache, items.csv, the CP formula) is loaded for real so the test
-    exercises the shipped data. No mock is left in ``sys.modules``: the module
-    imported here is the genuine one, and the ``services`` seam is swapped
-    per-test with an auto-reverting ``patch.object``.
+    The module under test is the GENUINE one — the pokedex cache, items.csv and
+    the CP formula are all loaded for real so the tests exercise the shipped
+    data, and the ``services`` seam is swapped per-test with an auto-reverting
+    ``patch.object``.
+
+    What is faked is only ``shop_obj``'s Qt import surface, and only because
+    Anki is absent headlessly: :func:`_install_qt_stubs` installs three
+    synthetic ``aqt`` modules (including ``MagicMock``s for ``aqt.mw``, ``Qt``,
+    ``QUrl``, ``QFrame`` and ``QWebEngineProfile``) and drops any mocked
+    ``PyQt6`` entries so the genuine package loads. Both are restored on
+    teardown.
+
+    **If you add a Qt import to shop_obj.py, extend `_install_qt_stubs` to
+    match.** An import failure here is a hard error, not a skip: PyQt6 is a
+    documented test dependency and ``aqt`` is supplied by this fixture, so
+    nothing is left that an unimportable module could legitimately mean except
+    that the stub set has drifted. Skipping instead is how all 31 of these tests
+    — the Rhydon/Protector regression included — went years without running
+    anywhere but a developer box with Anki installed.
     """
     for pkg in (
         "Ankimon",
@@ -158,13 +172,19 @@ def shop_obj():
     sys.modules.pop("Ankimon.ankimon_items_web.shop_obj", None)
     try:
         module = importlib.import_module("Ankimon.ankimon_items_web.shop_obj")
-    except Exception as e:  # pragma: no cover - environment guard
+    except Exception as e:
         for name, previous in saved.items():
             if previous is None:
                 sys.modules.pop(name, None)
             else:
                 sys.modules[name] = previous
-        pytest.skip(f"web-shell host not importable headlessly: {e}")
+        # Deliberately NOT pytest.skip: see the docstring. A skip here reports
+        # green while every test in this file silently stops running.
+        raise AssertionError(
+            "shop_obj is no longer importable with this file's Qt stubs — "
+            "extend _install_qt_stubs() to cover its new imports "
+            f"(rather than letting these tests silently skip). Original error: {e!r}"
+        ) from e
 
     yield module
 

--- a/tests/test_web_bag_trade_evolutions.py
+++ b/tests/test_web_bag_trade_evolutions.py
@@ -26,6 +26,8 @@ from unittest.mock import patch
 
 import pytest
 
+from conftest import isolated_modules
+
 _SRC = Path(__file__).parent.parent / "src"
 _POKEDEX = json.loads(
     (_SRC / "Ankimon" / "data_files" / "pokedex.json").read_text(encoding="utf-8")
@@ -75,37 +77,25 @@ TRADE_ITEM_SPECIES = _trade_item_species()
 
 
 def _install_qt_stubs():
-    """Make ``shop_obj``'s module-top Qt imports resolvable in a headless run.
+    """Install the Qt names ``shop_obj`` imports at module top.
 
-    Two separate obstacles, both of which used to land in the ``pytest.skip``
-    below — so this whole file, the Rhydon/Protector regression included,
-    quietly never executed anywhere but a developer box with Anki installed:
+    Two separate obstacles, both of which used to land in a ``pytest.skip`` — so
+    this whole file, the Rhydon/Protector regression included, quietly never
+    executed anywhere but a developer box with Anki installed:
 
     * ``shop_obj`` does ``from aqt import QDialog, ... QWebEngineView`` and
       subclasses those. Anki is absent from every CI run (AGENTS.md installs
       only pytest/pytest-qt/PyQt6/markdown). Plain empty classes are enough —
       nothing here constructs a widget; the tests call ``get_pokemon_choices``
       unbound against ``_StubHost``.
-    * Earlier test modules in the suite replace ``PyQt6`` with a ``MagicMock``,
-      which turns ``from PyQt6.QtWebChannel import QWebChannel`` into
-      "PyQt6 is not a package". Dropping those entries lets the genuine PyQt6
-      (a documented test dependency) load instead.
+    * Earlier test modules replace ``PyQt6`` with a ``MagicMock``, which turns
+      ``from PyQt6.QtWebChannel import QWebChannel`` into "PyQt6 is not a
+      package".
 
-    Returns the previous ``sys.modules`` entries so the caller can put them back.
+    Clearing and restoring both namespaces is ``isolated_modules``' job around
+    the caller, so this only installs; it never has to clean up.
     """
     from unittest.mock import MagicMock
-
-    saved = {name: sys.modules.get(name) for name in ("aqt", "aqt.qt", "aqt.utils")}
-    saved.update(
-        {
-            name: mod
-            for name, mod in sys.modules.items()
-            if name.split(".")[0] == "PyQt6"
-        }
-    )
-    for name in list(saved):
-        if name.split(".")[0] == "PyQt6":
-            del sys.modules[name]
 
     aqt = types.ModuleType("aqt")
     aqt.__path__ = []
@@ -128,7 +118,6 @@ def _install_qt_stubs():
     sys.modules["aqt"] = aqt
     sys.modules["aqt.qt"] = aqt_qt
     sys.modules["aqt.utils"] = aqt_utils
-    return saved
 
 
 @pytest.fixture(scope="module")
@@ -141,19 +130,21 @@ def shop_obj():
     ``patch.object``.
 
     What is faked is only ``shop_obj``'s Qt import surface, and only because
-    Anki is absent headlessly: :func:`_install_qt_stubs` installs three
-    synthetic ``aqt`` modules (including ``MagicMock``s for ``aqt.mw``, ``Qt``,
-    ``QUrl``, ``QFrame`` and ``QWebEngineProfile``) and drops any mocked
-    ``PyQt6`` entries so the genuine package loads. Both are restored on
-    teardown.
+    Anki is absent headlessly: :func:`_install_qt_stubs` supplies the four
+    ``aqt`` names the module subclasses, while ``isolated_modules`` drops any
+    mocked ``PyQt6`` so the genuine package loads — and restores ``sys.modules``
+    EXACTLY on the way out, including removing the synthetic ``aqt`` modules and
+    the PyQt6 submodules imported inside. Without that last part a later test
+    that installs a mocked ``PyQt6`` parent would inherit genuine children such
+    as ``PyQt6.QtWebChannel`` from here, which is order-dependent and miserable
+    to debug.
 
     **If you add a Qt import to shop_obj.py, extend `_install_qt_stubs` to
     match.** An import failure here is a hard error, not a skip: PyQt6 is a
     documented test dependency and ``aqt`` is supplied by this fixture, so
     nothing is left that an unimportable module could legitimately mean except
     that the stub set has drifted. Skipping instead is how all 31 of these tests
-    — the Rhydon/Protector regression included — went years without running
-    anywhere but a developer box with Anki installed.
+    went years without running anywhere but a developer box with Anki installed.
     """
     for pkg in (
         "Ankimon",
@@ -168,34 +159,23 @@ def shop_obj():
             mod.__package__ = pkg
             sys.modules[pkg] = mod
 
-    saved = _install_qt_stubs()
-    sys.modules.pop("Ankimon.ankimon_items_web.shop_obj", None)
-    try:
-        module = importlib.import_module("Ankimon.ankimon_items_web.shop_obj")
-    except Exception as e:
-        for name, previous in saved.items():
-            if previous is None:
-                sys.modules.pop(name, None)
-            else:
-                sys.modules[name] = previous
-        # Deliberately NOT pytest.skip: see the docstring. A skip here reports
-        # green while every test in this file silently stops running.
-        raise AssertionError(
-            "shop_obj is no longer importable with this file's Qt stubs — "
-            "extend _install_qt_stubs() to cover its new imports "
-            f"(rather than letting these tests silently skip). Original error: {e!r}"
-        ) from e
+    with isolated_modules(
+        "PyQt6", "aqt", extra=("Ankimon.ankimon_items_web.shop_obj",)
+    ):
+        _install_qt_stubs()
+        try:
+            module = importlib.import_module("Ankimon.ankimon_items_web.shop_obj")
+        except Exception as e:
+            # Deliberately NOT pytest.skip: see the docstring. A skip here
+            # reports green while every test in this file silently stops
+            # running.
+            raise AssertionError(
+                "shop_obj is no longer importable with this file's Qt stubs — "
+                "extend _install_qt_stubs() to cover its new imports (rather "
+                f"than letting these tests silently skip). Original error: {e!r}"
+            ) from e
 
-    yield module
-
-    # The module keeps direct references to the names it imported, so handing
-    # `aqt` back to whatever owned it is safe and keeps the stub from leaking
-    # into the rest of the suite.
-    for name, previous in saved.items():
-        if previous is None:
-            sys.modules.pop(name, None)
-        else:
-            sys.modules[name] = previous
+        yield module
 
 
 class _StubHost:

--- a/tests/test_web_bag_trade_evolutions.py
+++ b/tests/test_web_bag_trade_evolutions.py
@@ -377,3 +377,77 @@ def test_picker_agrees_with_canonical_helper_on_gender(
     assert flagged is (expected is not None), (
         f"picker and helper disagree for a {gender} {name}"
     )
+
+
+# --------------------------------------------------------------------------- #
+# The web bag already holds the record, so it hands it to Check_Evo_Item.
+#
+# ``handle_use_with_target`` reads the selected Pokemon to resolve the pre-evo's
+# pokedex id. ``Check_Evo_Item`` then needs the same record's gender for the gate
+# — but re-reading it costs a second query AND lets the id and the gender come
+# from different snapshots. Worse, a failed re-read is indistinguishable from
+# "this Pokemon has no gender", which is the fail-open that hands a female Kirlia
+# the male-only Gallade (see tests/test_evolution_item_gender_lookup.py).
+#
+# Passing the record through is the fix; these pin the caller's half of it.
+# --------------------------------------------------------------------------- #
+class _UseHost:
+    """The slice of ``AnkimonItemsWeb`` that ``handle_use_with_target`` reads."""
+
+    def __init__(self, bag, item=None):
+        self.item_window = bag
+        self.profile_data = None
+        self._pokemon_choices_cache = None
+        self._item = item or {
+            "name": _DAWN_STONE,
+            "category": "evolution",
+            "owned_quantity": 1,
+        }
+
+    def _find_serialized(self, item_name):
+        return self._item if item_name == self._item["name"] else None
+
+    def _invalidate_pokemon_cache(self):
+        self._pokemon_choices_cache = None
+
+
+class _RecordingBag:
+    """Stands in for ``ItemWindow``, recording how Check_Evo_Item was called."""
+
+    def __init__(self):
+        self.calls = []
+
+    def Check_Evo_Item(self, individual_id, prevo_id, item_name, pokemon_data=None):
+        self.calls.append((individual_id, prevo_id, item_name, pokemon_data))
+
+
+def _use_on(shop_obj, record):
+    """Run the web bag's "use this item on that Pokemon" with one stored record."""
+    reads = []
+
+    def get_pokemon(individual_id):
+        reads.append(individual_id)
+        return record
+
+    bag = _RecordingBag()
+    services = types.SimpleNamespace(
+        db=types.SimpleNamespace(get_pokemon=get_pokemon),
+        settings=None,
+        logger=None,
+    )
+
+    with patch.object(shop_obj, "services", services):
+        result = shop_obj.AnkimonItemsWeb.handle_use_with_target(
+            _UseHost(bag), _DAWN_STONE, "kirlia-1"
+        )
+    return result, bag, reads
+
+
+def test_the_web_bag_hands_the_loaded_record_to_check_evo_item(shop_obj):
+    record = {"id": 281, "gender": "F", "name": "Kirlia"}
+    result, bag, reads = _use_on(shop_obj, record)
+
+    assert result["ok"] is True
+    assert bag.calls == [("kirlia-1", 281, _DAWN_STONE, record)]
+    # Exactly one read: the gender arrives with the id, not from a second query.
+    assert reads == ["kirlia-1"]

--- a/tests/test_web_bag_trade_evolutions.py
+++ b/tests/test_web_bag_trade_evolutions.py
@@ -74,6 +74,63 @@ def _trade_item_species():
 TRADE_ITEM_SPECIES = _trade_item_species()
 
 
+def _install_qt_stubs():
+    """Make ``shop_obj``'s module-top Qt imports resolvable in a headless run.
+
+    Two separate obstacles, both of which used to land in the ``pytest.skip``
+    below — so this whole file, the Rhydon/Protector regression included,
+    quietly never executed anywhere but a developer box with Anki installed:
+
+    * ``shop_obj`` does ``from aqt import QDialog, ... QWebEngineView`` and
+      subclasses those. Anki is absent from every CI run (AGENTS.md installs
+      only pytest/pytest-qt/PyQt6/markdown). Plain empty classes are enough —
+      nothing here constructs a widget; the tests call ``get_pokemon_choices``
+      unbound against ``_StubHost``.
+    * Earlier test modules in the suite replace ``PyQt6`` with a ``MagicMock``,
+      which turns ``from PyQt6.QtWebChannel import QWebChannel`` into
+      "PyQt6 is not a package". Dropping those entries lets the genuine PyQt6
+      (a documented test dependency) load instead.
+
+    Returns the previous ``sys.modules`` entries so the caller can put them back.
+    """
+    from unittest.mock import MagicMock
+
+    saved = {name: sys.modules.get(name) for name in ("aqt", "aqt.qt", "aqt.utils")}
+    saved.update(
+        {
+            name: mod
+            for name, mod in sys.modules.items()
+            if name.split(".")[0] == "PyQt6"
+        }
+    )
+    for name in list(saved):
+        if name.split(".")[0] == "PyQt6":
+            del sys.modules[name]
+
+    aqt = types.ModuleType("aqt")
+    aqt.__path__ = []
+    for cls_name in ("QDialog", "QVBoxLayout", "QWebEngineView", "QWebEnginePage"):
+        setattr(
+            aqt,
+            cls_name,
+            type(cls_name, (), {"__init__": lambda self, *a, **k: None}),
+        )
+    aqt.mw = MagicMock()
+
+    aqt_qt = types.ModuleType("aqt.qt")
+    for name in ("Qt", "QUrl", "QFrame", "QWebEngineProfile"):
+        setattr(aqt_qt, name, MagicMock())
+
+    aqt_utils = types.ModuleType("aqt.utils")
+    aqt_utils.tooltip = lambda *a, **k: None
+    aqt_utils.showInfo = lambda *a, **k: None
+
+    sys.modules["aqt"] = aqt
+    sys.modules["aqt.qt"] = aqt_qt
+    sys.modules["aqt.utils"] = aqt_utils
+    return saved
+
+
 @pytest.fixture(scope="module")
 def shop_obj():
     """Import the real web-shell host once, headlessly.
@@ -96,10 +153,29 @@ def shop_obj():
             mod.__path__ = [str(_SRC / pkg.replace(".", "/"))]
             mod.__package__ = pkg
             sys.modules[pkg] = mod
+
+    saved = _install_qt_stubs()
+    sys.modules.pop("Ankimon.ankimon_items_web.shop_obj", None)
     try:
-        return importlib.import_module("Ankimon.ankimon_items_web.shop_obj")
+        module = importlib.import_module("Ankimon.ankimon_items_web.shop_obj")
     except Exception as e:  # pragma: no cover - environment guard
+        for name, previous in saved.items():
+            if previous is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = previous
         pytest.skip(f"web-shell host not importable headlessly: {e}")
+
+    yield module
+
+    # The module keeps direct references to the names it imported, so handing
+    # `aqt` back to whatever owned it is safe and keeps the stub from leaking
+    # into the rest of the suite.
+    for name, previous in saved.items():
+        if previous is None:
+            sys.modules.pop(name, None)
+        else:
+            sys.modules[name] = previous
 
 
 class _StubHost:

--- a/tests/test_web_bag_trade_evolutions.py
+++ b/tests/test_web_bag_trade_evolutions.py
@@ -206,3 +206,98 @@ def test_picker_agrees_with_canonical_helper(
     assert choices[mon["individual_id"]].get("e") == 1, (
         f"web bag picker hides {prevo_name} when using {item_identifier}"
     )
+
+
+# --------------------------------------------------------------------------- #
+# Gender-gated item evolutions must agree with the canonical helper too.
+#
+# ``check_evolution_by_item`` learned the CSV ``gender_id`` gate (Gallade needs
+# a male Kirlia, Froslass a female Snorunt), and ``Check_Evo_Item`` — which is
+# what ``handle_use_with_target`` ultimately calls — now passes the selected
+# Pokemon's gender. The picker's inline copy had to learn it as well: shop.js
+# filters this list to ``e === 1``, so leaving it out means the bag offers the
+# player exactly the Pokemon the use is about to refuse with "This Pokemon does
+# not need this item."
+# --------------------------------------------------------------------------- #
+_DAWN_STONE = "dawn-stone"
+
+
+def _gendered(name, pokedex_id, gender):
+    mon = _pokemon(name, pokedex_id)
+    mon["gender"] = gender
+    return mon
+
+
+def test_male_kirlia_is_offered_the_dawn_stone(shop_obj):
+    mon = _gendered("Kirlia", 281, "M")
+    choices = _choices(shop_obj, [mon], _DAWN_STONE)
+    assert choices[mon["individual_id"]].get("e") == 1
+
+
+def test_female_kirlia_is_not_offered_the_dawn_stone(shop_obj):
+    # Gallade (475) is the only Dawn Stone target Kirlia has, and it is male-only.
+    mon = _gendered("Kirlia", 281, "F")
+    choices = _choices(shop_obj, [mon], _DAWN_STONE)
+    assert "e" not in choices[mon["individual_id"]]
+
+
+def test_female_snorunt_is_offered_the_dawn_stone(shop_obj):
+    mon = _gendered("Snorunt", 361, "F")
+    choices = _choices(shop_obj, [mon], _DAWN_STONE)
+    assert choices[mon["individual_id"]].get("e") == 1
+
+
+def test_male_snorunt_is_not_offered_the_dawn_stone(shop_obj):
+    mon = _gendered("Snorunt", 361, "M")
+    choices = _choices(shop_obj, [mon], _DAWN_STONE)
+    assert "e" not in choices[mon["individual_id"]]
+
+
+def test_missing_gender_keeps_the_historical_no_check_behavior(shop_obj):
+    # Old saves without a stored gender must not lose access to the evolution.
+    mon = _pokemon("Kirlia", 281)  # no "gender" key at all
+    choices = _choices(shop_obj, [mon], _DAWN_STONE)
+    assert choices[mon["individual_id"]].get("e") == 1
+
+
+def test_genderless_value_degrades_to_no_check(shop_obj):
+    for junk in ("Genderless", "N", "", "x"):
+        mon = _gendered("Kirlia", 281, junk)
+        choices = _choices(shop_obj, [mon], _DAWN_STONE)
+        assert choices[mon["individual_id"]].get("e") == 1, junk
+
+
+def test_ungated_item_evolution_ignores_gender(shop_obj):
+    # A Thunder Stone on Pikachu carries no gender_id row; both sexes qualify.
+    for gender in ("M", "F"):
+        mon = _gendered("pikachu", 25, gender)
+        choices = _choices(shop_obj, [mon], "thunder-stone")
+        assert choices[mon["individual_id"]].get("e") == 1, gender
+
+
+@pytest.mark.parametrize(
+    "name,pokedex_id,gender,expected",
+    [
+        ("Kirlia", 281, "M", 475),
+        ("Snorunt", 361, "F", 478),
+        ("Kirlia", 281, "F", None),
+        ("Snorunt", 361, "M", None),
+    ],
+)
+def test_picker_agrees_with_canonical_helper_on_gender(
+    shop_obj, name, pokedex_id, gender, expected
+):
+    """Pin the two implementations to each other on the gender branch as well."""
+    item_id = shop_obj.return_id_for_item_name(_DAWN_STONE)
+    assert item_id, "dawn-stone is missing from items.csv"
+
+    helper = shop_obj.check_evolution_by_item(pokedex_id, item_id, gender=gender)
+    assert helper == expected
+
+    mon = _gendered(name, pokedex_id, gender)
+    choices = _choices(shop_obj, [mon], _DAWN_STONE)
+    flagged = choices[mon["individual_id"]].get("e") == 1
+
+    assert flagged is (expected is not None), (
+        f"picker and helper disagree for a {gender} {name}"
+    )


### PR DESCRIPTION
## Summary

While reviewing **#785** ("Ensure Eevee evolves into Sylveon if proper conditions met") I found it is one instance of a whole *class* of bugs: **evolution requirements carried by the bundled data but ignored — or evaluated at the wrong time — by the code**. This PR fixes that class, covering everything #785, #744 and #706 set out to do plus further instances found in a full-codebase sweep.

Hardening the tests to actually *prove* those fixes then surfaced a second, unrelated class — **Qt widgets built without a `QApplication`, which calls `abort()` and kills the process rather than raising** — so a handful of headless-safety fixes ride along. They are listed separately below; skip to [Headless / Qt safety](#headless--qt-safety) if that is the part you care about.

No existing PR is closed, merged or modified.

## The evolution bug class

| # | Instance | Data that was being ignored |
|---|----------|------------------------------|
| 1 | Sylveon unreachable via the friendship path (#785) | both `pokemon_evolution.csv` rows for `evolved_species_id=700` carry `known_move_type_id=18` (Fairy) |
| 2 | The victory-time auto-prompt offered Sylveon on *unconfirmed* data (#744's target) | same column |
| 3 | Move-based evolutions checked **before** new moves were learned, so they fired a level late or never (#706) | the fresh moveset the caller already held |
| 4 | Dawn Stone ignored gender: a female Kirlia could become Gallade, a male Snorunt Froslass | `gender_id` (Gallade = 2/male, Froslass = 1/female) |
| 5 | Level-up ignored gender too: a male Combee could become Vespiquen; Burmy always became Wormadam, so **Mothim was unreachable** | `gender_id` on the level rows (Combee, Salandit, Burmy) |
| 6 | Espurr always became the **male** Meowstic, Lechonk the male Oinkologne | veekun models these as *forms*, so the CSV carries no gate — `pokedex.json` does, on each form's own `gender` |
| 7 | The PC's manual "Evolve now" button bypassed every gate above | — |
| 8 | The web bag's picker offered candidates `Check_Evo_Item` would then refuse | — |
| 9 | `rows_for_key_in_table` was defined twice, the second shadowing the first | — |

## What changed

### Evolution gating

**`friendship_evolution.py`** — `FriendshipEvolution` gains `known_move_type`, parsed from `known_move_type_id` through a canonical veekun type table (`18 -> "fairy"`); junk ids degrade to "no requirement" rather than blocking evolutions. `_select_evolution` drops rows whose move gate is unmet, and **fail-closed**: with an unknown moveset (`None`) gated rows are dropped too, so a move-gated evolution is never offered on missing data. Among eligible rows a *satisfied* move gate outranks the day/night clock — see [the one open question](#the-one-thing-that-needs-a-maintainer-call). `evolution_readiness` folds the gate into `ready` (so the branch that returns a representative row for the UI cannot fail open) and exports `required_move_type` / `gated_alternatives` so `status_text` can say *why*:

```
40 friendship to evolve into Espeon · needs Day · Sylveon needs a Fairy-type move
Needs a Fairy-type move to evolve into Sylveon
Needs to be Female to evolve into Vespiquen
```

**`pokedex_functions.py`** — `check_evolution_for_pokemon` takes `current_attacks=` (move gates evaluate the caller's just-updated moveset; an empty fresh list is authoritative and never silently replaced by stale stored data) and `gender=`. `check_evolution_by_item` takes `gender=`. Both enforce the CSV `gender_id` gate through one shared helper, `gender_allows_evolution` / `evolution_gender_allows`, which the web bag picker and the PC readiness path also use — so the automatic path, the manual button and the picker cannot drift apart. Cloak/form ids (`>= 10000`, e.g. Wormadam-Sandy) resolve to their base species first, per the repo tripwire. `filter_gender_split_forms` adds the second gender source for the form-modelled splits (Espurr, Lechonk); it narrows siblings only and can never empty the candidate list. Duplicate `rows_for_key_in_table` removed.

**Ordering and plumbing** — `save_main_pokemon_progress` runs the level-evolution check **after** the level-up attack merge (#706's reorder), so learning Mimic at a level triggers Bonsly→Sudowoodo on *that* event. `trainer_functions.py`'s XP-share path passes its live state into both checkers. `pokemon_details.py` passes `gender` so the details panel enforces what the grid does.

**Review-path cost** — the gender lookup would otherwise re-parse the ~500-row CSV on every eligible candidate on every level-up, against AGENTS.md's "no synchronous disk I/O in the review path". `pokemon_evolution.csv` is now indexed by `evolved_species_id` once at startup (`evolution_rows_for_evolved_species`, a drop-in for `rows_for_key_in_table` on that column — there is a test sweeping all ~479 species and both key types to prove it), with an `lru_cache` over the scan. `test_evolution_row_gender_id_opens_no_file_once_initialised` pins **zero file opens** across a spread of distinct keys. The victory-time checker also takes `attacks=` / `pokemon_defeated=` from state callers already hold, so it does no synchronous DB read on a no-level-up defeat.

### Headless / Qt safety

Constructing a `QWidget` with no `QApplication` makes Qt call `abort()` — a process death, not a catchable exception — so the `try/except Exception` wrappers used as the "headless is fine" guard do not contain it. They were written against *"PyQt6 is not installed"* and do not cover *"PyQt6 is installed but nothing created an application"*, which is the shape of a dev box running the Tier-1 harness.

- **`InfoLogger.py`** — `log_and_showinfo` is on the review path (`save_main_pokemon_progress` calls it whenever a level-up move must be replaced), so this killed any headless play-through that got that far.
- **`error_handler.py`** — `show_warning_with_traceback` is the funnel every `except Exception:` in the add-on reaches, so it turned any *recoverable* error into a force-close, exactly inverting the module's purpose.
- **`download_sprites.py`**, **`ankimon_shop.py`** — the daily-item pool was built at module scope, so merely importing it scanned the sprite directory and could pop the download-agreement dialog; `singletons` imports that module and `battle_loop` imports `singletons` from inside `on_review_card`. Now built on first use.
- All three guards test `isinstance(QApplication.instance(), QApplication)`, not `is not None`: `instance()` is inherited from `QCoreApplication` and hands back whatever application exists, so a console-only `QCoreApplication` reads as non-`None` and a `QWidget` built after it aborts anyway.

### Web bag

`shop_obj.py` applies the gender gate in the picker's eligibility pass (`shop.js` filters to `e === 1`, so without it the player was shown the one candidate the actual use would refuse), and `Check_Evo_Item` now gates on the **selected** Pokémon's gender rather than the active battle Pokémon's. `shop.js` gains a third empty state — the eligibility filter can empty the list with the search box untouched, and blaming a search the player never typed reads as a broken picker rather than an answer.

`shop_obj.py`, `item_window.py`, `download_sprites.py` and `trainer_functions.py` carry sizeable `ruff format` reflow of pre-existing code (the CI format job checks every file a PR touches). The reflow is isolated into its own commit where practical: `fb91a90d` is a `ruff format` pass with no logic change (its only token-level differences are wrapping parentheses and magic trailing commas).

## The one thing that needs a maintainer call

**Sylveon semantics.** Because a satisfied move gate outranks the day/night clock, an Eevee that knows a Fairy move becomes **Sylveon-only** — Espeon and Umbreon unreachable at any hour. Wild movesets are `random.sample(level-legal learnset, 4)`, and Eevee's own learnset carries Baby-Doll Eyes (L15) and Charm (L50), so this is not rare. Exact probabilities from the bundled data:

| Eevee obtained at level | legal moves | Fairy among them | P(Sylveon forced) |
|---|---|---|---|
| 5 | 6 | 0 | 0.0% |
| 15 | 8 | 1 | **50.0%** |
| 25 | 10 | 1 | **40.0%** |
| 40 | 13 | 1 | **30.8%** |
| 50+ | 15–16 | 2 | **45–48%** |

Before this PR Sylveon was 0% reachable; after it, it is *forced* for roughly a third to a half of Eevee.

There is **no sort order that satisfies both sides**: Sylveon's CSV row is blank-time while Espeon (day) and Umbreon (night) cover the whole clock, so the moment the move gate stops outranking time-of-day, Sylveon loses every comparison and reverts to 0% reachable. The real options are **(a)** ship canon as implemented, or **(b)** prompt the player when more than one friendship evolution qualifies — the only way to keep all three reachable. This PR implements (a); (b) is a larger change and belongs in its own PR. It is recoverable either way via the PC-box move editor, and the status line names the gate during the whole friendship climb.

## Player-visible changes worth a release note

The gender gates **remove evolutions that previously worked** on existing saves:

- male Combee → Vespiquen, male Salandit → Salazzle (both species are 87.5% male, so these get markedly rarer)
- female Kirlia → Gallade, male Snorunt → Froslass

All four are canon-correct and intended, but they are a silent takeaway mid-save. Conversely Mothim, Meowstic-F, Oinkologne-F and Sylveon become reachable for the first time.

A Pokémon whose save has no stored gender, or `"Genderless"`, keeps the historical no-check behaviour — the gate is only enforced on a recognised `"M"`/`"F"`.

## Do not re-apply this "optimization"

The victory-time friendship check falls back to `services.db.get_pokemon()` for whichever of `attacks` / `pokemon_defeated` the caller leaves `None`. Replacing that with the in-memory `main_pokemon.attacks` removes 42 of 49 DB reads over 400 answers — and is **wrong**. The level-up merge writes the learned move to `mainpkmndata` (the DB dict) only; nothing assigns back to the `PokemonObject`, and `update_main_pokemon()` runs only at boot, on an evolution, or from the profile/shop screens. Measured: an Eevee that learns Baby-Doll Eyes at L15 still reports `['tackle', 'growl']` in memory against `['tackle', 'growl', 'babydolleyes', 'swift']` in the DB, **1,200 answers later**. Feeding that to the move gate stops offering Sylveon to an Eevee that *has* learned a Fairy move, and flip-flops, because the rarer level-up defeats still pass a fresh list. `9a54562f` reverts it and `test_victory_path_move_gate_sees_moves_learned_at_level_up` pins the behaviour.

**Follow-up worth its own PR:** that in-memory/DB divergence is a real bug beyond this gate — the battle engine reads `self.attacks` via `to_engine_format`, so a move learned at level-up appears unusable until the profile is reopened. Out of scope here (battle behaviour, not evolution gating).

## Test plan

- [x] **All 7 GitHub Actions checks green** on head `f365f285` (Tier 1, Tier 2, Tier 2 WebEngine, integrity, ruff, check-profile, private-emails). *CodeRabbit reports "pass" but its status is "Review rate limited" — it has not reviewed this head.*
- [x] Suite **913 passed / 85 skipped**, identical across two consecutive runs on a frozen tree (baseline on `main`, same box: 764 / 105). Local box is Python 3.12 + PyQt6 offscreen; Qt-gated skip counts differ from a GUI runner.
- [x] Tier-1 harness (`python3 harness/check.py`) **PASS — 9/9**.
- [x] `ruff check` and `ruff format --check --config ci_ruff_check.toml` clean on every touched file.

New coverage, all against the **real bundled data**:

| File | Tests | Covers |
|---|---|---|
| `test_evolution_gender_gate.py` | 40 (new) | Kirlia/Snorunt + Dawn Stone both ways, Combee/Salandit/Burmy level gating incl. cloak forms, Espurr/Lechonk form splits, junk-gender degradation, trigger scoping, index-vs-CSV equivalence over all ~479 species, zero-file-open pinning, cache invalidation |
| `test_friendship_evolution.py` | +47 | the Fairy gate end to end, Sylveon only with a Fairy move, move gate beating time-of-day, fail-closed on a missing moveset, gate visibility in `status_text`, manual-vs-automatic agreement |
| `test_move_evo_timing.py` | 5 (new) | real Bonsly(438)→Sudowoodo(185) same-level triggering, DB fallback, empty-list-is-authoritative, everstone/rejection still blocking |
| `test_headless_qt_guards.py` | 13 (new) | no widget without a `QApplication`, `QCoreApplication`-only processes, events still emitted when the dialog is skipped, `isolated_modules` isolation |
| `test_shop_pool_lazy.py` | 5 (new) | no directory scan or dialog at import time |
| `test_web_bag_trade_evolutions.py` | +8 | picker agrees with `check_evolution_by_item` on gender, and these 13 tests now actually **run** headlessly (they had been silently skipping) |
| `test_encounter_functions.py` | +5 | victory-path moveset seeding and its identity guard |

The last commit (`f365f285`) closes five findings from a review pass over the branch; each carries a regression test verified to **fail** against the previous head `57f7429e`. It also folds four hand-copied gender-gate blocks into one helper — verified behaviour-preserving by a sweep of **19,522 verdicts** across every species, gender, trigger scope and evolution item in the bundled data: zero differences.

## Not verified here

Tier 2 with **real Qt windows** on a local box — CI's Tier-2 and Tier-2-WebEngine jobs are green, and the `Check_Evo_Item` / picker changes are exercised directly, but not click-through. One manual Dawn-Stone-on-a-female-Kirlia click before release would close it. Pixels, CSS and felt latency on real hardware are out of scope for the harness.
