### PR TITLE
feat(companion): active companion selection and team-save correctness

### DIFF
--- a/src/Ankimon/ankimon_profile_web/profile.css
+++ b/src/Ankimon/ankimon_profile_web/profile.css
@@ -252,6 +252,14 @@ body {
     border-color: rgba(210, 153, 34, 0.6);
     box-shadow: 0 0 0 1px rgba(210, 153, 34, 0.45) inset;
 }
+.slot.companion {
+    border-color: rgba(88, 166, 255, 0.6);
+    box-shadow: 0 0 0 1px rgba(88, 166, 255, 0.45) inset;
+}
+/* Both badges active: blend the two accent colors into one ring. */
+.slot.companion.xp-share {
+    box-shadow: 0 0 0 1px rgba(210, 153, 34, 0.45) inset, 0 0 0 3px rgba(88, 166, 255, 0.3) inset;
+}
 
 .slot-num { position: absolute; top: 10px; left: 12px; font-size: 0.66rem; font-weight: 700; color: var(--text-muted); }
 .slot-rotation-badge {
@@ -279,12 +287,23 @@ body {
 .slot-remove { right: 8px; }
 .slot-remove:hover { color: var(--accent-red); border-color: rgba(248, 81, 73, 0.5); }
 .slot-star { right: 40px; }
-/* The active XP-Share star stays visible even when the slot isn't hovered. With
-   the ✕ hidden, park it in the top-right corner (where the ✕ would sit) so it
-   doesn't look stranded; it slides back beside the ✕ once the slot is hovered. */
-.slot-star.on { color: var(--accent-gold); border-color: rgba(210, 153, 34, 0.6); background: rgba(210, 153, 34, 0.14); opacity: 1; pointer-events: auto; right: 8px; }
-.slot.filled:hover .slot-star.on,
-.slot.filled:focus-within .slot-star.on { right: 40px; }
+.slot-crown { right: 72px; }
+/* Active badges (XP-Share star, Companion crown) stay visible even when the
+   slot isn't hovered, each parked in its own corner so they never collide:
+   crown (the more consequential pick — who actually battles) takes the
+   prominent top-right spot the ✕ would use; star parks one slot in. Both
+   slide out to their normal hover positions once the slot is hovered. */
+.slot-star.on { color: var(--accent-gold); border-color: rgba(210, 153, 34, 0.6); background: rgba(210, 153, 34, 0.14); opacity: 1; pointer-events: auto; right: 40px; }
+.slot-crown.on { color: var(--accent-blue); border-color: rgba(88, 166, 255, 0.6); background: rgba(88, 166, 255, 0.14); opacity: 1; pointer-events: auto; right: 8px; }
+.slot.filled:hover .slot-crown.on,
+.slot.filled:focus-within .slot-crown.on { right: 72px; }
+.slot-companion-badge {
+    margin-left: 5px;
+    font-size: 0.8rem;
+    color: var(--accent-blue);
+    vertical-align: middle;
+    cursor: help;
+}
 
 .slot-sprite-wrap {
     flex: 1 1 auto; min-height: 80px; max-height: 148px; width: 100%;

--- a/src/Ankimon/ankimon_profile_web/profile_data.py
+++ b/src/Ankimon/ankimon_profile_web/profile_data.py
@@ -604,6 +604,7 @@ class ProfileData:
         return out
 
     def get_team_data(self):
+        """Team screen payload: roster, XP Share holder, and Active Companion."""
         members = self._team_member_stubs()
         for m in members:
             m["cp"] = self._calc_cp(m["id"])
@@ -620,10 +621,9 @@ class ProfileData:
             cycle_count = 3
             sprite_mode = "static"
 
-        # companion/companion_info expose the current main Pokémon as a ready
-        # read-seam for the deferred Active Companion picker (team.js does not
-        # render them yet — see handle_save_team). Kept so that UI can wire in
-        # without a Python change.
+        # companion/companion_info: the current main Pokémon (is_main=1 in the
+        # DB) — team.js renders this as the ⚔ badge and lets it be changed via
+        # handle_save_team's companion_id.
         db = services.db
         main_pkmn = db.get_main_pokemon() if db else None
         companion_id = main_pkmn.get("individual_id") if main_pkmn else None
@@ -751,14 +751,55 @@ class ProfileData:
             print(f"[Ankimon] profile: CP calc failed for {individual_id}: {e}")
             return 0
 
+    # team.js sends this in place of a real individual_id when the Active
+    # Companion selection was never touched this session (the ⚔ button was
+    # never clicked, and no slot holding it was removed/replaced) — every
+    # OTHER team save (reordering, swapping an unrelated slot, XP Share only)
+    # must go through this path too, so it can't be a real id and must be
+    # left completely alone here: it used to be treated the same as "no
+    # companion" and cleared whatever main Pokémon was already set on every
+    # single save that didn't touch the crown, which is the actual regression
+    # this sentinel exists to prevent.
+    #
+    # The literal is mirrored in team.js (``COMPANION_UNCHANGED``). The two
+    # are pinned together by test_team_save_companion.py, which reads team.js
+    # off disk and asserts this exact string appears in it — a rename on
+    # either side that isn't mirrored would otherwise silently make every
+    # ordinary save look "touched" again and resurrect the regression above.
+    _COMPANION_UNCHANGED = "__companion_unchanged__"
+
     def handle_save_team(self, team_ids, xp_share_id, companion_id):
         """Persist the chosen team + XP Share holder.
 
-        ``companion_id`` (Active Companion / main-Pokémon override) is a ready
-        write-seam, but NO shipped UI populates it yet — the Team screen's
-        companion picker is deferred (team.js sends ''), so the set_main_pokemon
-        branch below is inert until that UI lands. Do not describe Active
-        Companion as a working feature."""
+        ``companion_id`` is the Active Companion — whichever team member should
+        actually be the one battling (``is_main=1`` in the DB). team.js's ⚔
+        button on a team slot sets/clears it; ``_COMPANION_UNCHANGED`` means
+        this save never touched that selection at all and the existing
+        is_main row (however it got there — the crown, or an older pathway
+        like starter selection/PC box) must be left alone.
+
+        Anything else is a companion *change*, and a change never ends with
+        the game having no battler at all: a real, valid team-member id is a
+        set, and an explicit clear promotes the first member of the team being
+        saved. The three ways a change can't be honoured — an id that isn't in
+        the team being saved (bad input), a clear with an empty team (nobody to
+        promote), and an id whose captured_pokemon row is gone by the time
+        set_main_pokemon() runs (released, or a stale roster cache) — all fall
+        back to leaving the existing is_main row exactly where it is, and none
+        of them report a ``companion`` back. This method never drops it: zero
+        is_main=1 rows makes the next load fall through
+        ``update_main_pokemon()`` to ``MAIN_POKEMON_DEFAULT``, the level-5
+        Ditto named "Please Restart Anki", and a stale-but-real battler beats
+        that in every case.
+
+        Whenever the companion is actually set, the live ``main_pokemon``
+        object is reloaded from the DB and the reviewer HUD + Ankimon Window
+        repaint so the swap is visible immediately. The response carries a
+        ``companion`` key back to team.js in that case, because a clear can be
+        rewritten into a promotion here and the page would otherwise keep
+        showing no crown while the DB has one."""
+        companion_touched = companion_id != self._COMPANION_UNCHANGED
+
         seen = set()
         clean_ids = []
         for raw in team_ids or []:
@@ -772,7 +813,32 @@ class ProfileData:
 
         team_data = [{"individual_id": ind_id} for ind_id in clean_ids]
         xp_share_id = str(xp_share_id) if xp_share_id else None
-        companion_id = str(companion_id) if companion_id else None
+        companion_id = str(companion_id) if (companion_touched and companion_id) else None
+        # The Active Companion has to actually be a member of the team being
+        # saved — otherwise a slot swap in the same save could point
+        # set_main_pokemon at a Pokémon that just got dropped from the roster,
+        # leaving the battler out of sync with what the team screen shows.
+        # An id that fails this check is bad INPUT, not an instruction: drop
+        # the companion field from this save entirely (back to "unchanged")
+        # rather than letting a bridge race, a stale cached team.js or a
+        # third-party caller delete the player's battler.
+        if companion_id and companion_id not in clean_ids:
+            companion_id = None
+            companion_touched = False
+        # An explicit clear — the crown toggled off, or the companion's own
+        # slot removed/replaced in team.js — means "somebody else battles
+        # now", never "nobody does". Leaving zero is_main=1 rows makes the
+        # NEXT load fall through update_main_pokemon() to
+        # MAIN_POKEMON_DEFAULT: the level-5 Ditto literally named "Please
+        # Restart Anki". Promote the first member of the team being saved;
+        # if the save empties the team there is nobody to promote, so treat
+        # it as "unchanged" and leave the existing battler alone rather than
+        # leaving the player with none at all.
+        elif companion_touched and not companion_id:
+            if clean_ids:
+                companion_id = clean_ids[0]
+            else:
+                companion_touched = False
 
         try:
             # NOTE: no legacy "trainer.team" config write — the DB team table
@@ -780,10 +846,49 @@ class ProfileData:
             # uses; settings.py migrates/deletes the old config key on load.
             self.settings_obj.set("trainer.xp_share", xp_share_id)
             services.db.save_team(team_data)
-            if companion_id:
-                services.db.set_main_pokemon(companion_id)
+            # companion_touched now means exactly "this save has an id to
+            # set": the sentinel, a rejected id and an unpromotable clear have
+            # all been folded into "leave the existing is_main row alone".
+            if not companion_touched:
+                pass  # leave whatever main Pokémon is already set alone
+            elif not services.db.set_main_pokemon(companion_id):
+                # set_main_pokemon() returns False when the individual_id has
+                # no captured_pokemon row — the id was only checked against the
+                # team team.js just sent, so a release or a stale roster cache
+                # between page load and save lands here. Nothing was written:
+                # the old is_main row still stands, so this is the same
+                # "unchanged" outcome as a rejected id, and reporting a
+                # companion back would make team.js show a crown the DB never
+                # got.
+                companion_touched = False
+            else:
                 from ..functions.update_main_pokemon import update_main_pokemon
+
                 update_main_pokemon(services.main_pokemon)
+                # Repaint the reviewer HUD + the Ankimon Window popup so the
+                # switch is visible immediately, not just after the next
+                # battle turn (same seam cycle_team_pokemon() in reviewer_ui.py
+                # uses for its own companion swap).
+                try:
+                    if services.reviewer is not None:
+                        services.reviewer.refresh_hud()
+                except Exception:
+                    pass
+                try:
+                    # is_alive(), not a bare None-check: a closed-and-deleted
+                    # Ankimon Window is still a non-None sip wrapper, and
+                    # calling into it raises "wrapped C/C++ object deleted"
+                    # — which the except below would swallow, silently
+                    # skipping the repaint this branch exists to do.
+                    from ..utils import is_alive
+
+                    test_window = services.test_window
+                    if is_alive(test_window) and test_window.isVisible():
+                        test_window.main_pokemon = services.main_pokemon
+                        if test_window.current_view == "battle":
+                            test_window.force_display_battle()
+                except Exception:
+                    pass
         except Exception as e:
             return {"ok": False, "message": f"Failed to save team: {e}"}
 
@@ -794,7 +899,13 @@ class ProfileData:
             pass
 
         self._roster_cache = None
-        return {"ok": True, "message": "Team saved.", "count": len(team_data)}
+        result = {"ok": True, "message": "Team saved.", "count": len(team_data)}
+        if companion_touched:
+            # What the save actually left as the Active Companion — team.js
+            # applies this so a clear that was rewritten into a promotion
+            # shows its crown straight away instead of after a page reload.
+            result["companion"] = companion_id
+        return result
 
     # ------------------------------------------------------------------
     # Trainer sprite picker

--- a/src/Ankimon/ankimon_profile_web/team.js
+++ b/src/Ankimon/ankimon_profile_web/team.js
@@ -10,11 +10,31 @@
 
     const SPRITE_BASE = '../user_files/sprites/front_default';
     const FALLBACK = SPRITE_BASE + '/0.png';
+    // Sent as the companion arg when this session never touched the Active
+    // Companion selection, so the backend leaves whatever main Pokémon is
+    // already set alone instead of reading "no companion" as "clear it" —
+    // impossible as a real individual_id, so it can't collide with one.
+    const COMPANION_UNCHANGED = '__companion_unchanged__';
 
     const state = {
         team: [null, null, null, null, null, null],
         xpShare: null,         // individual_id of the XP Share holder (any owned Pokémon)
         xpShareInfo: null,     // display stub for the holder (may be benched)
+        companionId: null,     // individual_id of the Active Companion (must be a team slot member)
+        // The last companion the BACKEND confirmed — the page load's value, or
+        // whatever a save reported back. companionId above is optimistic the
+        // moment the crown is clicked, and handle_save_team can refuse the
+        // change (id not in the saved team, nothing to promote, row already
+        // released) while still saving the team; reverting to this is what
+        // keeps the ⚔ badge showing the DB's battler instead of a wish.
+        companionConfirmedId: null,
+        // Whether THIS session actually changed the companion (crown toggle,
+        // or an implicit clear because the companion's slot got removed/
+        // replaced) — vs. simply never having touched it. Only a touched
+        // change is sent to the backend as authoritative; an untouched save
+        // (e.g. just reordering the team) must leave whatever main Pokémon
+        // is already set alone, not wipe it. See saveTeam()/applyData().
+        companionTouched: false,
         maxSize: 6,
         teamCycleCount: 3,     // limit for hotkey 9 rotation
         roster: null,          // null = not loaded yet
@@ -26,11 +46,6 @@
         spriteMode: 'static',
     };
 
-    // NOTE: the "Active Companion" picker (an iframe mode="companion-picker"
-    // flow) was never finished — no page hosts the iframe and its helpers were
-    // undefined — so that dead path is removed here. The Python read/write seam
-    // (get_team_data.companion / handle_save_team companion_id) is retained for
-    // whenever the picker UI is actually built; saveTeam sends '' until then.
     let teamBridge = null;
 
     function spriteUrl(stub, mode = state.spriteMode) {
@@ -165,17 +180,21 @@
             const m = state.team[i];
             const slot = document.createElement('div');
             const isXp = !!(m && state.xpShare && String(m.id) === String(state.xpShare));
-            slot.className = 'slot ' + (m ? 'filled' : 'empty') + (isXp ? ' xp-share' : '');
+            const isCompanion = !!(m && state.companionId && String(m.id) === String(state.companionId));
+            slot.className = 'slot ' + (m ? 'filled' : 'empty') + (isXp ? ' xp-share' : '') + (isCompanion ? ' companion' : '');
 
             if (m) {
                 const cp = (m.cp === undefined || m.cp === null) ? '—' : num(m.cp);
                 const types = (m.types || []).map(typeBadge).join('');
                 const hasCycle = state.teamCycleCount > 1 && i < state.teamCycleCount;
                 const cycleBadge = hasCycle ? '<span class="slot-rotation-badge" title="Cycled via Hotkey 9">↻</span>' : '';
+                const companionBadge = isCompanion ? '<span class="slot-companion-badge" title="Active Companion">⚔</span>' : '';
 
                 slot.title = 'Click to switch';
                 slot.innerHTML = `
-                    <span class="slot-num">${i + 1}${cycleBadge}</span>
+                    <span class="slot-num">${i + 1}${cycleBadge}${companionBadge}</span>
+                    <button class="slot-corner slot-crown${isCompanion ? ' on' : ''}" data-act="companion" data-slot="${i}"
+                            title="${isCompanion ? 'Active Companion (battling now)' : 'Set as Active Companion'}">⚔</button>
                     <button class="slot-corner slot-star${isXp ? ' on' : ''}" data-act="xp" data-slot="${i}"
                             title="${isXp ? 'Remove XP Share' : 'Set as XP Share'}">★</button>
                     <button class="slot-corner slot-remove" data-act="remove" data-slot="${i}" title="Remove">✕</button>
@@ -201,13 +220,14 @@
         }
         grid.replaceChildren(frag);
 
-        // Corner buttons (★ XP Share, ✕ remove) override the card's click-to-switch.
+        // Corner buttons (⚔ Companion, ★ XP Share, ✕ remove) override the card's click-to-switch.
         grid.querySelectorAll('[data-act]').forEach((btn) => {
             const i = Number(btn.dataset.slot);
             btn.addEventListener('click', (e) => {
                 e.stopPropagation();
                 if (btn.dataset.act === 'remove') removeSlot(i);
                 else if (btn.dataset.act === 'xp') toggleXp(i);
+                else if (btn.dataset.act === 'companion') toggleCompanion(i);
             });
         });
 
@@ -220,6 +240,20 @@
         if (!m) return;
         if (state.xpShare && String(m.id) === String(state.xpShare)) setXpShare(null);
         else setXpShare(m);
+    }
+
+    // ---------------- Active Companion ----------------
+    // The companion must be an actual team member (it's who battles), so
+    // this only ever operates on a filled team slot — no separate roster
+    // picker needed. There's always exactly one, or none.
+    function toggleCompanion(slot) {
+        const m = state.team[slot];
+        if (!m) return;
+        const id = String(m.id);
+        state.companionId = (state.companionId === id) ? null : id;
+        state.companionTouched = true;
+        markDirty();
+        renderTeam();
     }
 
     // Sidebar team overview: filled count, average level, total CP, type coverage.
@@ -274,12 +308,27 @@
     function removeSlot(slot) {
         // XP Share is independent of team membership now — removing a Pokémon
         // from a slot leaves it owned, so we keep it as the XP Share holder.
+        // Active Companion, though, MUST be a team member — clear it if the
+        // Pokémon leaving the slot was the companion.
+        const m = state.team[slot];
+        if (m && state.companionId && String(m.id) === String(state.companionId)) {
+            state.companionId = null;
+            state.companionTouched = true;
+        }
         state.team[slot] = null;
         markDirty();
         renderTeam();
     }
 
     function assignSlot(slot, stub) {
+        // Swapping out the slot that held the companion clears it — the new
+        // occupant isn't automatically the companion, and the old one is no
+        // longer a team member.
+        const prev = state.team[slot];
+        if (prev && state.companionId && String(prev.id) === String(state.companionId)) {
+            state.companionId = null;
+            state.companionTouched = true;
+        }
         // Copy so editing one slot can't alias another / the roster entry.
         const member = { id: stub.id, p: stub.p, n: stub.n, l: stub.l };
         if (stub.s) member.s = 1;
@@ -548,11 +597,38 @@
             updateSaveUI();
             return Promise.resolve({ ok: true });
         }
-        // Third arg is companion_id — always '' (no shipped companion picker; the
-        // Python seam accepts it for when that UI is built).
-        return teamBridge.saveTeam(JSON.stringify(ids), state.xpShare || '', '').then((res) => {
+        const companionArg = state.companionTouched ? (state.companionId || '') : COMPANION_UNCHANGED;
+        const companionWasTouched = state.companionTouched;
+        return teamBridge.saveTeam(JSON.stringify(ids), state.xpShare || '', companionArg).then((res) => {
             if (res && res.ok) {
                 state.dirty = false;
+                // The save is now the new baseline. companionTouched used to
+                // only ever clear in applyData() (page init), so after ONE
+                // companion edit every later save in the session kept sending
+                // an authoritative companion — and since the backend rewrites
+                // an empty one into "promote the first team member", editing
+                // slot 1 later would silently re-crown whoever landed there.
+                state.companionTouched = false;
+                // The backend reports what it actually left as the Active
+                // Companion whenever this save was authoritative, because a
+                // clear can come back as a promotion. Adopt it so the crown
+                // on screen matches the DB without a reload.
+                if (res.companion !== undefined) {
+                    state.companionId = res.companion ? String(res.companion) : null;
+                    state.companionConfirmedId = state.companionId;
+                    renderTeam();
+                } else if (companionWasTouched) {
+                    // The team saved but the companion change did NOT: the
+                    // backend omits the key on every outcome that leaves the
+                    // existing is_main row alone (id not on the saved team,
+                    // an empty team with nobody to promote, or a row already
+                    // released). companionTouched has just been cleared, so
+                    // nothing would ever re-send this id — keeping it on
+                    // screen would leave the ⚔ badge pointing at a Pokémon
+                    // that is not the DB's battler until a page reload.
+                    state.companionId = state.companionConfirmedId;
+                    renderTeam();
+                }
                 updateSaveUI();
                 toast(res.message || 'Team saved.', 'success');
                 return res;
@@ -581,6 +657,9 @@
         for (let i = 0; i < state.maxSize; i++) state.team.push(team[i] || null);
         state.xpShare = data.xp_share ? String(data.xp_share) : null;
         state.xpShareInfo = data.xp_share_info || null;
+        state.companionId = data.companion ? String(data.companion) : null;
+        state.companionConfirmedId = state.companionId;   // straight from the DB
+        state.companionTouched = false;   // fresh load — nothing changed yet
         state.spriteMode = data.sprite_mode || 'static';
         state.teamCycleCount = data.team_cycle_count || 3;
 
@@ -690,6 +769,7 @@
                 max_size: 6,
                 xp_share: '2',
                 xp_share_info: { id: '2', p: 6, n: 'Charizard', l: 52, s: 1 },
+                companion: '1',
                 team: [
                     { id: '1', p: 25, n: 'Pikachu', l: 18, cp: 820, types: ['Electric'] },
                     { id: '2', p: 6, n: 'Charizard', l: 52, s: 1, cp: 2410, types: ['Fire', 'Flying'] },

--- a/tests/test_reviewer_ownership_cache.py
+++ b/tests/test_reviewer_ownership_cache.py
@@ -590,6 +590,7 @@ def _load_encounter_functions():
     ef.trainer_card = MagicMock()
     ef.services = MagicMock()
     ef.events = MagicMock()
+    ef.translator = MagicMock()
     # Canned generator so new_pokemon does no RNG work.
     ef.generate_random_pokemon = lambda *a, **k: (
         "Pikachu",

--- a/tests/test_team_save_companion.py
+++ b/tests/test_team_save_companion.py
@@ -1,0 +1,386 @@
+"""Regression test for the Active Companion clearing bug: handle_save_team()
+used to treat ANY falsy companion_id (including "team.js never touched the
+companion picker this save") as an explicit "clear the main Pokémon" —
+meaning every ordinary team save that didn't touch the crown (reordering the
+team, swapping an unrelated slot, XP Share only) wiped whatever main Pokémon
+was already set, even one assigned through an older pathway (starter
+selection, PC box) team.js never knew about.
+
+The fix: team.js now sends a distinct ``_COMPANION_UNCHANGED`` sentinel when
+the companion selection was never touched this session, and handle_save_team
+leaves the DB's is_main row completely alone in that case.
+
+A companion *change* never ends with the game having no battler at all,
+either — ``update_main_pokemon()`` falls back to ``MAIN_POKEMON_DEFAULT`` (the
+level-5 Ditto named "Please Restart Anki") the moment ``get_main_pokemon()``
+returns None, so any path to zero ``is_main=1`` rows is user-hostile. An
+explicit clear therefore promotes the first member of the team being saved, and
+the two changes that cannot be honoured — an id that isn't in the team being
+saved, and a clear with an empty team — both leave the existing is_main row
+exactly where it is. handle_save_team never drops it.
+
+Loads profile_data.py directly with its own dependencies stubbed (it's a
+plain, non-Qt data layer per its own module docstring), so this pins the
+branching logic without needing a real Qt/services stack.
+"""
+
+import importlib.util
+import re
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+_SRC = Path(__file__).parent.parent / "src"
+_MODULE_NAME = "Ankimon.ankimon_profile_web.profile_data"
+
+
+class _FakeDB:
+    def __init__(self, set_main_result=True):
+        self.saved_team = None
+        self.set_main_calls = []
+        self.clear_main_calls = 0
+        # The real set_main_pokemon() returns False when individual_id has no
+        # captured_pokemon row, which handle_save_team has to treat as "nothing
+        # was written" rather than a successful change.
+        self.set_main_result = set_main_result
+
+    def save_team(self, team_data):
+        self.saved_team = team_data
+
+    def set_main_pokemon(self, individual_id):
+        self.set_main_calls.append(individual_id)
+        return self.set_main_result
+
+    def clear_main_pokemon(self):
+        self.clear_main_calls += 1
+
+
+class _FakeTestWindow:
+    """Stands in for the Ankimon Window on the companion repaint branch.
+
+    Only the attributes that branch touches: ``is_alive()`` probes
+    ``objectName()``, and the repaint is gated on visibility + the battle view.
+    """
+
+    def __init__(self, *, visible=True, current_view="battle"):
+        self._visible = visible
+        self.current_view = current_view
+        self.main_pokemon = None
+        self.force_display_calls = 0
+
+    def objectName(self):
+        return "AnkimonWindow"
+
+    def isVisible(self):
+        return self._visible
+
+    def force_display_battle(self):
+        self.force_display_calls += 1
+
+
+class _FakeSettings:
+    def __init__(self):
+        self.values = {}
+
+    def get(self, key, default=None):
+        return self.values.get(key, default)
+
+    def set(self, key, val):
+        self.values[key] = val
+
+
+@pytest.fixture
+def pd_module(monkeypatch, tmp_path):
+    # Every sys.modules write below goes through monkeypatch.setitem (and
+    # delitem for the module actually loaded fresh) so pytest restores the
+    # real entries after this test, instead of leaking these fakes into
+    # whatever test file happens to run next in the same session — the same
+    # cross-file sys.modules pollution pattern this suite has bitten on
+    # before (see test_pokemon_details_gui.py's own isolation notes).
+    for name in ("Ankimon", "Ankimon.ankimon_profile_web"):
+        pkg = types.ModuleType(name)
+        pkg.__path__ = [str(_SRC / name.replace(".", "/"))]
+        pkg.__package__ = name
+        monkeypatch.setitem(sys.modules, name, pkg)
+
+    services_mod = types.ModuleType("Ankimon.services")
+    fake_services = types.SimpleNamespace(
+        db=_FakeDB(),
+        main_pokemon=None,
+        reviewer=None,
+        test_window=None,
+    )
+    services_mod.services = fake_services
+    monkeypatch.setitem(sys.modules, "Ankimon.services", services_mod)
+
+    utils_mod = types.ModuleType("Ankimon.utils")
+    utils_mod.get_all_sprites = lambda *a, **k: []
+    utils_mod.POKEMON_NAME_LOOKUP = {}
+    # handle_save_team does `from ..utils import is_alive` inside a bare
+    # `except Exception: pass` on the companion repaint branch. Without this
+    # stub that import raises ImportError, the except swallows it, and the
+    # repaint branch silently no-ops on EVERY test in this file — a regression
+    # there would never be caught.
+    utils_mod.is_alive = lambda obj: obj is not None
+    monkeypatch.setitem(sys.modules, "Ankimon.utils", utils_mod)
+
+    resources_mod = types.ModuleType("Ankimon.resources")
+    resources_mod.trainer_sprites_path = tmp_path
+    monkeypatch.setitem(sys.modules, "Ankimon.resources", resources_mod)
+
+    for name in ("Ankimon.functions",):
+        pkg = types.ModuleType(name)
+        pkg.__path__ = [str(_SRC / name.replace(".", "/"))]
+        pkg.__package__ = name
+        monkeypatch.setitem(sys.modules, name, pkg)
+
+    update_main_pokemon_mod = types.ModuleType("Ankimon.functions.update_main_pokemon")
+    update_main_pokemon_mod.update_main_pokemon = lambda *a, **k: None
+    monkeypatch.setitem(
+        sys.modules, "Ankimon.functions.update_main_pokemon", update_main_pokemon_mod
+    )
+
+    monkeypatch.delitem(sys.modules, _MODULE_NAME, raising=False)
+    spec = importlib.util.spec_from_file_location(
+        _MODULE_NAME, _SRC / "Ankimon" / "ankimon_profile_web" / "profile_data.py"
+    )
+    mod = importlib.util.module_from_spec(spec)
+    monkeypatch.setitem(sys.modules, _MODULE_NAME, mod)
+    spec.loader.exec_module(mod)
+
+    yield mod, fake_services
+
+
+def _make_pd(pd_module):
+    mod, _ = pd_module
+    return mod.ProfileData(
+        # Never read/written in the handle_save_team path this file exercises
+        # — just needs to be a real Path, not an actual writable location.
+        addon_dir=Path(__file__).parent,
+        trainer_card=None,
+        settings_obj=_FakeSettings(),
+        logger=None,
+    )
+
+
+def test_unchanged_sentinel_leaves_existing_main_pokemon_alone(pd_module):
+    """The core regression: a normal save (companion never touched) must NOT
+    clear an existing main Pokémon."""
+    mod, fake_services = pd_module
+    pd = _make_pd(pd_module)
+
+    result = pd.handle_save_team(
+        ["a", "b"], "", mod.ProfileData._COMPANION_UNCHANGED
+    )
+
+    assert result["ok"] is True
+    assert fake_services.db.clear_main_calls == 0
+    assert fake_services.db.set_main_calls == []
+
+
+def test_empty_companion_when_touched_promotes_the_first_team_member(pd_module):
+    """An explicit clear means "somebody else battles now", not "nobody does".
+
+    Un-crowning used to call clear_main_pokemon(), leaving zero is_main rows —
+    and the next Anki start then handed the game MAIN_POKEMON_DEFAULT, the
+    level-5 Ditto named "Please Restart Anki". The same destructive path was
+    reachable without ever touching the crown: team.js marks the companion
+    touched and sends "" whenever the slot holding it is removed or replaced,
+    which is an ordinary team edit.
+    """
+    mod, fake_services = pd_module
+    pd = _make_pd(pd_module)
+
+    result = pd.handle_save_team(["a", "b"], "", "")
+
+    assert result["ok"] is True
+    assert fake_services.db.set_main_calls == ["a"]
+    assert fake_services.db.clear_main_calls == 0
+
+
+def test_empty_companion_with_an_empty_team_leaves_main_pokemon_alone(pd_module):
+    """Clearing the last team member must not leave the game with no battler.
+
+    There is nobody to promote here, so the save simply doesn't touch is_main.
+    Dropping the row instead would hand the next Anki start
+    MAIN_POKEMON_DEFAULT — a stale-but-real battler beats the placeholder
+    Ditto in every case, and a player who empties their whole team to rebuild
+    it should not lose their Pokémon over it.
+    """
+    mod, fake_services = pd_module
+    pd = _make_pd(pd_module)
+
+    result = pd.handle_save_team([], "", "")
+
+    assert result["ok"] is True
+    assert fake_services.db.clear_main_calls == 0
+    assert fake_services.db.set_main_calls == []
+    # Nothing authoritative happened, so nothing to report back to team.js.
+    assert "companion" not in result
+
+
+def test_handle_save_team_never_clears_the_main_pokemon(pd_module):
+    """No input reaches clear_main_pokemon() — the placeholder-Ditto path is
+    closed off entirely, not just narrowed."""
+    mod, fake_services = pd_module
+    pd = _make_pd(pd_module)
+
+    for team_ids, companion in (
+        (["a", "b"], mod.ProfileData._COMPANION_UNCHANGED),
+        (["a", "b"], ""),
+        (["a", "b"], "a"),
+        (["a", "b"], "not-on-team"),
+        ([], ""),
+        ([], mod.ProfileData._COMPANION_UNCHANGED),
+        ([], "not-on-team"),
+    ):
+        assert pd.handle_save_team(team_ids, "", companion)["ok"] is True
+
+    assert fake_services.db.clear_main_calls == 0
+
+
+def test_the_resulting_companion_is_reported_back_to_team_js(pd_module):
+    """A clear can come back as a promotion, so the page has to be told what
+    the save actually left set or its crown silently diverges from the DB."""
+    mod, fake_services = pd_module
+    pd = _make_pd(pd_module)
+
+    assert pd.handle_save_team(["a", "b"], "", "b")["companion"] == "b"
+    assert pd.handle_save_team(["a", "b"], "", "")["companion"] == "a"
+    # Nothing authoritative: no key at all, so team.js keeps what it has.
+    assert "companion" not in pd.handle_save_team(
+        ["a", "b"], "", mod.ProfileData._COMPANION_UNCHANGED
+    )
+    assert "companion" not in pd.handle_save_team(["a", "b"], "", "not-on-team")
+
+
+def test_valid_companion_sets_main_pokemon(pd_module):
+    mod, fake_services = pd_module
+    pd = _make_pd(pd_module)
+
+    result = pd.handle_save_team(["a", "b"], "", "a")
+
+    assert result["ok"] is True
+    assert fake_services.db.set_main_calls == ["a"]
+    assert fake_services.db.clear_main_calls == 0
+
+
+def test_setting_the_companion_repaints_an_open_ankimon_window(pd_module):
+    """The repaint branch is real code, so pin that it actually runs.
+
+    It sits behind `from ..utils import is_alive` inside a bare
+    `except Exception: pass`, which means any import or attribute error in
+    there degrades to a silent no-op — the failure mode is "the crown changes
+    but the battle scene keeps showing the old battler until the next turn",
+    which no other assertion in this file would notice.
+    """
+    mod, fake_services = pd_module
+    window = _FakeTestWindow()
+    fake_services.test_window = window
+    # A distinct sentinel, NOT the None both sides already default to: the
+    # window has to receive the battler this save promoted, and `is None`
+    # would hold just as well if the branch never assigned anything at all.
+    battler = object()
+    fake_services.main_pokemon = battler
+    pd = _make_pd(pd_module)
+
+    result = pd.handle_save_team(["a", "b"], "", "b")
+
+    assert result["ok"] is True
+    assert fake_services.db.set_main_calls == ["b"]
+    assert window.force_display_calls == 1
+    assert window.main_pokemon is battler
+
+
+def test_a_window_off_the_battle_view_is_updated_but_not_repainted(pd_module):
+    """The death/catch screen must not be painted over by a team save.
+
+    The window still takes the new battler — it just isn't repainted until it
+    is back on the battle view, so the next render shows the right Pokémon.
+    """
+    mod, fake_services = pd_module
+    window = _FakeTestWindow(current_view="death")
+    fake_services.test_window = window
+    battler = object()
+    fake_services.main_pokemon = battler
+    pd = _make_pd(pd_module)
+
+    assert pd.handle_save_team(["a", "b"], "", "b")["ok"] is True
+    assert window.main_pokemon is battler
+    assert window.force_display_calls == 0
+
+
+def test_a_vanished_companion_row_is_not_reported_as_a_change(pd_module):
+    """set_main_pokemon() returning False means nothing was written.
+
+    companion_id is only validated against the team team.js just sent, never
+    against captured_pokemon — so an id released (or dropped by a stale roster
+    cache) between page load and save reaches the DB and is refused there. The
+    old is_main row still stands, so this save changed nothing: reporting a
+    ``companion`` back would make team.js park its crown on a Pokémon the DB
+    never accepted, and the repaint would advertise a switch that didn't
+    happen.
+    """
+    mod, fake_services = pd_module
+    fake_services.db.set_main_result = False
+    window = _FakeTestWindow()
+    fake_services.test_window = window
+    pd = _make_pd(pd_module)
+
+    result = pd.handle_save_team(["a", "b"], "", "a")
+
+    assert result["ok"] is True
+    assert fake_services.db.set_main_calls == ["a"]  # it was attempted...
+    assert "companion" not in result  # ...and reported as unchanged
+    assert window.force_display_calls == 0
+    assert fake_services.db.clear_main_calls == 0
+
+
+def test_companion_not_in_saved_team_is_rejected_without_touching_is_main(pd_module):
+    """A companion id that isn't part of the team being saved is bad INPUT.
+
+    It must not be set (it isn't on the team) — but it must not be treated as
+    a clear either: a bridge race, a stale cached team.js or a third-party
+    caller sending a known-good-but-benched id would otherwise delete the
+    player's battler. Reject the field, change nothing.
+    """
+    mod, fake_services = pd_module
+    pd = _make_pd(pd_module)
+
+    result = pd.handle_save_team(["a", "b"], "", "not-on-team")
+
+    assert result["ok"] is True
+    assert fake_services.db.set_main_calls == []
+    assert fake_services.db.clear_main_calls == 0
+
+
+def test_sentinel_literal_is_mirrored_in_team_js():
+    """The protocol sentinel is hand-duplicated in team.js and profile_data.py.
+
+    Nothing at runtime asserts the two literals match, and a rename on either
+    side silently makes ``companion_touched`` True on every ordinary save —
+    resurrecting the exact regression this file exists to pin. Read the JS off
+    disk and require the Python literal to appear in it.
+    """
+    profile_data_src = (
+        _SRC / "Ankimon" / "ankimon_profile_web" / "profile_data.py"
+    ).read_text(encoding="utf-8")
+    team_js = (_SRC / "Ankimon" / "ankimon_profile_web" / "team.js").read_text(
+        encoding="utf-8"
+    )
+
+    # Pulled straight out of the source text so this test needs none of the
+    # module's import-time dependencies stubbed.
+    match = re.search(
+        r"_COMPANION_UNCHANGED\s*=\s*[\"\'](?P<literal>[^\"\']+)[\"\']",
+        profile_data_src,
+    )
+    assert match, "profile_data.py no longer defines _COMPANION_UNCHANGED"
+    literal = match.group("literal")
+
+    assert f"'{literal}'" in team_js or f'"{literal}"' in team_js, (
+        f"team.js does not send the {literal!r} sentinel profile_data.py expects "
+        "— the two hand-duplicated literals have diverged"
+    )


### PR DESCRIPTION
### Description

Adds a way to pick which team Pokémon is the active companion directly from the
profile/team web view, and persists that choice. The reviewer ownership cache
and the team-save path are updated so the selection stays consistent across
encounters and window reloads.

Files: `ankimon_profile_web/profile_data.py`, `ankimon_profile_web/team.js`,
`ankimon_profile_web/profile.css`, `tests/test_team_save_companion.py` (new),
`tests/test_reviewer_ownership_cache.py`.


### Checklist
- [x] My code follows the code style and guidelines of this project.
- [x] I have run tests locally (`pytest tests/` and `pytest tests/test_addon_integrity.py`) and they all pass.