### PR TITLE
Fix/discord reconnect

### DIFF
--- a/src/Ankimon/discord_integration.py
+++ b/src/Ankimon/discord_integration.py
@@ -20,14 +20,16 @@ def setup_discord_hooks():
             mw.ankimon_presence = DiscordPresence(
                 CLIENT_ID, LARGE_IMAGE_URL, ankimon_tracker_obj, logger, settings_obj
             )
-        # start() manages .loop itself and (re)connects if Discord has since
-        # opened. Don't pre-set .loop here: a failed start would leave it True
-        # and block every later reconnect attempt.
-        if mw.ankimon_presence.loop is False:
-            mw.ankimon_presence.start()
+        # start() is idempotent and owns .loop: it resumes a worker still parked
+        # in its sleep, restarts a dead one, and rate-limits its own reconnects.
+        # Gating on .loop out here is what used to strand the presence — a
+        # worker that died with .loop still True was never restarted again, and
+        # pre-setting .loop True had the mirror problem after a failed start.
+        mw.ankimon_presence.start()
 
     def on_reviewer_will_end(*args):
-        mw.ankimon_presence.loop = False
+        # stop_presence() clears .loop itself; poking the flag from out here is
+        # what let the two drift apart.
         mw.ankimon_presence.stop_presence()
 
     gui_hooks.reviewer_did_answer_card.append(on_reviewer_initialized)

--- a/src/Ankimon/discord_integration.py
+++ b/src/Ankimon/discord_integration.py
@@ -20,8 +20,10 @@ def setup_discord_hooks():
             mw.ankimon_presence = DiscordPresence(
                 CLIENT_ID, LARGE_IMAGE_URL, ankimon_tracker_obj, logger, settings_obj
             )
+        # start() manages .loop itself and (re)connects if Discord has since
+        # opened. Don't pre-set .loop here: a failed start would leave it True
+        # and block every later reconnect attempt.
         if mw.ankimon_presence.loop is False:
-            mw.ankimon_presence.loop = True
             mw.ankimon_presence.start()
 
     def on_reviewer_will_end(*args):

--- a/src/Ankimon/functions/discord_function.py
+++ b/src/Ankimon/functions/discord_function.py
@@ -61,19 +61,50 @@ class DiscordPresence:
             "Gotta review ‘em all, Ankimon style!"
         ]
         self.state = random.choice(self.quotes)
+        self._client_id = client_id
+        self._checked_conflicts = False
+        # Throttle (re)connection attempts so a closed Discord doesn't make
+        # every answered card hammer the RPC socket. -inf => attempt on the
+        # first call; then at most once per RECONNECT_INTERVAL seconds.
+        self._last_connect_attempt = float("-inf")
+        self._connect(initial=True)
+
+    RECONNECT_INTERVAL = 60  # seconds between reconnection attempts
+
+    def _connect(self, initial: bool = False) -> bool:
+        """Try to open the RPC connection. Safe to call repeatedly: a no-op
+        when already connected, and rate-limited when not. Returns
+        ``self.connected``. This is what makes Discord opening *after* Anki
+        started still pick up — ``start()`` calls it on each review."""
+        if self.connected:
+            return True
+        now = time.time()
+        if not initial and now - self._last_connect_attempt < self.RECONNECT_INTERVAL:
+            return False
+        self._last_connect_attempt = now
         try:
-            self.RPC = Presence(client_id)
+            self.RPC = Presence(self._client_id)
             self.RPC.connect()
             self.connected = True
-            # Check for conflicting addons
+            self.start_time = time.time()
+        except Exception as e:
+            self.RPC = None
+            self.connected = False
+            self.logger_obj.log(
+                "error" if initial else "debug", f"Error with Discord setup: {e}"
+            )
+            if initial:
+                _show_discord_error("Error with Discord setup. Is Discord running?")
+            return False
+
+        # First successful connection only: warn about conflicting add-ons.
+        if not self._checked_conflicts:
+            self._checked_conflicts = True
             conflicting_addons = check_conflicting_discord_addons()
             if conflicting_addons:
                 conflict_list = ', '.join(conflicting_addons)
                 self.logger_obj.log_and_showinfo("warning", f"⚠️ Conflicting Discord Rich Presence addons detected: \n{conflict_list}\n\nPlease remove them to avoid issues with Ankimon's Discord status, or turn off Discord Rich Presence in Ankimon settings :) ")
-
-        except Exception as e:
-            self.logger_obj.log("error",f"Error with Discord setup: {e}")
-            _show_discord_error("Error with Discord setup. Is Discord running?")
+        return True
 
     def _get_special_quotes(self):
         return [
@@ -113,6 +144,10 @@ class DiscordPresence:
                 )
                 time.sleep(30)  # Sleep for 30 seconds before updating again
         except Exception as e:
+            # Connection dropped (Discord was closed mid-session). Mark it so
+            # the next start() re-attempts instead of silently staying dead.
+            self.connected = False
+            self.RPC = None
             self.logger_obj.log("error",f"Error with Discord Rich Presence: {e}")
             _show_discord_error(
                 "Error with Discord Rich Presence. Is Discord running?"
@@ -122,7 +157,7 @@ class DiscordPresence:
         """
         Start updating the Discord Rich Presence in a separate thread.
         """
-        if not self.connected:
+        if not self._connect():
             return
         try:
             if not hasattr(self, 'thread') or self.thread is None or not self.thread.is_alive():

--- a/src/Ankimon/functions/discord_function.py
+++ b/src/Ankimon/functions/discord_function.py
@@ -5,7 +5,12 @@ import random
 import time
 from typing import TYPE_CHECKING
 
-from ..addon_files.lib.pypresence import Presence
+from ..addon_files.lib.pypresence import (
+    DiscordError,
+    Presence,
+    ResponseTimeout,
+    ServerError,
+)
 from ..events import events
 
 if TYPE_CHECKING:
@@ -24,7 +29,41 @@ def _show_discord_error(message: str) -> None:
         return
 
 
+def _run_on_main(callback) -> None:
+    """Run ``callback`` on Anki's GUI thread.
+
+    Qt widgets may only be created on the main thread, and anything routed
+    through ``logger_obj.log_and_showinfo`` ends in a ``QMessageBox``. The
+    presence worker is a plain daemon thread, so whatever it wants to show has
+    to hop over here first. Only a missing ``aqt`` falls back to running inline:
+    that is the headless case, where there is no GUI thread to violate. Anything
+    else — a half-built ``mw`` during a hot reload, say — is left to raise rather
+    than quietly doing the unsafe thing on the worker.
+    """
+    try:
+        from aqt import mw
+    except ImportError:
+        callback()
+        return
+    mw.taskman.run_on_main(callback)
+
+
 class DiscordPresence:
+    #: Seconds between connection attempts once one has failed.
+    RECONNECT_INTERVAL = 60
+    #: How long a UI-thread caller waits for the worker to finish an RPC
+    #: round-trip before skipping its own call. Deliberately short: these run on
+    #: Anki's main thread from the sync and reviewer hooks.
+    RPC_LOCK_TIMEOUT = 0.5
+    #: Errors that mean "this request failed", not "the pipe is dead".
+    #: ``read_output()`` raises ``ResponseTimeout`` when Discord is slow to reply
+    #: and ``ServerError`` / ``DiscordError`` on an error payload, all with the
+    #: socket still open; only ``BrokenPipeError`` / ``struct.error`` become
+    #: ``PipeClosed``. Deliberately no ``RuntimeError``: ``_rpc_lock`` makes the
+    #: "this event loop is already running" collision impossible, so the only
+    #: RuntimeError left here is "Event loop is closed", which is fatal.
+    TRANSIENT_RPC_ERRORS = (ResponseTimeout, ServerError, DiscordError)
+
     def __init__(
         self,
         client_id,
@@ -37,15 +76,16 @@ class DiscordPresence:
         self.loop = False
         self.logger_obj = logger
         self.connected = False
-        # Set every plain attribute BEFORE the RPC connect, which raises when
-        # Discord is not running. Previously they were assigned after connect(),
-        # so a failed connect left a half-built object whose start()/stop()/
-        # update_presence() then blew up with "no attribute 'settings'" /
-        # "no attribute 'large_image_url'".
+        # Every plain attribute is assigned here, before anything can fail, so a
+        # failed connect can never leave a half-built object whose start() /
+        # stop() / update_presence() then blow up with "no attribute 'settings'".
         self.RPC = None
         self.large_image_url = large_image_url
         self.ankimon_tracker: AnkimonTracker = ankimon_tracker
         self.settings = settings_obj
+        # Discord renders this as the "elapsed" timer, so it marks the study
+        # session and is stamped once. A reconnect must not reset it, or someone
+        # who has been reviewing for hours watches it snap back to 0:00.
         self.start_time = time.time()
         self.thread = None
         self.quotes = [
@@ -63,48 +103,137 @@ class DiscordPresence:
         self.state = random.choice(self.quotes)
         self._client_id = client_id
         self._checked_conflicts = False
-        # Throttle (re)connection attempts so a closed Discord doesn't make
-        # every answered card hammer the RPC socket. -inf => attempt on the
-        # first call; then at most once per RECONNECT_INTERVAL seconds.
+        self._first_attempt = True
+        # Monotonic, not wall clock: resuming from sleep or an NTP correction
+        # must not silently extend (or erase) the retry interval.
         self._last_connect_attempt = float("-inf")
-        self._connect(initial=True)
+        # pypresence drives one asyncio loop per client, and update() / clear()
+        # both call run_until_complete() on it. Two threads inside that loop
+        # raise "This event loop is already running" and leave the
+        # request/response stream off by one, so every RPC call takes this lock.
+        # Re-entrant because the failure paths drop the connection while holding
+        # it.
+        self._rpc_lock = threading.RLock()
+        # No connect here. setup_discord_hooks() builds this object at add-on
+        # import time on Anki's main thread, and pypresence's handshake reads
+        # (baseclient.handshake) have no timeout at all, so a Discord that
+        # accepts the socket and never replies would hang Anki's boot. The first
+        # start() worker does the initial connect instead.
 
-    RECONNECT_INTERVAL = 60  # seconds between reconnection attempts
+    def _connect_due(self) -> bool:
+        """Is another connection attempt allowed yet?
 
-    def _connect(self, initial: bool = False) -> bool:
-        """Try to open the RPC connection. Safe to call repeatedly: a no-op
-        when already connected, and rate-limited when not. Returns
-        ``self.connected``. This is what makes Discord opening *after* Anki
-        started still pick up — ``start()`` calls it on each review."""
+        ``start()`` checks this too, not just the worker, so a session spent
+        with Discord closed doesn't spawn a thread per answered card only for it
+        to fail this same test and exit.
+        """
+        if self.connected or self._first_attempt:
+            return True
+        return time.monotonic() - self._last_connect_attempt >= self.RECONNECT_INTERVAL
+
+    def _connect(self) -> bool:
+        """Open the RPC connection. A no-op when already connected, rate-limited
+        when not, and safe to call on every review — this is what makes Discord
+        opening *after* Anki started still get picked up.
+
+        Runs on the worker thread only.
+        """
         if self.connected:
             return True
-        now = time.time()
-        if not initial and now - self._last_connect_attempt < self.RECONNECT_INTERVAL:
+        if not self._connect_due():
             return False
-        self._last_connect_attempt = now
+        initial = self._first_attempt
+        self._first_attempt = False
         try:
-            self.RPC = Presence(self._client_id)
-            self.RPC.connect()
+            with self._rpc_lock:
+                rpc = Presence(self._client_id)
+                rpc.connect()
+                self.RPC = rpc
             self.connected = True
-            self.start_time = time.time()
         except Exception as e:
+            # Only a *failed* attempt arms the throttle. Stamping successful ones
+            # too would make a drop that happens seconds later sit out the whole
+            # interval before the first retry.
+            self._last_connect_attempt = time.monotonic()
             self.RPC = None
             self.connected = False
+            # "info" rather than "debug" for the quiet retries: InfoLogger has no
+            # debug branch, so a debug line is written nowhere and someone
+            # reporting "presence never came back" would have no record of them.
             self.logger_obj.log(
-                "error" if initial else "debug", f"Error with Discord setup: {e}"
+                "error" if initial else "info", f"Error with Discord setup: {e}"
             )
             if initial:
                 _show_discord_error("Error with Discord setup. Is Discord running?")
             return False
 
-        # First successful connection only: warn about conflicting add-ons.
+        # First successful connection only, and on the GUI thread: this method
+        # runs on the worker and the warning ends in a QMessageBox.
         if not self._checked_conflicts:
             self._checked_conflicts = True
+            _run_on_main(self._warn_conflicting_addons)
+        return True
+
+    def _warn_conflicting_addons(self):
+        """Warn about other add-ons driving Discord Rich Presence. Main thread
+        only — see ``_run_on_main``."""
+        try:
             conflicting_addons = check_conflicting_discord_addons()
             if conflicting_addons:
                 conflict_list = ', '.join(conflicting_addons)
                 self.logger_obj.log_and_showinfo("warning", f"⚠️ Conflicting Discord Rich Presence addons detected: \n{conflict_list}\n\nPlease remove them to avoid issues with Ankimon's Discord status, or turn off Discord Rich Presence in Ankimon settings :) ")
-        return True
+        except Exception as e:
+            self.logger_obj.log(
+                "error", f"Error warning about conflicting Discord addons: {e}"
+            )
+
+    def _drop_connection(self, close: bool = False):
+        """Release the RPC and mark the presence disconnected so the next
+        ``start()`` reconnects.
+
+        ``close=True`` also shuts the client down, which nothing in pypresence
+        does for us — dropping the reference alone leaves the socket and its two
+        event loops for the garbage collector. Only the worker asks for that:
+        ``Presence.close()`` writes to the pipe and closes the event loop, and on
+        Windows a pipe transport fails writes asynchronously, so it is not
+        something to run on the UI thread. Off the worker we settle for the GC.
+        """
+        with self._rpc_lock:
+            rpc, self.RPC = self.RPC, None
+            self.connected = False
+        if close and rpc is not None:
+            try:
+                rpc.close()
+            except Exception:
+                pass
+
+    def _main_thread_rpc(self, action, log_prefix, tooltip_message):
+        """Run one RPC call from a UI-thread hook.
+
+        Takes ``_rpc_lock`` so it cannot enter pypresence's asyncio loop while
+        the worker is already inside it — but only briefly. These run on Anki's
+        main thread during a sync or when the reviewer closes, so a busy worker
+        means we skip the call rather than stall the UI behind a round-trip.
+        """
+        if not self._rpc_lock.acquire(timeout=self.RPC_LOCK_TIMEOUT):
+            self.logger_obj.log(
+                "info", f"{log_prefix}: presence worker busy, skipped"
+            )
+            return
+        try:
+            if self.RPC is None:
+                return
+            action(self.RPC)
+        except Exception as e:
+            self.logger_obj.log("error", f"{log_prefix}: {e}")
+            if isinstance(e, self.TRANSIENT_RPC_ERRORS):
+                # The socket is still good; don't discard a working connection
+                # or alarm the user over one late reply.
+                return
+            self._drop_connection()
+            _show_discord_error(tooltip_message)
+        finally:
+            self._rpc_lock.release()
 
     def _get_special_quotes(self):
         return [
@@ -135,42 +264,55 @@ class DiscordPresence:
         """
         if not self.connected:
             return
-        try:
-            while self.loop:
-                self.RPC.update(
-                    state = random.choice(self.quotes) if int(self.settings.get("misc.discord_rich_presence_text")) == 1 else random.choice(self._get_special_quotes()),
-                    large_image=self.large_image_url,
-                    start=self.start_time
-                )
-                time.sleep(30)  # Sleep for 30 seconds before updating again
-        except Exception as e:
-            # Connection dropped (Discord was closed mid-session). Mark it so
-            # the next start() re-attempts instead of silently staying dead.
-            # Clear self.loop too: this worker thread is about to exit, and the
-            # reviewer hook only re-calls start() while loop is False.
-            self.loop = False
-            self.connected = False
-            self.RPC = None
-            self.logger_obj.log("error",f"Error with Discord Rich Presence: {e}")
-            _show_discord_error(
-                "Error with Discord Rich Presence. Is Discord running?"
-            )
+        while self.loop:
+            try:
+                with self._rpc_lock:
+                    if self.RPC is None:
+                        break
+                    self.RPC.update(
+                        state = random.choice(self.quotes) if int(self.settings.get("misc.discord_rich_presence_text")) == 1 else random.choice(self._get_special_quotes()),
+                        large_image=self.large_image_url,
+                        start=self.start_time
+                    )
+            except Exception as e:
+                self.logger_obj.log("error", f"Error with Discord Rich Presence: {e}")
+                if isinstance(e, self.TRANSIENT_RPC_ERRORS):
+                    # A slow reply or a server-side error: the pipe is still
+                    # open, so keep the worker and try again on the next tick.
+                    pass
+                else:
+                    # Connection dropped (Discord was closed mid-session). Clear
+                    # self.loop too: this worker is about to exit, and start()
+                    # decides what to do next.
+                    self.loop = False
+                    self._drop_connection(close=True)
+                    _show_discord_error(
+                        "Error with Discord Rich Presence. Is Discord running?"
+                    )
+                    return
+            # Outside the lock: holding it across the sleep would park every
+            # main-thread caller for up to 30 seconds.
+            time.sleep(30)  # Sleep for 30 seconds before updating again
 
     def start(self):
         """
-        Spawn the presence worker (idempotent).
+        Ensure the presence worker is running (idempotent).
 
-        The worker owns the RPC connection end to end — ``_connect()`` runs
-        inside it, not here — so this call never blocks the caller
-        (``reviewer_did_answer_card`` runs on the UI thread and the RPC
-        handshake can stall), and every write to ``connected`` / ``RPC`` /
-        ``start_time`` stays on that one worker thread, with no main-thread
-        ``_connect()`` racing the worker's own teardown.
+        The worker owns the connection: ``_connect()`` runs inside it, never
+        here, so answering a card is never blocked behind pypresence's untimed
+        handshake reads. Main-thread hooks still reach the RPC through
+        ``stop()`` / ``stop_presence()``, so every RPC access takes
+        ``_rpc_lock``.
         """
         try:
-            if self.loop:
-                return
             if self.thread is not None and self.thread.is_alive():
+                # A worker is still parked in its sleep. Re-arm the loop so it
+                # resumes on the next wake instead of exiting — this is what
+                # brings the presence back when someone leaves the reviewer and
+                # returns inside the same 30s window.
+                self.loop = True
+                return
+            if not self._connect_due():
                 return
             self.loop = True
             self.thread = threading.Thread(target=self._run, daemon=True)
@@ -183,12 +325,18 @@ class DiscordPresence:
             )
 
     def _run(self):
-        """Worker body: connect, then loop updating presence. Off the UI
-        thread so a slow/blocking RPC handshake can't stall a card answer."""
-        if not self._connect():
+        """Worker body: connect, then loop updating presence. Off the UI thread
+        so a slow or blocking RPC handshake can't stall a card answer."""
+        try:
+            if self._connect():
+                self.update_presence()
+        except Exception as e:
+            self.logger_obj.log(
+                "error", f"Error in Discord Rich Presence worker: {e}"
+            )
+        finally:
+            # Never leave a dead worker looking like a running one.
             self.loop = False
-            return
-        self.update_presence()
 
     def stop(self):
         """
@@ -197,21 +345,15 @@ class DiscordPresence:
         self.loop = False
         if not self.connected:
             return
-        try:
-            if hasattr(self, 'thread') and self.thread and self.thread.is_alive():
-                # self.thread.join() # Removed to prevent blocking
-                self.thread = None  # Reset the thread
-            self.RPC.clear()
-        except Exception as e:
-            # A failing clear() means the connection is already broken — drop
-            # it so the next start() reconnects instead of trusting a stale
-            # self.connected (matches update_presence()'s failure path).
-            self.connected = False
-            self.RPC = None
-            self.logger_obj.log("error",f"Error clearing Discord Rich Presence: {e}")
-            _show_discord_error(
-                "Error clearing Discord Rich Presence. Please check Logger for info."
-            )
+        # self.thread is deliberately NOT reset here. The worker may still be
+        # parked in its sleep, and nulling a live handle lets the next start()
+        # spawn a second worker beside it — two threads then share one asyncio
+        # loop and collide.
+        self._main_thread_rpc(
+            lambda rpc: rpc.clear(),
+            "Error clearing Discord Rich Presence",
+            "Error clearing Discord Rich Presence. Please check Logger for info.",
+        )
 
     def stop_presence(self):
         """
@@ -220,19 +362,14 @@ class DiscordPresence:
         self.loop = False
         if not self.connected:
             return
-        try:
-            if not self.loop:
-                self.RPC.update(
-                    state="Break time! You’ve earned it.",
-                    large_image=self.large_image_url
-                )
-        except Exception as e:
-            self.connected = False
-            self.RPC = None
-            self.logger_obj.log("error",f"Error stopping Discord Rich Presence: {e}")
-            _show_discord_error(
-                "Error stopping Discord Rich Presence. Please check Logger for info."
-            )
+        self._main_thread_rpc(
+            lambda rpc: rpc.update(
+                state="Break time! You’ve earned it.",
+                large_image=self.large_image_url,
+            ),
+            "Error stopping Discord Rich Presence",
+            "Error stopping Discord Rich Presence. Please check Logger for info.",
+        )
 
 def check_conflicting_discord_addons():
     """

--- a/src/Ankimon/functions/discord_function.py
+++ b/src/Ankimon/functions/discord_function.py
@@ -146,6 +146,9 @@ class DiscordPresence:
         except Exception as e:
             # Connection dropped (Discord was closed mid-session). Mark it so
             # the next start() re-attempts instead of silently staying dead.
+            # Clear self.loop too: this worker thread is about to exit, and the
+            # reviewer hook only re-calls start() while loop is False.
+            self.loop = False
             self.connected = False
             self.RPC = None
             self.logger_obj.log("error",f"Error with Discord Rich Presence: {e}")

--- a/src/Ankimon/functions/discord_function.py
+++ b/src/Ankimon/functions/discord_function.py
@@ -36,28 +36,36 @@ class DiscordPresence:
     ):
         self.loop = False
         self.logger_obj = logger
+        self.connected = False
+        # Set every plain attribute BEFORE the RPC connect, which raises when
+        # Discord is not running. Previously they were assigned after connect(),
+        # so a failed connect left a half-built object whose start()/stop()/
+        # update_presence() then blew up with "no attribute 'settings'" /
+        # "no attribute 'large_image_url'".
+        self.RPC = None
+        self.large_image_url = large_image_url
+        self.ankimon_tracker: AnkimonTracker = ankimon_tracker
+        self.settings = settings_obj
+        self.start_time = time.time()
+        self.thread = None
+        self.quotes = [
+            "Study hard, your Ankimon is watching!",
+            "Ankimon, I choose you—let’s master this deck!",
+            "Your knowledge is super effective!",
+            "Critical hit! You mastered that concept.",
+            "Never give up! Every review gets you closer to evolution.",
+            "Your brain gained 50 XP! Keep going!",
+            "It’s dangerous to go alone—take your Ankimon deck!",
+            "A wild Flashcard appeared! What will you do?",
+            "Evolve your knowledge—level up with every session!",
+            "Gotta review ‘em all, Ankimon style!"
+        ]
+        self.state = random.choice(self.quotes)
         try:
             self.RPC = Presence(client_id)
             self.RPC.connect()
-            self.large_image_url = large_image_url
-            self.ankimon_tracker: AnkimonTracker = ankimon_tracker
-            self.settings = settings_obj
-            self.start_time = time.time()
-            self.thread = None
-            self.quotes = [
-                "Study hard, your Ankimon is watching!",
-                "Ankimon, I choose you—let’s master this deck!",
-                "Your knowledge is super effective!",
-                "Critical hit! You mastered that concept.",
-                "Never give up! Every review gets you closer to evolution.",
-                "Your brain gained 50 XP! Keep going!",
-                "It’s dangerous to go alone—take your Ankimon deck!",
-                "A wild Flashcard appeared! What will you do?",
-                "Evolve your knowledge—level up with every session!",
-                "Gotta review ‘em all, Ankimon style!"
-            ]
-            self.state = random.choice(self.quotes)
-                    # Check for conflicting addons
+            self.connected = True
+            # Check for conflicting addons
             conflicting_addons = check_conflicting_discord_addons()
             if conflicting_addons:
                 conflict_list = ', '.join(conflicting_addons)
@@ -94,6 +102,8 @@ class DiscordPresence:
         """
         Update the Discord Rich Presence with a new state message.
         """
+        if not self.connected:
+            return
         try:
             while self.loop:
                 self.RPC.update(
@@ -112,6 +122,8 @@ class DiscordPresence:
         """
         Start updating the Discord Rich Presence in a separate thread.
         """
+        if not self.connected:
+            return
         try:
             if not hasattr(self, 'thread') or self.thread is None or not self.thread.is_alive():
                 self.loop = True
@@ -127,8 +139,10 @@ class DiscordPresence:
         """
         Stop updating the Discord Rich Presence.
         """
+        self.loop = False
+        if not self.connected:
+            return
         try:
-            self.loop = False
             if hasattr(self, 'thread') and self.thread and self.thread.is_alive():
                 # self.thread.join() # Removed to prevent blocking
                 self.thread = None  # Reset the thread
@@ -143,8 +157,10 @@ class DiscordPresence:
         """
         Update the Discord Rich Presence to indicate a break when stopping.
         """
+        self.loop = False
+        if not self.connected:
+            return
         try:
-            self.loop = False
             if not self.loop:
                 self.RPC.update(
                     state="Break time! You’ve earned it.",

--- a/src/Ankimon/functions/discord_function.py
+++ b/src/Ankimon/functions/discord_function.py
@@ -158,20 +158,37 @@ class DiscordPresence:
 
     def start(self):
         """
-        Start updating the Discord Rich Presence in a separate thread.
+        Spawn the presence worker (idempotent).
+
+        The worker owns the RPC connection end to end — ``_connect()`` runs
+        inside it, not here — so this call never blocks the caller
+        (``reviewer_did_answer_card`` runs on the UI thread and the RPC
+        handshake can stall), and every write to ``connected`` / ``RPC`` /
+        ``start_time`` stays on that one worker thread, with no main-thread
+        ``_connect()`` racing the worker's own teardown.
         """
-        if not self._connect():
-            return
         try:
-            if not hasattr(self, 'thread') or self.thread is None or not self.thread.is_alive():
-                self.loop = True
-                self.thread = threading.Thread(target=self.update_presence, daemon=True)
-                self.thread.start()
+            if self.loop:
+                return
+            if self.thread is not None and self.thread.is_alive():
+                return
+            self.loop = True
+            self.thread = threading.Thread(target=self._run, daemon=True)
+            self.thread.start()
         except Exception as e:
+            self.loop = False
             self.logger_obj.log("error",f"Error starting Discord Rich Presence: {e}")
             _show_discord_error(
                 "Error starting Discord Rich Presence. Is Discord running?"
             )
+
+    def _run(self):
+        """Worker body: connect, then loop updating presence. Off the UI
+        thread so a slow/blocking RPC handshake can't stall a card answer."""
+        if not self._connect():
+            self.loop = False
+            return
+        self.update_presence()
 
     def stop(self):
         """
@@ -186,6 +203,11 @@ class DiscordPresence:
                 self.thread = None  # Reset the thread
             self.RPC.clear()
         except Exception as e:
+            # A failing clear() means the connection is already broken — drop
+            # it so the next start() reconnects instead of trusting a stale
+            # self.connected (matches update_presence()'s failure path).
+            self.connected = False
+            self.RPC = None
             self.logger_obj.log("error",f"Error clearing Discord Rich Presence: {e}")
             _show_discord_error(
                 "Error clearing Discord Rich Presence. Please check Logger for info."
@@ -205,6 +227,8 @@ class DiscordPresence:
                     large_image=self.large_image_url
                 )
         except Exception as e:
+            self.connected = False
+            self.RPC = None
             self.logger_obj.log("error",f"Error stopping Discord Rich Presence: {e}")
             _show_discord_error(
                 "Error stopping Discord Rich Presence. Please check Logger for info."

--- a/tests/test_discord_presence_threading.py
+++ b/tests/test_discord_presence_threading.py
@@ -128,6 +128,8 @@ def _presence_without_init(env):
     # a failure during a later RPC operation, so the guarded methods must see
     # a live connection.
     instance.connected = True
+    instance.loop = False
+    instance.thread = None
     instance._last_connect_attempt = float("-inf")
     return instance
 
@@ -207,6 +209,8 @@ def test_stop_failure_queues_non_modal_tooltip(discord_env):
 
     instance.stop()
 
+    assert instance.connected is False
+    assert instance.RPC is None
     _assert_queued_tooltip(
         discord_env,
         "Error clearing Discord Rich Presence. Please check Logger for info.",
@@ -223,7 +227,61 @@ def test_stop_presence_failure_queues_non_modal_tooltip(discord_env):
 
     instance.stop_presence()
 
+    assert instance.connected is False
+    assert instance.RPC is None
     _assert_queued_tooltip(
         discord_env,
         "Error stopping Discord Rich Presence. Please check Logger for info.",
     )
+
+
+def test_worker_restart_after_failure_reconnects(discord_env, monkeypatch):
+    """A card answer that lands right after the worker's failure handler
+    must end with a fresh, usable RPC — not a half-torn-down one. Because
+    _connect() now runs only inside the worker, start() cannot race it."""
+    connect_calls = {"n": 0}
+
+    class _Presence:
+        def __init__(self, client_id):
+            self.update = MagicMock()
+            self.clear = MagicMock()
+
+        def connect(self):
+            connect_calls["n"] += 1
+
+    monkeypatch.setattr(discord_env.module, "Presence", _Presence)
+
+    instance = _presence_without_init(discord_env)
+    # Break the worker's update loop after one iteration instead of the real
+    # 30s sleep, so the thread finishes and its final state can be asserted.
+    monkeypatch.setattr(
+        discord_env.module.time,
+        "sleep",
+        lambda _s: setattr(instance, "loop", False),
+    )
+    instance.settings = types.SimpleNamespace(get=lambda key: 1)
+    instance.quotes = ["Reviewing"]
+    instance.large_image_url = "image"
+    instance.start_time = 0
+    instance._client_id = "client-id"
+    instance._checked_conflicts = True
+
+    # 1) worker hits a mid-session RPC failure and tears its own state down.
+    instance.loop = True
+    instance.RPC = types.SimpleNamespace(
+        update=MagicMock(side_effect=RuntimeError("connection lost"))
+    )
+    instance.update_presence()
+    assert instance.loop is False
+    assert instance.connected is False
+    assert instance.RPC is None
+
+    # 2) the next card answer restarts the worker; it reconnects cleanly.
+    instance._last_connect_attempt = float("-inf")
+    instance.start()
+    instance.thread.join(timeout=2)
+
+    assert instance.thread.is_alive() is False
+    assert connect_calls["n"] == 1
+    assert instance.connected is True
+    assert instance.RPC is not None

--- a/tests/test_discord_presence_threading.py
+++ b/tests/test_discord_presence_threading.py
@@ -1,11 +1,33 @@
 import importlib.util
 import sys
 import threading
+import time
 import types
 from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
+
+
+class _PyPresenceException(Exception):
+    """Stand-in for the vendored pypresence exception hierarchy."""
+
+
+class _ResponseTimeout(_PyPresenceException):
+    """Discord did not answer in time. The socket is still open."""
+
+
+class _ServerError(_PyPresenceException):
+    """Discord answered with an error payload. The socket is still open."""
+
+
+class _DiscordError(_PyPresenceException):
+    """Discord answered with an error code. The socket is still open."""
+
+
+#: Levels ``ShowInfoLogger._record`` actually writes. Anything else — "debug",
+#: notably — falls through every branch and is recorded nowhere.
+RECORDED_LOG_LEVELS = {"info", "warning", "error", "game"}
 
 
 class _Taskman:
@@ -65,6 +87,12 @@ def discord_env(monkeypatch):
 
     presence_module = types.ModuleType("Ankimon.addon_files.lib.pypresence")
     presence_module.Presence = _Presence
+    # The real package re-exports these from pypresence.exceptions;
+    # discord_function imports them to tell "this request failed" apart from
+    # "the pipe is dead".
+    presence_module.DiscordError = _DiscordError
+    presence_module.ResponseTimeout = _ResponseTimeout
+    presence_module.ServerError = _ServerError
     modules[presence_module.__name__] = presence_module
 
     error_module = types.ModuleType("Ankimon.pyobj.error_handler")
@@ -121,17 +149,80 @@ def _assert_queued_tooltip(env, message):
     env.presenter_notify.assert_not_called()
 
 
-def _presence_without_init(env):
+def _presence_without_init(env, **overrides):
+    """A DiscordPresence with __init__ bypassed, set up as if it had connected.
+
+    Most tests here drive one method in isolation, so this fills in exactly the
+    state the real constructor would have left behind.
+    """
     instance = object.__new__(env.module.DiscordPresence)
     instance.logger_obj = env.logger
-    # These tests simulate a presence that connected successfully and then hit
-    # a failure during a later RPC operation, so the guarded methods must see
-    # a live connection.
     instance.connected = True
     instance.loop = False
     instance.thread = None
+    instance.RPC = None
+    instance.settings = types.SimpleNamespace(get=lambda key: 1)
+    instance.quotes = ["Reviewing"]
+    instance.large_image_url = "image"
+    instance.start_time = 0
+    instance._client_id = "client-id"
+    instance._checked_conflicts = True
+    instance._first_attempt = False
     instance._last_connect_attempt = float("-inf")
+    instance._rpc_lock = threading.RLock()
+    for name, value in overrides.items():
+        setattr(instance, name, value)
     return instance
+
+
+def _patch_clock(env, monkeypatch, sleep=lambda _s: None, monotonic=time.monotonic):
+    """Give the module its own clock.
+
+    ``monkeypatch.setattr(env.module.time, "sleep", ...)`` would patch the
+    stdlib module process-wide — ``env.module.time`` *is* ``sys.modules["time"]``
+    — so every other thread in the process would get the stub too. Replacing the
+    module's own ``time`` attribute keeps the blast radius to this module.
+    """
+    clock = types.SimpleNamespace(time=time.time, monotonic=monotonic, sleep=sleep)
+    monkeypatch.setattr(env.module, "time", clock)
+    return clock
+
+
+def _stop_after_one_update(instance):
+    """A `sleep` that ends the worker loop, so a test can join the thread."""
+
+    def _sleep(_seconds):
+        instance.loop = False
+
+    return _sleep
+
+
+def test_constructor_never_touches_the_rpc(discord_env, monkeypatch):
+    """setup_discord_hooks() builds this object at add-on import time on Anki's
+    main thread, and pypresence's handshake reads have no timeout, so the
+    constructor must not connect. The first start() worker does it instead."""
+
+    class _ExplodingPresence:
+        def __init__(self, client_id):
+            raise AssertionError("the constructor must not open the RPC")
+
+    monkeypatch.setattr(discord_env.module, "Presence", _ExplodingPresence)
+
+    instance = discord_env.module.DiscordPresence(
+        "client-id",
+        "image",
+        object(),
+        discord_env.logger,
+        types.SimpleNamespace(get=lambda key: 1),
+    )
+
+    assert instance.RPC is None
+    assert instance.connected is False
+    assert instance.loop is False
+    # Every attribute the other methods need exists even though nothing connected.
+    for attribute in ("settings", "large_image_url", "quotes", "state", "start_time"):
+        assert hasattr(instance, attribute)
+    discord_env.tooltip.assert_not_called()
 
 
 def test_setup_failure_queues_non_modal_tooltip(discord_env, monkeypatch):
@@ -143,31 +234,33 @@ def test_setup_failure_queues_non_modal_tooltip(discord_env, monkeypatch):
             raise RuntimeError("Discord is closed")
 
     monkeypatch.setattr(discord_env.module, "Presence", _FailingPresence)
+    _patch_clock(discord_env, monkeypatch)
 
-    discord_env.module.DiscordPresence(
+    instance = discord_env.module.DiscordPresence(
         "client-id",
         "image",
         object(),
         discord_env.logger,
         types.SimpleNamespace(get=lambda key: 1),
     )
+    instance.start()
+    instance.thread.join(timeout=2)
 
+    assert instance.thread.is_alive() is False
+    assert instance.loop is False
     _assert_queued_tooltip(
         discord_env, "Error with Discord setup. Is Discord running?"
     )
 
 
-def test_update_failure_queues_tooltip_from_worker(discord_env):
+def test_update_failure_queues_tooltip_from_worker(discord_env, monkeypatch):
     main_thread = threading.get_ident()
-    instance = _presence_without_init(discord_env)
-    instance.loop = True
-    instance.RPC = types.SimpleNamespace(
-        update=MagicMock(side_effect=RuntimeError("connection lost"))
+    _patch_clock(discord_env, monkeypatch)
+    rpc = types.SimpleNamespace(
+        update=MagicMock(side_effect=BrokenPipeError("connection lost")),
+        close=MagicMock(),
     )
-    instance.settings = types.SimpleNamespace(get=lambda key: 1)
-    instance.quotes = ["Reviewing"]
-    instance.large_image_url = "image"
-    instance.start_time = 0
+    instance = _presence_without_init(discord_env, loop=True, RPC=rpc)
 
     worker = threading.Thread(target=instance.update_presence)
     worker.start()
@@ -175,24 +268,127 @@ def test_update_failure_queues_tooltip_from_worker(discord_env):
 
     assert discord_env.taskman.calling_threads == [worker.ident]
     assert worker.ident != main_thread
-    # The worker cleared both flags on failure so the reviewer hook, which
-    # only re-calls start() while loop is False, can restart the reconnect.
+    # The worker cleared both flags on failure so start() treats it as a dead
+    # worker and spawns a fresh one on the next answered card.
     assert instance.loop is False
     assert instance.connected is False
+    assert instance.RPC is None
+    # The worker shuts the client down properly — nothing in pypresence does it
+    # for us, and this is the one thread where close() is safe to run.
+    rpc.close.assert_called_once_with()
     _assert_queued_tooltip(
         discord_env,
         "Error with Discord Rich Presence. Is Discord running?",
     )
 
 
+def test_transient_rpc_error_keeps_the_connection(discord_env, monkeypatch):
+    """A slow reply is not a dead pipe. read_output() raises ResponseTimeout
+    with the socket still open, so tearing the connection down over one costs
+    the user their presence for up to RECONNECT_INTERVAL for nothing."""
+    _patch_clock(discord_env, monkeypatch)
+    updates = {"n": 0}
+
+    def _update(**_kwargs):
+        updates["n"] += 1
+        if updates["n"] == 1:
+            raise discord_env.module.ResponseTimeout()
+
+    rpc = types.SimpleNamespace(update=_update, close=MagicMock())
+    instance = _presence_without_init(discord_env, loop=True, RPC=rpc)
+    monkeypatch.setattr(
+        discord_env.module.time, "sleep", _stop_after_one_update(instance)
+    )
+
+    instance.update_presence()
+
+    assert instance.connected is True
+    assert instance.RPC is rpc
+    rpc.close.assert_not_called()
+    # No tooltip: the connection is fine, so there is nothing to alarm about.
+    discord_env.event_emit.assert_not_called()
+    assert discord_env.taskman.callbacks == []
+
+
+def test_a_closed_event_loop_drops_the_connection(discord_env, monkeypatch):
+    """_rpc_lock rules out asyncio's "this event loop is already running", so the
+    only RuntimeError left on this path is "Event loop is closed" — fatal.
+    Treating it as transient would spin the worker every 30s forever, never
+    reconnecting and never telling anyone."""
+    rpc = types.SimpleNamespace(
+        update=MagicMock(side_effect=RuntimeError("Event loop is closed")),
+        close=MagicMock(),
+    )
+    instance = _presence_without_init(discord_env, loop=True, RPC=rpc)
+    # Bound the loop from the outside as well: if this error were ever
+    # classified as transient the worker would spin here forever, and the test
+    # should report that as a failed assertion rather than hang.
+    _patch_clock(discord_env, monkeypatch, sleep=_stop_after_one_update(instance))
+
+    instance.update_presence()
+
+    assert instance.loop is False
+    assert instance.connected is False
+    assert instance.RPC is None
+    _assert_queued_tooltip(
+        discord_env,
+        "Error with Discord Rich Presence. Is Discord running?",
+    )
+
+
+def test_a_broken_taskman_never_falls_back_to_the_worker(discord_env, monkeypatch):
+    """_run_on_main runs inline only when aqt is absent — the headless case. A
+    half-built mw (a hot reload, say) must raise instead, or we are back to
+    building the QMessageBox on the worker after all."""
+    _patch_clock(discord_env, monkeypatch)
+    monkeypatch.setattr(
+        discord_env.module,
+        "check_conflicting_discord_addons",
+        lambda: ["AnkiCord"],
+    )
+    monkeypatch.setattr(discord_env.mw, "taskman", types.SimpleNamespace())
+
+    class _RPC:
+        def __init__(self, client_id):
+            pass
+
+        def connect(self):
+            return None
+
+        def update(self, **_kwargs):
+            return None
+
+        def close(self):
+            return None
+
+    monkeypatch.setattr(discord_env.module, "Presence", _RPC)
+    instance = _presence_without_init(
+        discord_env, connected=False, _checked_conflicts=False
+    )
+    monkeypatch.setattr(
+        discord_env.module.time, "sleep", _stop_after_one_update(instance)
+    )
+
+    instance.start()
+    instance.thread.join(timeout=2)
+
+    discord_env.logger.log_and_showinfo.assert_not_called()
+    assert instance.loop is False
+    levels = {call.args[0] for call in discord_env.logger.log.call_args_list}
+    assert "error" in levels, "the worker must report why it gave up"
+
+
 def test_start_failure_queues_non_modal_tooltip(discord_env):
-    instance = _presence_without_init(discord_env)
-    instance.thread = types.SimpleNamespace(
-        is_alive=MagicMock(side_effect=RuntimeError("thread failed"))
+    instance = _presence_without_init(
+        discord_env,
+        thread=types.SimpleNamespace(
+            is_alive=MagicMock(side_effect=RuntimeError("thread failed"))
+        ),
     )
 
     instance.start()
 
+    assert instance.loop is False
     _assert_queued_tooltip(
         discord_env,
         "Error starting Discord Rich Presence. Is Discord running?",
@@ -200,17 +396,19 @@ def test_start_failure_queues_non_modal_tooltip(discord_env):
 
 
 def test_stop_failure_queues_non_modal_tooltip(discord_env):
-    instance = _presence_without_init(discord_env)
-    instance.loop = True
-    instance.thread = None
-    instance.RPC = types.SimpleNamespace(
-        clear=MagicMock(side_effect=RuntimeError("clear failed"))
+    rpc = types.SimpleNamespace(
+        clear=MagicMock(side_effect=BrokenPipeError("clear failed")),
+        close=MagicMock(),
     )
+    instance = _presence_without_init(discord_env, loop=True, RPC=rpc)
 
     instance.stop()
 
     assert instance.connected is False
     assert instance.RPC is None
+    # Not closed from here: Presence.close() writes to the pipe and closes the
+    # event loop, and this runs on Anki's main thread. The GC gets it instead.
+    rpc.close.assert_not_called()
     _assert_queued_tooltip(
         discord_env,
         "Error clearing Discord Rich Presence. Please check Logger for info.",
@@ -218,12 +416,14 @@ def test_stop_failure_queues_non_modal_tooltip(discord_env):
 
 
 def test_stop_presence_failure_queues_non_modal_tooltip(discord_env):
-    instance = _presence_without_init(discord_env)
-    instance.loop = True
-    instance.RPC = types.SimpleNamespace(
-        update=MagicMock(side_effect=RuntimeError("update failed"))
+    instance = _presence_without_init(
+        discord_env,
+        loop=True,
+        RPC=types.SimpleNamespace(
+            update=MagicMock(side_effect=BrokenPipeError("update failed")),
+            close=MagicMock(),
+        ),
     )
-    instance.large_image_url = "image"
 
     instance.stop_presence()
 
@@ -235,16 +435,358 @@ def test_stop_presence_failure_queues_non_modal_tooltip(discord_env):
     )
 
 
+def test_guarded_methods_are_silent_when_disconnected(discord_env):
+    """With no connection the hooks still fire on every card and every sync;
+    they must be no-ops, not tracebacks against a None RPC."""
+    instance = _presence_without_init(discord_env, connected=False, loop=True)
+
+    instance.update_presence()
+    instance.stop()
+    instance.stop_presence()
+
+    assert instance.loop is False
+    discord_env.logger.log.assert_not_called()
+    discord_env.event_emit.assert_not_called()
+
+
+def test_stop_does_not_orphan_a_live_worker(discord_env, monkeypatch):
+    """stop() used to null self.thread while the worker was still parked in its
+    sleep. The next card answer then passed start()'s liveness check and spawned
+    a second worker beside the first — two threads sharing one asyncio loop."""
+    _patch_clock(discord_env, monkeypatch)
+    parked = threading.Event()
+    updating_threads = []
+
+    class _RPC:
+        def update(self, **_kwargs):
+            updating_threads.append(threading.get_ident())
+
+        def clear(self):
+            return None
+
+        def close(self):
+            return None
+
+    instance = _presence_without_init(discord_env, RPC=_RPC())
+    monkeypatch.setattr(
+        discord_env.module.time, "sleep", lambda _s: parked.wait(5)
+    )
+
+    instance.start()  # a card is answered: worker A starts and parks
+    worker_a = instance.thread
+    for _ in range(500):
+        if updating_threads:
+            break
+        time.sleep(0.002)
+    assert updating_threads, "worker A never pushed an update"
+
+    instance.stop()  # a sync finishes while worker A is still parked
+    assert worker_a.is_alive()
+    assert instance.thread is worker_a, "a live worker must keep its handle"
+
+    instance.start()  # the next card is answered inside the same sleep window
+    assert instance.thread is worker_a, "no second worker may be spawned"
+    assert instance.loop is True, "the parked worker is re-armed instead"
+
+    instance.loop = False
+    parked.set()
+    worker_a.join(timeout=2)
+    assert set(updating_threads) == {worker_a.ident}
+
+
+def test_start_resumes_a_worker_parked_after_a_break(discord_env, monkeypatch):
+    """Leaving the reviewer pushes "Break time!" and clears loop. Coming back
+    inside the same 30s window must resume the parked worker, or the presence
+    sits on the break message while the user is actively reviewing."""
+    _patch_clock(discord_env, monkeypatch)
+    parked = threading.Event()
+    states = []
+
+    class _RPC:
+        def update(self, **kwargs):
+            states.append(kwargs.get("state"))
+
+        def close(self):
+            return None
+
+    instance = _presence_without_init(discord_env, RPC=_RPC())
+    monkeypatch.setattr(
+        discord_env.module.time, "sleep", lambda _s: parked.wait(5)
+    )
+
+    instance.start()
+    for _ in range(500):
+        if states:
+            break
+        time.sleep(0.002)
+    assert states == ["Reviewing"]
+
+    instance.stop_presence()  # reviewer_will_end
+    assert states[-1].startswith("Break time!")
+
+    instance.start()  # reviewer_did_answer_card, worker still parked
+    parked.set()
+    for _ in range(500):
+        if len(states) > 2:
+            break
+        time.sleep(0.002)
+    instance.loop = False
+    instance.thread.join(timeout=2)
+
+    assert states[-1] == "Reviewing", "the worker resumed instead of exiting"
+
+
+def test_conflict_warning_is_dispatched_to_the_main_thread(discord_env, monkeypatch):
+    """_connect() runs on the worker, and the conflicting-add-on warning ends in
+    a QMessageBox (ShowInfoLogger.log_and_showinfo). Qt widgets may only be
+    built on the GUI thread, so the warning has to hop over via taskman."""
+    _patch_clock(discord_env, monkeypatch)
+    monkeypatch.setattr(
+        discord_env.module,
+        "check_conflicting_discord_addons",
+        lambda: ["AnkiCord"],
+    )
+
+    class _RPC:
+        def __init__(self, client_id):
+            pass
+
+        def connect(self):
+            return None
+
+        def update(self, **_kwargs):
+            return None
+
+        def close(self):
+            return None
+
+    monkeypatch.setattr(discord_env.module, "Presence", _RPC)
+
+    instance = _presence_without_init(
+        discord_env, connected=False, _checked_conflicts=False
+    )
+    monkeypatch.setattr(
+        discord_env.module.time, "sleep", _stop_after_one_update(instance)
+    )
+
+    instance.start()
+    instance.thread.join(timeout=2)
+    worker_ident = instance.thread.ident
+
+    # Queued from the worker, but not executed there.
+    discord_env.logger.log_and_showinfo.assert_not_called()
+    assert discord_env.taskman.calling_threads == [worker_ident]
+    assert worker_ident != threading.get_ident()
+    assert len(discord_env.taskman.callbacks) == 1
+
+    discord_env.taskman.callbacks.pop()()  # Anki runs it on the main thread
+
+    level, message = discord_env.logger.log_and_showinfo.call_args[0]
+    assert level == "warning"
+    assert "AnkiCord" in message
+
+
+def test_main_thread_stop_never_enters_the_workers_event_loop(discord_env, monkeypatch):
+    """pypresence drives one asyncio loop per client and both update() and
+    clear() call run_until_complete() on it. Two threads inside it raise "This
+    event loop is already running" and desynchronise the request/response
+    stream, so a main-thread caller skips its turn rather than colliding."""
+    _patch_clock(discord_env, monkeypatch)
+    inside_update = threading.Event()
+    release = threading.Event()
+    rpc = types.SimpleNamespace(
+        update=lambda **_kwargs: (inside_update.set(), release.wait(5)),
+        clear=MagicMock(),
+        close=MagicMock(),
+    )
+    instance = _presence_without_init(discord_env, loop=True, RPC=rpc)
+    instance.RPC_LOCK_TIMEOUT = 0.05
+    monkeypatch.setattr(
+        discord_env.module.time, "sleep", _stop_after_one_update(instance)
+    )
+
+    worker = threading.Thread(target=instance.update_presence)
+    worker.start()
+    assert inside_update.wait(2), "worker never entered the RPC"
+
+    started = time.monotonic()
+    instance.stop()  # sync_did_finish, on the main thread
+    elapsed = time.monotonic() - started
+
+    rpc.clear.assert_not_called()
+    assert elapsed < 2, "stop() must not block the UI thread on the round-trip"
+    # Skipped, not torn down: the connection is healthy, the worker is just busy.
+    assert instance.connected is True
+    assert instance.RPC is rpc
+
+    release.set()
+    worker.join(timeout=2)
+
+
+def test_reconnect_is_throttled_on_a_monotonic_clock(discord_env, monkeypatch):
+    """Only failures arm the throttle, and it reads a monotonic clock: a
+    backward wall-clock step (resume from sleep, an NTP correction) must not
+    block reconnection for the size of the jump."""
+    now = {"t": 1000.0}
+    _patch_clock(discord_env, monkeypatch, monotonic=lambda: now["t"])
+    attempts = {"n": 0}
+
+    class _FlakyPresence:
+        def __init__(self, client_id):
+            pass
+
+        def connect(self):
+            attempts["n"] += 1
+            if attempts["n"] == 1:
+                raise RuntimeError("Discord is closed")
+
+    monkeypatch.setattr(discord_env.module, "Presence", _FlakyPresence)
+    instance = _presence_without_init(
+        discord_env, connected=False, _first_attempt=True
+    )
+
+    assert instance._connect() is False  # the first attempt is never throttled
+    assert attempts["n"] == 1
+
+    now["t"] += 30
+    assert instance._connect() is False, "inside the interval: no socket touched"
+    assert attempts["n"] == 1
+
+    now["t"] += 31
+    assert instance._connect() is True  # interval elapsed, Discord is up now
+    assert attempts["n"] == 2
+    assert instance.connected is True
+
+    # A success must not arm the throttle, or a drop seconds later would sit out
+    # the whole interval before the first retry.
+    instance.connected = False
+    instance.RPC = None
+    now["t"] += 1
+    assert instance._connect() is True
+    assert attempts["n"] == 3
+
+
+def test_no_thread_per_card_while_discord_is_closed(discord_env, monkeypatch):
+    """The throttle is checked in start() as well as in the worker, so a session
+    spent with Discord closed doesn't create a thread per answered card only for
+    it to fail the same test and exit."""
+    now = {"t": 1000.0}
+    _patch_clock(discord_env, monkeypatch, monotonic=lambda: now["t"])
+    spawned = []
+
+    class _FailingPresence:
+        def __init__(self, client_id):
+            pass
+
+        def connect(self):
+            raise RuntimeError("Discord is closed")
+
+    monkeypatch.setattr(discord_env.module, "Presence", _FailingPresence)
+
+    real_thread = threading.Thread
+
+    class _CountingThread(real_thread):
+        def start(self):
+            spawned.append(1)
+            super().start()
+
+    monkeypatch.setattr(discord_env.module.threading, "Thread", _CountingThread)
+
+    instance = _presence_without_init(
+        discord_env, connected=False, _first_attempt=True
+    )
+    for _ in range(50):  # 50 answered cards, all within one throttle window
+        instance.start()
+        if instance.thread is not None:
+            instance.thread.join(timeout=2)
+        now["t"] += 1
+
+    assert len(spawned) == 1
+
+
+def test_reconnect_failures_are_logged_at_a_level_the_logger_records(discord_env, monkeypatch):
+    """The quiet retries used to log at "debug", which ShowInfoLogger._record
+    has no branch for — so nothing reached app.log and a user reporting
+    "presence never came back" had no record of them."""
+    _patch_clock(discord_env, monkeypatch)
+
+    class _FailingPresence:
+        def __init__(self, client_id):
+            pass
+
+        def connect(self):
+            raise RuntimeError("Discord is closed")
+
+    monkeypatch.setattr(discord_env.module, "Presence", _FailingPresence)
+    instance = _presence_without_init(
+        discord_env, connected=False, _first_attempt=False
+    )
+
+    assert instance._connect() is False
+
+    levels = {call.args[0] for call in discord_env.logger.log.call_args_list}
+    assert levels, "the failure must be logged"
+    assert levels <= RECORDED_LOG_LEVELS
+    # Quiet: no popup for a background retry.
+    discord_env.event_emit.assert_not_called()
+    assert discord_env.taskman.callbacks == []
+
+
+def test_worker_death_does_not_wedge_start(discord_env, monkeypatch):
+    """start() gates on thread liveness, not on self.loop. A worker that dies
+    with loop still True used to make every later start() a no-op — presence was
+    then dead until Anki restarted."""
+    _patch_clock(discord_env, monkeypatch)
+    monkeypatch.setattr(
+        discord_env.module,
+        "check_conflicting_discord_addons",
+        MagicMock(side_effect=RuntimeError("addon manager exploded")),
+    )
+
+    class _RPC:
+        def __init__(self, client_id):
+            pass
+
+        def connect(self):
+            return None
+
+        def update(self, **_kwargs):
+            return None
+
+        def close(self):
+            return None
+
+    monkeypatch.setattr(discord_env.module, "Presence", _RPC)
+    instance = _presence_without_init(
+        discord_env, connected=False, _checked_conflicts=False
+    )
+    monkeypatch.setattr(
+        discord_env.module.time, "sleep", _stop_after_one_update(instance)
+    )
+
+    instance.start()
+    instance.thread.join(timeout=2)
+    assert instance.thread.is_alive() is False
+    assert instance.loop is False, "a dead worker never looks like a running one"
+
+    # The next answered card starts a fresh worker rather than no-opping.
+    first = instance.thread
+    instance.start()
+    instance.thread.join(timeout=2)
+    assert instance.thread is not first
+
+
 def test_worker_restart_after_failure_reconnects(discord_env, monkeypatch):
-    """A card answer that lands right after the worker's failure handler
-    must end with a fresh, usable RPC — not a half-torn-down one. Because
-    _connect() now runs only inside the worker, start() cannot race it."""
+    """A card answer that lands right after the worker's failure handler must
+    end with a fresh, usable RPC that is actually pushing updates — not a
+    half-torn-down one, and not a worker that connects and then does nothing."""
     connect_calls = {"n": 0}
 
     class _Presence:
         def __init__(self, client_id):
             self.update = MagicMock()
             self.clear = MagicMock()
+            self.close = MagicMock()
 
         def connect(self):
             connect_calls["n"] += 1
@@ -252,24 +794,15 @@ def test_worker_restart_after_failure_reconnects(discord_env, monkeypatch):
     monkeypatch.setattr(discord_env.module, "Presence", _Presence)
 
     instance = _presence_without_init(discord_env)
-    # Break the worker's update loop after one iteration instead of the real
-    # 30s sleep, so the thread finishes and its final state can be asserted.
-    monkeypatch.setattr(
-        discord_env.module.time,
-        "sleep",
-        lambda _s: setattr(instance, "loop", False),
-    )
-    instance.settings = types.SimpleNamespace(get=lambda key: 1)
-    instance.quotes = ["Reviewing"]
-    instance.large_image_url = "image"
-    instance.start_time = 0
-    instance._client_id = "client-id"
-    instance._checked_conflicts = True
+    # End the worker's loop after one iteration instead of the real 30s sleep,
+    # so the thread finishes and its final state can be asserted.
+    _patch_clock(discord_env, monkeypatch, sleep=_stop_after_one_update(instance))
 
-    # 1) worker hits a mid-session RPC failure and tears its own state down.
+    # 1) the worker hits a dead pipe mid-session and tears its own state down.
     instance.loop = True
     instance.RPC = types.SimpleNamespace(
-        update=MagicMock(side_effect=RuntimeError("connection lost"))
+        update=MagicMock(side_effect=BrokenPipeError("connection lost")),
+        close=MagicMock(),
     )
     instance.update_presence()
     assert instance.loop is False
@@ -277,7 +810,6 @@ def test_worker_restart_after_failure_reconnects(discord_env, monkeypatch):
     assert instance.RPC is None
 
     # 2) the next card answer restarts the worker; it reconnects cleanly.
-    instance._last_connect_attempt = float("-inf")
     instance.start()
     instance.thread.join(timeout=2)
 
@@ -285,3 +817,25 @@ def test_worker_restart_after_failure_reconnects(discord_env, monkeypatch):
     assert connect_calls["n"] == 1
     assert instance.connected is True
     assert instance.RPC is not None
+    assert instance.RPC.update.call_count == 1, "the worker must actually push a state"
+
+
+def test_reconnect_does_not_reset_the_elapsed_timer(discord_env, monkeypatch):
+    """Discord renders start_time as "elapsed". Re-stamping it on every
+    reconnect snaps it back to 0:00 for someone who has been studying for hours."""
+
+    class _Presence:
+        def __init__(self, client_id):
+            self.update = MagicMock()
+            self.close = MagicMock()
+
+        def connect(self):
+            return None
+
+    monkeypatch.setattr(discord_env.module, "Presence", _Presence)
+    instance = _presence_without_init(discord_env, connected=False, start_time=12345.0)
+    _patch_clock(discord_env, monkeypatch, sleep=_stop_after_one_update(instance))
+
+    assert instance._connect() is True
+
+    assert instance.start_time == 12345.0

--- a/tests/test_discord_presence_threading.py
+++ b/tests/test_discord_presence_threading.py
@@ -124,6 +124,11 @@ def _assert_queued_tooltip(env, message):
 def _presence_without_init(env):
     instance = object.__new__(env.module.DiscordPresence)
     instance.logger_obj = env.logger
+    # These tests simulate a presence that connected successfully and then hit
+    # a failure during a later RPC operation, so the guarded methods must see
+    # a live connection.
+    instance.connected = True
+    instance._last_connect_attempt = float("-inf")
     return instance
 
 

--- a/tests/test_discord_presence_threading.py
+++ b/tests/test_discord_presence_threading.py
@@ -173,6 +173,10 @@ def test_update_failure_queues_tooltip_from_worker(discord_env):
 
     assert discord_env.taskman.calling_threads == [worker.ident]
     assert worker.ident != main_thread
+    # The worker cleared both flags on failure so the reviewer hook, which
+    # only re-calls start() while loop is False, can restart the reconnect.
+    assert instance.loop is False
+    assert instance.connected is False
     _assert_queued_tooltip(
         discord_env,
         "Error with Discord Rich Presence. Is Discord running?",


### PR DESCRIPTION
### Description

Discord Rich Presence broke whenever Discord wasn't running when Anki started.

**1. It crashed repeatedly.** `DiscordPresence.__init__` assigned `self.settings`,
`self.large_image_url`, `self.quotes`, etc. *after* `self.RPC.connect()`. When Discord
is closed, `connect()` raises, the `except` swallows it, but the object is left
half-initialized. Every later `start()` / `stop()` / `stop_presence()` /
`update_presence()` call from the reviewer and sync hooks then threw
`'DiscordPresence' object has no attribute 'settings'` / `'large_image_url'`, and
`RPC.clear()` threw `You must connect your client before sending events!` on every
sync — filling the logs each session.

**2. It never recovered.** Opening Discord *after* Anki had started did nothing until
a full restart.

**Changes:**
- All plain attributes are assigned *before* the connection attempt, so a failed
  connect can't leave a half-built object.
- Connection is now a repeatable `_connect()` that `start()` calls on each answered
  card: no-op when already connected, rate-limited to one attempt per 60s otherwise,
  and only the first attempt shows the error tooltip / runs the conflicting-addon
  check (no spam).
- A `self.connected` flag gates every method — silent no-ops until a real connection
  exists.
- If the RPC drops mid-session (Discord closed), `update_presence()` clears
  `self.connected` so the next `start()` re-establishes it.
- `discord_integration.py` no longer pre-sets `.loop = True` before `start()` — that
  pinned it `True` after a failed start and blocked all future reconnects.

Verified with the headless harness gate and the full test suite (`787 passed`).

### Checklist
- [x] My code follows the code style and guidelines of this project.
- [x] I have run tests locally (`pytest tests/` and `pytest tests/test_addon_integrity.py`) and they all pass.