### PR TITLE
fix(db): write the Ankidex caught/seen history atomically, and heal a dropped mark

### DIFF
--- a/src/Ankimon/pyobj/database_manager.py
+++ b/src/Ankimon/pyobj/database_manager.py
@@ -14,7 +14,7 @@ import gc
 import time
 import contextlib
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, Iterable, List, Optional, Union
 
 import csv
 from ..resources import user_path, csv_file_items_cost, mypokemon_path, mainpokemon_path, items_path, badges_path, team_pokemon_path as team_path
@@ -347,6 +347,7 @@ class AnkimonDB:
         self._connection_epoch = 0
         self._connection_epoch_gui = -1
         self._setup_database()
+        self._reconcile_pokedex_history_safely()
 
     def _prepare_connection(self, conn):
         """Apply row factory, a generous busy-timeout, and (only when opted in)
@@ -748,7 +749,13 @@ class AnkimonDB:
                 raise
 
             self._log("info", f"Switched database to {db_filename}")
-            return True
+
+        # Deliberately outside ``quiesce``: that holds ``_conn_lock`` for the whole
+        # block, and the sweep takes ``_pokedex_lock`` and *then* a connection
+        # (i.e. ``_conn_lock``). Running it in there would invert the order every
+        # mark_as_caught uses and could deadlock against a concurrent save.
+        self._reconcile_pokedex_history_safely()
+        return True
 
     # --- Obfuscation / De-obfuscation ---
 
@@ -1004,13 +1011,16 @@ class AnkimonDB:
         conn.commit()
         self._clear_reviewer_ownership_cache()
 
-        # Automatically mark the pokemon as caught
+        # Automatically mark the pokemon as caught. The row is already committed,
+        # so a failure here must not fail the save -- but it is logged as an error
+        # (not a warning) because it means the Pokedex is now behind the
+        # collection until _reconcile_pokedex_history heals it on the next launch.
         pokemon_id = pokemon_data.get("id")
         if pokemon_id:
             try:
                 self.mark_as_caught(int(pokemon_id))
             except Exception as e:
-                self._log("warning", f"Failed to mark saved pokemon as caught: {e}")
+                self._log("error", f"Failed to mark saved pokemon as caught: {e}")
 
         return True
 
@@ -1194,13 +1204,15 @@ class AnkimonDB:
         conn.commit()
         self._clear_reviewer_ownership_cache()
 
-        # Automatically mark the pokemon as caught
+        # Automatically mark the pokemon as caught (see save_pokemon: logged as an
+        # error because the Pokedex is left behind the collection until the next
+        # _reconcile_pokedex_history sweep).
         pokemon_id = pokemon_data.get("id")
         if pokemon_id:
             try:
                 self.mark_as_caught(int(pokemon_id))
             except Exception as e:
-                self._log("warning", f"Failed to mark saved main pokemon as caught: {e}")
+                self._log("error", f"Failed to mark saved main pokemon as caught: {e}")
 
         return True
 
@@ -1520,8 +1532,71 @@ class AnkimonDB:
                 continue
         return ids
 
+    def _append_pokedex_ids(self, additions: Dict[str, Iterable[Any]]) -> Dict[str, int]:
+        """Append ids to the pokedex ``user_data`` lists in ONE transaction.
+
+        ``additions`` maps ``"pokedex_caught"`` / ``"pokedex_seen"`` to the ids
+        to record. Every key is read, merged and rewritten on the same
+        connection and committed exactly once, so the two lists cannot diverge:
+        either both land or neither does. Driving them through two
+        ``set_user_data`` calls instead (a commit each) can persist a caught id
+        whose matching seen id was lost to whatever failed in between — a disk
+        error, the busy-timeout expiring under write contention, or the process
+        going away — leaving the Ankidex with a species it counts as caught but
+        never saw, and no way to tell that happened.
+
+        The commit goes through the ConnectionWrapper rather than the raw
+        sqlite3 handle so a bulk mobile "Resolve All" (which sets
+        ``_disable_commit`` and holds one long write transaction) still folds
+        these writes into its outer transaction and rolls them back with it.
+
+        Callers must hold ``self._pokedex_lock``. Returns the number of ids
+        newly added per key.
+        """
+        conn = self._get_connection()
+        pending: List[tuple] = []
+        added: Dict[str, int] = {}
+
+        for key, ids in additions.items():
+            # De-duplicated on the way out as well as in: a list that a legacy
+            # write left holding "25" alongside 25 is stored back normalised
+            # once we have a reason to rewrite it.
+            known: set = set()
+            stored: List[int] = []
+            for pokemon_id in self._coerce_pokedex_id_list(self.get_user_data(key, [])):
+                if pokemon_id not in known:
+                    known.add(pokemon_id)
+                    stored.append(pokemon_id)
+
+            new_ids: List[int] = []
+            for raw_id in ids:
+                try:
+                    pokemon_id = int(raw_id)
+                except (TypeError, ValueError):
+                    continue
+                if pokemon_id not in known:
+                    known.add(pokemon_id)
+                    new_ids.append(pokemon_id)
+
+            added[key] = len(new_ids)
+            if new_ids:
+                pending.append((key, json.dumps(stored + new_ids)))
+
+        if pending:
+            with conn.cursor() as cursor:
+                cursor.executemany(
+                    "INSERT OR REPLACE INTO user_data (key, value) VALUES (?, ?)",
+                    pending,
+                )
+            conn.commit()
+        return added
+
     def mark_as_caught(self, pokemon_id: int):
-        """Marks a pokemon as caught in the pokedex history."""
+        """Marks a pokemon as caught (and seen) in the pokedex history.
+
+        Raises if the write fails — callers on a save path swallow and log that,
+        but the failure must be visible rather than reported as a success.
+        """
         try:
             pokemon_id = int(pokemon_id)
         except (TypeError, ValueError):
@@ -1530,22 +1605,75 @@ class AnkimonDB:
 
         # Both lists are rewritten wholesale, so hold the lock across the whole
         # read-modify-write (save_pokemon also runs on the mobile-sync thread).
+        # Catching implies seeing, so both are recorded in the same transaction.
         with self._pokedex_lock:
-            # Update caught list
-            caught_ids = self._coerce_pokedex_id_list(
-                self.get_user_data("pokedex_caught", [])
+            self._append_pokedex_ids(
+                {"pokedex_caught": (pokemon_id,), "pokedex_seen": (pokemon_id,)}
             )
-            if pokemon_id not in caught_ids:
-                caught_ids.append(pokemon_id)
-                self.set_user_data("pokedex_caught", caught_ids)
 
-            # Update seen list (catching implies seeing)
-            seen_ids = self._coerce_pokedex_id_list(
-                self.get_user_data("pokedex_seen", [])
+    def _reconcile_pokedex_history_safely(self):
+        """``_reconcile_pokedex_history`` that can never stop the DB from opening."""
+        try:
+            self._reconcile_pokedex_history()
+        except Exception as e:
+            self._log("error", f"Failed to reconcile pokedex history: {e}")
+
+    def _reconcile_pokedex_history(self):
+        """Heal the caught/seen lists from the Pokemon the DB still knows about.
+
+        ``mark_as_caught`` is best-effort at every call site — ``save_pokemon``
+        and the evolution window log a failure and carry on rather than fail the
+        catch — so one locked or failed write would otherwise drop a species
+        from the Ankidex permanently once its ``captured_pokemon`` row is
+        overwritten by an evolution. This idempotent startup sweep re-derives
+        the lists from the rows that are still authoritative (every owned
+        Pokemon, plus every released one in ``pokemon_history``), so a missed
+        mark heals on the next launch instead of becoming silent data loss.
+
+        It doubles as the backfill for databases written before the caught list
+        existed: those start empty, and without this the list only ever covers
+        Pokemon saved after the upgrade.
+        """
+        ids: set = set()
+
+        try:
+            cursor = self.execute(
+                "SELECT DISTINCT pokedex_id FROM captured_pokemon "
+                "WHERE pokedex_id IS NOT NULL"
             )
-            if pokemon_id not in seen_ids:
-                seen_ids.append(pokemon_id)
-                self.set_user_data("pokedex_seen", seen_ids)
+            ids.update(
+                self._coerce_pokedex_id_list([row[0] for row in cursor.fetchall()])
+            )
+        except Exception as e:
+            self._log("warning", f"Pokedex reconcile: could not read captured_pokemon: {e}")
+
+        # Released Pokemon: still caught for Pokedex purposes. Wrapped separately
+        # so an older DB without pokemon_history still reconciles the owned rows.
+        try:
+            cursor = self.execute(
+                "SELECT DISTINCT json_extract(data, '$.id') FROM pokemon_history"
+            )
+            ids.update(
+                self._coerce_pokedex_id_list([row[0] for row in cursor.fetchall()])
+            )
+        except Exception as e:
+            self._log("warning", f"Pokedex reconcile: could not read pokemon_history: {e}")
+
+        if not ids:
+            return
+
+        sorted_ids = sorted(ids)
+        with self._pokedex_lock:
+            added = self._append_pokedex_ids(
+                {"pokedex_caught": sorted_ids, "pokedex_seen": sorted_ids}
+            )
+        if any(added.values()):
+            self._log(
+                "info",
+                "Pokedex history reconciled from stored Pokemon: "
+                f"+{added.get('pokedex_caught', 0)} caught, "
+                f"+{added.get('pokedex_seen', 0)} seen.",
+            )
 
     def get_caught_ids(self) -> set[int]:
         """Returns a set of all pokemon IDs explicitly marked as caught."""

--- a/src/Ankimon/pyobj/evolution_window.py
+++ b/src/Ankimon/pyobj/evolution_window.py
@@ -375,11 +375,19 @@ class EvoWindow(QWidget):
             # Persist the pre-evolved species as caught before the id changes so
             # the Pokédex keeps crediting the earlier form (no-op on stores that
             # predate mark_as_caught — arrives with the PC-box/Pokédex leaf).
+            # Logged as an error, not a warning: unlike a failed mark on an
+            # ordinary save, this one is NOT recoverable. Once the id below is
+            # overwritten the pre-evolution is gone from captured_pokemon, so
+            # _reconcile_pokedex_history has nothing left to re-derive it from.
             if hasattr(db, "mark_as_caught"):
                 try:
                     db.mark_as_caught(int(prevo_id))
                 except Exception as e:
-                    self.logger.log("warning", f"Failed to mark prevo as caught: {e}")
+                    self.logger.log(
+                        "error",
+                        f"Failed to mark pre-evolution {prevo_id} as caught; it will "
+                        f"be missing from the Pokedex: {e}",
+                    )
 
             pokemon["name"] = evo_name.capitalize()
             pokemon["id"] = evo_id

--- a/tests/test_ankidex_caught_history.py
+++ b/tests/test_ankidex_caught_history.py
@@ -1,0 +1,380 @@
+"""Ankidex caught/seen history durability (``mark_as_caught``).
+
+Exercises the *real* ``AnkimonDB`` SQLite layer, not a stub. The flow under test
+is the one ``save_pokemon`` / ``save_main_pokemon`` / the evolution window all
+drive:
+
+    row committed  ->  mark_as_caught(id)  ->  pokedex_caught + pokedex_seen
+
+Before the fix those two lists were written by two ``set_user_data`` calls, each
+with its own commit, and every caller swallowed a failure — so an interrupted
+write could persist a caught id whose matching seen id never landed, and a
+failed write vanished into a log line while the save still reported success.
+The tests below pin the three properties that closes:
+
+* both lists move in ONE transaction (never one without the other);
+* the writes belong to the caller's transaction, so a rolled-back bulk resolve
+  does not leave Pokedex entries behind for Pokemon whose saves were undone;
+* a mark that never landed is re-derived from the stored Pokemon on the next
+  launch instead of being lost for good.
+"""
+
+import importlib.util
+import sqlite3
+import sys
+import threading
+import types
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+_SRC = Path(__file__).parent.parent / "src"
+
+
+def _load_ankimon_db():
+    """Load the real ``database_manager`` against stubbed Anki/aqt deps.
+
+    Every stub is torn down again as soon as the module has executed. pytest
+    imports all test modules during collection, so MagicMock entries left in
+    ``sys.modules`` for ``aqt`` / ``anki`` / ``Ankimon.resources`` would poison
+    unrelated test modules that import those for real. ``database_manager``
+    only needs them while it executes: afterwards it holds its own references,
+    and its one lazy ``..services`` import is already except-wrapped.
+    """
+    stub_names = [
+        "aqt",
+        "aqt.qt",
+        "aqt.utils",
+        "aqt.gui_hooks",
+        "aqt.operations",
+        "aqt.reviewer",
+        "aqt.webview",
+        "aqt.main",
+        "anki",
+        "anki.hooks",
+        "anki.collection",
+        "anki.models",
+        "anki.notes",
+        "anki.template",
+        "anki.buildinfo",
+    ]
+
+    class MockResources(types.ModuleType):
+        user_path = Path("/tmp")
+
+        def __getattr__(self, name):
+            return Path("/tmp") / name
+
+    module_name = "Ankimon.pyobj.database_manager"
+    saved = {
+        name: sys.modules.get(name)
+        for name in stub_names + ["Ankimon.resources", module_name]
+    }
+
+    try:
+        for name in stub_names:
+            sys.modules[name] = MagicMock()
+        sys.modules["Ankimon.resources"] = MockResources("Ankimon.resources")
+
+        spec = importlib.util.spec_from_file_location(
+            module_name, _SRC / "Ankimon" / "pyobj" / "database_manager.py"
+        )
+        db_mod = importlib.util.module_from_spec(spec)
+        sys.modules[module_name] = db_mod
+        spec.loader.exec_module(db_mod)
+        return db_mod
+    finally:
+        for name, previous in saved.items():
+            if previous is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = previous
+
+
+_DB_MOD = _load_ankimon_db()
+AnkimonDB = _DB_MOD.AnkimonDB
+
+
+class _MockLogger:
+    def __init__(self):
+        self.records = []
+
+    def log(self, level, msg):
+        self.records.append((level, str(msg)))
+
+    def log_and_showinfo(self, level, msg):
+        self.records.append((level, str(msg)))
+
+
+@pytest.fixture
+def db_path(tmp_path):
+    return tmp_path / "ankimon.db"
+
+
+@pytest.fixture
+def open_db(db_path):
+    """Factory opening a real AnkimonDB on one shared file (re-openable)."""
+    opened = []
+
+    def _open():
+        db = AnkimonDB(_MockLogger(), db_path=db_path)
+        opened.append(db)
+        return db
+
+    yield _open
+
+    for db in opened:
+        try:
+            db.close()
+        except Exception:
+            pass
+
+
+def _pokemon(individual_id, pokedex_id, name):
+    return {
+        "individual_id": individual_id,
+        "id": pokedex_id,
+        "name": name,
+        "level": 5,
+        "xp": 0,
+        "shiny": False,
+        "attacks": ["Tackle"],
+        "base_stats": {"hp": 45, "atk": 49, "def": 49, "spa": 65, "spd": 65, "spe": 45},
+        "stats": {"hp": 45, "atk": 49, "def": 49, "spa": 65, "spd": 65, "spe": 45},
+        "ev": {"hp": 0, "atk": 0, "def": 0, "spa": 0, "spd": 0, "spe": 0},
+        "iv": {"hp": 15, "atk": 15, "def": 15, "spa": 15, "spd": 15, "spe": 15},
+        "ability": "Overgrow",
+        "growth_rate": "medium",
+        "base_experience": 64,
+        "gender": "M",
+    }
+
+
+def _raw_user_data(db_path):
+    """Read user_data on a SEPARATE connection: only committed rows are visible."""
+    conn = sqlite3.connect(str(db_path))
+    try:
+        return dict(conn.execute("SELECT key, value FROM user_data").fetchall())
+    finally:
+        conn.close()
+
+
+# --------------------------------------------------------------------------- #
+# 1. caught and seen move together
+# --------------------------------------------------------------------------- #
+def test_mark_as_caught_records_both_lists(open_db):
+    db = open_db()
+    db.mark_as_caught(25)
+
+    assert db.get_caught_ids() == {25}
+    assert db.get_seen_ids() == {25}
+    # Catching implies seeing: caught must never outrun seen.
+    assert db.get_caught_ids() <= db.get_seen_ids()
+
+
+def test_repeated_marks_do_not_duplicate(open_db):
+    db = open_db()
+    for _ in range(3):
+        db.mark_as_caught(25)
+    db.mark_as_caught(26)
+
+    assert db.get_user_data("pokedex_caught", []) == [25, 26]
+    assert db.get_user_data("pokedex_seen", []) == [25, 26]
+
+
+def test_legacy_string_ids_are_normalised_on_the_next_write(open_db):
+    """A legacy list holding "25" and 25 is read as {25} and stored back clean."""
+    db = open_db()
+    db.set_user_data("pokedex_caught", ["25", 25, "junk", None])
+    db.set_user_data("pokedex_seen", ["25"])
+
+    assert db.get_caught_ids() == {25}
+
+    db.mark_as_caught(26)
+
+    assert db.get_user_data("pokedex_caught", []) == [25, 26]
+    assert db.get_caught_ids() == {25, 26}
+    assert db.get_seen_ids() == {25, 26}
+
+
+def test_non_numeric_id_is_ignored(open_db):
+    db = open_db()
+    db.mark_as_caught("not-an-id")
+
+    assert db.get_caught_ids() == set()
+    assert db.get_seen_ids() == set()
+
+
+# --------------------------------------------------------------------------- #
+# 2. a failed write leaves NEITHER list changed
+# --------------------------------------------------------------------------- #
+def test_failed_commit_persists_neither_list(open_db, db_path):
+    """The P2 case: the write fails, so no half-written history is committed."""
+    db = open_db()
+    db.mark_as_caught(1)  # a committed baseline to diverge from
+
+    conn = db._get_connection()
+    with patch.object(
+        type(conn), "commit", side_effect=sqlite3.OperationalError("disk I/O error")
+    ):
+        with pytest.raises(sqlite3.OperationalError):
+            db.mark_as_caught(2)
+
+    # Nothing from the failed mark reached the file: not the caught id, and not
+    # a seen id orphaned from it.
+    persisted = _raw_user_data(db_path)
+    assert persisted["pokedex_caught"] == "[1]"
+    assert persisted["pokedex_seen"] == "[1]"
+
+    conn.rollback()
+    assert db.get_caught_ids() == {1}
+    assert db.get_seen_ids() == {1}
+
+
+def test_save_pokemon_survives_a_failed_mark(open_db):
+    """A dex-mark failure must not fail the catch — but must be logged loudly."""
+    db = open_db()
+    with patch.object(
+        AnkimonDB, "mark_as_caught", side_effect=sqlite3.OperationalError("locked")
+    ):
+        assert db.save_pokemon(_pokemon("pika-uuid", 25, "Pikachu")) is True
+
+    assert db.get_pokemon("pika-uuid") is not None
+    assert any(
+        level == "error" and "caught" in msg for level, msg in db.logger.records
+    ), db.logger.records
+
+
+# --------------------------------------------------------------------------- #
+# 3. the marks belong to the caller's transaction
+# --------------------------------------------------------------------------- #
+def test_marks_roll_back_with_the_enclosing_transaction(open_db, db_path):
+    """Mobile "Resolve All" holds one long transaction (``_disable_commit``).
+
+    Committing the Pokedex write independently would leave the dex crediting a
+    species whose save was rolled back with that transaction.
+    """
+    db = open_db()
+    conn = db._get_connection()
+    conn._disable_commit = True
+    try:
+        db.mark_as_caught(151)
+        # Visible to this connection (uncommitted), invisible to any other.
+        assert db.get_caught_ids() == {151}
+        assert "pokedex_caught" not in _raw_user_data(db_path)
+    finally:
+        conn._disable_commit = False
+        conn.rollback()
+
+    assert db.get_caught_ids() == set()
+    assert db.get_seen_ids() == set()
+
+
+# --------------------------------------------------------------------------- #
+# 4. a mark that never landed heals on the next launch
+# --------------------------------------------------------------------------- #
+def test_startup_reconcile_recovers_a_dropped_mark(open_db):
+    """save_pokemon reports success even when the mark fails; reopening heals it."""
+    db = open_db()
+    with patch.object(
+        AnkimonDB, "mark_as_caught", side_effect=sqlite3.OperationalError("locked")
+    ):
+        db.save_pokemon(_pokemon("pika-uuid", 25, "Pikachu"))
+
+    assert db.get_caught_ids() == set()
+    db.close()
+
+    healed = open_db()
+    assert 25 in healed.get_caught_ids()
+    assert 25 in healed.get_seen_ids()
+
+
+def test_startup_reconcile_backfills_a_pre_existing_collection(open_db, db_path):
+    """A database written before the caught list existed does not start empty."""
+    db = open_db()
+    db.save_pokemon(_pokemon("bulba-uuid", 1, "Bulbasaur"))
+    db.save_pokemon(_pokemon("chari-uuid", 6, "Charizard"))
+    db.add_to_history(_pokemon("squirt-uuid", 7, "Squirtle"))
+
+    # Simulate the pre-upgrade state: rows present, no pokedex history at all.
+    conn = sqlite3.connect(str(db_path))
+    conn.execute(
+        "DELETE FROM user_data WHERE key IN ('pokedex_caught', 'pokedex_seen')"
+    )
+    conn.commit()
+    conn.close()
+    db.close()
+
+    backfilled = open_db()
+    assert {1, 6, 7} <= backfilled.get_caught_ids()
+    assert {1, 6, 7} <= backfilled.get_seen_ids()
+
+
+def test_startup_reconcile_is_idempotent(open_db):
+    db = open_db()
+    db.save_pokemon(_pokemon("bulba-uuid", 1, "Bulbasaur"))
+    db.close()
+
+    second = open_db()
+    stored = second.get_user_data("pokedex_caught", [])
+    second.close()
+
+    third = open_db()
+    assert third.get_user_data("pokedex_caught", []) == stored
+
+
+def test_startup_reconcile_writes_nothing_for_an_empty_collection(open_db, db_path):
+    open_db().close()
+    assert _raw_user_data(db_path).get("pokedex_caught") is None
+
+
+# --------------------------------------------------------------------------- #
+# 5. lock ordering: the sweep must never run under the connection lock
+# --------------------------------------------------------------------------- #
+def test_reconcile_never_runs_under_the_connection_lock(open_db, tmp_path, monkeypatch):
+    """``switch_database`` holds ``_conn_lock`` for its whole ``quiesce`` block.
+
+    The sweep takes ``_pokedex_lock`` and *then* a connection, the reverse of
+    that order, so running it inside the block would deadlock against a
+    background ``mark_as_caught`` parked between the two.
+    """
+    db = open_db()
+    if not hasattr(db._conn_lock, "_is_owned"):
+        pytest.skip("RLock._is_owned() unavailable on this interpreter")
+
+    owned_at_call = []
+    real_reconcile = db._reconcile_pokedex_history
+
+    def spy():
+        owned_at_call.append(db._conn_lock._is_owned())
+        return real_reconcile()
+
+    monkeypatch.setattr(db, "_reconcile_pokedex_history", spy)
+    monkeypatch.setattr(_DB_MOD, "user_path", tmp_path)
+
+    assert db.switch_database("other_profile.db") is True
+    assert owned_at_call == [False], "pokedex reconcile ran while holding _conn_lock"
+
+
+def test_concurrent_marks_keep_every_id(open_db):
+    """Interleaved saves rewrite both lists wholesale; none may be lost."""
+    db = open_db()
+    ids = list(range(1, 61))
+    barrier = threading.Barrier(4)
+
+    def worker(chunk):
+        barrier.wait()
+        for pokemon_id in chunk:
+            db.mark_as_caught(pokemon_id)
+
+    threads = [
+        threading.Thread(target=worker, args=(ids[i::4],)) for i in range(4)
+    ]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(30)
+
+    assert db.get_caught_ids() == set(ids)
+    assert db.get_seen_ids() == set(ids)


### PR DESCRIPTION
### Description

Follow-up to #722, which added the persistent `pokedex_caught` / `pokedex_seen`
history. **P2 — `mark_as_caught()` can persist an inconsistent or missing Ankidex
history.** The flow it landed is effectively:

```
save_pokemon()  -> conn.commit()                                # row
                -> mark_as_caught(id)
                     -> set_user_data("pokedex_caught", [...])  # commit 1
                     -> set_user_data("pokedex_seen",   [...])  # commit 2
                   (any failure -> caught, logged as a warning, save returns True)
```

Three separate transactions, and every call site swallows a failure. That leaves
two bad end states:

* **Inconsistent** — commit 1 lands, commit 2 does not, so a caught id is stored
  whose matching seen id was lost to whatever failed in between (a disk error,
  the 30s busy-timeout expiring while a bulk mobile "Resolve All" holds the write
  lock, the process going away).
* **Missing** — neither list is written, `save_pokemon` still returns `True`, and
  the whole thing is one `warning` line. This is the one that actually costs a
  user something: the caught list exists *precisely* so an evolution can
  overwrite a `captured_pokemon` row without the Pokedex forgetting the earlier
  form, so a mark dropped today is a species silently gone from the Ankidex
  tomorrow.

There is a third, smaller variant: because `set_user_data` commits on its own,
the dex write could commit *independently of the caller's transaction* — a bulk
resolve that rolled back would still leave Pokedex entries behind for saves that
were undone.

#### What this changes

**`_append_pokedex_ids()` — one transaction, one commit.** Both lists are read,
merged and rewritten on the same connection and committed once, so either both
land or neither does. The commit goes through the `ConnectionWrapper` (not the
raw sqlite3 handle), so a bulk resolve's `_disable_commit` still folds these
writes into its outer transaction and rolls them back with it. While it has a
list open to rewrite, it also stores it back de-duplicated and int-normalised —
so a legacy list holding `"25"` next to `25` gets cleaned up rather than growing.

**`_reconcile_pokedex_history()` — a dropped mark heals instead of persisting.**
At startup (and after a profile switch) both lists are re-derived from the rows
that are still authoritative: every owned Pokemon (`captured_pokemon`, via the
existing `pokedex_id` index) plus every released one (`pokemon_history`). So a
mark that failed today is recovered on the next launch, *before* an evolution can
make it unrecoverable. It doubles as the backfill for databases written before
the caught list existed, which otherwise start empty and only ever cover Pokemon
saved after the upgrade. Measured at ~8 ms over a 4000-row collection, and it
writes nothing when there is nothing new.

It deliberately runs *outside* `switch_database`'s `quiesce` block: that holds
`_conn_lock` for its whole body, and the sweep takes `_pokedex_lock` and *then* a
connection — running it in there would invert the order `mark_as_caught` uses and
could deadlock against a concurrent background save. There is a test pinning
that.

**Failures are no longer a shrug.** `save_pokemon` / `save_main_pokemon` still
return `True` (dex bookkeeping must not fail a catch) but log at `error`. The
evolution window says so explicitly in its message, because that mark is the one
case nothing can re-derive: once the id is overwritten, the pre-evolution is gone
from `captured_pokemon` and the sweep has nothing left to work from.

#### Tests

`tests/test_ankidex_caught_history.py` — 13 tests against the *real* `AnkimonDB`
SQLite layer (no stub): caught/seen atomicity and `caught ⊆ seen`; a failed
commit persisting **neither** list (verified on a second connection, so only
committed rows count); marks rolling back with an enclosing `_disable_commit`
transaction; a save surviving a failed mark and the next launch healing it;
backfill of a pre-existing collection; idempotence; the lock ordering above; and
4 threads interleaving marks without losing an id.

Verified: `pytest tests/` **855 passed, 58 skipped** (baseline on `main` is 842 +
the 13 new). `python3 harness/check.py` is at parity with `main` on this machine
(the same 3 checks fail before and after — a local Qt/QApplication env issue,
unrelated). A 400-review Tier-1 harness run: 0 error events, 32 species caught,
all 32 recorded, `caught ⊆ seen`, and reopening the DB leaves the history
byte-identical (the sweep is a no-op when nothing is missing).

### Related Issue

Follow-up to #722. Related: #735.

### Checklist
- [x] My code follows the code style and guidelines of this project.
- [x] I have run tests locally (`pytest tests/` and `pytest tests/test_addon_integrity.py`) and they all pass.
- [ ] **(Optional)** I have added/updated my entry in `.all-contributorsrc` at the root of the repository to specify my custom `"nickname"` and `"discord_id"` for release announcements and Discord pings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xk6pbwmSiUiG5vXLfopYh4
