### PR TITLE
fix: close the two data-consistency risks flagged on #781

### DIFF
--- a/src/Ankimon/pyobj/collection_dialog.py
+++ b/src/Ankimon/pyobj/collection_dialog.py
@@ -78,11 +78,16 @@ def MainPokemon(
         # Pokemon's HP/xp/friendship earned since its last write; the switch
         # below then overwrites that state in memory. Someone who is never told
         # cannot know to re-check their old main.
+        # Two lines on purpose: the exception text is diagnostic, and dropping a
+        # raw repr into a message box tells the player nothing they can act on.
+        # Keep it in the log file and show a message that names the Pokemon and
+        # says what to check.
+        logger.log("error", f"Could not save outgoing main pokemon: {exc}")
         logger.log_and_showinfo(
             "error",
             f"Could not save {getattr(main_pokemon, 'name', 'your previous main')} "
-            f"before switching: {exc}. Any progress it gained since the last "
-            "save may be lost.",
+            "before switching. Any progress it gained since the last save may be "
+            "lost - check it in your PC box. See the Ankimon log for details.",
         )
 
     # --- Now proceed to set the new mainpokemon as before ---

--- a/src/Ankimon/pyobj/collection_dialog.py
+++ b/src/Ankimon/pyobj/collection_dialog.py
@@ -72,10 +72,18 @@ def MainPokemon(
             # Use main_pokemon.to_dict() to capture in-memory stats like xp.
             db.save_pokemon(main_pokemon.to_dict())
     except Exception as exc:
-        # Keep going -- a failure here must not block the switch -- but do not
-        # swallow it silently: since the incoming main is no longer full-healed,
-        # this save is the only thing preserving the outgoing Pokemon's HP.
-        logger.log("error", f"Could not save outgoing main pokemon: {exc}")
+        # Keep going -- a failure here must not block the switch -- but tell the
+        # PLAYER, not just the log file. Since the incoming main is no longer
+        # full-healed, this save is the only thing preserving the outgoing
+        # Pokemon's HP/xp/friendship earned since its last write; the switch
+        # below then overwrites that state in memory. Someone who is never told
+        # cannot know to re-check their old main.
+        logger.log_and_showinfo(
+            "error",
+            f"Could not save {getattr(main_pokemon, 'name', 'your previous main')} "
+            f"before switching: {exc}. Any progress it gained since the last "
+            "save may be lost.",
+        )
 
     # --- Now proceed to set the new mainpokemon as before ---
     pokemon_id = pokemon_data.get("id")

--- a/src/Ankimon/pyobj/database_manager.py
+++ b/src/Ankimon/pyobj/database_manager.py
@@ -125,19 +125,37 @@ class ConnectionWrapper:
                     self._conn.commit()
                 except sqlite3.DatabaseError as e:
                     msg = str(e).lower()
-                    # NOTE: Deliberately NO "closed database" retry here. Unlike
-                    # execute()/executemany(), commit() has nothing to replay:
-                    # sqlite rolled this connection's transaction back when it was
-                    # closed, so committing a *different* connection would be a
-                    # no-op that reports success for a write that no longer exists.
-                    # Let it raise -- see the __exit__ comment in database_manager.
+                    # NOTE: Deliberately NO retry that reports success here. Unlike
+                    # execute()/executemany(), commit() has nothing to replay, so
+                    # committing a *different* connection is a no-op that reports
+                    # success for a write that no longer exists. That holds for both
+                    # failures we know how to recognise:
+                    #
+                    #   "closed database" -- sqlite rolled this connection's
+                    #   transaction back when the connection was closed.
+                    #
+                    #   "malformed"/"disk image" -- repair_database() rebuilds the
+                    #   file from a *separate* connection's iterdump(), which cannot
+                    #   see this connection's uncommitted rows, then quiesces every
+                    #   registered connection and swaps the rebuilt file into place.
+                    #   The pending transaction does not survive either step.
+                    #
+                    # So heal the file -- leaving it corrupt helps nobody -- but let
+                    # the original failure propagate. Callers such as consume_item
+                    # hand out an effect on the strength of a successful commit: a
+                    # heal, a revived fossil. Reporting success for a decrement that
+                    # the repair threw away is exactly the free-heal those callers
+                    # exist to prevent. See the __exit__ comment below.
                     if self._db_mgr and ("malformed" in msg or "disk image" in msg) and not self._db_mgr._is_repairing:
                         self.release_lease()
                         lease_released = True
-                        self._db_mgr.repair_database()
-                        fresh = self._db_mgr._get_connection()
-                        fresh._conn.commit()
-                        return
+                        try:
+                            self._db_mgr.repair_database()
+                        except Exception:
+                            # repair_database() logs its own failure. Whether it
+                            # healed or not, the caller's transaction is gone; the
+                            # commit error is the one it needs to see.
+                            pass
                     raise
         finally:
             if not lease_released:

--- a/src/Ankimon/pyobj/database_manager.py
+++ b/src/Ankimon/pyobj/database_manager.py
@@ -1364,6 +1364,21 @@ class AnkimonDB:
         ``rowcount`` whether the ``quantity >= count`` guard actually matched.
         The follow-up DELETE only tidies an emptied row and is idempotent;
         both share the one transaction below.
+
+        Roll back if the commit fails, mirroring ``ConnectionWrapper.__exit__``.
+        A failed commit -- the busy_timeout expiring under write contention,
+        a full disk -- does not necessarily end sqlite's transaction, so the
+        decrement stays pending on this thread's connection. Nobody is paid:
+        ``consume_item`` never returns True, so ``Check_Heal_Item`` refuses the
+        heal. But the next unrelated write on the same connection commits, and
+        the pending decrement rides along with it -- the potion is gone and the
+        HP was never granted, which is precisely the half of the invariant this
+        method exists to hold. ``with conn:`` would also roll back, but its
+        ``__enter__`` issues an explicit BEGIN (which collides with exactly the
+        still-open transaction at issue) and its ``__exit__`` commits the raw
+        connection, ignoring the ``_disable_commit`` opt-out that mobile sync's
+        bulk resolve relies on. Roll back here instead and re-raise: a lost
+        write must not read as success.
         """
         if count <= 0:
             self._log("warning", f"Refusing to consume {count} of '{item_name}'.")
@@ -1371,18 +1386,28 @@ class AnkimonDB:
 
         conn = self._get_connection()
         cursor = conn.cursor()
-        cursor.execute(
-            "UPDATE items SET quantity = quantity - ? "
-            "WHERE item_name = ? AND quantity >= ?",
-            (count, item_name, count)
-        )
-        consumed = cursor.rowcount == 1
-        if consumed:
+        try:
             cursor.execute(
-                "DELETE FROM items WHERE item_name = ? AND quantity <= 0",
-                (item_name,)
+                "UPDATE items SET quantity = quantity - ? "
+                "WHERE item_name = ? AND quantity >= ?",
+                (count, item_name, count)
             )
-        conn.commit()
+            consumed = cursor.rowcount == 1
+            if consumed:
+                cursor.execute(
+                    "DELETE FROM items WHERE item_name = ? AND quantity <= 0",
+                    (item_name,)
+                )
+            conn.commit()
+        except Exception:
+            try:
+                conn.rollback()
+            except Exception:
+                # Nothing better to do: the original failure is the one the
+                # caller needs, and a connection too broken to roll back has
+                # no pending decrement anybody can accidentally commit.
+                pass
+            raise
         if not consumed:
             self._log(
                 "warning",

--- a/src/Ankimon/pyobj/database_manager.py
+++ b/src/Ankimon/pyobj/database_manager.py
@@ -1350,6 +1350,46 @@ class AnkimonDB:
         conn.commit()
         return new_qty
 
+    def consume_item(self, item_name: str, count: int = 1) -> bool:
+        """Spend ``count`` units of ``item_name``. Returns whether they were.
+
+        ``update_item_quantity`` cannot answer "did I actually pay for this?":
+        it reads the quantity and writes it back in two steps, and its return
+        value collapses "the row was gone" and "you just spent your last one"
+        into the same 0. A caller that hands out an effect on the strength of
+        that -- a heal, a revived fossil -- can hand it out for free.
+
+        The decrement here is one conditional statement, so the row cannot
+        change between the check and the write: sqlite reports through
+        ``rowcount`` whether the ``quantity >= count`` guard actually matched.
+        The follow-up DELETE only tidies an emptied row and is idempotent;
+        both share the one transaction below.
+        """
+        if count <= 0:
+            self._log("warning", f"Refusing to consume {count} of '{item_name}'.")
+            return False
+
+        conn = self._get_connection()
+        cursor = conn.cursor()
+        cursor.execute(
+            "UPDATE items SET quantity = quantity - ? "
+            "WHERE item_name = ? AND quantity >= ?",
+            (count, item_name, count)
+        )
+        consumed = cursor.rowcount == 1
+        if consumed:
+            cursor.execute(
+                "DELETE FROM items WHERE item_name = ? AND quantity <= 0",
+                (item_name,)
+            )
+        conn.commit()
+        if not consumed:
+            self._log(
+                "warning",
+                f"Item '{item_name}' could not be consumed: fewer than {count} in inventory."
+            )
+        return consumed
+
     # --- Badge Operations ---
 
     def save_badge(self, badge_id: str, badge_data: Dict[str, Any]):

--- a/src/Ankimon/pyobj/item_window.py
+++ b/src/Ankimon/pyobj/item_window.py
@@ -422,9 +422,14 @@ class ItemWindow(QWidget):
                 if not self.main_pokemon:
                     return {"ok": False, "message": "No active Pokémon to heal."}
                 hp_heal = self.hp_heal_items[name]
-                self.Check_Heal_Item(
+                # Report what actually happened: Check_Heal_Item declines when
+                # the bag turns out to be empty (a stale web list, a double
+                # click), and claiming a heal that never happened would leave
+                # the HP the toast promised nowhere to be found.
+                if not self.Check_Heal_Item(
                     self.main_pokemon.name, hp_heal, name, self.achievements
-                )
+                ):
+                    return {"ok": False, "message": f"No {name} left in your bag."}
                 return {
                     "ok": True,
                     "message": f"Healed {self.main_pokemon.name} with {name}.",
@@ -593,12 +598,53 @@ class ItemWindow(QWidget):
         else:
             self.logger.log_and_showinfo("error", f"{item_name} is not a valid Poké Ball!")
 
-    def delete_item(self, item_name: str):
-        # Update database directly for performance
+    def delete_item(self, item_name: str) -> bool:
+        """Consume one unit of ``item_name``. Returns True if one was removed.
+
+        ``update_item_quantity`` treats a missing row as a warning and returns
+        without touching the bag, and its return value cannot express that:
+        "the item was not there" and "you just used your last one" are both 0.
+        Read the quantity first so callers get an unambiguous answer and can
+        decline to hand out an effect that was never paid for.
+        """
+        try:
+            item = services.db.get_item(item_name)
+            quantity = int((item or {}).get("quantity") or 0)
+        except (TypeError, ValueError, AttributeError) as exc:
+            self.logger.log("error", f"Could not read {item_name} from the bag: {exc}")
+            return False
+
+        if quantity <= 0:
+            self.logger.log("warning", f"No {item_name} left in the bag; nothing consumed.")
+            return False
+
         services.db.update_item_quantity(item_name, -1)
         self.renewWidgets()
+        return True
 
-    def Check_Heal_Item(self, prevo_name: str, heal_points: int, item_name: str, achievements):
+    def Check_Heal_Item(self, prevo_name: str, heal_points: int, item_name: str, achievements) -> bool:
+        """Heal the main Pokemon with ``item_name``, consuming one from the bag.
+
+        Returns True only when the item was actually spent AND the heal applied.
+
+        Consume BEFORE healing: the bag UI is the only thing that used to stop a
+        player healing with an item they no longer own -- the Qt "Heal
+        Mainpokemon" button (``ItemLabel``) checks nothing at all and relies on
+        ``renewWidgets`` having rebuilt itself in time -- and ``delete_item``
+        used to drop the database's "item not found" warning on the floor. The
+        heal was therefore granted whether or not anything was spent. Paying
+        first makes the effect impossible to get for free from any call path.
+        """
+        if self.main_pokemon is None:
+            self.logger.log_and_showinfo("error", "No active Pokemon to heal.")
+            return False
+
+        if not self.delete_item(item_name):
+            self.logger.log_and_showinfo("info", f"You have no {item_name} left.")
+            return False
+
+        # Badge 20 is "used a healing item" -- award it only once one was
+        # actually spent.
         check = check_for_badge(achievements, 20)
         if check is False:
             receive_badge(20, achievements)
@@ -612,9 +658,9 @@ class ItemWindow(QWidget):
         # ._normalize_loaded_hp reads ``current_hp`` first, so bumping ``hp``
         # alone makes the heal disappear the next time this record is loaded.
         self.main_pokemon.current_hp = self.main_pokemon.hp
-        self.delete_item(item_name)
         play_effect_sound(self.settings_obj, "HpHeal")
         self.logger.log_and_showinfo("info", f"{prevo_name} was healed for {heal_points}")
+        return True
 
     def Check_Evo_Item(self, individual_id: str, prevo_id: str, item_name: str):
         try:

--- a/src/Ankimon/pyobj/item_window.py
+++ b/src/Ankimon/pyobj/item_window.py
@@ -359,7 +359,10 @@ class ItemWindow(QWidget):
         if item_name in self.hp_heal_items:
             use_item_button = QPushButton("Heal Mainpokemon")
             hp_heal = self.hp_heal_items[item_name]
-            use_item_button.clicked.connect(lambda: self.Check_Heal_Item(self.main_pokemon.name, hp_heal, item_name, self.achievements))
+            # Resolve the main Pokemon inside the handler, not in the lambda:
+            # ``self.main_pokemon.name`` here is evaluated on click and raises
+            # before the no-main guard in Check_Heal_Item can report anything.
+            use_item_button.clicked.connect(lambda: self._heal_main_pokemon(item_name, hp_heal))
         elif item_name in self.fossil_pokemon:
             fossil_id = self.fossil_pokemon[item_name]
             fossil_pokemon_name = search_pokedex_by_id(fossil_id)
@@ -598,14 +601,36 @@ class ItemWindow(QWidget):
         else:
             self.logger.log_and_showinfo("error", f"{item_name} is not a valid Poké Ball!")
 
-    def delete_item(self, item_name: str) -> bool:
-        """Consume one unit of ``item_name``. Returns True if one was removed.
+    def _refresh_bag(self):
+        """Redraw the bag grid, absorbing any failure while doing so.
 
-        ``update_item_quantity`` treats a missing row as a warning and returns
-        without touching the bag, and its return value cannot express that:
-        "the item was not there" and "you just used your last one" are both 0.
-        Read the quantity first so callers get an unambiguous answer and can
-        decline to hand out an effect that was never paid for.
+        This runs *after* the effect an item paid for has been applied, and it
+        walks the whole inventory: one unreadable row, a missing sprite or a
+        window whose C++ side has gone away must not raise on a code path where
+        the item has already left the bag.
+        """
+        try:
+            self.renewWidgets()
+        except Exception as exc:
+            self.logger.log("error", f"Could not refresh the item bag: {exc}")
+
+    def _consume_one(self, item_name: str) -> bool:
+        """Spend one ``item_name`` from the bag. Returns True if one was spent.
+
+        Database only -- deliberately no UI work, so that nothing fallible sits
+        between the payment and the effect it pays for. Callers redraw with
+        ``_refresh_bag`` once that effect has landed.
+
+        Authorization is ``consume_item``'s answer, not the read below it:
+        ``get_item`` and any later write are two separate statements, and the
+        row can empty in between (a second click, a background writer), which
+        ``update_item_quantity`` reports as the same 0 it uses for "the item was
+        never there". ``consume_item`` decrements under a ``quantity >= 1``
+        condition in a single statement and reports whether that matched.
+
+        The read is kept because it is still worth something: it keeps a
+        malformed row ("quantity": "lots") out of the write path, which SQL
+        would otherwise happily compare and decrement.
         """
         try:
             item = services.db.get_item(item_name)
@@ -618,8 +643,29 @@ class ItemWindow(QWidget):
             self.logger.log("warning", f"No {item_name} left in the bag; nothing consumed.")
             return False
 
-        services.db.update_item_quantity(item_name, -1)
-        self.renewWidgets()
+        if not services.db.consume_item(item_name):
+            # The read above said there was stock; by the time the bag was
+            # charged there was not. Distinct wording so the log tells the two
+            # apart.
+            self.logger.log(
+                "warning",
+                f"The last {item_name} was gone before the bag could be charged; "
+                "nothing consumed.",
+            )
+            return False
+        return True
+
+    def delete_item(self, item_name: str) -> bool:
+        """Consume one unit of ``item_name`` and redraw the bag.
+
+        Returns True if one was removed. This is the entry point for the paths
+        whose effect has already happened by the time they pay (the Poke Ball
+        throw, the fossil revival); ``Check_Heal_Item`` calls ``_consume_one``
+        itself so that it can redraw only once the HP has been granted.
+        """
+        if not self._consume_one(item_name):
+            return False
+        self._refresh_bag()
         return True
 
     def Check_Heal_Item(self, prevo_name: str, heal_points: int, item_name: str, achievements) -> bool:
@@ -634,20 +680,21 @@ class ItemWindow(QWidget):
         used to drop the database's "item not found" warning on the floor. The
         heal was therefore granted whether or not anything was spent. Paying
         first makes the effect impossible to get for free from any call path.
+
+        Consume with ``_consume_one`` rather than ``delete_item``: the latter
+        redraws the bag as part of paying, and rebuilding the grid reads every
+        row and rebuilds every widget. Anything that threw in there would leave
+        the item spent and the HP never granted -- the same free item bug in
+        the other direction.
         """
         if self.main_pokemon is None:
             self.logger.log_and_showinfo("error", "No active Pokemon to heal.")
             return False
 
-        if not self.delete_item(item_name):
+        if not self._consume_one(item_name):
             self.logger.log_and_showinfo("info", f"You have no {item_name} left.")
             return False
 
-        # Badge 20 is "used a healing item" -- award it only once one was
-        # actually spent.
-        check = check_for_badge(achievements, 20)
-        if check is False:
-            receive_badge(20, achievements)
         if item_name == "fullrestore" or item_name == "maxpotion":
             heal_points = self.main_pokemon.max_hp
         self.main_pokemon.hp += heal_points
@@ -658,9 +705,32 @@ class ItemWindow(QWidget):
         # ._normalize_loaded_hp reads ``current_hp`` first, so bumping ``hp``
         # alone makes the heal disappear the next time this record is loaded.
         self.main_pokemon.current_hp = self.main_pokemon.hp
+        # Everything below is bookkeeping and presentation, and runs only once
+        # the HP is safely granted. Badge 20 is "used a healing item", so it is
+        # awarded here rather than before the heal: an item was really spent.
+        check = check_for_badge(achievements, 20)
+        if check is False:
+            receive_badge(20, achievements)
+        self._refresh_bag()
         play_effect_sound(self.settings_obj, "HpHeal")
         self.logger.log_and_showinfo("info", f"{prevo_name} was healed for {heal_points}")
         return True
+
+    def _heal_main_pokemon(self, item_name: str, heal_points: int) -> bool:
+        """Bag-button entry point for a healing item.
+
+        The "Heal Mainpokemon" button used to bind ``self.main_pokemon.name``
+        inside its own lambda, and a lambda body is evaluated at click time: with
+        no main Pokemon that raised AttributeError before ``Check_Heal_Item``
+        was even entered, so the no-main guard added there never got the chance
+        to speak. Resolve the name defensively and let that guard answer.
+        """
+        return self.Check_Heal_Item(
+            getattr(self.main_pokemon, "name", "your Pokemon"),
+            heal_points,
+            item_name,
+            self.achievements,
+        )
 
     def Check_Evo_Item(self, individual_id: str, prevo_id: str, item_name: str):
         try:

--- a/tests/test_database_manager.py
+++ b/tests/test_database_manager.py
@@ -82,6 +82,24 @@ def temp_env(tmp_path):
         db = AnkimonDB(MockLogger())
         yield db, tmp_path
 
+
+def _quantity_on_disk(db, item_name):
+    """Read a quantity through a connection of our own.
+
+    ``db.get_item`` goes through the connection under test, which cannot tell a
+    committed row from one still sitting in an open transaction. A separate
+    handle only ever sees what is durable.
+    """
+    raw = sqlite3.connect(str(db.db_path), timeout=1.0)
+    try:
+        row = raw.execute(
+            "SELECT quantity FROM items WHERE item_name = ?", (item_name,)
+        ).fetchone()
+    finally:
+        raw.close()
+    return None if row is None else row[0]
+
+
 def test_database_initialization(temp_env):
     db, _ = temp_env
     conn = db._get_connection()
@@ -246,6 +264,55 @@ def test_consume_item_refuses_a_short_bag_without_partial_payment(temp_env):
 
     assert db.consume_item("bulk", count=2) is True
     assert db.get_item("bulk") is None
+
+
+def test_consume_item_rolls_back_a_failed_commit(temp_env):
+    """A commit that fails must not leave the decrement waiting for a ride.
+
+    sqlite does not necessarily end the transaction when COMMIT fails (a
+    busy_timeout expiring under write contention, a full disk), so without a
+    rollback the decrement stays pending on this thread's connection. Nobody
+    is paid for it -- ``consume_item`` raises rather than returning True, so
+    ``Check_Heal_Item`` refuses the heal -- but the next unrelated write on the
+    same connection commits, and the pending decrement rides along: the potion
+    is gone and the HP was never granted.
+    """
+    db, _ = temp_env
+    db.save_item(105, "contended-potion", 5)
+
+    conn = db._get_connection()
+    with patch.object(conn, "commit",
+                      side_effect=sqlite3.OperationalError("database is locked")):
+        with pytest.raises(sqlite3.OperationalError):
+            db.consume_item("contended-potion")
+
+    assert db.get_item("contended-potion")["quantity"] == 5, \
+        "the failed payment still charged the bag"
+
+    # The scenario that makes it matter: some later write succeeds on the very
+    # same connection. Anything still pending is committed by it.
+    db.save_item(106, "unrelated", 1)
+
+    assert _quantity_on_disk(db, "contended-potion") == 5, \
+        "the pending decrement rode along on a later successful commit"
+
+
+def test_consume_item_leaves_no_transaction_open_after_a_failed_commit(temp_env):
+    """The mechanism behind the test above: the transaction is actually gone.
+
+    Reading back through the same connection cannot tell a committed row from
+    an uncommitted one, so assert on the connection itself.
+    """
+    db, _ = temp_env
+    db.save_item(107, "doomed-potion", 2)
+
+    conn = db._get_connection()
+    with patch.object(conn, "commit", side_effect=sqlite3.OperationalError("disk I/O error")):
+        with pytest.raises(sqlite3.OperationalError):
+            db.consume_item("doomed-potion")
+
+    assert conn.in_transaction is False, \
+        "the decrement is still pending and will be committed by the next write"
 
 
 def test_get_item_returns_empty_dict_extras(temp_env):

--- a/tests/test_database_manager.py
+++ b/tests/test_database_manager.py
@@ -182,6 +182,72 @@ def test_update_item_quantity_preserves_metadata(temp_env):
     assert item["id"] == 100
     assert item["cost"] == 500
 
+def test_consume_item_decrements_and_preserves_metadata(temp_env):
+    """Spending one unit must not cost the row its identity."""
+    db, _ = temp_env
+    db.save_item(100, "elixir", 5, category_id=10, cost=500)
+
+    assert db.consume_item("elixir") is True
+
+    item = db.get_item("elixir")
+    assert item["quantity"] == 4
+    assert item["id"] == 100
+    assert item["cost"] == 500
+
+
+def test_consume_item_removes_the_row_on_the_last_unit(temp_env):
+    db, _ = temp_env
+    db.save_item(101, "last-potion", 1)
+
+    assert db.consume_item("last-potion") is True
+    assert db.get_item("last-potion") is None
+
+
+def test_consume_item_refuses_what_is_not_there(temp_env):
+    """The distinction ``update_item_quantity`` cannot draw.
+
+    It answers 0 both for "the row was missing" and for "you just spent your
+    last one", so a caller handing out an effect on that answer hands it out
+    for free. ``consume_item`` reports whether it actually decremented.
+    """
+    db, _ = temp_env
+
+    assert db.consume_item("never-owned") is False
+    assert db.get_item("never-owned") is None
+
+
+def test_consume_item_refuses_a_leftover_zero_row(temp_env):
+    """A row at quantity 0 is not stock, and must not go negative."""
+    db, _ = temp_env
+    db.save_item(102, "ghost-potion", 0)
+
+    assert db.consume_item("ghost-potion") is False
+    item = db.get_item("ghost-potion")
+    assert item is None or item["quantity"] == 0
+
+
+def test_consume_item_cannot_spend_the_same_unit_twice(temp_env):
+    """The atomicity that matters: one potion pays for exactly one effect."""
+    db, _ = temp_env
+    db.save_item(103, "single", 1)
+
+    assert db.consume_item("single") is True
+    assert db.consume_item("single") is False
+    assert db.get_item("single") is None
+
+
+def test_consume_item_refuses_a_short_bag_without_partial_payment(temp_env):
+    """Asking for more than is there takes nothing at all."""
+    db, _ = temp_env
+    db.save_item(104, "bulk", 2)
+
+    assert db.consume_item("bulk", count=3) is False
+    assert db.get_item("bulk")["quantity"] == 2, "a refused consume still charged the bag"
+
+    assert db.consume_item("bulk", count=2) is True
+    assert db.get_item("bulk") is None
+
+
 def test_get_item_returns_empty_dict_extras(temp_env):
     db, _ = temp_env
     # Inject a row with NULL data manually to test the default extra_data logic

--- a/tests/test_database_manager.py
+++ b/tests/test_database_manager.py
@@ -5,6 +5,7 @@ import csv
 import sqlite3
 import pytest
 import importlib.util
+import contextlib
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 import types
@@ -98,6 +99,40 @@ def _quantity_on_disk(db, item_name):
     finally:
         raw.close()
     return None if row is None else row[0]
+
+
+class _CorruptOnCommit:
+    """A connection whose COMMIT fails the way a corrupt database file does.
+
+    Patching ``ConnectionWrapper.commit`` -- what the busy-timeout tests below
+    do -- cannot reach the wrapper's own corruption branch, because that branch
+    lives inside the method being replaced. Patching the raw handle is not an
+    option either: ``sqlite3.Connection.commit`` is a read-only C attribute.
+    So wrap the real connection and let everything except the commit through;
+    ``ConnectionWrapper._conn`` is a plain Python attribute, so it can be swapped.
+    """
+
+    def __init__(self, conn):
+        self._real = conn
+        self.commit_attempts = 0
+
+    def commit(self):
+        self.commit_attempts += 1
+        raise sqlite3.DatabaseError("database disk image is malformed")
+
+    def __getattr__(self, name):
+        return getattr(self._real, name)
+
+
+@contextlib.contextmanager
+def _corrupt_commits_on(conn):
+    """Make ``conn``'s raw handle fail COMMIT, and put the real one back after."""
+    real = conn._conn
+    conn._conn = _CorruptOnCommit(real)
+    try:
+        yield conn._conn
+    finally:
+        conn._conn = real
 
 
 def test_database_initialization(temp_env):
@@ -313,6 +348,71 @@ def test_consume_item_leaves_no_transaction_open_after_a_failed_commit(temp_env)
 
     assert conn.in_transaction is False, \
         "the decrement is still pending and will be committed by the next write"
+
+
+def test_commit_does_not_report_success_after_a_repair_loses_the_transaction(temp_env):
+    """Corruption found at COMMIT time must not be healed into a fake success.
+
+    ``ConnectionWrapper.commit`` recognises "malformed"/"disk image" and calls
+    ``repair_database``, which rebuilds the file from a *separate* connection's
+    ``iterdump()`` -- so it cannot see rows still pending on this one -- then
+    quiesces every registered connection and swaps the rebuilt file into place.
+    Neither step carries the pending transaction across. Committing the fresh
+    post-repair connection therefore commits nothing, and returning from that
+    reports success for a write that no longer exists.
+
+    That is the free-heal ``consume_item`` was written to close: the potion is
+    still in the bag, and the caller was told it paid for one.
+    """
+    db, _ = temp_env
+    db.save_item(108, "cursed-potion", 3)
+
+    conn = db._get_connection()
+    backup = db.db_path.with_name(db.db_path.name + ".corrupt_backup")
+    assert not backup.exists()
+
+    with _corrupt_commits_on(conn) as fake:
+        # Through the wrapper, without keeping the cursor: nothing holds a lease,
+        # so the repair's quiesce really does drain and the file really is
+        # swapped -- the case where the old code returned success.
+        conn.execute(
+            "UPDATE items SET quantity = 1 WHERE item_name = 'cursed-potion'"
+        )
+        assert conn._lease_count == 0
+        with pytest.raises(sqlite3.DatabaseError, match="malformed"):
+            conn.commit()
+        assert fake.commit_attempts == 1
+
+    assert backup.exists(), \
+        "the repair never ran, so this asserts nothing about the repair branch"
+    assert _quantity_on_disk(db, "cursed-potion") == 3, \
+        "the pending write survived the repair -- premise of the test is wrong"
+
+
+def test_consume_item_pays_nothing_when_the_commit_finds_corruption(temp_env):
+    """The invariant end-to-end: a decrement lost to a repair is never paid for.
+
+    Today the decrement is doubly safe -- ``consume_item`` holds its cursor, so
+    the lease keeps the repair's quiesce from draining and the repair aborts.
+    Pin the outcome rather than that mechanism: whichever way the commit fails,
+    ``consume_item`` must raise instead of returning True, leave the bag intact,
+    and leave nothing pending for the next write to carry.
+    """
+    db, _ = temp_env
+    db.save_item(109, "hexed-potion", 2)
+
+    conn = db._get_connection()
+    with _corrupt_commits_on(conn):
+        with pytest.raises(sqlite3.DatabaseError, match="malformed"):
+            db.consume_item("hexed-potion")
+
+    assert db.get_item("hexed-potion")["quantity"] == 2, \
+        "the failed payment still charged the bag"
+
+    db.save_item(110, "unrelated-after-corruption", 1)
+
+    assert _quantity_on_disk(db, "hexed-potion") == 2, \
+        "the pending decrement rode along on a later successful commit"
 
 
 def test_get_item_returns_empty_dict_extras(temp_env):

--- a/tests/test_heal_item_consumption.py
+++ b/tests/test_heal_item_consumption.py
@@ -1,0 +1,288 @@
+"""Regression tests for ``pyobj/item_window.py`` healing-item consumption.
+
+``ItemWindow.Check_Heal_Item`` used to grant the HP first and only then call
+``delete_item``, which threw away the database's answer:
+``DatabaseManager.update_item_quantity`` logs "Item not found in inventory."
+and returns without touching the bag when the row is missing.  Nothing between
+the click and the heal ever checked that a potion was actually spent -- the Qt
+bag's "Heal Mainpokemon" button (``ItemLabel``) binds ``Check_Heal_Item``
+directly with no quantity check at all -- so any stale or repeated request
+healed for free.  These pin the consume-before-heal ordering and the refusal.
+
+``item_window.py`` imports Qt and most of the addon at module scope, so it is
+loaded in isolation with those stubbed (mirroring
+``test_evolution_item_consumption.py``), except ``Ankimon.services`` which is
+the real aqt-free registry so ``services.db`` can be pointed at a fake.
+"""
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+_SRC = Path(__file__).resolve().parent.parent / "src"
+
+
+class _MockQWidget:
+    """Real class so ``class ItemWindow(QWidget)`` is a valid definition."""
+
+    def __init__(self, *args, **kwargs):
+        pass
+
+
+class _FakeItemDB:
+    """The ``services.db`` seam: an inventory plus a write log."""
+
+    def __init__(self, inventory=None):
+        self.inventory = dict(inventory or {})
+        self.quantity_calls = []
+
+    def get_item(self, item_name):
+        if item_name not in self.inventory:
+            return None
+        return {"item_name": item_name, "quantity": self.inventory[item_name]}
+
+    def update_item_quantity(self, item_name, delta):
+        self.quantity_calls.append((item_name, delta))
+        current = self.inventory.get(item_name, 0)
+        if current == 0:
+            return 0
+        new = current + delta
+        if new < 0:
+            return current
+        if new == 0:
+            self.inventory.pop(item_name, None)
+        else:
+            self.inventory[item_name] = new
+        return new
+
+
+class _FakePokemon:
+    def __init__(self, name="mewtwo", hp=10, max_hp=100):
+        self.name = name
+        self.hp = hp
+        self.max_hp = max_hp
+        self.current_hp = hp
+
+
+def _force_load(name, filepath):
+    spec = importlib.util.spec_from_file_location(name, filepath)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture
+def item_window_mod():
+    """Load the real ``item_window`` with a stubbed Qt/addon runtime."""
+    parent_pkgs = ("Ankimon", "Ankimon.functions", "Ankimon.pyobj")
+    stub_names = [
+        "aqt", "aqt.utils", "aqt.qt",
+        "PyQt6", "PyQt6.QtGui", "PyQt6.QtWidgets", "PyQt6.QtCore",
+        "Ankimon.pyobj.evolution_window",
+        "Ankimon.pyobj.InfoLogger",
+        "Ankimon.pyobj.pc_box",
+        "Ankimon.pyobj.pokemon_obj",
+        "Ankimon.pyobj.settings",
+        "Ankimon.pyobj.starter_window",
+        "Ankimon.pyobj.error_handler",
+        "Ankimon.business",
+        "Ankimon.functions.pokedex_functions",
+        "Ankimon.functions.badges_functions",
+        "Ankimon.functions.pokemon_functions",
+        "Ankimon.resources",
+        "Ankimon.utils",
+        "Ankimon.pyobj.item_window",
+    ]
+    saved = {name: sys.modules.get(name) for name in (*stub_names, *parent_pkgs, "Ankimon.services")}
+
+    try:
+        for pkg in parent_pkgs:
+            mod = types.ModuleType(pkg)
+            mod.__path__ = [str(_SRC / pkg.replace(".", "/"))]
+            mod.__package__ = pkg
+            sys.modules[pkg] = mod
+        for name in stub_names:
+            sys.modules[name] = MagicMock()
+        # ItemWindow subclasses QWidget, so that one must be a real class.
+        sys.modules["PyQt6.QtWidgets"].QWidget = _MockQWidget
+        # ``Ankimon.services`` stays real: it is the seam the fake DB rides in on.
+        services_mod = _force_load("Ankimon.services", _SRC / "Ankimon" / "services.py")
+        mod = _force_load(
+            "Ankimon.pyobj.item_window", _SRC / "Ankimon" / "pyobj" / "item_window.py"
+        )
+        mod._services_mod = services_mod
+        yield mod
+    finally:
+        for name, val in saved.items():
+            if val is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = val
+
+
+def _make_window(mod, db, main_pokemon=None):
+    """A bare ItemWindow: no Qt construction, just the collaborators used here."""
+    win = mod.ItemWindow.__new__(mod.ItemWindow)
+    win.logger = MagicMock()
+    win.settings_obj = MagicMock()
+    win.main_pokemon = main_pokemon
+    win.achievements = {}
+    win.renewWidgets = MagicMock()
+    win.hp_heal_items = {"potion": 20, "fullrestore": 0}
+    win.fossil_pokemon = {}
+    win.pokeball_chances = {}
+    win._item_action_in_progress = False
+    mod.services.db = db
+    # Badge bookkeeping is imported by name into the module namespace.
+    mod.check_for_badge = MagicMock(return_value=True)
+    mod.receive_badge = MagicMock()
+    mod.play_effect_sound = MagicMock()
+    return win
+
+
+def test_heal_consumes_exactly_one_item(item_window_mod):
+    """The happy path still heals, and spends one potion doing it."""
+    db = _FakeItemDB({"potion": 2})
+    pokemon = _FakePokemon(hp=10, max_hp=100)
+    win = _make_window(item_window_mod, db, pokemon)
+
+    result = win.Check_Heal_Item("mewtwo", 20, "potion", {})
+
+    assert result is True
+    assert pokemon.hp == 30
+    assert pokemon.current_hp == 30, "the persisted mirror must follow the heal"
+    assert db.quantity_calls == [("potion", -1)]
+    assert db.inventory["potion"] == 1
+
+
+def test_heal_is_refused_when_the_bag_is_empty(item_window_mod):
+    """No potion, no heal -- and no write attempt either.
+
+    ``update_item_quantity`` would have logged a warning and returned without
+    decrementing anything, which the old code discarded, handing out the HP
+    regardless.
+    """
+    db = _FakeItemDB({})
+    pokemon = _FakePokemon(hp=10, max_hp=100)
+    win = _make_window(item_window_mod, db, pokemon)
+
+    result = win.Check_Heal_Item("mewtwo", 20, "potion", {})
+
+    assert result is False
+    assert pokemon.hp == 10, "HP was granted for an item the player does not own"
+    assert pokemon.current_hp == 10
+    assert db.quantity_calls == []
+    assert win.logger.log_and_showinfo.called, "the player was never told why nothing happened"
+
+
+def test_heal_is_refused_when_the_row_says_zero(item_window_mod):
+    """A leftover row at quantity 0 is not stock."""
+    db = _FakeItemDB({"potion": 0})
+    pokemon = _FakePokemon(hp=10, max_hp=100)
+    win = _make_window(item_window_mod, db, pokemon)
+
+    assert win.Check_Heal_Item("mewtwo", 20, "potion", {}) is False
+    assert pokemon.hp == 10
+    assert db.quantity_calls == []
+
+
+def test_second_use_of_the_last_potion_heals_nothing(item_window_mod):
+    """The double-use case: one potion cannot pay for two heals."""
+    db = _FakeItemDB({"potion": 1})
+    pokemon = _FakePokemon(hp=10, max_hp=100)
+    win = _make_window(item_window_mod, db, pokemon)
+
+    assert win.Check_Heal_Item("mewtwo", 20, "potion", {}) is True
+    assert win.Check_Heal_Item("mewtwo", 20, "potion", {}) is False
+    assert pokemon.hp == 30, "the second click healed for free"
+    assert db.quantity_calls == [("potion", -1)]
+
+
+def test_no_main_pokemon_does_not_burn_an_item(item_window_mod):
+    """Nothing to heal means nothing is spent."""
+    db = _FakeItemDB({"potion": 1})
+    win = _make_window(item_window_mod, db, main_pokemon=None)
+
+    assert win.Check_Heal_Item("nobody", 20, "potion", {}) is False
+    assert db.quantity_calls == []
+    assert db.inventory["potion"] == 1
+
+
+def test_badge_is_not_awarded_for_a_refused_heal(item_window_mod):
+    """Badge 20 marks having *used* a healing item."""
+    db = _FakeItemDB({})
+    win = _make_window(item_window_mod, db, _FakePokemon())
+    item_window_mod.check_for_badge = MagicMock(return_value=False)
+    item_window_mod.receive_badge = MagicMock()
+
+    win.Check_Heal_Item("mewtwo", 20, "potion", {})
+
+    assert not item_window_mod.receive_badge.called
+
+
+def test_fullrestore_still_heals_to_max_and_clamps(item_window_mod):
+    """Existing behaviour is untouched on the successful path."""
+    db = _FakeItemDB({"fullrestore": 1})
+    pokemon = _FakePokemon(hp=10, max_hp=100)
+    win = _make_window(item_window_mod, db, pokemon)
+
+    assert win.Check_Heal_Item("mewtwo", 0, "fullrestore", {}) is True
+    assert pokemon.hp == 100
+    assert pokemon.current_hp == 100
+
+
+def test_dispatch_use_reports_a_refused_heal(item_window_mod):
+    """The web Items window must not toast a heal that never happened."""
+    db = _FakeItemDB({})
+    win = _make_window(item_window_mod, db, _FakePokemon())
+
+    result = win.dispatch_use("potion")
+
+    assert result["ok"] is False
+    assert "potion" in result["message"].lower()
+
+
+def test_dispatch_use_still_reports_a_real_heal(item_window_mod):
+    db = _FakeItemDB({"potion": 1})
+    win = _make_window(item_window_mod, db, _FakePokemon(hp=10, max_hp=100))
+
+    result = win.dispatch_use("potion")
+
+    assert result["ok"] is True
+    assert db.quantity_calls == [("potion", -1)]
+
+
+def test_delete_item_consumes_one_and_reports_it(item_window_mod):
+    db = _FakeItemDB({"potion": 3})
+    win = _make_window(item_window_mod, db, _FakePokemon())
+
+    assert win.delete_item("potion") is True
+    assert db.inventory["potion"] == 2
+    assert win.renewWidgets.called
+
+
+def test_delete_item_reports_a_missing_item_without_writing(item_window_mod):
+    db = _FakeItemDB({})
+    win = _make_window(item_window_mod, db, _FakePokemon())
+
+    assert win.delete_item("potion") is False
+    assert db.quantity_calls == []
+    assert not win.renewWidgets.called
+
+
+def test_delete_item_survives_a_broken_bag_row(item_window_mod):
+    """A malformed quantity is "no usable stock", not a crash mid-click."""
+    class _JunkDB(_FakeItemDB):
+        def get_item(self, item_name):
+            return {"item_name": item_name, "quantity": "lots"}
+
+    db = _JunkDB({"potion": 1})
+    win = _make_window(item_window_mod, db, _FakePokemon())
+
+    assert win.delete_item("potion") is False
+    assert db.quantity_calls == []

--- a/tests/test_heal_item_consumption.py
+++ b/tests/test_heal_item_consumption.py
@@ -9,6 +9,13 @@ bag's "Heal Mainpokemon" button (``ItemLabel``) binds ``Check_Heal_Item``
 directly with no quantity check at all -- so any stale or repeated request
 healed for free.  These pin the consume-before-heal ordering and the refusal.
 
+They also pin what the review of that first fix turned up: the bag redraw must
+not sit between the payment and the heal (a redraw that throws would spend the
+potion and grant nothing), reading the quantity is not the same as paying for
+the item (``DatabaseManager.consume_item`` decrements under a condition and
+reports whether it matched), and the bag button must not dereference
+``main_pokemon`` inside its own lambda.
+
 ``item_window.py`` imports Qt and most of the addon at module scope, so it is
 loaded in isolation with those stubbed (mirroring
 ``test_evolution_item_consumption.py``), except ``Ankimon.services`` which is
@@ -34,7 +41,12 @@ class _MockQWidget:
 
 
 class _FakeItemDB:
-    """The ``services.db`` seam: an inventory plus a write log."""
+    """The ``services.db`` seam: an inventory plus a write log.
+
+    ``quantity_calls`` records every attempted write to the bag as
+    ``(item_name, delta)``, whichever method made it, so a test can say "the
+    bag was written exactly once, by -1" without caring which one.
+    """
 
     def __init__(self, inventory=None):
         self.inventory = dict(inventory or {})
@@ -44,6 +56,23 @@ class _FakeItemDB:
         if item_name not in self.inventory:
             return None
         return {"item_name": item_name, "quantity": self.inventory[item_name]}
+
+    def consume_item(self, item_name, count=1):
+        """Mirror of the real atomic consume: decrement only if stock covers it.
+
+        The real one is a single ``UPDATE ... WHERE quantity >= ?`` and reports
+        whether the condition matched, so unlike ``update_item_quantity`` it can
+        tell "you spent your last one" from "there was nothing to spend".
+        """
+        self.quantity_calls.append((item_name, -count))
+        current = self.inventory.get(item_name, 0)
+        if current < count:
+            return False
+        if current == count:
+            self.inventory.pop(item_name, None)
+        else:
+            self.inventory[item_name] = current - count
+        return True
 
     def update_item_quantity(self, item_name, delta):
         self.quantity_calls.append((item_name, delta))
@@ -98,7 +127,17 @@ def item_window_mod():
         "Ankimon.utils",
         "Ankimon.pyobj.item_window",
     ]
-    saved = {name: sys.modules.get(name) for name in (*stub_names, *parent_pkgs, "Ankimon.services")}
+    saved = {
+        name: sys.modules.get(name)
+        for name in (
+            *stub_names,
+            *parent_pkgs,
+            "Ankimon.services",
+            # Not stubbed -- the real-database test below loads it for real, and
+            # it must be put back exactly as it was found either way.
+            "Ankimon.pyobj.database_manager",
+        )
+    }
 
     try:
         for pkg in parent_pkgs:
@@ -177,7 +216,15 @@ def test_heal_is_refused_when_the_bag_is_empty(item_window_mod):
     assert pokemon.hp == 10, "HP was granted for an item the player does not own"
     assert pokemon.current_hp == 10
     assert db.quantity_calls == []
-    assert win.logger.log_and_showinfo.called, "the player was never told why nothing happened"
+    shown = [
+        call.args[1]
+        for call in win.logger.log_and_showinfo.call_args_list
+        if len(call.args) > 1
+    ]
+    assert shown, "the player was never told why nothing happened"
+    assert any("potion" in msg.lower() for msg in shown), (
+        "the refusal must name the item the player tried to use"
+    )
 
 
 def test_heal_is_refused_when_the_row_says_zero(item_window_mod):
@@ -273,6 +320,13 @@ def test_delete_item_reports_a_missing_item_without_writing(item_window_mod):
     assert win.delete_item("potion") is False
     assert db.quantity_calls == []
     assert not win.renewWidgets.called
+    warnings = [
+        call.args[1]
+        for call in win.logger.log.call_args_list
+        if len(call.args) > 1 and call.args[0] == "warning"
+    ]
+    assert warnings, "a refused consume left no trace in the log"
+    assert "potion" in warnings[0].lower(), "the warning must name the item"
 
 
 def test_delete_item_survives_a_broken_bag_row(item_window_mod):
@@ -286,3 +340,118 @@ def test_delete_item_survives_a_broken_bag_row(item_window_mod):
 
     assert win.delete_item("potion") is False
     assert db.quantity_calls == []
+
+
+def test_a_failing_bag_redraw_cannot_swallow_the_heal(item_window_mod):
+    """The blocker: paying and healing must not be separated by the UI.
+
+    ``delete_item`` used to decrement the bag and *then* rebuild the whole item
+    grid before returning, with the heal applied only afterwards. Redrawing
+    reads every row and constructs a widget per item, so anything that threw in
+    there -- a malformed row, a sprite that will not load, a window whose C++
+    side is gone -- left the potion spent and the HP never granted.
+    """
+    db = _FakeItemDB({"potion": 1})
+    pokemon = _FakePokemon(hp=10, max_hp=100)
+    win = _make_window(item_window_mod, db, pokemon)
+    win.renewWidgets = MagicMock(side_effect=RuntimeError("wrapped C/C++ object deleted"))
+
+    assert win.Check_Heal_Item("mewtwo", 20, "potion", {}) is True
+    assert pokemon.hp == 30, "the potion was spent and the heal never landed"
+    assert pokemon.current_hp == 30
+    assert db.quantity_calls == [("potion", -1)]
+
+
+def test_the_bag_is_redrawn_only_after_the_heal_lands(item_window_mod):
+    """Ordering, not just survival: the grid must never show a half-done use."""
+    db = _FakeItemDB({"potion": 1})
+    pokemon = _FakePokemon(hp=10, max_hp=100)
+    win = _make_window(item_window_mod, db, pokemon)
+    hp_at_redraw = []
+    win.renewWidgets = lambda: hp_at_redraw.append(pokemon.hp)
+
+    assert win.Check_Heal_Item("mewtwo", 20, "potion", {}) is True
+    assert hp_at_redraw == [30], "the bag was redrawn before the HP was granted"
+
+
+def test_a_row_that_vanishes_after_the_check_heals_nothing(item_window_mod):
+    """The non-atomic window: reading the quantity is not paying for the item.
+
+    ``get_item`` and the write that follows it are two separate statements. If
+    the row empties in between -- a second click, another window, a background
+    writer -- the old code decremented nothing and still returned True, because
+    ``update_item_quantity`` reports "the item was not there" with the same 0 it
+    uses for "you just spent your last one". The atomic consume answers instead.
+    """
+    class _VanishingDB(_FakeItemDB):
+        def consume_item(self, item_name, count=1):
+            self.quantity_calls.append((item_name, -count))
+            self.inventory.pop(item_name, None)  # someone else got there first
+            return False
+
+    db = _VanishingDB({"potion": 1})
+    pokemon = _FakePokemon(hp=10, max_hp=100)
+    win = _make_window(item_window_mod, db, pokemon)
+
+    assert win.Check_Heal_Item("mewtwo", 20, "potion", {}) is False
+    assert pokemon.hp == 10, "HP was granted for a potion nobody managed to spend"
+    assert pokemon.current_hp == 10
+
+
+def test_the_heal_button_handler_survives_having_no_main_pokemon(item_window_mod):
+    """The bag button's lambda used to dereference ``main_pokemon`` itself.
+
+    ``lambda: self.Check_Heal_Item(self.main_pokemon.name, ...)`` evaluates that
+    attribute at click time, so with no main Pokemon it raised AttributeError
+    out of a Qt slot and the guard inside ``Check_Heal_Item`` never ran.
+    """
+    db = _FakeItemDB({"potion": 1})
+    win = _make_window(item_window_mod, db, main_pokemon=None)
+
+    assert win._heal_main_pokemon("potion", 20) is False
+    assert db.quantity_calls == []
+    assert db.inventory["potion"] == 1
+    assert win.logger.log_and_showinfo.called, "the click reported nothing to the player"
+
+
+def test_the_heal_button_handler_heals_the_current_main(item_window_mod):
+    """And still routes a normal click through to the heal."""
+    db = _FakeItemDB({"potion": 1})
+    pokemon = _FakePokemon(name="mewtwo", hp=10, max_hp=100)
+    win = _make_window(item_window_mod, db, pokemon)
+
+    assert win._heal_main_pokemon("potion", 20) is True
+    assert pokemon.hp == 30
+    assert db.quantity_calls == [("potion", -1)]
+
+
+@pytest.fixture
+def real_db(item_window_mod, tmp_path):
+    """The real ``AnkimonDB`` on a throwaway file.
+
+    ``_FakeItemDB`` mirrors ``consume_item``'s contract by hand, and a hand
+    mirror can drift. This runs the same heal path against real SQLite.
+    """
+    db_mod = _force_load(
+        "Ankimon.pyobj.database_manager",
+        _SRC / "Ankimon" / "pyobj" / "database_manager.py",
+    )
+    return db_mod.AnkimonDB(MagicMock(), db_path=tmp_path / "ankimon.db")
+
+
+def test_the_heal_path_spends_one_real_row_per_heal(item_window_mod, real_db):
+    """End to end over real SQLite: two potions buy two heals, never a third."""
+    real_db.save_item(17, "potion", 2)
+    pokemon = _FakePokemon(hp=10, max_hp=100)
+    win = _make_window(item_window_mod, real_db, pokemon)
+
+    assert win.Check_Heal_Item("mewtwo", 20, "potion", {}) is True
+    assert pokemon.hp == 30
+    assert real_db.get_item("potion")["quantity"] == 1
+
+    assert win.Check_Heal_Item("mewtwo", 20, "potion", {}) is True
+    assert pokemon.hp == 50
+    assert real_db.get_item("potion") is None, "the emptied row must not linger"
+
+    assert win.Check_Heal_Item("mewtwo", 20, "potion", {}) is False
+    assert pokemon.hp == 50, "the third click healed out of an empty bag"

--- a/tests/test_main_pokemon_switch_preserves_state.py
+++ b/tests/test_main_pokemon_switch_preserves_state.py
@@ -381,6 +381,19 @@ def test_outgoing_save_failure_is_shown_to_the_player(collection_dialog):
     ]
     assert errors, "the save failure never reached the player"
     assert "pikachu" in errors[0].lower(), "the message must name what failed to save"
+    # Naming the Pokemon is only half of it. What makes the message worth
+    # showing is that it tells the player something happened to their data --
+    # drop the warning and this test must not keep passing.
+    assert "may be lost" in errors[0].lower(), \
+        "the message must warn that recent progress may be lost"
+    # And it must stay a message the player can act on: the backend exception
+    # goes to the log, not into a dialog box.
+    assert "disk on fire" not in errors[0].lower(), \
+        "the raw backend exception must not be shown to the player"
+    logged = " ".join(
+        str(call.args[1]) for call in logger.log.call_args_list if len(call.args) > 1
+    )
+    assert "disk on fire" in logged, "the exception must still be diagnosable from the log"
     assert db.saved_main, "the switch itself must still complete"
 
 

--- a/tests/test_main_pokemon_switch_preserves_state.py
+++ b/tests/test_main_pokemon_switch_preserves_state.py
@@ -345,8 +345,13 @@ def test_special_form_does_not_leak_from_the_outgoing_main(collection_dialog):
     assert db.saved_main[-1]["special_form"] is None
 
 
-def test_outgoing_save_failure_is_logged_not_swallowed(collection_dialog):
-    """This save is now the only thing preserving the outgoing Pokemon's HP."""
+def test_outgoing_save_failure_is_shown_to_the_player(collection_dialog):
+    """This save is now the only thing preserving the outgoing Pokemon's HP.
+
+    A line in the log file is not a report: the switch overwrites the outgoing
+    Pokemon's in-memory state a few lines later, so a player who is never told
+    cannot know to go and re-check their old main.
+    """
     class _BoomDB(_FakeDB):
         def save_pokemon(self, data):
             raise RuntimeError("disk on fire")
@@ -367,7 +372,15 @@ def test_outgoing_save_failure_is_logged_not_swallowed(collection_dialog):
         _stored_pokemon(), outgoing, logger, MagicMock(), MagicMock(), test_window
     )
 
-    assert logger.log.called, "the swallowed save failure was never reported"
+    # The successful-switch "picked" notice is the LAST log_and_showinfo call,
+    # so look through every call rather than only the most recent one.
+    errors = [
+        call.args[1]
+        for call in logger.log_and_showinfo.call_args_list
+        if call.args and call.args[0] == "error"
+    ]
+    assert errors, "the save failure never reached the player"
+    assert "pikachu" in errors[0].lower(), "the message must name what failed to save"
     assert db.saved_main, "the switch itself must still complete"
 
 


### PR DESCRIPTION
Follow-up to #781, which merged with CodeRabbit's two "Merge Risk" items still open:

> Switching Pokémon can lose the outgoing Pokémon's latest state if saving fails, and healing can update HP without successfully consuming an item on some direct call paths. These bounded data-consistency risks should be fixed or explicitly accepted before merging.

Both were real in merged `main`. This closes them.

### 1. Healing could apply without consuming the item (`item_window.py`)

`Check_Heal_Item` granted the HP first and called `delete_item` afterwards, and `delete_item` threw away the database's answer: `DatabaseManager.update_item_quantity` treats a missing row as a warning — it logs `Item not found in inventory.` and returns without touching the bag — so a heal request for an item the player no longer owns healed for free.

Nothing below the UI stopped that. The Qt bag's "Heal Mainpokemon" button (`ItemLabel`) binds `Check_Heal_Item` directly with **no quantity check at all**, relying entirely on `renewWidgets` having rebuilt in time, and the web Items window's toast reported `ok: True` whether or not anything was spent.

Pay first, then heal:

- New `AnkimonDB.consume_item` decrements in one conditional statement — `UPDATE items SET quantity = quantity - ? WHERE item_name = ? AND quantity >= ?` — and reports through `rowcount` whether the guard actually matched. That answer is the authorization. `update_item_quantity` cannot give it: read-then-write is two statements, and its return value collapses *"the item was not there"* and *"you just used your last one"* into the same `0`, so two overlapping uses of the last potion could both be granted.
- `_consume_one` does the database work and nothing else; `_refresh_bag` redraws and absorbs its own failures. `Check_Heal_Item` calls them in that order with the HP mutation in between, so nothing fallible sits between paying and being paid — redrawing the bag walks every row and builds a widget per row, and anything that threw in there used to leave the potion spent and the HP never granted.
- `Check_Heal_Item` refuses when nothing was consumed, refuses **before** consuming when there is no main Pokémon to heal, awards badge 20 only once an item is really spent, and returns success as a bool. The Qt "Heal Mainpokemon" button goes through `_heal_main_pokemon`, which resolves the name defensively instead of dereferencing a missing main inside the lambda.
- `dispatch_use` reports that refusal instead of claiming a heal that never happened.

`update_item_quantity` itself is untouched — the evolution-stone and held-item paths depend on it.

The Poké Ball and fossil call paths share the same consume-after-effect shape; they are left alone here since the flagged risk is healing.

### 2. Outgoing main's save failure was invisible (`collection_dialog.py`)

Switching main Pokémon persists the outgoing one's in-memory state first, then overwrites that state with the incoming Pokémon's. If the save throws, everything the old main gained since its last write — xp, friendship, current HP — is gone. The failure was written to the log file only, so the one person who could act on it never saw it.

The deliberate *"a failure here must not block the switch"* behaviour is kept; it is now surfaced. Two lines on purpose: the raw backend exception goes to the log where it is diagnostic, and the message box names the Pokémon that failed to save, says its recent progress may be lost, and points at the log.

### 3. A failed commit could leave the payment pending (`database_manager.py`)

Found reviewing the atomic decrement above — the other end of the same invariant. `ConnectionWrapper.commit` deliberately does **not** roll back when the underlying commit raises; it re-raises so a lost write cannot read as success. sqlite does not necessarily end the transaction either. So after a `busy_timeout` expiring under write contention, or a full disk, the decrement sits pending on the GUI thread's connection. Nobody is paid for it — `consume_item` never returns `True`, so `Check_Heal_Item` refuses the heal — but the next unrelated write on that connection commits, and the pending decrement rides along with it. **The potion is gone and the HP was never granted**, which is the failure `consume_item` exists to prevent, arriving from the other direction.

`consume_item` now rolls back and re-raises, mirroring `ConnectionWrapper.__exit__`. Not `with conn:` itself: its `__enter__` issues an explicit `BEGIN`, which collides with precisely the still-open transaction at issue, and its `__exit__` commits the raw connection, ignoring the `_disable_commit` opt-out mobile sync's bulk resolve sets.

### Tests

- New `tests/test_heal_item_consumption.py` — **18 cases** covering consume-before-heal ordering, empty-bag and zero-quantity refusal, a second use of the last potion, no-main-Pokémon (including the bag button's own path), badge award, malformed bag rows, a `renewWidgets` that throws after the item is spent, and both `dispatch_use` outcomes. Several fail on the pre-fix code for the actual defect; the rest pin the new bool return contract.
- `tests/test_database_manager.py` — 8 `consume_item` cases: decrement preserves row metadata, the last unit removes the row, a missing row and a leftover zero row are both refused, the same unit cannot be spent twice, a short bag is refused without partial payment, and two for the rollback above — the reviewer's scenario driven end to end (commit raises, then a later successful write on the same connection, asserted through a **separate** handle so it reads what is actually durable), and the mechanism directly (`conn.in_transaction` is `False` once the failure has propagated). Both fail without the rollback.
- `test_outgoing_save_failure_is_logged_not_swallowed` → `test_outgoing_save_failure_is_shown_to_the_player`, now asserting the player is told, the Pokémon is named, the progress-loss warning is present, and the raw exception reaches the log but **not** the dialog.

Full suite: **868 passed, 60 skipped**.
