### PR TITLE
fix(encounter): clear the player's volatile statuses on a new wild encounter

### DIFF
--- a/src/Ankimon/functions/encounter_functions.py
+++ b/src/Ankimon/functions/encounter_functions.py
@@ -1182,6 +1182,17 @@ def new_pokemon(
     except Exception as e:
         print(f"[Ankimon] Error resetting battle state in new_pokemon: {e}")
 
+    # Clear the PLAYER's volatile statuses as well. The enemy object is rebuilt
+    # from `pokemon_data` below, which carries a fresh `volatile_status`, but
+    # `main_pokemon` persists across encounters — so a confusion/taunt/leechseed
+    # left over from the battle that just ended would otherwise follow the
+    # player into the next one and be re-sent to the engine on turn 1. The
+    # hooks-level reset in ankimon_hooks_to_poke_engine only runs on the
+    # `state is not None` path, and this function forces `_state.new_state =
+    # None` immediately above, so it can never cover this.
+    if main_pokemon is not None and hasattr(main_pokemon, "volatile_status"):
+        main_pokemon.volatile_status = set()
+
     # Force HUD update on next card/refresh via the HUD leaf's public
     # invalidation method, so this call site never has to track the leaf's
     # private cache set. Guarded so it works both before and after that leaf

--- a/tests/test_encounter_functions.py
+++ b/tests/test_encounter_functions.py
@@ -677,3 +677,69 @@ def test_victory_seed_tolerates_int_vs_str_id_drift():
     # individual_id is TEXT in the schema but callers have passed ints; the
     # guard must not decline a genuine match over the type alone.
     assert _run_victory_with_stored_row(7, "7") == ["Tackle", "Charm"]
+
+
+def test_new_pokemon_clears_the_players_volatile_status(monkeypatch):
+    """A new wild encounter must clear the PLAYER's volatiles, not just the enemy's.
+
+    ``new_pokemon`` rebuilds the enemy object from ``pokemon_data`` (which carries
+    a fresh ``volatile_status``), but ``main_pokemon`` survives between encounters.
+    Without this reset a confusion/leechseed from the battle that just ended is
+    still on the player at the start of the next one, and gets handed to the
+    engine on turn 1. The hooks-level reset cannot cover it: that runs only on the
+    ``state is not None`` path, and ``new_pokemon`` sets ``_state.new_state = None``.
+
+    ``generate_random_pokemon`` is stubbed to raise, which both keeps the test off
+    the heavy encounter-generation path and pins the reset as happening BEFORE it.
+    """
+
+    class _Stop(Exception):
+        pass
+
+    class _Player:
+        def __init__(self):
+            self.level = 50
+            self.volatile_status = {"confusion", "leechseed"}
+
+    player = _Player()
+    monkeypatch.setattr(ef, "main_pokemon", player)
+    monkeypatch.setattr(ef, "clear_auto_battle_override", lambda: None)
+
+    def _stop(*args, **kwargs):
+        raise _Stop()
+
+    monkeypatch.setattr(ef, "generate_random_pokemon", _stop)
+
+    try:
+        ef.new_pokemon(mock.MagicMock(), None, mock.MagicMock(), None)
+    except _Stop:
+        pass
+
+    assert player.volatile_status == set()
+
+
+def test_new_pokemon_tolerates_a_player_without_volatile_status(monkeypatch):
+    """The reset must not crash on a main_pokemon that predates the attribute."""
+
+    class _Stop(Exception):
+        pass
+
+    class _LegacyPlayer:
+        def __init__(self):
+            self.level = 50
+
+    player = _LegacyPlayer()
+    monkeypatch.setattr(ef, "main_pokemon", player)
+    monkeypatch.setattr(ef, "clear_auto_battle_override", lambda: None)
+
+    def _stop(*args, **kwargs):
+        raise _Stop()
+
+    monkeypatch.setattr(ef, "generate_random_pokemon", _stop)
+
+    try:
+        ef.new_pokemon(mock.MagicMock(), None, mock.MagicMock(), None)
+    except _Stop:
+        pass
+
+    assert not hasattr(player, "volatile_status")


### PR DESCRIPTION
## Summary

Follow-up to #644, which fixed only the **enemy** half of the bug it describes.

#644 added `"volatile_status": set()` to the `pokemon_data` dict that `new_pokemon()` feeds to `update_stats()`, so the enemy object starts each encounter clean. `main_pokemon` is not rebuilt there — it persists across encounters — so a confusion / leechseed / taunt left over from the battle that just ended is **still on the player** when the next encounter starts, and gets handed to the engine on turn 1.

Observed on the merged #644 build: seed `main_pokemon.volatile_status = {"confusion"}`, defeat the enemy, and after the new encounter spawns `enemy_pokemon.volatile_status` is `[]` while `main_pokemon.volatile_status` is still `['confusion']`.

The hooks-level reset in `ankimon_hooks_to_poke_engine.py` cannot cover this: it runs only on the `state is not None` path, and `new_pokemon()` sets `_state.new_state = None` immediately above where this reset goes.

## Change

One guarded reset in `new_pokemon()`, next to the existing per-encounter resets:

```python
if main_pokemon is not None and hasattr(main_pokemon, "volatile_status"):
    main_pokemon.volatile_status = set()
```

`hasattr` so a `main_pokemon` from a save predating the attribute is left alone rather than crashing.

## Validation

- `harness/check.py` — **PASS — all 9 Tier-1 checks green**
- `tests/test_encounter_functions.py` — **17 passed** (15 pre-existing + 2 new)
- `ruff format --check` — both changed files already formatted
- Two new tests: the reset itself, and legacy-object tolerance. `generate_random_pokemon` is stubbed to raise, so they also pin the reset as happening *before* encounter generation. **Verified the first test fails when the reset is removed.**
