### PR TITLE
fix(discord): resolve the IPC socket path so Discord RPC works on Linux

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -251,6 +251,17 @@
       ],
       "nickname": "slager",
       "discord_id": "955178102097600622"
+    },
+    {
+      "login": "JadonKJones",
+      "name": "JadonKJones",
+      "avatar_url": "https://github.com/JadonKJones.png",
+      "profile": "https://github.com/JadonKJones",
+      "contributions": [
+        "code"
+      ],
+      "nickname": "sakamotosan",
+      "discord_id": "1404969660931379230"
     }
   ],
   "contributorsPerLine": 5

--- a/src/Ankimon/addon_files/lib/pypresence/utils.py
+++ b/src/Ankimon/addon_files/lib/pypresence/utils.py
@@ -35,13 +35,21 @@ def test_ipc_path(path):
 
 # Returns on first IPC pipe matching Discord's
 def get_ipc_path(pipe=None):
+    """Find Discord's local IPC socket, checking native, Snap, and Flatpak
+    sandbox locations (including Vesktop's) in turn."""
     ipc = 'discord-ipc-'
     if pipe is not None:
         ipc = f"{ipc}{pipe}"
 
     if sys.platform in ('linux', 'darwin'):
         tempdir = os.environ.get('XDG_RUNTIME_DIR') or (f"/run/user/{os.getuid()}" if os.path.exists(f"/run/user/{os.getuid()}") else tempfile.gettempdir())
-        paths = ['.', 'snap.discord', 'app/com.discordapp.Discord', 'app/com.discordapp.DiscordCanary']
+        paths = [
+            '.',
+            'snap.discord',
+            'app/com.discordapp.Discord',
+            'app/com.discordapp.DiscordCanary',
+            '.flatpak/dev.vencord.Vesktop/xdg-run',
+        ]
     elif sys.platform == 'win32':
         tempdir = r'\\?\pipe'
         paths = ['.']

--- a/tests/test_discord_ipc_path.py
+++ b/tests/test_discord_ipc_path.py
@@ -1,0 +1,94 @@
+"""Tests for pypresence's Discord IPC socket discovery, specifically the
+Vesktop (Flatpak sandbox) path added for Linux Rich Presence support.
+
+test_ipc_path() normally opens a real AF_UNIX connection to verify a
+candidate socket actually works; that's mocked out here (kept True whenever
+the path exists) so these tests only exercise get_ipc_path's own directory
+search, not real socket I/O.
+"""
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+# Other test files stub sys.modules["Ankimon"] with a bare, path-less
+# ModuleType and never restore it (a known pre-existing pattern in this
+# suite — see test_scaffolding_smoke.py / test_review_based_damage_multiplier.py).
+# Depending on collection order that stub can still be in sys.modules, which
+# breaks importing the real Ankimon.addon_files subpackage through the normal
+# `import Ankimon...` path. Load the module directly from disk by file path
+# instead, so this test doesn't depend on the shared Ankimon package state.
+_pypresence_dir = (
+    Path(__file__).parent.parent / "src" / "Ankimon" / "addon_files" / "lib" / "pypresence"
+)
+
+# utils.py does `from .exceptions import ...`, a relative import, so it needs
+# a real parent package registered in sys.modules (not just loaded standalone).
+_pkg_name = "ankimon_pypresence_under_test"
+if _pkg_name not in sys.modules:
+    _pkg = importlib.util.module_from_spec(
+        importlib.util.spec_from_file_location(
+            _pkg_name, _pypresence_dir / "__init__.py", submodule_search_locations=[str(_pypresence_dir)]
+        )
+    )
+    sys.modules[_pkg_name] = _pkg
+    _pkg.__spec__.loader.exec_module(_pkg)
+
+_spec = importlib.util.spec_from_file_location(
+    f"{_pkg_name}.utils", _pypresence_dir / "utils.py"
+)
+pypresence_utils = importlib.util.module_from_spec(_spec)
+pypresence_utils.__package__ = _pkg_name
+sys.modules[_spec.name] = pypresence_utils
+_spec.loader.exec_module(pypresence_utils)
+get_ipc_path = pypresence_utils.get_ipc_path
+
+pytestmark = pytest.mark.skipif(
+    sys.platform not in ("linux", "darwin"), reason="this IPC search path is Linux/macOS only"
+)
+
+
+@pytest.fixture(autouse=True)
+def fake_socket_test(monkeypatch):
+    """Any file that exists 'works' — isolates the directory-search logic
+    under test from real AF_UNIX connection behavior."""
+    monkeypatch.setattr(pypresence_utils, "test_ipc_path", lambda path: True)
+
+
+@pytest.fixture
+def runtime_dir(tmp_path, monkeypatch):
+    monkeypatch.setenv("XDG_RUNTIME_DIR", str(tmp_path))
+    return tmp_path
+
+
+def test_finds_native_discord_socket(runtime_dir):
+    sock_path = runtime_dir / "discord-ipc-0"
+    sock_path.write_text("")
+    assert get_ipc_path() == str(sock_path)
+
+
+def test_finds_vesktop_flatpak_sandbox_socket(runtime_dir):
+    """The actual bug this fixed: Vesktop's Flatpak build doesn't write its
+    IPC socket into XDG_RUNTIME_DIR directly — it lands inside the sandbox's
+    own bind-mounted runtime dir at .flatpak/dev.vencord.Vesktop/xdg-run."""
+    vesktop_dir = runtime_dir / ".flatpak" / "dev.vencord.Vesktop" / "xdg-run"
+    vesktop_dir.mkdir(parents=True)
+    sock_path = vesktop_dir / "discord-ipc-0"
+    sock_path.write_text("")
+    assert get_ipc_path() == str(sock_path)
+
+
+def test_returns_none_when_no_socket_anywhere(runtime_dir):
+    assert get_ipc_path() is None
+
+
+def test_prefers_native_path_over_vesktop_when_both_present(runtime_dir):
+    native = runtime_dir / "discord-ipc-0"
+    native.write_text("")
+    vesktop_dir = runtime_dir / ".flatpak" / "dev.vencord.Vesktop" / "xdg-run"
+    vesktop_dir.mkdir(parents=True)
+    (vesktop_dir / "discord-ipc-0").write_text("")
+
+    assert get_ipc_path() == str(native)


### PR DESCRIPTION
### Description

Discord Rich Presence never connects when the user runs **Vesktop** (the Flatpak
build), even though pypresence already knows about the official Snap and Flatpak
Discord socket locations.

`pypresence/utils.py:get_ipc_path()` searches a fixed list of subdirectories
under `XDG_RUNTIME_DIR` for a `discord-ipc-N` socket:

    '.', 'snap.discord', 'app/com.discordapp.Discord', 'app/com.discordapp.DiscordCanary'

Vesktop's Flatpak sandbox doesn't expose its IPC socket at any of those — it
bind-mounts its runtime dir at `.flatpak/dev.vencord.Vesktop/xdg-run/`, so the
probe finds nothing and RPC silently fails with no error surfaced to the user.

**Change:** add `.flatpak/dev.vencord.Vesktop/xdg-run` to the candidate list,
after the existing entries so a native / official-package socket still wins when
both are present. Also adds a docstring to `get_ipc_path()` noting the sandbox
locations it now covers.

Vendored file touched: `src/Ankimon/addon_files/lib/pypresence/utils.py`.

**Tests:** new `tests/test_discord_ipc_path.py` (4 tests) covers the directory
search — native socket found, Vesktop sandbox socket found, `None` when nothing
exists, native preferred over Vesktop when both present. `test_ipc_path()`'s real
AF_UNIX connect is stubbed so the tests exercise only the search logic. The
module is loaded directly from disk to sidestep a pre-existing
`sys.modules["Ankimon"]` stubbing pattern in the suite.

### Checklist
- [x] My code follows the code style and guidelines of this project.
- [x] I have run tests locally (`pytest tests/` and `pytest tests/test_addon_integrity.py`) and they all pass.
- [x] **(Optional)** I have added/updated my entry in `.all-contributorsrc` (nickname `sakamotosan`).