### PR TITLE
fix(migration): safely handle strings in legacy JSON save data

### DIFF
--- a/src/Ankimon/pyobj/database_manager.py
+++ b/src/Ankimon/pyobj/database_manager.py
@@ -1966,6 +1966,8 @@ class AnkimonDB:
                     with open(mypokemon_path, 'r', encoding='utf-8') as f:
                         pokemon_list = json.load(f)
                     for pokemon in pokemon_list:
+                        if isinstance(pokemon, str):
+                            continue
                         if self.save_pokemon(pokemon):
                             stats["pokemon"] += 1
                     self._log("info", f"Migrated {stats['pokemon']} pokemon from mypokemon.json")
@@ -1980,7 +1982,7 @@ class AnkimonDB:
                     if main_data:
                         # mainpokemon.json is a list with one item
                         main_pokemon = main_data[0] if isinstance(main_data, list) else main_data
-                        if self.save_main_pokemon(main_pokemon):
+                        if not isinstance(main_pokemon, str) and self.save_main_pokemon(main_pokemon):
                             stats["main"] = 1
                     self._log("info", "Migrated main pokemon from mainpokemon.json")
                 except Exception as e:
@@ -1995,10 +1997,17 @@ class AnkimonDB:
                     for item in items_list:
                         if not item: continue
                         # Support multiple legacy keys for item name
-                        item_name = item.get("item") or item.get("name") or item.get("item_name")
-                        quantity = item.get("quantity", item.get("amount", 1))
+                        if isinstance(item, str):
+                            item_name = item
+                            quantity = 1
+                            extra_data = None
+                        else:
+                            item_name = item.get("item") or item.get("name") or item.get("item_name")
+                            quantity = item.get("quantity", item.get("amount", 1))
+                            extra_data = item
+
                         if item_name:
-                            if self.add_item(item_name, quantity, extra_data=item, commit=False):
+                            if self.add_item(item_name, quantity, extra_data=extra_data, commit=False):
                                 stats["items"] += 1
                     
                     self._get_connection().commit()


### PR DESCRIPTION
Fixes an `AttributeError: 'str' object has no attribute 'get'` crash during the legacy JSON to SQLite migration.

### Background
Older versions of Ankimon (e.g., 2.03 and earlier) sometimes saved data in JSON files (`mypokemon.json`, `mainpokemon.json`, `items.json`) as flat string arrays (e.g., `["potion"]`) rather than objects (e.g., `[{"name": "potion", "quantity": 1}]`). 

When migrating these arrays, the migration logic expects dictionaries and attempts to call `.get()`, causing the migration to crash at 0%.

### Changes
* `mypokemon.json`: `isinstance(pokemon, str)` check added to skip entries that are strings, as they lack the attributes needed to create a valid Pokémon object.
* `mainpokemon.json`: Safely skips migrating `mainpokemon` if the payload is a string.
* `items.json`: Handled `isinstance(item, str)` explicitly to allow importing simple strings directly as an item name with a default quantity of 1.

---
*PR created automatically by Jules for task [6089182826349877584](https://jules.google.com/task/6089182826349877584) started by @h0tp-ftw*