### PR TITLE
Fix discord on linux

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -251,6 +251,17 @@
       ],
       "nickname": "slager",
       "discord_id": "955178102097600622"
+    },
+    {
+      "login": "JadonKJones",
+      "name": "JadonKJones",
+      "avatar_url": "https://github.com/JadonKJones.png",
+      "profile": "https://github.com/JadonKJones",
+      "contributions": [
+        "code"
+      ],
+      "nickname": "sakamotosan",
+      "discord_id": "1404969660931379230"
     }
   ],
   "contributorsPerLine": 5

--- a/src/Ankimon/addon_files/lib/pypresence/utils.py
+++ b/src/Ankimon/addon_files/lib/pypresence/utils.py
@@ -41,7 +41,13 @@ def get_ipc_path(pipe=None):
 
     if sys.platform in ('linux', 'darwin'):
         tempdir = os.environ.get('XDG_RUNTIME_DIR') or (f"/run/user/{os.getuid()}" if os.path.exists(f"/run/user/{os.getuid()}") else tempfile.gettempdir())
-        paths = ['.', 'snap.discord', 'app/com.discordapp.Discord', 'app/com.discordapp.DiscordCanary']
+        paths = [
+            '.',
+            'snap.discord',
+            'app/com.discordapp.Discord',
+            'app/com.discordapp.DiscordCanary',
+            '.flatpak/dev.vencord.Vesktop/xdg-run',
+        ]
     elif sys.platform == 'win32':
         tempdir = r'\\?\pipe'
         paths = ['.']

--- a/src/Ankimon/ankimon_items_web/shop_obj.py
+++ b/src/Ankimon/ankimon_items_web/shop_obj.py
@@ -199,8 +199,8 @@ class TeamBridge(QObject):
         return self._w.profile_data.get_member_stats(individual_id)
 
     # JSON string in (PyQt QVariant-list unwrap is unreliable on first call).
-    @pyqtSlot(str, str, str, result="QVariant")
-    def saveTeam(self, team_json, xp_share_json, companion_id):
+    @pyqtSlot(str, str, str, bool, result="QVariant")
+    def saveTeam(self, team_json, xp_share_json, companion_id, xp_share_full_team):
         try:
             team_ids = json.loads(team_json) if team_json else []
             if not isinstance(team_ids, list):
@@ -213,7 +213,9 @@ class TeamBridge(QObject):
                 raise ValueError("xp_share payload must be a list")
         except (TypeError, ValueError) as e:
             return {"ok": False, "message": f"Invalid XP Share payload: {e}"}
-        return self._w.profile_data.handle_save_team(team_ids, xp_share_ids, companion_id or None)
+        return self._w.profile_data.handle_save_team(
+            team_ids, xp_share_ids, companion_id or None, bool(xp_share_full_team)
+        )
 
 
 class SettingsBridge(QObject):

--- a/src/Ankimon/ankimon_items_web/shop_obj.py
+++ b/src/Ankimon/ankimon_items_web/shop_obj.py
@@ -200,14 +200,20 @@ class TeamBridge(QObject):
 
     # JSON string in (PyQt QVariant-list unwrap is unreliable on first call).
     @pyqtSlot(str, str, str, result="QVariant")
-    def saveTeam(self, team_json, xp_share_id, companion_id):
+    def saveTeam(self, team_json, xp_share_json, companion_id):
         try:
             team_ids = json.loads(team_json) if team_json else []
             if not isinstance(team_ids, list):
                 raise ValueError("team payload must be a list")
         except (TypeError, ValueError) as e:
             return {"ok": False, "message": f"Invalid team payload: {e}"}
-        return self._w.profile_data.handle_save_team(team_ids, xp_share_id or None, companion_id or None)
+        try:
+            xp_share_ids = json.loads(xp_share_json) if xp_share_json else []
+            if not isinstance(xp_share_ids, list):
+                raise ValueError("xp_share payload must be a list")
+        except (TypeError, ValueError) as e:
+            return {"ok": False, "message": f"Invalid XP Share payload: {e}"}
+        return self._w.profile_data.handle_save_team(team_ids, xp_share_ids, companion_id or None)
 
 
 class SettingsBridge(QObject):

--- a/src/Ankimon/ankimon_mobile_web/mobile.css
+++ b/src/Ankimon/ankimon_mobile_web/mobile.css
@@ -397,6 +397,18 @@ body {
   transform: scale(0.98);
 }
 
+.btn:disabled {
+  cursor: not-allowed;
+  opacity: 0.4;
+  filter: grayscale(0.6);
+  transform: none;
+}
+.btn:disabled:hover,
+.btn:disabled:active {
+  filter: grayscale(0.6);
+  transform: none;
+}
+
 .btn-primary {
   background: var(--accent-blue);
   color: #06111f;

--- a/src/Ankimon/ankimon_mobile_web/mobile.js
+++ b/src/Ankimon/ankimon_mobile_web/mobile.js
@@ -710,8 +710,17 @@ function renderReplayBattle(result) {
     enemySprite.className = 'battle-sprite enemy-battle-sprite'; // remove caught/fainted fade classes
 
     const playerSprite = document.getElementById('replay-player-sprite');
-    if (playerSprite && result.companion_sprite) {
-        playerSprite.src = result.companion_sprite;
+    if (playerSprite) {
+        if (result.companion_sprite) {
+            playerSprite.src = result.companion_sprite;
+        }
+        // Remove any leftover 'fainted-fade' from a PREVIOUS lost battle —
+        // that class's animation ends with opacity:0 (forwards-filled), so
+        // without this reset the companion sprite stays invisible for every
+        // battle after the first loss, even though the fight itself
+        // continues normally (narration, HP bars, attacks all still work —
+        // only the sprite is gone).
+        playerSprite.className = 'battle-sprite player-battle-sprite';
     }
 
     document.getElementById('replay-enemy-name').textContent = result.enemy_name || '???';

--- a/src/Ankimon/ankimon_profile_web/profile.css
+++ b/src/Ankimon/ankimon_profile_web/profile.css
@@ -372,6 +372,21 @@ body {
     font-size: 0.66rem; text-transform: uppercase; letter-spacing: 0.6px;
     color: var(--text-muted); font-weight: 700; margin-bottom: 9px;
 }
+.ts-section-title-row {
+    display: flex; align-items: center; justify-content: space-between;
+    gap: 8px; margin-bottom: 9px;
+}
+.ts-section-title-row .ts-section-title { margin-bottom: 0; }
+.xps-fullteam-toggle {
+    font-size: 0.62rem; font-weight: 800; text-transform: uppercase; letter-spacing: 0.4px;
+    padding: 4px 9px; border-radius: 999px;
+    background: var(--bg-card); border: 1px solid var(--border-main);
+    color: var(--text-muted); cursor: pointer; transition: var(--transition-fast);
+}
+.xps-fullteam-toggle:hover { border-color: var(--accent-blue); color: var(--text-bright); }
+.xps-fullteam-toggle.on {
+    background: rgba(88, 166, 255, 0.16); border-color: var(--accent-blue); color: var(--accent-blue);
+}
 /* Fill the column's height: summary pinned top, the type-analysis block grows
    to fill, XP Share sits just above Save. Rather than stretch the gaps between
    sections, the chips THEMSELVES scale with viewport height (see
@@ -458,6 +473,11 @@ body {
     padding: 13px; border-radius: 12px; cursor: pointer; transition: var(--transition-fast);
 }
 .xps-empty:hover { border-color: var(--accent-gold); color: var(--text-bright); }
+.xps-fullteam-note {
+    width: 100%; background: rgba(88, 166, 255, 0.1); border: 1px dashed var(--accent-blue);
+    color: var(--text-muted); font-size: 0.78rem; font-weight: 600; line-height: 1.4;
+    padding: 13px; border-radius: 12px; text-align: center;
+}
 /* Sidebar chips fill the column on tall screens by growing VERTICALLY — taller
    pills (scaled top/bottom padding) + bigger row gaps — while font size and
    horizontal padding stay fixed so the wrapping (chips-per-row) never changes.

--- a/src/Ankimon/ankimon_profile_web/profile.css
+++ b/src/Ankimon/ankimon_profile_web/profile.css
@@ -252,6 +252,14 @@ body {
     border-color: rgba(210, 153, 34, 0.6);
     box-shadow: 0 0 0 1px rgba(210, 153, 34, 0.45) inset;
 }
+.slot.companion {
+    border-color: rgba(88, 166, 255, 0.6);
+    box-shadow: 0 0 0 1px rgba(88, 166, 255, 0.45) inset;
+}
+/* Both badges active: blend the two accent colors into one ring. */
+.slot.companion.xp-share {
+    box-shadow: 0 0 0 1px rgba(210, 153, 34, 0.45) inset, 0 0 0 3px rgba(88, 166, 255, 0.3) inset;
+}
 
 .slot-num { position: absolute; top: 10px; left: 12px; font-size: 0.66rem; font-weight: 700; color: var(--text-muted); }
 .slot-rotation-badge {
@@ -279,12 +287,23 @@ body {
 .slot-remove { right: 8px; }
 .slot-remove:hover { color: var(--accent-red); border-color: rgba(248, 81, 73, 0.5); }
 .slot-star { right: 40px; }
-/* The active XP-Share star stays visible even when the slot isn't hovered. With
-   the ✕ hidden, park it in the top-right corner (where the ✕ would sit) so it
-   doesn't look stranded; it slides back beside the ✕ once the slot is hovered. */
-.slot-star.on { color: var(--accent-gold); border-color: rgba(210, 153, 34, 0.6); background: rgba(210, 153, 34, 0.14); opacity: 1; pointer-events: auto; right: 8px; }
-.slot.filled:hover .slot-star.on,
-.slot.filled:focus-within .slot-star.on { right: 40px; }
+.slot-crown { right: 72px; }
+/* Active badges (XP-Share star, Companion crown) stay visible even when the
+   slot isn't hovered, each parked in its own corner so they never collide:
+   crown (the more consequential pick — who actually battles) takes the
+   prominent top-right spot the ✕ would use; star parks one slot in. Both
+   slide out to their normal hover positions once the slot is hovered. */
+.slot-star.on { color: var(--accent-gold); border-color: rgba(210, 153, 34, 0.6); background: rgba(210, 153, 34, 0.14); opacity: 1; pointer-events: auto; right: 40px; }
+.slot-crown.on { color: var(--accent-blue); border-color: rgba(88, 166, 255, 0.6); background: rgba(88, 166, 255, 0.14); opacity: 1; pointer-events: auto; right: 8px; }
+.slot.filled:hover .slot-crown.on,
+.slot.filled:focus-within .slot-crown.on { right: 72px; }
+.slot-companion-badge {
+    margin-left: 5px;
+    font-size: 0.8rem;
+    color: var(--accent-blue);
+    vertical-align: middle;
+    cursor: help;
+}
 
 .slot-sprite-wrap {
     flex: 1 1 auto; min-height: 80px; max-height: 148px; width: 100%;
@@ -393,10 +412,13 @@ body {
     box-shadow: 0 0 0 2px rgba(88, 166, 255, 0.15);
 }
 
-/* XP Share holder — a gold-tinted mini-card with the holder's sprite. */
+/* XP Share holder — one or more gold-tinted mini-cards, each with the
+   holder's sprite. Multiple targets wrap onto their own rows. */
+.xpshare-holder {
+    display: flex; flex-direction: column; gap: 10px;
+}
 /* Vertical, whole-card-pressable (like a team slot): the sprite sits directly on
-   the card (no inner frame), the name shows in full, and "Change" is a
-   hover-revealed hint at the bottom. */
+   the card (no inner frame), the name shows in full, and a ✕ button removes it. */
 .xps-card {
     position: relative;
     display: flex; flex-direction: column; align-items: center; text-align: center;
@@ -421,16 +443,15 @@ body {
     line-height: 1.2; word-break: break-word;
 }
 .xps-lv { font-size: 0.74rem; color: var(--accent-gold); font-weight: 700; margin-top: 3px; }
-.xps-change-hint {
-    position: absolute; left: 0; right: 0; bottom: 0;
-    padding: 7px; text-align: center;
-    font-size: 0.66rem; font-weight: 800; color: var(--accent-gold);
-    text-transform: uppercase; letter-spacing: 0.4px;
-    background: linear-gradient(to top, var(--bg-darker), transparent);
-    border-radius: 0 0 12px 12px;
-    opacity: 0; transition: opacity 0.15s; pointer-events: none;
+.xps-remove {
+    position: absolute; top: 6px; right: 6px;
+    width: 20px; height: 20px; border-radius: 50%;
+    display: flex; align-items: center; justify-content: center;
+    background: var(--bg-darker); border: 1px solid var(--border-main);
+    color: var(--text-muted); font-size: 0.72rem; line-height: 1; cursor: pointer;
+    transition: var(--transition-fast);
 }
-.xps-card:hover .xps-change-hint { opacity: 1; }
+.xps-remove:hover { border-color: var(--accent-red, #f85149); color: var(--accent-red, #f85149); }
 .xps-empty {
     width: 100%; background: var(--bg-card); border: 1px dashed var(--border-main);
     color: var(--text-muted); font-family: inherit; font-size: 0.82rem; font-weight: 700;

--- a/src/Ankimon/ankimon_profile_web/profile_data.py
+++ b/src/Ankimon/ankimon_profile_web/profile_data.py
@@ -618,6 +618,7 @@ class ProfileData:
                 xp_share_ids = [str(raw_xp_share)]
             else:
                 xp_share_ids = []
+            xp_share_full_team = bool(self.settings_obj.get("trainer.xp_share_full_team"))
             cycle_count = self.settings_obj.get("controls.team_cycle_count", 3)
             sprite_mode = self.settings_obj.get(
                 "ankidex.spriteMode",
@@ -625,6 +626,7 @@ class ProfileData:
             )
         except Exception:
             xp_share_ids = []
+            xp_share_full_team = False
             cycle_count = 3
             sprite_mode = "static"
 
@@ -644,6 +646,7 @@ class ProfileData:
                     self._resolve_stub(ind_id, members) for ind_id in xp_share_ids
                 ) if stub
             ],
+            "xp_share_full_team": xp_share_full_team,
             "companion": str(companion_id) if companion_id else None,
             "companion_info": self._resolve_stub(companion_id, members) if companion_id else None,
             "sprite_mode": sprite_mode,
@@ -762,13 +765,19 @@ class ProfileData:
             print(f"[Ankimon] profile: CP calc failed for {individual_id}: {e}")
             return 0
 
-    def handle_save_team(self, team_ids, xp_share_ids, companion_id):
+    def handle_save_team(self, team_ids, xp_share_ids, companion_id, xp_share_full_team=False):
         """Persist the chosen team + XP Share holders.
 
         ``xp_share_ids`` is a list of individual_ids (0 or more) — the XP
         earned per defeat is split evenly across however many are set, on top
         of the main Pokémon's own half (see functions.trainer_functions.
         xp_share_gain_exp).
+
+        ``xp_share_full_team``: the mainline Gen-6+ style toggle — when on,
+        every current team member shares XP and the individual picks in
+        ``xp_share_ids`` are ignored at read time (see
+        functions.trainer_functions.resolve_xp_share_targets). Still stored
+        here either way, so turning the toggle back off restores your picks.
 
         ``companion_id`` is the Active Companion — whichever team member should
         actually be the one battling (``is_main=1`` in the DB). team.js's ⚔
@@ -805,6 +814,7 @@ class ProfileData:
             # (services.db.save_team) is the sole source of truth every read path
             # uses; settings.py migrates/deletes the old config key on load.
             self.settings_obj.set("trainer.xp_share", clean_xp_share_ids)
+            self.settings_obj.set("trainer.xp_share_full_team", bool(xp_share_full_team))
             services.db.save_team(team_data)
             if companion_id:
                 services.db.set_main_pokemon(companion_id)

--- a/src/Ankimon/ankimon_profile_web/profile_data.py
+++ b/src/Ankimon/ankimon_profile_web/profile_data.py
@@ -609,21 +609,28 @@ class ProfileData:
             m["cp"] = self._calc_cp(m["id"])
 
         try:
-            xp_share = self.settings_obj.get("trainer.xp_share") or None
+            raw_xp_share = self.settings_obj.get("trainer.xp_share")
+            # Legacy saves stored a single bare id; normalize to a list here so
+            # every reader (this method, the JS UI) only ever deals with lists.
+            if isinstance(raw_xp_share, list):
+                xp_share_ids = [str(x) for x in raw_xp_share if x]
+            elif raw_xp_share:
+                xp_share_ids = [str(raw_xp_share)]
+            else:
+                xp_share_ids = []
             cycle_count = self.settings_obj.get("controls.team_cycle_count", 3)
             sprite_mode = self.settings_obj.get(
                 "ankidex.spriteMode",
                 self.settings_obj.get("pokedex_v2.spriteMode", "static")
             )
         except Exception:
-            xp_share = None
+            xp_share_ids = []
             cycle_count = 3
             sprite_mode = "static"
 
-        # companion/companion_info expose the current main Pokémon as a ready
-        # read-seam for the deferred Active Companion picker (team.js does not
-        # render them yet — see handle_save_team). Kept so that UI can wire in
-        # without a Python change.
+        # companion/companion_info: the current main Pokémon (is_main=1 in the
+        # DB) — team.js renders this as the ⚔ badge and lets it be changed via
+        # handle_save_team's companion_id.
         db = services.db
         main_pkmn = db.get_main_pokemon() if db else None
         companion_id = main_pkmn.get("individual_id") if main_pkmn else None
@@ -631,8 +638,12 @@ class ProfileData:
         return {
             "max_size": MAX_TEAM_SIZE,
             "team": members,
-            "xp_share": str(xp_share) if xp_share else None,
-            "xp_share_info": self._resolve_stub(xp_share, members) if xp_share else None,
+            "xp_share": xp_share_ids,
+            "xp_share_info": [
+                stub for stub in (
+                    self._resolve_stub(ind_id, members) for ind_id in xp_share_ids
+                ) if stub
+            ],
             "companion": str(companion_id) if companion_id else None,
             "companion_info": self._resolve_stub(companion_id, members) if companion_id else None,
             "sprite_mode": sprite_mode,
@@ -751,14 +762,20 @@ class ProfileData:
             print(f"[Ankimon] profile: CP calc failed for {individual_id}: {e}")
             return 0
 
-    def handle_save_team(self, team_ids, xp_share_id, companion_id):
-        """Persist the chosen team + XP Share holder.
+    def handle_save_team(self, team_ids, xp_share_ids, companion_id):
+        """Persist the chosen team + XP Share holders.
 
-        ``companion_id`` (Active Companion / main-Pokémon override) is a ready
-        write-seam, but NO shipped UI populates it yet — the Team screen's
-        companion picker is deferred (team.js sends ''), so the set_main_pokemon
-        branch below is inert until that UI lands. Do not describe Active
-        Companion as a working feature."""
+        ``xp_share_ids`` is a list of individual_ids (0 or more) — the XP
+        earned per defeat is split evenly across however many are set, on top
+        of the main Pokémon's own half (see functions.trainer_functions.
+        xp_share_gain_exp).
+
+        ``companion_id`` is the Active Companion — whichever team member should
+        actually be the one battling (``is_main=1`` in the DB). team.js's ⚔
+        button on a team slot sets/clears it; '' means "no change" (most saves
+        don't touch it). Setting it here reloads the live ``main_pokemon``
+        object from the DB and repaints the reviewer HUD + Ankimon Window so
+        the swap is visible immediately."""
         seen = set()
         clean_ids = []
         for raw in team_ids or []:
@@ -771,19 +788,47 @@ class ProfileData:
                 break
 
         team_data = [{"individual_id": ind_id} for ind_id in clean_ids]
-        xp_share_id = str(xp_share_id) if xp_share_id else None
+
+        xp_seen = set()
+        clean_xp_share_ids = []
+        for raw in xp_share_ids or []:
+            ind_id = str(raw) if raw is not None else ""
+            if not ind_id or ind_id in xp_seen:
+                continue
+            xp_seen.add(ind_id)
+            clean_xp_share_ids.append(ind_id)
+
         companion_id = str(companion_id) if companion_id else None
 
         try:
             # NOTE: no legacy "trainer.team" config write — the DB team table
             # (services.db.save_team) is the sole source of truth every read path
             # uses; settings.py migrates/deletes the old config key on load.
-            self.settings_obj.set("trainer.xp_share", xp_share_id)
+            self.settings_obj.set("trainer.xp_share", clean_xp_share_ids)
             services.db.save_team(team_data)
             if companion_id:
                 services.db.set_main_pokemon(companion_id)
                 from ..functions.update_main_pokemon import update_main_pokemon
+
                 update_main_pokemon(services.main_pokemon)
+                # Repaint the reviewer HUD + the Ankimon Window popup so the
+                # switch is visible immediately, not just after the next
+                # battle turn (same seam cycle_team_pokemon() in reviewer_ui.py
+                # uses for its own companion swap).
+                try:
+                    if services.reviewer is not None:
+                        services.reviewer.refresh_hud()
+                except Exception:
+                    pass
+                try:
+                    test_window = services.test_window
+                    if test_window is not None and test_window.isVisible():
+                        test_window.main_pokemon = services.main_pokemon
+                        if test_window.current_view == "battle":
+                            test_window._last_display_time = 0
+                            test_window.display_battle()
+                except Exception:
+                    pass
         except Exception as e:
             return {"ok": False, "message": f"Failed to save team: {e}"}
 

--- a/src/Ankimon/ankimon_profile_web/team.html
+++ b/src/Ankimon/ankimon_profile_web/team.html
@@ -79,7 +79,13 @@
                     <div class="ts-tile hero"><div class="tv" id="ts-cp">—</div><div class="tk">Total CP</div></div>
                 </div>
                 <div class="ts-section ts-xpshare">
-                    <div class="ts-section-title">XP Share</div>
+                    <div class="ts-section-title-row">
+                        <div class="ts-section-title">XP Share</div>
+                        <button id="xpshare-fullteam-toggle" class="xps-fullteam-toggle" type="button"
+                                title="Mainline Gen 6+ style: the whole team shares XP instead of picked targets">
+                            Whole Team
+                        </button>
+                    </div>
                     <div class="xpshare-holder" id="xpshare-holder"></div>
                 </div>
 

--- a/src/Ankimon/ankimon_profile_web/team.js
+++ b/src/Ankimon/ankimon_profile_web/team.js
@@ -13,8 +13,9 @@
 
     const state = {
         team: [null, null, null, null, null, null],
-        xpShare: null,         // individual_id of the XP Share holder (any owned Pokémon)
-        xpShareInfo: null,     // display stub for the holder (may be benched)
+        xpShareIds: [],        // individual_ids of every XP Share holder (any owned Pokémon)
+        xpShareInfos: [],      // display stubs for the holders (may be benched), same order as xpShareIds
+        companionId: null,     // individual_id of the Active Companion (must be a team slot member)
         maxSize: 6,
         teamCycleCount: 3,     // limit for hotkey 9 rotation
         roster: null,          // null = not loaded yet
@@ -164,18 +165,22 @@
         for (let i = 0; i < state.maxSize; i++) {
             const m = state.team[i];
             const slot = document.createElement('div');
-            const isXp = !!(m && state.xpShare && String(m.id) === String(state.xpShare));
-            slot.className = 'slot ' + (m ? 'filled' : 'empty') + (isXp ? ' xp-share' : '');
+            const isXp = !!(m && state.xpShareIds.some((id) => String(id) === String(m.id)));
+            const isCompanion = !!(m && state.companionId && String(m.id) === String(state.companionId));
+            slot.className = 'slot ' + (m ? 'filled' : 'empty') + (isXp ? ' xp-share' : '') + (isCompanion ? ' companion' : '');
 
             if (m) {
                 const cp = (m.cp === undefined || m.cp === null) ? '—' : num(m.cp);
                 const types = (m.types || []).map(typeBadge).join('');
                 const hasCycle = state.teamCycleCount > 1 && i < state.teamCycleCount;
                 const cycleBadge = hasCycle ? '<span class="slot-rotation-badge" title="Cycled via Hotkey 9">↻</span>' : '';
+                const companionBadge = isCompanion ? '<span class="slot-companion-badge" title="Active Companion">⚔</span>' : '';
 
                 slot.title = 'Click to switch';
                 slot.innerHTML = `
-                    <span class="slot-num">${i + 1}${cycleBadge}</span>
+                    <span class="slot-num">${i + 1}${cycleBadge}${companionBadge}</span>
+                    <button class="slot-corner slot-crown${isCompanion ? ' on' : ''}" data-act="companion" data-slot="${i}"
+                            title="${isCompanion ? 'Active Companion (battling now)' : 'Set as Active Companion'}">⚔</button>
                     <button class="slot-corner slot-star${isXp ? ' on' : ''}" data-act="xp" data-slot="${i}"
                             title="${isXp ? 'Remove XP Share' : 'Set as XP Share'}">★</button>
                     <button class="slot-corner slot-remove" data-act="remove" data-slot="${i}" title="Remove">✕</button>
@@ -201,13 +206,14 @@
         }
         grid.replaceChildren(frag);
 
-        // Corner buttons (★ XP Share, ✕ remove) override the card's click-to-switch.
+        // Corner buttons (⚔ Companion, ★ XP Share, ✕ remove) override the card's click-to-switch.
         grid.querySelectorAll('[data-act]').forEach((btn) => {
             const i = Number(btn.dataset.slot);
             btn.addEventListener('click', (e) => {
                 e.stopPropagation();
                 if (btn.dataset.act === 'remove') removeSlot(i);
                 else if (btn.dataset.act === 'xp') toggleXp(i);
+                else if (btn.dataset.act === 'companion') toggleCompanion(i);
             });
         });
 
@@ -218,8 +224,21 @@
     function toggleXp(slot) {
         const m = state.team[slot];
         if (!m) return;
-        if (state.xpShare && String(m.id) === String(state.xpShare)) setXpShare(null);
-        else setXpShare(m);
+        if (state.xpShareIds.some((id) => String(id) === String(m.id))) removeXpShare(m.id);
+        else addXpShare(m);
+    }
+
+    // ---------------- Active Companion ----------------
+    // Unlike XP Share, the companion must be an actual team member (it's who
+    // battles), so this only ever operates on a filled team slot — no
+    // separate roster picker needed. There's always exactly one, or none.
+    function toggleCompanion(slot) {
+        const m = state.team[slot];
+        if (!m) return;
+        const id = String(m.id);
+        state.companionId = (state.companionId === id) ? null : id;
+        markDirty();
+        renderTeam();
     }
 
     // Sidebar team overview: filled count, average level, total CP, type coverage.
@@ -242,30 +261,43 @@
         renderTypeCounts('resistances', teamDefense(filled, (mult) => mult < 1), 'Add Pokémon to see resistances');
     }
 
+    function resolveXpShareMember(id) {
+        // A holder may be benched, so prefer its resolved stub; fall back to a
+        // team member if it happens to be on the team.
+        const info = state.xpShareInfos.find((s) => s && String(s.id) === String(id));
+        if (info) return info;
+        return state.team.find((p) => p && String(p.id) === String(id)) || null;
+    }
+
     function renderXpShare() {
         const holder = document.getElementById('xpshare-holder');
         if (!holder) return;
-        // The holder may be benched, so prefer the resolved stub; fall back to a
-        // team member if it happens to be on the team.
-        let m = state.xpShareInfo;
-        if (!m && state.xpShare) {
-            m = state.team.find((p) => p && String(p.id) === String(state.xpShare)) || null;
-        }
-        if (m) {
-            holder.innerHTML = `
-                <div class="xps-card" title="Change XP Share">
-                    <img class="xps-sprite" src="${spriteUrl(m)}" alt="${esc(m.n)}"
-                         onerror="if (this.src.indexOf('_gif') !== -1) { this.src = this.src.replace('_gif', '').replace('.gif', '.png'); } else { this.onerror=null; this.src='${FALLBACK}'; }">
-                    <div class="xps-name">${esc(m.n)}${m.s ? ' <span class="shiny-dot">★</span>' : ''}</div>
-                    <div class="xps-lv">★ Lv ${esc(m.l)}</div>
-                    <div class="xps-change-hint">⇄ Change</div>
-                </div>`;
-        } else {
-            holder.innerHTML = '<button class="xps-empty" type="button">+ Set XP Share</button>';
-        }
-        // Whole card is the trigger (like a team slot) — opens the XP Share picker.
-        const trigger = holder.querySelector('.xps-card, .xps-empty');
-        if (trigger) trigger.addEventListener('click', openXpSharePicker);
+        const members = state.xpShareIds.map(resolveXpShareMember).filter(Boolean);
+
+        const cards = members.map((m) => `
+            <div class="xps-card" data-xp-id="${esc(m.id)}" title="Click to remove">
+                <img class="xps-sprite" src="${spriteUrl(m)}" alt="${esc(m.n)}"
+                     onerror="if (this.src.indexOf('_gif') !== -1) { this.src = this.src.replace('_gif', '').replace('.gif', '.png'); } else { this.onerror=null; this.src='${FALLBACK}'; }">
+                <div class="xps-name">${esc(m.n)}${m.s ? ' <span class="shiny-dot">★</span>' : ''}</div>
+                <div class="xps-lv">★ Lv ${esc(m.l)}</div>
+                <button class="xps-remove" type="button" data-xp-remove="${esc(m.id)}" title="Remove">✕</button>
+            </div>`).join('');
+
+        const addBtn = '<button class="xps-empty xps-add" type="button">+ Add XP Share</button>';
+        holder.innerHTML = cards + addBtn;
+
+        holder.querySelectorAll('[data-xp-remove]').forEach((btn) => {
+            btn.addEventListener('click', (e) => {
+                e.stopPropagation();
+                removeXpShare(btn.getAttribute('data-xp-remove'));
+            });
+        });
+        // Clicking the rest of a card also opens the picker (to swap/add more).
+        holder.querySelectorAll('.xps-card').forEach((card) => {
+            card.addEventListener('click', openXpSharePicker);
+        });
+        const addTrigger = holder.querySelector('.xps-add');
+        if (addTrigger) addTrigger.addEventListener('click', openXpSharePicker);
     }
 
 
@@ -274,12 +306,25 @@
     function removeSlot(slot) {
         // XP Share is independent of team membership now — removing a Pokémon
         // from a slot leaves it owned, so we keep it as the XP Share holder.
+        // Active Companion, though, MUST be a team member — clear it if the
+        // Pokémon leaving the slot was the companion.
+        const m = state.team[slot];
+        if (m && state.companionId && String(m.id) === String(state.companionId)) {
+            state.companionId = null;
+        }
         state.team[slot] = null;
         markDirty();
         renderTeam();
     }
 
     function assignSlot(slot, stub) {
+        // Swapping out the slot that held the companion clears it — the new
+        // occupant isn't automatically the companion, and the old one is no
+        // longer a team member.
+        const prev = state.team[slot];
+        if (prev && state.companionId && String(prev.id) === String(state.companionId)) {
+            state.companionId = null;
+        }
         // Copy so editing one slot can't alias another / the roster entry.
         const member = { id: stub.id, p: stub.p, n: stub.n, l: stub.l };
         if (stub.s) member.s = 1;
@@ -303,16 +348,30 @@
     }
 
     // ---------------- XP Share ----------------
-    function setXpShare(stub) {
-        if (stub) {
-            state.xpShare = String(stub.id);
-            state.xpShareInfo = { id: stub.id, p: stub.p, n: stub.n, l: stub.l };
-            if (stub.s) state.xpShareInfo.s = 1;
-            if (stub.sprite) state.xpShareInfo.sprite = stub.sprite;
-        } else {
-            state.xpShare = null;
-            state.xpShareInfo = null;
-        }
+    function addXpShare(stub) {
+        if (!stub) return;
+        const id = String(stub.id);
+        if (state.xpShareIds.some((existing) => String(existing) === id)) return;
+        state.xpShareIds.push(id);
+        const info = { id: stub.id, p: stub.p, n: stub.n, l: stub.l };
+        if (stub.s) info.s = 1;
+        if (stub.sprite) info.sprite = stub.sprite;
+        state.xpShareInfos.push(info);
+        markDirty();
+        renderTeam();
+    }
+
+    function removeXpShare(id) {
+        const idStr = String(id);
+        state.xpShareIds = state.xpShareIds.filter((existing) => String(existing) !== idStr);
+        state.xpShareInfos = state.xpShareInfos.filter((info) => String(info.id) !== idStr);
+        markDirty();
+        renderTeam();
+    }
+
+    function clearXpShare() {
+        state.xpShareIds = [];
+        state.xpShareInfos = [];
         markDirty();
         renderTeam();
     }
@@ -481,20 +540,23 @@
         list.classList.remove('hidden');
 
         const frag = document.createDocumentFragment();
-        // XP Share mode: a "No XP Share" clear card pinned first.
+        // XP Share mode: a "No XP Share" clear-all card pinned first, and
+        // picking targets TOGGLES membership without closing the picker (so
+        // several can be selected in one visit); everything else still
+        // picks-and-closes.
         if (xpMode) {
             const none = document.createElement('div');
-            none.className = 'roster-card' + (!state.xpShare ? ' current' : '');
+            none.className = 'roster-card' + (!state.xpShareIds.length ? ' current' : '');
             none.innerHTML = `
                 <div class="rc-sprite" style="display:flex;align-items:center;justify-content:center;color:var(--text-muted);font-size:1.7rem;">✕</div>
                 <div class="rc-name" style="color:var(--text-muted);">No XP Share</div>`;
-            none.addEventListener('click', () => { setXpShare(null); showPicker(false); });
+            none.addEventListener('click', () => { clearXpShare(); showPicker(false); });
             frag.appendChild(none);
         }
         const CAP = 200;
         choices.slice(0, CAP).forEach((c) => {
             const inTeam = !xpMode && taken.has(String(c.id));
-            const isCurrent = xpMode && String(state.xpShare) === String(c.id);
+            const isCurrent = xpMode && state.xpShareIds.some((id) => String(id) === String(c.id));
             const card = document.createElement('div');
             card.className = 'roster-card' + (inTeam ? ' in-team' : '') + (isCurrent ? ' current' : '');
             const types = (c.types || []).map(typeBadge).join('');
@@ -504,15 +566,17 @@
                 <div class="rc-name">${esc(c.n)}${c.s ? ' <span class="shiny-dot">★</span>' : ''}</div>
                 ${types ? `<div class="rc-types">${types}</div>` : ''}
                 <div class="rc-stats"><span>Lv ${esc(c.l)}</span><span>·</span><span class="rc-cp">${cp}</span><span>CP</span></div>
-                ${inTeam ? '<div class="rc-tag">On team</div>' : (isCurrent ? '<div class="rc-tag">Current</div>' : '')}`;
+                ${inTeam ? '<div class="rc-tag">On team</div>' : (isCurrent ? '<div class="rc-tag">Selected</div>' : '')}`;
             if (!inTeam) {
                 card.addEventListener('click', () => {
                     if (xpMode) {
-                        setXpShare(c);
+                        if (isCurrent) removeXpShare(c.id);
+                        else addXpShare(c);
+                        renderRosterList();   // stay open — reflect the toggle immediately
                     } else {
                         assignSlot(state.pickerSlot, c);
+                        showPicker(false);
                     }
-                    showPicker(false);
                 });
             }
             frag.appendChild(card);
@@ -548,9 +612,7 @@
             updateSaveUI();
             return Promise.resolve({ ok: true });
         }
-        // Third arg is companion_id — always '' (no shipped companion picker; the
-        // Python seam accepts it for when that UI is built).
-        return teamBridge.saveTeam(JSON.stringify(ids), state.xpShare || '', '').then((res) => {
+        return teamBridge.saveTeam(JSON.stringify(ids), JSON.stringify(state.xpShareIds), state.companionId || '').then((res) => {
             if (res && res.ok) {
                 state.dirty = false;
                 updateSaveUI();
@@ -579,8 +641,19 @@
         const team = (data.team || []).slice(0, state.maxSize);
         state.team = [];
         for (let i = 0; i < state.maxSize; i++) state.team.push(team[i] || null);
-        state.xpShare = data.xp_share ? String(data.xp_share) : null;
-        state.xpShareInfo = data.xp_share_info || null;
+        // Back-compat: an old bridge/preview payload may still send a bare
+        // xp_share string (and xp_share_info as a single stub) instead of lists.
+        if (Array.isArray(data.xp_share)) {
+            state.xpShareIds = data.xp_share.map(String);
+        } else {
+            state.xpShareIds = data.xp_share ? [String(data.xp_share)] : [];
+        }
+        if (Array.isArray(data.xp_share_info)) {
+            state.xpShareInfos = data.xp_share_info;
+        } else {
+            state.xpShareInfos = data.xp_share_info ? [data.xp_share_info] : [];
+        }
+        state.companionId = data.companion ? String(data.companion) : null;
         state.spriteMode = data.sprite_mode || 'static';
         state.teamCycleCount = data.team_cycle_count || 3;
 
@@ -688,8 +761,12 @@
             // *after* it for the no-bridge picker to have something to show.
             applyData({
                 max_size: 6,
-                xp_share: '2',
-                xp_share_info: { id: '2', p: 6, n: 'Charizard', l: 52, s: 1 },
+                xp_share: ['2', '4'],
+                xp_share_info: [
+                    { id: '2', p: 6, n: 'Charizard', l: 52, s: 1 },
+                    { id: '4', p: 3, n: 'Venusaur', l: 41 },
+                ],
+                companion: '1',
                 team: [
                     { id: '1', p: 25, n: 'Pikachu', l: 18, cp: 820, types: ['Electric'] },
                     { id: '2', p: 6, n: 'Charizard', l: 52, s: 1, cp: 2410, types: ['Fire', 'Flying'] },

--- a/src/Ankimon/ankimon_profile_web/team.js
+++ b/src/Ankimon/ankimon_profile_web/team.js
@@ -16,6 +16,7 @@
         xpShareIds: [],        // individual_ids of every XP Share holder (any owned Pokémon)
         xpShareInfos: [],      // display stubs for the holders (may be benched), same order as xpShareIds
         companionId: null,     // individual_id of the Active Companion (must be a team slot member)
+        xpShareFullTeam: false, // mainline Gen 6+ style: whole team shares XP instead of picked targets
         maxSize: 6,
         teamCycleCount: 3,     // limit for hotkey 9 rotation
         roster: null,          // null = not loaded yet
@@ -269,9 +270,30 @@
         return state.team.find((p) => p && String(p.id) === String(id)) || null;
     }
 
+    function toggleXpShareFullTeam() {
+        state.xpShareFullTeam = !state.xpShareFullTeam;
+        markDirty();
+        renderXpShare();
+    }
+
     function renderXpShare() {
+        const toggleBtn = document.getElementById('xpshare-fullteam-toggle');
+        if (toggleBtn) {
+            toggleBtn.classList.toggle('on', state.xpShareFullTeam);
+            toggleBtn.textContent = state.xpShareFullTeam ? 'Whole Team ✓' : 'Whole Team';
+        }
+
         const holder = document.getElementById('xpshare-holder');
         if (!holder) return;
+
+        // Mainline Gen 6+ toggle wins: individual picks are stored but
+        // ignored while this is on (see resolve_xp_share_targets), so the
+        // picker is paused rather than shown as if it still mattered.
+        if (state.xpShareFullTeam) {
+            holder.innerHTML = '<div class="xps-fullteam-note">Sharing XP with your whole team — individual picks are paused.</div>';
+            return;
+        }
+
         const members = state.xpShareIds.map(resolveXpShareMember).filter(Boolean);
 
         const cards = members.map((m) => `
@@ -612,7 +634,7 @@
             updateSaveUI();
             return Promise.resolve({ ok: true });
         }
-        return teamBridge.saveTeam(JSON.stringify(ids), JSON.stringify(state.xpShareIds), state.companionId || '').then((res) => {
+        return teamBridge.saveTeam(JSON.stringify(ids), JSON.stringify(state.xpShareIds), state.companionId || '', state.xpShareFullTeam).then((res) => {
             if (res && res.ok) {
                 state.dirty = false;
                 updateSaveUI();
@@ -654,6 +676,7 @@
             state.xpShareInfos = data.xp_share_info ? [data.xp_share_info] : [];
         }
         state.companionId = data.companion ? String(data.companion) : null;
+        state.xpShareFullTeam = !!data.xp_share_full_team;
         state.spriteMode = data.sprite_mode || 'static';
         state.teamCycleCount = data.team_cycle_count || 3;
 
@@ -675,7 +698,10 @@
 
     function wireStaticControls() {
         document.getElementById('save-btn').addEventListener('click', saveTeam);
-        
+
+        const fullTeamToggle = document.getElementById('xpshare-fullteam-toggle');
+        if (fullTeamToggle) fullTeamToggle.addEventListener('click', toggleXpShareFullTeam);
+
         const cycleSelect = document.getElementById('cycle-select');
         if (cycleSelect) {
             cycleSelect.addEventListener('change', (e) => {
@@ -767,6 +793,7 @@
                     { id: '4', p: 3, n: 'Venusaur', l: 41 },
                 ],
                 companion: '1',
+                xp_share_full_team: false,
                 team: [
                     { id: '1', p: 25, n: 'Pikachu', l: 18, cp: 820, types: ['Electric'] },
                     { id: '2', p: 6, n: 'Charizard', l: 52, s: 1, cp: 2410, types: ['Fire', 'Flying'] },

--- a/src/Ankimon/battle_loop.py
+++ b/src/Ankimon/battle_loop.py
@@ -368,8 +368,23 @@ def on_review_card(*args):
         # deleted-but-non-None widget can't raise on the end-of-turn repaint.
         final_window = services.test_window
         if is_alive(final_window) and enemy_pokemon.hp > 0:
+            # formatted_battle_log/true_dmg_from_*_move are only set on turns
+            # where the cards-per-round batch actually ran the poke_engine
+            # simulation above (the `if cards_battle_round >= ...` block) — on
+            # other turns they're simply not in scope, so read them defensively.
+            _turn_text = locals().get("formatted_battle_log")
+            # The ATTACKER shakes, not the one hit: main dealing damage means
+            # main attacked (shake main's sprite), enemy dealing damage means
+            # enemy attacked (shake enemy's sprite) — both can be true in the
+            # same turn if neither side fainted the other first.
+            _shake_main = bool(locals().get("true_dmg_from_user_move"))
+            _shake_enemy = bool(locals().get("true_dmg_from_enemy_move"))
             try:
-                final_window.display_battle()
+                final_window.display_battle(
+                    message_text=_turn_text,
+                    shake_enemy=_shake_enemy,
+                    shake_main=_shake_main,
+                )
             except RuntimeError:
                 pass
     except Exception as e:

--- a/src/Ankimon/functions/battle_functions.py
+++ b/src/Ankimon/functions/battle_functions.py
@@ -304,8 +304,16 @@ def _process_battle_effects(
                 target = "user" if key.startswith("user.") else "opponent"
                 pokemon_name = get_pokemon_name(target)
 
-                # Status applied
-                if before in ("fighting", None) and after not in ("fighting", None):
+                # Status applied — fainting gets its own dedicated message
+                # elsewhere (enemy_pokemon_fainted / player_pokemon_fainted),
+                # so skip it here: falling through to the generic
+                # status_unknown_apply template produced the nonsensical
+                # "X is affected by Fainted!".
+                if (
+                    before in ("fighting", None)
+                    and after not in ("fighting", None)
+                    and after != "fainted"
+                ):
                     normalized_status = normalize_status_name(after)
                     translation_key = f"status_{normalized_status}_apply"
 
@@ -324,8 +332,14 @@ def _process_battle_effects(
                         )
                     effect_messages.append(message)
 
-                # Status removed
-                elif before not in ("fighting", None) and after in ("fighting", None):
+                # Status removed — same "fainted" exclusion as above (a
+                # fresh encounter resetting fainted -> fighting shouldn't
+                # print "X recovers from Fainted!").
+                elif (
+                    before not in ("fighting", None)
+                    and after in ("fighting", None)
+                    and before != "fainted"
+                ):
                     normalized_status = normalize_status_name(before)
                     translation_key = f"status_{normalized_status}_remove"
 

--- a/src/Ankimon/functions/encounter_functions.py
+++ b/src/Ankimon/functions/encounter_functions.py
@@ -1280,6 +1280,10 @@ def new_pokemon(
         max_hp=pokemon.max_hp,
     )
 
+    display_name = getattr(pokemon, "display_name", pokemon.name)
+    shiny_prefix = "✨ Shiny " if pokemon.shiny else ""
+    tooltipWithColour(f"A wild {shiny_prefix}{display_name} appeared!", "#F7DC6F")
+
     # Re-render the reviewer HUD. refresh_hud() grabs the live webview under
     # Anki and is a recorded no-op headless.
     if update_hud and reviewer_obj is not None:

--- a/src/Ankimon/functions/encounter_functions.py
+++ b/src/Ankimon/functions/encounter_functions.py
@@ -40,7 +40,7 @@ from ..functions.friendship_evolution import (
     check_friendship_evolution_for_pokemon,
 )
 from ..pyobj.error_handler import show_warning_with_traceback
-from ..functions.trainer_functions import xp_share_gain_exp
+from ..functions.trainer_functions import xp_share_gain_exp, resolve_xp_share_targets
 from ..functions.badges_functions import check_for_badge, receive_badge
 from ..functions.drawing_utils import tooltipWithColour
 from ..utils import (
@@ -1667,7 +1667,7 @@ def kill_pokemon(
     exp = max(1, math.ceil(exp))
 
     # Handle XP share logic
-    xp_share_individual_id = settings_obj.get("trainer.xp_share")
+    xp_share_individual_id = resolve_xp_share_targets(settings_obj)
     if xp_share_individual_id:
         try:
             exp = xp_share_gain_exp(

--- a/src/Ankimon/functions/mobile_sync.py
+++ b/src/Ankimon/functions/mobile_sync.py
@@ -185,18 +185,37 @@ def _parse_cards_per_round(settings_obj) -> tuple[int, int]:
     cpr_split = cards_per_round
     return cards_per_round, cpr_split
 
-def _xp_share_split(earned_xp: int, earner_id, xp_share_id) -> tuple[int, int]:
+def _xp_share_split(earned_xp: int, earner_id, xp_share_ids) -> tuple[int, dict]:
     """Split one companion's battle XP under trainer.xp_share.
 
-    Returns ``(xp_kept_by_earner, xp_for_share_target)`` mirroring the 50/50
-    split desktop ``encounter_functions.kill_pokemon`` applies. No share when
-    XP-Share is unset, points at the earner itself, or there is no positive XP;
-    the earner keeps the odd remainder so no XP is lost.
+    ``xp_share_ids`` accepts a single individual_id (legacy/back-compat) or a
+    list of them. Returns ``(xp_kept_by_earner, {target_id: xp_for_target})``
+    mirroring the split desktop ``encounter_functions.kill_pokemon`` applies:
+    the earner keeps half, the other half is divided evenly across however
+    many (deduplicated, earner-excluded) targets are configured. No share
+    when XP-Share is unset/empty or there is no positive XP.
     """
-    if not xp_share_id or earned_xp <= 0 or str(xp_share_id) == str(earner_id):
-        return earned_xp, 0
+    if not xp_share_ids or earned_xp <= 0:
+        return earned_xp, {}
+
+    if isinstance(xp_share_ids, str):
+        xp_share_ids = [xp_share_ids]
+
+    seen = set()
+    targets = []
+    for ind_id in xp_share_ids:
+        if not ind_id or str(ind_id) == str(earner_id) or ind_id in seen:
+            continue
+        seen.add(ind_id)
+        targets.append(ind_id)
+
+    if not targets:
+        return earned_xp, {}
+
     share_half = int(earned_xp * 0.5)
-    return earned_xp - share_half, share_half
+    kept = earned_xp - share_half
+    per_target = max(1, share_half // len(targets)) if share_half > 0 else 0
+    return kept, {tid: per_target for tid in targets}
 
 def _compute_initial_reviews(db, tracker, day_cutoff: int) -> int:
     """Computes the adjusted total review count for encounter seeding based on day_cutoff."""
@@ -1584,13 +1603,14 @@ def _run_mobile_battles_impl(
         # suppression / thread serialisation still hold — the mobile path does
         # not open the evolution window for companions, so we intentionally do
         # not route through the desktop evo-triggering xp_share_gain_exp here.
-        xp_share_id = settings_obj.get("trainer.xp_share") if settings_obj else None
-        xp_share_pending = 0
+        xp_share_ids = settings_obj.get("trainer.xp_share") if settings_obj else None
+        xp_share_pending = {}  # target_id -> accumulated xp across all companions
         for cid, earned_xp in companion_xp.items():
             evs_gained = companion_evs.get(cid, {"hp": 0, "atk": 0, "def": 0, "spa": 0, "spd": 0, "spe": 0})
             battles_fought = companion_battle_count.get(cid, 0)
-            grant_xp, share_half = _xp_share_split(earned_xp, cid, xp_share_id)
-            xp_share_pending += share_half
+            grant_xp, share_amounts = _xp_share_split(earned_xp, cid, xp_share_ids)
+            for target_id, amount in share_amounts.items():
+                xp_share_pending[target_id] = xp_share_pending.get(target_id, 0) + amount
             if grant_xp > 0 or any(evs_gained.values()) or battles_fought > 0:
                 if main_pokemon and cid == main_pokemon.individual_id:
                     class DummyEnemy:
@@ -1615,12 +1635,13 @@ def _run_mobile_battles_impl(
                     _attribute_xp_and_evs_to_companion(cid, grant_xp, evs_gained, settings_obj, battles_fought=battles_fought, db=db, logger=logger)
 
         # Grant the accumulated XP-Share half to the configured target Pokémon.
-        if xp_share_id and xp_share_pending > 0:
-            _attribute_xp_and_evs_to_companion(
-                str(xp_share_id), xp_share_pending,
-                {"hp": 0, "atk": 0, "def": 0, "spa": 0, "spd": 0, "spe": 0},
-                settings_obj, battles_fought=0, db=db, logger=logger
-            )
+        for target_id, pending_amount in xp_share_pending.items():
+            if pending_amount > 0:
+                _attribute_xp_and_evs_to_companion(
+                    str(target_id), pending_amount,
+                    {"hp": 0, "atk": 0, "def": 0, "spa": 0, "spd": 0, "spe": 0},
+                    settings_obj, battles_fought=0, db=db, logger=logger
+                )
 
         total_trainer_xp = 0
         from ..pyobj.trainer_card import POKEMON_TIERS
@@ -1908,20 +1929,22 @@ def commit_replay_outcome(choice: str, outcome_data: dict, db, settings_obj, tra
                     # replay prep). Runs on this QueryOp background thread under
                     # _mobile_sync_lock via the mobile attribution path, so no
                     # evo-window / tooltip Qt work happens here.
-                    xp_share_id = settings_obj.get("trainer.xp_share") if settings_obj else None
-                    grant_xp, share_half = (
-                        _xp_share_split(total_xp, companion_id, xp_share_id)
-                        if companion_id else (total_xp, 0)
+                    xp_share_ids = settings_obj.get("trainer.xp_share") if settings_obj else None
+                    grant_xp, share_amounts = (
+                        _xp_share_split(total_xp, companion_id, xp_share_ids)
+                        if companion_id else (total_xp, {})
                     )
 
                     if companion_id and (grant_xp > 0 or any(accumulated_evs.values())):
                         _attribute_xp_and_evs_to_companion(companion_id, grant_xp, accumulated_evs, settings_obj, db=db, logger=logger)
-                    if companion_id and xp_share_id and share_half > 0:
-                        _attribute_xp_and_evs_to_companion(
-                            str(xp_share_id), share_half,
-                            {"hp": 0, "atk": 0, "def": 0, "spa": 0, "spd": 0, "spe": 0},
-                            settings_obj, battles_fought=0, db=db, logger=logger
-                        )
+                    if companion_id:
+                        for target_id, amount in share_amounts.items():
+                            if amount > 0:
+                                _attribute_xp_and_evs_to_companion(
+                                    str(target_id), amount,
+                                    {"hp": 0, "atk": 0, "def": 0, "spa": 0, "spd": 0, "spe": 0},
+                                    settings_obj, battles_fought=0, db=db, logger=logger
+                                )
 
                 # 3. Mark resolved in DB
                 if review_ids:

--- a/src/Ankimon/functions/mobile_sync.py
+++ b/src/Ankimon/functions/mobile_sync.py
@@ -1603,7 +1603,9 @@ def _run_mobile_battles_impl(
         # suppression / thread serialisation still hold — the mobile path does
         # not open the evolution window for companions, so we intentionally do
         # not route through the desktop evo-triggering xp_share_gain_exp here.
-        xp_share_ids = settings_obj.get("trainer.xp_share") if settings_obj else None
+        from .trainer_functions import resolve_xp_share_targets
+
+        xp_share_ids = resolve_xp_share_targets(settings_obj) if settings_obj else None
         xp_share_pending = {}  # target_id -> accumulated xp across all companions
         for cid, earned_xp in companion_xp.items():
             evs_gained = companion_evs.get(cid, {"hp": 0, "atk": 0, "def": 0, "spa": 0, "spd": 0, "spe": 0})
@@ -1929,7 +1931,9 @@ def commit_replay_outcome(choice: str, outcome_data: dict, db, settings_obj, tra
                     # replay prep). Runs on this QueryOp background thread under
                     # _mobile_sync_lock via the mobile attribution path, so no
                     # evo-window / tooltip Qt work happens here.
-                    xp_share_ids = settings_obj.get("trainer.xp_share") if settings_obj else None
+                    from .trainer_functions import resolve_xp_share_targets
+
+                    xp_share_ids = resolve_xp_share_targets(settings_obj) if settings_obj else None
                     grant_xp, share_amounts = (
                         _xp_share_split(total_xp, companion_id, xp_share_ids)
                         if companion_id else (total_xp, {})

--- a/src/Ankimon/functions/trainer_functions.py
+++ b/src/Ankimon/functions/trainer_functions.py
@@ -59,17 +59,69 @@ def find_trainer_rank(highest_level, trainer_level):
         print("Error: One of the files (Pokedex or MyPokemon) could not be found.")
         return "Unknown Rank"
 
-def xp_share_gain_exp(logger, settings_obj, evo_window, main_pokemon_id, exp, xp_share_individual_id):
-    # Ensure that the XP Share Pokémon is set and different from the main Pokémon
-    if not xp_share_individual_id:
+def remove_xp_share_target(settings_obj, individual_id):
+    """Drop one Pokémon from the XP Share list (e.g. it was released/traded).
+
+    Handles both the current list-of-ids storage and a legacy bare-string
+    value, so a Pokémon being removed cleanly disappears from the target set
+    either way instead of leaving a dangling id behind.
+    """
+    if settings_obj is None:
+        return
+    current = settings_obj.get("trainer.xp_share")
+    individual_id = str(individual_id)
+    if isinstance(current, list):
+        remaining = [ind_id for ind_id in current if str(ind_id) != individual_id]
+        if remaining != current:
+            settings_obj.set("trainer.xp_share", remaining)
+    elif current and str(current) == individual_id:
+        settings_obj.set("trainer.xp_share", None)
+
+
+def xp_share_gain_exp(logger, settings_obj, evo_window, main_pokemon_id, exp, xp_share_ids):
+    """Split defeat XP between the main Pokémon and one or more XP Share targets.
+
+    ``xp_share_ids`` accepts either a single individual_id (legacy/back-compat
+    — older saves stored ``trainer.xp_share`` as a bare string) or a list of
+    them. The main Pokémon always keeps half; the other half is divided evenly
+    across however many (deduplicated, main-excluded) targets are given, and
+    each target is leveled up/evolved exactly as the old single-target flow did.
+    """
+    if not xp_share_ids:
         return exp
 
-    if xp_share_individual_id == main_pokemon_id:
+    if isinstance(xp_share_ids, str):
+        xp_share_ids = [xp_share_ids]
+
+    # De-dupe and drop the main Pokémon (it already gets its own half below).
+    seen = set()
+    targets = []
+    for ind_id in xp_share_ids:
+        if not ind_id or ind_id == main_pokemon_id or ind_id in seen:
+            continue
+        seen.add(ind_id)
+        targets.append(ind_id)
+
+    if not targets:
         return exp
 
     original_exp = int(exp * 0.5)
+    shared_exp = int(exp * 0.5)
+    # Split the shared half evenly across every target.
+    per_target_exp = max(1, shared_exp // len(targets)) if shared_exp > 0 else 0
+
+    for target_id in targets:
+        _xp_share_gain_exp_one(
+            logger, settings_obj, evo_window, target_id, per_target_exp
+        )
+
+    return original_exp  # The main Pokémon's own half.
+
+
+def _xp_share_gain_exp_one(logger, settings_obj, evo_window, xp_share_individual_id, exp):
+    """Apply one XP Share target's share of XP (leveling/evolution included)."""
     remove_level_cap = settings_obj.get("misc.remove_level_cap")
-    exp = int(exp * 0.5)  # Convert the experience to an integer
+    exp = int(exp)  # Convert the experience to an integer
 
     # Load pokemon from database
     db = services.db
@@ -82,12 +134,17 @@ def xp_share_gain_exp(logger, settings_obj, evo_window, main_pokemon_id, exp, xp
     # selected, leaving a dangling individual_id in settings. get_pokemon then
     # returns None and any pokemon[...] access below would raise
     # "'NoneType' object is not subscriptable" on the next review/defeat.
-    # Clear the stale setting and return the already-computed half-exp so the
-    # main Pokémon still gets its share and the review continues normally.
+    # Drop just this stale id from the list (the other targets, if any, still
+    # get their share) so the review continues normally.
     if pokemon is None:
-        settings_obj.set("trainer.xp_share", None)
-        logger.log("info", "XP Share target no longer exists; cleared the setting.")
-        return original_exp
+        remaining = [
+            ind_id
+            for ind_id in (settings_obj.get("trainer.xp_share") or [])
+            if ind_id != xp_share_individual_id
+        ] if isinstance(settings_obj.get("trainer.xp_share"), list) else None
+        settings_obj.set("trainer.xp_share", remaining)
+        logger.log("info", "An XP Share target no longer exists; removed it from the list.")
+        return
 
     current_level = int(pokemon['level'])  # MODIFIED: Use local variable for level
     if pokemon.get('held_item') == "lucky-egg":
@@ -180,4 +237,3 @@ def xp_share_gain_exp(logger, settings_obj, evo_window, main_pokemon_id, exp, xp
         db.save_pokemon(pokemon)
 
     logger.log("info", f"{msg}")
-    return original_exp  # Return the amount of experience added

--- a/src/Ankimon/functions/trainer_functions.py
+++ b/src/Ankimon/functions/trainer_functions.py
@@ -59,6 +59,28 @@ def find_trainer_rank(highest_level, trainer_level):
         print("Error: One of the files (Pokedex or MyPokemon) could not be found.")
         return "Unknown Rank"
 
+def resolve_xp_share_targets(settings_obj):
+    """The individual_ids XP Share should actually apply to right now.
+
+    When ``trainer.xp_share_full_team`` is on (the mainline Gen-6+ "whole
+    party" style — X/Y, ORAS, Sun/Moon and everything since, where Exp.
+    Share became a key item shared by the whole team instead of a single
+    held item), every current team member is a target, ignoring whatever
+    individual picks are stored. Otherwise falls back to the manually
+    picked list in ``trainer.xp_share`` (list, or a bare string for
+    older saves). ``xp_share_gain_exp``/``_xp_share_split`` already
+    de-dupe and drop the main Pokémon, so no filtering needed here.
+    """
+    try:
+        if settings_obj.get("trainer.xp_share_full_team"):
+            db = services.db
+            if db is not None:
+                return [m["individual_id"] for m in db.get_team() if m.get("individual_id")]
+    except Exception:
+        pass
+    return settings_obj.get("trainer.xp_share")
+
+
 def remove_xp_share_target(settings_obj, individual_id):
     """Drop one Pokémon from the XP Share list (e.g. it was released/traded).
 

--- a/src/Ankimon/gui_classes/pokemon_details.py
+++ b/src/Ankimon/gui_classes/pokemon_details.py
@@ -1658,15 +1658,13 @@ def PokemonFree(
     else:
         logger.log_and_showinfo("error", f"Failed to add {name} to history.")
 
-    # If this Pokémon is the current XP-Share target, clear the setting before
-    # it disappears from the DB. Otherwise the dangling individual_id would make
+    # If this Pokémon is an XP-Share target, drop it from the list before it
+    # disappears from the DB. Otherwise the dangling individual_id would make
     # xp_share_gain_exp look up a now-missing Pokémon and crash on the next
-    # review. str() guards against any id type mismatch in the compare.
-    settings_obj = services.settings
-    if settings_obj is not None and str(settings_obj.get("trainer.xp_share")) == str(
-        individual_id
-    ):
-        settings_obj.set("trainer.xp_share", None)
+    # review.
+    from ..functions.trainer_functions import remove_xp_share_target
+
+    remove_xp_share_target(services.settings, individual_id)
 
     # Delete from database
     db.delete_pokemon(individual_id)

--- a/src/Ankimon/pyobj/pokemon_trade.py
+++ b/src/Ankimon/pyobj/pokemon_trade.py
@@ -772,13 +772,12 @@ class PokemonTrade:
             try:
                 db.replace_pokemon(new_pokemon, self.individual_id)
                 # The traded-away Pokémon's individual_id is now gone from the DB
-                # (it was swapped for new_pokemon's fresh id). If it was the
-                # XP-Share target, clear the setting so xp_share_gain_exp doesn't
-                # later look up a missing Pokémon and crash. str() guards against
-                # any id type mismatch in the compare.
-                settings_obj = services.settings
-                if settings_obj is not None and str(settings_obj.get("trainer.xp_share")) == str(self.individual_id):
-                    settings_obj.set("trainer.xp_share", None)
+                # (it was swapped for new_pokemon's fresh id). If it was an
+                # XP-Share target, drop it from the list so xp_share_gain_exp
+                # doesn't later look up a missing Pokémon and crash.
+                from ..functions.trainer_functions import remove_xp_share_target
+
+                remove_xp_share_target(services.settings, self.individual_id)
             except Exception as e:
                 show_warning_with_traceback(parent=self.parent_window, exception=e, message=f"An error occurred during trade: {e}")
 

--- a/src/Ankimon/pyobj/reviewer_obj.py
+++ b/src/Ankimon/pyobj/reviewer_obj.py
@@ -52,6 +52,27 @@ class Reviewer_Manager:
         self._ownership_cache.clear()
         self._last_state = None
 
+        # The Ankimon Window popup keeps showing its last battle line (e.g.
+        # "Oshawott used Tackle!") after the deck runs out and the review
+        # session ends — nothing else tells it the battle is over. Clear it
+        # so a fresh encounter (or a stale re-show) doesn't display leftover
+        # text from the previous session.
+        try:
+            from ..utils import is_alive
+
+            test_window = services.test_window
+            if is_alive(test_window):
+                test_window.last_message_text = ""
+                if test_window.current_view == "battle":
+                    # Bypass the render debounce: this fires right after the
+                    # turn's own display_battle() call, well inside the 50ms
+                    # window, so without resetting it the "clear" repaint
+                    # would silently no-op and the stale text stays on screen.
+                    test_window._last_display_time = 0
+                    test_window.display_battle()
+        except Exception:
+            pass
+
     def invalidate_hud_cache(self):
         """Clear the per-encounter HUD perf caches so the next repaint rebuilds.
 

--- a/src/Ankimon/pyobj/settings.py
+++ b/src/Ankimon/pyobj/settings.py
@@ -96,6 +96,10 @@ DEFAULT_CONFIG = {
     "trainer.mobile_reviews_resolved_since_payout": 0,
     "trainer.level": 0,
     "trainer.xp": 0,
+    # Mainline Gen-6+ style (X/Y, ORAS, Sun/Moon onward): when on, the whole
+    # team shares XP instead of only the individually-picked trainer.xp_share
+    # targets. See functions.trainer_functions.resolve_xp_share_targets.
+    "trainer.xp_share_full_team": False,
     "mobile.enabled": True,
     "mobile.resolution_mode": "manual",
     "mobile.inactive_companions": [],

--- a/src/Ankimon/pyobj/test_window.py
+++ b/src/Ankimon/pyobj/test_window.py
@@ -18,6 +18,7 @@ from aqt.qt import (
 from aqt.utils import showWarning
 
 from PyQt6.QtGui import QIcon, QColor, QFontMetrics, QPainterPath
+from PyQt6.QtCore import QTimer, QRect
 
 from PyQt6.QtWidgets import (
     QDialog,
@@ -114,6 +115,9 @@ class TestWindow(QWidget):
         self.catch_button = None
         self.nickname_input = None
         self._last_display_time = 0
+        self.last_message_text = ""
+        self._enemy_shake_offset = (0, 0)
+        self._main_shake_offset = (0, 0)
 
         self.init_ui()
         # self.update()
@@ -363,6 +367,7 @@ class TestWindow(QWidget):
 
         # calculate wild pokemon max hp
         message_box_text = f"{self.translator.translate('wild_pokemon_appeared', enemy_pokemon_name=lang_name.capitalize())}"
+        self.last_message_text = message_box_text
 
         bckgimage_path = battlescene_path / self.ankimon_tracker_obj.battlescene_file
 
@@ -377,6 +382,47 @@ class TestWindow(QWidget):
         image_label, msg_font = self.window_show(bckgimage_path, lang_name)
 
         return image_label
+
+    # Message text geometry — inset within the dialog box baked into the
+    # background art (pkmnbattlescene.png et al), not a box drawn in code.
+    _MESSAGE_BOX_RECT = QRect(2, 265, 551, 96)
+    _MESSAGE_BOX_BORDER_THICKNESS = 13
+
+    def _draw_message_box_layer(self, painter):
+        """Draw the battle-log text over the (existing, art-baked-in) box."""
+        rect = self._MESSAGE_BOX_RECT
+        t = self._MESSAGE_BOX_BORDER_THICKNESS
+
+        if self.last_message_text:
+            battle_text_font = load_custom_font(
+                20, int(self.settings_obj.get("misc.language"))
+            )
+            painter.setFont(battle_text_font)
+            painter.setPen(QColor(240, 240, 208))
+            painter.drawText(
+                rect.adjusted(t + 8, t + 6, -(t + 8), -(t + 6)),
+                Qt.AlignmentFlag.AlignLeft | Qt.TextFlag.TextWordWrap,
+                self.last_message_text,
+            )
+
+    @staticmethod
+    def _fit_sprite(pixmap, max_w=120, max_h=120):
+        """Scale a sprite to fit within a max_w x max_h box, aspect preserved.
+
+        ``resize_pixmap_img`` (used for item/badge art) forces width to an
+        exact value regardless of the source image's proportions. Animated
+        (GIF) sprite sheets are typically framed much tighter than the static
+        PNGs — far less transparent padding around the actual artwork — so
+        width-only scaling to the same target made them read as visibly
+        bigger and let the main Pokémon's sprite dip into the message box
+        below it. Capping both dimensions keeps every source proportionate
+        and inside the battle scene regardless of its native framing.
+        """
+        if pixmap.width() <= 0 or pixmap.height() <= 0:
+            return pixmap
+        return pixmap.scaled(
+            max_w, max_h, Qt.AspectRatioMode.KeepAspectRatio, Qt.TransformationMode.SmoothTransformation
+        )
 
     def _load_sprite(self, pokemon, side):
         """Load a Pokémon's sprite, falling back to the substitute.
@@ -418,8 +464,8 @@ class TestWindow(QWidget):
         # Scale both to a fixed width, keeping the aspect ratio. Reading the
         # dimensions back off the scaled pixmaps keeps the draw offsets correct
         # even when a sprite is missing and cannot be scaled at all.
-        pixmap = resize_pixmap_img(pixmap, 150)
-        pixmap2 = resize_pixmap_img(pixmap2, 150)
+        pixmap = self._fit_sprite(pixmap)
+        pixmap2 = self._fit_sprite(pixmap2)
 
         new_width, new_height = pixmap.width(), pixmap.height()
         new_width2, new_height2 = pixmap2.width(), pixmap2.height()
@@ -466,8 +512,8 @@ class TestWindow(QWidget):
         mpkmn_height = new_height2
 
         # draw pokemon image to a specific pixel
-        painter.drawPixmap((410 - wpkmn_width), (170 - wpkmn_height), pixmap)
-        painter.drawPixmap((144 - mpkmn_width), (290 - mpkmn_height), pixmap2)
+        painter.drawPixmap((410 - wpkmn_width) + self._enemy_shake_offset[0], (170 - wpkmn_height) + self._enemy_shake_offset[1], pixmap)
+        painter.drawPixmap((144 - mpkmn_width) + self._main_shake_offset[0], (275 - mpkmn_height) + self._main_shake_offset[1], pixmap2)
 
         experience = int(
             find_experience_for_level(
@@ -532,11 +578,6 @@ class TestWindow(QWidget):
         painter.drawText(max_hp_x, 238, str(main_max_hp))
         painter.drawText(hp_x, 238, str(main_hp))
 
-        painter.setFont(msg_font)
-        painter.setPen(QColor(240, 240, 208))  # Text color
-
-        painter.drawText(40, 320, message_box_text)
-
         painter.setFont(hp_enemy_text_font)
         painter.setPen(QColor(31, 31, 39))  # Text color
         enemy_hp_x = 41 if enemy_max_hp < 100 else 40  # Shift left if 3 digits
@@ -553,6 +594,11 @@ class TestWindow(QWidget):
         )
 
         self._draw_cp_pp(painter)
+
+        # Repaint the message box as the topmost layer — see
+        # _draw_message_box_layer's docstring for why this is drawn fresh
+        # here instead of trusting sprite sizing to stay clear of it.
+        self._draw_message_box_layer(painter)
 
         painter.end()
 
@@ -602,13 +648,10 @@ class TestWindow(QWidget):
     def pokemon_display_battle(self):
         # No pokemon_encounter increment here — the battle loop owns the
         # per-round counter; incrementing per render double-counted rounds.
+        # Always keep the dialog-box background (never switch to the
+        # boxless variant) — only the Pokémon sprites/HP/text should change
+        # turn to turn, not the box itself.
         bckgimage_path = battlescene_path / self.ankimon_tracker_obj.battlescene_file
-
-        if self.ankimon_tracker_obj.pokemon_encounter > 1:
-            bckgimage_path = (
-                battlescene_path_without_dialog
-                / self.ankimon_tracker_obj.battlescene_file
-            )
 
         ui_path = battle_ui_path
 
@@ -630,8 +673,8 @@ class TestWindow(QWidget):
         # Scale both to a fixed width, keeping the aspect ratio. Reading the
         # dimensions back off the scaled pixmaps keeps the draw offsets correct
         # even when a sprite is missing and cannot be scaled at all.
-        pixmap = resize_pixmap_img(pixmap, 150)
-        pixmap2 = resize_pixmap_img(pixmap2, 150)
+        pixmap = self._fit_sprite(pixmap)
+        pixmap2 = self._fit_sprite(pixmap2)
 
         new_width, new_height = pixmap.width(), pixmap.height()
         new_width2, new_height2 = pixmap2.width(), pixmap2.height()
@@ -678,10 +721,11 @@ class TestWindow(QWidget):
         mpkmn_width = new_width2 // 2
         mpkmn_height = new_height2
 
-        # draw pokemon image to a specific pixel
-        painter.drawPixmap((410 - wpkmn_width), (170 - wpkmn_height), pixmap)
-        # Reposition main pokemon to be fully visible when message box disappears
-        painter.drawPixmap((144 - mpkmn_width), (270 - mpkmn_height), pixmap2)
+        # draw pokemon image to a specific pixel — same spot as the intro
+        # frame, since the dialog box (and thus the available space) no
+        # longer changes turn to turn.
+        painter.drawPixmap((410 - wpkmn_width) + self._enemy_shake_offset[0], (170 - wpkmn_height) + self._enemy_shake_offset[1], pixmap)
+        painter.drawPixmap((144 - mpkmn_width) + self._main_shake_offset[0], (275 - mpkmn_height) + self._main_shake_offset[1], pixmap2)
 
         experience = int(
             find_experience_for_level(
@@ -765,6 +809,11 @@ class TestWindow(QWidget):
         )
 
         self._draw_cp_pp(painter)
+
+        # Repaint the message box as the topmost layer — see
+        # _draw_message_box_layer's docstring for why this is drawn fresh
+        # here instead of trusting sprite sizing to stay clear of it.
+        self._draw_message_box_layer(painter)
 
         painter.end()
 
@@ -1056,16 +1105,55 @@ class TestWindow(QWidget):
         self.setStyleSheet("background-color: rgb(44,44,44);")
         self.current_view = "battle"
 
-    def display_battle(self):
+    def display_battle(self, message_text=None, shake_enemy=False, shake_main=False):
         # Debounce: prevent flicker from duplicate hooks (especially during reloads)
         if self._same_view_debounced("battle"):
             return
+
+        if message_text is not None:
+            self.last_message_text = message_text
 
         # Update the existing label without clearing the layout
         new_label = self.pokemon_display_battle()
         self.main_label.setPixmap(new_label.pixmap())
         self.button_widget.hide()
         self.current_view = "battle"
+
+        if shake_enemy:
+            self._shake_sprite("enemy")
+        if shake_main:
+            self._shake_sprite("main")
+
+    def _shake_sprite(self, side, magnitude=7, step_ms=45):
+        """Jitter one Pokémon's sprite in place — the one actually attacking
+        this turn, not the whole window. Diagonal, not side-to-side: reads as
+        a little lunge/recoil rather than a plain horizontal wobble. Since
+        the scene is a single QPainter-composited image (no per-element
+        widgets to animate), this works by nudging that sprite's (dx, dy)
+        draw-offset through a few values via QTimer and forcing a redraw at
+        each step, then settling back to (0, 0).
+        """
+        attr = "_enemy_shake_offset" if side == "enemy" else "_main_shake_offset"
+        half = magnitude // 2
+        offsets = [
+            (magnitude, -half),
+            (-magnitude, half),
+            (magnitude, -half),
+            (-magnitude, half),
+            (0, 0),
+        ]
+
+        def _step(offset):
+            try:
+                setattr(self, attr, offset)
+                if self.current_view == "battle":
+                    self._last_display_time = 0
+                    self.display_battle()
+            except RuntimeError:
+                pass
+
+        for i, offset in enumerate(offsets):
+            QTimer.singleShot(step_ms * i, lambda offset=offset: _step(offset))
 
     def rate_display_item(self, item):
         Receive_Window = QDialog(mw)

--- a/src/Ankimon/utils.py
+++ b/src/Ankimon/utils.py
@@ -596,6 +596,9 @@ def get_item_description(item_name, language_id):
         return None
 
 
+_registered_fonts = set()  # font_file names already handed to QFontDatabase
+
+
 def load_custom_font(font_size, language):
     if language == 1:
         font_file = "pkmn_w.ttf"
@@ -612,10 +615,19 @@ def load_custom_font(font_size, language):
         font_file = "Early GameBoy.ttf"
         font_size = int((font_size * 2) / 5)
 
-    # Register the custom font with its file path. Qt imported lazily so utils
-    # stays importable headless (custom fonts are a GUI-only concern).
+    # Register the custom font with its file path — but ONLY the first time
+    # per file. addApplicationFont() adds a brand new entry to Qt's font
+    # database on every call, even for a file already registered; this
+    # function is called on every battle-scene redraw, so without caching it
+    # could silently register the same font hundreds of times over a play
+    # session — bloating the font database until fontconfig's internal
+    # font-set sort crashes with a stack overflow (observed: SIGSEGV inside
+    # FcFontSetSort). Qt imported lazily so utils stays importable headless
+    # (custom fonts are a GUI-only concern).
     from PyQt6.QtGui import QFontDatabase, QFont
-    QFontDatabase.addApplicationFont(str(font_path / font_file))
+    if font_file not in _registered_fonts:
+        QFontDatabase.addApplicationFont(str(font_path / font_file))
+        _registered_fonts.add(font_file)
     custom_font = QFont(
         font_name
     )  # Use the font family name you specified in the font file


### PR DESCRIPTION
### Description
- Fixed IPC socket discovery to find Vesktop's Flatpak sandbox path (.flatpak/dev.vencord.Vesktop/xdg-run) so RPC actually connects.
- trainer.xp_share is now a list of Pokémon (similar to Alpha Sapphire). XP splits evenly across however many targets you set, on top of your active Pokémon's own half. Applies on both desktop and mobile-sync paths.
- Releasing/trading a Pokémon now just drops it from the list instead of nuking the whole setting.
- Team screen (team.js/profile.css) got a real multi-select UI for it — each target shows as its own card with a remove button.
- The Team screen's "who actually battles" picker was previously a dead stub. Wired it up for real: a ⚔ button on any team slot sets it as your active battler, updates the live game state, and repaints the HUD/battle window immediately. -Message box text now renders correctly every turn instead of going blank after the first frame, and stays put instead of the background art swapping mid-battle. -Fixed sprite sizing so main and enemy sprites are capped consistently (was letting sprites overflow/overlap the message box).
- Attack shake is now per-Pokémon (only the one actually attacking jitters, diagonally) instead of shaking the whole window.
- Added a proper "A wild X appeared!" message on new encounters.
- load_custom_font() registered a brand-new duplicate Qt font entry on every single call instead of once — this function fires on every battle-scene redraw, so over a play session it could pile up thousands of duplicate font registrations, eventually crashing fontconfig's internal sort. Now cached so each font file registers exactly once.
- Battle log no longer prints "X is affected by Fainted!" — fainting already has its own proper message; it was falling through to a generic status-effect template.
- Fixed a CSS-class leak where the companion sprite could go permanently invisible after your first loss (an animation: ... forwards class never got reset on the next battle) — matches the "he's just gone" bug you hit. Buttons now actually look disabled when they are (there was zero :disabled styling, so a correctly-disabled Catch button looked identical to an active one — that was the real "does nothing" bug).

### Checklist
- [x] My code follows the code style and guidelines of this project.
- [x] I have run tests locally (`pytest tests/` and `pytest tests/test_addon_integrity.py`) and they all pass.
- [x] **(Optional)** I have added/updated my entry in `.all-contributorsrc` at the root of the repository to specify my custom `"nickname"` and `"discord_id"` for release announcements and Discord pings.
