### PR TITLE
fix: use individual_id for XP share self-check

### DIFF
--- a/src/Ankimon/functions/encounter_functions.py
+++ b/src/Ankimon/functions/encounter_functions.py
@@ -1670,7 +1670,7 @@ def kill_pokemon(
                 logger,
                 settings_obj,
                 evo_window,
-                main_pokemon.id,
+                main_pokemon.individual_id,
                 exp,
                 xp_share_individual_id,
             )

--- a/src/Ankimon/functions/trainer_functions.py
+++ b/src/Ankimon/functions/trainer_functions.py
@@ -59,12 +59,12 @@ def find_trainer_rank(highest_level, trainer_level):
         print("Error: One of the files (Pokedex or MyPokemon) could not be found.")
         return "Unknown Rank"
 
-def xp_share_gain_exp(logger, settings_obj, evo_window, main_pokemon_id, exp, xp_share_individual_id):
+def xp_share_gain_exp(logger, settings_obj, evo_window, main_pokemon_individual_id, exp, xp_share_individual_id):
     # Ensure that the XP Share Pokémon is set and different from the main Pokémon
     if not xp_share_individual_id:
         return exp
 
-    if xp_share_individual_id == main_pokemon_id:
+    if xp_share_individual_id == main_pokemon_individual_id:
         return exp
 
     original_exp = int(exp * 0.5)


### PR DESCRIPTION
Fixes a bug where the `xp_share_gain_exp` function checked the XP Share Pokemon's unique `individual_id` against the active battling Pokemon's species `id`. Since an integer `id` and a UUID string never match, the active Pokemon was incorrectly allowed to receive XP Share experience if it was set as the XP Share target.

By replacing `main_pokemon.id` with `main_pokemon.individual_id`, the function correctly performs a UUID-to-UUID check and ensures the correct logic prevents the active battling Pokemon from receiving dual XP payouts.

---
*PR created automatically by Jules for task [735189074588900174](https://jules.google.com/task/735189074588900174) started by @h0tp-ftw*