### PR TITLE
fix(ui): parent move/attack dialogs and make hook dispatch mutation-safe

### DIFF
--- a/src/Ankimon/classes/choose_move_dialog.py
+++ b/src/Ankimon/classes/choose_move_dialog.py
@@ -7,8 +7,11 @@ from ..move_names import format_move_name
 import random
 
 class MoveSelectionDialog(QDialog):
-    def __init__(self, mainpokemon_attacks):
-        super().__init__()
+    def __init__(self, mainpokemon_attacks, parent=None):
+        """``parent`` should always be the main window: a parentless dialog
+        can spawn with no stacking/focus cue on some window managers, so
+        exec() blocks the calling turn on a dialog nobody can see."""
+        super().__init__(parent)
 
         # Dialog settings
         self.setWindowTitle("Select a Move")

--- a/src/Ankimon/gui_classes/pokemon_details.py
+++ b/src/Ankimon/gui_classes/pokemon_details.py
@@ -3,7 +3,7 @@ import json
 from typing import Any, Callable
 import re
 
-from aqt import qconnect
+from aqt import mw, qconnect
 from PyQt6.QtGui import QPixmap, QPainter, QIcon, QColor, QPolygonF, QPen, QBrush
 from PyQt6.QtCore import (
     Qt,
@@ -1439,7 +1439,9 @@ def remember_attack(
             msg += f"\n Your {pokemon_data['name'].capitalize()} has learned {new_attack} !"
             logger.log_and_showinfo("info", f"{msg}")
         else:
-            dialog = AttackDialog(attacks, new_attack)
+            dialog = AttackDialog(attacks, new_attack, parent=mw)
+            dialog.raise_()
+            dialog.activateWindow()
             if dialog.exec() == QDialog.DialogCode.Accepted:
                 selected_attack = dialog.selected_attack
                 try:

--- a/src/Ankimon/gui_classes/pokemon_details.py
+++ b/src/Ankimon/gui_classes/pokemon_details.py
@@ -1440,9 +1440,14 @@ def remember_attack(
             logger.log_and_showinfo("info", f"{msg}")
         else:
             dialog = AttackDialog(attacks, new_attack, parent=mw)
+            dialog.show()
             dialog.raise_()
             dialog.activateWindow()
-            if dialog.exec() == QDialog.DialogCode.Accepted:
+            try:
+                result = dialog.exec()
+            finally:
+                dialog.deleteLater()
+            if result == QDialog.DialogCode.Accepted:
                 selected_attack = dialog.selected_attack
                 try:
                     index_to_replace = attacks.index(selected_attack)

--- a/src/Ankimon/gui_classes/pokemon_details.py
+++ b/src/Ankimon/gui_classes/pokemon_details.py
@@ -11,6 +11,7 @@ from PyQt6.QtCore import (
     QRectF,
     QPropertyAnimation,
     QEasingCurve,
+    QTimer,
     pyqtProperty,
 )
 from PyQt6.QtWidgets import QScrollArea
@@ -1440,9 +1441,13 @@ def remember_attack(
             logger.log_and_showinfo("info", f"{msg}")
         else:
             dialog = AttackDialog(attacks, new_attack, parent=mw)
-            dialog.show()
-            dialog.raise_()
-            dialog.activateWindow()
+            QTimer.singleShot(
+                0,
+                lambda: (
+                    dialog.raise_(),
+                    dialog.activateWindow(),
+                ),
+            )
             try:
                 result = dialog.exec()
             finally:

--- a/src/Ankimon/gui_presenter.py
+++ b/src/Ankimon/gui_presenter.py
@@ -33,19 +33,30 @@ class QtPresenter:
         # just invisible. (finding: turns stopped advancing despite correct
         # review answers, with controls.allow_to_choose_moves enabled.)
         dialog = MoveSelectionDialog(list(attacks), parent=mw)
+        # show() first so raise_()/activateWindow() act on a real native
+        # window; deleteLater() in finally so the mw-parented dialog is not
+        # kept alive as a hidden child until Anki closes.
+        dialog.show()
         dialog.raise_()
         dialog.activateWindow()
-        if dialog.exec() == QDialog.DialogCode.Accepted and dialog.selected_move:
-            return dialog.selected_move
-        return None
+        try:
+            if dialog.exec() == QDialog.DialogCode.Accepted and dialog.selected_move:
+                return dialog.selected_move
+            return None
+        finally:
+            dialog.deleteLater()
 
     def choose_attack_to_replace(self, attacks, new_attack):
         dialog = AttackDialog(list(attacks), new_attack, parent=mw)
+        dialog.show()
         dialog.raise_()
         dialog.activateWindow()
-        if dialog.exec() == QDialog.DialogCode.Accepted:
-            return dialog.selected_attack
-        return None
+        try:
+            if dialog.exec() == QDialog.DialogCode.Accepted:
+                return dialog.selected_attack
+            return None
+        finally:
+            dialog.deleteLater()
 
     def notify(self, level, message):
         if level == "warning":

--- a/src/Ankimon/gui_presenter.py
+++ b/src/Ankimon/gui_presenter.py
@@ -13,7 +13,7 @@ never be imported headless. See :mod:`Ankimon.ui_port` for the contract.
 from __future__ import annotations
 
 from aqt import mw
-from aqt.qt import QDialog
+from aqt.qt import QDialog, QTimer
 from aqt.utils import showInfo, showWarning
 
 from .classes.choose_move_dialog import MoveSelectionDialog
@@ -33,12 +33,16 @@ class QtPresenter:
         # just invisible. (finding: turns stopped advancing despite correct
         # review answers, with controls.allow_to_choose_moves enabled.)
         dialog = MoveSelectionDialog(list(attacks), parent=mw)
-        # show() first so raise_()/activateWindow() act on a real native
-        # window; deleteLater() in finally so the mw-parented dialog is not
-        # kept alive as a hidden child until Anki closes.
-        dialog.show()
-        dialog.raise_()
-        dialog.activateWindow()
+        # Let exec() establish modality and show the dialog first, then raise
+        # and activate it on the next event-loop iteration so it cannot appear
+        # behind the Anki/battle windows.
+        QTimer.singleShot(
+            0,
+            lambda: (
+                dialog.raise_(),
+                dialog.activateWindow(),
+            ),
+        )
         try:
             if dialog.exec() == QDialog.DialogCode.Accepted and dialog.selected_move:
                 return dialog.selected_move
@@ -48,9 +52,13 @@ class QtPresenter:
 
     def choose_attack_to_replace(self, attacks, new_attack):
         dialog = AttackDialog(list(attacks), new_attack, parent=mw)
-        dialog.show()
-        dialog.raise_()
-        dialog.activateWindow()
+        QTimer.singleShot(
+            0,
+            lambda: (
+                dialog.raise_(),
+                dialog.activateWindow(),
+            ),
+        )
         try:
             if dialog.exec() == QDialog.DialogCode.Accepted:
                 return dialog.selected_attack

--- a/src/Ankimon/gui_presenter.py
+++ b/src/Ankimon/gui_presenter.py
@@ -12,6 +12,7 @@ never be imported headless. See :mod:`Ankimon.ui_port` for the contract.
 
 from __future__ import annotations
 
+from aqt import mw
 from aqt.qt import QDialog
 from aqt.utils import showInfo, showWarning
 
@@ -24,13 +25,24 @@ class QtPresenter:
     """Shows real Qt dialogs for the UI-port interactions."""
 
     def choose_move(self, attacks):
-        dialog = MoveSelectionDialog(list(attacks))
+        # Parent to mw and force it to the front: a parentless QDialog can
+        # spawn behind the main Anki window (or the Ankimon battle popup)
+        # with no taskbar/focus cue on some window managers — exec() still
+        # blocks the calling turn on it, so the battle silently freezes with
+        # nothing in the logs, since nothing actually failed; the dialog is
+        # just invisible. (finding: turns stopped advancing despite correct
+        # review answers, with controls.allow_to_choose_moves enabled.)
+        dialog = MoveSelectionDialog(list(attacks), parent=mw)
+        dialog.raise_()
+        dialog.activateWindow()
         if dialog.exec() == QDialog.DialogCode.Accepted and dialog.selected_move:
             return dialog.selected_move
         return None
 
     def choose_attack_to_replace(self, attacks, new_attack):
-        dialog = AttackDialog(list(attacks), new_attack)
+        dialog = AttackDialog(list(attacks), new_attack, parent=mw)
+        dialog.raise_()
+        dialog.activateWindow()
         if dialog.exec() == QDialog.DialogCode.Accepted:
             return dialog.selected_attack
         return None

--- a/src/Ankimon/hook_registry.py
+++ b/src/Ankimon/hook_registry.py
@@ -44,7 +44,12 @@ def CatchPokemonHook(collected_pokemon_ids):
             reviewer_obj,
             update_hud=True,
         )
-    for hook in catch_pokemon_hooks:
+    # list(): a hook may unregister itself from this very bucket while it
+    # runs (the double-faint resolver does), and removing the element at the
+    # current index makes the iterator skip the NEXT hook. These buckets are
+    # public to other add-ons via mw.add_catch_pokemon_hook, so that
+    # skipped hook could belong to anyone.
+    for hook in list(catch_pokemon_hooks):
         hook()
 
 
@@ -65,5 +70,10 @@ def DefeatPokemonHook():
             reviewer_obj,
             update_hud=True,
         )
-    for hook in defeat_pokemon_hooks:
+    # list(): a hook may unregister itself from this very bucket while it
+    # runs (the double-faint resolver does), and removing the element at the
+    # current index makes the iterator skip the NEXT hook. These buckets are
+    # public to other add-ons via mw.add_defeat_pokemon_hook, so that
+    # skipped hook could belong to anyone.
+    for hook in list(defeat_pokemon_hooks):
         hook()

--- a/src/Ankimon/pyobj/attack_dialog.py
+++ b/src/Ankimon/pyobj/attack_dialog.py
@@ -4,8 +4,11 @@ from PyQt6.QtCore import Qt
 from ..utils import format_move_name
 
 class AttackDialog(QDialog):
-    def __init__(self, attacks, new_attack):
-        super().__init__()
+    def __init__(self, attacks, new_attack, parent=None):
+        """``parent`` should always be a real window: a parentless dialog
+        can spawn with no stacking/focus cue on some window managers, so
+        exec() blocks the calling flow on a dialog nobody can see."""
+        super().__init__(parent)
         self.attacks = attacks
         self.new_attack = new_attack
         self.selected_attack = None

--- a/src/Ankimon/pyobj/evolution_window.py
+++ b/src/Ankimon/pyobj/evolution_window.py
@@ -394,9 +394,14 @@ class EvoWindow(QWidget):
                         attacks.append(new_attack)
                     else:
                         dialog = AttackDialog(attacks, new_attack, parent=self)
+                        dialog.show()
                         dialog.raise_()
                         dialog.activateWindow()
-                        if dialog.exec() == QDialog.DialogCode.Accepted:
+                        try:
+                            _accepted = dialog.exec() == QDialog.DialogCode.Accepted
+                        finally:
+                            dialog.deleteLater()
+                        if _accepted:
                             selected_attack = dialog.selected_attack
                             try:
                                 index_to_replace = attacks.index(selected_attack)
@@ -604,9 +609,14 @@ class EvoWindow(QWidget):
                         attacks.append(new_attack)
                     else:
                         dialog = AttackDialog(attacks, new_attack, parent=self)
+                        dialog.show()
                         dialog.raise_()
                         dialog.activateWindow()
-                        if dialog.exec() == QDialog.DialogCode.Accepted:
+                        try:
+                            _accepted = dialog.exec() == QDialog.DialogCode.Accepted
+                        finally:
+                            dialog.deleteLater()
+                        if _accepted:
                             selected_attack = dialog.selected_attack
                             try:
                                 index_to_replace = attacks.index(selected_attack)

--- a/src/Ankimon/pyobj/evolution_window.py
+++ b/src/Ankimon/pyobj/evolution_window.py
@@ -393,7 +393,9 @@ class EvoWindow(QWidget):
                     if len(attacks) < 4:
                         attacks.append(new_attack)
                     else:
-                        dialog = AttackDialog(attacks, new_attack)
+                        dialog = AttackDialog(attacks, new_attack, parent=self)
+                        dialog.raise_()
+                        dialog.activateWindow()
                         if dialog.exec() == QDialog.DialogCode.Accepted:
                             selected_attack = dialog.selected_attack
                             try:
@@ -601,7 +603,9 @@ class EvoWindow(QWidget):
                     if len(attacks) < 4:
                         attacks.append(new_attack)
                     else:
-                        dialog = AttackDialog(attacks, new_attack)
+                        dialog = AttackDialog(attacks, new_attack, parent=self)
+                        dialog.raise_()
+                        dialog.activateWindow()
                         if dialog.exec() == QDialog.DialogCode.Accepted:
                             selected_attack = dialog.selected_attack
                             try:

--- a/src/Ankimon/pyobj/evolution_window.py
+++ b/src/Ankimon/pyobj/evolution_window.py
@@ -10,6 +10,7 @@ from aqt.qt import (
     QVBoxLayout,
     QWidget,
     QDialog,
+    QTimer,
     qconnect,
 )
 from PyQt6.QtGui import QColor, QPen
@@ -397,12 +398,16 @@ class EvoWindow(QWidget):
                         # popup. EvoWindow is a separate top-level window that
                         # gets torn down/hidden mid-flow; a child dialog of it
                         # can lose its focus/taskbar cue or misbehave on macOS.
-                        # Matches gui_presenter / pokemon_details, which parent
-                        # to mw.
+                        # Let exec() establish modality before the timer raises
+                        # and activates the visible dialog.
                         dialog = AttackDialog(attacks, new_attack, parent=mw)
-                        dialog.show()
-                        dialog.raise_()
-                        dialog.activateWindow()
+                        QTimer.singleShot(
+                            0,
+                            lambda: (
+                                dialog.raise_(),
+                                dialog.activateWindow(),
+                            ),
+                        )
                         try:
                             _accepted = dialog.exec() == QDialog.DialogCode.Accepted
                         finally:
@@ -618,12 +623,16 @@ class EvoWindow(QWidget):
                         # popup. EvoWindow is a separate top-level window that
                         # gets torn down/hidden mid-flow; a child dialog of it
                         # can lose its focus/taskbar cue or misbehave on macOS.
-                        # Matches gui_presenter / pokemon_details, which parent
-                        # to mw.
+                        # Let exec() establish modality before the timer raises
+                        # and activates the visible dialog.
                         dialog = AttackDialog(attacks, new_attack, parent=mw)
-                        dialog.show()
-                        dialog.raise_()
-                        dialog.activateWindow()
+                        QTimer.singleShot(
+                            0,
+                            lambda: (
+                                dialog.raise_(),
+                                dialog.activateWindow(),
+                            ),
+                        )
                         try:
                             _accepted = dialog.exec() == QDialog.DialogCode.Accepted
                         finally:

--- a/src/Ankimon/pyobj/evolution_window.py
+++ b/src/Ankimon/pyobj/evolution_window.py
@@ -393,7 +393,13 @@ class EvoWindow(QWidget):
                     if len(attacks) < 4:
                         attacks.append(new_attack)
                     else:
-                        dialog = AttackDialog(attacks, new_attack, parent=self)
+                        # Parent to the Anki main window, not this evolution
+                        # popup. EvoWindow is a separate top-level window that
+                        # gets torn down/hidden mid-flow; a child dialog of it
+                        # can lose its focus/taskbar cue or misbehave on macOS.
+                        # Matches gui_presenter / pokemon_details, which parent
+                        # to mw.
+                        dialog = AttackDialog(attacks, new_attack, parent=mw)
                         dialog.show()
                         dialog.raise_()
                         dialog.activateWindow()
@@ -608,7 +614,13 @@ class EvoWindow(QWidget):
                     if len(attacks) < 4:
                         attacks.append(new_attack)
                     else:
-                        dialog = AttackDialog(attacks, new_attack, parent=self)
+                        # Parent to the Anki main window, not this evolution
+                        # popup. EvoWindow is a separate top-level window that
+                        # gets torn down/hidden mid-flow; a child dialog of it
+                        # can lose its focus/taskbar cue or misbehave on macOS.
+                        # Matches gui_presenter / pokemon_details, which parent
+                        # to mw.
+                        dialog = AttackDialog(attacks, new_attack, parent=mw)
                         dialog.show()
                         dialog.raise_()
                         dialog.activateWindow()

--- a/tests/test_evolution_item_consumption.py
+++ b/tests/test_evolution_item_consumption.py
@@ -164,6 +164,52 @@ def _apply_common_patches():
     return handles
 
 
+def _install_dialog_order_probe(evo_mod):
+    """Record the move prompt's event-loop ordering without importing Qt."""
+    events = []
+    callbacks = []
+
+    class ProbeTimer:
+        @staticmethod
+        def singleShot(interval, callback):
+            assert interval == 0
+            events.append("scheduled")
+            callbacks.append(callback)
+
+    class ProbeDialogCode:
+        Accepted = 1
+
+    class ProbeQDialog:
+        DialogCode = ProbeDialogCode
+
+    class ProbeAttackDialog:
+        def __init__(self, attacks, new_attack, parent=None):
+            self.selected_attack = attacks[0]
+
+        def show(self):
+            events.append("show")
+
+        def raise_(self):
+            events.append("raise")
+
+        def activateWindow(self):
+            events.append("activate")
+
+        def exec(self):
+            events.append("exec")
+            while callbacks:
+                callbacks.pop(0)()
+            return 0
+
+        def deleteLater(self):
+            events.append("delete")
+
+    evo_mod.QTimer = ProbeTimer
+    evo_mod.QDialog = ProbeQDialog
+    evo_mod.AttackDialog = ProbeAttackDialog
+    return events
+
+
 def test_evolve_pokemon_consumes_stone():
     evo_mod, _ = _load_evo_window()
     mock_db = MagicMock()
@@ -325,3 +371,70 @@ def test_evolve_pokemon_regional_form_growth_rate_fallback():
         assert int(pokemon_data["id"]) == 10115
     finally:
         patch.stopall()
+
+
+def test_evolve_pokemon_establishes_modality_before_foregrounding_move_dialog():
+    evo_mod, pokedex_funcs = _load_evo_window()
+    mock_db = MagicMock()
+    mock_db.save_pokemon.return_value = True
+    mock_db.get_pokemon.return_value = {
+        "id": 133,
+        "name": "Eevee",
+        "nickname": "Eevee",
+        "level": 20,
+        "attacks": ["tackle", "growl", "bite", "swift"],
+        "iv": {},
+        "ev": {},
+        "xp": 100,
+    }
+    evo_mod.services.db = mock_db
+    events = _install_dialog_order_probe(evo_mod)
+
+    handles = _apply_common_patches()
+    try:
+        handles["moves"].return_value = ["quick-attack"]
+        handles["search"].side_effect = lambda name, key: {
+            "types": ["Normal"],
+            "baseStats": {"hp": 50},
+            "abilities": {"0": "run-away"},
+        }[key]
+        pokedex_funcs.get_pretty_name_for_id = lambda pokemon_id: (
+            "Eevee" if int(pokemon_id) == 133 else "Vaporeon"
+        )
+
+        win = _make_evo_window(evo_mod)
+        win.evolve_pokemon(
+            individual_id="some-uuid",
+            prevo_id=133,
+            prevo_name="eevee",
+            evo_id=134,
+            evo_name="vaporeon",
+            main_pokemon=None,
+        )
+
+        assert events == ["scheduled", "exec", "raise", "activate", "delete"]
+    finally:
+        patch.stopall()
+
+
+def test_cancel_evolution_establishes_modality_before_foregrounding_move_dialog():
+    evo_mod, _ = _load_evo_window()
+    mock_db = MagicMock()
+    mock_db.get_pokemon.return_value = {
+        "id": 133,
+        "name": "Eevee",
+        "level": 20,
+        "attacks": ["tackle", "growl", "bite", "swift"],
+    }
+    evo_mod.services.db = mock_db
+    events = _install_dialog_order_probe(evo_mod)
+
+    with patch(
+        "Ankimon.pyobj.evolution_window.get_random_moves_for_pokemon",
+        return_value=["quick-attack"],
+    ):
+        win = _make_evo_window(evo_mod)
+        win.main_pokemon = None
+        win.cancel_evolution("some-uuid", "eevee")
+
+    assert events == ["scheduled", "exec", "raise", "activate", "delete"]

--- a/tests/test_gui_presenter_modal_dialogs.py
+++ b/tests/test_gui_presenter_modal_dialogs.py
@@ -1,0 +1,135 @@
+"""Regression tests for modal move-selection dialogs in ``QtPresenter``."""
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+
+_SRC = Path(__file__).parent.parent / "src"
+_MODULE_NAME = "Ankimon.gui_presenter"
+
+
+class _DialogCode:
+    Accepted = 1
+
+
+class _QDialog:
+    DialogCode = _DialogCode
+
+
+@pytest.fixture
+def presenter_module(monkeypatch):
+    """Load the real presenter with only its Anki/dialog imports isolated."""
+    for package_name in ("Ankimon", "Ankimon.classes", "Ankimon.pyobj"):
+        package = types.ModuleType(package_name)
+        package.__path__ = [str(_SRC / package_name.replace(".", "/"))]
+        package.__package__ = package_name
+        monkeypatch.setitem(sys.modules, package_name, package)
+
+    aqt = types.ModuleType("aqt")
+    aqt.mw = object()
+    monkeypatch.setitem(sys.modules, "aqt", aqt)
+
+    aqt_qt = types.ModuleType("aqt.qt")
+    aqt_qt.QDialog = _QDialog
+    aqt_qt.QTimer = object
+    monkeypatch.setitem(sys.modules, "aqt.qt", aqt_qt)
+
+    aqt_utils = types.ModuleType("aqt.utils")
+    aqt_utils.showInfo = lambda *_args, **_kwargs: None
+    aqt_utils.showWarning = lambda *_args, **_kwargs: None
+    monkeypatch.setitem(sys.modules, "aqt.utils", aqt_utils)
+
+    choose_move = types.ModuleType("Ankimon.classes.choose_move_dialog")
+    choose_move.MoveSelectionDialog = object
+    monkeypatch.setitem(sys.modules, "Ankimon.classes.choose_move_dialog", choose_move)
+
+    attack_dialog = types.ModuleType("Ankimon.pyobj.attack_dialog")
+    attack_dialog.AttackDialog = object
+    monkeypatch.setitem(sys.modules, "Ankimon.pyobj.attack_dialog", attack_dialog)
+
+    error_handler = types.ModuleType("Ankimon.pyobj.error_handler")
+    error_handler.show_warning_with_traceback = lambda *_args, **_kwargs: None
+    monkeypatch.setitem(sys.modules, "Ankimon.pyobj.error_handler", error_handler)
+
+    spec = importlib.util.spec_from_file_location(
+        _MODULE_NAME, _SRC / "Ankimon" / "gui_presenter.py"
+    )
+    module = importlib.util.module_from_spec(spec)
+    monkeypatch.setitem(sys.modules, _MODULE_NAME, module)
+    spec.loader.exec_module(module)
+    return module
+
+
+class _DialogProbe:
+    """Run queued callbacks only after the simulated modal loop starts."""
+
+    def __init__(self, events, callbacks):
+        self.events = events
+        self.callbacks = callbacks
+        self.selected_move = "tackle"
+        self.selected_attack = "growl"
+
+    def show(self):
+        self.events.append("show")
+
+    def raise_(self):
+        self.events.append("raise")
+
+    def activateWindow(self):
+        self.events.append("activate")
+
+    def exec(self):
+        self.events.append("exec")
+        while self.callbacks:
+            self.callbacks.pop(0)()
+        return _DialogCode.Accepted
+
+    def deleteLater(self):
+        self.events.append("delete")
+
+
+@pytest.mark.parametrize(
+    ("method_name", "dialog_name", "arguments", "expected"),
+    [
+        ("choose_move", "MoveSelectionDialog", (["tackle"],), "tackle"),
+        (
+            "choose_attack_to_replace",
+            "AttackDialog",
+            (["growl"], "tackle"),
+            "growl",
+        ),
+    ],
+)
+def test_presenter_establishes_modality_before_showing_dialog(
+    monkeypatch,
+    presenter_module,
+    method_name,
+    dialog_name,
+    arguments,
+    expected,
+):
+    """A foregrounded dialog must already block the other application windows."""
+    events = []
+    callbacks = []
+
+    class ProbeTimer:
+        @staticmethod
+        def singleShot(interval, callback):
+            assert interval == 0
+            events.append("scheduled")
+            callbacks.append(callback)
+
+    def make_dialog(*_args, **_kwargs):
+        return _DialogProbe(events, callbacks)
+
+    monkeypatch.setattr(presenter_module, dialog_name, make_dialog)
+    monkeypatch.setattr(presenter_module, "QTimer", ProbeTimer, raising=False)
+
+    result = getattr(presenter_module.QtPresenter(), method_name)(*arguments)
+
+    assert result == expected
+    assert events == ["scheduled", "exec", "raise", "activate", "delete"]

--- a/tests/test_hook_dispatch_mutation.py
+++ b/tests/test_hook_dispatch_mutation.py
@@ -1,0 +1,103 @@
+"""A hook may unregister itself from the bucket it is being dispatched from —
+the manual-mode double-faint resolver does exactly that. Iterating the live
+list meant ``remove()`` shifted every later element down one while the
+iterator held an index, so the hook registered immediately AFTER the
+self-removing one was silently skipped for that catch/defeat.
+
+These buckets are published to other add-ons via ``mw.add_catch_pokemon_hook``
+(profile_hooks.py), so the skipped hook can belong to a third party.
+"""
+
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+_SRC = Path(__file__).resolve().parent.parent / "src"
+
+
+@pytest.fixture
+def hooks(monkeypatch, request):
+    monkeypatch.syspath_prepend(str(_SRC))
+    for name in ("Ankimon", "Ankimon.functions"):
+        mod = sys.modules.get(name)
+        if mod is None or not hasattr(mod, "__path__"):
+            pkg = types.ModuleType(name)
+            pkg.__path__ = [str(_SRC / name.replace(".", "/"))]
+            pkg.__package__ = name
+            monkeypatch.setitem(sys.modules, name, pkg)
+
+    # Stub the two heavy imports hook_registry pulls in at module scope.
+    singletons = types.ModuleType("Ankimon.singletons")
+    singletons.enemy_pokemon = types.SimpleNamespace(hp=10)  # >0 => skip catch/kill
+    singletons.main_pokemon = object()
+    singletons.ankimon_tracker_obj = object()
+    singletons.get_test_window = lambda: None
+    singletons.get_evo_window = lambda: None
+    singletons.logger = None
+    singletons.achievements = {}
+    singletons.trainer_card = None
+    singletons.reviewer_obj = None
+    monkeypatch.setitem(sys.modules, "Ankimon.singletons", singletons)
+
+    enc = types.ModuleType("Ankimon.functions.encounter_functions")
+    enc.catch_pokemon = lambda *a, **k: None
+    enc.kill_pokemon = lambda *a, **k: None
+    enc.new_pokemon = lambda *a, **k: None
+    monkeypatch.setitem(sys.modules, "Ankimon.functions.encounter_functions", enc)
+
+    import importlib
+
+    # Restore BOTH the sys.modules entry and the attribute the import machinery
+    # binds on the parent package. Restoring only sys.modules leaves
+    # ``Ankimon.hook_registry`` pointing at this test's replacement, so a later
+    # ``from Ankimon import hook_registry`` keeps resolving to it.
+    parent = sys.modules["Ankimon"]
+    prev_module = sys.modules.get("Ankimon.hook_registry")
+    had_attr = "hook_registry" in vars(parent)
+    prev_attr = getattr(parent, "hook_registry", None)
+
+    def _restore():
+        if prev_module is not None:
+            sys.modules["Ankimon.hook_registry"] = prev_module
+        else:
+            sys.modules.pop("Ankimon.hook_registry", None)
+        if had_attr:
+            parent.hook_registry = prev_attr
+        else:
+            vars(parent).pop("hook_registry", None)
+
+    request.addfinalizer(_restore)
+    sys.modules.pop("Ankimon.hook_registry", None)
+    return importlib.import_module("Ankimon.hook_registry")
+
+
+@pytest.mark.parametrize(
+    "bucket_name,dispatch",
+    [
+        ("catch_pokemon_hooks", lambda hr: hr.CatchPokemonHook([])),
+        ("defeat_pokemon_hooks", lambda hr: hr.DefeatPokemonHook()),
+    ],
+)
+def test_a_self_removing_hook_does_not_skip_the_next_one(hooks, bucket_name, dispatch):
+    bucket = getattr(hooks, bucket_name)
+    bucket.clear()
+    ran = []
+
+    def self_removing():
+        ran.append("first")
+        bucket.remove(self_removing)
+
+    def third_party():
+        ran.append("second")
+
+    bucket.append(self_removing)
+    bucket.append(third_party)
+
+    dispatch(hooks)
+
+    assert ran == ["first", "second"], (
+        f"{bucket_name}: the hook after a self-removing one was skipped ({ran})"
+    )
+    assert bucket == [third_party]

--- a/tests/test_pokemon_details_gui.py
+++ b/tests/test_pokemon_details_gui.py
@@ -213,16 +213,23 @@ def details(qapp, tmp_path):
 
     class AttackDialog:
         # remember_attack() calls AttackDialog(attacks, new_attack, parent=mw)
-        # then .raise_()/.activateWindow() before .exec() (the battle-freeze
-        # fix: an unparented dialog could spawn invisibly) — the double needs
-        # to accept/tolerate all of that.
+        # then .show()/.raise_()/.activateWindow() before .exec(), and
+        # .deleteLater() in a finally (the battle-freeze fix: an unparented
+        # dialog could spawn invisibly, plus mw-parented dialog cleanup) —
+        # the double needs to accept/tolerate all of that.
         def __init__(self, attacks, new_attack, parent=None):
             self.selected_attack = attacks[0]
+
+        def show(self):
+            pass
 
         def raise_(self):
             pass
 
         def activateWindow(self):
+            pass
+
+        def deleteLater(self):
             pass
 
         def exec(self):

--- a/tests/test_pokemon_details_gui.py
+++ b/tests/test_pokemon_details_gui.py
@@ -213,15 +213,10 @@ def details(qapp, tmp_path):
 
     class AttackDialog:
         # remember_attack() calls AttackDialog(attacks, new_attack, parent=mw)
-        # then .show()/.raise_()/.activateWindow() before .exec(), and
-        # .deleteLater() in a finally (the battle-freeze fix: an unparented
-        # dialog could spawn invisibly, plus mw-parented dialog cleanup) —
-        # the double needs to accept/tolerate all of that.
+        # then schedules .raise_()/.activateWindow() for the modal event loop,
+        # and .deleteLater() in a finally (the battle-freeze fix plus cleanup).
         def __init__(self, attacks, new_attack, parent=None):
             self.selected_attack = attacks[0]
-
-        def show(self):
-            pass
 
         def raise_(self):
             pass
@@ -758,6 +753,69 @@ def test_remember_attack_with_a_full_moveset_goes_through_the_replace_dialog(det
     # The dialog was declined (double's default), so the moveset is untouched
     # rather than silently growing past 4 or swapping something unintended.
     assert db.saved[-1]["attacks"] == ["tackle", "thunderbolt", "quick-attack", "growl"]
+
+
+def test_remember_attack_establishes_modality_before_showing_dialog(
+    details, monkeypatch
+):
+    """The fifth-move prompt must be modal before it becomes visible."""
+    events = []
+    callbacks = []
+
+    class ProbeTimer:
+        @staticmethod
+        def singleShot(interval, callback):
+            assert interval == 0
+            events.append("scheduled")
+            callbacks.append(callback)
+
+    class ModalProbeAttackDialog:
+        def __init__(self, attacks, new_attack, parent=None):
+            self.selected_attack = attacks[0]
+
+        def show(self):
+            events.append("show")
+
+        def raise_(self):
+            events.append("raise")
+
+        def activateWindow(self):
+            events.append("activate")
+
+        def exec(self):
+            events.append("exec")
+            while callbacks:
+                callbacks.pop(0)()
+            return 0
+
+        def deleteLater(self):
+            events.append("delete")
+
+    monkeypatch.setattr(details, "AttackDialog", ModalProbeAttackDialog)
+    monkeypatch.setattr(details, "QTimer", ProbeTimer, raising=False)
+    details._test_services.db = _FakeDB(
+        pokemon={
+            "uuid-1": {
+                "individual_id": "uuid-1",
+                "name": "pikachu",
+                "attacks": ["tackle", "thunderbolt", "quick-attack", "growl"],
+            }
+        },
+        main_pokemon={
+            "individual_id": "uuid-1",
+            "attacks": ["tackle", "thunderbolt", "quick-attack", "growl"],
+        },
+    )
+
+    details.remember_attack(
+        "uuid-1",
+        ["tackle", "thunderbolt", "quick-attack", "growl"],
+        "thunder",
+        _RecorderLogger(),
+        lambda: None,
+    )
+
+    assert events == ["scheduled", "exec", "raise", "activate", "delete"]
 
 
 def test_forget_attack_refuses_to_remove_last_move(details):

--- a/tests/test_pokemon_details_gui.py
+++ b/tests/test_pokemon_details_gui.py
@@ -188,6 +188,7 @@ def details(qapp, tmp_path):
 
     aqt_mod = types.ModuleType("aqt")
     aqt_mod.qconnect = lambda signal, func: signal.connect(func)
+    aqt_mod.mw = types.SimpleNamespace()
     sys.modules["aqt"] = aqt_mod
 
     sv = types.ModuleType("Ankimon.services")
@@ -211,8 +212,18 @@ def details(qapp, tmp_path):
     ad = types.ModuleType("Ankimon.pyobj.attack_dialog")
 
     class AttackDialog:
-        def __init__(self, attacks, new_attack):
+        # remember_attack() calls AttackDialog(attacks, new_attack, parent=mw)
+        # then .raise_()/.activateWindow() before .exec() (the battle-freeze
+        # fix: an unparented dialog could spawn invisibly) — the double needs
+        # to accept/tolerate all of that.
+        def __init__(self, attacks, new_attack, parent=None):
             self.selected_attack = attacks[0]
+
+        def raise_(self):
+            pass
+
+        def activateWindow(self):
+            pass
 
         def exec(self):
             return 0  # rejected by default
@@ -706,6 +717,40 @@ def test_remember_attack_saves_via_services_db_and_refreshes(details):
     # The main pokemon mirror is kept in sync too.
     assert db.saved_main and db.saved_main[-1]["attacks"] == ["tackle", "thunderbolt"]
     assert refreshed == [True]
+
+
+def test_remember_attack_with_a_full_moveset_goes_through_the_replace_dialog(details):
+    # 4 known moves -> the "learn a 5th" path can't just append, it has to
+    # prompt AttackDialog(attacks, new_attack, parent=mw) for a replacement —
+    # the double's exec() returns 0 (rejected) by default, so the new move is
+    # discarded and the original 4 attacks are unchanged.
+    db = _FakeDB(
+        pokemon={
+            "uuid-1": {
+                "individual_id": "uuid-1",
+                "name": "pikachu",
+                "attacks": ["tackle", "thunderbolt", "quick-attack", "growl"],
+            }
+        },
+        main_pokemon={
+            "individual_id": "uuid-1",
+            "attacks": ["tackle", "thunderbolt", "quick-attack", "growl"],
+        },
+    )
+    details._test_services.db = db
+    logger = _RecorderLogger()
+
+    details.remember_attack(
+        "uuid-1",
+        ["tackle", "thunderbolt", "quick-attack", "growl"],
+        "thunder",
+        logger,
+        lambda: None,
+    )
+
+    # The dialog was declined (double's default), so the moveset is untouched
+    # rather than silently growing past 4 or swapping something unintended.
+    assert db.saved[-1]["attacks"] == ["tackle", "thunderbolt", "quick-attack", "growl"]
 
 
 def test_forget_attack_refuses_to_remove_last_move(details):


### PR DESCRIPTION
### Description

Two independent robustness fixes around battle-turn UI.

**Qt dialog parenting.** `MoveSelectionDialog` and `AttackDialog` were
constructed parentless. On some window managers a parentless modal spawns with
no stacking or focus cue — behind the main Anki window or the battle popup —
while `exec()` blocks the turn on it. The battle appears to freeze with nothing
in the logs, because nothing actually failed: the dialog is just invisible.
(Observed as turns silently not advancing despite correct review answers, with
`controls.allow_to_choose_moves` on.) Both dialogs now take a `parent` argument,
and every call site passes one (`mw` or the calling window) and calls
`raise_()` + `activateWindow()`: `gui_presenter`, `pokemon_details.remember_attack`,
and both `EvoWindow` move-replacement paths.

**Hook dispatch.** `CatchPokemonHook` / `DefeatPokemonHook` iterated their hook
buckets directly. A hook may unregister itself from the same bucket while it
runs (the double-faint resolver does), and removing the current element makes
the iterator skip the *next* hook. These buckets are public to other add-ons via
`mw.add_catch_pokemon_hook` / `mw.add_defeat_pokemon_hook`, so the skipped hook
could belong to anyone. Iterate over a `list()` copy.

Files: `classes/choose_move_dialog.py`, `pyobj/attack_dialog.py`,
`pyobj/evolution_window.py`, `gui_classes/pokemon_details.py`, `gui_presenter.py`,
`hook_registry.py`, `tests/test_pokemon_details_gui.py`,
`tests/test_hook_dispatch_mutation.py` (new).


### Checklist
- [x] My code follows the code style and guidelines of this project.
- [x] I have run tests locally (`pytest tests/` and `pytest tests/test_addon_integrity.py`) and they all pass.
- [ ] **(Optional)** I have added/updated my entry in `.all-contributorsrc`.