### PR TITLE
fix(items): share one item-name normalizer, and fold the csv side too

### DIFF
--- a/src/Ankimon/ankimon_items_web/shop_obj.py
+++ b/src/Ankimon/ankimon_items_web/shop_obj.py
@@ -2116,8 +2116,12 @@ class AnkimonItemsWeb(QDialog):
                                 # Normalize both sides by stripping spaces, hyphens and
                                 # apostrophes so pokedex.json display names (e.g.
                                 # "King's Rock") match items.csv identifiers (e.g.
-                                # "kings-rock"), which drop the apostrophe. Mirrors the
-                                # canonical logic in functions/pokedex_functions.py.
+                                # "kings-rock"), which drop the apostrophe. This is a
+                                # LOOSER fold than pokedex_functions.normalize_item_identifier:
+                                # it also strips hyphens (so "up-grade" and "upgrade" meet)
+                                # but does no NFKD or U+2019 folding. Deliberately separate —
+                                # it matches pokedex.json evoItem names, not items.csv keys —
+                                # so do not "unify" the two without checking both call sites.
                                 required_item = (
                                     (target_data.get("evoItem") or "")
                                     .lower()

--- a/src/Ankimon/functions/pokedex_functions.py
+++ b/src/Ankimon/functions/pokedex_functions.py
@@ -397,6 +397,24 @@ def load_items_cost_index():
     return _items_cost_index
 
 
+def items_cost_index_for(file_path):
+    """:func:`load_items_cost_index`, but only when ``file_path`` IS items.csv.
+
+    The path comparison lives here rather than in the caller so that it cannot
+    disagree with the file the index was built from: a module that rebinds its
+    own ``csv_file_items_cost`` (a test patching the name, say) would otherwise
+    be handed the bundled index for a different file entirely.
+
+    ``None`` means "no index for this path" — either it is another file, or the
+    index came back empty because items.csv could not be read. Both send the
+    caller down its own file scan, which is what still surfaces an unreadable
+    file as that caller's warning-plus-fallback rather than a silent miss.
+    """
+    if str(file_path) != str(csv_file_items_cost):
+        return None
+    return load_items_cost_index() or None
+
+
 # === POKEMON NAME & DESCRIPTION CACHES ===
 _pokemon_names_cache = {}  # {(pokemon_id, language): name}
 _pokemon_descriptions_cache = {}  # {(species_id, language): description}
@@ -473,6 +491,11 @@ def clear_pokedex_caches():
     _pokedex_id_index = None
     _pokemon_names_cache = {}
     _pokemon_descriptions_cache = {}
+    # _items_cost_cache / _items_cost_index are deliberately NOT reset: items.csv
+    # is bundled static data, identical across profiles, so a profile switch has
+    # nothing to reload. If that ever changes they must be cleared as a PAIR —
+    # the index holds references into the rows the cache built, so clearing only
+    # the cache would leave the index answering from the pre-clear file.
 
 
 def _normalize_language_id(language):

--- a/src/Ankimon/functions/pokedex_functions.py
+++ b/src/Ankimon/functions/pokedex_functions.py
@@ -21,6 +21,7 @@ import functools
 import json
 import math
 import random
+import unicodedata
 import csv
 from ..pyobj.error_handler import show_warning_with_traceback
 from ..pyobj.pokemon_obj import PokemonObject
@@ -1784,6 +1785,32 @@ def return_name_for_id(pokemon_id):
         return None
 
 
+def normalize_item_identifier(value) -> str:
+    """Fold an item name to the shape ``items.csv`` keys on.
+
+    Applied to BOTH sides of every lookup, so a display name and the CSV
+    identifier meet in the middle. Without folding the CSV side too, the nine
+    identifiers that themselves carry a typographic apostrophe or an accent
+    (``koraidon’s-poké-ball``, ``kofu’s-wallet``, ``leader’s-crest``,
+    ``jalapeño``, ``flabébé-pollen``, the three ``-poké-ball-pick`` rows)
+    stay unreachable from any name a user or the UI would supply.
+
+    The steps, in order: strip, lowercase, fold U+2019 to a plain apostrophe,
+    strip combining accents via NFKD, spaces to hyphens, then drop apostrophes.
+
+    Verified against the shipped items.csv: this merges no two DISTINCT
+    identifiers (2510 rows, 2165 distinct folded keys — every collision bucket
+    holds repeats of one identical raw string, which the file already contained
+    344 of before any folding). Non-string input folds to ``""`` rather than
+    raising, so a caller passing an int gets a clean miss.
+    """
+    if not isinstance(value, str):
+        return ""
+    folded = unicodedata.normalize("NFKD", value.strip().lower().replace("’", "'"))
+    folded = "".join(ch for ch in folded if not unicodedata.combining(ch))
+    return folded.replace(" ", "-").replace("'", "")
+
+
 def return_id_for_item_name(item_name):
     """
     Returns the ID of an item based on its name (identifier) from a CSV file.
@@ -1796,10 +1823,10 @@ def return_id_for_item_name(item_name):
         None: If no matching item is found or an error occurs.
     """
     try:
-        normalized_name = (item_name or "").lower().replace(" ", "-").replace("'", "")
+        normalized_name = normalize_item_identifier(item_name)
         cache = _load_items_cost_cache()
         for row in cache:
-            if row["identifier"] == normalized_name:
+            if normalize_item_identifier(row["identifier"]) == normalized_name:
                 return row["id"]
 
         # Log a message if the item is not found

--- a/src/Ankimon/functions/pokedex_functions.py
+++ b/src/Ankimon/functions/pokedex_functions.py
@@ -194,6 +194,7 @@ _stats_csv_cache = None
 _poke_evo_cache = None
 _moves_cache = None
 _items_cost_cache = None
+_items_cost_index = None
 
 
 def _load_pokemon_csv_cache():
@@ -364,6 +365,36 @@ def _load_items_cost_cache():
             print(f"Error loading items cost CSV cache: {e}")
             _items_cost_cache = []
     return _items_cost_cache
+
+
+def load_items_cost_index():
+    """Build ``{folded identifier: row}`` over items.csv for O(1) item lookups.
+
+    The three item lookups fold BOTH sides of the comparison (see
+    :func:`normalize_item_identifier`), and folding the stored identifier is the
+    expensive half: done per row per call it re-folds all 2510 rows on every
+    lookup, which turned one shop build (``utils.daily_item_list``, two price
+    lookups per item over the sprite directory) into ~0.5s of pure NFKD.
+
+    Folding once at load leaves the ANSWER identical. The first row for a folded
+    key wins, exactly as the linear scan returned the first match — which
+    matters, because items.csv holds 345 surplus duplicate rows and five
+    identifiers whose duplicates disagree (``metronome`` is id 254/cost 4000 at
+    its first row and id 20118/cost 1000 later).
+
+    A row whose identifier folds to ``""`` is skipped, so a malformed blank
+    identifier cell cannot answer a lookup; callers pair this with rejecting an
+    empty folded name, since both sides fold to the same ``""``.
+    """
+    global _items_cost_index
+    if _items_cost_index is None:
+        index = {}
+        for row in _load_items_cost_cache():
+            folded = normalize_item_identifier(row.get("identifier"))
+            if folded and folded not in index:
+                index[folded] = row
+        _items_cost_index = index
+    return _items_cost_index
 
 
 # === POKEMON NAME & DESCRIPTION CACHES ===
@@ -1799,10 +1830,12 @@ def normalize_item_identifier(value) -> str:
     strip combining accents via NFKD, spaces to hyphens, then drop apostrophes.
 
     Verified against the shipped items.csv: this merges no two DISTINCT
-    identifiers (2510 rows, 2165 distinct folded keys — every collision bucket
-    holds repeats of one identical raw string, which the file already contained
-    344 of before any folding). Non-string input folds to ``""`` rather than
-    raising, so a caller passing an int gets a clean miss.
+    identifiers — 2165 distinct raw identifiers over 2510 rows fold to exactly
+    2165 distinct keys, so every collision bucket holds repeats of one identical
+    raw string (the file already contained 344 such repeated identifiers before
+    any folding). Non-string input folds to ``""`` rather than raising, so a
+    caller passing an int gets a clean miss; callers must treat that ``""`` as a
+    miss outright rather than a key to match on.
     """
     if not isinstance(value, str):
         return ""
@@ -1824,9 +1857,9 @@ def return_id_for_item_name(item_name):
     """
     try:
         normalized_name = normalize_item_identifier(item_name)
-        cache = _load_items_cost_cache()
-        for row in cache:
-            if normalize_item_identifier(row["identifier"]) == normalized_name:
+        if normalized_name:
+            row = load_items_cost_index().get(normalized_name)
+            if row is not None:
                 return row["id"]
 
         # Log a message if the item is not found

--- a/src/Ankimon/utils.py
+++ b/src/Ankimon/utils.py
@@ -16,7 +16,7 @@ from .pyobj.InfoLogger import ShowInfoLogger
 from .functions.battle_functions import calculate_hp
 from .functions.pokedex_functions import (
     find_details_move,
-    load_items_cost_index,
+    items_cost_index_for,
     normalize_item_identifier,
     search_pokedex,
 )
@@ -465,24 +465,6 @@ def give_item(item_name: str, item_type: Optional[str] = None):
     db.add_item(item_name, 1, extra_data)
 
 
-def _bundled_items_index(file_path):
-    """The folded items.csv index, but only for the bundled file.
-
-    Both lookups take a ``file_path`` for tests and callers that want another
-    file; nothing in the add-on passes one. For the bundled path the index makes
-    the lookup O(1) instead of re-folding all 2510 identifiers per call, and it
-    is built from the same rows in the same order, so first-match still wins.
-
-    Returns ``None`` for any other path AND for an index that came back empty —
-    an unreadable items.csv memoizes an empty cache, and sending the caller down
-    its own file scan is what still surfaces that as the historical warning-plus-
-    fallback rather than a silent miss.
-    """
-    if str(file_path) != str(csv_file_items_cost):
-        return None
-    return load_items_cost_index() or None
-
-
 # Function to return a cost of an item
 def get_item_price(item_name, file_path=csv_file_items_cost):
     """
@@ -498,20 +480,21 @@ def get_item_price(item_name, file_path=csv_file_items_cost):
     try:
         # Both sides folded so display names ("King's Rock", "Poke Ball") reach
         # the CSV identifiers, which are lowercase and hyphenated and in nine
-        # rows carry a typographic apostrophe or an accent. A name that folds to
-        # "" is a miss outright — a blank identifier cell folds to "" too, and
-        # must not answer for it.
+        # rows carry a typographic apostrophe or an accent. A blank identifier
+        # cell folds to "" as well, so an empty folded name must never match
+        # one — but that check stays INSIDE each branch rather than returning
+        # early, because returning early would skip the open() below and with it
+        # the warning an unreadable file still owes its caller.
         wanted = normalize_item_identifier(item_name)
-        if not wanted:
-            return None
-        index = _bundled_items_index(file_path)
+        index = items_cost_index_for(file_path)
         if index is not None:
-            row = index.get(wanted)
+            row = index.get(wanted) if wanted else None
             return int(row["cost"]) if row is not None else None
         with open(file_path, mode="r", newline="", encoding="utf-8") as csvfile:
             reader = csv.DictReader(csvfile)
             for row in reader:
-                if normalize_item_identifier(row["identifier"]) == wanted:
+                folded = normalize_item_identifier(row["identifier"])
+                if folded and folded == wanted:
                     cost = row["cost"]
                     return int(cost)
     except FileNotFoundError:
@@ -541,16 +524,15 @@ def get_item_id(item_name, file_path=csv_file_items_cost):
     """
     try:
         wanted = normalize_item_identifier(item_name)
-        if not wanted:
-            return None
-        index = _bundled_items_index(file_path)
+        index = items_cost_index_for(file_path)
         if index is not None:
-            row = index.get(wanted)
+            row = index.get(wanted) if wanted else None
             return int(row["id"]) if row is not None else None
         with open(file_path, mode="r", newline="", encoding="utf-8") as csvfile:
             reader = csv.DictReader(csvfile)
             for row in reader:
-                if normalize_item_identifier(row["identifier"]) == wanted:
+                folded = normalize_item_identifier(row["identifier"])
+                if folded and folded == wanted:
                     id = row["id"]
                     return int(id)
     except (OSError, KeyError) as e:

--- a/src/Ankimon/utils.py
+++ b/src/Ankimon/utils.py
@@ -14,7 +14,11 @@ from .pyobj.settings import Settings
 from .pyobj.InfoLogger import ShowInfoLogger
 
 from .functions.battle_functions import calculate_hp
-from .functions.pokedex_functions import find_details_move, search_pokedex
+from .functions.pokedex_functions import (
+    find_details_move,
+    normalize_item_identifier,
+    search_pokedex,
+)
 
 from .pyobj.error_handler import show_warning_with_traceback
 from .resources import (
@@ -475,8 +479,12 @@ def get_item_price(item_name, file_path=csv_file_items_cost):
     try:
         with open(file_path, mode="r", newline="", encoding="utf-8") as csvfile:
             reader = csv.DictReader(csvfile)
+            # Both sides folded so display names ("King's Rock", "Poke Ball")
+            # reach the CSV identifiers, which are lowercase and hyphenated and
+            # in nine rows carry a typographic apostrophe or an accent.
+            wanted = normalize_item_identifier(item_name)
             for row in reader:
-                if row["identifier"] == item_name:
+                if normalize_item_identifier(row["identifier"]) == wanted:
                     cost = row["cost"]
                     return int(cost)
     except FileNotFoundError:
@@ -507,8 +515,9 @@ def get_item_id(item_name, file_path=csv_file_items_cost):
     try:
         with open(file_path, mode="r", newline="", encoding="utf-8") as csvfile:
             reader = csv.DictReader(csvfile)
+            wanted = normalize_item_identifier(item_name)
             for row in reader:
-                if row["identifier"] == item_name:
+                if normalize_item_identifier(row["identifier"]) == wanted:
                     id = row["id"]
                     return int(id)
     except (OSError, KeyError) as e:

--- a/src/Ankimon/utils.py
+++ b/src/Ankimon/utils.py
@@ -16,6 +16,7 @@ from .pyobj.InfoLogger import ShowInfoLogger
 from .functions.battle_functions import calculate_hp
 from .functions.pokedex_functions import (
     find_details_move,
+    load_items_cost_index,
     normalize_item_identifier,
     search_pokedex,
 )
@@ -464,6 +465,24 @@ def give_item(item_name: str, item_type: Optional[str] = None):
     db.add_item(item_name, 1, extra_data)
 
 
+def _bundled_items_index(file_path):
+    """The folded items.csv index, but only for the bundled file.
+
+    Both lookups take a ``file_path`` for tests and callers that want another
+    file; nothing in the add-on passes one. For the bundled path the index makes
+    the lookup O(1) instead of re-folding all 2510 identifiers per call, and it
+    is built from the same rows in the same order, so first-match still wins.
+
+    Returns ``None`` for any other path AND for an index that came back empty —
+    an unreadable items.csv memoizes an empty cache, and sending the caller down
+    its own file scan is what still surfaces that as the historical warning-plus-
+    fallback rather than a silent miss.
+    """
+    if str(file_path) != str(csv_file_items_cost):
+        return None
+    return load_items_cost_index() or None
+
+
 # Function to return a cost of an item
 def get_item_price(item_name, file_path=csv_file_items_cost):
     """
@@ -477,12 +496,20 @@ def get_item_price(item_name, file_path=csv_file_items_cost):
         int: The cost of the item, or None if the item is not found or has no id.
     """
     try:
+        # Both sides folded so display names ("King's Rock", "Poke Ball") reach
+        # the CSV identifiers, which are lowercase and hyphenated and in nine
+        # rows carry a typographic apostrophe or an accent. A name that folds to
+        # "" is a miss outright — a blank identifier cell folds to "" too, and
+        # must not answer for it.
+        wanted = normalize_item_identifier(item_name)
+        if not wanted:
+            return None
+        index = _bundled_items_index(file_path)
+        if index is not None:
+            row = index.get(wanted)
+            return int(row["cost"]) if row is not None else None
         with open(file_path, mode="r", newline="", encoding="utf-8") as csvfile:
             reader = csv.DictReader(csvfile)
-            # Both sides folded so display names ("King's Rock", "Poke Ball")
-            # reach the CSV identifiers, which are lowercase and hyphenated and
-            # in nine rows carry a typographic apostrophe or an accent.
-            wanted = normalize_item_identifier(item_name)
             for row in reader:
                 if normalize_item_identifier(row["identifier"]) == wanted:
                     cost = row["cost"]
@@ -513,9 +540,15 @@ def get_item_id(item_name, file_path=csv_file_items_cost):
         int: The id of the item, or None if the item is not found or has no id.
     """
     try:
+        wanted = normalize_item_identifier(item_name)
+        if not wanted:
+            return None
+        index = _bundled_items_index(file_path)
+        if index is not None:
+            row = index.get(wanted)
+            return int(row["id"]) if row is not None else None
         with open(file_path, mode="r", newline="", encoding="utf-8") as csvfile:
             reader = csv.DictReader(csvfile)
-            wanted = normalize_item_identifier(item_name)
             for row in reader:
                 if normalize_item_identifier(row["identifier"]) == wanted:
                     id = row["id"]

--- a/tests/test_item_name_normalization.py
+++ b/tests/test_item_name_normalization.py
@@ -58,3 +58,92 @@ def test_utils_item_lookups_accept_display_names():
     # priced item; exp-share is priced 0 and is excluded from the shop by that.
     assert utils.get_item_price("Potion") == utils.get_item_price("potion")
     assert utils.get_item_price("Potion") > 0
+
+
+def test_item_lookups_reject_names_and_rows_that_fold_to_empty(tmp_path):
+    """A blank identifier cell must not answer for a blank/non-string name.
+
+    Both sides fold, and both a blank name and a blank identifier fold to "",
+    so a malformed row would otherwise match every degenerate lookup. The
+    shipped items.csv has no such row — this pins the guard, not the data.
+    """
+    import Ankimon.utils as utils
+
+    malformed = tmp_path / "items.csv"
+    malformed.write_text(
+        "id,identifier,category_id,cost,fling_power,fling_effect_id\n"
+        "9999,,1,7777,,\n"
+        "4,poke-ball,34,200,,\n",
+        encoding="utf-8",
+    )
+
+    for bad in (None, "", "   ", 301):
+        assert utils.get_item_price(bad, malformed) is None
+        assert utils.get_item_id(bad, malformed) is None
+    # A real row in the same file still resolves, so the guard rejects the
+    # empty key rather than the whole file.
+    assert utils.get_item_price("Poke Ball", malformed) == 200
+    assert utils.get_item_id("Poke Ball", malformed) == 4
+
+
+def test_bundled_lookups_miss_cleanly_on_empty_and_non_string_names():
+    from Ankimon.functions.pokedex_functions import return_id_for_item_name
+    import Ankimon.utils as utils
+
+    for bad in (None, "", "   ", 301, "’"):
+        assert return_id_for_item_name(bad) is None
+        assert utils.get_item_price(bad) is None
+        assert utils.get_item_id(bad) is None
+
+
+def test_items_cost_index_keeps_the_first_row_for_a_folded_key():
+    """items.csv repeats identifiers, and five repeats disagree on id/cost.
+
+    The lookups scanned the file and returned the FIRST match; the index must
+    answer the same. ``metronome`` is the sharp case: id 254/cost 4000 on its
+    first row, id 20118/cost 1000 on the two later ones.
+    """
+    from Ankimon.functions.pokedex_functions import (
+        load_items_cost_index,
+        return_id_for_item_name,
+    )
+    import Ankimon.utils as utils
+
+    assert load_items_cost_index()["metronome"]["id"] == "254"
+    assert return_id_for_item_name("Metronome") == "254"
+    assert utils.get_item_id("Metronome") == 254
+    assert utils.get_item_price("Metronome") == 4000
+
+
+def test_items_cost_index_answers_exactly_like_the_linear_scan():
+    """Equivalence over the whole shipped file, not a sampled few.
+
+    Guards the optimization itself: for every identifier in items.csv the index
+    must return the same row the old first-match scan did, and no identifier may
+    fold onto another's key.
+    """
+    import csv
+
+    from Ankimon.functions.pokedex_functions import (
+        load_items_cost_index,
+        normalize_item_identifier,
+        return_id_for_item_name,
+    )
+    from Ankimon.resources import csv_file_items_cost
+
+    with open(csv_file_items_cost, mode="r", encoding="utf-8") as csvfile:
+        rows = list(csv.DictReader(csvfile))
+
+    first_match = {}
+    for row in rows:
+        first_match.setdefault(row["identifier"], row["id"])
+
+    index = load_items_cost_index()
+    for identifier, expected_id in first_match.items():
+        assert index[normalize_item_identifier(identifier)]["id"] == expected_id
+        assert return_id_for_item_name(identifier) == expected_id
+
+    # No two distinct identifiers share a folded key, which is what makes
+    # folding the stored side safe in the first place.
+    assert len(index) == len({normalize_item_identifier(i) for i in first_match})
+    assert len(index) == len(first_match)

--- a/tests/test_item_name_normalization.py
+++ b/tests/test_item_name_normalization.py
@@ -147,3 +147,139 @@ def test_items_cost_index_answers_exactly_like_the_linear_scan():
     # folding the stored side safe in the first place.
     assert len(index) == len({normalize_item_identifier(i) for i in first_match})
     assert len(index) == len(first_match)
+
+
+def _reset_items_caches(monkeypatch, csv_path):
+    """Point the item caches at ``csv_path`` and rebuild them from scratch.
+
+    Both globals are module state that outlives a test, so they are set to None
+    on the way in AND restored on the way out via monkeypatch's undo.
+    """
+    from Ankimon.functions import pokedex_functions as pf
+
+    monkeypatch.setattr(pf, "csv_file_items_cost", csv_path)
+    monkeypatch.setattr(pf, "_items_cost_cache", None)
+    monkeypatch.setattr(pf, "_items_cost_index", None)
+    return pf
+
+
+def test_index_build_skips_rows_whose_identifier_folds_to_empty(monkeypatch, tmp_path):
+    """The row-side half of the blank-identifier guard, on its own.
+
+    ``load_items_cost_index`` must not key a blank identifier cell, or every
+    lookup made with a blank name would find it.
+    """
+    malformed = tmp_path / "items.csv"
+    malformed.write_text(
+        "id,identifier,category_id,cost,fling_power,fling_effect_id\n"
+        "9999,,1,7777,,\n"
+        "9998,   ,1,6666,,\n"
+        "4,poke-ball,34,200,,\n",
+        encoding="utf-8",
+    )
+    pf = _reset_items_caches(monkeypatch, malformed)
+
+    index = pf.load_items_cost_index()
+    assert "" not in index
+    assert set(index) == {"poke-ball"}
+    assert pf.return_id_for_item_name(None) is None
+    assert pf.return_id_for_item_name("") is None
+    assert pf.return_id_for_item_name("Poke Ball") == "4"
+
+
+def test_lookups_never_use_an_empty_folded_name_as_a_key(monkeypatch):
+    """The caller-side half, tested independently of the row-side half.
+
+    The two guards are deliberate defence in depth: even handed an index that
+    somehow keys "", no lookup may ask for it. Injecting that index is the only
+    way to exercise this half while the row-side guard is doing its job.
+    """
+    from Ankimon.functions import pokedex_functions as pf
+    import Ankimon.utils as utils
+
+    poisoned = {
+        "": {"id": "9999", "cost": "7777"},
+        "poke-ball": {"id": "4", "cost": "200"},
+    }
+    monkeypatch.setattr(pf, "_items_cost_index", poisoned)
+
+    for bad in (None, "", "   ", 301, "’"):
+        assert pf.return_id_for_item_name(bad) is None
+        assert utils.get_item_price(bad) is None
+        assert utils.get_item_id(bad) is None
+    # The same index still answers a real name, so the guard rejects the empty
+    # key rather than refusing to look anything up.
+    assert pf.return_id_for_item_name("Poke Ball") == "4"
+    assert utils.get_item_id("Poke Ball") == 4
+
+
+def test_unreadable_items_csv_still_warns_and_falls_back(monkeypatch, tmp_path):
+    """An empty index must not silently answer "miss" for an unreadable file.
+
+    ``_load_items_cost_cache`` memoizes ``[]`` when items.csv cannot be read, so
+    the index comes back empty. ``items_cost_index_for`` returns None for that,
+    which sends both lookups down their own open() — the only thing that still
+    reports the failure as the historical warning-plus-fallback (1000 / 4).
+    """
+    import Ankimon.utils as utils
+
+    missing = tmp_path / "does-not-exist.csv"
+    pf = _reset_items_caches(monkeypatch, missing)
+
+    warnings = []
+    monkeypatch.setattr(
+        utils, "showWarning", lambda msg, *a, **kw: warnings.append(msg)
+    )
+    monkeypatch.setattr(
+        utils,
+        "show_warning_with_traceback",
+        lambda *a, **kw: warnings.append("traceback"),
+    )
+
+    assert pf.load_items_cost_index() == {}
+    assert pf.items_cost_index_for(missing) is None
+
+    assert utils.get_item_price("Potion", missing) == 1000
+    assert utils.get_item_id("Potion", missing) == 4
+    assert len(warnings) == 2
+
+    # A degenerate name takes the same route: it must not short-circuit past the
+    # open() and turn an unreadable file into a silent miss.
+    assert utils.get_item_price(None, missing) == 1000
+    assert utils.get_item_id(None, missing) == 4
+    assert len(warnings) == 4
+
+
+def test_items_cost_index_for_refuses_a_path_that_is_not_the_bundled_file(tmp_path):
+    """The index answers only for the file it was built from."""
+    from Ankimon.functions.pokedex_functions import items_cost_index_for
+    from Ankimon.resources import csv_file_items_cost
+
+    assert items_cost_index_for(tmp_path / "items.csv") is None
+    assert items_cost_index_for(str(csv_file_items_cost)) is not None
+
+
+def test_capitalized_sprite_names_now_resolve_and_leave_the_mart():
+    """The one player-visible change in this branch, pinned.
+
+    ``Black-Augurite.png`` and ``Peat-Block.png`` are the only sprite filenames
+    that are BOTH capitalized and a real items.csv row. Before the fold they
+    raw-missed, so ``get_item_price`` returned None; ``daily_item_list`` filters
+    on ``price == 0``, ``None == 0`` is False, and both shipped into the daily
+    Mart with a null price. Folded, they resolve to their real cost of 0 and the
+    existing filter drops them — the Mart goes from 188 entries to 186.
+
+    That is the correct outcome (a null-priced Mart entry was never buyable in
+    any meaningful sense, and both are still granted by ``random_item()``), but
+    it IS a behaviour change, so it gets a test rather than a surprise.
+    """
+    import Ankimon.utils as utils
+
+    assert utils.get_item_price("Black-Augurite") == 0
+    assert utils.get_item_price("Peat-Block") == 0
+    assert utils.get_item_id("Black-Augurite") == 10001
+    assert utils.get_item_id("Peat-Block") == 10002
+    # The lowercase identifiers always resolved; the capitalization was the only
+    # thing standing between the sprite name and the row.
+    assert utils.get_item_price("black-augurite") == 0
+    assert utils.get_item_price("peat-block") == 0

--- a/tests/test_item_name_normalization.py
+++ b/tests/test_item_name_normalization.py
@@ -6,3 +6,55 @@ def test_return_id_for_item_name_normalization():
     assert return_id_for_item_name("Dubious Disc") == "301"
     assert return_id_for_item_name("King's Rock") == "198"
     assert return_id_for_item_name("Up-Grade") == "229"
+
+
+def test_normalize_item_identifier_folds_both_shapes():
+    from Ankimon.functions.pokedex_functions import normalize_item_identifier
+
+    # Display shape -> csv shape.
+    assert normalize_item_identifier("King's Rock") == "kings-rock"
+    assert normalize_item_identifier("  Dubious Disc  ") == "dubious-disc"
+    # U+2019 (typographic apostrophe) folds the same as the ASCII one, which is
+    # what lets the csv side meet the display side.
+    assert normalize_item_identifier("Kofu’s Wallet") == "kofus-wallet"
+    assert normalize_item_identifier("Kofu's Wallet") == "kofus-wallet"
+    # Combining accents are stripped, so "Poke" reaches "poké".
+    assert normalize_item_identifier("Poké Ball") == "poke-ball"
+    assert normalize_item_identifier("Flabébé Pollen") == "flabebe-pollen"
+    # Already-canonical identifiers are unchanged (the folding is idempotent).
+    assert normalize_item_identifier("dubious-disc") == "dubious-disc"
+    # Non-string input misses cleanly instead of raising.
+    assert normalize_item_identifier(301) == ""
+    assert normalize_item_identifier(None) == ""
+
+
+def test_return_id_for_item_name_reaches_accented_identifiers():
+    """The nine rows whose identifier carries U+2019 or an accent.
+
+    Folding only the caller's side (as the original fix did) cannot match these,
+    because the stored identifier is the odd one. Both sides are folded now.
+    """
+    from Ankimon.functions.pokedex_functions import return_id_for_item_name
+
+    assert return_id_for_item_name("Poke Ball") == "4"
+    assert return_id_for_item_name("Poké Ball") == "4"
+    assert return_id_for_item_name("Leader's Crest") == "2046"
+    assert return_id_for_item_name("Koraidon's Poke Ball") == "1667"
+    assert return_id_for_item_name("Jalapeno") == "1756"
+    # And the cases the original fix already handled keep working.
+    assert return_id_for_item_name("Dubious Disc") == "301"
+
+
+def test_utils_item_lookups_accept_display_names():
+    """get_item_id/get_item_price did the same raw match and were left behind."""
+    import Ankimon.utils as utils
+
+    assert utils.get_item_id("Dubious Disc") == 301
+    assert utils.get_item_id("King's Rock") == 198
+    assert utils.get_item_id("Poké Ball") == 4
+    assert utils.get_item_id("poke-ball") == 4
+
+    # get_item_price returns the cost for the same folded lookup. potion is a
+    # priced item; exp-share is priced 0 and is excluded from the shop by that.
+    assert utils.get_item_price("Potion") == utils.get_item_price("potion")
+    assert utils.get_item_price("Potion") > 0


### PR DESCRIPTION
## Summary

Follow-up to #784, which normalized only `return_id_for_item_name`, and only the **caller's** side.

**1. The same raw match survived in two other functions.** `utils.get_item_id()` and `utils.get_item_price()` do the identical `row["identifier"] == item_name` comparison against the same `items.csv`, and were left untouched — so the normalizer lived in one of the three lookups that need it.

**2. Folding one side cannot reach nine rows.** These identifiers carry a typographic apostrophe (U+2019) or a combining accent **in the CSV itself**, so no amount of folding the caller's input will match them:

`koraidon’s-poké-ball`, `miraidon’s-poké-ball`, `kofu’s-wallet`, `leader’s-crest`, `jalapeño`, `flabébé-pollen`, and the three `-poké-ball-pick` rows.

### Scope, stated honestly

**Mostly robustness — with one real, player-visible change.** `Black-Augurite.png` and `Peat-Block.png` are the only sprite filenames that are both capitalized *and* a real `items.csv` row. They raw-missed before, so `get_item_price` returned `None`; `daily_item_list` filters on `price == 0`, `None == 0` is False, and both shipped into the daily Mart **with a null price**. Folded, they resolve to their real cost of `0` and the existing filter drops them:

| | daily Mart entries |
|---|---|
| `main` | **188** — including `("Black-Augurite", None)` and `("Peat-Block", None)` |
| this branch | **186** |

That is the right outcome — a null-priced Mart entry was never meaningfully buyable, and both items are still granted by `random_item()`, which this PR does not touch — but it is a behaviour change, so `test_capitalized_sprite_names_now_resolve_and_leave_the_mart` pins it. Every other one of the 359 sprites resolves identically before and after.

Beyond that it is robustness. The nine accented rows above have no sprite today, so nothing asks for them yet, and `get_item_id`'s only caller (`get_item_description`) has no static caller of its own.

What the change buys is that a display-form name — `"King's Rock"`, `"Poké Ball"` — resolves through **any** of the three lookups rather than one, and that the nine odd identifiers become reachable at all. Bag item names come out of the database, so legacy saves and the `items.json` string→object migration are the paths most likely to hand these lookups something non-canonical; that is not something the code paths alone can rule out.

## Change

`normalize_item_identifier()` now lives in `pokedex_functions` — the lower-level module, since `utils` imports *it*, not the other way round — and is applied to **both sides** of all three lookups:

> strip → lowercase → U+2019 to ASCII apostrophe → NFKD accent strip → spaces to hyphens → drop apostrophes

`load_items_cost_index()` folds the file **once** into `{folded identifier: row}`, over the rows `_load_items_cost_cache()` already holds, and all three lookups go through it. Folding the *stored* side is the expensive half — done per row per call it re-ran NFKD over all 2510 identifiers on every lookup, and `daily_item_list` makes two lookups per sprite. `utils` keeps its own file scan for a caller-supplied `file_path` **and** for an index that came back empty, so an unreadable `items.csv` still surfaces the historical warning-plus-fallback rather than a silent miss.

A name that folds to `""` is rejected before matching, and rows whose identifier folds to `""` are skipped at index build — both sides fold to the same `""`, so a malformed blank identifier cell could otherwise answer `get_item_price(None)` with its own cost. (Not reachable today: the shipped file has no such row and nothing passes a custom `file_path`.)

## Why folding the CSV side is safe

Verified against the shipped `items.csv`: **this merges no two distinct identifiers.** 2165 distinct raw identifiers across 2510 rows fold to exactly **2165** distinct keys, so every collision bucket holds repeats of one *identical raw string* — the file already contained **344** such repeated identifiers (343 doubles plus one triple) before any folding.

First match still wins, which matters: five identifiers have duplicate rows that *disagree*. `metronome` is id `254` / cost `4000` on its first row and id `20118` / cost `1000` on the two later ones, and it still resolves to `254` — the pre-existing answer.

Non-string input folds to `""` (a clean miss) instead of raising, which also removes the `AttributeError`-into-traceback-dialog path #784 introduced for a non-str argument.

## Performance

`daily_item_list()` against the full upstream sprite set (359 PNGs), on aarch64:

| ref | cold | warm |
|---|---|---|
| `main` | 2154.8 ms | 2159.8 ms |
| `95724b6a` (fold only) | 3337.9 ms | 3342.8 ms |
| **head** | **63.3 ms** | **8.1 ms** |

**34× faster than `main` cold, 266× warm.** Worst-case single lookup (a miss, full scan): **11.20 ms → 0.0029 ms**.

Note that `95724b6a` **alone** is a 1.55× regression against `main` — folding the stored identifier per row per call costs more than it saves. The two commits must ship together; they are on the same branch, so they do.

It is memoized in `_DAILY_ITEMS_POOL`, so this is first-shop-open latency, not the review path. Cost: ~1.3 MB retained per session for the row cache plus a 166 KB index, and rows are shared references, nothing duplicated.

## Validation

- `harness/check.py` — **PASS — all 9 Tier-1 checks green**
- full `pytest tests/` — **1087 passed, 41 skipped**
- item/shop/pokedex suites (`test_random_item`, `test_shop_pool_lazy`, `test_held_items`, `test_item_popup_toggle`, `test_item_name_normalization`) — **26 passed, 1 skipped**
- `ruff check --config ci_ruff_check.toml` — clean. `ruff format` reports the **same 13 hunks** in `utils.py` before and after the change: no new formatting drift, and no drive-by reformat of untouched code.
- Merged against `origin/main` (11 commits ahead, none touching these files): clean, gate green, **1096 passed, 41 skipped**.
- Equivalence, not sampling: a 7743-name sweep across all three lookups (every CSV identifier in four casings, every sprite stem, display names, and non-string junk) finds **0** differences between `95724b6a` and head, and **0** changed answers versus `main` — every difference is a miss becoming a hit. The index returns the same row as the old first-match scan for **all 2165 identifiers**.
- Headless harness: `smoke_play`, `economy` and `longrun` on all three refs — **0** `type == "error"` events, identical event counts.
- 13 tests. Mutation-checked — restoring the raw match makes `test_utils_item_lookups_accept_display_names` fail, and **every one of the five guard lines added by this branch fails a test when deleted**.
