### PR TITLE
feat: display daily cash limit progress on profile

### DIFF
--- a/src/Ankimon/ankimon_profile_web/profile.js
+++ b/src/Ankimon/ankimon_profile_web/profile.js
@@ -173,8 +173,13 @@
         const shinyRate = (caught > 0 && shinies > 0)
             ? '1 in ' + Math.round(caught / shinies).toLocaleString()
             : '—';
+        const desktopCashEarned = Number(data.cash_earned_today) || 0;
+        const mobileCashEarned = Number(data.mobile_cash_earned_today) || 0;
+        const dailyCash = desktopCashEarned + mobileCashEarned;
+        const cashValue = `${num(data.cash)} ¥<div style="font-size:0.7em; opacity:0.8; margin-top:4px;">Daily Limit: ${num(dailyCash)} / 400 ¥</div>`;
+
         const tiles = [
-            ['Cash', num(data.cash) + ' ¥', 'var(--accent-gold)'],
+            ['Cash', cashValue, 'var(--accent-gold)'],
             ['Caught', num(data.caught), 'var(--accent-green)'],
             ['Pokédex', num(data.dex_seen), 'var(--accent-blue)'],
             ['Shinies', num(data.shinies), 'var(--accent-gold)'],

--- a/src/Ankimon/ankimon_profile_web/profile_data.py
+++ b/src/Ankimon/ankimon_profile_web/profile_data.py
@@ -297,6 +297,8 @@ class ProfileData:
             "total_xp": _safe(lambda: int(tc.total_xp), 0),
             "xp_for_next_level": _safe(lambda: int(tc.xp_for_next_level()), 0),
             "cash": _safe(lambda: int(tc.cash), 0),
+            "cash_earned_today": _safe(lambda: int(self.settings_obj.get("trainer.cash_earned_today", 0)), 0),
+            "mobile_cash_earned_today": _safe(lambda: int(self.settings_obj.get("trainer.mobile_cash_earned_today", 0)), 0),
             "favorite_pokemon": format_pokemon_name(
                 getattr(tc, "favorite_pokemon", "") or "None"
             ),


### PR DESCRIPTION
Resolves user request to see daily money earned so far. Added a 'Daily Limit' metric to the Cash tile on the Profile page that displays how much has been earned towards the 400¥ cap today.

---
*PR created automatically by Jules for task [14357601532867006744](https://jules.google.com/task/14357601532867006744) started by @h0tp-ftw*