### PR TITLE
fix(mobile): persist pending move-learns and apply choices to the liv…

### DIFF
--- a/src/Ankimon/ankimon_mobile_web/mobile.css
+++ b/src/Ankimon/ankimon_mobile_web/mobile.css
@@ -397,6 +397,18 @@ body {
   transform: scale(0.98);
 }
 
+.btn:disabled {
+  cursor: not-allowed;
+  opacity: 0.4;
+  filter: grayscale(0.6);
+  transform: none;
+}
+.btn:disabled:hover,
+.btn:disabled:active {
+  filter: grayscale(0.6);
+  transform: none;
+}
+
 .btn-primary {
   background: var(--accent-blue);
   color: #06111f;

--- a/src/Ankimon/ankimon_mobile_web/mobile.js
+++ b/src/Ankimon/ankimon_mobile_web/mobile.js
@@ -710,8 +710,17 @@ function renderReplayBattle(result) {
     enemySprite.className = 'battle-sprite enemy-battle-sprite'; // remove caught/fainted fade classes
 
     const playerSprite = document.getElementById('replay-player-sprite');
-    if (playerSprite && result.companion_sprite) {
-        playerSprite.src = result.companion_sprite;
+    if (playerSprite) {
+        if (result.companion_sprite) {
+            playerSprite.src = result.companion_sprite;
+        }
+        // Remove any leftover 'fainted-fade' from a PREVIOUS lost battle —
+        // that class's animation ends with opacity:0 (forwards-filled), so
+        // without this reset the companion sprite stays invisible for every
+        // battle after the first loss, even though the fight itself
+        // continues normally (narration, HP bars, attacks all still work —
+        // only the sprite is gone).
+        playerSprite.className = 'battle-sprite player-battle-sprite';
     }
 
     document.getElementById('replay-enemy-name').textContent = result.enemy_name || '???';

--- a/src/Ankimon/functions/mobile_sync.py
+++ b/src/Ankimon/functions/mobile_sync.py
@@ -2135,7 +2135,376 @@ def _resolve_internal(mode="all", companion_id="", limit=None, db=None, settings
             utils.in_bulk_resolve = False
 
 
+# Move-replacement decisions that could not be put to the player when they
+# came up.
+#
+# _attribute_xp_and_evs_to_companion runs on a QueryOp worker thread on every
+# real mobile sync (resolve_next's run_sim, commit_replay_outcome's do_db_work),
+# and a QDialog cannot be constructed or exec()'d off Qt's GUI thread. Simply
+# skipping the prompt there threw the learned move away silently: the companion
+# kept its old four moves with no tooltip, no log line and nothing queued, so
+# the player was never told a move had been learned and lost. Park the decision
+# here instead and replay it on the GUI thread — see _schedule_move_learn_flush.
+def _row_attacks(pkmndata) -> list:
+    """The move list on a captured_pokemon row, normalized to a plain list.
+
+    Rows persist ``attacks`` as either a JSON string or a list depending on
+    which write path last touched them, so every reader has to cope with both.
+    """
+    attacks = (pkmndata or {}).get("attacks", [])
+    if isinstance(attacks, str):
+        try:
+            attacks = json.loads(attacks)
+        except Exception:
+            attacks = []
+    return list(attacks or [])
+
+
+_pending_move_learns = []
+_pending_move_learns_lock = threading.Lock()
+
+# A replay that RAISES (locked DB, collection closing mid-flush) is retried, but
+# only a bounded number of times: a row that fails every attempt would otherwise
+# bounce between the queue and a self-rescheduled flush forever. This counts
+# TOTAL attempts (the first pass plus retries); once a row has failed this many
+# times it is dropped with an error log rather than retried again.
+_MOVE_LEARN_MAX_ATTEMPTS = 3
+# Delay before a failure-triggered retry, so a transiently locked DB has a moment
+# to free up instead of the retry racing straight back into the same lock.
+_MOVE_LEARN_RETRY_DELAY_MS = 2000
+
+
+def _queue_move_learn_prompt(individual_id, name, new_attack, db=None) -> None:
+    """Park one deferred move-replacement decision. Safe off the GUI thread.
+
+    The decision is written to the ``pending_move_learns`` table as well as the
+    in-memory queue. The table is what makes the move survivable: the in-memory
+    queue alone lost it outright whenever the process went away before the GUI
+    callback ran -- Anki quit or crashed after the XP was committed, the profile
+    closed with a decision pending, or the database stayed locked through the
+    retry window. The mobile battle is already resolved by then, so there is
+    nothing left to reconstruct it from. When the caller is inside a bulk
+    transaction this INSERT joins it, landing atomically with the level/XP write
+    the move came from.
+    """
+    if not individual_id or not new_attack:
+        return
+    if db is not None:
+        try:
+            db.add_pending_move_learn(individual_id, name, new_attack)
+        except Exception:
+            # Durability is best-effort: never let a failed park abort the
+            # attribution that produced it. The in-memory queue below still
+            # carries the decision for this session.
+            pass
+    with _pending_move_learns_lock:
+        for pending in _pending_move_learns:
+            if (pending["individual_id"], pending["new_attack"]) == (
+                individual_id,
+                new_attack,
+            ):
+                return  # already queued — a bulk resolve can re-learn the same move
+        _pending_move_learns.append(
+            {
+                "individual_id": individual_id,
+                "name": name,
+                "new_attack": new_attack,
+                "retries": 0,
+            }
+        )
+
+
+def _hydrate_pending_move_learns(db) -> None:
+    """Pull durably-parked decisions back into the in-memory queue.
+
+    This is what recovers a move across a restart: rows survive in
+    ``pending_move_learns`` when the process went away before the prompt could
+    be shown, and this puts them back in front of the player. Entries already
+    queued in memory are left alone so an in-flight retry count is not reset.
+    """
+    if db is None:
+        return
+    try:
+        rows = db.get_pending_move_learns()
+    except Exception:
+        return
+    if not rows:
+        return
+    with _pending_move_learns_lock:
+        known = {
+            (p["individual_id"], p["new_attack"]) for p in _pending_move_learns
+        }
+        for row in rows:
+            key = (row["individual_id"], row["new_attack"])
+            if key in known:
+                continue
+            _pending_move_learns.append(
+                {
+                    "individual_id": row["individual_id"],
+                    "name": row["name"],
+                    "new_attack": row["new_attack"],
+                    "retries": 0,
+                }
+            )
+
+
+def _settle_move_learn(db, individual_id, new_attack) -> None:
+    """Drop the durable row for a decision that is finished -- learned,
+    declined, or moot. Never called for a transient failure."""
+    if db is None:
+        return
+    try:
+        db.delete_pending_move_learn(individual_id, new_attack)
+    except Exception:
+        pass
+
+
+def flush_pending_move_learns(db=None, logger=None) -> None:
+    """Replay every deferred move-replacement prompt. GUI thread only.
+
+    Each Pokémon is re-read from the DB rather than trusting the snapshot the
+    worker thread took: after parking the decision that worker went on to write
+    level/XP/EV/stat changes for the same row, so the authoritative move list is
+    whatever landed there — and a slot may even have opened up in the meantime,
+    in which case there is nothing to ask about and the move is just learned.
+
+    An entry whose replay RAISES is put back on the queue AND a delayed retry is
+    scheduled onto the GUI thread — a failure with no other mobile-sync
+    attribution behind it (the common case at shutdown) would otherwise sit in
+    memory with nothing left to ever drain it. In-session retries are bounded by
+    ``_MOVE_LEARN_MAX_ATTEMPTS`` so this cannot loop forever -- but hitting that
+    ceiling only stops retrying NOW; the durable ``pending_move_learns`` row is
+    left in place and re-offered on the next sync or launch. Nothing here
+    discards a move because a write failed.
+
+    The durable row is deleted only once the decision is genuinely settled:
+    learned, declined by the player, or moot (the row is gone, or the move is
+    already known). Those are decisions, not failures, so they are not requeued
+    either.
+    """
+    from ..services import services
+    from .drawing_utils import tooltipWithColour
+
+    if db is None:
+        db = services.db
+
+    # Recover anything parked durably by a previous session before draining, so
+    # a move stranded by a crash/quit is re-offered rather than lost.
+    _hydrate_pending_move_learns(db)
+
+    with _pending_move_learns_lock:
+        pending = list(_pending_move_learns)
+        del _pending_move_learns[:]
+    if not pending:
+        return
+    # Fall back to the shared logger rather than letting a caller that passed
+    # logger=None (the common case: _attribute_xp_and_evs_to_companion's own
+    # default) swallow a failure silently.
+    if logger is None:
+        logger = getattr(services, "logger", None)
+    ui = getattr(services, "ui", None)
+    main_pokemon_singleton = services.main_pokemon
+    failed = []
+
+    for entry in pending:
+        individual_id = entry["individual_id"]
+        new_attack = entry["new_attack"]
+        try:
+            pkmndata = db.get_pokemon(individual_id) if db is not None else None
+            if not pkmndata:
+                # The Pokemon is gone (released/traded). Moot, not a failure.
+                _settle_move_learn(db, individual_id, new_attack)
+                continue
+
+            attacks = _row_attacks(pkmndata)
+            if new_attack in attacks:
+                _settle_move_learn(db, individual_id, new_attack)  # already knows it
+                continue
+
+            name = str(entry.get("name") or pkmndata.get("name") or "Pokemon").capitalize()
+
+            if len(attacks) < 4:
+                attacks.append(new_attack)
+            elif ui is not None:
+                selected_attack = ui.choose_attack_to_replace(attacks, new_attack)
+                if selected_attack not in attacks:
+                    # The player chose to keep the current move set. That is a
+                    # decision, so the parked row is finished.
+                    _settle_move_learn(db, individual_id, new_attack)
+                    continue
+
+                # choose_attack_to_replace() runs AttackDialog.exec() -- an
+                # open-ended modal wait. On its own connection a sync QueryOp
+                # worker can, while it is open, finish
+                # _attribute_xp_and_evs_to_companion for this same row (new
+                # level / xp / EV / friendship) or change its moves outright.
+                # save_pokemon() below writes the WHOLE row, so re-read it and
+                # re-apply the player's choice to the CURRENT move list --
+                # writing back the pre-dialog snapshot would silently revert
+                # every one of those fields.
+                fresh = db.get_pokemon(individual_id) if db is not None else None
+                if fresh:
+                    pkmndata = fresh
+                    attacks = _row_attacks(pkmndata)
+                    if new_attack in attacks:
+                        continue  # something else taught it while we waited
+
+                if len(attacks) < 4:
+                    attacks.append(new_attack)  # a slot opened up during the wait
+                elif selected_attack in attacks:
+                    attacks[attacks.index(selected_attack)] = new_attack
+                else:
+                    # The move the player chose to discard is no longer on the
+                    # row, so their decision cannot be applied as given. Ask
+                    # again against the moves that are actually there rather
+                    # than guessing which one they would drop now.
+                    selected_attack = ui.choose_attack_to_replace(attacks, new_attack)
+                    if selected_attack not in attacks:
+                        _settle_move_learn(db, individual_id, new_attack)
+                        continue
+                    attacks[attacks.index(selected_attack)] = new_attack
+            else:
+                # Nothing can put the choice to the player. Tell them what was
+                # learned and where to act on it, rather than dropping the move
+                # on the floor without a trace the way the guard this replaces
+                # did.
+                # NOT settled: the parked row stays, so the next pass that has
+                # a UI can still put the choice to the player.
+                tooltipWithColour(
+                    f"{name} learned {new_attack}, but already knows four moves — "
+                    "swap it in from Pokémon Details.",
+                    "#6A4DAC",
+                )
+                if logger:
+                    logger.log(
+                        "warning",
+                        f"{name} learned {new_attack} during mobile sync, but no UI "
+                        "was available to choose which move it replaces.",
+                    )
+                continue
+
+            pkmndata["attacks"] = attacks
+            db.save_pokemon(pkmndata)
+            if (
+                main_pokemon_singleton is not None
+                and getattr(main_pokemon_singleton, "individual_id", None) == individual_id
+            ):
+                main_pokemon_singleton.attacks = list(attacks)
+            _settle_move_learn(db, individual_id, new_attack)
+            tooltipWithColour(f"{name} learned {new_attack}!", "#6A4DAC")
+        except Exception as e:
+            attempts = int(entry.get("retries", 0)) + 1
+            if attempts >= _MOVE_LEARN_MAX_ATTEMPTS:
+                # Stop retrying in THIS session -- but the durable row stays put.
+                # The move is not discarded: _hydrate_pending_move_learns() picks
+                # it up again on the next sync or the next launch. A locked
+                # database has to delay the decision, never destroy it.
+                if logger:
+                    logger.log(
+                        "error",
+                        f"Deferred move-learn prompt for {individual_id} failed "
+                        f"{attempts} times; leaving it parked for a later pass: {e}",
+                    )
+                # Own try: a tooltip failure here must not abort the entries
+                # still to be processed in this loop.
+                try:
+                    name = str(entry.get("name") or "A Pokémon")
+                    tooltipWithColour(
+                        f"{name} learned {new_attack}, but the swap couldn't be "
+                        "saved right now — Ankimon will ask again later.",
+                        "#E12939",
+                    )
+                except Exception:
+                    pass
+            else:
+                entry["retries"] = attempts
+                failed.append(entry)
+                if logger:
+                    logger.log(
+                        "error",
+                        f"Deferred move-learn prompt failed for {individual_id} "
+                        f"(attempt {attempts}): {e}",
+                    )
+
+    if not failed:
+        return
+
+    # Requeue AFTER the loop, never inside it: the lock is shared and re-adding
+    # mid-drain could hand a concurrent flush an entry this one is still working
+    # on. Preserve the retry count rather than routing back through
+    # _queue_move_learn_prompt, which would reset it to 0.
+    with _pending_move_learns_lock:
+        for entry in failed:
+            if not any(
+                (p["individual_id"], p["new_attack"])
+                == (entry["individual_id"], entry["new_attack"])
+                for p in _pending_move_learns
+            ):
+                _pending_move_learns.append(entry)
+
+    # A raised replay has no other attribution event guaranteed behind it, so
+    # schedule our own bounded retry instead of waiting for the next mobile sync.
+    try:
+        from aqt.qt import QTimer
+
+        # singleShot fires on the GUI thread (this whole function is GUI-thread
+        # only), so it can call the flush directly.
+        QTimer.singleShot(
+            _MOVE_LEARN_RETRY_DELAY_MS,
+            lambda: flush_pending_move_learns(db=db, logger=logger),
+        )
+    except Exception:
+        # Headless / no Anki: the entries stay queued for the next main-thread
+        # pass. Logged, because "stays queued" can still mean "gone at exit".
+        if logger:
+            logger.log(
+                "warning",
+                "Move-learn retry could not be scheduled: no GUI thread available.",
+            )
+
+
+def _schedule_move_learn_flush(db=None, logger=None) -> None:
+    """Get flush_pending_move_learns() onto the GUI thread.
+
+    Only ever called AFTER this companion's db.save_pokemon(), so the worker's
+    own write cannot land on top of the move swap the flush persists.
+    """
+    with _pending_move_learns_lock:
+        if not _pending_move_learns:
+            return
+
+    # Deliberately the SAME predicate the enqueue above uses. utils.is_main_thread()
+    # would be wrong here: it answers True whenever Qt isn't loaded or there is no
+    # QApplication yet, so the two could disagree and the flush would open
+    # AttackDialog on the very worker thread this whole mechanism exists to keep
+    # dialogs off.
+    if threading.current_thread() is threading.main_thread():
+        flush_pending_move_learns(db=db, logger=logger)
+        return
+
+    try:
+        from aqt import mw
+
+        mw.taskman.run_on_main(lambda: flush_pending_move_learns(db=db, logger=logger))
+    except Exception:
+        # No Anki to marshal onto (harness, headless callers). The entries stay
+        # queued for the next main-thread pass rather than being lost — and it
+        # is logged, because "stays queued" can still mean "gone at exit".
+        active_logger = logger
+        if active_logger is None:
+            from ..services import services
+
+            active_logger = getattr(services, "logger", None)
+        if active_logger:
+            active_logger.log(
+                "warning",
+                "Move-replacement prompt deferred: no GUI thread available to show it.",
+            )
+
+
 def _attribute_xp_and_evs_to_companion(companion_id: str, xp_gained: int, ev_yield_gained: dict, settings_obj, battles_fought=1, db=None, logger=None) -> None:
+    """Apply mobile-battle XP/EVs to one companion, leveling/evolving it and
+    prompting for a move replacement when it outgrows its 4 known moves."""
     if xp_gained <= 0 and not any(ev_yield_gained.values()) and battles_fought <= 0:
         return
 
@@ -2180,6 +2549,10 @@ def _attribute_xp_and_evs_to_companion(companion_id: str, xp_gained: int, ev_yie
     color = "#6A4DAC"
 
     levels_gained = 0
+    # Move-replacement decisions this call has to defer to the GUI thread.
+    # Held here and only published to the shared queue once this companion's
+    # row has been saved — see the enqueue site below for why.
+    deferred_move_learns = []
     # level-ups
     while int(find_experience_for_level(growth_rate, level, remove_cap)) < xp and (level_cap is None or level < level_cap):
         if levels_gained >= 10:
@@ -2229,15 +2602,49 @@ def _attribute_xp_and_evs_to_companion(companion_id: str, xp_gained: int, ev_yie
                         msg_learn = f"{pkmndata.get('name', '').capitalize()} learned {new_attack}!"
                         tooltipWithColour(msg_learn, color)
                 elif new_attack not in attacks:
+                    # This function is reachable from a QueryOp worker thread
+                    # (resolve_next's run_sim / commit_replay_outcome's
+                    # do_db_work both call it off the main thread in
+                    # production), and constructing or .exec()'ing a QDialog
+                    # off the GUI thread is undefined behavior in Qt. So the
+                    # prompt runs inline only when this call actually landed
+                    # on the main thread (the PYTEST_CURRENT_TEST synchronous
+                    # path, or any future main-thread caller); otherwise the
+                    # decision is parked and replayed on the GUI thread once
+                    # this companion's row has been written — never dropped.
+                    #
+                    # The prompt goes through the services.ui presenter port
+                    # (the same seam pokemon_details.py / gui_presenter.py
+                    # use) rather than constructing AttackDialog directly:
+                    # keeps this module aqt-free at import time and testable
+                    # against HeadlessPresenter, while production's QtPresenter
+                    # still shows the identical parent=mw dialog. Guarded on
+                    # services.ui being present so a sparse/partial services
+                    # object (an incomplete test double, a mid-reload state)
+                    # queues instead of raising here — an uncaught exception
+                    # would lose the whole XP/EV grant for the turn, not just
+                    # the move choice.
                     if is_active and not in_bulk:
-                        from ..pyobj.attack_dialog import AttackDialog
-                        from PyQt6.QtWidgets import QDialog
-                        dialog = AttackDialog(attacks, new_attack)
-                        if dialog.exec() == QDialog.DialogCode.Accepted:
-                            selected_attack = dialog.selected_attack
+                        if (
+                            threading.current_thread() is threading.main_thread()
+                            and getattr(services, "ui", None) is not None
+                        ):
+                            selected_attack = services.ui.choose_attack_to_replace(
+                                attacks, new_attack
+                            )
                             if selected_attack in attacks:
                                 idx = attacks.index(selected_attack)
                                 attacks[idx] = new_attack
+                        else:
+                            # Parked LOCALLY, not on the global queue, until
+                            # this row is written further down. The queue is
+                            # process-wide and every flush drains all of it,
+                            # so publishing here would let an earlier
+                            # companion's already-scheduled run_on_main
+                            # callback pick this entry up, save the move
+                            # swap, and then have our own save_pokemon()
+                            # below overwrite it with this pre-swap snapshot.
+                            deferred_move_learns.append(new_attack)
             pkmndata["attacks"] = attacks
 
     pkmndata["level"] = level
@@ -2348,4 +2755,16 @@ def _attribute_xp_and_evs_to_companion(companion_id: str, xp_gained: int, ev_yie
         if "attacks" in pkmndata:
             mp.attacks = list(pkmndata["attacks"])
         mp.invalidate_cp_cache()
+
+    # Only now — the row this function owns is written, so the flush's own
+    # save_pokemon() for a move swap can no longer be clobbered by it. Both
+    # steps belong here for the same reason: publishing only after the save
+    # is what keeps the process-wide queue free of decisions whose row is
+    # still in flight, so a flush scheduled by an earlier grant can drain it
+    # at any point without racing this one.
+    for pending_attack in deferred_move_learns:
+        _queue_move_learn_prompt(
+            companion_id, pkmndata.get("name", ""), pending_attack, db=db
+        )
+    _schedule_move_learn_flush(db=db, logger=logger)
 

--- a/src/Ankimon/pyobj/database_manager.py
+++ b/src/Ankimon/pyobj/database_manager.py
@@ -82,6 +82,14 @@ class CursorWrapper:
         return getattr(self._cursor, name)
 
 
+class _MainPokemonVanished(Exception):
+    """Internal: the target row of set_main_pokemon() does not exist.
+
+    Raised inside the transaction purely to trigger its rollback, and caught
+    by set_main_pokemon() itself -- it never escapes this module.
+    """
+
+
 class ConnectionWrapper:
     """Wraps a sqlite3.Connection, proxying everything, with a re-entrant
     ``with conn:`` transaction and an opt-out commit flag (used by bulk paths)."""
@@ -919,6 +927,27 @@ class AnkimonDB:
             )
         """)
 
+        # A level-up move that needs the player to pick which of four moves it
+        # replaces. The decision cannot be taken on a QueryOp worker thread (a
+        # QDialog is GUI-thread-only), so it is parked here and replayed on the
+        # GUI thread. This table exists because parking it in memory ALONE lost
+        # the move outright whenever the process went away first -- Anki quit or
+        # crashed after the XP was committed, the profile closed with a decision
+        # pending, or the database stayed locked through the retry window. The
+        # mobile battle is already marked resolved by then, so nothing can
+        # reconstruct it. A row is deleted only once the move is genuinely
+        # settled: learned, declined by the player, or moot (already known, or
+        # the Pokemon is gone).
+        cursor.execute("""
+            CREATE TABLE IF NOT EXISTS pending_move_learns (
+                individual_id TEXT NOT NULL,
+                name          TEXT,
+                new_attack    TEXT NOT NULL,
+                created_at    INTEGER NOT NULL,
+                PRIMARY KEY (individual_id, new_attack)
+            )
+        """)
+
         conn.commit()
         self._log("info", "AnkimonDB: Database schema initialized.")
         try:
@@ -1190,21 +1219,125 @@ class AnkimonDB:
         return None
 
     def set_main_pokemon(self, individual_id: str) -> bool:
-        """Sets a pokemon as the main pokemon by individual_id. Returns False if pokemon not found."""
+        """Make one Pokemon the main/active companion, atomically.
+
+        Returns False -- having changed NOTHING -- when ``individual_id`` has
+        no captured_pokemon row.
+
+        Both UPDATEs run inside one transaction, and the new main is set
+        FIRST, so this can never leave the save with zero ``is_main = 1``
+        rows. The previous version checked existence with a separate SELECT,
+        then cleared the old main and set the new one with no rowcount check
+        and no transaction, so:
+
+            this call                     another writer
+            ---------                     --------------
+            SELECT target -> exists
+                                          release/delete target
+            UPDATE ... is_main = 0        (old main cleared)
+            UPDATE ... is_main = 1        (0 rows matched)
+            commit; return True
+
+        left the database with NO main Pokemon while reporting success. The
+        next load then fell through update_main_pokemon() to
+        MAIN_POKEMON_DEFAULT -- the level-5 Ditto named "Please Restart Anki".
+        Ordering the writes this way means the failure mode is "the main
+        Pokemon did not change", never "there is no main Pokemon".
+        """
+        conn = self._get_connection()
+        try:
+            with conn:
+                cursor = conn.cursor()
+                cursor.execute(
+                    "UPDATE captured_pokemon SET is_main = 1 WHERE individual_id = ?",
+                    (individual_id,),
+                )
+                if cursor.rowcount != 1:
+                    # No such row (or it vanished mid-flight). Roll back before
+                    # anything has cleared the incumbent main.
+                    raise _MainPokemonVanished(individual_id)
+                cursor.execute(
+                    "UPDATE captured_pokemon SET is_main = 0 "
+                    "WHERE is_main = 1 AND individual_id != ?",
+                    (individual_id,),
+                )
+        except _MainPokemonVanished:
+            return False
+        return True
+
+    def clear_main_pokemon(self) -> None:
+        """Clears the is_main flag from whichever Pokémon currently holds it,
+        leaving no main Pokémon persisted.
+
+        Deliberately does not touch the live in-memory main_pokemon singleton
+        for the current session — this only affects what the NEXT load reads
+        back, the same way get_main_pokemon() already tolerates returning
+        None (a brand-new save with no starter picked yet is this exact
+        state).
+
+        NOTE: nothing in the add-on calls this today. It used to back the Team
+        screen's "companion cleared" case, but leaving zero is_main=1 rows
+        makes the next load fall through update_main_pokemon() to
+        MAIN_POKEMON_DEFAULT — the level-5 Ditto named "Please Restart Anki" —
+        so handle_save_team now promotes another team member (or leaves the
+        existing row alone when it can't) instead. Kept as a primitive; think
+        hard about that fallback before wiring it to anything."""
         conn = self._get_connection()
         cursor = conn.cursor()
-        
-        # Check if pokemon exists
-        cursor.execute("SELECT individual_id FROM captured_pokemon WHERE individual_id = ?", (individual_id,))
-        if not cursor.fetchone():
-            return False
-        
-        # Clear old main
         cursor.execute("UPDATE captured_pokemon SET is_main = 0 WHERE is_main = 1")
-        # Set new main
-        cursor.execute("UPDATE captured_pokemon SET is_main = 1 WHERE individual_id = ?", (individual_id,))
+        conn.commit()
+
+    # --- Pending move-learn decisions (durable) ---
+
+    def add_pending_move_learn(self, individual_id: str, name: str, new_attack: str) -> bool:
+        """Durably park one move-replacement decision.
+
+        Idempotent on (individual_id, new_attack): re-queuing the same move for
+        the same Pokemon keeps the original ``created_at`` rather than stacking
+        duplicate prompts. Does NOT commit when a caller already holds a
+        transaction (``conn._disable_commit``), so this can join the same
+        transaction that writes the level/XP the move came from.
+        """
+        if not individual_id or not new_attack:
+            return False
+        conn = self._get_connection()
+        cursor = conn.cursor()
+        cursor.execute(
+            "INSERT OR IGNORE INTO pending_move_learns "
+            "(individual_id, name, new_attack, created_at) VALUES (?, ?, ?, ?)",
+            (str(individual_id), str(name or ""), str(new_attack), int(time.time())),
+        )
         conn.commit()
         return True
+
+    def get_pending_move_learns(self) -> List[Dict[str, Any]]:
+        """Every parked move-replacement decision, oldest first."""
+        cursor = self.execute(
+            "SELECT individual_id, name, new_attack, created_at "
+            "FROM pending_move_learns ORDER BY created_at ASC, rowid ASC"
+        )
+        return [
+            {
+                "individual_id": row[0],
+                "name": row[1],
+                "new_attack": row[2],
+                "created_at": row[3],
+            }
+            for row in cursor.fetchall()
+        ]
+
+    def delete_pending_move_learn(self, individual_id: str, new_attack: str) -> bool:
+        """Drop one parked decision. Call ONLY once the move is settled --
+        learned, declined, or moot. A transient failure (locked database, no UI
+        available) must leave the row in place so the next pass can retry it."""
+        conn = self._get_connection()
+        cursor = conn.cursor()
+        cursor.execute(
+            "DELETE FROM pending_move_learns WHERE individual_id = ? AND new_attack = ?",
+            (str(individual_id), str(new_attack)),
+        )
+        conn.commit()
+        return cursor.rowcount > 0
 
     # --- Item Operations ---
 

--- a/tests/test_database_manager.py
+++ b/tests/test_database_manager.py
@@ -859,3 +859,136 @@ def test_user_data_to_config_migration_rolls_back_on_write_failure(temp_env):
     assert db.get_user_data("username") == "legacy-user"
     assert db.get_user_data("api_key") == "legacy-key"
 
+
+
+def test_clear_main_pokemon_drops_the_is_main_flag(temp_env):
+    """clear_main_pokemon() leaves no Pokémon flagged as main — used when the
+    Active Companion selection on the team screen is explicitly cleared, so a
+    stale is_main=1 row can't resurface for a Pokémon no longer on the team."""
+    db, _ = temp_env
+    db.save_pokemon({"individual_id": "uuid-a", "name": "pikachu", "id": 25, "level": 5})
+    db.set_main_pokemon("uuid-a")
+    assert db.get_main_pokemon() is not None
+
+    db.clear_main_pokemon()
+
+    assert db.get_main_pokemon() is None
+
+
+def test_clear_main_pokemon_is_a_safe_no_op_when_nothing_is_main(temp_env):
+    db, _ = temp_env
+    db.save_pokemon({"individual_id": "uuid-a", "name": "pikachu", "id": 25, "level": 5})
+    assert db.get_main_pokemon() is None
+
+    db.clear_main_pokemon()  # must not raise
+
+    assert db.get_main_pokemon() is None
+
+
+# --- set_main_pokemon() must never leave the save with no main -------------
+
+
+def test_set_main_pokemon_on_a_missing_row_keeps_the_incumbent(temp_env):
+    """A target that does not exist must be a no-op, NOT a cleared main.
+
+    The old implementation checked existence with a separate SELECT, then
+    cleared the old main and set the new one with no rowcount check, so a
+    target released between the two left zero is_main=1 rows while still
+    returning True. The next load then fell through update_main_pokemon() to
+    the level-5 "Please Restart Anki" Ditto.
+    """
+    db, _ = temp_env
+    db.save_pokemon({"individual_id": "uuid-a", "name": "pikachu", "id": 25, "level": 5})
+    db.set_main_pokemon("uuid-a")
+    assert db.get_main_pokemon()["individual_id"] == "uuid-a"
+
+    assert db.set_main_pokemon("does-not-exist") is False
+
+    still_main = db.get_main_pokemon()
+    assert still_main is not None, "the save was left with NO main Pokemon"
+    assert still_main["individual_id"] == "uuid-a"
+
+
+def test_set_main_pokemon_moves_the_flag_and_leaves_exactly_one(temp_env):
+    db, _ = temp_env
+    for iid in ("uuid-a", "uuid-b", "uuid-c"):
+        db.save_pokemon({"individual_id": iid, "name": "pikachu", "id": 25, "level": 5})
+
+    assert db.set_main_pokemon("uuid-a") is True
+    assert db.set_main_pokemon("uuid-b") is True
+
+    cursor = db.execute("SELECT individual_id FROM captured_pokemon WHERE is_main = 1")
+    mains = [r[0] for r in cursor.fetchall()]
+    assert mains == ["uuid-b"], f"expected exactly one main, got {mains}"
+
+
+def test_set_main_pokemon_is_idempotent_for_the_current_main(temp_env):
+    """Re-selecting the Pokemon that is already the companion must not clear it
+    (the clear-others UPDATE excludes the target for exactly this reason)."""
+    db, _ = temp_env
+    db.save_pokemon({"individual_id": "uuid-a", "name": "pikachu", "id": 25, "level": 5})
+    db.set_main_pokemon("uuid-a")
+
+    assert db.set_main_pokemon("uuid-a") is True
+
+    cursor = db.execute("SELECT individual_id FROM captured_pokemon WHERE is_main = 1")
+    assert [r[0] for r in cursor.fetchall()] == ["uuid-a"]
+
+
+def test_set_main_pokemon_survives_the_target_vanishing_mid_call(temp_env, monkeypatch):
+    """The actual race: the target exists when checked, then another writer
+    releases it before the flag is moved.
+
+    The old implementation checked existence with a SELECT, then cleared the
+    incumbent and set the target with no rowcount check -- so this interleaving
+    committed ZERO is_main=1 rows and still returned True. Whatever this call
+    decides, the save must never be left with no main Pokemon.
+    """
+    db, _ = temp_env
+    db.save_pokemon({"individual_id": "uuid-a", "name": "pikachu", "id": 25, "level": 5})
+    db.save_pokemon({"individual_id": "uuid-b", "name": "eevee", "id": 133, "level": 5})
+    db.set_main_pokemon("uuid-a")
+    assert db.get_main_pokemon()["individual_id"] == "uuid-a"
+
+    wrapper_cls = type(db._get_connection())
+    original_cursor = wrapper_cls.cursor
+    state = {"raced": False}
+
+    def racing_cursor(self, *args, **kwargs):
+        cur = original_cursor(self, *args, **kwargs)
+        original_execute = cur.execute
+
+        def execute(sql, parameters=()):
+            # Let any existence check see the row, THEN delete it -- exactly the
+            # window the old code left open between its SELECT and its UPDATEs.
+            if (
+                not state["raced"]
+                and sql.strip().upper().startswith("SELECT")
+                and "captured_pokemon" in sql
+            ):
+                state["raced"] = True
+                result = original_execute(sql, parameters)
+                # A SEPARATE cursor: issuing the delete on `cur` would reset the
+                # result set the caller is about to fetch from, which would make
+                # the existence check simply fail instead of reproducing the race.
+                other = original_cursor(self)
+                other.execute(
+                    "DELETE FROM captured_pokemon WHERE individual_id = ?", ("uuid-b",)
+                )
+                return result
+            return original_execute(sql, parameters)
+
+        cur.execute = execute
+        return cur
+
+    monkeypatch.setattr(wrapper_cls, "cursor", racing_cursor)
+
+    db.set_main_pokemon("uuid-b")
+
+    monkeypatch.undo()
+    cursor = db.execute("SELECT individual_id FROM captured_pokemon WHERE is_main = 1")
+    mains = [r[0] for r in cursor.fetchall()]
+    assert len(mains) == 1, (
+        f"save left with {len(mains)} main Pokemon; zero means the next load "
+        f'falls through to the "Please Restart Anki" Ditto'
+    )

--- a/tests/test_mobile_sync.py
+++ b/tests/test_mobile_sync.py
@@ -717,3 +717,697 @@ def test_attribute_xp_and_evs_defaults_missing_iv_to_15_and_ev_to_0(mobile_db, m
     assert updated["ev"] == {"hp": 0, "atk": 0, "def": 0, "spa": 0, "spd": 0, "spe": 0}
 
 
+
+
+# --- deferred move-replacement prompts (off the GUI thread) ------------------
+#
+# _attribute_xp_and_evs_to_companion runs on a QueryOp worker thread on every
+# real mobile sync, and a QDialog cannot be built or exec()'d there. The guard
+# that recognised this used to just skip the prompt, which silently threw the
+# learned move away: the companion kept its old four moves with no tooltip, no
+# log line and nothing queued. The decision is now parked and replayed on the
+# GUI thread instead.
+
+import threading as _threading
+
+
+@pytest.fixture(autouse=True)
+def _drain_pending_move_learns():
+    """Never leak a parked decision into the next test."""
+    with ms._pending_move_learns_lock:
+        del ms._pending_move_learns[:]
+    yield
+    with ms._pending_move_learns_lock:
+        del ms._pending_move_learns[:]
+
+
+def _run_off_thread(fn, *args, **kwargs):
+    box = {}
+
+    def _target():
+        try:
+            box["value"] = fn(*args, **kwargs)
+        except BaseException as exc:  # surfaced on the calling thread below
+            box["error"] = exc
+
+    # daemon so a deadlocked fn cannot keep the interpreter alive at exit —
+    # the join(timeout) below already gave up on it, and a live non-daemon
+    # thread would hang the whole suite on shutdown anyway.
+    worker = _threading.Thread(target=_target, daemon=True)
+    worker.start()
+    worker.join(timeout=30)
+    assert not worker.is_alive(), "worker thread hung"
+    if "error" in box:
+        raise box["error"]
+    return box.get("value")
+
+
+def _full_moveset_row(individual_id="OFFTHREAD"):
+    return {
+        "individual_id": individual_id,
+        "name": "Pikachu",
+        "id": 25,
+        "level": 5,
+        "xp": 0,
+        "attacks": ["tackle", "growl", "quick-attack", "thunder-shock"],
+        "base_stats": {"hp": 35, "atk": 55, "def": 40, "spa": 50, "spd": 50, "spe": 90},
+        "growth_rate": "medium-fast",
+    }
+
+
+def _full_moveset_companion(db, individual_id="OFFTHREAD"):
+    pkmndata = _full_moveset_row(individual_id)
+    db.save_pokemon(pkmndata)
+    return pkmndata
+
+
+class _FakeCompanionDB:
+    """Just the two accessors _attribute_xp_and_evs_to_companion touches."""
+
+    def __init__(self, *rows):
+        self.rows = {row["individual_id"]: dict(row) for row in rows}
+
+    def get_pokemon(self, individual_id):
+        row = self.rows.get(individual_id)
+        return dict(row) if row else None
+
+    def save_pokemon(self, pkmndata):
+        self.rows[pkmndata["individual_id"]] = dict(pkmndata)
+
+
+class _FakeCompanionSingleton:
+    def __init__(self, individual_id):
+        self.individual_id = individual_id
+        self.attacks = []
+        self.xp = 0
+        self.level = 1
+        self.ev = {}
+        self.friendship = 0
+        self.pokemon_defeated = 0
+
+    def invalidate_cp_cache(self):
+        pass
+
+
+def test_off_main_thread_move_learn_is_queued_not_dropped(monkeypatch):
+    """The regression: off the GUI thread the learned move used to vanish.
+
+    The production path this stands in for: resolve_next (mode="next", which
+    unlike resolve_all never sets utils.in_bulk_resolve) -> run_mobile_battles'
+    XP-Share grant, when the XP Share holder IS the main Pokemon — that is the
+    one call reaching this branch with is_active True and in_bulk False, and it
+    runs on a QueryOp worker thread.
+
+    Driven against a fake DB and a pinned level-up table so it stays hermetic —
+    several other files in this suite leave stubs for the pokedex/pokemon
+    modules in ``sys.modules``, and the point here is the thread guard, not the
+    XP curve.
+    """
+    from Ankimon import utils as _utils
+
+    # The real submodule object mobile_sync's function-local
+    # ``from .pokemon_functions import ...`` resolves — NOT
+    # ``Ankimon.functions.pokemon_functions`` as an attribute of the package,
+    # which other test files in this suite replace with a MagicMock.
+    _pf = sys.modules["Ankimon.functions.pokemon_functions"]
+    monkeypatch.setattr(
+        _pf, "find_experience_for_level", lambda *a, **k: 50, raising=False
+    )
+    monkeypatch.setattr(
+        _pf,
+        "get_levelup_move_for_pokemon",
+        lambda name, level: ["thunderbolt"],
+        raising=False,
+    )
+    monkeypatch.setattr(
+        services, "main_pokemon", _FakeCompanionSingleton("OFFTHREAD"), raising=False
+    )
+    # This is about the GUI-thread guard, not bulk mode — and in_bulk_resolve is
+    # module-level state a failed resolve_all elsewhere in the suite can leave
+    # set, which would suppress the prompt for an unrelated reason.
+    monkeypatch.setattr(_utils, "in_bulk_resolve", False, raising=False)
+    # Assert on the queue itself, not on whatever the scheduler manages to do
+    # with it in a stubbed-Qt test environment.
+    monkeypatch.setattr(ms, "_schedule_move_learn_flush", lambda **kw: None)
+
+    db = _FakeCompanionDB(_full_moveset_row("OFFTHREAD"))
+
+    _run_off_thread(
+        ms._attribute_xp_and_evs_to_companion,
+        "OFFTHREAD",
+        100,
+        {},
+        _Settings(),
+        db=db,
+    )
+
+    with ms._pending_move_learns_lock:
+        parked = list(ms._pending_move_learns)
+
+    assert [(p["individual_id"], p["new_attack"]) for p in parked] == [
+        ("OFFTHREAD", "thunderbolt")
+    ]
+    # The level-up itself still landed...
+    assert db.rows["OFFTHREAD"]["level"] == 6
+    # ...and the existing four moves are untouched until the player chooses.
+    assert db.rows["OFFTHREAD"]["attacks"] == [
+        "tackle", "growl", "quick-attack", "thunder-shock",
+    ]
+
+
+def test_flush_landing_mid_attribution_cannot_lose_the_move(monkeypatch):
+    """A queued decision must not be drained before its own row is written.
+
+    The queue is process-wide and every flush drains all of it, but each
+    attribution only schedules its flush after its own ``save_pokemon()``. A
+    grant earlier in the same batch can therefore have a ``run_on_main``
+    callback already in flight when the worker reaches the next grant — and
+    that callback lands on the GUI thread whenever Anki gets round to it,
+    including in the window between this grant queuing its decision and
+    writing its row. Draining there means the flush saves the swap and this
+    grant's in-flight ``save_pokemon()`` immediately overwrites it with the
+    pre-swap snapshot: the move is gone, with the queue empty and nothing
+    logged. The decision is held locally until the row is written instead.
+
+    The interleave is forced deterministically (no second thread, no sleeps)
+    by flushing from inside ``save_pokemon`` — exactly the moment that is
+    unsafe.
+    """
+    from Ankimon import utils as _utils
+
+    # Same submodule object mobile_sync's function-local import resolves; the
+    # explicit import keeps this test runnable on its own (``-k`` a single
+    # name), not just after whichever earlier test happened to pull it in.
+    import Ankimon.functions.pokemon_functions  # noqa: F401
+
+    _pf = sys.modules["Ankimon.functions.pokemon_functions"]
+    monkeypatch.setattr(
+        _pf, "find_experience_for_level", lambda *a, **k: 50, raising=False
+    )
+    monkeypatch.setattr(
+        _pf,
+        "get_levelup_move_for_pokemon",
+        lambda name, level: ["thunderbolt"],
+        raising=False,
+    )
+    monkeypatch.setattr(
+        services, "main_pokemon", _FakeCompanionSingleton("RACE"), raising=False
+    )
+    monkeypatch.setattr(_utils, "in_bulk_resolve", False, raising=False)
+    # The flush under test is the interleaved one below, not whatever the
+    # scheduler would manage in a stubbed-Qt environment.
+    monkeypatch.setattr(ms, "_schedule_move_learn_flush", lambda **kw: None)
+
+    class _InterleavingDB(_FakeCompanionDB):
+        """Stands in for the earlier grant's GUI callback firing mid-save."""
+
+        def __init__(self, *rows):
+            super().__init__(*rows)
+            self.interleaved = False
+
+        def save_pokemon(self, pkmndata):
+            if not self.interleaved:
+                self.interleaved = True  # set first: flush saves through here too
+                ms.flush_pending_move_learns(db=self, logger=_Logger())
+            super().save_pokemon(pkmndata)
+
+    class _Presenter:
+        def choose_attack_to_replace(self, attacks, new_attack):
+            return "growl"
+
+    monkeypatch.setattr(services, "ui", _Presenter(), raising=False)
+
+    db = _InterleavingDB(_full_moveset_row("RACE"))
+
+    _run_off_thread(
+        ms._attribute_xp_and_evs_to_companion,
+        "RACE",
+        100,
+        {},
+        _Settings(),
+        db=db,
+    )
+
+    assert db.interleaved, "the mid-save flush never ran — test proves nothing"
+
+    # The next GUI-thread pass, now that the row is written.
+    ms.flush_pending_move_learns(db=db, logger=_Logger())
+
+    assert db.rows["RACE"]["attacks"] == [
+        "tackle", "thunderbolt", "quick-attack", "thunder-shock",
+    ]
+    with ms._pending_move_learns_lock:
+        assert ms._pending_move_learns == []
+
+
+def test_queued_move_learns_are_deduped(mobile_db):
+    ms._queue_move_learn_prompt("A", "Pikachu", "thunderbolt")
+    ms._queue_move_learn_prompt("A", "Pikachu", "thunderbolt")
+    ms._queue_move_learn_prompt("A", "Pikachu", "iron-tail")
+    ms._queue_move_learn_prompt("", "Pikachu", "thunderbolt")  # no id -> ignored
+
+    with ms._pending_move_learns_lock:
+        parked = [(p["individual_id"], p["new_attack"]) for p in ms._pending_move_learns]
+
+    assert parked == [("A", "thunderbolt"), ("A", "iron-tail")]
+
+
+def test_flush_prompts_persists_the_swap_and_syncs_the_singleton(mobile_db, monkeypatch):
+    db, _ = mobile_db
+    _full_moveset_companion(db, "FLUSH")
+    singleton = _FakeCompanionSingleton("FLUSH")
+    monkeypatch.setattr(services, "main_pokemon", singleton, raising=False)
+
+    asked = []
+
+    class _Presenter:
+        def choose_attack_to_replace(self, attacks, new_attack):
+            asked.append((list(attacks), new_attack))
+            return "growl"
+
+    monkeypatch.setattr(services, "ui", _Presenter(), raising=False)
+    ms._queue_move_learn_prompt("FLUSH", "Pikachu", "thunderbolt")
+
+    ms.flush_pending_move_learns(db=db, logger=_Logger())
+
+    assert asked == [
+        (["tackle", "growl", "quick-attack", "thunder-shock"], "thunderbolt")
+    ]
+    assert db.get_pokemon("FLUSH")["attacks"] == [
+        "tackle", "thunderbolt", "quick-attack", "thunder-shock",
+    ]
+    assert singleton.attacks == [
+        "tackle", "thunderbolt", "quick-attack", "thunder-shock",
+    ]
+    with ms._pending_move_learns_lock:
+        assert ms._pending_move_learns == []  # drained
+
+
+def test_flush_declined_prompt_keeps_the_current_moves(mobile_db, monkeypatch):
+    db, _ = mobile_db
+    _full_moveset_companion(db, "DECLINE")
+    monkeypatch.setattr(services, "main_pokemon", None, raising=False)
+
+    class _Presenter:
+        def choose_attack_to_replace(self, attacks, new_attack):
+            return None  # player closed the dialog
+
+    monkeypatch.setattr(services, "ui", _Presenter(), raising=False)
+    ms._queue_move_learn_prompt("DECLINE", "Pikachu", "thunderbolt")
+
+    ms.flush_pending_move_learns(db=db, logger=_Logger())
+
+    assert db.get_pokemon("DECLINE")["attacks"] == [
+        "tackle", "growl", "quick-attack", "thunder-shock",
+    ]
+
+
+def test_flush_rereads_the_db_and_just_learns_when_a_slot_opened_up(mobile_db, monkeypatch):
+    """The worker wrote more rows after parking the decision, and the player may
+    have freed a slot in between — re-read rather than trusting the snapshot."""
+    db, _ = mobile_db
+    _full_moveset_companion(db, "SLOT")
+    monkeypatch.setattr(services, "main_pokemon", None, raising=False)
+
+    asked = []
+
+    class _Presenter:
+        def choose_attack_to_replace(self, attacks, new_attack):
+            asked.append(new_attack)
+            return attacks[0]
+
+    monkeypatch.setattr(services, "ui", _Presenter(), raising=False)
+    ms._queue_move_learn_prompt("SLOT", "Pikachu", "thunderbolt")
+
+    # The player drops a move from Pokémon Details before the flush runs.
+    pkmndata = db.get_pokemon("SLOT")
+    pkmndata["attacks"] = ["tackle", "growl", "quick-attack"]
+    db.save_pokemon(pkmndata)
+
+    ms.flush_pending_move_learns(db=db, logger=_Logger())
+
+    assert asked == []  # nothing to choose between
+    assert db.get_pokemon("SLOT")["attacks"] == [
+        "tackle", "growl", "quick-attack", "thunderbolt",
+    ]
+
+
+def test_flush_without_a_presenter_reports_instead_of_silently_dropping(mobile_db, monkeypatch):
+    db, _ = mobile_db
+    _full_moveset_companion(db, "NOUI")
+    monkeypatch.setattr(services, "main_pokemon", None, raising=False)
+    monkeypatch.setattr(services, "ui", None, raising=False)
+
+    from Ankimon.functions import drawing_utils as _drawing_utils
+
+    seen = []
+    monkeypatch.setattr(
+        _drawing_utils, "tooltipWithColour", lambda msg, *a, **k: seen.append(msg)
+    )
+
+    warnings = []
+
+    class _WarnLogger(_Logger):
+        def log(self, level, msg, *a, **k):
+            warnings.append((level, msg))
+
+    ms._queue_move_learn_prompt("NOUI", "Pikachu", "thunderbolt")
+    ms.flush_pending_move_learns(db=db, logger=_WarnLogger())
+
+    assert any("thunderbolt" in msg for msg in seen)
+    assert any(level == "warning" and "thunderbolt" in msg for level, msg in warnings)
+    # Nothing guessed on the player's behalf.
+    assert db.get_pokemon("NOUI")["attacks"] == [
+        "tackle", "growl", "quick-attack", "thunder-shock",
+    ]
+
+
+def test_flush_requeues_an_entry_whose_save_blew_up(mobile_db, monkeypatch):
+    """A failed replay must stay pending, not vanish.
+
+    flush drains the whole queue up front, so before this every exception below
+    the drain took the parked decision with it: the player was told nothing, the
+    move was never written, and there was no entry left for a later pass to
+    retry — the same silent loss the deferral mechanism exists to prevent, just
+    moved one step later.
+    """
+    db, _ = mobile_db
+    _full_moveset_companion(db, "BOOM")
+    monkeypatch.setattr(services, "main_pokemon", None, raising=False)
+
+    class _Presenter:
+        def choose_attack_to_replace(self, attacks, new_attack):
+            return "growl"
+
+    monkeypatch.setattr(services, "ui", _Presenter(), raising=False)
+
+    def _explode(_pkmndata):
+        raise RuntimeError("database is locked")
+
+    monkeypatch.setattr(db, "save_pokemon", _explode)
+
+    errors = []
+
+    class _ErrLogger(_Logger):
+        def log(self, level, msg, *a, **k):
+            errors.append((level, msg))
+
+    ms._queue_move_learn_prompt("BOOM", "Pikachu", "thunderbolt")
+    ms.flush_pending_move_learns(db=db, logger=_ErrLogger())
+
+    assert any(level == "error" and "BOOM" in msg for level, msg in errors)
+    with ms._pending_move_learns_lock:
+        parked = [(p["individual_id"], p["new_attack"]) for p in ms._pending_move_learns]
+    assert parked == [("BOOM", "thunderbolt")], "the failed entry was dropped"
+
+
+def test_flush_retries_a_requeued_entry_on_the_next_pass(mobile_db, monkeypatch):
+    """Requeueing is only worth anything if the retry actually lands."""
+    db, _ = mobile_db
+    _full_moveset_companion(db, "RETRY")
+    monkeypatch.setattr(services, "main_pokemon", None, raising=False)
+
+    class _Presenter:
+        def choose_attack_to_replace(self, attacks, new_attack):
+            return "growl"
+
+    monkeypatch.setattr(services, "ui", _Presenter(), raising=False)
+
+    real_save = db.save_pokemon
+    calls = []
+
+    def _fail_once(pkmndata):
+        calls.append(pkmndata["individual_id"])
+        if len(calls) == 1:
+            raise RuntimeError("database is locked")
+        return real_save(pkmndata)
+
+    monkeypatch.setattr(db, "save_pokemon", _fail_once)
+
+    ms._queue_move_learn_prompt("RETRY", "Pikachu", "thunderbolt")
+    ms.flush_pending_move_learns(db=db, logger=_Logger())   # fails, requeues
+    ms.flush_pending_move_learns(db=db, logger=_Logger())   # succeeds
+
+    assert db.get_pokemon("RETRY")["attacks"] == [
+        "tackle", "thunderbolt", "quick-attack", "thunder-shock",
+    ]
+    with ms._pending_move_learns_lock:
+        assert ms._pending_move_learns == []  # drained for good this time
+
+
+def test_flush_schedules_its_own_retry_after_a_failure(mobile_db, monkeypatch):
+    """A raised replay has no other attribution event guaranteed behind it, so
+    the flush must arrange its own bounded retry rather than leave the entry to
+    rot in memory until shutdown."""
+    db, _ = mobile_db
+    _full_moveset_companion(db, "SELFRETRY")
+    monkeypatch.setattr(services, "main_pokemon", None, raising=False)
+
+    class _Presenter:
+        def choose_attack_to_replace(self, attacks, new_attack):
+            return "growl"
+
+    monkeypatch.setattr(services, "ui", _Presenter(), raising=False)
+    from Ankimon.functions import drawing_utils as _du
+
+    monkeypatch.setattr(_du, "tooltipWithColour", lambda *a, **k: None)
+
+    scheduled = []
+    fake_qt = types.ModuleType("aqt.qt")
+    fake_qt.QTimer = types.SimpleNamespace(
+        singleShot=lambda ms_delay, cb: scheduled.append((ms_delay, cb))
+    )
+    monkeypatch.setitem(sys.modules, "aqt.qt", fake_qt)
+
+    fail = {"on": True}
+    real_save = db.save_pokemon
+
+    def _save(pkmndata):
+        if fail["on"]:
+            raise RuntimeError("database is locked")
+        return real_save(pkmndata)
+
+    monkeypatch.setattr(db, "save_pokemon", _save)
+
+    ms._queue_move_learn_prompt("SELFRETRY", "Pikachu", "thunderbolt")
+    ms.flush_pending_move_learns(db=db, logger=_Logger())
+
+    # Entry kept AND a retry queued onto the GUI-thread timer.
+    with ms._pending_move_learns_lock:
+        assert [e["individual_id"] for e in ms._pending_move_learns] == ["SELFRETRY"]
+    assert len(scheduled) == 1
+    assert scheduled[0][0] == ms._MOVE_LEARN_RETRY_DELAY_MS
+
+    # Let the scheduled retry run against a now-healthy DB: it lands.
+    fail["on"] = False
+    scheduled[0][1]()
+    assert db.get_pokemon("SELFRETRY")["attacks"] == [
+        "tackle", "thunderbolt", "quick-attack", "thunder-shock",
+    ]
+    with ms._pending_move_learns_lock:
+        assert ms._pending_move_learns == []
+
+
+def test_flush_stops_retrying_at_the_ceiling_but_keeps_the_move(mobile_db, monkeypatch):
+    """Hitting the retry ceiling must stop retrying, NOT discard the move.
+
+    The in-memory queue alone used to drop the entry here, telling the player
+    the move "was discarded" -- with the mobile battle already resolved there
+    was nothing left to reconstruct it from. The durable pending_move_learns
+    row must survive so a later pass can still offer the swap.
+    """
+    db, _ = mobile_db
+    _full_moveset_companion(db, "DOOMED")
+    monkeypatch.setattr(services, "main_pokemon", None, raising=False)
+
+    class _Presenter:
+        def choose_attack_to_replace(self, attacks, new_attack):
+            return "growl"
+
+    monkeypatch.setattr(services, "ui", _Presenter(), raising=False)
+
+    scheduled = []
+    monkeypatch.setitem(
+        sys.modules,
+        "aqt.qt",
+        types.SimpleNamespace(
+            QTimer=types.SimpleNamespace(
+                singleShot=lambda delay, cb: scheduled.append((delay, cb))
+            )
+        ),
+    )
+    working_save = db.save_pokemon
+    monkeypatch.setattr(
+        db, "save_pokemon", lambda *_a: (_ for _ in ()).throw(RuntimeError("locked"))
+    )
+
+    records = []
+
+    class _CapturingLogger:
+        def log(self, *args, **kwargs):
+            records.append(args)
+
+    ms._queue_move_learn_prompt("DOOMED", "Pikachu", "thunderbolt", db=db)
+    for _ in range(ms._MOVE_LEARN_MAX_ATTEMPTS):
+        ms.flush_pending_move_learns(db=db, logger=_CapturingLogger())
+
+    # The in-memory queue is drained (no unbounded loop) and no further retry
+    # is scheduled once the ceiling is hit.
+    with ms._pending_move_learns_lock:
+        assert ms._pending_move_learns == []
+    assert len(scheduled) == ms._MOVE_LEARN_MAX_ATTEMPTS - 1
+    assert all(delay == ms._MOVE_LEARN_RETRY_DELAY_MS for delay, _ in scheduled)
+    assert any(
+        "DOOMED" in str(rec) and "parked" in str(rec) for rec in records
+    ), records
+
+    # THE POINT: the decision is still on disk, so the move is not lost.
+    parked = db.get_pending_move_learns()
+    assert [(r["individual_id"], r["new_attack"]) for r in parked] == [
+        ("DOOMED", "thunderbolt")
+    ]
+
+    # A later pass, once the database is writable again, still lands the swap.
+    monkeypatch.setattr(db, "save_pokemon", working_save)
+    ms.flush_pending_move_learns(db=db, logger=_CapturingLogger())
+
+    assert db.get_pokemon("DOOMED")["attacks"] == [
+        "tackle", "thunderbolt", "quick-attack", "thunder-shock",
+    ]
+    assert db.get_pending_move_learns() == []  # settled, so the row is gone
+
+
+def test_a_move_parked_before_a_crash_is_recovered_on_the_next_flush(
+    mobile_db, monkeypatch
+):
+    """The crash case: the process goes away between parking the decision and
+    showing the prompt, so the in-memory queue is gone. The durable row must
+    bring it back."""
+    db, _ = mobile_db
+    _full_moveset_companion(db, "CRASHED")
+    monkeypatch.setattr(services, "main_pokemon", None, raising=False)
+
+    ms._queue_move_learn_prompt("CRASHED", "Pikachu", "thunderbolt", db=db)
+
+    # Simulate the restart: everything in RAM is gone, the DB row is not.
+    with ms._pending_move_learns_lock:
+        del ms._pending_move_learns[:]
+    assert len(db.get_pending_move_learns()) == 1
+
+    asked = []
+
+    class _Presenter:
+        def choose_attack_to_replace(self, attacks, new_attack):
+            asked.append(new_attack)
+            return "growl"
+
+    monkeypatch.setattr(services, "ui", _Presenter(), raising=False)
+    ms.flush_pending_move_learns(db=db, logger=_Logger())
+
+    assert asked == ["thunderbolt"], "the parked decision was never re-offered"
+    assert db.get_pokemon("CRASHED")["attacks"] == [
+        "tackle", "thunderbolt", "quick-attack", "thunder-shock",
+    ]
+    assert db.get_pending_move_learns() == []
+
+
+def test_no_ui_available_keeps_the_decision_parked(mobile_db, monkeypatch):
+    """With nothing able to show the dialog the move is NOT settled -- the row
+    stays so a later pass with a UI can still put the choice to the player."""
+    db, _ = mobile_db
+    _full_moveset_companion(db, "NOUI")
+    monkeypatch.setattr(services, "main_pokemon", None, raising=False)
+    monkeypatch.setattr(services, "ui", None, raising=False)
+
+    ms._queue_move_learn_prompt("NOUI", "Pikachu", "thunderbolt", db=db)
+    ms.flush_pending_move_learns(db=db, logger=_Logger())
+
+    assert [r["new_attack"] for r in db.get_pending_move_learns()] == ["thunderbolt"]
+
+
+def test_flush_does_not_requeue_a_declined_prompt(mobile_db, monkeypatch):
+    """Declining is a DECISION, not a failure — re-asking every pass would nag."""
+    db, _ = mobile_db
+    _full_moveset_companion(db, "NONAG")
+    monkeypatch.setattr(services, "main_pokemon", None, raising=False)
+
+    class _Presenter:
+        def choose_attack_to_replace(self, attacks, new_attack):
+            return None  # player closed the dialog
+
+    monkeypatch.setattr(services, "ui", _Presenter(), raising=False)
+    ms._queue_move_learn_prompt("NONAG", "Pikachu", "thunderbolt")
+
+    ms.flush_pending_move_learns(db=db, logger=_Logger())
+
+    with ms._pending_move_learns_lock:
+        assert ms._pending_move_learns == []
+
+
+# --- The move choice must be applied to the CURRENT row, not a stale snapshot -
+#
+# choose_attack_to_replace() blocks on a modal, during which a sync worker on
+# its own connection can change the same row -- including its moves. Re-reading
+# the row is not enough on its own: the pre-dialog move list must not be written
+# back over it.
+
+
+def test_moves_changed_during_the_dialog_are_not_clobbered(mobile_db, monkeypatch):
+    db, _ = mobile_db
+    _full_moveset_companion(db, "RACE")
+    monkeypatch.setattr(services, "main_pokemon", None, raising=False)
+
+    prompts = []
+
+    class _Presenter:
+        def choose_attack_to_replace(self, attacks, new_attack):
+            prompts.append(list(attacks))
+            if len(prompts) == 1:
+                # A sync worker commits a different move set (and a level bump)
+                # for this same row while the modal is open.
+                row = db.get_pokemon("RACE")
+                row["attacks"] = ["surf", "growl", "quick-attack", "thunder-shock"]
+                row["level"] = 9
+                db.save_pokemon(row)
+                return "tackle"  # no longer on the row by the time we save
+            return "surf"
+
+    monkeypatch.setattr(services, "ui", _Presenter(), raising=False)
+    ms._queue_move_learn_prompt("RACE", "Pikachu", "thunderbolt")
+
+    ms.flush_pending_move_learns(db=db, logger=_Logger())
+
+    # The stale choice is re-put to the player against the CURRENT moves.
+    assert len(prompts) == 2, "a selection that vanished must trigger a re-prompt"
+    assert prompts[1] == ["surf", "growl", "quick-attack", "thunder-shock"]
+
+    row = db.get_pokemon("RACE")
+    # The worker's move rewrite survived -- "tackle" was not resurrected.
+    assert row["attacks"] == ["thunderbolt", "growl", "quick-attack", "thunder-shock"]
+    assert row["level"] == 9, "the concurrent level write must not be reverted"
+
+
+def test_a_slot_freed_during_the_dialog_just_learns_the_move(mobile_db, monkeypatch):
+    """If the worker dropped a move while the modal was open there is now room,
+    so the replacement the player picked is not needed at all."""
+    db, _ = mobile_db
+    _full_moveset_companion(db, "FREED")
+    monkeypatch.setattr(services, "main_pokemon", None, raising=False)
+
+    prompts = []
+
+    class _Presenter:
+        def choose_attack_to_replace(self, attacks, new_attack):
+            prompts.append(list(attacks))
+            row = db.get_pokemon("FREED")
+            row["attacks"] = ["tackle", "growl"]
+            db.save_pokemon(row)
+            return "tackle"
+
+    monkeypatch.setattr(services, "ui", _Presenter(), raising=False)
+    ms._queue_move_learn_prompt("FREED", "Pikachu", "thunderbolt")
+
+    ms.flush_pending_move_learns(db=db, logger=_Logger())
+
+    assert len(prompts) == 1, "no re-prompt is needed once a slot is free"
+    assert db.get_pokemon("FREED")["attacks"] == ["tackle", "growl", "thunderbolt"]


### PR DESCRIPTION
### Description

Deferred move-learning over the mobile-sync path could lose or misapply the
player's move choice:

- The pending move-learn was held only in memory, so it was dropped on restart
  before the player ever answered.
- When the choice came back, it was written to a stale copy of the Pokémon row
  rather than the row as it currently exists, so concurrent changes were
  clobbered or the choice was silently lost.
- `set_main_pokemon` wasn't atomic — a failure mid-write could leave the save
  with no main Pokémon at all.

Change: persist pending move-learns through the database manager so they survive
a restart; make `set_main_pokemon` a single atomic transaction; and re-read the
current row before applying the chosen move.

Files: `functions/mobile_sync.py`, `pyobj/database_manager.py`,
`ankimon_mobile_web/mobile.{css,js}`, `tests/test_mobile_sync.py`,
`tests/test_database_manager.py`.


### Checklist
- [x] My code follows the code style and guidelines of this project.
- [x] I have run tests locally (`pytest tests/` and `pytest tests/test_addon_integrity.py`) and they all pass.