### PR TITLE
fix(font): register each custom font with Qt only once

### DIFF
--- a/src/Ankimon/utils.py
+++ b/src/Ankimon/utils.py
@@ -596,7 +596,13 @@ def get_item_description(item_name, language_id):
         return None
 
 
+_registered_fonts = set()  # font_file names already handed to QFontDatabase
+
+
 def load_custom_font(font_size, language):
+    """Return a QFont for the addon's pixel font, registering the file with
+    Qt's font database only the first time it's needed (see the caching note
+    below — repeat registrations here bloated fontconfig into crashing)."""
     if language == 1:
         font_file = "pkmn_w.ttf"
         font_file_path = font_path / font_file
@@ -612,10 +618,28 @@ def load_custom_font(font_size, language):
         font_file = "Early GameBoy.ttf"
         font_size = int((font_size * 2) / 5)
 
-    # Register the custom font with its file path. Qt imported lazily so utils
-    # stays importable headless (custom fonts are a GUI-only concern).
+    # Register the custom font with its file path — but ONLY the first time
+    # per file. addApplicationFont() adds a brand new entry to Qt's font
+    # database on every call, even for a file already registered; this
+    # function is called on every battle-scene redraw, so without caching it
+    # could silently register the same font hundreds of times over a play
+    # session — bloating the font database until fontconfig's internal
+    # font-set sort crashes with a stack overflow (observed: SIGSEGV inside
+    # FcFontSetSort). Qt imported lazily so utils stays importable headless
+    # (custom fonts are a GUI-only concern).
     from PyQt6.QtGui import QFontDatabase, QFont
-    QFontDatabase.addApplicationFont(str(font_path / font_file))
+    if font_file not in _registered_fonts:
+        # addApplicationFont() returns -1 on failure. Only cache the file as
+        # "registered" when it actually succeeded — caching a failure here
+        # would silently and permanently skip every retry for that file.
+        font_id = QFontDatabase.addApplicationFont(str(font_path / font_file))
+        # In a test env where QFontDatabase itself is mocked, addApplicationFont
+        # can return a MagicMock instead of a real int — not a failure signal,
+        # just not a real Qt call, so treat anything other than a genuine
+        # negative int as success (preserves the old always-cache behavior
+        # there) rather than letting the comparison raise.
+        if not (isinstance(font_id, int) and font_id < 0):
+            _registered_fonts.add(font_file)
     custom_font = QFont(
         font_name
     )  # Use the font family name you specified in the font file

--- a/tests/test_load_custom_font_caching.py
+++ b/tests/test_load_custom_font_caching.py
@@ -1,0 +1,120 @@
+"""load_custom_font() used to call QFontDatabase.addApplicationFont() on
+every single call — with no caching, a brand-new duplicate font entry got
+registered every time, even for a file already registered (confirmed live:
+20 uncached calls returned 20 distinct font ids — Qt's own
+QFontDatabase.families() never shows the duplication, so that can't be used
+to detect it; only the call count / returned ids can). Since this function
+runs on every battle-scene redraw, a real play session could pile up
+thousands of duplicate registrations, eventually bloating Qt's font database
+until fontconfig's internal font-set sort crashed with a stack overflow
+(observed as a SIGSEGV inside FcFontSetSort). Fixed by registering each font
+file exactly once.
+"""
+
+import pytest
+
+
+@pytest.fixture(scope="session")
+def qapp():
+    from PyQt6.QtWidgets import QApplication
+
+    app = QApplication.instance()
+    if not app:
+        app = QApplication([])
+    return app
+
+
+def test_repeated_calls_register_the_font_file_only_once(qapp, monkeypatch):
+    import Ankimon.utils as ankimon_utils
+    from PyQt6.QtGui import QFontDatabase
+
+    calls = []
+    real_add = QFontDatabase.addApplicationFont
+
+    def spy_add(path):
+        calls.append(path)
+        return real_add(path)
+
+    monkeypatch.setattr(QFontDatabase, "addApplicationFont", staticmethod(spy_add))
+    # The cache is a module-level set, shared across the whole process —
+    # reset it so an earlier test's registration doesn't hide a regression.
+    monkeypatch.setattr(ankimon_utils, "_registered_fonts", set())
+
+    for _ in range(20):
+        font = ankimon_utils.load_custom_font(20, 0)
+        assert font is not None
+
+    assert len(calls) == 1, (
+        f"expected exactly 1 addApplicationFont() call across 20 load_custom_font() "
+        f"calls for the same font file, got {len(calls)}"
+    )
+
+
+def test_different_language_fonts_each_register_once(qapp, monkeypatch):
+    """language=1 (Western) and language=0 (default) use different font
+    files — both should still register at most once each, not per-call."""
+    import Ankimon.utils as ankimon_utils
+    from PyQt6.QtGui import QFontDatabase
+
+    calls = []
+    real_add = QFontDatabase.addApplicationFont
+
+    def spy_add(path):
+        calls.append(path)
+        return real_add(path)
+
+    monkeypatch.setattr(QFontDatabase, "addApplicationFont", staticmethod(spy_add))
+    monkeypatch.setattr(ankimon_utils, "_registered_fonts", set())
+
+    for _ in range(10):
+        ankimon_utils.load_custom_font(20, 0)
+        ankimon_utils.load_custom_font(20, 1)
+
+    # At most one registration per distinct underlying font file.
+    assert len(calls) == len(set(calls))
+    # And both language paths were actually exercised, not just one of them
+    # happening to dedupe against itself — pin the exact distinct paths seen.
+    from Ankimon.resources import font_path
+
+    pkmn_w_bundled = (font_path / "pkmn_w.ttf").exists()
+    assert any("Early GameBoy.ttf" in c for c in calls)
+    if pkmn_w_bundled:
+        # This repo ships pkmn_w.ttf, so language=1 must actually register
+        # it — not silently reuse the Early GameBoy path, which would pass
+        # the weaker "at most 2 distinct paths" check just as well.
+        assert any("pkmn_w.ttf" in c for c in calls)
+        assert len(set(calls)) == 2
+    else:
+        # No pkmn_w.ttf bundled -> language=1 falls back to Early GameBoy too.
+        assert len(set(calls)) == 1
+
+
+def test_a_failed_registration_is_retried_on_the_next_call(qapp, monkeypatch):
+    """addApplicationFont() returning -1 (failure) must not be cached as a
+    success — otherwise every later call for that file silently gives up
+    retrying forever. First call fails, second call (for the same file)
+    should genuinely retry the real registration rather than skip it."""
+    import Ankimon.utils as ankimon_utils
+    from PyQt6.QtGui import QFontDatabase
+
+    real_add = QFontDatabase.addApplicationFont
+    calls = []
+
+    def flaky_add(path):
+        calls.append(path)
+        if len(calls) == 1:
+            return -1  # simulate a failed registration
+        return real_add(path)
+
+    monkeypatch.setattr(QFontDatabase, "addApplicationFont", staticmethod(flaky_add))
+    monkeypatch.setattr(ankimon_utils, "_registered_fonts", set())
+
+    font1 = ankimon_utils.load_custom_font(20, 0)
+    font2 = ankimon_utils.load_custom_font(20, 0)
+
+    assert font1 is not None and font2 is not None
+    # The failure must have triggered a genuine retry, not a skipped no-op.
+    assert len(calls) == 2
+    # And the retry succeeded, so a third call must NOT register again.
+    ankimon_utils.load_custom_font(20, 0)
+    assert len(calls) == 2


### PR DESCRIPTION
### Description

`utils.load_custom_font()` is called on every battle-scene redraw, and each call
ran `QFontDatabase.addApplicationFont()` unconditionally. That adds a brand-new
entry to Qt's font database every time, even for a file already registered, so
over a play session the same font is registered hundreds of times. The database
bloats until fontconfig's internal font-set sort overflows its stack and the
process crashes (SIGSEGV inside `FcFontSetSort`).

Change: keep a module-level set of font files already handed to
`QFontDatabase`, and skip re-registration for a file that's in it. A file is
only added to the set after `addApplicationFont()` actually succeeds
(`addApplicationFont` returns `-1` on failure), so a transient failure can still
be retried on a later call. The mocked-`QFontDatabase` test case is handled too
— a non-int return is treated as success rather than raising on the comparison.

Files: `src/Ankimon/utils.py`, `tests/test_load_custom_font_caching.py` (new).

### Checklist
- [x] My code follows the code style and guidelines of this project.
- [x] I have run tests locally (`pytest tests/` and `pytest tests/test_addon_integrity.py`) and they all pass.