### PR TITLE
fix: prevent white space in team rotation dropdown

### DIFF
--- a/src/Ankimon/ankimon_profile_web/profile.css
+++ b/src/Ankimon/ankimon_profile_web/profile.css
@@ -4,6 +4,7 @@
  * independent module (no cross-import of the Items shell's CSS). */
 
 :root {
+    color-scheme: dark;
     --bg-darker: #080a0c;
     --bg-dark: #0d1117;
     --bg-card: #161b22;
@@ -383,6 +384,10 @@ body {
     background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 12 12'%3E%3Cpath fill='%238b949e' d='M2 4.5l4 4 4-4'/%3E%3C/svg%3E");
     background-repeat: no-repeat;
     background-position: right 12px center;
+}
+.cycle-select option {
+    background: var(--bg-card);
+    color: var(--text-main);
 }
 .cycle-select:hover {
     border-color: var(--accent-blue);


### PR DESCRIPTION
Fixes a visual bug in the Team Selection UI where clicking the "team rotation" `<select>` menu would sometimes show empty white space.

This happens because standard `<select>` dropdowns can fall back to the operating system's default light theme in some WebEngine/WebKit implementations.

This PR adds `color-scheme: dark;` to `:root` to instruct the browser to use dark native UI controls and adds explicit text/background colors to `.cycle-select option` elements to ensure the list renders properly.

---
*PR created automatically by Jules for task [11610638325266299615](https://jules.google.com/task/11610638325266299615) started by @h0tp-ftw*