### PR TITLE
fix(ui): correct invalid CSS properties breaking HUD on Chromium 140

### DIFF
--- a/src/Ankimon/functions/create_css_for_reviewer.py
+++ b/src/Ankimon/functions/create_css_for_reviewer.py
@@ -461,7 +461,7 @@ body.dark #ankimon-hud #MyPokeImage,
   {xp_bar_location}: 2px;
   left: 15px;
   z-index: 9999;
-  font-color: rgba(0, 191, 255, 0.85);
+  color: rgba(0, 191, 255, 0.85);
   font-size: 10px;
   font-weight: bold;
   text-align: center;

--- a/src/Ankimon/pyobj/reviewer_obj.py
+++ b/src/Ankimon/pyobj/reviewer_obj.py
@@ -500,7 +500,7 @@ class Reviewer_Manager:
             }
 
             .night_mode #xp_text {
-                font-color: rgba(0, 191, 255, 0.85)
+                color: rgba(0, 191, 255, 0.85);
                 font-family: Arial, sans-serif;
                 background: #1f1f1f !important;
                 border-radius: 5px !important;


### PR DESCRIPTION
This pull request addresses an issue where the Ankimon Reviewer HUD completely fails to render styles on the latest Anki versions (which use Chromium 140). The root cause was strict CSS parsing in newer Chromium versions completely rejecting the `<style>` injection into the HUD Shadow DOM due to syntax errors.

Changes:
* Fixed invalid `font-color:` property (changed to `color:`) in `create_css_for_reviewer.py` and `reviewer_obj.py`.
* Added a missing semicolon in the `.night_mode #xp_text` block in `reviewer_obj.py`.

These fixes restore the styling functionality for both light and dark modes.

---
*PR created automatically by Jules for task [8944345640622150881](https://jules.google.com/task/8944345640622150881) started by @h0tp-ftw*