### PR TITLE
feature(monPC): text presentation and shiny overlay

### DIFF
--- a/src/Ankimon/lang/ch_text.json
+++ b/src/Ankimon/lang/ch_text.json
@@ -459,6 +459,8 @@
   "bp_label": "BP",
   "combat_power": "战斗力",
   "battle_power": "对战能力",
+  "level_label": "等级 {level}",
+  "shiny_tooltip": "闪光宝可梦",
   "friendship_label": "亲密度",
   "friendship_tooltip": "测量你和宝可梦之间的羁绊。",
   "bff_tooltip": "💖 最好的朋友 (最高亲密度)",

--- a/src/Ankimon/lang/cz_text.json
+++ b/src/Ankimon/lang/cz_text.json
@@ -459,6 +459,8 @@
   "bp_label": "BP",
   "combat_power": "Bojová síla",
   "battle_power": "Bojová síla",
+  "level_label": "Úroveň {level}",
+  "shiny_tooltip": "Lesklý Pokémon",
   "friendship_label": "Přátelství",
   "friendship_tooltip": "Měří pouto mezi vámi a vaším pokémonem.",
   "bff_tooltip": "💖 Nejlepší přítel (Nejvyšší přátelství)",

--- a/src/Ankimon/lang/de_text.json
+++ b/src/Ankimon/lang/de_text.json
@@ -459,6 +459,8 @@
   "bp_label": "KP",
   "combat_power": "Wettkampfpunkte",
   "battle_power": "Kampfstärke",
+  "level_label": "Lvl {level}",
+  "shiny_tooltip": "Schillerndes Pokémon",
   "friendship_label": "Freundschaft",
   "friendship_tooltip": "Misst die Bindung zwischen dir und deinem Pokémon.",
   "bff_tooltip": "💖 Bester Freund (Höchste Freundschaft)",

--- a/src/Ankimon/lang/en_text.json
+++ b/src/Ankimon/lang/en_text.json
@@ -460,6 +460,8 @@
   "bp_label": "BP",
   "combat_power": "Combat Power",
   "battle_power": "Battle Power",
+  "level_label": "Lvl {level}",
+  "shiny_tooltip": "Shiny Pokémon",
   "friendship_label": "Friendship",
   "friendship_tooltip": "Measures the bond between you and your Pokémon.",
   "bff_tooltip": "💖 Best Friend (Highest Friendship)",

--- a/src/Ankimon/lang/es_latam_text.json
+++ b/src/Ankimon/lang/es_latam_text.json
@@ -458,6 +458,8 @@
   "bp_label": "PC",
   "combat_power": "Poder de combate",
   "battle_power": "Poder de combate",
+  "level_label": "Nv. {level}",
+  "shiny_tooltip": "Pokémon variocolor",
   "friendship_label": "Amistad",
   "friendship_tooltip": "Mide el vínculo entre tú y tu Pokémon.",
   "bff_tooltip": "💖 Mejor Amigo (Amistad Máxima)",

--- a/src/Ankimon/lang/fr_text.json
+++ b/src/Ankimon/lang/fr_text.json
@@ -459,6 +459,8 @@
   "bp_label": "PB",
   "combat_power": "Puissance de combat",
   "battle_power": "Puissance de combat",
+  "level_label": "Niv. {level}",
+  "shiny_tooltip": "Pokémon chromatique",
   "friendship_label": "Amitié",
   "friendship_tooltip": "Mesure le lien entre vous et votre Pokémon.",
   "bff_tooltip": "💖 Meilleur Ami (Amitié maximale)",

--- a/src/Ankimon/lang/it_text.json
+++ b/src/Ankimon/lang/it_text.json
@@ -459,6 +459,8 @@
   "bp_label": "PL",
   "combat_power": "Potenza di combattimento",
   "battle_power": "Potenza di lotta",
+  "level_label": "Liv. {level}",
+  "shiny_tooltip": "Pokémon cromatico",
   "friendship_label": "Amicizia",
   "friendship_tooltip": "Misura il legame tra te e il tuo Pokémon.",
   "bff_tooltip": "💖 Migliore Amico (Amicizia Massima)",

--- a/src/Ankimon/lang/jp_text.json
+++ b/src/Ankimon/lang/jp_text.json
@@ -459,6 +459,8 @@
   "bp_label": "BP",
   "combat_power": "戦闘力",
   "battle_power": "バトルパワー",
+  "level_label": "Lv.{level}",
+  "shiny_tooltip": "色違いのポケモン",
   "friendship_label": "なかよし度",
   "friendship_tooltip": "あなたとポケモンの絆の強さです。",
   "bff_tooltip": "💖 最高の相棒 (なかよし度最大)",

--- a/src/Ankimon/lang/kr_text.json
+++ b/src/Ankimon/lang/kr_text.json
@@ -459,6 +459,8 @@
   "bp_label": "BP",
   "combat_power": "전투력",
   "battle_power": "배틀 파워",
+  "level_label": "Lv.{level}",
+  "shiny_tooltip": "색이 다른 포켓몬",
   "friendship_label": "친밀도",
   "friendship_tooltip": "당신과 포켓몬 사이의 유대감을 측정합니다.",
   "bff_tooltip": "💖 베스트 프렌드 (최고 친밀도)",

--- a/src/Ankimon/lang/po_text.json
+++ b/src/Ankimon/lang/po_text.json
@@ -459,6 +459,8 @@
   "bp_label": "PB",
   "combat_power": "Poder de combate",
   "battle_power": "Poder de batalha",
+  "level_label": "Nv. {level}",
+  "shiny_tooltip": "Pokémon brilhante",
   "friendship_label": "Amizade",
   "friendship_tooltip": "Mede o vínculo entre você e seu Pokémon.",
   "bff_tooltip": "💖 Melhor Amigo (Amizade Máxima)",

--- a/src/Ankimon/lang/sp_text.json
+++ b/src/Ankimon/lang/sp_text.json
@@ -458,6 +458,8 @@
   "bp_label": "PC",
   "combat_power": "Poder de combate",
   "battle_power": "Poder de combate",
+  "level_label": "Nv. {level}",
+  "shiny_tooltip": "Pokémon variocolor",
   "friendship_label": "Amistad",
   "friendship_tooltip": "Mide el vínculo entre tú y tu Pokémon.",
   "bff_tooltip": "💖 Mejor Amigo (Amistad Máxima)",

--- a/src/Ankimon/pyobj/pc_box.py
+++ b/src/Ankimon/pyobj/pc_box.py
@@ -533,6 +533,49 @@ def format_item_name(item_name: str) -> str:
     return item_name.replace("-", " ").title()
 
 
+def fit_text_to_slot(text, font_metrics, max_width, max_lines=2):
+    """Lay `text` onto at most `max_lines` lines of `max_width` px, eliding the rest.
+
+    QLabel.setWordWrap can only break on spaces, so a single long species name
+    ("Crabominable", "Gigantamax Charizard") overflows a PC slot and is cut off
+    mid-glyph. Wrapping by hand and eliding whatever still does not fit keeps the
+    label readable; callers pair this with a tooltip carrying the untruncated name.
+    """
+    text = (text or "").strip()
+    if not text:
+        return ""
+
+    elide = Qt.TextElideMode.ElideRight
+
+    def fits(candidate):
+        return font_metrics.horizontalAdvance(candidate) <= max_width
+
+    if fits(text):
+        return text
+
+    words = text.split()
+    lines = []
+    i = 0
+    while i < len(words) and len(lines) < max_lines:
+        word = words[i]
+        if not fits(word):
+            # A single word wider than the slot can only be elided.
+            lines.append(font_metrics.elidedText(word, elide, max_width))
+            i += 1
+            continue
+        line = word
+        i += 1
+        while i < len(words) and fits(f"{line} {words[i]}"):
+            line = f"{line} {words[i]}"
+            i += 1
+        lines.append(line)
+
+    if i < len(words):
+        # Out of lines with words left over: mark the truncation on the last one.
+        lines[-1] = font_metrics.elidedText(f"{lines[-1]} \u2026", elide, max_width)
+    return "\n".join(lines)
+
+
 def clear_layout(layout):
     """
     Recursively removes all widgets and nested layouts from a given layout.
@@ -1439,6 +1482,14 @@ class PokemonPC(QDialog):
                 pokemon = pokemon_list_slice[pokemon_idx]
 
                 show_sprites = self.show_sprites_across_ankimon
+                is_shiny = bool(pokemon.get("shiny", False))
+
+                pokemon_button = PokemonSlotButton("", self.grid_container)
+                pokemon_button.setObjectName("pokemonSlot")
+                pokemon_button.setFixedSize(self.slot_size, self.slot_size)
+
+                # Set in text mode only; also used as the slot's tooltip title.
+                display_name = None
 
                 if show_sprites:
                     # SPRITE MODE: Show the Pokémon sprite
@@ -1446,25 +1497,15 @@ class PokemonPC(QDialog):
                         "front",
                         "gif" if self.gif_in_collection else "png",
                         pokemon["id"],
-                        pokemon.get("shiny", False),
+                        is_shiny,
                         pokemon["gender"],
                         pokemon.get("name"),
                     )
-                    pokemon_button = PokemonSlotButton("", self.grid_container)
-                    pokemon_button.setObjectName("pokemonSlot")
-                    pokemon_button.setFixedSize(self.slot_size, self.slot_size)
                 else:
                     # TEXT MODE: Show species name and level
-                    pokemon_button = PokemonSlotButton("", self.grid_container)
-                    pokemon_button.setObjectName("pokemonSlot")
-                    pokemon_button.setFixedSize(self.slot_size, self.slot_size)
-
-                    display_name = pokemon.get("nickname") or pokemon.get("name", "???")
-                    if display_name:
-                        if pokemon.get("nickname"):
-                            pass
-                        else:
-                            display_name = format_lore_name(display_name)
+                    display_name = pokemon.get("nickname") or format_lore_name(
+                        pokemon.get("name") or "???"
+                    )
 
                     # Create a vertical layout for the text
                     text_layout = QVBoxLayout(pokemon_button)
@@ -1472,19 +1513,32 @@ class PokemonPC(QDialog):
                     text_layout.setSpacing(2)
                     text_layout.setAlignment(Qt.AlignmentFlag.AlignCenter)
 
-                    # Species name label with theme-aware color
-                    name_label = QLabel(display_name)
+                    # Species name label with theme-aware color. The font is set
+                    # on the widget rather than in the stylesheet so that the
+                    # metrics used for eliding below match what actually renders.
+                    name_label = QLabel()
+                    name_font = QFont(name_label.font())
+                    name_font.setPixelSize(11)
+                    name_font.setBold(True)
+                    name_label.setFont(name_font)
                     name_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
                     name_label.setStyleSheet(f"""
                         QLabel {{
                             color: {species_color};
-                            font-size: 11px;
-                            font-weight: bold;
                             background: transparent;
                             padding: 0px;
                         }}
                     """)
-                    name_label.setWordWrap(True)
+                    # Wrapping is done by hand: setWordWrap cannot break a single
+                    # long name, and the slot has no room for a third line.
+                    name_label.setWordWrap(False)
+                    name_label.setText(
+                        fit_text_to_slot(
+                            display_name,
+                            name_label.fontMetrics(),
+                            self.slot_size - 8,  # minus the layout's 4px margins
+                        )
+                    )
 
                     level_text = self.translator.translate("level_label", level=pokemon.get('level', 1))
                     level_label = QLabel(level_text)
@@ -1501,9 +1555,6 @@ class PokemonPC(QDialog):
 
                     text_layout.addWidget(name_label)
                     text_layout.addWidget(level_label)
-
-                    pokemon_button._name_label = name_label
-                    pokemon_button._level_label = level_label
 
                 # BFF (highest friendship) takes visual precedence
                 is_bff = bff_id is not None and pokemon.get("individual_id") == bff_id
@@ -1591,7 +1642,7 @@ class PokemonPC(QDialog):
                     )
                     badge_tooltips.append(self.translator.translate("bff_tooltip"))
 
-                if pokemon.get("shiny", False):
+                if is_shiny:
                     shiny_badge = QLabel("⭐", self.grid_container)
                     shiny_badge.setAttribute(
                         Qt.WidgetAttribute.WA_TransparentForMouseEvents
@@ -1621,9 +1672,11 @@ class PokemonPC(QDialog):
                     evo_badge.setAttribute(
                         Qt.WidgetAttribute.WA_TransparentForMouseEvents
                     )
-                    evo_badge.setFixedSize(
-                        23, 23
-                    )
+                    # Sit below the shiny star when there is one. The label has to
+                    # grow with the margin: a top margin taller than the widget
+                    # leaves a negative content height and nothing is painted.
+                    evo_margin_top = 24 if is_shiny else 2
+                    evo_badge.setFixedSize(23, evo_margin_top + 21)
 
                     # Load the generated high-quality PNG asset
                     badge_path = addon_dir / "addon_sprites" / "evolution_indicator.png"
@@ -1636,37 +1689,22 @@ class PokemonPC(QDialog):
                             Qt.TransformationMode.SmoothTransformation,
                         )
                         evo_badge.setPixmap(scaled_pixmap)
-                        if pokemon.get("shiny", False):
-                            evo_badge.setStyleSheet(
-                                "margin-top: 24px; margin-right: 1px; background: transparent;"
-                            )
-                        else:
-                            evo_badge.setStyleSheet(
-                                "margin-top: 2px; margin-right: 1px; background: transparent;"
-                            )
+                        evo_badge.setStyleSheet(
+                            f"margin-top: {evo_margin_top}px; margin-right: 1px;"
+                            " background: transparent;"
+                        )
                     else:
                         # Fallback to plain text ⇈ if asset is not found
                         evo_badge.setText("⇈")
-                        if pokemon.get("shiny", False):
-                            evo_badge.setStyleSheet(
-                                "QLabel {"
-                                "  color: #3b82f6;"
-                                "  font-weight: bold;"
-                                "  margin-top: 24px;"
-                                "  margin-right: 1px;"
-                                "  background: transparent;"
-                                "}"
-                            )
-                        else:
-                            evo_badge.setStyleSheet(
-                                "QLabel {"
-                                "  color: #3b82f6;"
-                                "  font-weight: bold;"
-                                "  margin-top: 2px;"
-                                "  margin-right: 1px;"
-                                "  background: transparent;"
-                                "}"
-                            )
+                        evo_badge.setStyleSheet(
+                            "QLabel {"
+                            "  color: #3b82f6;"
+                            "  font-weight: bold;"
+                            f"  margin-top: {evo_margin_top}px;"
+                            "  margin-right: 1px;"
+                            "  background: transparent;"
+                            "}"
+                        )
 
                     evo_badge.setAlignment(Qt.AlignmentFlag.AlignCenter)
                     self.pokemon_grid.addWidget(
@@ -1689,22 +1727,14 @@ class PokemonPC(QDialog):
                     wait_badge.setAttribute(
                         Qt.WidgetAttribute.WA_TransparentForMouseEvents
                     )
-                    if pokemon.get("shiny", False):
-                        wait_badge.setStyleSheet(
-                            "QLabel {"
-                            "  margin-top: 24px;"
-                            "  margin-right: 5px;"
-                            "  background: transparent;"
-                            "}"
-                        )
-                    else:
-                        wait_badge.setStyleSheet(
-                            "QLabel {"
-                            "  margin-top: 5px;"
-                            "  margin-right: 5px;"
-                            "  background: transparent;"
-                            "}"
-                        )
+                    # No setFixedSize here, so the label grows with the margin.
+                    wait_badge.setStyleSheet(
+                        "QLabel {"
+                        f"  margin-top: {24 if is_shiny else 5}px;"
+                        "  margin-right: 5px;"
+                        "  background: transparent;"
+                        "}"
+                    )
                     wait_badge.setAlignment(Qt.AlignmentFlag.AlignCenter)
                     self.pokemon_grid.addWidget(
                         wait_badge,
@@ -1719,8 +1749,13 @@ class PokemonPC(QDialog):
                         else "badge_wait_day"
                     )
                     badge_tooltips.append(self.translator.translate(key))
-                if badge_tooltips:
-                    pokemon_button.setToolTip("\n".join(badge_tooltips))
+                # In text mode the name may have been elided to fit the slot, so
+                # the tooltip leads with the full name before any badge text.
+                tooltip_lines = badge_tooltips
+                if display_name:
+                    tooltip_lines = [display_name] + badge_tooltips
+                if tooltip_lines:
+                    pokemon_button.setToolTip("\n".join(tooltip_lines))
         self._update_count_label()
         self._refresh_slot_selection()
 

--- a/src/Ankimon/pyobj/pc_box.py
+++ b/src/Ankimon/pyobj/pc_box.py
@@ -306,7 +306,7 @@ class MoveManagerWidget(QWidget):
                     QPushButton { 
                         text-align: left; 
                         font-size: 12px; 
-                        color: #00112b; 
+                        color: #e6edf3; 
                         font-weight: 600; 
                         border: none; 
                         padding: 4px 8px; 
@@ -972,7 +972,7 @@ class PokemonPC(QDialog):
             + """
             #countLabel {
                 font-size: 11px;
-                color: #00112b;
+                color: #94a3b8;
                 padding: 2px 8px 4px 8px;
                 letter-spacing: 0.3px;
             }
@@ -1419,8 +1419,8 @@ class PokemonPC(QDialog):
         is_dark_mode = theme_manager.night_mode
 
         if is_dark_mode:
-            species_color = "#e6edf3"
-            level_color = "#ffffff"
+            species_color = "#ffffff"
+            level_color = "#e6edf3"
         else:
             species_color = "#010a1c"
             level_color = "#00112b"
@@ -1459,10 +1459,12 @@ class PokemonPC(QDialog):
                     pokemon_button.setObjectName("pokemonSlot")
                     pokemon_button.setFixedSize(self.slot_size, self.slot_size)
 
-                    # Get the species name (use nickname if available, otherwise the species name)
                     display_name = pokemon.get("nickname") or pokemon.get("name", "???")
                     if display_name:
-                        display_name = display_name.capitalize()
+                        if pokemon.get("nickname"):
+                            pass
+                        else:
+                            display_name = format_lore_name(display_name)
 
                     # Create a vertical layout for the text
                     text_layout = QVBoxLayout(pokemon_button)
@@ -1633,10 +1635,9 @@ class PokemonPC(QDialog):
                             Qt.TransformationMode.SmoothTransformation,
                         )
                         evo_badge.setPixmap(scaled_pixmap)
-                        # If more than one overlap is present, adjust margin to avoid overlap
                         if pokemon.get("shiny", False):
                             evo_badge.setStyleSheet(
-                                "margin-top: 28px; margin-right: 1px; background: transparent;"
+                                "margin-top: 24px; margin-right: 1px; background: transparent;"
                             )
                         else:
                             evo_badge.setStyleSheet(
@@ -1650,7 +1651,7 @@ class PokemonPC(QDialog):
                                 "QLabel {"
                                 "  color: #3b82f6;"
                                 "  font-weight: bold;"
-                                "  margin-top: 28px;"
+                                "  margin-top: 24px;"
                                 "  margin-right: 1px;"
                                 "  background: transparent;"
                                 "}"
@@ -1690,7 +1691,7 @@ class PokemonPC(QDialog):
                     if pokemon.get("shiny", False):
                         wait_badge.setStyleSheet(
                             "QLabel {"
-                            "  margin-top: 28px;"
+                            "  margin-top: 24px;"
                             "  margin-right: 5px;"
                             "  background: transparent;"
                             "}"

--- a/src/Ankimon/pyobj/pc_box.py
+++ b/src/Ankimon/pyobj/pc_box.py
@@ -1486,7 +1486,8 @@ class PokemonPC(QDialog):
                     """)
                     name_label.setWordWrap(True)
 
-                    level_label = QLabel(f"Lvl {pokemon.get('level', 1)}")
+                    level_text = self.translator.translate("level_label", level=pokemon.get('level', 1))
+                    level_label = QLabel(level_text)
                     level_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
                     level_label.setStyleSheet(f"""
                         QLabel {{
@@ -1611,7 +1612,7 @@ class PokemonPC(QDialog):
                         alignment=Qt.AlignmentFlag.AlignTop
                         | Qt.AlignmentFlag.AlignRight,
                     )
-                    badge_tooltips.append("Shiny Pokémon")
+                    badge_tooltips.append(self.translator.translate("shiny_tooltip"))
 
                 if readiness["ready"] and (
                     readiness["method"] == "level" or friendship_time_enabled

--- a/src/Ankimon/pyobj/pc_box.py
+++ b/src/Ankimon/pyobj/pc_box.py
@@ -306,7 +306,7 @@ class MoveManagerWidget(QWidget):
                     QPushButton { 
                         text-align: left; 
                         font-size: 12px; 
-                        color: #e6edf3; 
+                        color: #00112b; 
                         font-weight: 600; 
                         border: none; 
                         padding: 4px 8px; 
@@ -972,7 +972,7 @@ class PokemonPC(QDialog):
             + """
             #countLabel {
                 font-size: 11px;
-                color: #94a3b8;
+                color: #00112b;
                 padding: 2px 8px 4px 8px;
                 letter-spacing: 0.3px;
             }
@@ -1416,6 +1416,15 @@ class PokemonPC(QDialog):
         theme_vars = self.theme_vars
         border = theme_vars["button_border"]
 
+        is_dark_mode = theme_manager.night_mode
+
+        if is_dark_mode:
+            species_color = "#e6edf3"
+            level_color = "#ffffff"
+        else:
+            species_color = "#010a1c"
+            level_color = "#00112b"
+
         for row in range(self.n_rows):
             for col in range(self.n_cols):
                 pokemon_idx = row * self.n_cols + col
@@ -1428,17 +1437,70 @@ class PokemonPC(QDialog):
                     continue
 
                 pokemon = pokemon_list_slice[pokemon_idx]
-                pkmn_image_path = get_sprite_path(
-                    "front",
-                    "gif" if self.gif_in_collection else "png",
-                    pokemon["id"],
-                    pokemon.get("shiny", False),
-                    pokemon["gender"],
-                    pokemon.get("name"),
-                )
-                pokemon_button = PokemonSlotButton("", self.grid_container)
-                pokemon_button.setObjectName("pokemonSlot")
-                pokemon_button.setFixedSize(self.slot_size, self.slot_size)
+
+                show_sprites = self.show_sprites_across_ankimon
+
+                if show_sprites:
+                    # SPRITE MODE: Show the Pokémon sprite
+                    pkmn_image_path = get_sprite_path(
+                        "front",
+                        "gif" if self.gif_in_collection else "png",
+                        pokemon["id"],
+                        pokemon.get("shiny", False),
+                        pokemon["gender"],
+                        pokemon.get("name"),
+                    )
+                    pokemon_button = PokemonSlotButton("", self.grid_container)
+                    pokemon_button.setObjectName("pokemonSlot")
+                    pokemon_button.setFixedSize(self.slot_size, self.slot_size)
+                else:
+                    # TEXT MODE: Show species name and level
+                    pokemon_button = PokemonSlotButton("", self.grid_container)
+                    pokemon_button.setObjectName("pokemonSlot")
+                    pokemon_button.setFixedSize(self.slot_size, self.slot_size)
+
+                    # Get the species name (use nickname if available, otherwise the species name)
+                    display_name = pokemon.get("nickname") or pokemon.get("name", "???")
+                    if display_name:
+                        display_name = display_name.capitalize()
+
+                    # Create a vertical layout for the text
+                    text_layout = QVBoxLayout(pokemon_button)
+                    text_layout.setContentsMargins(4, 4, 4, 4)
+                    text_layout.setSpacing(2)
+                    text_layout.setAlignment(Qt.AlignmentFlag.AlignCenter)
+
+                    # Species name label with theme-aware color
+                    name_label = QLabel(display_name)
+                    name_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
+                    name_label.setStyleSheet(f"""
+                        QLabel {{
+                            color: {species_color};
+                            font-size: 11px;
+                            font-weight: bold;
+                            background: transparent;
+                            padding: 0px;
+                        }}
+                    """)
+                    name_label.setWordWrap(True)
+
+                    level_label = QLabel(f"Lvl {pokemon.get('level', 1)}")
+                    level_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
+                    level_label.setStyleSheet(f"""
+                        QLabel {{
+                            color: {level_color};
+                            font-size: 10px;
+                            font-weight: normal;
+                            background: transparent;
+                            padding: 0px;
+                        }}
+                    """)
+
+                    text_layout.addWidget(name_label)
+                    text_layout.addWidget(level_label)
+
+                    pokemon_button._name_label = name_label
+                    pokemon_button._level_label = level_label
 
                 # BFF (highest friendship) takes visual precedence
                 is_bff = bff_id is not None and pokemon.get("individual_id") == bff_id
@@ -1478,29 +1540,30 @@ class PokemonPC(QDialog):
                     pokemon_button, row, col, alignment=Qt.AlignmentFlag.AlignCenter
                 )
 
-                if self.gif_in_collection and self.show_sprites_across_ankimon:
-                    scaled_movie_label = ScaledMovieLabel(
-                        pkmn_image_path,
-                        self.slot_size - 10,
-                        self.slot_size - 10,
-                        self.grid_container,
-                    )
-                    scaled_movie_label.setAttribute(
-                        Qt.WidgetAttribute.WA_TransparentForMouseEvents
-                    )
-                    self.pokemon_grid.addWidget(
-                        scaled_movie_label,
-                        row,
-                        col,
-                        alignment=Qt.AlignmentFlag.AlignCenter,
-                    )
-                elif self.show_sprites_across_ankimon:
-                    pokemon_button.setIcon(QIcon(pkmn_image_path))
-                    pokemon_button.setIconSize(
-                        QSize(self.slot_size - 10, self.slot_size - 10)
-                    )
+                if show_sprites:
+                    if self.gif_in_collection:
+                        scaled_movie_label = ScaledMovieLabel(
+                            pkmn_image_path,
+                            self.slot_size - 10,
+                            self.slot_size - 10,
+                            self.grid_container,
+                        )
+                        scaled_movie_label.setAttribute(
+                            Qt.WidgetAttribute.WA_TransparentForMouseEvents
+                        )
+                        self.pokemon_grid.addWidget(
+                            scaled_movie_label,
+                            row,
+                            col,
+                            alignment=Qt.AlignmentFlag.AlignCenter,
+                        )
+                    else:
+                        pokemon_button.setIcon(QIcon(pkmn_image_path))
+                        pokemon_button.setIconSize(
+                            QSize(self.slot_size - 10, self.slot_size - 10)
+                        )
 
-                # Overlays (Heart for BFF, Star/Moon/Sun for Evolution)
+                # Overlays (Heart for BFF, Star for Shiny, Evolution indicators)
                 badge_tooltips = []
                 readiness = evolution_readiness(pokemon)
 
@@ -1525,6 +1588,29 @@ class PokemonPC(QDialog):
                     )
                     badge_tooltips.append(self.translator.translate("bff_tooltip"))
 
+                if pokemon.get("shiny", False):
+                    shiny_badge = QLabel("⭐", self.grid_container)
+                    shiny_badge.setAttribute(
+                        Qt.WidgetAttribute.WA_TransparentForMouseEvents
+                    )
+                    shiny_badge.setStyleSheet(
+                        "QLabel {"
+                        "  margin-top: 5px;"
+                        "  margin-right: 5px;"
+                        "  background: transparent;"
+                        "  font-size: 16px;"
+                        "}"
+                    )
+                    shiny_badge.setAlignment(Qt.AlignmentFlag.AlignCenter)
+                    self.pokemon_grid.addWidget(
+                        shiny_badge,
+                        row,
+                        col,
+                        alignment=Qt.AlignmentFlag.AlignTop
+                        | Qt.AlignmentFlag.AlignRight,
+                    )
+                    badge_tooltips.append("Shiny Pokémon")
+
                 if readiness["ready"] and (
                     readiness["method"] == "level" or friendship_time_enabled
                 ):
@@ -1534,7 +1620,7 @@ class PokemonPC(QDialog):
                     )
                     evo_badge.setFixedSize(
                         23, 23
-                    )  # Slightly larger size to accommodate margins cleanly
+                    )
 
                     # Load the generated high-quality PNG asset
                     badge_path = addon_dir / "addon_sprites" / "evolution_indicator.png"
@@ -1547,21 +1633,38 @@ class PokemonPC(QDialog):
                             Qt.TransformationMode.SmoothTransformation,
                         )
                         evo_badge.setPixmap(scaled_pixmap)
-                        evo_badge.setStyleSheet(
-                            "margin-top: 2px; margin-right: 1px; background: transparent;"
-                        )
+                        # If more than one overlap is present, adjust margin to avoid overlap
+                        if pokemon.get("shiny", False):
+                            evo_badge.setStyleSheet(
+                                "margin-top: 28px; margin-right: 1px; background: transparent;"
+                            )
+                        else:
+                            evo_badge.setStyleSheet(
+                                "margin-top: 2px; margin-right: 1px; background: transparent;"
+                            )
                     else:
                         # Fallback to plain text ⇈ if asset is not found
                         evo_badge.setText("⇈")
-                        evo_badge.setStyleSheet(
-                            "QLabel {"
-                            "  color: #3b82f6;"
-                            "  font-weight: bold;"
-                            "  margin-top: 2px;"
-                            "  margin-right: 1px;"
-                            "  background: transparent;"
-                            "}"
-                        )
+                        if pokemon.get("shiny", False):
+                            evo_badge.setStyleSheet(
+                                "QLabel {"
+                                "  color: #3b82f6;"
+                                "  font-weight: bold;"
+                                "  margin-top: 28px;"
+                                "  margin-right: 1px;"
+                                "  background: transparent;"
+                                "}"
+                            )
+                        else:
+                            evo_badge.setStyleSheet(
+                                "QLabel {"
+                                "  color: #3b82f6;"
+                                "  font-weight: bold;"
+                                "  margin-top: 2px;"
+                                "  margin-right: 1px;"
+                                "  background: transparent;"
+                                "}"
+                            )
 
                     evo_badge.setAlignment(Qt.AlignmentFlag.AlignCenter)
                     self.pokemon_grid.addWidget(
@@ -1584,13 +1687,23 @@ class PokemonPC(QDialog):
                     wait_badge.setAttribute(
                         Qt.WidgetAttribute.WA_TransparentForMouseEvents
                     )
-                    wait_badge.setStyleSheet(
-                        "QLabel {"
-                        "  margin-top: 5px;"
-                        "  margin-right: 5px;"
-                        "  background: transparent;"
-                        "}"
-                    )
+                    if pokemon.get("shiny", False):
+                        wait_badge.setStyleSheet(
+                            "QLabel {"
+                            "  margin-top: 28px;"
+                            "  margin-right: 5px;"
+                            "  background: transparent;"
+                            "}"
+                        )
+                    else:
+                        wait_badge.setStyleSheet(
+                            "QLabel {"
+                            "  margin-top: 5px;"
+                            "  margin-right: 5px;"
+                            "  background: transparent;"
+                            "}"
+                        )
+                    wait_badge.setAlignment(Qt.AlignmentFlag.AlignCenter)
                     self.pokemon_grid.addWidget(
                         wait_badge,
                         row,


### PR DESCRIPTION
### At A Glance, This PR
- Adds a **text representation** for the **Mon PC**
- Adds a **Shiny icon overlay** for Shiny Mons

### What This PR Does
Consider these as a small feature "facelift" for the **Mon PC** before a large refactoring (conversion to Web UI) occurs.
1. In light of **Show Sprites Across Ankimon**, hiding sprites empties the Mon boxes - trainers have to click on every box to check out / find their Mons. Now, when the setting is disabled, the **Mon's species and level** replace the sprites, so trainers can read their collection **at a glance**. Note: **nicknames** take priority of species if both are present. 
2. While working on the Mon PC, I realised that the favourite and evolution overlay icons come pretty handy for quick screens. Hence, this PR adds a **star icon as the Shiny overlay** - useful to **identify rare Mons** from the rest (or, for example, when **screening** one's collection **after review**).

### What Each File Does
This PR modifies only **`pc_box.py`** in the following ways:
- Adds the **Mon species & level display**
- Wires the **Shiny icon overlay**
- Handles the possibility of **more than one icon overlap**

### Expected Behaviour
Trainer views their Mon PC in Ankimon > Collection > Pokémon PC
- With Show Sprites Across Ankimon enabled, Mon species and level successfully replaced the sprites.
- Regardless of whether sprites are enabled, all shiny Mon have a star emoji on their box. 

#### Example With Sprites Disabled
<img width="452" height="279" alt="image" src="https://github.com/user-attachments/assets/f514a0c4-ea41-4d39-83fd-70d75f4b5720" />

### Future Enhancements
Conversion of the Mon PC window to the Web UI. 

### Related Issues
_N/A_

### Checklist
- [x] My code and commit messages follow the code style and guidelines of this project.
- [x] I have personally viewed the Mon PC collection with sprites disabled: the text and shiny overlay display as intended. 