### PR TITLE
fix(hud): make dark mode reach the HUD, and stop overriding the XP pill

### DIFF
--- a/src/Ankimon/functions/create_css_for_reviewer.py
+++ b/src/Ankimon/functions/create_css_for_reviewer.py
@@ -54,14 +54,19 @@ def create_css_for_reviewer(
   transform: scaleX(-1) !important;
 }
 
-/* Theme variables */
-:host, :root {
+/* Theme variables. Keyed off the night_mode class the HUD carries (set from
+   theme_manager.night_mode in reviewer_obj.py), not @media
+   (prefers-color-scheme: dark): the media query tracks the OS, so once the
+   pills started following Anki the outline was the one thing left following
+   the desktop -- a white pill ringed in #1F1F1F for anyone running Anki light
+   on a dark desktop, and a white ring around the black XP pill in the mirror
+   case. Every var(--ankimon-outline) consumer is a descendant of
+   #ankimon-hud, so defining it there still inherits to all of them. */
+#ankimon-hud {
   --ankimon-outline: #FFFFFF; /* Light mode outline */
 }
-@media (prefers-color-scheme: dark) {
-  :host, :root {
-    --ankimon-outline: #1F1F1F; /* Dark mode outline */
-  }
+#ankimon-hud.night_mode {
+  --ankimon-outline: #1F1F1F; /* Dark mode outline */
 }
 
 /* If any parent applies invert, force HUD back to normal colors */

--- a/src/Ankimon/functions/create_css_for_reviewer.py
+++ b/src/Ankimon/functions/create_css_for_reviewer.py
@@ -84,37 +84,14 @@ def create_css_for_reviewer(
   background-position: bottom;
 }
 
-/* If a global inversion is applied above #ankimon-hud (e.g., body/html),
-   double-invert these to visually cancel it. This only takes effect if parent is inverted. */
-@supports (filter: invert(100%)) {
-  html[style*="invert("] #ankimon-hud #PokeImage,
-  html[style*="invert("] #ankimon-hud #MyPokeImage,
-  body[style*="invert("] #ankimon-hud #PokeImage,
-  body[style*="invert("] #ankimon-hud #MyPokeImage {
-    filter: invert(100%) hue-rotate(180deg) !important;
-  }
-}
-
-/* Also counter popular dark-mode classes some themes add */
-html.dark #ankimon-hud,
-body.dark #ankimon-hud,
-.night_mode #ankimon-hud,
-.theme-dark #ankimon-hud {
-  filter: none !important;
-  -webkit-filter: none !important;
-}
-html.dark #ankimon-hud #PokeImage,
-html.dark #ankimon-hud #MyPokeImage,
-body.dark #ankimon-hud #PokeImage,
-body.dark #ankimon-hud #MyPokeImage,
-.night_mode #ankimon-hud #PokeImage,
-.night_mode #ankimon-hud #MyPokeImage,
-.theme-dark #ankimon-hud #PokeImage,
-.theme-dark #ankimon-hud #MyPokeImage {
-  filter: none !important;
-  -webkit-filter: none !important;
-  mix-blend-mode: normal !important;
-}
+/* NOTE: there used to be ancestor-anchored dark-mode blocks here
+   (html.dark / body.dark / .night_mode / .theme-dark, and an
+   html[style*="invert("] @supports block). They could never match: this
+   stylesheet is injected into a closed shadow root whose host is appended to
+   <html>, so a class or inline style on <body> is neither visible across the
+   shadow boundary nor an ancestor of the host. They were also redundant --
+   the unconditional #ankimon-hud rules above already force filter: none, and
+   the portal applies its own counter-filter on the host element. */
 
 /* Shared pill style (more vivid than 25%, outlined, no glow) */
 #ankimon-hud .ankimon-pill {
@@ -462,6 +439,9 @@ body.dark #ankimon-hud #MyPokeImage,
   left: 15px;
   z-index: 9999;
   color: rgba(0, 191, 255, 0.85);
+  /* The shadow root resets inherited styles, and #xp_text no longer shares the
+     display-pill rule in reviewer_obj.py, so it states its own font. */
+  font-family: Arial, sans-serif;
   font-size: 10px;
   font-weight: bold;
   text-align: center;

--- a/src/Ankimon/pyobj/reviewer_obj.py
+++ b/src/Ankimon/pyobj/reviewer_obj.py
@@ -53,6 +53,14 @@ class Reviewer_Manager:
         _handlers = (
             (gui_hooks.reviewer_will_end, self.reviewer_reset_life_bar_inject),
             (gui_hooks.reviewer_did_answer_card, self.update_life_bar),
+            # Anki announces a theme flip by toggling classes on <html>/<body>
+            # (aqt.webview.on_theme_did_change); it never reloads the page.
+            # That signal cannot cross the HUD's closed shadow boundary, so the
+            # HUD has to repaint itself or it keeps the old palette until the
+            # next answered card. The same hook covers an OS flip while Anki is
+            # set to "Automatic" -- theme_manager fires it either way -- which
+            # is what @media (prefers-color-scheme: dark) used to handle live.
+            (gui_hooks.theme_did_change, self.refresh_hud),
         )
         for _hook, _handler in _handlers:
             _hook.append(_handler)

--- a/src/Ankimon/pyobj/reviewer_obj.py
+++ b/src/Ankimon/pyobj/reviewer_obj.py
@@ -10,6 +10,18 @@ from ..services import services
 from .pokemon_obj import PokemonObject
 
 
+def _anki_night_mode():
+    """Anki's resolved night-mode flag, or False if the theme layer is
+    unavailable (older Anki, or a headless context without a theme manager).
+    The HUD only uses it to pick a class, so degrading to light is harmless."""
+    try:
+        from aqt.theme import theme_manager
+
+        return bool(theme_manager.night_mode)
+    except Exception:
+        return False
+
+
 class Reviewer_Manager:
     def __init__(self, settings_obj, main_pokemon, enemy_pokemon, ankimon_tracker):
         self.settings = settings_obj
@@ -297,6 +309,10 @@ class Reviewer_Manager:
             self.settings.get("gui.hud_enemy_shiny_indicator"),
             self.settings.get("gui.hud_player_shiny_indicator"),
             self.settings.get("gui.reviewer_text_message_box"),
+            # Anki's theme drives a class on the HUD, so a theme flip has to
+            # invalidate the repaint cache or the HUD keeps the old palette
+            # until some other piece of state happens to change.
+            _anki_night_mode(),
         )
         if self._last_state == current_state and card is not None:
             return  # No changes, skip update
@@ -341,8 +357,15 @@ class Reviewer_Manager:
         enemy_hp_true_percent = (enemy_hp / enemy_max_hp) * 100
         main_hp_true_percent = (main_hp / main_max_hp) * 100
 
-        # Build hud_html
-        hud_html = '<div id="ankimon-hud">'
+        # Build hud_html. The HUD carries Anki's theme as its own class: its
+        # stylesheet lives in a closed shadow root, so it cannot see the
+        # night-mode class Anki sets on <body>. theme_manager.night_mode is the
+        # resolved value, so "Automatic" follows the OS correctly.
+        hud_html = (
+            '<div id="ankimon-hud" class="night_mode">'
+            if _anki_night_mode()
+            else '<div id="ankimon-hud">'
+        )
         if self.settings.get("gui.hud_hp_bars"):
             hud_html += '<div id="life-bar" class="Ankimon"></div>'
         if self.settings.get("gui.hud_xp_bar"):
@@ -471,8 +494,18 @@ class Reviewer_Manager:
                 enemy_hp_true_percent,
                 main_hp_true_percent,
             )
+            # Theme selectors are anchored on #ankimon-hud itself (see the
+            # ``night_mode`` class added in hud_html above), never on an
+            # ancestor such as ``.night_mode``/``html.dark``. The HUD lives in
+            # a closed shadow root whose host is appended to <html>, so a class
+            # Anki sets on <body> is neither reachable across the shadow
+            # boundary nor an ancestor of the host — those rules never matched.
+            #
+            # #xp_text is deliberately absent here: create_css_for_reviewer
+            # gives it its own cyan-on-black pill matching the XP bar, and
+            # listing it in these groups overrode that with a plain pill.
             hud_css += """
-            #ankimon-hud #name-display, #ankimon-hud #myname-display, #ankimon-hud #hp-display, #ankimon-hud #myhp-display, #ankimon-hud #xp_text {
+            #ankimon-hud #name-display, #ankimon-hud #myname-display, #ankimon-hud #hp-display, #ankimon-hud #myhp-display {
                 font-family: Arial, sans-serif;
                 background: white !important;
                 color: var(--text-fg, #6D6D6E);
@@ -480,29 +513,18 @@ class Reviewer_Manager:
                 padding: 4px 8px !important;
             }
 
-            @media (prefers-color-scheme: dark) {
-                #ankimon-hud #name-display, #ankimon-hud #myname-display, #ankimon-hud #hp-display, #ankimon-hud #myhp-display, #ankimon-hud #xp_text {
-                    font-family: Arial, sans-serif;
-                    background: #1f1f1f !important;
-                    color: white !important;
-                    border-radius: 5px !important;
-                    padding: 4px 8px !important;
-                }
-            }
-
-            .night_mode #ankimon-hud #name-display, .night_mode #ankimon-hud #myname-display, .night_mode #ankimon-hud #hp-display,
-            .night_mode #ankimon-hud #myhp-display, .night_mode #ankimon-hud{
+            /* Dark mode keys off Anki's own theme, not the OS. There is no
+               @media (prefers-color-scheme: dark) rule here on purpose:
+               theme_manager.night_mode already resolves Anki's "Automatic"
+               setting against the OS, so a media query adds nothing when the
+               two agree and actively contradicts Anki when they differ — a
+               user on a dark OS who deliberately runs Anki in light mode got
+               dark HUD pills. */
+            #ankimon-hud.night_mode #name-display, #ankimon-hud.night_mode #myname-display,
+            #ankimon-hud.night_mode #hp-display, #ankimon-hud.night_mode #myhp-display {
                 font-family: Arial, sans-serif;
                 background: #1f1f1f !important;
                 color: white !important;
-                border-radius: 5px !important;
-                padding: 4px 8px !important;
-            }
-
-            .night_mode #ankimon-hud #xp_text {
-                color: rgba(0, 191, 255, 0.85) !important;
-                font-family: Arial, sans-serif;
-                background: #1f1f1f !important;
                 border-radius: 5px !important;
                 padding: 4px 8px !important;
             }

--- a/tests/test_reviewer_hud_css.py
+++ b/tests/test_reviewer_hud_css.py
@@ -46,3 +46,79 @@ def test_no_selector_opens_a_block_it_never_fills():
             f"selector {first!r} opens a block whose next line {second!r} "
             "opens another — the first block is never filled or closed"
         )
+
+
+def _create_css_source():
+    """The other half of the HUD stylesheet, built by create_css_for_reviewer."""
+    path = (
+        Path(__file__).parent.parent
+        / "src"
+        / "Ankimon"
+        / "functions"
+        / "create_css_for_reviewer.py"
+    )
+    return path.read_text(encoding="utf-8")
+
+
+# A selector that leads with any of these needs an element OUTSIDE the HUD's
+# shadow root to match. The stylesheet is injected into a closed shadow root
+# whose host is appended to <html>, so such a selector is doubly unreachable:
+# it cannot cross the shadow boundary, and <body> is not even an ancestor of
+# the host. Anki's theme reaches the HUD as a class on #ankimon-hud instead.
+_ANCESTOR_THEME_PREFIXES = (
+    ".night_mode ",
+    ".theme-dark ",
+    "html.",
+    "body.",
+    "html[",
+    "body[",
+)
+
+
+def _selector_lines(css):
+    for line in css.splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith(("/*", "*", "@")):
+            continue
+        # selector lines either open a block or continue a comma-separated list
+        if stripped.endswith("{") or stripped.endswith(","):
+            yield stripped
+
+
+def test_no_rule_depends_on_an_ancestor_outside_the_shadow_root():
+    for source_name, css in (
+        ("reviewer_obj.py", _hud_css_literal()),
+        ("create_css_for_reviewer.py", _create_css_source()),
+    ):
+        for selector in _selector_lines(css):
+            for prefix in _ANCESTOR_THEME_PREFIXES:
+                assert not selector.startswith(prefix), (
+                    f"{source_name}: selector {selector!r} matches on an ancestor "
+                    "outside the HUD's shadow root, so it can never apply. "
+                    "Anchor it on #ankimon-hud (e.g. '#ankimon-hud.night_mode')."
+                )
+
+
+def test_hud_markup_carries_ankis_theme_as_a_class():
+    """The night-mode class must be on #ankimon-hud itself — that is the only
+    theme signal that survives the shadow boundary."""
+    source = REVIEWER_OBJ.read_text(encoding="utf-8")
+    assert '<div id="ankimon-hud" class="night_mode">' in source, (
+        "the HUD no longer emits Anki's theme as a class on #ankimon-hud"
+    )
+    assert "#ankimon-hud.night_mode" in _hud_css_literal(), (
+        "no rule consumes the night_mode class, so dark mode styles nothing"
+    )
+
+
+def test_xp_text_is_not_overridden_by_the_display_pill_group():
+    """#xp_text has its own cyan-on-black pill in create_css_for_reviewer.
+    Listing it in reviewer_obj's later display-pill rules silently overrode
+    that (equal specificity, later wins), which is what made the colour fix
+    in #795 invisible."""
+    for selector in _selector_lines(_hud_css_literal()):
+        assert "#xp_text" not in selector, (
+            f"selector {selector!r} re-styles #xp_text after "
+            "create_css_for_reviewer already did; the later rule wins and the "
+            "dedicated XP styling is lost"
+        )

--- a/tests/test_reviewer_hud_css.py
+++ b/tests/test_reviewer_hud_css.py
@@ -122,3 +122,54 @@ def test_xp_text_is_not_overridden_by_the_display_pill_group():
             "create_css_for_reviewer already did; the later rule wins and the "
             "dedicated XP styling is lost"
         )
+
+
+def _without_comments(css):
+    """Rules only. Both files *explain* in comments why the OS media query is
+    gone, and a naive substring search would read those explanations as the
+    thing they warn about."""
+    return re.sub(r"/\*.*?\*/", "", css, flags=re.S)
+
+
+def test_no_hud_rule_keys_off_the_operating_system_theme():
+    """``prefers-color-scheme`` reports the OS, never Anki. Once the HUD takes
+    its theme from ``theme_manager.night_mode`` (the resolved flag, which
+    already folds in the OS for Anki's "Automatic"), any surviving media query
+    is a second, contradicting source of truth: it darkened the HUD for a user
+    who deliberately ran Anki light on a dark desktop."""
+    for source_name, css in (
+        ("reviewer_obj.py", _hud_css_literal()),
+        ("create_css_for_reviewer.py", _create_css_source()),
+    ):
+        css = _without_comments(css)
+        assert "prefers-color-scheme" not in css, (
+            f"{source_name}: a rule still keys off the OS colour scheme. "
+            "The HUD's theme is Anki's resolved night_mode flag — see the "
+            "night_mode class on #ankimon-hud."
+        )
+
+
+def test_the_outline_variable_follows_the_same_theme_as_everything_else():
+    """--ankimon-outline feeds every pill and bar outline. When it was the one
+    property still driven by the OS it disagreed with the pills it outlined:
+    Anki light on a dark desktop drew a #1F1F1F ring around a white pill."""
+    css = _create_css_source()
+    for selector in ("#ankimon-hud {", "#ankimon-hud.night_mode {"):
+        assert any(
+            "--ankimon-outline" in block for block in _blocks_for(css, selector)
+        ), (
+            f"no {selector!r} block defines --ankimon-outline; the light and "
+            "dark values must both hang off the HUD's own theme class, or the "
+            "outline goes back to disagreeing with the pill it outlines"
+        )
+
+
+def _blocks_for(css, selector):
+    """Every block opened by ``selector``, body only. A selector can legitimately
+    appear more than once (``#ankimon-hud`` also carries the filter reset), so
+    callers check whether ANY of its blocks declares what they are after."""
+    start = css.find(selector)
+    while start != -1:
+        body_start = start + len(selector)
+        yield css[body_start : css.find("}", body_start)]
+        start = css.find(selector, body_start)

--- a/tests/test_reviewer_theme_repaint.py
+++ b/tests/test_reviewer_theme_repaint.py
@@ -1,0 +1,244 @@
+"""Anki's theme has to reach the HUD, and has to reach it when it *changes*.
+
+The HUD is rendered inside a closed shadow root whose host is appended to
+``<html>`` (``web/ankimon_hud_portal.js``), so none of Anki's theme signals can
+reach it on their own. Anki announces a theme flip by evaluating a snippet that
+toggles classes on ``<html>``/``<body>`` (``aqt.webview.AnkiWebView
+.on_theme_did_change``) and never reloads the page — that snippet cannot cross
+the shadow boundary, and ``<body>`` is not even an ancestor of the host.
+
+So two things have to hold, and neither is visible from the stylesheet alone:
+the emitted markup must carry the resolved theme as a class on ``#ankimon-hud``
+itself, and ``Reviewer_Manager`` must subscribe to ``theme_did_change`` and
+repaint. Without the subscription the HUD keeps the old palette until the next
+answered card happens to repaint it — and for anyone running Anki's
+"Automatic", that is a regression against the ``@media (prefers-color-scheme:
+dark)`` rule this replaced, which repainted live.
+"""
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+from unittest.mock import MagicMock
+
+_src = Path(__file__).parent.parent / "src"
+_orig_modules = {}
+
+
+# Module (un)loading — snapshot/restore so this file cannot leak its mocks into
+# the rest of the suite (same guard as test_reviewer_ownership_cache.py).
+def setup_module():
+    global _orig_modules
+    _orig_modules = sys.modules.copy()
+
+
+def teardown_module():
+    for k in [k for k in sys.modules if k not in _orig_modules]:
+        del sys.modules[k]
+    sys.modules.update(_orig_modules)
+
+
+class FakeHooks:
+    """gui_hooks stub whose hooks are plain lists, so an unmatched remove()
+    fails loudly instead of being absorbed by a MagicMock."""
+
+    def __init__(self):
+        self.reviewer_will_end = []
+        self.reviewer_did_answer_card = []
+        self.theme_did_change = []
+
+
+class FakeCursor:
+    def fetchone(self):
+        return None
+
+
+class FakeDB:
+    def execute(self, sql, params=()):
+        return FakeCursor()
+
+
+class FakeSettings:
+    def __init__(self):
+        self.values = {
+            "gui.show_mainpkmn_in_reviewer": 0,
+            "gui.reviewer_image_gif": False,
+            "gui.hud_player_sprite": True,
+            "gui.hud_enemy_sprite": True,
+            "gui.hud_xp_bar": True,
+            "gui.hud_hp_bars": True,
+            "gui.hud_hp_text": True,
+            "gui.hud_pokemon_id": True,
+            "gui.hud_pokemon_gen": True,
+            "gui.hud_pokemon_lvl": True,
+            "gui.hud_pokemon_name": True,
+            "gui.hud_status_badge": True,
+            "gui.hud_owned_indicator": True,
+            "gui.hud_enemy_shiny_indicator": True,
+            "gui.hud_player_shiny_indicator": True,
+            "gui.reviewer_text_message_box": False,
+            "gui.review_hp_bar_thickness": 1,
+            "gui.hud_hidden_on_startup": False,
+            "misc.language": 9,
+            "misc.remove_level_cap": False,
+        }
+
+    def get(self, key, default=None):
+        from Ankimon.pyobj.settings import DEFAULT_CONFIG
+
+        if key in self.values:
+            return self.values[key]
+        return DEFAULT_CONFIG.get(key, default)
+
+    def compute_special_variable(self, name):
+        return 0
+
+
+class FakePokemon:
+    def __init__(self, pid=25):
+        self.id = pid
+        self.hp = 10
+        self.max_hp = 20
+        self.battle_status = ""
+        self.shiny = False
+        self.level = 5
+        self.xp = 0
+        self.display_name = "Pikachu"
+        self.pokedex_id = pid
+        self.generation = 1
+        self.growth_rate = "medium"
+
+    def get_sprite_path(self, side, image_format):
+        return "/tmp/sprite." + image_format
+
+    def to_engine_format(self):
+        return {}
+
+
+def _load_reviewer_obj(hooks, fake_services):
+    for name in [
+        "aqt",
+        "aqt.qt",
+        "aqt.utils",
+        "aqt.reviewer",
+        "aqt.gui_hooks",
+        "anki",
+        "anki.hooks",
+    ]:
+        sys.modules[name] = MagicMock()
+    sys.modules["aqt"].gui_hooks = hooks
+
+    services_mod = types.ModuleType("Ankimon.services")
+    services_mod.services = fake_services
+    sys.modules["Ankimon.services"] = services_mod
+    events_mod = types.ModuleType("Ankimon.events")
+    events_mod.events = MagicMock()
+    sys.modules["Ankimon.events"] = events_mod
+
+    for sub in [
+        "Ankimon.pyobj.pokemon_obj",
+        "Ankimon.functions.pokemon_functions",
+        "Ankimon.functions.create_css_for_reviewer",
+        "Ankimon.functions.create_gui_functions",
+        "Ankimon.resources",
+    ]:
+        sys.modules[sub] = MagicMock()
+
+    spec = importlib.util.spec_from_file_location(
+        "Ankimon.pyobj.reviewer_obj", _src / "Ankimon" / "pyobj" / "reviewer_obj.py"
+    )
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["Ankimon.pyobj.reviewer_obj"] = mod
+    spec.loader.exec_module(mod)
+
+    # Render helpers come from now-mocked modules; make them concrete so
+    # update_life_bar runs end to end and emits real markup.
+    mod.create_status_html = lambda *a, **k: ""
+    mod.create_css_for_reviewer = lambda *a, **k: ""
+    mod.find_experience_for_level = lambda *a, **k: 100
+    return mod
+
+
+def _manager(night_mode=False):
+    hooks = FakeHooks()
+    fake_services = types.SimpleNamespace(db=FakeDB(), settings=None, reviewer=None)
+    mod = _load_reviewer_obj(hooks, fake_services)
+    mod._anki_night_mode = lambda: night_mode
+    mgr = mod.Reviewer_Manager(
+        FakeSettings(), FakePokemon(1), FakePokemon(25), MagicMock()
+    )
+    return mod, mgr, hooks, fake_services
+
+
+def _painted_markup(reviewer):
+    """Everything the manager pushed into the webview this far."""
+    return "".join(str(call.args[0]) for call in reviewer.web.eval.call_args_list)
+
+
+def test_theme_did_change_repaints_the_hud():
+    _, mgr, hooks, _ = _manager()
+    assert mgr.refresh_hud in hooks.theme_did_change, (
+        "Reviewer_Manager does not subscribe to theme_did_change, so flipping "
+        "Anki's theme leaves the already-rendered HUD on the old palette — "
+        "Anki's own class toggle cannot reach into the closed shadow root"
+    )
+
+
+def test_a_rebuilt_manager_does_not_double_subscribe():
+    """Reload safety: the registry-anchored handler records must unregister the
+    previous instance's theme handler, or an add-on reload repaints N times."""
+    mod, _, hooks, fake_services = _manager()
+    second = mod.Reviewer_Manager(
+        FakeSettings(), FakePokemon(1), FakePokemon(25), MagicMock()
+    )
+    assert hooks.theme_did_change == [second.refresh_hud], (
+        "a rebuilt Reviewer_Manager left the old instance subscribed to "
+        "theme_did_change"
+    )
+
+
+def test_dark_mode_reaches_the_hud_as_a_class_on_the_hud_itself():
+    _, mgr, _, _ = _manager(night_mode=True)
+    reviewer = MagicMock()
+    mgr.update_life_bar(reviewer, 0, 0)
+    assert '<div id=\\"ankimon-hud\\" class=\\"night_mode\\">' in _painted_markup(
+        reviewer
+    ), "Anki's dark theme did not reach the emitted HUD markup"
+
+
+def test_light_mode_emits_no_theme_class():
+    _, mgr, _, _ = _manager(night_mode=False)
+    reviewer = MagicMock()
+    mgr.update_life_bar(reviewer, 0, 0)
+    painted = _painted_markup(reviewer)
+    # The stylesheet always ships BOTH palettes — the dark one is inert until
+    # the class appears — so this asserts on the markup, not on the CSS.
+    assert '<div id=\\"ankimon-hud\\">' in painted, (
+        "the HUD did not emit its container in light mode"
+    )
+    assert 'class=\\"night_mode\\"' not in painted, (
+        "the HUD claimed Anki's dark theme while Anki was in light mode"
+    )
+
+
+def test_flipping_the_theme_repaints_rather_than_being_cached_away():
+    """The repaint cache short-circuits when nothing else about the encounter
+    changed. A theme flip changes nothing *but* the theme, so the theme has to
+    be part of the cache key or the repaint that theme_did_change triggers is
+    silently dropped."""
+    mod, mgr, _, _ = _manager(night_mode=False)
+    reviewer = MagicMock()
+    mgr.update_life_bar(reviewer, 0, 0)
+    light_calls = len(reviewer.web.eval.call_args_list)
+
+    mod._anki_night_mode = lambda: True
+    mgr.update_life_bar(reviewer, 0, 0)
+
+    assert len(reviewer.web.eval.call_args_list) > light_calls, (
+        "the second repaint was skipped: the theme is missing from the HUD "
+        "repaint cache key, so a theme flip alone never reaches the webview"
+    )
+    assert 'class=\\"night_mode\\"' in _painted_markup(reviewer), (
+        "the repaint after the theme flip still carried the light palette"
+    )


### PR DESCRIPTION
### At A Glance
Follow-up to **#795** (and the CSS finding in **#791**). The reviewer HUD's dark-mode CSS **never applied at all**, and the `font-color` → `color` correction in #795 was **invisible on screen**. Both are fixed here, with the result measured in the same Chromium build Anki embeds.

### The bug
The HUD is rendered inside a **closed shadow root** whose host is appended to `<html>` (`web/ankimon_hud_portal.js`). Every theme rule in its stylesheet was anchored on an **ancestor** — `.night_mode`, `html.dark`, `body.dark`, `.theme-dark` — so none could ever match. Two independent reasons: the selector can't cross the shadow boundary, and `<body>` isn't even an ancestor of the host.

Measured, with `document.body.classList.contains("night_mode") === true`:

```
portal_mounts_host_under:        "HTML"
night_mode_is_ancestor_of_host:  false
nightModeSelectorMatches:        false
```

So the HUD was themed *only* by `@media (prefers-color-scheme: dark)`, which tracks the **OS**, not Anki.

Separately, `#xp_text` was listed in the display-pill groups in `reviewer_obj.py`. Those re-declare `color` at **equal specificity, later in the same stylesheet**, so they beat the dedicated cyan-on-black XP styling in `create_css_for_reviewer.py`. That is exactly why #795's `font-color` → `color` fix changed nothing visible.

### The fix
Anki's theme now reaches the HUD as a **class on `#ankimon-hud` itself**, set from `theme_manager.night_mode` — the pattern already used in `pc_box.py`, `settings_window.py` and `update_dialog.py`. Because that flag is the *resolved* one, "Automatic" still follows the OS.

- **Dark pills apply for the first time.** The `@media (prefers-color-scheme: dark)` block is dropped: the resolved flag already covers the case where OS and Anki agree, and is *correct* when they disagree. Previously a user on a dark OS who deliberately ran Anki in light mode got dark HUD pills.
- **`#xp_text` removed from the pill groups**, so its own cyan-on-black styling (matching the XP bar) survives. It states its own `font-family` now that it no longer shares the group's.
- **Dead blocks deleted** from `create_css_for_reviewer.py` (`html.dark`/`body.dark`/`.night_mode`/`.theme-dark`, and the `html[style*="invert("]` `@supports` block). Unreachable for the same reason, and redundant anyway — the unconditional `#ankimon-hud` rules already force `filter: none`, and the portal applies its own counter-filter on the host.
- The HUD repaint cache key includes the theme flag, so flipping Anki's theme repaints instead of keeping the old palette.

### Measured result
`getComputedStyle` in real Chromium (PyQt6-WebEngine), portal shadow root reproduced faithfully, all four OS × Anki combinations:

| | `#xp_text` | display pill |
|---|---|---|
| **before** — Anki light *or* dark, OS light | grey `#6D6D6E` on white | grey on white |
| **before** — Anki light *or* dark, OS dark | white on `#1f1f1f` | white on `#1f1f1f` |
| **after** — Anki light, either OS | **cyan `rgba(0,191,255,.85)` on black** | grey on white |
| **after** — Anki dark, either OS | **cyan `rgba(0,191,255,.85)` on black** | white on `#1f1f1f` |

Note the "before" rows: Anki's own theme made **no difference** to the HUD, and the intended cyan appeared in no state at all.

### Tests
`tests/test_reviewer_hud_css.py` gains three guards, all of which **fail on current `main`** and pass here:
- no selector may depend on an ancestor outside the shadow root (this is the class of bug that produced silent dead CSS twice already),
- the HUD must emit the theme class *and* some rule must consume it,
- nothing may re-style `#xp_text` after `create_css_for_reviewer` has.

### Verification
- `python3 harness/check.py` — **9/9 Tier-1 green**
- `pytest tests/` — **1065 passed, 40 skipped**
- `probe_real_boot` / `probe_real_play` / `probe_real_webengine` — **all PASS** (real add-on offscreen Qt + real Chromium Settings shell)
- `ruff` — clean on every changed file (the 10 repo-wide findings are pre-existing and identical on `main`)

### Not verified here
Actual on-screen appearance in a running Anki. The colours above are measured computed values from the same engine, but whether cyan-on-black XP text looks right in situ is a human call — a dark-mode spot-check of the reviewer would confirm.

### Checklist
- [x] My code and commit messages follow the code style and guidelines of this project.
- [x] Behaviour verified by running the code, not only by reading it.
