### PR TITLE
feature(badges): highlight obtained badges

### DIFF
--- a/src/Ankimon/ankimon_profile_web/profile.css
+++ b/src/Ankimon/ankimon_profile_web/profile.css
@@ -864,6 +864,12 @@ body {
     display: flex;
     align-items: center;
     justify-content: center;
+    transition: background 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
+}
+.badge-cell.unlocked {
+    background: var(--accent-blue);
+    border-color: var(--accent-blue);
+    box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.08);
 }
 .badge-cell img { width: 62%; height: 62%; object-fit: contain; image-rendering: pixelated; }
 .badge-cell.locked img { filter: grayscale(100%) brightness(0.55); }

--- a/src/Ankimon/ankimon_profile_web/profile.js
+++ b/src/Ankimon/ankimon_profile_web/profile.js
@@ -201,7 +201,7 @@
         const frag = document.createDocumentFragment();
         grid.forEach((b) => {
             const cell = document.createElement('div');
-            cell.className = 'badge-cell' + (b.unlocked ? '' : ' locked');
+            cell.className = 'badge-cell' + (b.unlocked ? ' unlocked' : ' locked');
             cell.innerHTML = `
                 <img src="${BADGE_BASE}/${b.id}.png" alt="${esc(b.name)}"
                      onerror="this.onerror=null;this.src='${BADGE_BASE}/default.png';">


### PR DESCRIPTION
### At A Glance
- This PR **fills** the **box** of every **obtained achievement** with a **blue background**.

### Why This Feature
This PR brings two notable benefits:
1. Following the introduction of **Show Sprites Across Ankimon**, it was impossible to find out which achievements are obtained once the **badge sprites are hidden** from view. Filling the boxes blue enables users to view their achievement collection even with sprites disabled.
2. Secondly, as the icing on the Alcremie, this also addresses the **confusion** experienced by a trainer in Discord between **obtained and non-obtained badges** (for example, the unlocked colour of 100 cards in a session! is **grey**, which clashes with the equivalently **dark** UI). This feature lets trainers **quickly identify** obtained badges with near-zero room for misinterpretation. 

### What Each File Does
This PR modifies the following files:
- **`ankimon_profile_web/profile.css`**: Adds **styling** for unlocked's blue fill.
- **`ankimon_profile_web/profile.js`**: **Wires** unlocked's blue fill.

### Expected Behaviour
1. Trainer views their Achievements in Ankimon > Profile > Achievements
2. Obtained achievements have their box filled blue, regardless of whether sprites are present. 

#### Example With Sprites
<img width="737" height="359" alt="image" src="https://github.com/user-attachments/assets/ac310b73-3fd3-4d53-a8ce-b677c58af349" />

#### Example Without Sprites
<img width="759" height="366" alt="image" src="https://github.com/user-attachments/assets/b6b0ab7b-e718-44ac-b79f-0a6f5dfea294" />

### Related Issues
Thanks to poline on Discord for inspiring this feature!

### Checklist
- [x] My code and commit messages follow the code style and guidelines of this project.
- [x] I have personally viewed the achievement collection, and they are highlighted appropriately as intended. 