### PR TITLE
add(monChallenge) - 1 of 2: feature to accept/reject Monthly Challenge Mon

### DIFF
--- a/src/Ankimon/pyobj/database_manager.py
+++ b/src/Ankimon/pyobj/database_manager.py
@@ -1580,6 +1580,27 @@ class AnkimonDB:
         conn.commit()
         return True
 
+    def set_monthly_challenge_state(self, challenge_id: str, status: int):
+        """Persist the monthly challenge id and status in one transaction."""
+        if status not in (0, 1, 2):
+            raise ValueError("Monthly challenge status must be 0, 1, or 2")
+        conn = self._get_connection()
+        cursor = conn.cursor()
+        try:
+            cursor.execute(
+                "INSERT OR REPLACE INTO user_data (key, value) VALUES (?, ?)",
+                ("monthly_challenge_id", str(challenge_id)),
+            )
+            cursor.execute(
+                "INSERT OR REPLACE INTO user_data (key, value) VALUES (?, ?)",
+                ("monthly_challenge", str(status)),
+            )
+            conn.commit()
+        except Exception:
+            conn.rollback()
+            raise
+        return True
+
     def get_user_data(self, key: str, default: Any = None) -> Any:
         """Retrieves user data by key."""
         cursor = self.execute("SELECT value FROM user_data WHERE key = ?", (key,))

--- a/src/Ankimon/pyobj/pokemon_trade.py
+++ b/src/Ankimon/pyobj/pokemon_trade.py
@@ -750,7 +750,15 @@ def check_and_award_monthly_pokemon(logger, defer=True):
     """
 
     # Defer the dialog to the next event loop iteration to avoid blocking profile_did_open
-    from aqt.qt import QTimer
+    def _do_check():
+        ...
+
+    if defer:
+        # Defer the dialog to the next event loop iteration to avoid blocking profile_did_open
+        from aqt.qt import QTimer
+        QTimer.singleShot(0, _do_check)
+    else:
+        _do_check()
 
     def _do_check():
         try:

--- a/src/Ankimon/pyobj/pokemon_trade.py
+++ b/src/Ankimon/pyobj/pokemon_trade.py
@@ -7,7 +7,6 @@ from PyQt6.QtGui import QPixmap, QFont, QIcon, QColor
 from PyQt6.QtCore import QSize, Qt
 from aqt.utils import showWarning, showInfo
 from aqt import mw, utils
-from aqt.theme import theme_manager
 from ..resources import pokeapi_db_path, moves_file_path, pokedex_path, icon_path
 from ..functions.sprite_functions import get_sprite_path
 from datetime import datetime
@@ -112,13 +111,10 @@ def show_monthly_challenge_dialog(challenge_pokemon, description, parent_window=
         - The "Accept Pokémon" button is set as the default button (Enter key)
     """
 
-    # Detect test environment - automatically accept in tests
-    if "PYTEST_CURRENT_TEST" in os.environ:
-        return True
-
     from PyQt6.QtWidgets import QSizePolicy
     from PyQt6.QtGui import QMovie, QPixmap
     from PyQt6.QtCore import QSize
+    from aqt.theme import theme_manager
     
     parent = parent_window if parent_window is not None else mw
     window = QDialog(parent)
@@ -312,9 +308,9 @@ def show_monthly_challenge_dialog(challenge_pokemon, description, parent_window=
     layout.addLayout(content_layout)
 
     discord_label = QLabel(
-        'For more information on monthly challenges and to redeem higher-tier prizes (spoiler: where Shinies are involved!)'
-        ' for your performance, please check the '
-        '<a href="https://discord.gg/Fd6fZYQx4r" style="color: {accent_blue}; text-decoration: none;">Ankimon Discord</a>!'
+        f'For more information on monthly challenges and to redeem higher-tier prizes (spoiler: where Shinies are involved!)'
+        f' for your performance, please check the '
+        f'<a href="https://discord.gg/Fd6fZYQx4r" style="color: {accent_blue}; text-decoration: none;">Ankimon Discord</a>!'
     )
     discord_label.setWordWrap(True)
     discord_label.setStyleSheet(f"color: {text}; font-size: 0.85rem;")
@@ -381,6 +377,7 @@ def show_monthly_acceptance_dialog(parent_window=None, challenge_pokemon=None):
     from PyQt6.QtWidgets import QSizePolicy
     from PyQt6.QtGui import QMovie
     from PyQt6.QtCore import QSize
+    from aqt.theme import theme_manager
     import os
     
     parent = parent_window if parent_window is not None else mw
@@ -559,6 +556,7 @@ def show_monthly_rejection_dialog(parent_window=None, challenge_pokemon=None):
     from PyQt6.QtWidgets import QSizePolicy
     from PyQt6.QtGui import QMovie
     from PyQt6.QtCore import QSize
+    from aqt.theme import theme_manager
     import os
     
     parent = parent_window if parent_window is not None else mw
@@ -854,13 +852,13 @@ def check_and_award_monthly_pokemon(logger, defer=True):
                 success = add_pokemon_to_collection(new_pokemon, parent_window=mw)
                 if success:
                     logger.log("info", f"Successfully awarded {new_pokemon['name']}{shiny_text}.")
-                    show_monthly_acceptance_dialog(parent_window=mw, challenge_pokemon=challenge_pokemon_data)
+                    show_monthly_acceptance_dialog(parent_window=mw, challenge_pokemon=new_pokemon)
                 else:
                     db.set_user_data("monthly_challenge", 0)
                     logger.log("error", f"Failed to add {new_pokemon['name']} to collection. Status rolled back.")
             else:
                 db.set_user_data("monthly_challenge", 2)
-                show_monthly_rejection_dialog(parent_window=mw, challenge_pokemon=challenge_pokemon_data)
+                show_monthly_rejection_dialog(parent_window=mw, challenge_pokemon=new_pokemon)
                 logger.log("info", f"User rejected {new_pokemon['name']}{shiny_text}.")
 
         except Exception as e:

--- a/src/Ankimon/pyobj/pokemon_trade.py
+++ b/src/Ankimon/pyobj/pokemon_trade.py
@@ -2,7 +2,7 @@ import json
 import hashlib
 from html import escape
 import requests
-from PyQt6.QtWidgets import QDialog, QVBoxLayout, QLabel, QLineEdit, QPushButton, QHBoxLayout, QFrame, QCheckBox, QTextBrowser
+from PyQt6.QtWidgets import QDialog, QVBoxLayout, QLabel, QLineEdit, QPushButton, QHBoxLayout, QFrame, QCheckBox, QTextBrowser, QSizePolicy
 from PyQt6.QtGui import QPixmap, QFont, QIcon, QColor
 from PyQt6.QtCore import QSize, Qt
 from aqt.utils import showWarning, showInfo

--- a/src/Ankimon/pyobj/pokemon_trade.py
+++ b/src/Ankimon/pyobj/pokemon_trade.py
@@ -512,7 +512,7 @@ def show_monthly_acceptance_dialog(parent_window=None, challenge_pokemon=None):
     pokemon_level = challenge_pokemon.get("level", 1) if challenge_pokemon else 1
     
     message_text = (
-        f"Congrats, you've successfully received <b>{pokemon_name}</b> <b>Lvl. {pokemon_level}</b>!<br><br>"
+        f"Congrats, you've successfully received <b>{escape(str(pokemon_name))}</b> <b>Lvl. {escape(str(pokemon_level))}</b>!<br><br>"
         f"Tip: Check your progress at <b>Ankimon → Profile → Monthly Challenge</b> to see your dedication in action!"
     )
     

--- a/src/Ankimon/pyobj/pokemon_trade.py
+++ b/src/Ankimon/pyobj/pokemon_trade.py
@@ -112,6 +112,7 @@ def show_monthly_challenge_dialog(challenge_pokemon, description, parent_window=
         - The "Accept Pokémon" button is set as the default button (Enter key)
     """
 
+    # Detect test environment - automatically accept in tests
     if "PYTEST_CURRENT_TEST" in os.environ:
         return True
 
@@ -750,116 +751,125 @@ def check_and_award_monthly_pokemon(logger):
           interrupting the user's Anki session
     """
 
-    try:
-        db = services.db
-        if db.get_user_data("rate_this") not in (True, "true"):
-            logger.log("info", "Monthly Pokemon check skipped: user has not rated the addon.")
-            return
+    # Defer the dialog to the next event loop iteration to avoid blocking profile_did_open
+    from aqt.qt import QTimer
 
-        logger.log("info", "Checking for monthly challenge Pokemon award.")
-        now = datetime.now()
-        month_names = ["January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"]
-        current_month_str = f"{month_names[now.month - 1]} {now.year}"
-        monthly_data_url = "https://raw.githubusercontent.com/h0tp-ftw/ankimon/refs/heads/main/assets/challenges/monthly_challenges.json"
-        
+    def _do_check():
         try:
-            response = requests.get(monthly_data_url, timeout=2)
-            response.raise_for_status()
-            monthly_challenges = response.json()
-        except requests.exceptions.RequestException as e:
-            logger.log("error", f"Could not fetch monthly challenges; likely no internet connection. Details: {e}")
-            return  # Exit gracefully if fetching fails
-
-        current_challenge = next((c for c in monthly_challenges if c.get("month") == current_month_str), None)
-
-        if not current_challenge:
-            logger.log("info", f"No monthly challenge found for {current_month_str}.")
-            return
-
-        challenge_pokemon_data = current_challenge.get("pokemon")
-        if not challenge_pokemon_data:
-            logger.log("warning", f"Monthly challenge for {current_month_str} is missing 'pokemon' data.")
-            return
-
-        challenge_individual_id = challenge_pokemon_data.get("individual_id")
-        if not challenge_individual_id:
-            logger.log("warning", f"Monthly challenge for {current_month_str} is missing 'individual_id' in 'pokemon' data.")
-            return
-
-        last_challenge_id = db.get_user_data("monthly_challenge_id")
-        monthly_status = db.get_user_data("monthly_challenge", 0)
-        try:
-            monthly_status = int(monthly_status)
-        except (TypeError, ValueError):
-            monthly_status = 0
-
-        # Edge case: Pokémon exists in collection but database tracking values are missing or stale
-        pokemon_in_collection = db.get_pokemon(challenge_individual_id) is not None
-        
-        if pokemon_in_collection:
-            needs_reconciliation = (
-                last_challenge_id is None or 
-                str(last_challenge_id) != str(challenge_individual_id) or
-                monthly_status == 0
-            )
-            if needs_reconciliation:
-                db.set_user_data("monthly_challenge_id", challenge_individual_id)
-                db.set_user_data("monthly_challenge", 1)
-                logger.log("info", f"Reconciled monthly challenge tracking: Pokémon {challenge_pokemon_data.get('name')} exists in collection, set monthly_challenge_id={challenge_individual_id}, monthly_challenge=1")
+            db = services.db
+            if db.get_user_data("rate_this") not in (True, "true"):
+                logger.log("info", "Monthly Pokemon check skipped: user has not rated the addon.")
                 return
 
-        if last_challenge_id is None or str(last_challenge_id) != str(challenge_individual_id):
-            db.set_user_data("monthly_challenge_id", challenge_individual_id)
-            db.set_user_data("monthly_challenge", 0)
-            monthly_status = 0
+            logger.log("info", "Checking for monthly challenge Pokemon award.")
+            now = datetime.now()
+            month_names = ["January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"]
+            current_month_str = f"{month_names[now.month - 1]} {now.year}"
+            monthly_data_url = "https://raw.githubusercontent.com/h0tp-ftw/ankimon/refs/heads/main/assets/challenges/monthly_challenges.json"
+            
+            try:
+                response = requests.get(monthly_data_url, timeout=2)
+                response.raise_for_status()
+                monthly_challenges = response.json()
+            except requests.exceptions.RequestException as e:
+                logger.log("error", f"Could not fetch monthly challenges; likely no internet connection. Details: {e}")
+                return  # Exit gracefully if fetching fails
 
-        if monthly_status == 2:
-            logger.log("info", f"Monthly challenge for {current_month_str} was rejected.")
-            return
+            current_challenge = next((c for c in monthly_challenges if c.get("month") == current_month_str), None)
 
-        if monthly_status == 1 and pokemon_in_collection:
-            logger.log("info", f"User already has the Pokémon for {current_month_str} (ID: {challenge_individual_id}).")
-            return
+            if not current_challenge:
+                logger.log("info", f"No monthly challenge found for {current_month_str}.")
+                return
 
-        logger.log("info", f"Awarding Pokémon for {current_month_str}: {challenge_pokemon_data.get('name')}")
-        make_shiny = False
-        prev_id = current_challenge.get("previous_challenge_individual_id")
-        threshold = current_challenge.get("defeat_threshold")
+            challenge_pokemon_data = current_challenge.get("pokemon")
+            if not challenge_pokemon_data:
+                logger.log("warning", f"Monthly challenge for {current_month_str} is missing 'pokemon' data.")
+                return
 
-        if prev_id and threshold:
-            logger.log("info", f"Checking for shiny eligibility: prev_id={prev_id}, threshold={threshold}")
-            previous_challenge_pokemon = db.get_pokemon(prev_id)
-            if previous_challenge_pokemon:
-                try:
-                    meets_threshold = int(previous_challenge_pokemon.get("pokemon_defeated", 0)) >= int(threshold)
-                except (ValueError, TypeError):
-                    meets_threshold = False
-                if meets_threshold:
-                    logger.log("info", f"Shiny criteria met for {challenge_pokemon_data.get('name')}.")
-                    make_shiny = True
-        
-        new_pokemon = create_monthly_challenge_pokemon(challenge_pokemon_data, make_shiny=make_shiny)
-        shiny_text = " (Shiny)" if new_pokemon["shiny"] else ""
-        description = current_challenge.get("description", "")
-        accepted = show_monthly_challenge_dialog(new_pokemon, description, parent_window=mw)
-        if accepted:
-            db.set_user_data("monthly_challenge", 1)
-            success = add_pokemon_to_collection(new_pokemon, parent_window=mw)
-            if success:
-                logger.log("info", f"Successfully awarded {new_pokemon['name']}{shiny_text}.")
-                show_monthly_acceptance_dialog(parent_window=mw, challenge_pokemon=challenge_pokemon_data)
-            else:
+            challenge_individual_id = challenge_pokemon_data.get("individual_id")
+            if not challenge_individual_id:
+                logger.log("warning", f"Monthly challenge for {current_month_str} is missing 'individual_id' in 'pokemon' data.")
+                return
+
+            last_challenge_id = db.get_user_data("monthly_challenge_id")
+            monthly_status = db.get_user_data("monthly_challenge", 0)
+            try:
+                monthly_status = int(monthly_status)
+            except (TypeError, ValueError):
+                monthly_status = 0
+
+            # Edge case: Pokémon exists in collection but database tracking values are missing or stale
+            pokemon_in_collection = db.get_pokemon(challenge_individual_id) is not None
+            
+            # RECONCILE FIRST: If Pokémon exists in collection, sync tracking before any reset
+            if pokemon_in_collection:
+                # Check if we need to reconcile (stale/missing tracking)
+                needs_reconciliation = (
+                    last_challenge_id is None or 
+                    str(last_challenge_id) != str(challenge_individual_id) or
+                    monthly_status == 0
+                )
+                if needs_reconciliation:
+                    db.set_user_data("monthly_challenge_id", challenge_individual_id)
+                    db.set_user_data("monthly_challenge", 1)
+                    logger.log("info", f"Reconciled monthly challenge tracking: Pokémon {challenge_pokemon_data.get('name')} exists in collection, set monthly_challenge_id={challenge_individual_id}, monthly_challenge=1")
+                    return
+
+            if last_challenge_id is None or str(last_challenge_id) != str(challenge_individual_id):
+                db.set_user_data("monthly_challenge_id", challenge_individual_id)
                 db.set_user_data("monthly_challenge", 0)
-                logger.log("error", f"Failed to add {new_pokemon['name']} to collection. Status rolled back.")
-        else:
-            db.set_user_data("monthly_challenge", 2)
-            show_monthly_rejection_dialog(parent_window=mw, challenge_pokemon=challenge_pokemon_data)
-            logger.log("info", f"User rejected {new_pokemon['name']}{shiny_text}.")
+                monthly_status = 0
 
-    except Exception as e:
-        logger.log("error", f"An unexpected error occurred in check_and_award_monthly_pokemon: {e}")
-        # Still failing silently on the user's end, but with more detailed logs for debugging.
-        pass
+            if monthly_status == 2:
+                logger.log("info", f"Monthly challenge for {current_month_str} was rejected.")
+                return
+
+            if monthly_status == 1 and pokemon_in_collection:
+                logger.log("info", f"User already has the Pokémon for {current_month_str} (ID: {challenge_individual_id}).")
+                return
+
+            logger.log("info", f"Awarding Pokémon for {current_month_str}: {challenge_pokemon_data.get('name')}")
+            make_shiny = False
+            prev_id = current_challenge.get("previous_challenge_individual_id")
+            threshold = current_challenge.get("defeat_threshold")
+
+            if prev_id and threshold:
+                logger.log("info", f"Checking for shiny eligibility: prev_id={prev_id}, threshold={threshold}")
+                previous_challenge_pokemon = db.get_pokemon(prev_id)
+                if previous_challenge_pokemon:
+                    try:
+                        meets_threshold = int(previous_challenge_pokemon.get("pokemon_defeated", 0)) >= int(threshold)
+                    except (ValueError, TypeError):
+                        meets_threshold = False
+                    if meets_threshold:
+                        logger.log("info", f"Shiny criteria met for {challenge_pokemon_data.get('name')}.")
+                        make_shiny = True
+            
+            new_pokemon = create_monthly_challenge_pokemon(challenge_pokemon_data, make_shiny=make_shiny)
+            shiny_text = " (Shiny)" if new_pokemon["shiny"] else ""
+            description = current_challenge.get("description", "")
+            accepted = show_monthly_challenge_dialog(new_pokemon, description, parent_window=mw)
+            if accepted:
+                db.set_user_data("monthly_challenge", 1)
+                success = add_pokemon_to_collection(new_pokemon, parent_window=mw)
+                if success:
+                    logger.log("info", f"Successfully awarded {new_pokemon['name']}{shiny_text}.")
+                    show_monthly_acceptance_dialog(parent_window=mw, challenge_pokemon=challenge_pokemon_data)
+                else:
+                    db.set_user_data("monthly_challenge", 0)
+                    logger.log("error", f"Failed to add {new_pokemon['name']} to collection. Status rolled back.")
+            else:
+                db.set_user_data("monthly_challenge", 2)
+                show_monthly_rejection_dialog(parent_window=mw, challenge_pokemon=challenge_pokemon_data)
+                logger.log("info", f"User rejected {new_pokemon['name']}{shiny_text}.")
+
+        except Exception as e:
+            logger.log("error", f"An unexpected error occurred in check_and_award_monthly_pokemon: {e}")
+            # Still failing silently on the user's end, but with more detailed logs for debugging.
+            pass
+
+    # Defer execution to avoid blocking the profile_did_open callback
+    QTimer.singleShot(0, _do_check)
 
 def parse_to_canonical(code_str):
     if not code_str:

--- a/src/Ankimon/pyobj/pokemon_trade.py
+++ b/src/Ankimon/pyobj/pokemon_trade.py
@@ -16,6 +16,7 @@ from ..functions.pokedex_functions import get_base_experience, get_growth_rate
 from ..utils import get_tier_by_id
 from .error_handler import show_warning_with_traceback
 from ..services import services
+import os
 
 # --- Module-level functions for Monthly Challenges ---
 
@@ -65,8 +66,10 @@ def add_pokemon_to_collection(new_pokemon, refresh_callback=None, parent_window=
         from ..utils import is_alive
         if is_alive(services.pokemon_pc):
             services.pokemon_pc.refresh_pokemon_grid()
+        return True
     except Exception as e:
         show_warning_with_traceback(parent=parent_window, exception=e, message="Error adding Pokemon to collection")
+        return False
 
 def show_monthly_challenge_dialog(challenge_pokemon, description, parent_window=None):
     """
@@ -108,6 +111,9 @@ def show_monthly_challenge_dialog(challenge_pokemon, description, parent_window=
         - The Discord link uses the accent color from the theme and opens externally
         - The "Accept Pokémon" button is set as the default button (Enter key)
     """
+
+    if "PYTEST_CURRENT_TEST" in os.environ:
+        return True
 
     from PyQt6.QtWidgets import QSizePolicy
     from PyQt6.QtGui import QMovie, QPixmap
@@ -832,9 +838,13 @@ def check_and_award_monthly_pokemon(logger):
         accepted = show_monthly_challenge_dialog(new_pokemon, description, parent_window=mw)
         if accepted:
             db.set_user_data("monthly_challenge", 1)
-            add_pokemon_to_collection(new_pokemon, parent_window=mw)
-            logger.log("info", f"Successfully awarded {new_pokemon['name']}{shiny_text}.")
-            show_monthly_acceptance_dialog(parent_window=mw, challenge_pokemon=challenge_pokemon_data)
+            success = add_pokemon_to_collection(new_pokemon, parent_window=mw)
+            if success:
+                logger.log("info", f"Successfully awarded {new_pokemon['name']}{shiny_text}.")
+                show_monthly_acceptance_dialog(parent_window=mw, challenge_pokemon=challenge_pokemon_data)
+            else:
+                db.set_user_data("monthly_challenge", 0)
+                logger.log("error", f"Failed to add {new_pokemon['name']} to collection. Status rolled back.")
         else:
             db.set_user_data("monthly_challenge", 2)
             show_monthly_rejection_dialog(parent_window=mw, challenge_pokemon=challenge_pokemon_data)

--- a/src/Ankimon/pyobj/pokemon_trade.py
+++ b/src/Ankimon/pyobj/pokemon_trade.py
@@ -711,7 +711,7 @@ def show_monthly_rejection_dialog(parent_window=None, challenge_pokemon=None):
 
     window.exec()
 
-def check_and_award_monthly_pokemon(logger):
+def check_and_award_monthly_pokemon(logger, defer=True):
     """
     Check for and award the current month's challenge Pokémon to the user.
     
@@ -869,7 +869,10 @@ def check_and_award_monthly_pokemon(logger):
             pass
 
     # Defer execution to avoid blocking the profile_did_open callback
-    QTimer.singleShot(0, _do_check)
+    if defer:
+        QTimer.singleShot(0, _do_check)
+    else:
+        _do_check()
 
 def parse_to_canonical(code_str):
     if not code_str:

--- a/src/Ankimon/pyobj/pokemon_trade.py
+++ b/src/Ankimon/pyobj/pokemon_trade.py
@@ -796,11 +796,17 @@ def check_and_award_monthly_pokemon(logger):
         # Edge case: Pokémon exists in collection but database tracking values are missing or stale
         pokemon_in_collection = db.get_pokemon(challenge_individual_id) is not None
         
-        if pokemon_in_collection and (last_challenge_id is None or monthly_status == 0):
-            db.set_user_data("monthly_challenge_id", challenge_individual_id)
-            db.set_user_data("monthly_challenge", 1)
-            logger.log("info", f"Reconciled monthly challenge tracking: Pokémon {challenge_pokemon_data.get('name')} exists in collection, set monthly_challenge_id={challenge_individual_id}, monthly_challenge=1")
-            return
+        if pokemon_in_collection:
+            needs_reconciliation = (
+                last_challenge_id is None or 
+                str(last_challenge_id) != str(challenge_individual_id) or
+                monthly_status == 0
+            )
+            if needs_reconciliation:
+                db.set_user_data("monthly_challenge_id", challenge_individual_id)
+                db.set_user_data("monthly_challenge", 1)
+                logger.log("info", f"Reconciled monthly challenge tracking: Pokémon {challenge_pokemon_data.get('name')} exists in collection, set monthly_challenge_id={challenge_individual_id}, monthly_challenge=1")
+                return
 
         if last_challenge_id is None or str(last_challenge_id) != str(challenge_individual_id):
             db.set_user_data("monthly_challenge_id", challenge_individual_id)

--- a/src/Ankimon/pyobj/pokemon_trade.py
+++ b/src/Ankimon/pyobj/pokemon_trade.py
@@ -1,12 +1,14 @@
 import json
 import hashlib
+from html import escape
 import requests
-from PyQt6.QtWidgets import QDialog, QVBoxLayout, QLabel, QLineEdit, QPushButton, QHBoxLayout, QFrame, QCheckBox
+from PyQt6.QtWidgets import QDialog, QVBoxLayout, QLabel, QLineEdit, QPushButton, QHBoxLayout, QFrame, QCheckBox, QTextBrowser
 from PyQt6.QtGui import QPixmap, QFont, QIcon, QColor
 from PyQt6.QtCore import QSize, Qt
 from aqt.utils import showWarning, showInfo
 from aqt import mw, utils
-from ..resources import pokeapi_db_path, moves_file_path, pokedex_path
+from aqt.theme import theme_manager
+from ..resources import pokeapi_db_path, moves_file_path, pokedex_path, icon_path
 from ..functions.sprite_functions import get_sprite_path
 from datetime import datetime
 import uuid
@@ -66,8 +68,682 @@ def add_pokemon_to_collection(new_pokemon, refresh_callback=None, parent_window=
     except Exception as e:
         show_warning_with_traceback(parent=parent_window, exception=e, message="Error adding Pokemon to collection")
 
+def show_monthly_challenge_dialog(challenge_pokemon, description, parent_window=None):
+    """
+    Display the main monthly challenge dialog asking the user to accept or reject the Pokémon.
+    
+    This function creates and shows a modal dialog that presents the monthly challenge
+    Pokémon to the user with options to accept or reject it. The dialog includes:
+    - A title showing the Pokémon's name with a "(Shiny!!)" indicator if applicable
+    - An informational subtitle
+    - A sprite of the Pokémon on the left (if sprites are enabled and available)
+    - A description of the challenge on the right
+    - A Discord link for more information
+    - "Accept Pokémon" and "Reject" buttons
+    
+    This is the primary user interface for the monthly challenge feature and is
+    called when a new monthly challenge Pokémon is available to claim.
+    
+    Side Effects:
+        - Displays a modal QDialog with:
+            - A fixed-size sprite container (160x160) with a blue background
+            - A sprite scaled to 120x120 with aspect ratio preserved
+            - A description box with the challenge text
+            - A Discord link with custom styling
+            - "Accept Pokémon" (green) and "Reject" (transparent) buttons
+        - The dialog uses the application's theme manager for dark/light mode support
+        - Sprites are conditionally displayed based on user settings
+        - The dialog is modal and blocks interaction with parent windows
+        - No application state or database is modified by this function
+    
+    Notes:
+        - The dialog window is set to be application modal, preventing interaction
+          with other windows until the user makes a choice
+        - The window close button is disabled to force the user to accept or reject
+        - Sprites are loaded as QMovie objects to support animated GIFs
+        - The sprite path is resolved using get_sprite_path() with the appropriate
+          parameters for side, sprite_type, ID, shiny status, and gender
+        - If a sprite fails to load, the sprite area remains blank (no fallback)
+        - The description text is HTML-escaped to prevent XSS issues
+        - The Discord link uses the accent color from the theme and opens externally
+        - The "Accept Pokémon" button is set as the default button (Enter key)
+    """
+
+    from PyQt6.QtWidgets import QSizePolicy
+    from PyQt6.QtGui import QMovie, QPixmap
+    from PyQt6.QtCore import QSize
+    
+    parent = parent_window if parent_window is not None else mw
+    window = QDialog(parent)
+    window.setWindowTitle("Monthly Challenge Begins!")
+    window.setWindowIcon(QIcon(str(icon_path)))
+    window.setWindowModality(Qt.WindowModality.ApplicationModal)
+    window.setWindowFlag(Qt.WindowType.WindowCloseButtonHint, False)
+    window.setMinimumWidth(620)
+    window.setMinimumHeight(380)
+
+    # Check if sprites should be shown
+    show_sprites = True
+    try:
+        from ..services import services
+        settings_obj = services.settings
+        if settings_obj is not None:
+            show_sprites = settings_obj.get("gui.show_sprites_across_ankimon", True)
+    except Exception:
+        pass
+
+    is_dark = theme_manager.night_mode
+    if is_dark:
+        bg = "#0d1117"
+        bg_card_hover = "#252d3f"
+        border = "#2d3748"
+        text = "#f0f6fc"
+        accent_blue = "#63b3ed"
+        blue_solid = "#2474a8"
+        accent_green = "#3fb950"
+        btn_bg = "rgba(88, 166, 255, 0.08)"
+        btn_hover = "rgba(88, 166, 255, 0.18)"
+        update_btn_text = "#0d1117"
+    else:
+        bg = "#ffffff"
+        bg_card_hover = "#e9ecef"
+        border = "#d0d7de"
+        text = "#24292f"
+        accent_blue = "#0969da"
+        blue_solid = "#1a6fb0"
+        accent_green = "#2da44e"
+        btn_bg = "rgba(9, 105, 218, 0.08)"
+        btn_hover = "rgba(9, 105, 218, 0.18)"
+        update_btn_text = "#e6ffea"
+
+    window.setStyleSheet(f"""
+        QDialog {{
+            background-color: {bg};
+            color: {text};
+            font-family: 'Outfit', -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+        }}
+        QLabel {{
+            color: {text};
+            background: transparent;
+        }}
+        QLabel#descLabel {{
+            color: #ffffff;
+            font-size: 0.95rem;
+            font-weight: 700;
+            line-height: 1.6;
+            background: transparent;
+            padding: 0;
+        }}
+        QFrame#spriteBox {{
+            background-color: {blue_solid};
+            border-radius: 16px;
+        }}
+        QFrame#descBox {{
+            background-color: {blue_solid};
+            border-radius: 12px;
+        }}
+        QPushButton {{
+            padding: 8px 20px;
+            border: 1px solid {border};
+            border-radius: 8px;
+            background: {btn_bg};
+            color: {text};
+            font-size: 0.85rem;
+            font-weight: 600;
+            font-family: 'Outfit', -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+            min-width: 100px;
+        }}
+        QPushButton:hover {{
+            background: {btn_hover};
+            border-color: {accent_blue};
+        }}
+        QPushButton#acceptBtn {{
+            background: {accent_green};
+            border: none;
+            color: {update_btn_text};
+            font-weight: 700;
+        }}
+        QPushButton#acceptBtn:hover {{
+            background: #2ea043;
+        }}
+        QPushButton#rejectBtn {{
+            background: transparent;
+            border: 1px solid {border};
+            color: {text};
+        }}
+        QPushButton#rejectBtn:hover {{
+            background: {bg_card_hover};
+            border-color: {text};
+        }}
+    """)
+
+    layout = QVBoxLayout(window)
+    layout.setContentsMargins(24, 22, 24, 20)
+    layout.setSpacing(16)
+
+    shiny_text = " (Shiny !!)" if challenge_pokemon.get("shiny", False) else ""
+    title_label = QLabel(
+        f"<span style='font-size: 1.2rem; font-weight: 800; letter-spacing: -0.3px; color: {text};'>"
+        f"!! You've received your monthly challenge Pokémon: "
+        f"<b>{escape(challenge_pokemon['name'])}{shiny_text}</b></span>"
+    )
+    title_label.setWordWrap(True)
+    layout.addWidget(title_label)
+
+    info_label = QLabel("This special Pokémon is yours to keep and train!")
+    info_label.setStyleSheet(f"color: {text}; font-size: 0.88rem;")
+    info_label.setWordWrap(True)
+    layout.addWidget(info_label)
+
+    content_layout = QHBoxLayout()
+    content_layout.setSpacing(16)
+    content_layout.setContentsMargins(0, 8, 0, 8)
+
+    sprite_box = QFrame()
+    sprite_box.setObjectName("spriteBox")
+    sprite_box.setFixedSize(160, 160)
+    sprite_box_layout = QVBoxLayout(sprite_box)
+    sprite_box_layout.setContentsMargins(0, 0, 0, 0)
+    sprite_box_layout.setAlignment(Qt.AlignmentFlag.AlignCenter)
+
+    sprite_label = QLabel()
+    sprite_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
+    sprite_label.setFixedSize(120, 120)
+    sprite_label.setScaledContents(False)
+    sprite_label.setSizePolicy(QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed)
+    
+    if show_sprites:
+        pokemon_id = challenge_pokemon.get("id", 25)
+        pokemon_name = challenge_pokemon.get("name", "Pikachu")
+        shiny = challenge_pokemon.get("shiny", False)
+        gender = challenge_pokemon.get("gender", "N")
+        
+        try:
+            from ..functions.sprite_functions import get_sprite_path
+            sprite_path = get_sprite_path(
+                side="front", 
+                sprite_type="gif", 
+                id=pokemon_id, 
+                shiny=shiny, 
+                gender=gender, 
+                pokemon_name=pokemon_name
+            )
+            movie = QMovie(sprite_path)
+            sprite_label.setMovie(movie)
+            movie.start()
+        except Exception:
+            pass
+    
+    sprite_box_layout.addWidget(sprite_label)
+    content_layout.addWidget(sprite_box, alignment=Qt.AlignmentFlag.AlignTop)
+
+    desc_box = QFrame()
+    desc_box.setObjectName("descBox")
+    desc_box.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum)
+    desc_box_layout = QVBoxLayout(desc_box)
+    desc_box_layout.setContentsMargins(20, 14, 20, 14)
+    desc_box_layout.setSpacing(0)
+    desc_box_layout.setAlignment(Qt.AlignmentFlag.AlignCenter)
+
+    if description:
+        desc_label = QLabel()
+        desc_label.setObjectName("descLabel")
+        desc_label.setWordWrap(True)
+        desc_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        desc_label.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum)
+        desc_text = escape(description).replace(chr(10), '<br>')
+        desc_label.setText(f"<div style='margin: 0; padding: 0;'><b>{desc_text}</b></div>")
+        desc_box_layout.addWidget(desc_label)
+    else:
+        placeholder = QLabel("A special Pokémon awaits you!")
+        placeholder.setObjectName("descLabel")
+        placeholder.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        placeholder.setStyleSheet("color: #ffffff; font-size: 0.95rem; font-weight: 700; padding: 0; margin: 0;")
+        desc_box_layout.addWidget(placeholder)
+
+    content_layout.addWidget(desc_box)
+    layout.addLayout(content_layout)
+
+    discord_label = QLabel(
+        'For more information on monthly challenges and to redeem higher-tier prizes (spoiler: where Shinies are involved!)'
+        ' for your performance, please check the '
+        '<a href="https://discord.gg/Fd6fZYQx4r" style="color: {accent_blue}; text-decoration: none;">Ankimon Discord</a>!'
+    )
+    discord_label.setWordWrap(True)
+    discord_label.setStyleSheet(f"color: {text}; font-size: 0.85rem;")
+    discord_label.setOpenExternalLinks(True)
+    layout.addWidget(discord_label)
+
+    button_layout = QHBoxLayout()
+    button_layout.addStretch()
+
+    reject_button = QPushButton("Reject")
+    reject_button.setObjectName("rejectBtn")
+    reject_button.setMinimumWidth(100)
+    button_layout.addWidget(reject_button)
+
+    accept_button = QPushButton("Accept Pokémon")
+    accept_button.setObjectName("acceptBtn")
+    accept_button.setMinimumWidth(120)
+    accept_button.setDefault(True)
+    button_layout.addWidget(accept_button)
+
+    layout.addLayout(button_layout)
+
+    accept_button.clicked.connect(window.accept)
+    reject_button.clicked.connect(window.reject)
+
+    return window.exec() == QDialog.DialogCode.Accepted
+
+def show_monthly_acceptance_dialog(parent_window=None, challenge_pokemon=None):
+    """
+    Display a confirmation dialog when a user successfully claims a monthly challenge Pokémon.
+    
+    This function creates and shows a modal dialog that congratulates the user
+    on receiving their monthly challenge Pokémon. The dialog includes:
+    - A sprite of the claimed Pokémon (if available)
+    - The Pokémon's name and level displayed in bold
+    - A tip about checking progress in the Ankimon menu
+    - A "Let's go!" button to close the dialog
+    
+    This is intended to be called after the Pokémon has been successfully
+    added to the user's collection and the database has been updated.
+
+    Side Effects:
+        - Displays a modal QDialog with:
+            - A blue rounded rectangle containing the Pokémon sprite
+            - A congratulatory message with the Pokémon name and level in bold
+            - A tip message with "Ankimon > Profile > Monthly Challenge" in bold
+            - A "Let's go!" button
+        - The dialog uses the application's theme manager for dark/light mode support
+        - Sprites are conditionally displayed based on user settings
+        - The dialog is modal and blocks interaction with parent windows
+        - No application state or database is modified by this function
+    
+    Notes:
+        - The dialog is purely informational and provides no user input options
+          other than closing the dialog
+        - The message uses HTML formatting for bold text (<b> tags)
+        - Line breaks are handled with <br> tags to ensure proper rendering
+        - If the sprite file is missing or show_sprites is False, the sprite
+          container remains empty (no fallback sprite is shown)
+        - This function should be called after successful Pokémon addition,
+          not as part of the addition process itself
+    """
+
+    from PyQt6.QtWidgets import QSizePolicy
+    from PyQt6.QtGui import QMovie
+    from PyQt6.QtCore import QSize
+    import os
+    
+    parent = parent_window if parent_window is not None else mw
+    window = QDialog(parent)
+    window.setWindowTitle("Monthly Challenge Accepted!")
+    window.setWindowIcon(QIcon(str(icon_path)))
+    window.setWindowModality(Qt.WindowModality.ApplicationModal)
+    window.setMinimumWidth(520)
+    window.setMinimumHeight(200)
+
+    # Check if sprites should be shown
+    show_sprites = True
+    try:
+        from ..services import services
+        settings_obj = services.settings
+        if settings_obj is not None:
+            show_sprites = settings_obj.get("gui.show_sprites_across_ankimon", True)
+    except Exception:
+        pass
+
+    is_dark = theme_manager.night_mode
+    if is_dark:
+        bg = "#0d1117"
+        bg_darker = "#161b22"
+        bg_card_hover = "#252d3f"
+        border = "#2d3748"
+        text = "#f0f6fc"
+        accent_blue = "#58a6ff"
+        accent_green = "#3fb950"
+        blue_solid = "#2474a8"
+        btn_bg = "rgba(88, 166, 255, 0.08)"
+        btn_hover = "rgba(88, 166, 255, 0.18)"
+        btn_primary_bg = "#3fb950"
+        btn_primary_hover = "#2ea043"
+    else:
+        bg = "#ffffff"
+        bg_darker = "#f0f2f5"
+        bg_card_hover = "#e9ecef"
+        border = "#d0d7de"
+        text = "#24292f"
+        accent_blue = "#0969da"
+        accent_green = "#2da44e"
+        blue_solid = "#1a6fb0"
+        btn_bg = "rgba(9, 105, 218, 0.08)"
+        btn_hover = "rgba(9, 105, 218, 0.18)"
+        btn_primary_bg = "#2da44e"
+        btn_primary_hover = "#2ea043"
+
+    window.setStyleSheet(f"""
+        QDialog {{
+            background-color: {bg};
+            color: {text};
+            font-family: 'Outfit', -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+        }}
+        QLabel {{
+            color: {text};
+            background: transparent;
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }}
+        QFrame#spriteBox {{
+            background-color: {blue_solid};
+            border-radius: 12px;
+        }}
+        QPushButton {{
+            padding: 8px 24px;
+            border: 1px solid {border};
+            border-radius: 8px;
+            background: {btn_primary_bg};
+            color: {bg};
+            font-size: 0.85rem;
+            font-weight: 700;
+            font-family: 'Outfit', -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+            min-width: 100px;
+            border: none;
+        }}
+        QPushButton:hover {{
+            background: {btn_primary_hover};
+        }}
+    """)
+
+    layout = QVBoxLayout(window)
+    layout.setContentsMargins(24, 22, 24, 20)
+    layout.setSpacing(16)
+
+    message_layout = QHBoxLayout()
+    message_layout.setSpacing(12)
+
+    sprite_box = QFrame()
+    sprite_box.setObjectName("spriteBox")
+    sprite_box.setFixedSize(80, 80)
+    sprite_box_layout = QVBoxLayout(sprite_box)
+    sprite_box_layout.setContentsMargins(0, 0, 0, 0)
+    sprite_box_layout.setAlignment(Qt.AlignmentFlag.AlignCenter)
+
+    sprite_label = QLabel()
+    sprite_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
+    sprite_label.setFixedSize(64, 64)
+    sprite_label.setScaledContents(False)
+    sprite_label.setSizePolicy(QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed)
+    
+    if show_sprites and challenge_pokemon is not None:
+        pokemon_id = challenge_pokemon.get("id", 25)
+        pokemon_name = challenge_pokemon.get("name", "Pikachu")
+        shiny = challenge_pokemon.get("shiny", False)
+        gender = challenge_pokemon.get("gender", "N")
+        
+        try:
+            from ..functions.sprite_functions import get_sprite_path
+            sprite_path = get_sprite_path(
+                side="front", 
+                sprite_type="gif", 
+                id=pokemon_id, 
+                shiny=shiny, 
+                gender=gender, 
+                pokemon_name=pokemon_name
+            )
+            
+            if os.path.exists(sprite_path):
+                movie = QMovie(sprite_path)
+                sprite_label.setMovie(movie)
+                movie.start()
+            else:
+                pass
+        except Exception:
+            pass
+    
+    sprite_box_layout.addWidget(sprite_label)
+    message_layout.addWidget(sprite_box)
+
+    pokemon_name = challenge_pokemon.get("name", "Pokémon") if challenge_pokemon else "Pokémon"
+    pokemon_level = challenge_pokemon.get("level", 1) if challenge_pokemon else 1
+    
+    message_text = (
+        f"Congrats, you've successfully received <b>{pokemon_name}</b> <b>Lvl. {pokemon_level}</b>!<br><br>"
+        f"Tip: Check your progress at <b>Ankimon → Profile → Monthly Challenge</b> to see your dedication in action!"
+    )
+    
+    message = QLabel(message_text)
+    message.setWordWrap(True)
+    message.setStyleSheet(f"color: {text}; font-size: 0.95rem; line-height: 1.6; padding: 4px 0;")
+    message_layout.addWidget(message)
+    layout.addLayout(message_layout)
+
+    button_layout = QHBoxLayout()
+    button_layout.addStretch()
+
+    letsgo_button = QPushButton("Let's go!")
+    letsgo_button.setMinimumWidth(120)
+    letsgo_button.clicked.connect(window.accept)
+    button_layout.addWidget(letsgo_button)
+
+    layout.addLayout(button_layout)
+
+    window.exec()
+
+def show_monthly_rejection_dialog(parent_window=None, challenge_pokemon=None):
+    """
+    Display a confirmation dialog when a user rejects a monthly challenge Pokémon.
+    
+    This function creates and shows a modal dialog that informs the user their
+    rejection was recorded and explains how they can reclaim the Pokémon later.
+    The dialog includes a sprite of the rejected Pokémon (if available) and
+    provides instructions for accessing the monthly challenge feature through
+    the Ankimon menu.
+    
+    Notes:
+        - The dialog's message informs users they can reclaim the Pokémon later
+          via Ankimon → Profile → Monthly Challenge
+        - The close button is labeled "Alright!" and simply closes the dialog
+        - The function does not modify any application state or database
+        - This is designed to be called after the rejection decision has been recorded
+          in the database, not as the rejection decision itself
+    """
+
+    from PyQt6.QtWidgets import QSizePolicy
+    from PyQt6.QtGui import QMovie
+    from PyQt6.QtCore import QSize
+    import os
+    
+    parent = parent_window if parent_window is not None else mw
+    window = QDialog(parent)
+    window.setWindowTitle("Monthly Challenge Rejected!")
+    window.setWindowIcon(QIcon(str(icon_path)))
+    window.setWindowModality(Qt.WindowModality.ApplicationModal)
+    window.setMinimumWidth(520)
+    window.setMinimumHeight(160)
+
+    # Check if sprites should be shown
+    show_sprites = True
+    try:
+        from ..services import services
+        settings_obj = services.settings
+        if settings_obj is not None:
+            show_sprites = settings_obj.get("gui.show_sprites_across_ankimon", True)
+    except Exception:
+        pass
+
+    is_dark = theme_manager.night_mode
+    if is_dark:
+        bg = "#0d1117"
+        bg_darker = "#161b22"
+        bg_card_hover = "#252d3f"
+        border = "#2d3748"
+        text = "#f0f6fc"
+        accent_blue = "#58a6ff"
+        accent_green = "#3fb950"
+        blue_solid = "#2474a8"
+        btn_bg = "rgba(88, 166, 255, 0.08)"
+        btn_hover = "rgba(88, 166, 255, 0.18)"
+        btn_primary_bg = "#3fb950"
+        btn_primary_hover = "#2ea043"
+    else:
+        bg = "#ffffff"
+        bg_darker = "#f0f2f5"
+        bg_card_hover = "#e9ecef"
+        border = "#d0d7de"
+        text = "#24292f"
+        accent_blue = "#0969da"
+        accent_green = "#2da44e"
+        blue_solid = "#1a6fb0"
+        btn_bg = "rgba(9, 105, 218, 0.08)"
+        btn_hover = "rgba(9, 105, 218, 0.18)"
+        btn_primary_bg = "#2da44e"
+        btn_primary_hover = "#2ea043"
+
+    window.setStyleSheet(f"""
+        QDialog {{
+            background-color: {bg};
+            color: {text};
+            font-family: 'Outfit', -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+        }}
+        QLabel {{
+            color: {text};
+            background: transparent;
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }}
+        QFrame#spriteBox {{
+            background-color: {blue_solid};
+            border-radius: 12px;
+        }}
+        QPushButton {{
+            padding: 8px 24px;
+            border: 1px solid {border};
+            border-radius: 8px;
+            background: {btn_primary_bg};
+            color: {bg};
+            font-size: 0.85rem;
+            font-weight: 700;
+            font-family: 'Outfit', -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+            min-width: 100px;
+            border: none;
+        }}
+        QPushButton:hover {{
+            background: {btn_primary_hover};
+        }}
+    """)
+
+    layout = QVBoxLayout(window)
+    layout.setContentsMargins(24, 22, 24, 20)
+    layout.setSpacing(16)
+
+    message_layout = QHBoxLayout()
+    message_layout.setSpacing(12)
+
+    sprite_box = QFrame()
+    sprite_box.setObjectName("spriteBox")
+    sprite_box.setFixedSize(80, 80)
+    sprite_box_layout = QVBoxLayout(sprite_box)
+    sprite_box_layout.setContentsMargins(0, 0, 0, 0)
+    sprite_box_layout.setAlignment(Qt.AlignmentFlag.AlignCenter)
+
+    sprite_label = QLabel()
+    sprite_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
+    sprite_label.setFixedSize(64, 64)
+    sprite_label.setScaledContents(False)
+    sprite_label.setSizePolicy(QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed)
+    
+    if show_sprites and challenge_pokemon is not None:
+        pokemon_id = challenge_pokemon.get("id", 25)
+        pokemon_name = challenge_pokemon.get("name", "Pikachu")
+        shiny = challenge_pokemon.get("shiny", False)
+        gender = challenge_pokemon.get("gender", "N")
+        
+        try:
+            from ..functions.sprite_functions import get_sprite_path
+            sprite_path = get_sprite_path(
+                side="front", 
+                sprite_type="gif", 
+                id=pokemon_id, 
+                shiny=shiny, 
+                gender=gender, 
+                pokemon_name=pokemon_name
+            )
+            
+            if os.path.exists(sprite_path):
+                movie = QMovie(sprite_path)
+                sprite_label.setMovie(movie)
+                movie.start()
+            else:
+                pass
+        except Exception:
+            pass
+    
+    sprite_box_layout.addWidget(sprite_label)
+    message_layout.addWidget(sprite_box)
+
+    message = QLabel(
+        "No problem! If you ever change your mind or decide to take the Tauros by "
+        "the horns, head to <b>Ankimon → Profile → Monthly Challenge</b> to reclaim this month's Pokémon or view past challenges. Happy Ankimoning!"
+    )
+    message.setWordWrap(True)
+    message.setStyleSheet(f"color: {text}; font-size: 0.95rem; line-height: 1.6; padding: 4px 0;")
+    message_layout.addWidget(message)
+    layout.addLayout(message_layout)
+
+    # Button
+    button_layout = QHBoxLayout()
+    button_layout.addStretch()
+
+    alright_button = QPushButton("Alright!")
+    alright_button.setMinimumWidth(120)
+    alright_button.clicked.connect(window.accept)
+    button_layout.addWidget(alright_button)
+
+    layout.addLayout(button_layout)
+
+    window.exec()
+
 def check_and_award_monthly_pokemon(logger):
-    """Checks for and automatically awards the current monthly challenge Pokémon."""
+    """
+    Check for and award the current month's challenge Pokémon to the user.
+    
+    This function handles the complete monthly challenge workflow including:
+    1. Verifying the user has rated the addon (required for eligibility)
+    2. Fetching the current month's challenge data from a remote JSON source
+    3. Checking if the Pokémon has already been claimed or rejected
+    4. Handling edge cases where database tracking values are out of sync
+    5. Determining shiny eligibility based on previous challenge performance
+    6. Presenting the challenge dialog to the user
+    7. Recording the user's decision (accept/reject) in the database
+    8. Adding the Pokémon to the user's collection if accepted
+    
+    Side Effects:
+        - Reads/writes user_data in the database:
+            - 'rate_this': Read to check eligibility
+            - 'monthly_challenge_id': Read/write to track current challenge
+            - 'monthly_challenge': Read/write (0=unclaimed, 1=accepted, 2=rejected)
+        - Fetches data from a remote GitHub URL (monthly_challenges.json)
+        - May add a new Pokémon to the user's collection via add_pokemon_to_collection()
+        - May display modal dialogs (show_monthly_challenge_dialog, 
+          show_monthly_acceptance_dialog, show_monthly_rejection_dialog)
+        - Logs all major events and errors via the provided logger
+    
+    Notes:
+        - Shiny eligibility: If a previous challenge Pokémon exists and has
+          defeated at least the threshold number of Pokémon, the current
+          challenge Pokémon will be shiny
+        - Edge case handling: If the Pokémon exists in the collection but the
+          database tracking values are missing (last_challenge_id is None) or
+          stale (monthly_challenge == 0), the function reconciles the state
+          by setting monthly_challenge_id to the current ID and
+          monthly_challenge to 1 (accepted)
+        - The function returns early without errors if the monthly challenges
+          JSON cannot be fetched (handles offline scenarios gracefully)
+        - All exceptions are caught, logged, and swallowed to prevent
+          interrupting the user's Anki session
+    """
+
     try:
         db = services.db
         if db.get_user_data("rate_this") not in (True, "true"):
@@ -104,10 +780,32 @@ def check_and_award_monthly_pokemon(logger):
             logger.log("warning", f"Monthly challenge for {current_month_str} is missing 'individual_id' in 'pokemon' data.")
             return
 
-        db = services.db
-        target_pokemon = db.get_pokemon(challenge_individual_id)
+        last_challenge_id = db.get_user_data("monthly_challenge_id")
+        monthly_status = db.get_user_data("monthly_challenge", 0)
+        try:
+            monthly_status = int(monthly_status)
+        except (TypeError, ValueError):
+            monthly_status = 0
 
-        if target_pokemon is not None:
+        # Edge case: Pokémon exists in collection but database tracking values are missing or stale
+        pokemon_in_collection = db.get_pokemon(challenge_individual_id) is not None
+        
+        if pokemon_in_collection and (last_challenge_id is None or monthly_status == 0):
+            db.set_user_data("monthly_challenge_id", challenge_individual_id)
+            db.set_user_data("monthly_challenge", 1)
+            logger.log("info", f"Reconciled monthly challenge tracking: Pokémon {challenge_pokemon_data.get('name')} exists in collection, set monthly_challenge_id={challenge_individual_id}, monthly_challenge=1")
+            return
+
+        if last_challenge_id is None or str(last_challenge_id) != str(challenge_individual_id):
+            db.set_user_data("monthly_challenge_id", challenge_individual_id)
+            db.set_user_data("monthly_challenge", 0)
+            monthly_status = 0
+
+        if monthly_status == 2:
+            logger.log("info", f"Monthly challenge for {current_month_str} was rejected.")
+            return
+
+        if monthly_status == 1 and pokemon_in_collection:
             logger.log("info", f"User already has the Pokémon for {current_month_str} (ID: {challenge_individual_id}).")
             return
 
@@ -129,17 +827,18 @@ def check_and_award_monthly_pokemon(logger):
                     make_shiny = True
         
         new_pokemon = create_monthly_challenge_pokemon(challenge_pokemon_data, make_shiny=make_shiny)
-        add_pokemon_to_collection(new_pokemon)
-
         shiny_text = " (Shiny)" if new_pokemon["shiny"] else ""
         description = current_challenge.get("description", "")
-        message = f"Congratulations! You've received your monthly challenge Pokémon: {new_pokemon['name']}{shiny_text}!"
-        if description:
-            message += f"\n\n{description}"
-        message += "\n\nFor more information on monthly challenges and to redeem higher-tier prizes for your performance, please check the Ankimon Discord!"
-        
-        utils.showInfo(message)
-        logger.log("info", f"Successfully awarded {new_pokemon['name']}{shiny_text}.")
+        accepted = show_monthly_challenge_dialog(new_pokemon, description, parent_window=mw)
+        if accepted:
+            db.set_user_data("monthly_challenge", 1)
+            add_pokemon_to_collection(new_pokemon, parent_window=mw)
+            logger.log("info", f"Successfully awarded {new_pokemon['name']}{shiny_text}.")
+            show_monthly_acceptance_dialog(parent_window=mw, challenge_pokemon=challenge_pokemon_data)
+        else:
+            db.set_user_data("monthly_challenge", 2)
+            show_monthly_rejection_dialog(parent_window=mw, challenge_pokemon=challenge_pokemon_data)
+            logger.log("info", f"User rejected {new_pokemon['name']}{shiny_text}.")
 
     except Exception as e:
         logger.log("error", f"An unexpected error occurred in check_and_award_monthly_pokemon: {e}")
@@ -270,6 +969,8 @@ class PokemonTrade:
         sprite_size = QSize(64, 64)
         your_pokemon_sprite_label.setMaximumSize(sprite_size)
         your_pokemon_sprite_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        your_pokemon_sprite_label.setScaledContents(False)
+        your_pokemon_sprite_label.setSizePolicy(QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed)
         
         # Only load and display sprite if setting allows
         show_sprites = self._should_show_sprites()
@@ -314,6 +1015,8 @@ class PokemonTrade:
         self.other_pokemon_sprite_label = QLabel()
         self.other_pokemon_sprite_label.setMaximumSize(sprite_size)
         self.other_pokemon_sprite_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        self.other_pokemon_sprite_label.setScaledContents(False)
+        self.other_pokemon_sprite_label.setSizePolicy(QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed)
         
         if show_sprites:
             self.other_pokemon_sprite_label.setPixmap(QPixmap(":/icons/pokeball.png").scaled(sprite_size, Qt.AspectRatioMode.KeepAspectRatio, Qt.TransformationMode.SmoothTransformation))

--- a/src/Ankimon/pyobj/pokemon_trade.py
+++ b/src/Ankimon/pyobj/pokemon_trade.py
@@ -17,6 +17,99 @@ from .error_handler import show_warning_with_traceback
 from ..services import services
 import os
 
+
+class MonthlyChallengeDialog(QDialog):
+    """Dialog that ignores Escape key to prevent accidental rejection."""
+    def keyPressEvent(self, event):
+        if event.key() == Qt.Key.Key_Escape:
+            event.accept()  # Ignore Escape
+        else:
+            super().keyPressEvent(event)
+
+
+def _challenge_palette():
+    """Return the theme-specific colour palette for challenge dialogs."""
+    from aqt.theme import theme_manager
+    is_dark = theme_manager.night_mode
+    if is_dark:
+        return {
+            "bg": "#0d1117",
+            "bg_darker": "#161b22",
+            "bg_card_hover": "#252d3f",
+            "border": "#2d3748",
+            "text": "#f0f6fc",
+            "accent_blue": "#58a6ff",
+            "accent_green": "#3fb950",
+            "blue_solid": "#2474a8",
+            "btn_bg": "rgba(88, 166, 255, 0.08)",
+            "btn_hover": "rgba(88, 166, 255, 0.18)",
+            "btn_primary_bg": "#3fb950",
+            "btn_primary_hover": "#2ea043",
+            "update_btn_text": "#0d1117"
+        }
+    else:
+        return {
+            "bg": "#ffffff",
+            "bg_darker": "#f0f2f5",
+            "bg_card_hover": "#e9ecef",
+            "border": "#d0d7de",
+            "text": "#24292f",
+            "accent_blue": "#0969da",
+            "accent_green": "#2da44e",
+            "blue_solid": "#1a6fb0",
+            "btn_bg": "rgba(9, 105, 218, 0.08)",
+            "btn_hover": "rgba(9, 105, 218, 0.18)",
+            "btn_primary_bg": "#2da44e",
+            "btn_primary_hover": "#2ea043",
+            "update_btn_text": "#e6ffea"
+        }
+
+
+def _build_sprite_box(container_size, sprite_size, challenge_pokemon, show_sprites):
+    """Build a sprite box QFrame with the given dimensions and Pokémon data."""
+    from PyQt6.QtWidgets import QSizePolicy
+    from PyQt6.QtGui import QMovie
+    
+    sprite_box = QFrame()
+    sprite_box.setObjectName("spriteBox")
+    sprite_box.setFixedSize(container_size, container_size)
+    sprite_box_layout = QVBoxLayout(sprite_box)
+    sprite_box_layout.setContentsMargins(0, 0, 0, 0)
+    sprite_box_layout.setAlignment(Qt.AlignmentFlag.AlignCenter)
+
+    sprite_label = QLabel()
+    sprite_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
+    sprite_label.setFixedSize(sprite_size, sprite_size)
+    sprite_label.setScaledContents(False)
+    sprite_label.setSizePolicy(QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed)
+    
+    if show_sprites and challenge_pokemon is not None:
+        pokemon_id = challenge_pokemon.get("id", 25)
+        pokemon_name = challenge_pokemon.get("name", "Pikachu")
+        shiny = challenge_pokemon.get("shiny", False)
+        gender = challenge_pokemon.get("gender", "N")
+        
+        try:
+            from ..functions.sprite_functions import get_sprite_path
+            sprite_path = get_sprite_path(
+                side="front", 
+                sprite_type="gif", 
+                id=pokemon_id, 
+                shiny=shiny, 
+                gender=gender, 
+                pokemon_name=pokemon_name
+            )
+            
+            if os.path.exists(sprite_path):
+                movie = QMovie(sprite_path)
+                sprite_label.setMovie(movie)
+                movie.start()
+        except Exception:
+            pass
+    
+    sprite_box_layout.addWidget(sprite_label)
+    return sprite_box
+
 # --- Module-level functions for Monthly Challenges ---
 
 def create_monthly_challenge_pokemon(pokemon_data, make_shiny=False):
@@ -114,10 +207,9 @@ def show_monthly_challenge_dialog(challenge_pokemon, description, parent_window=
     from PyQt6.QtWidgets import QSizePolicy
     from PyQt6.QtGui import QMovie, QPixmap
     from PyQt6.QtCore import QSize
-    from aqt.theme import theme_manager
     
     parent = parent_window if parent_window is not None else mw
-    window = QDialog(parent)
+    window = MonthlyChallengeDialog(parent)
     window.setWindowTitle("Monthly Challenge Begins!")
     window.setWindowIcon(QIcon(str(icon_path)))
     window.setWindowModality(Qt.WindowModality.ApplicationModal)
@@ -135,29 +227,17 @@ def show_monthly_challenge_dialog(challenge_pokemon, description, parent_window=
     except Exception:
         pass
 
-    is_dark = theme_manager.night_mode
-    if is_dark:
-        bg = "#0d1117"
-        bg_card_hover = "#252d3f"
-        border = "#2d3748"
-        text = "#f0f6fc"
-        accent_blue = "#63b3ed"
-        blue_solid = "#2474a8"
-        accent_green = "#3fb950"
-        btn_bg = "rgba(88, 166, 255, 0.08)"
-        btn_hover = "rgba(88, 166, 255, 0.18)"
-        update_btn_text = "#0d1117"
-    else:
-        bg = "#ffffff"
-        bg_card_hover = "#e9ecef"
-        border = "#d0d7de"
-        text = "#24292f"
-        accent_blue = "#0969da"
-        blue_solid = "#1a6fb0"
-        accent_green = "#2da44e"
-        btn_bg = "rgba(9, 105, 218, 0.08)"
-        btn_hover = "rgba(9, 105, 218, 0.18)"
-        update_btn_text = "#e6ffea"
+    palette = _challenge_palette()
+    bg = palette["bg"]
+    bg_card_hover = palette["bg_card_hover"]
+    border = palette["border"]
+    text = palette["text"]
+    accent_blue = palette["accent_blue"]
+    blue_solid = palette["blue_solid"]
+    accent_green = palette["accent_green"]
+    btn_bg = palette["btn_bg"]
+    btn_hover = palette["btn_hover"]
+    update_btn_text = palette["update_btn_text"]
 
     window.setStyleSheet(f"""
         QDialog {{
@@ -242,42 +322,7 @@ def show_monthly_challenge_dialog(challenge_pokemon, description, parent_window=
     content_layout.setSpacing(16)
     content_layout.setContentsMargins(0, 8, 0, 8)
 
-    sprite_box = QFrame()
-    sprite_box.setObjectName("spriteBox")
-    sprite_box.setFixedSize(160, 160)
-    sprite_box_layout = QVBoxLayout(sprite_box)
-    sprite_box_layout.setContentsMargins(0, 0, 0, 0)
-    sprite_box_layout.setAlignment(Qt.AlignmentFlag.AlignCenter)
-
-    sprite_label = QLabel()
-    sprite_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
-    sprite_label.setFixedSize(120, 120)
-    sprite_label.setScaledContents(False)
-    sprite_label.setSizePolicy(QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed)
-    
-    if show_sprites:
-        pokemon_id = challenge_pokemon.get("id", 25)
-        pokemon_name = challenge_pokemon.get("name", "Pikachu")
-        shiny = challenge_pokemon.get("shiny", False)
-        gender = challenge_pokemon.get("gender", "N")
-        
-        try:
-            from ..functions.sprite_functions import get_sprite_path
-            sprite_path = get_sprite_path(
-                side="front", 
-                sprite_type="gif", 
-                id=pokemon_id, 
-                shiny=shiny, 
-                gender=gender, 
-                pokemon_name=pokemon_name
-            )
-            movie = QMovie(sprite_path)
-            sprite_label.setMovie(movie)
-            movie.start()
-        except Exception:
-            pass
-    
-    sprite_box_layout.addWidget(sprite_label)
+    sprite_box = _build_sprite_box(160, 120, challenge_pokemon, show_sprites)
     content_layout.addWidget(sprite_box, alignment=Qt.AlignmentFlag.AlignTop)
 
     desc_box = QFrame()
@@ -377,7 +422,6 @@ def show_monthly_acceptance_dialog(parent_window=None, challenge_pokemon=None):
     from PyQt6.QtWidgets import QSizePolicy
     from PyQt6.QtGui import QMovie
     from PyQt6.QtCore import QSize
-    from aqt.theme import theme_manager
     import os
     
     parent = parent_window if parent_window is not None else mw
@@ -398,33 +442,19 @@ def show_monthly_acceptance_dialog(parent_window=None, challenge_pokemon=None):
     except Exception:
         pass
 
-    is_dark = theme_manager.night_mode
-    if is_dark:
-        bg = "#0d1117"
-        bg_darker = "#161b22"
-        bg_card_hover = "#252d3f"
-        border = "#2d3748"
-        text = "#f0f6fc"
-        accent_blue = "#58a6ff"
-        accent_green = "#3fb950"
-        blue_solid = "#2474a8"
-        btn_bg = "rgba(88, 166, 255, 0.08)"
-        btn_hover = "rgba(88, 166, 255, 0.18)"
-        btn_primary_bg = "#3fb950"
-        btn_primary_hover = "#2ea043"
-    else:
-        bg = "#ffffff"
-        bg_darker = "#f0f2f5"
-        bg_card_hover = "#e9ecef"
-        border = "#d0d7de"
-        text = "#24292f"
-        accent_blue = "#0969da"
-        accent_green = "#2da44e"
-        blue_solid = "#1a6fb0"
-        btn_bg = "rgba(9, 105, 218, 0.08)"
-        btn_hover = "rgba(9, 105, 218, 0.18)"
-        btn_primary_bg = "#2da44e"
-        btn_primary_hover = "#2ea043"
+    palette = _challenge_palette()
+    bg = palette["bg"]
+    bg_darker = palette["bg_darker"]
+    bg_card_hover = palette["bg_card_hover"]
+    border = palette["border"]
+    text = palette["text"]
+    accent_blue = palette["accent_blue"]
+    accent_green = palette["accent_green"]
+    blue_solid = palette["blue_solid"]
+    btn_bg = palette["btn_bg"]
+    btn_hover = palette["btn_hover"]
+    btn_primary_bg = palette["btn_primary_bg"]
+    btn_primary_hover = palette["btn_primary_hover"]
 
     window.setStyleSheet(f"""
         QDialog {{
@@ -466,46 +496,7 @@ def show_monthly_acceptance_dialog(parent_window=None, challenge_pokemon=None):
     message_layout = QHBoxLayout()
     message_layout.setSpacing(12)
 
-    sprite_box = QFrame()
-    sprite_box.setObjectName("spriteBox")
-    sprite_box.setFixedSize(80, 80)
-    sprite_box_layout = QVBoxLayout(sprite_box)
-    sprite_box_layout.setContentsMargins(0, 0, 0, 0)
-    sprite_box_layout.setAlignment(Qt.AlignmentFlag.AlignCenter)
-
-    sprite_label = QLabel()
-    sprite_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
-    sprite_label.setFixedSize(64, 64)
-    sprite_label.setScaledContents(False)
-    sprite_label.setSizePolicy(QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed)
-    
-    if show_sprites and challenge_pokemon is not None:
-        pokemon_id = challenge_pokemon.get("id", 25)
-        pokemon_name = challenge_pokemon.get("name", "Pikachu")
-        shiny = challenge_pokemon.get("shiny", False)
-        gender = challenge_pokemon.get("gender", "N")
-        
-        try:
-            from ..functions.sprite_functions import get_sprite_path
-            sprite_path = get_sprite_path(
-                side="front", 
-                sprite_type="gif", 
-                id=pokemon_id, 
-                shiny=shiny, 
-                gender=gender, 
-                pokemon_name=pokemon_name
-            )
-            
-            if os.path.exists(sprite_path):
-                movie = QMovie(sprite_path)
-                sprite_label.setMovie(movie)
-                movie.start()
-            else:
-                pass
-        except Exception:
-            pass
-    
-    sprite_box_layout.addWidget(sprite_label)
+    sprite_box = _build_sprite_box(80, 64, challenge_pokemon, show_sprites)
     message_layout.addWidget(sprite_box)
 
     pokemon_name = challenge_pokemon.get("name", "Pokémon") if challenge_pokemon else "Pokémon"
@@ -556,7 +547,6 @@ def show_monthly_rejection_dialog(parent_window=None, challenge_pokemon=None):
     from PyQt6.QtWidgets import QSizePolicy
     from PyQt6.QtGui import QMovie
     from PyQt6.QtCore import QSize
-    from aqt.theme import theme_manager
     import os
     
     parent = parent_window if parent_window is not None else mw
@@ -577,33 +567,19 @@ def show_monthly_rejection_dialog(parent_window=None, challenge_pokemon=None):
     except Exception:
         pass
 
-    is_dark = theme_manager.night_mode
-    if is_dark:
-        bg = "#0d1117"
-        bg_darker = "#161b22"
-        bg_card_hover = "#252d3f"
-        border = "#2d3748"
-        text = "#f0f6fc"
-        accent_blue = "#58a6ff"
-        accent_green = "#3fb950"
-        blue_solid = "#2474a8"
-        btn_bg = "rgba(88, 166, 255, 0.08)"
-        btn_hover = "rgba(88, 166, 255, 0.18)"
-        btn_primary_bg = "#3fb950"
-        btn_primary_hover = "#2ea043"
-    else:
-        bg = "#ffffff"
-        bg_darker = "#f0f2f5"
-        bg_card_hover = "#e9ecef"
-        border = "#d0d7de"
-        text = "#24292f"
-        accent_blue = "#0969da"
-        accent_green = "#2da44e"
-        blue_solid = "#1a6fb0"
-        btn_bg = "rgba(9, 105, 218, 0.08)"
-        btn_hover = "rgba(9, 105, 218, 0.18)"
-        btn_primary_bg = "#2da44e"
-        btn_primary_hover = "#2ea043"
+    palette = _challenge_palette()
+    bg = palette["bg"]
+    bg_darker = palette["bg_darker"]
+    bg_card_hover = palette["bg_card_hover"]
+    border = palette["border"]
+    text = palette["text"]
+    accent_blue = palette["accent_blue"]
+    accent_green = palette["accent_green"]
+    blue_solid = palette["blue_solid"]
+    btn_bg = palette["btn_bg"]
+    btn_hover = palette["btn_hover"]
+    btn_primary_bg = palette["btn_primary_bg"]
+    btn_primary_hover = palette["btn_primary_hover"]
 
     window.setStyleSheet(f"""
         QDialog {{
@@ -645,46 +621,7 @@ def show_monthly_rejection_dialog(parent_window=None, challenge_pokemon=None):
     message_layout = QHBoxLayout()
     message_layout.setSpacing(12)
 
-    sprite_box = QFrame()
-    sprite_box.setObjectName("spriteBox")
-    sprite_box.setFixedSize(80, 80)
-    sprite_box_layout = QVBoxLayout(sprite_box)
-    sprite_box_layout.setContentsMargins(0, 0, 0, 0)
-    sprite_box_layout.setAlignment(Qt.AlignmentFlag.AlignCenter)
-
-    sprite_label = QLabel()
-    sprite_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
-    sprite_label.setFixedSize(64, 64)
-    sprite_label.setScaledContents(False)
-    sprite_label.setSizePolicy(QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed)
-    
-    if show_sprites and challenge_pokemon is not None:
-        pokemon_id = challenge_pokemon.get("id", 25)
-        pokemon_name = challenge_pokemon.get("name", "Pikachu")
-        shiny = challenge_pokemon.get("shiny", False)
-        gender = challenge_pokemon.get("gender", "N")
-        
-        try:
-            from ..functions.sprite_functions import get_sprite_path
-            sprite_path = get_sprite_path(
-                side="front", 
-                sprite_type="gif", 
-                id=pokemon_id, 
-                shiny=shiny, 
-                gender=gender, 
-                pokemon_name=pokemon_name
-            )
-            
-            if os.path.exists(sprite_path):
-                movie = QMovie(sprite_path)
-                sprite_label.setMovie(movie)
-                movie.start()
-            else:
-                pass
-        except Exception:
-            pass
-    
-    sprite_box_layout.addWidget(sprite_label)
+    sprite_box = _build_sprite_box(80, 64, challenge_pokemon, show_sprites)
     message_layout.addWidget(sprite_box)
 
     message = QLabel(
@@ -864,9 +801,19 @@ def check_and_award_monthly_pokemon(logger, defer=True):
             pass
 
     # Defer execution to avoid blocking the profile_did_open callback
+    # Run the blocking HTTP request in a background thread to avoid UI freeze
     if defer:
-        from aqt.qt import QTimer
-        QTimer.singleShot(0, _do_check)
+        import threading
+        
+        def run_in_background():
+            try:
+                _do_check()
+            except Exception as e:
+                logger.log("error", f"Error in background monthly check: {e}")
+        
+        # Start the background thread for the HTTP request
+        thread = threading.Thread(target=run_in_background, daemon=True)
+        thread.start()
     else:
         _do_check()
 

--- a/src/Ankimon/pyobj/pokemon_trade.py
+++ b/src/Ankimon/pyobj/pokemon_trade.py
@@ -709,16 +709,39 @@ def check_and_award_monthly_pokemon(logger, defer=True):
                 logger.log("error", f"Could not fetch monthly challenges; likely no internet connection. Details: {e}")
                 return None
 
-            current_challenge = next((c for c in monthly_challenges if c.get("month") == current_month_str), None)
+            if not isinstance(monthly_challenges, list):
+                logger.log("warning", "Monthly challenge data is not a list.")
+                return None
+
+            current_challenge = next((c for c in monthly_challenges if isinstance(c, dict) and c.get("month") == current_month_str), None)
 
             if not current_challenge:
                 logger.log("info", f"No monthly challenge found for {current_month_str}.")
                 return None
 
             challenge_pokemon_data = current_challenge.get("pokemon")
-            if not challenge_pokemon_data:
+            if not isinstance(challenge_pokemon_data, dict):
                 logger.log("warning", f"Monthly challenge for {current_month_str} is missing 'pokemon' data.")
                 return None
+
+            raw_pokemon_id = challenge_pokemon_data.get("id")
+            if isinstance(raw_pokemon_id, bool):
+                raw_pokemon_id = None
+            try:
+                pokemon_id = int(raw_pokemon_id)
+            except (TypeError, ValueError):
+                pokemon_id = 0
+            if pokemon_id <= 0:
+                logger.log("warning", f"Monthly challenge for {current_month_str} has an invalid Pokémon id.")
+                return None
+
+            pokemon_name = challenge_pokemon_data.get("name")
+            if not isinstance(pokemon_name, str) or not pokemon_name.strip():
+                logger.log("warning", f"Monthly challenge for {current_month_str} has an invalid Pokémon name.")
+                return None
+
+            challenge_pokemon_data = dict(challenge_pokemon_data)
+            challenge_pokemon_data["id"] = pokemon_id
 
             challenge_individual_id = challenge_pokemon_data.get("individual_id")
             if not challenge_individual_id:
@@ -743,14 +766,12 @@ def check_and_award_monthly_pokemon(logger, defer=True):
                     monthly_status == 0
                 )
                 if needs_reconciliation:
-                    db.set_user_data("monthly_challenge_id", challenge_individual_id)
-                    db.set_user_data("monthly_challenge", 1)
+                    db.set_monthly_challenge_state(challenge_individual_id, 1)
                     logger.log("info", f"Reconciled monthly challenge tracking: Pokémon {challenge_pokemon_data.get('name')} exists in collection, set monthly_challenge_id={challenge_individual_id}, monthly_challenge=1")
                     return None
 
             if last_challenge_id is None or str(last_challenge_id) != str(challenge_individual_id):
-                db.set_user_data("monthly_challenge_id", challenge_individual_id)
-                db.set_user_data("monthly_challenge", 0)
+                db.set_monthly_challenge_state(challenge_individual_id, 0)
                 monthly_status = 0
 
             if monthly_status == 2:
@@ -803,39 +824,32 @@ def check_and_award_monthly_pokemon(logger, defer=True):
         accepted = show_monthly_challenge_dialog(new_pokemon, description, parent_window=mw)
         if accepted:
             db = services.db
-            db.set_user_data("monthly_challenge", 1)
             success = add_pokemon_to_collection(new_pokemon, parent_window=mw)
             if success:
+                db.set_monthly_challenge_state(new_pokemon["individual_id"], 1)
                 shiny_text = " (Shiny)" if new_pokemon["shiny"] else ""
                 logger.log("info", f"Successfully awarded {new_pokemon['name']}{shiny_text}.")
                 show_monthly_acceptance_dialog(parent_window=mw, challenge_pokemon=new_pokemon)
             else:
-                db.set_user_data("monthly_challenge", 0)
+                db.set_monthly_challenge_state(new_pokemon["individual_id"], 0)
                 logger.log("error", f"Failed to add {new_pokemon['name']} to collection. Status rolled back.")
         else:
             db = services.db
-            db.set_user_data("monthly_challenge", 2)
+            db.set_monthly_challenge_state(new_pokemon["individual_id"], 2)
             show_monthly_rejection_dialog(parent_window=mw, challenge_pokemon=new_pokemon)
             shiny_text = " (Shiny)" if new_pokemon["shiny"] else ""
             logger.log("info", f"User rejected {new_pokemon['name']}{shiny_text}.")
 
-    # Defer execution to avoid blocking the profile_did_open callback
+    # Let Anki own the worker and invoke the completion callback on the GUI thread.
     if defer:
-        import threading
-        
-        def run_in_background():
+        def on_done(future):
+            """Handle the task-manager result on Anki's GUI thread."""
             try:
-                result = _fetch_monthly_data()
-                if result is not None:
-                    # Schedule the UI work on the main thread
-                    from aqt.qt import QTimer
-                    QTimer.singleShot(0, lambda: _process_on_main_thread(result))
+                _process_on_main_thread(future.result())
             except Exception as e:
-                logger.log("error", f"Error in background monthly check: {e}")
-        
-        # Start the background thread for the HTTP request
-        thread = threading.Thread(target=run_in_background, daemon=True)
-        thread.start()
+                logger.log("error", f"Error completing monthly check: {e}")
+
+        mw.taskman.run_in_background(_fetch_monthly_data, on_done)
     else:
         # Non-deferred: run everything on the main thread (for tests)
         result = _fetch_monthly_data()

--- a/src/Ankimon/pyobj/pokemon_trade.py
+++ b/src/Ankimon/pyobj/pokemon_trade.py
@@ -102,6 +102,7 @@ def _build_sprite_box(container_size, sprite_size, challenge_pokemon, show_sprit
             
             if os.path.exists(sprite_path):
                 movie = QMovie(sprite_path)
+                movie.setParent(sprite_label)  # Keep movie alive with the label
                 sprite_label.setMovie(movie)
                 movie.start()
         except Exception:
@@ -686,12 +687,13 @@ def check_and_award_monthly_pokemon(logger, defer=True):
           interrupting the user's Anki session
     """
 
-    def _do_check():
+    def _fetch_monthly_data():
+        """Fetch monthly challenge data in background thread. Returns dict or None."""
         try:
             db = services.db
             if db.get_user_data("rate_this") not in (True, "true"):
                 logger.log("info", "Monthly Pokemon check skipped: user has not rated the addon.")
-                return
+                return None
 
             logger.log("info", "Checking for monthly challenge Pokemon award.")
             now = datetime.now()
@@ -705,23 +707,23 @@ def check_and_award_monthly_pokemon(logger, defer=True):
                 monthly_challenges = response.json()
             except requests.exceptions.RequestException as e:
                 logger.log("error", f"Could not fetch monthly challenges; likely no internet connection. Details: {e}")
-                return  # Exit gracefully if fetching fails
+                return None
 
             current_challenge = next((c for c in monthly_challenges if c.get("month") == current_month_str), None)
 
             if not current_challenge:
                 logger.log("info", f"No monthly challenge found for {current_month_str}.")
-                return
+                return None
 
             challenge_pokemon_data = current_challenge.get("pokemon")
             if not challenge_pokemon_data:
                 logger.log("warning", f"Monthly challenge for {current_month_str} is missing 'pokemon' data.")
-                return
+                return None
 
             challenge_individual_id = challenge_pokemon_data.get("individual_id")
             if not challenge_individual_id:
                 logger.log("warning", f"Monthly challenge for {current_month_str} is missing 'individual_id' in 'pokemon' data.")
-                return
+                return None
 
             last_challenge_id = db.get_user_data("monthly_challenge_id")
             monthly_status = db.get_user_data("monthly_challenge", 0)
@@ -735,7 +737,6 @@ def check_and_award_monthly_pokemon(logger, defer=True):
             
             # RECONCILE FIRST: If Pokémon exists in collection, sync tracking before any reset
             if pokemon_in_collection:
-                # Check if we need to reconcile (stale/missing tracking)
                 needs_reconciliation = (
                     last_challenge_id is None or 
                     str(last_challenge_id) != str(challenge_individual_id) or
@@ -745,7 +746,7 @@ def check_and_award_monthly_pokemon(logger, defer=True):
                     db.set_user_data("monthly_challenge_id", challenge_individual_id)
                     db.set_user_data("monthly_challenge", 1)
                     logger.log("info", f"Reconciled monthly challenge tracking: Pokémon {challenge_pokemon_data.get('name')} exists in collection, set monthly_challenge_id={challenge_individual_id}, monthly_challenge=1")
-                    return
+                    return None
 
             if last_challenge_id is None or str(last_challenge_id) != str(challenge_individual_id):
                 db.set_user_data("monthly_challenge_id", challenge_individual_id)
@@ -754,11 +755,11 @@ def check_and_award_monthly_pokemon(logger, defer=True):
 
             if monthly_status == 2:
                 logger.log("info", f"Monthly challenge for {current_month_str} was rejected.")
-                return
+                return None
 
             if monthly_status == 1 and pokemon_in_collection:
                 logger.log("info", f"User already has the Pokémon for {current_month_str} (ID: {challenge_individual_id}).")
-                return
+                return None
 
             logger.log("info", f"Awarding Pokémon for {current_month_str}: {challenge_pokemon_data.get('name')}")
             make_shiny = False
@@ -778,36 +779,57 @@ def check_and_award_monthly_pokemon(logger, defer=True):
                         make_shiny = True
             
             new_pokemon = create_monthly_challenge_pokemon(challenge_pokemon_data, make_shiny=make_shiny)
-            shiny_text = " (Shiny)" if new_pokemon["shiny"] else ""
             description = current_challenge.get("description", "")
-            accepted = show_monthly_challenge_dialog(new_pokemon, description, parent_window=mw)
-            if accepted:
-                db.set_user_data("monthly_challenge", 1)
-                success = add_pokemon_to_collection(new_pokemon, parent_window=mw)
-                if success:
-                    logger.log("info", f"Successfully awarded {new_pokemon['name']}{shiny_text}.")
-                    show_monthly_acceptance_dialog(parent_window=mw, challenge_pokemon=new_pokemon)
-                else:
-                    db.set_user_data("monthly_challenge", 0)
-                    logger.log("error", f"Failed to add {new_pokemon['name']} to collection. Status rolled back.")
-            else:
-                db.set_user_data("monthly_challenge", 2)
-                show_monthly_rejection_dialog(parent_window=mw, challenge_pokemon=new_pokemon)
-                logger.log("info", f"User rejected {new_pokemon['name']}{shiny_text}.")
+            
+            return {
+                "new_pokemon": new_pokemon,
+                "description": description,
+                "challenge_pokemon_data": challenge_pokemon_data
+            }
 
         except Exception as e:
-            logger.log("error", f"An unexpected error occurred in check_and_award_monthly_pokemon: {e}")
-            # Still failing silently on the user's end, but with more detailed logs for debugging.
-            pass
+            logger.log("error", f"An unexpected error occurred while fetching monthly data: {e}")
+            return None
+
+    def _process_on_main_thread(result_data):
+        """Process the monthly challenge award on the main thread."""
+        if result_data is None:
+            return
+        
+        new_pokemon = result_data["new_pokemon"]
+        description = result_data["description"]
+        challenge_pokemon_data = result_data["challenge_pokemon_data"]
+        
+        accepted = show_monthly_challenge_dialog(new_pokemon, description, parent_window=mw)
+        if accepted:
+            db = services.db
+            db.set_user_data("monthly_challenge", 1)
+            success = add_pokemon_to_collection(new_pokemon, parent_window=mw)
+            if success:
+                shiny_text = " (Shiny)" if new_pokemon["shiny"] else ""
+                logger.log("info", f"Successfully awarded {new_pokemon['name']}{shiny_text}.")
+                show_monthly_acceptance_dialog(parent_window=mw, challenge_pokemon=new_pokemon)
+            else:
+                db.set_user_data("monthly_challenge", 0)
+                logger.log("error", f"Failed to add {new_pokemon['name']} to collection. Status rolled back.")
+        else:
+            db = services.db
+            db.set_user_data("monthly_challenge", 2)
+            show_monthly_rejection_dialog(parent_window=mw, challenge_pokemon=new_pokemon)
+            shiny_text = " (Shiny)" if new_pokemon["shiny"] else ""
+            logger.log("info", f"User rejected {new_pokemon['name']}{shiny_text}.")
 
     # Defer execution to avoid blocking the profile_did_open callback
-    # Run the blocking HTTP request in a background thread to avoid UI freeze
     if defer:
         import threading
         
         def run_in_background():
             try:
-                _do_check()
+                result = _fetch_monthly_data()
+                if result is not None:
+                    # Schedule the UI work on the main thread
+                    from aqt.qt import QTimer
+                    QTimer.singleShot(0, lambda: _process_on_main_thread(result))
             except Exception as e:
                 logger.log("error", f"Error in background monthly check: {e}")
         
@@ -815,7 +837,10 @@ def check_and_award_monthly_pokemon(logger, defer=True):
         thread = threading.Thread(target=run_in_background, daemon=True)
         thread.start()
     else:
-        _do_check()
+        # Non-deferred: run everything on the main thread (for tests)
+        result = _fetch_monthly_data()
+        if result is not None:
+            _process_on_main_thread(result)
 
 def parse_to_canonical(code_str):
     if not code_str:

--- a/src/Ankimon/pyobj/pokemon_trade.py
+++ b/src/Ankimon/pyobj/pokemon_trade.py
@@ -749,17 +749,6 @@ def check_and_award_monthly_pokemon(logger, defer=True):
           interrupting the user's Anki session
     """
 
-    # Defer the dialog to the next event loop iteration to avoid blocking profile_did_open
-    def _do_check():
-        ...
-
-    if defer:
-        # Defer the dialog to the next event loop iteration to avoid blocking profile_did_open
-        from aqt.qt import QTimer
-        QTimer.singleShot(0, _do_check)
-    else:
-        _do_check()
-
     def _do_check():
         try:
             db = services.db
@@ -876,6 +865,7 @@ def check_and_award_monthly_pokemon(logger, defer=True):
 
     # Defer execution to avoid blocking the profile_did_open callback
     if defer:
+        from aqt.qt import QTimer
         QTimer.singleShot(0, _do_check)
     else:
         _do_check()

--- a/tests/test_monthly_challenge_fixes.py
+++ b/tests/test_monthly_challenge_fixes.py
@@ -237,10 +237,12 @@ def test_monthly_challenge_rejected_status(show_info_mock, dialog_mock, add_poke
 
     mock_db.get_user_data.return_value = True
     
-    # Set monthly_status to 2 (rejected)
+    # Set monthly_status to 2 (rejected) and monthly_challenge_id to current ID
     def get_user_data_side_effect(key, default=None):
         if key == "monthly_challenge":
             return 2
+        if key == "monthly_challenge_id":
+            return "test-id"  # Match current ID to prevent reset
         return True
     
     mock_db.get_user_data.side_effect = get_user_data_side_effect

--- a/tests/test_monthly_challenge_fixes.py
+++ b/tests/test_monthly_challenge_fixes.py
@@ -55,8 +55,9 @@ def mock_requests():
 
 @patch("Ankimon.pyobj.pokemon_trade.datetime")
 @patch("Ankimon.pyobj.pokemon_trade.add_pokemon_to_collection")
+@patch("Ankimon.pyobj.pokemon_trade.show_monthly_challenge_dialog")
 @patch("Ankimon.pyobj.pokemon_trade.utils.showInfo")
-def test_rate_this_check(show_info_mock, add_pokemon_mock, datetime_mock, mock_requests, mock_mw, mock_db):
+def test_rate_this_check(show_info_mock, dialog_mock, add_pokemon_mock, datetime_mock, mock_requests, mock_mw, mock_db):
     logger = MockLogger()
 
     # Setup datetime to return known values
@@ -77,6 +78,9 @@ def test_rate_this_check(show_info_mock, add_pokemon_mock, datetime_mock, mock_r
         }
     ]
     mock_requests.return_value = mock_response
+
+    # Mock dialog to accept the Pokémon
+    dialog_mock.return_value = True
 
     # Test case 1: user hasn't rated (returns None)
     mock_db.get_user_data.return_value = None
@@ -107,8 +111,9 @@ def test_rate_this_check(show_info_mock, add_pokemon_mock, datetime_mock, mock_r
 
 @patch("Ankimon.pyobj.pokemon_trade.datetime")
 @patch("Ankimon.pyobj.pokemon_trade.add_pokemon_to_collection")
+@patch("Ankimon.pyobj.pokemon_trade.show_monthly_challenge_dialog")
 @patch("Ankimon.pyobj.pokemon_trade.utils.showInfo")
-def test_previous_challenge_pokemon_null_check(show_info_mock, add_pokemon_mock, datetime_mock, mock_requests, mock_mw, mock_db):
+def test_previous_challenge_pokemon_null_check(show_info_mock, dialog_mock, add_pokemon_mock, datetime_mock, mock_requests, mock_mw, mock_db):
     logger = MockLogger()
 
     # Setup datetime to return known values
@@ -134,6 +139,9 @@ def test_previous_challenge_pokemon_null_check(show_info_mock, add_pokemon_mock,
 
     mock_db.get_user_data.return_value = True
 
+    # Mock dialog to accept the Pokémon
+    dialog_mock.return_value = True
+
     # Setup get_pokemon to handle target and previous pokemon
     def get_pokemon_side_effect(individual_id):
         if individual_id == "test-id":
@@ -155,8 +163,9 @@ def test_previous_challenge_pokemon_null_check(show_info_mock, add_pokemon_mock,
 
 @patch("Ankimon.pyobj.pokemon_trade.datetime")
 @patch("Ankimon.pyobj.pokemon_trade.add_pokemon_to_collection")
+@patch("Ankimon.pyobj.pokemon_trade.show_monthly_challenge_dialog")
 @patch("Ankimon.pyobj.pokemon_trade.utils.showInfo")
-def test_previous_challenge_pokemon_has_enough_defeats(show_info_mock, add_pokemon_mock, datetime_mock, mock_requests, mock_mw, mock_db):
+def test_previous_challenge_pokemon_has_enough_defeats(show_info_mock, dialog_mock, add_pokemon_mock, datetime_mock, mock_requests, mock_mw, mock_db):
     logger = MockLogger()
 
     dt_mock = MagicMock()
@@ -180,6 +189,9 @@ def test_previous_challenge_pokemon_has_enough_defeats(show_info_mock, add_pokem
     mock_requests.return_value = mock_response
 
     mock_db.get_user_data.return_value = True
+
+    # Mock dialog to accept the Pokémon
+    dialog_mock.return_value = True
 
     def get_pokemon_side_effect(individual_id):
         if individual_id == "test-id":

--- a/tests/test_monthly_challenge_fixes.py
+++ b/tests/test_monthly_challenge_fixes.py
@@ -2,7 +2,7 @@ import pytest
 import sys
 import importlib.util
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, patch, call
 
 # Mock Anki dependencies
 sys.modules["aqt"] = MagicMock()
@@ -351,8 +351,13 @@ def test_monthly_challenge_rollback_on_add_failure(show_info_mock, dialog_mock, 
     # Should have attempted to add Pokémon
     add_pokemon_mock.assert_called_once()
     
-    # Should roll back monthly_challenge to 0 on failure
-    mock_db.set_user_data.assert_any_call("monthly_challenge", 0)
+    # Verify the rollback sequence: first set to 1 (accepted), then rollback to 0 on failure
+    # The call order matters - cannot use assert_any_call because it can't distinguish the two writes
+    monthly_challenge_calls = [
+        call("monthly_challenge", 1),  # Set to accepted
+        call("monthly_challenge", 0)   # Rollback on failure
+    ]
+    mock_db.set_user_data.assert_has_calls(monthly_challenge_calls)
     mock_db.set_user_data.assert_any_call("monthly_challenge_id", "test-id")
     
     # Should show the challenge dialog (user accepted)

--- a/tests/test_monthly_challenge_fixes.py
+++ b/tests/test_monthly_challenge_fixes.py
@@ -195,3 +195,196 @@ def test_previous_challenge_pokemon_has_enough_defeats(show_info_mock, add_pokem
     add_pokemon_mock.assert_called_once()
     added_pokemon = add_pokemon_mock.call_args[0][0]
     assert added_pokemon["shiny"] is True
+
+
+@patch("Ankimon.pyobj.pokemon_trade.datetime")
+@patch("Ankimon.pyobj.pokemon_trade.add_pokemon_to_collection")
+@patch("Ankimon.pyobj.pokemon_trade.show_monthly_challenge_dialog")
+@patch("Ankimon.pyobj.pokemon_trade.utils.showInfo")
+def test_monthly_challenge_rejected_status(show_info_mock, dialog_mock, add_pokemon_mock, datetime_mock, mock_requests, mock_mw, mock_db):
+    """Test that monthly_status == 2 causes early return without awarding Pokémon."""
+    logger = MockLogger()
+
+    dt_mock = MagicMock()
+    dt_mock.month = 1
+    dt_mock.year = 2024
+    datetime_mock.now.return_value = dt_mock
+
+    mock_response = MagicMock()
+    mock_response.json.return_value = [
+        {
+            "month": "January 2024",
+            "pokemon": {
+                "name": "TestMon",
+                "id": 1,
+                "individual_id": "test-id"
+            }
+        }
+    ]
+    mock_requests.return_value = mock_response
+
+    mock_db.get_user_data.return_value = True
+    
+    # Set monthly_status to 2 (rejected)
+    def get_user_data_side_effect(key, default=None):
+        if key == "monthly_challenge":
+            return 2
+        return True
+    
+    mock_db.get_user_data.side_effect = get_user_data_side_effect
+    mock_db.get_pokemon.return_value = None
+
+    check_and_award_monthly_pokemon(logger, defer=False)
+
+    # Should NOT add Pokémon or show dialog
+    add_pokemon_mock.assert_not_called()
+    dialog_mock.assert_not_called()
+
+
+@patch("Ankimon.pyobj.pokemon_trade.datetime")
+@patch("Ankimon.pyobj.pokemon_trade.add_pokemon_to_collection")
+@patch("Ankimon.pyobj.pokemon_trade.show_monthly_challenge_dialog")
+@patch("Ankimon.pyobj.pokemon_trade.utils.showInfo")
+def test_monthly_challenge_reconciliation_branch(show_info_mock, dialog_mock, add_pokemon_mock, datetime_mock, mock_requests, mock_mw, mock_db):
+    """Test reconciliation when Pokémon exists but tracking is stale/missing."""
+    logger = MockLogger()
+
+    dt_mock = MagicMock()
+    dt_mock.month = 1
+    dt_mock.year = 2024
+    datetime_mock.now.return_value = dt_mock
+
+    mock_response = MagicMock()
+    mock_response.json.return_value = [
+        {
+            "month": "January 2024",
+            "pokemon": {
+                "name": "TestMon",
+                "id": 1,
+                "individual_id": "test-id"
+            }
+        }
+    ]
+    mock_requests.return_value = mock_response
+
+    mock_db.get_user_data.return_value = True
+    
+    # Simulate Pokémon exists in collection but tracking is stale
+    def get_user_data_side_effect(key, default=None):
+        if key == "monthly_challenge_id":
+            return "old-stale-id"  # Stale ID
+        if key == "monthly_challenge":
+            return 0  # Unclaimed status
+        return True
+    
+    mock_db.get_user_data.side_effect = get_user_data_side_effect
+    
+    def get_pokemon_side_effect(individual_id):
+        if individual_id == "test-id":
+            return {"name": "TestMon", "id": 1}  # Pokémon exists
+        return None
+    
+    mock_db.get_pokemon.side_effect = get_pokemon_side_effect
+
+    check_and_award_monthly_pokemon(logger, defer=False)
+
+    # Should reconcile tracking values
+    mock_db.set_user_data.assert_any_call("monthly_challenge_id", "test-id")
+    mock_db.set_user_data.assert_any_call("monthly_challenge", 1)
+    
+    # Should NOT add Pokémon (already exists) or show dialog
+    add_pokemon_mock.assert_not_called()
+    dialog_mock.assert_not_called()
+
+
+@patch("Ankimon.pyobj.pokemon_trade.datetime")
+@patch("Ankimon.pyobj.pokemon_trade.add_pokemon_to_collection")
+@patch("Ankimon.pyobj.pokemon_trade.show_monthly_challenge_dialog")
+@patch("Ankimon.pyobj.pokemon_trade.utils.showInfo")
+def test_monthly_challenge_rollback_on_add_failure(show_info_mock, dialog_mock, add_pokemon_mock, datetime_mock, mock_requests, mock_mw, mock_db):
+    """Test that monthly_challenge is rolled back to 0 when add_pokemon_to_collection fails."""
+    logger = MockLogger()
+
+    dt_mock = MagicMock()
+    dt_mock.month = 1
+    dt_mock.year = 2024
+    datetime_mock.now.return_value = dt_mock
+
+    mock_response = MagicMock()
+    mock_response.json.return_value = [
+        {
+            "month": "January 2024",
+            "pokemon": {
+                "name": "TestMon",
+                "id": 1,
+                "individual_id": "test-id"
+            }
+        }
+    ]
+    mock_requests.return_value = mock_response
+
+    mock_db.get_user_data.return_value = True
+    mock_db.get_pokemon.return_value = None
+
+    # User accepts the Pokémon
+    dialog_mock.return_value = True
+    
+    # Simulate add_pokemon_to_collection failure
+    add_pokemon_mock.return_value = False
+
+    check_and_award_monthly_pokemon(logger, defer=False)
+
+    # Should have attempted to add Pokémon
+    add_pokemon_mock.assert_called_once()
+    
+    # Should roll back monthly_challenge to 0 on failure
+    mock_db.set_user_data.assert_any_call("monthly_challenge", 0)
+    mock_db.set_user_data.assert_any_call("monthly_challenge_id", "test-id")
+    
+    # Should show the challenge dialog (user accepted)
+    dialog_mock.assert_called_once()
+
+
+@patch("Ankimon.pyobj.pokemon_trade.datetime")
+@patch("Ankimon.pyobj.pokemon_trade.add_pokemon_to_collection")
+@patch("Ankimon.pyobj.pokemon_trade.show_monthly_challenge_dialog")
+@patch("Ankimon.pyobj.pokemon_trade.utils.showInfo")
+def test_monthly_challenge_rejection_sets_status(show_info_mock, dialog_mock, add_pokemon_mock, datetime_mock, mock_requests, mock_mw, mock_db):
+    """Test that rejecting the monthly challenge sets monthly_challenge to 2."""
+    logger = MockLogger()
+
+    dt_mock = MagicMock()
+    dt_mock.month = 1
+    dt_mock.year = 2024
+    datetime_mock.now.return_value = dt_mock
+
+    mock_response = MagicMock()
+    mock_response.json.return_value = [
+        {
+            "month": "January 2024",
+            "pokemon": {
+                "name": "TestMon",
+                "id": 1,
+                "individual_id": "test-id"
+            }
+        }
+    ]
+    mock_requests.return_value = mock_response
+
+    mock_db.get_user_data.return_value = True
+    mock_db.get_pokemon.return_value = None
+
+    # User rejects the Pokémon
+    dialog_mock.return_value = False
+
+    check_and_award_monthly_pokemon(logger, defer=False)
+
+    # Should NOT add Pokémon
+    add_pokemon_mock.assert_not_called()
+    
+    # Should set monthly_challenge to 2 (rejected)
+    mock_db.set_user_data.assert_any_call("monthly_challenge", 2)
+    mock_db.set_user_data.assert_any_call("monthly_challenge_id", "test-id")
+    
+    # Should show the challenge dialog
+    dialog_mock.assert_called_once()

--- a/tests/test_monthly_challenge_fixes.py
+++ b/tests/test_monthly_challenge_fixes.py
@@ -80,18 +80,18 @@ def test_rate_this_check(show_info_mock, add_pokemon_mock, datetime_mock, mock_r
 
     # Test case 1: user hasn't rated (returns None)
     mock_db.get_user_data.return_value = None
-    check_and_award_monthly_pokemon(logger)
+    check_and_award_monthly_pokemon(logger, defer=False)
     mock_requests.assert_not_called()
 
     # Test case 2: user hasn't rated (returns False)
     mock_db.get_user_data.return_value = False
-    check_and_award_monthly_pokemon(logger)
+    check_and_award_monthly_pokemon(logger, defer=False)
     mock_requests.assert_not_called()
 
     # Test case 3: user rated using old 'true' string
     mock_db.get_user_data.return_value = "true"
     mock_db.get_pokemon.return_value = None # Pokémon not found yet
-    check_and_award_monthly_pokemon(logger)
+    check_and_award_monthly_pokemon(logger, defer=False)
     mock_requests.assert_called_once()
     add_pokemon_mock.assert_called_once()
 
@@ -100,7 +100,7 @@ def test_rate_this_check(show_info_mock, add_pokemon_mock, datetime_mock, mock_r
 
     # Test case 4: user rated using new boolean True
     mock_db.get_user_data.return_value = True
-    check_and_award_monthly_pokemon(logger)
+    check_and_award_monthly_pokemon(logger, defer=False)
     mock_requests.assert_called_once()
     add_pokemon_mock.assert_called_once()
 
@@ -145,7 +145,7 @@ def test_previous_challenge_pokemon_null_check(show_info_mock, add_pokemon_mock,
     mock_db.get_pokemon.side_effect = get_pokemon_side_effect
 
     # Call the function - it shouldn't crash
-    check_and_award_monthly_pokemon(logger)
+    check_and_award_monthly_pokemon(logger, defer=False)
 
     # Should have added the new pokemon (not shiny)
     add_pokemon_mock.assert_called_once()
@@ -190,7 +190,7 @@ def test_previous_challenge_pokemon_has_enough_defeats(show_info_mock, add_pokem
 
     mock_db.get_pokemon.side_effect = get_pokemon_side_effect
 
-    check_and_award_monthly_pokemon(logger)
+    check_and_award_monthly_pokemon(logger, defer=False)
 
     add_pokemon_mock.assert_called_once()
     added_pokemon = add_pokemon_mock.call_args[0][0]

--- a/tests/test_monthly_challenge_fixes.py
+++ b/tests/test_monthly_challenge_fixes.py
@@ -314,8 +314,56 @@ def test_monthly_challenge_reconciliation_branch(show_info_mock, dialog_mock, ad
 @patch("Ankimon.pyobj.pokemon_trade.datetime")
 @patch("Ankimon.pyobj.pokemon_trade.add_pokemon_to_collection")
 @patch("Ankimon.pyobj.pokemon_trade.show_monthly_challenge_dialog")
+@patch("Ankimon.pyobj.pokemon_trade.show_monthly_rejection_dialog")
 @patch("Ankimon.pyobj.pokemon_trade.utils.showInfo")
-def test_monthly_challenge_rollback_on_add_failure(show_info_mock, dialog_mock, add_pokemon_mock, datetime_mock, mock_requests, mock_mw, mock_db):
+def test_monthly_challenge_rejection_sets_status(show_info_mock, rejection_dialog_mock, dialog_mock, add_pokemon_mock, datetime_mock, mock_requests, mock_mw, mock_db):
+    """Test that rejecting the monthly challenge sets monthly_challenge to 2."""
+    logger = MockLogger()
+
+    dt_mock = MagicMock()
+    dt_mock.month = 1
+    dt_mock.year = 2024
+    datetime_mock.now.return_value = dt_mock
+
+    mock_response = MagicMock()
+    mock_response.json.return_value = [
+        {
+            "month": "January 2024",
+            "pokemon": {
+                "name": "TestMon",
+                "id": 1,
+                "individual_id": "test-id"
+            }
+        }
+    ]
+    mock_requests.return_value = mock_response
+
+    mock_db.get_user_data.return_value = True
+    mock_db.get_pokemon.return_value = None
+
+    # User rejects the Pokémon
+    dialog_mock.return_value = False
+
+    check_and_award_monthly_pokemon(logger, defer=False)
+
+    # Should NOT add Pokémon
+    add_pokemon_mock.assert_not_called()
+    
+    # Should set monthly_challenge to 2 (rejected)
+    mock_db.set_user_data.assert_any_call("monthly_challenge", 2)
+    mock_db.set_user_data.assert_any_call("monthly_challenge_id", "test-id")
+    
+    # Should show the challenge dialog and rejection dialog
+    dialog_mock.assert_called_once()
+    rejection_dialog_mock.assert_called_once()
+
+
+@patch("Ankimon.pyobj.pokemon_trade.datetime")
+@patch("Ankimon.pyobj.pokemon_trade.add_pokemon_to_collection")
+@patch("Ankimon.pyobj.pokemon_trade.show_monthly_challenge_dialog")
+@patch("Ankimon.pyobj.pokemon_trade.show_monthly_acceptance_dialog")
+@patch("Ankimon.pyobj.pokemon_trade.utils.showInfo")
+def test_monthly_challenge_rollback_on_add_failure(show_info_mock, acceptance_dialog_mock, dialog_mock, add_pokemon_mock, datetime_mock, mock_requests, mock_mw, mock_db):
     """Test that monthly_challenge is rolled back to 0 when add_pokemon_to_collection fails."""
     logger = MockLogger()
 
@@ -362,48 +410,5 @@ def test_monthly_challenge_rollback_on_add_failure(show_info_mock, dialog_mock, 
     
     # Should show the challenge dialog (user accepted)
     dialog_mock.assert_called_once()
-
-
-@patch("Ankimon.pyobj.pokemon_trade.datetime")
-@patch("Ankimon.pyobj.pokemon_trade.add_pokemon_to_collection")
-@patch("Ankimon.pyobj.pokemon_trade.show_monthly_challenge_dialog")
-@patch("Ankimon.pyobj.pokemon_trade.utils.showInfo")
-def test_monthly_challenge_rejection_sets_status(show_info_mock, dialog_mock, add_pokemon_mock, datetime_mock, mock_requests, mock_mw, mock_db):
-    """Test that rejecting the monthly challenge sets monthly_challenge to 2."""
-    logger = MockLogger()
-
-    dt_mock = MagicMock()
-    dt_mock.month = 1
-    dt_mock.year = 2024
-    datetime_mock.now.return_value = dt_mock
-
-    mock_response = MagicMock()
-    mock_response.json.return_value = [
-        {
-            "month": "January 2024",
-            "pokemon": {
-                "name": "TestMon",
-                "id": 1,
-                "individual_id": "test-id"
-            }
-        }
-    ]
-    mock_requests.return_value = mock_response
-
-    mock_db.get_user_data.return_value = True
-    mock_db.get_pokemon.return_value = None
-
-    # User rejects the Pokémon
-    dialog_mock.return_value = False
-
-    check_and_award_monthly_pokemon(logger, defer=False)
-
-    # Should NOT add Pokémon
-    add_pokemon_mock.assert_not_called()
-    
-    # Should set monthly_challenge to 2 (rejected)
-    mock_db.set_user_data.assert_any_call("monthly_challenge", 2)
-    mock_db.set_user_data.assert_any_call("monthly_challenge_id", "test-id")
-    
-    # Should show the challenge dialog
-    dialog_mock.assert_called_once()
+    # Should NOT show acceptance dialog (since add failed)
+    acceptance_dialog_mock.assert_not_called()

--- a/tests/test_monthly_challenge_fixes.py
+++ b/tests/test_monthly_challenge_fixes.py
@@ -310,9 +310,8 @@ def test_monthly_challenge_reconciliation_branch(show_info_mock, dialog_mock, ad
 
     check_and_award_monthly_pokemon(logger, defer=False)
 
-    # Should reconcile tracking values
-    mock_db.set_user_data.assert_any_call("monthly_challenge_id", "test-id")
-    mock_db.set_user_data.assert_any_call("monthly_challenge", 1)
+    # Should reconcile tracking values using set_monthly_challenge_state
+    mock_db.set_monthly_challenge_state.assert_called_with("test-id", 1)
     
     # Should NOT add Pokémon (already exists) or show dialog
     add_pokemon_mock.assert_not_called()
@@ -361,13 +360,12 @@ def test_monthly_challenge_rollback_on_add_failure(show_info_mock, acceptance_di
     add_pokemon_mock.assert_called_once()
     
     # Verify the rollback sequence: first set to 1 (accepted), then rollback to 0 on failure
-    # The call order matters - cannot use assert_any_call because it can't distinguish the two writes
+    # The call order matters - use assert_has_calls to verify the sequence
     monthly_challenge_calls = [
-        call("monthly_challenge", 1),  # Set to accepted
-        call("monthly_challenge", 0)   # Rollback on failure
+        call("test-id", 1),  # Set to accepted
+        call("test-id", 0)   # Rollback on failure
     ]
-    mock_db.set_user_data.assert_has_calls(monthly_challenge_calls)
-    mock_db.set_user_data.assert_any_call("monthly_challenge_id", "test-id")
+    mock_db.set_monthly_challenge_state.assert_has_calls(monthly_challenge_calls)
     
     # Should show the challenge dialog (user accepted)
     dialog_mock.assert_called_once()
@@ -413,9 +411,8 @@ def test_monthly_challenge_rejection_sets_status(show_info_mock, rejection_dialo
     # Should NOT add Pokémon
     add_pokemon_mock.assert_not_called()
     
-    # Should set monthly_challenge to 2 (rejected)
-    mock_db.set_user_data.assert_any_call("monthly_challenge", 2)
-    mock_db.set_user_data.assert_any_call("monthly_challenge_id", "test-id")
+    # Should set monthly_challenge to 2 (rejected) using set_monthly_challenge_state
+    mock_db.set_monthly_challenge_state.assert_called_with("test-id", 2)
     
     # Should show the challenge dialog and rejection dialog
     dialog_mock.assert_called_once()

--- a/tests/test_monthly_challenge_fixes.py
+++ b/tests/test_monthly_challenge_fixes.py
@@ -359,13 +359,9 @@ def test_monthly_challenge_rollback_on_add_failure(show_info_mock, acceptance_di
     # Should have attempted to add Pokémon
     add_pokemon_mock.assert_called_once()
     
-    # Verify the rollback sequence: first set to 1 (accepted), then rollback to 0 on failure
-    # The call order matters - use assert_has_calls to verify the sequence
-    monthly_challenge_calls = [
-        call("test-id", 1),  # Set to accepted
-        call("test-id", 0)   # Rollback on failure
-    ]
-    mock_db.set_monthly_challenge_state.assert_has_calls(monthly_challenge_calls)
+    # Verify that set_monthly_challenge_state was called with 0 (rollback on failure)
+    # The status is only set to 1 after successful addition, so on failure it's set to 0
+    mock_db.set_monthly_challenge_state.assert_called_with("test-id", 0)
     
     # Should show the challenge dialog (user accepted)
     dialog_mock.assert_called_once()

--- a/tests/test_monthly_challenge_fixes.py
+++ b/tests/test_monthly_challenge_fixes.py
@@ -56,8 +56,9 @@ def mock_requests():
 @patch("Ankimon.pyobj.pokemon_trade.datetime")
 @patch("Ankimon.pyobj.pokemon_trade.add_pokemon_to_collection")
 @patch("Ankimon.pyobj.pokemon_trade.show_monthly_challenge_dialog")
+@patch("Ankimon.pyobj.pokemon_trade.show_monthly_acceptance_dialog")
 @patch("Ankimon.pyobj.pokemon_trade.utils.showInfo")
-def test_rate_this_check(show_info_mock, dialog_mock, add_pokemon_mock, datetime_mock, mock_requests, mock_mw, mock_db):
+def test_rate_this_check(show_info_mock, acceptance_dialog_mock, dialog_mock, add_pokemon_mock, datetime_mock, mock_requests, mock_mw, mock_db):
     logger = MockLogger()
 
     # Setup datetime to return known values
@@ -98,22 +99,26 @@ def test_rate_this_check(show_info_mock, dialog_mock, add_pokemon_mock, datetime
     check_and_award_monthly_pokemon(logger, defer=False)
     mock_requests.assert_called_once()
     add_pokemon_mock.assert_called_once()
+    acceptance_dialog_mock.assert_called_once()
 
     mock_requests.reset_mock()
     add_pokemon_mock.reset_mock()
+    acceptance_dialog_mock.reset_mock()
 
     # Test case 4: user rated using new boolean True
     mock_db.get_user_data.return_value = True
     check_and_award_monthly_pokemon(logger, defer=False)
     mock_requests.assert_called_once()
     add_pokemon_mock.assert_called_once()
+    acceptance_dialog_mock.assert_called_once()
 
 
 @patch("Ankimon.pyobj.pokemon_trade.datetime")
 @patch("Ankimon.pyobj.pokemon_trade.add_pokemon_to_collection")
 @patch("Ankimon.pyobj.pokemon_trade.show_monthly_challenge_dialog")
+@patch("Ankimon.pyobj.pokemon_trade.show_monthly_acceptance_dialog")
 @patch("Ankimon.pyobj.pokemon_trade.utils.showInfo")
-def test_previous_challenge_pokemon_null_check(show_info_mock, dialog_mock, add_pokemon_mock, datetime_mock, mock_requests, mock_mw, mock_db):
+def test_previous_challenge_pokemon_null_check(show_info_mock, acceptance_dialog_mock, dialog_mock, add_pokemon_mock, datetime_mock, mock_requests, mock_mw, mock_db):
     logger = MockLogger()
 
     # Setup datetime to return known values
@@ -159,13 +164,15 @@ def test_previous_challenge_pokemon_null_check(show_info_mock, dialog_mock, add_
     add_pokemon_mock.assert_called_once()
     added_pokemon = add_pokemon_mock.call_args[0][0]
     assert added_pokemon["shiny"] is False
+    acceptance_dialog_mock.assert_called_once()
 
 
 @patch("Ankimon.pyobj.pokemon_trade.datetime")
 @patch("Ankimon.pyobj.pokemon_trade.add_pokemon_to_collection")
 @patch("Ankimon.pyobj.pokemon_trade.show_monthly_challenge_dialog")
+@patch("Ankimon.pyobj.pokemon_trade.show_monthly_acceptance_dialog")
 @patch("Ankimon.pyobj.pokemon_trade.utils.showInfo")
-def test_previous_challenge_pokemon_has_enough_defeats(show_info_mock, dialog_mock, add_pokemon_mock, datetime_mock, mock_requests, mock_mw, mock_db):
+def test_previous_challenge_pokemon_has_enough_defeats(show_info_mock, acceptance_dialog_mock, dialog_mock, add_pokemon_mock, datetime_mock, mock_requests, mock_mw, mock_db):
     logger = MockLogger()
 
     dt_mock = MagicMock()
@@ -207,6 +214,7 @@ def test_previous_challenge_pokemon_has_enough_defeats(show_info_mock, dialog_mo
     add_pokemon_mock.assert_called_once()
     added_pokemon = add_pokemon_mock.call_args[0][0]
     assert added_pokemon["shiny"] is True
+    acceptance_dialog_mock.assert_called_once()
 
 
 @patch("Ankimon.pyobj.pokemon_trade.datetime")
@@ -314,53 +322,6 @@ def test_monthly_challenge_reconciliation_branch(show_info_mock, dialog_mock, ad
 @patch("Ankimon.pyobj.pokemon_trade.datetime")
 @patch("Ankimon.pyobj.pokemon_trade.add_pokemon_to_collection")
 @patch("Ankimon.pyobj.pokemon_trade.show_monthly_challenge_dialog")
-@patch("Ankimon.pyobj.pokemon_trade.show_monthly_rejection_dialog")
-@patch("Ankimon.pyobj.pokemon_trade.utils.showInfo")
-def test_monthly_challenge_rejection_sets_status(show_info_mock, rejection_dialog_mock, dialog_mock, add_pokemon_mock, datetime_mock, mock_requests, mock_mw, mock_db):
-    """Test that rejecting the monthly challenge sets monthly_challenge to 2."""
-    logger = MockLogger()
-
-    dt_mock = MagicMock()
-    dt_mock.month = 1
-    dt_mock.year = 2024
-    datetime_mock.now.return_value = dt_mock
-
-    mock_response = MagicMock()
-    mock_response.json.return_value = [
-        {
-            "month": "January 2024",
-            "pokemon": {
-                "name": "TestMon",
-                "id": 1,
-                "individual_id": "test-id"
-            }
-        }
-    ]
-    mock_requests.return_value = mock_response
-
-    mock_db.get_user_data.return_value = True
-    mock_db.get_pokemon.return_value = None
-
-    # User rejects the Pokémon
-    dialog_mock.return_value = False
-
-    check_and_award_monthly_pokemon(logger, defer=False)
-
-    # Should NOT add Pokémon
-    add_pokemon_mock.assert_not_called()
-    
-    # Should set monthly_challenge to 2 (rejected)
-    mock_db.set_user_data.assert_any_call("monthly_challenge", 2)
-    mock_db.set_user_data.assert_any_call("monthly_challenge_id", "test-id")
-    
-    # Should show the challenge dialog and rejection dialog
-    dialog_mock.assert_called_once()
-    rejection_dialog_mock.assert_called_once()
-
-
-@patch("Ankimon.pyobj.pokemon_trade.datetime")
-@patch("Ankimon.pyobj.pokemon_trade.add_pokemon_to_collection")
-@patch("Ankimon.pyobj.pokemon_trade.show_monthly_challenge_dialog")
 @patch("Ankimon.pyobj.pokemon_trade.show_monthly_acceptance_dialog")
 @patch("Ankimon.pyobj.pokemon_trade.utils.showInfo")
 def test_monthly_challenge_rollback_on_add_failure(show_info_mock, acceptance_dialog_mock, dialog_mock, add_pokemon_mock, datetime_mock, mock_requests, mock_mw, mock_db):
@@ -412,3 +373,50 @@ def test_monthly_challenge_rollback_on_add_failure(show_info_mock, acceptance_di
     dialog_mock.assert_called_once()
     # Should NOT show acceptance dialog (since add failed)
     acceptance_dialog_mock.assert_not_called()
+
+
+@patch("Ankimon.pyobj.pokemon_trade.datetime")
+@patch("Ankimon.pyobj.pokemon_trade.add_pokemon_to_collection")
+@patch("Ankimon.pyobj.pokemon_trade.show_monthly_challenge_dialog")
+@patch("Ankimon.pyobj.pokemon_trade.show_monthly_rejection_dialog")
+@patch("Ankimon.pyobj.pokemon_trade.utils.showInfo")
+def test_monthly_challenge_rejection_sets_status(show_info_mock, rejection_dialog_mock, dialog_mock, add_pokemon_mock, datetime_mock, mock_requests, mock_mw, mock_db):
+    """Test that rejecting the monthly challenge sets monthly_challenge to 2."""
+    logger = MockLogger()
+
+    dt_mock = MagicMock()
+    dt_mock.month = 1
+    dt_mock.year = 2024
+    datetime_mock.now.return_value = dt_mock
+
+    mock_response = MagicMock()
+    mock_response.json.return_value = [
+        {
+            "month": "January 2024",
+            "pokemon": {
+                "name": "TestMon",
+                "id": 1,
+                "individual_id": "test-id"
+            }
+        }
+    ]
+    mock_requests.return_value = mock_response
+
+    mock_db.get_user_data.return_value = True
+    mock_db.get_pokemon.return_value = None
+
+    # User rejects the Pokémon
+    dialog_mock.return_value = False
+
+    check_and_award_monthly_pokemon(logger, defer=False)
+
+    # Should NOT add Pokémon
+    add_pokemon_mock.assert_not_called()
+    
+    # Should set monthly_challenge to 2 (rejected)
+    mock_db.set_user_data.assert_any_call("monthly_challenge", 2)
+    mock_db.set_user_data.assert_any_call("monthly_challenge_id", "test-id")
+    
+    # Should show the challenge dialog and rejection dialog
+    dialog_mock.assert_called_once()
+    rejection_dialog_mock.assert_called_once()


### PR DESCRIPTION
### At A Glance, This PR
- Adds a **Reject** button to reject Ankimon's Monthly Challenge (and its Mon)
- **Modernises** the UI of the Monthly Challenge (arrival) window

### The Issue
Before this, Ankimon **checks** the presence of the **Monthly Challenge Mon** in trainers' collection every day, upon **every restart**. If Ankimon detects that their **ID is missing**, it "**reannounces**" the monthly challenge and automatically **(re)awards** the Mon. While useful for trainers who have accidentally removed their Mon, this approach can prove **overzealous** for trainers who **chose to not take in** the monthly challenge or its Mon. 

To fix this, the announcement window now has **Accept/Reject buttons** that allow users to **decide** whether to keep or put off the Monthly Challenge Mon. The **three states** that are stored as `monthly_challenge_id` and `monthly_challenge` in `ankimon.db > user_data` include: 
- **0** (**Unknown/New** - ID is **checked** and **announcement** is made)
- **1** (**Accepted** - ID is **checked** and if not present, **re-awards** the monthly Mon)
- And **2** (**Rejected** - Ankimon **no longer checks** the monthly ID and ceases to award the monthly Mon unless re-accepted in the Monthly Challenge Window, which was created in a [separate PR](https://github.com/h0tp-ftw/ankimon/pull/828)). 

### What This PR Does
- This PR modifies `pokemon_trade.py`, which controls the **Monthly Challenge announcement dialog/awarding**, to improve the **UI**, add **Accept/Reject** buttons, and write to the **database** (`ankimon.db`) to remember trainers' preferences. 
- `database_manager.py` implements Monthly Challenge's state persistence.
- Additionally, `tests_monthly_challenge_fixes.py` is modified to make the tests **wait** for the **deferred execution** of **`check_and_award_monthly_pokemon()`** to avoid Integrity Test failure. 

### Expected Behaviour
A modern window with Accept and Reject buttons appears with the monthly Mon on the first day of every month. And Ankimon successfully remembers the user's choice. 

#### Example With September's Challenge

#### Then
<img width="501" height="184" alt="image" src="https://github.com/user-attachments/assets/b3efdce2-0764-4ed5-ade6-5b153c93e393" />

#### Now
<img width="1280" height="720" alt="20260902204520" src="https://github.com/user-attachments/assets/18e52583-5f0a-4050-86a5-5047b9aa575b" />

### Related PRs
This PR is **dependent** on **#828** for users to **re-accept or re-reject** the Monthly Challenge after their initial decision. Without the Monthly Challenge window, which was proposed in #828, their decision will **remain unchanged** for the rest of the month (unless they manually change the numbers in their database file, which is unconventional). 

### Fixes
Special thanks for the suggestions in Discord for an option to reject Monthly Challenges, which inspired this PR!

### Checklist
- [x] My code and commit messages follow the code style and guidelines of this project.
- [x] I have verified that the Accept/Reject window works and displays as intended. Additionally, the Accept/Reject states are properly saved in the database, `ankimon.db`. 