### PR TITLE
add(monChallenge) - 2 of 2: dedicated Monthly Challenge window

### DIFF
--- a/src/Ankimon/ankidex/ankidex.html
+++ b/src/Ankimon/ankidex/ankidex.html
@@ -80,6 +80,13 @@
                                 <span class="nav-menu-desc">Configure Ankimon</span>
                             </div>
                         </button>
+                        <button class="nav-menu-item" role="menuitem" data-screen="monthly">
+                            <span class="nav-menu-icon"><img src="../user_files/sprites/items/lucky-punch.png" class="icon-item-sprite" alt=""></span>
+                            <div class="nav-menu-text">
+                                <span class="nav-menu-title">Monthly Challenge</span>
+                                <span class="nav-menu-desc">Claim your monthly Pokémon</span>
+                            </div>
+                        </button>
                         <button class="nav-menu-item" role="menuitem" data-screen="mobile">
                             <span class="nav-menu-icon"><img src="../user_files/sprites/items/elixir.png" class="icon-item-sprite" alt=""></span>
                             <div class="nav-menu-text">

--- a/src/Ankimon/ankimon_items_web/settings.html
+++ b/src/Ankimon/ankimon_items_web/settings.html
@@ -84,6 +84,13 @@
                                 <span class="nav-menu-desc">Configure Ankimon</span>
                             </div>
                         </button>
+                        <button class="nav-menu-item" role="menuitem" data-screen="monthly">
+                            <span class="nav-menu-icon"><img src="../user_files/sprites/items/lucky-punch.png" class="icon-item-sprite" alt=""></span>
+                            <div class="nav-menu-text">
+                                <span class="nav-menu-title">Monthly Challenge</span>
+                                <span class="nav-menu-desc">Claim your monthly Pokémon</span>
+                            </div>
+                        </button>
                         <button class="nav-menu-item" role="menuitem" data-screen="mobile">
                             <span class="nav-menu-icon"><img src="../user_files/sprites/items/elixir.png" class="icon-item-sprite" alt=""></span>
                             <div class="nav-menu-text">

--- a/src/Ankimon/ankimon_items_web/shop.html
+++ b/src/Ankimon/ankimon_items_web/shop.html
@@ -78,6 +78,13 @@
                                 <span class="nav-menu-desc">Configure Ankimon</span>
                             </div>
                         </button>
+                        <button class="nav-menu-item" role="menuitem" data-screen="monthly">
+                            <span class="nav-menu-icon"><img src="../user_files/sprites/items/lucky-punch.png" class="icon-item-sprite" alt=""></span>
+                            <div class="nav-menu-text">
+                                <span class="nav-menu-title">Monthly Challenge</span>
+                                <span class="nav-menu-desc">Claim your monthly Pokémon</span>
+                            </div>
+                        </button>
                         <button class="nav-menu-item" role="menuitem" data-screen="mobile">
                             <span class="nav-menu-icon"><img src="../user_files/sprites/items/elixir.png" class="icon-item-sprite" alt=""></span>
                             <div class="nav-menu-text">

--- a/src/Ankimon/ankimon_items_web/shop_obj.py
+++ b/src/Ankimon/ankimon_items_web/shop_obj.py
@@ -18,7 +18,25 @@ from datetime import datetime
 import requests
 from aqt import QDialog, QVBoxLayout, QWebEngineView, QWebEnginePage, mw
 from aqt.qt import Qt, QUrl, QFrame, QWebEngineProfile
-from aqt.operations import QueryOp
+try:
+    from aqt.operations import QueryOp
+except ImportError:
+    # Test environment - use a stub
+    class QueryOp:
+        def __init__(self, parent=None, op=None, success=None):
+            self.parent = parent
+            self.op = op
+            self.success = success
+        
+        def without_collection(self):
+            return self
+        
+        def run_in_background(self):
+            if self.op:
+                result = self.op(None)
+                if self.success:
+                    self.success(result)
+            return self
 from PyQt6.QtCore import QObject, pyqtSlot, QTimer, QByteArray, QVariant
 from PyQt6.QtGui import QColor
 from PyQt6.QtWebChannel import QWebChannel

--- a/src/Ankimon/ankimon_items_web/shop_obj.py
+++ b/src/Ankimon/ankimon_items_web/shop_obj.py
@@ -1124,6 +1124,9 @@ class AnkimonItemsWeb(QDialog):
         # Monthly challenge cache - prevents blocking HTTP on GUI thread
         self._monthly_challenge_cache = None
         self._monthly_challenge_cache_time = None
+        self._monthly_fetch_pending = False
+        self._monthly_fetch_failure_time = None
+        self._monthly_fetch_callbacks = []
 
         self.current_screen = None
         self.setWindowTitle("Ankimon")
@@ -1705,13 +1708,30 @@ class AnkimonItemsWeb(QDialog):
                     callback(self._monthly_challenge_cache)
                 return
         
+        # If a fetch is already in progress, queue the callback
+        if self._monthly_fetch_pending:
+            if callback:
+                self._monthly_fetch_callbacks.append(callback)
+            return
+        
+        # If we failed recently (within 60 seconds), wait before retrying
+        if self._monthly_fetch_failure_time:
+            if time.time() - self._monthly_fetch_failure_time < 60:
+                if callback:
+                    if self._monthly_challenge_cache:
+                        callback(self._monthly_challenge_cache)
+                    else:
+                        callback({"ok": False, "loading": True, "message": "Loading monthly challenge data..."})
+                return
+        
+        self._monthly_fetch_pending = True
+        
         def run_fetch(col):
             try:
                 url = "https://raw.githubusercontent.com/h0tp-ftw/ankimon/refs/heads/main/assets/challenges/monthly_challenges.json"
                 response = requests.get(url, timeout=5)
                 response.raise_for_status()
                 data = response.json()
-                # Ensure the data is wrapped in the expected format
                 if isinstance(data, list):
                     return {"challenges": data}
                 return data
@@ -1719,11 +1739,22 @@ class AnkimonItemsWeb(QDialog):
                 return {"error": str(e)}
         
         def on_success(data):
+            self._monthly_fetch_pending = False
             if data and (not isinstance(data, dict) or "error" not in data):
                 self._monthly_challenge_cache = data
                 self._monthly_challenge_cache_time = time.time()
+                self._monthly_fetch_failure_time = None
+            else:
+                self._monthly_fetch_failure_time = time.time()
+            
+            # Call all pending callbacks
+            callbacks = self._monthly_fetch_callbacks[:]
+            self._monthly_fetch_callbacks = []
             if callback:
-                callback(data)
+                callbacks.append(callback)
+            for cb in callbacks:
+                if cb:
+                    cb(data)
         
         QueryOp(parent=self, op=run_fetch, success=on_success).without_collection().run_in_background()
 
@@ -1801,24 +1832,14 @@ class AnkimonItemsWeb(QDialog):
             # Get current month
             current_month = datetime.now().strftime("%B %Y")
             
-            # Get current challenge status from DB
-            db = services.db
-            current_individual_id = None
-            current_status = 0
+            # Use _get_monthly_challenge_context() to get current status - avoids duplicating DB writes
+            _, _, current_individual_id, current_status = self._get_monthly_challenge_context()
             
-            # Find the current month's challenge
-            current_challenge = next((c for c in all_challenges if c.get("month") == current_month), None)
-            if current_challenge and current_challenge.get("pokemon"):
-                current_individual_id = current_challenge["pokemon"].get("individual_id")
-                if current_individual_id:
-                    last_id = db.get_user_data("monthly_challenge_id")
-                    if str(last_id) != str(current_individual_id):
-                        db.set_user_data("monthly_challenge_id", current_individual_id)
-                        db.set_user_data("monthly_challenge", 0)
-                    try:
-                        current_status = int(db.get_user_data("monthly_challenge", 0))
-                    except (TypeError, ValueError):
-                        current_status = 0
+            # If context returned None for individual_id, try to find it from challenges
+            if current_individual_id is None:
+                current_challenge = next((c for c in all_challenges if c.get("month") == current_month), None)
+                if current_challenge and current_challenge.get("pokemon"):
+                    current_individual_id = current_challenge["pokemon"].get("individual_id")
             
             # Get sprite visibility setting
             show_sprites = True
@@ -1851,20 +1872,14 @@ class AnkimonItemsWeb(QDialog):
                     if next_id:
                         needed_ids.append(next_id)
             
-            # Fetch only needed Pokémon in one query
+            # Fetch only needed Pokémon using the existing API
             all_pokemon_in_collection = {}
             if needed_ids:
                 try:
-                    # Use a targeted query with IN clause
-                    placeholders = ','.join(['?'] * len(needed_ids))
-                    query = f"SELECT * FROM pokemon WHERE individual_id IN ({placeholders})"
-                    cursor = db.execute(query, needed_ids)
-                    for row in cursor.fetchall():
-                        # Convert row to dict based on column names
-                        row_dict = dict(row)
-                        ind_id = row_dict.get("individual_id")
-                        if ind_id:
-                            all_pokemon_in_collection[ind_id] = row_dict
+                    for ind_id in needed_ids:
+                        pokemon_data = db.get_pokemon(ind_id)
+                        if pokemon_data:
+                            all_pokemon_in_collection[ind_id] = pokemon_data
                 except Exception as e:
                     logger = services.logger
                     if logger:
@@ -2001,26 +2016,16 @@ class AnkimonItemsWeb(QDialog):
                     next_pokemon_in_db = all_pokemon_in_collection.get(next_individual_id) if next_individual_id else None
                     
                     if is_collected and next_pokemon_in_db is None:
-                        # Month A's ID is present, Month B's ID is NOT present → Pending: Accepted
                         entry["result"] = "pending_accepted"
-                        if logger:
-                            logger.log("debug", f"[Monthly] {month}: → Pending: Accepted")
                     elif not is_collected and next_pokemon_in_db is None:
-                        # Month A's ID is NOT present, Month B's ID is NOT present → Pending: Rejected
                         entry["result"] = "pending_rejected"
-                        if logger:
-                            logger.log("debug", f"[Monthly] {month}: → Pending: Rejected")
                     elif not is_collected:
-                        # ID not in collection → Rejected
                         entry["result"] = "rejected"
-                        if logger:
-                            logger.log("debug", f"[Monthly] {month}: NOT in collection → Rejected")
                     else:
                         # ID IS in collection → Check if next month's Pokémon is shiny
                         next_is_shiny = False
                         if next_pokemon_in_db:
                             raw_shiny = next_pokemon_in_db.get("shiny", False)
-                            # Handle both boolean and integer storage
                             if isinstance(raw_shiny, bool):
                                 next_is_shiny = raw_shiny
                             elif isinstance(raw_shiny, int):
@@ -2030,36 +2035,21 @@ class AnkimonItemsWeb(QDialog):
                             else:
                                 next_is_shiny = bool(raw_shiny)
                         
-                        # CRITICAL: Log everything for debugging
-                        if logger:
-                            next_month_name = next_challenge.get("month", "None") if next_challenge else "None"
-                            logger.log("debug", f"[Monthly] ===== CHECKING {month} =====")
-                            logger.log("debug", f"[Monthly] current_month_in_db: {is_collected}")
-                            logger.log("debug", f"[Monthly] next_month: {next_month_name}")
-                            logger.log("debug", f"[Monthly] next_individual_id: {next_individual_id}")
-                            logger.log("debug", f"[Monthly] next_pokemon_in_db: {next_pokemon_in_db is not None}")
-                            if next_pokemon_in_db:
-                                logger.log("debug", f"[Monthly] next_pokemon shiny raw value: {next_pokemon_in_db.get('shiny', 'NOT FOUND')}")
-                                logger.log("debug", f"[Monthly] next_pokemon name: {next_pokemon_in_db.get('name', 'UNKNOWN')}")
-                            logger.log("debug", f"[Monthly] next_is_shiny: {next_is_shiny}")
-                        
                         if next_pokemon_in_db and next_is_shiny:
-                            # Current month's ID is in collection AND next month's Mon is in collection AND shiny → Succeeded!
                             entry["result"] = "success"
-                            if logger:
-                                logger.log("debug", f"[Monthly] {month}: → SUCCEEDED!")
                         elif next_pokemon_in_db and not next_is_shiny:
-                            # Current month's ID is in collection AND next month's Mon is in collection BUT NOT shiny → Next time's a charm!
                             entry["result"] = "next_time"
-                            if logger:
-                                logger.log("debug", f"[Monthly] {month}: → NEXT TIME'S A CHARM!")
                         else:
-                            # Current month's ID is in collection but next month's Mon is not collected → Accepted
                             entry["result"] = "accepted"
-                            if logger:
-                                logger.log("debug", f"[Monthly] {month}: → Accepted")
                 
                 challenges_list.append(entry)
+            
+            # Single summary log per render instead of per-challenge debug logging
+            if logger:
+                logger.log("debug", f"[Monthly] Rendered {len(challenges_list)} challenges, "
+                                    f"current_month={current_month}, "
+                                    f"current_status={current_status}, "
+                                    f"loaded_collection_entries={len(all_pokemon_in_collection)}")
             
             return {
                 "ok": True,
@@ -2081,15 +2071,17 @@ class AnkimonItemsWeb(QDialog):
 
     def _save_pokemon_in_transaction(self, conn, pokemon_data):
         """Save a Pokémon using an existing transaction connection."""
+        # Normalize name: lowercase and strip hyphens
+        name = pokemon_data.get('name', '').lower().replace('-', '')
         conn.execute(
-            """INSERT OR REPLACE INTO pokemon 
+            """INSERT OR REPLACE INTO captured_pokemon 
                (individual_id, id, name, level, gender, shiny, type, stats, 
                 pokemon_defeated, held_item, nickname, cp, ivs)
                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
             (
                 pokemon_data.get('individual_id'),
                 pokemon_data.get('id'),
-                pokemon_data.get('name'),
+                name,
                 pokemon_data.get('level'),
                 pokemon_data.get('gender'),
                 pokemon_data.get('shiny'),
@@ -2099,7 +2091,6 @@ class AnkimonItemsWeb(QDialog):
                 pokemon_data.get('held_item'),
                 pokemon_data.get('nickname'),
                 pokemon_data.get('cp'),
-                # Fix: Use 'iv' field, not 'ivs' - create_monthly_challenge_pokemon returns "iv"
                 json.dumps(pokemon_data.get('iv', {}))
             )
         )
@@ -2135,7 +2126,7 @@ class AnkimonItemsWeb(QDialog):
             with db._get_connection() as conn:
                 # Check if already collected within the transaction
                 cursor = conn.execute(
-                    "SELECT individual_id FROM pokemon WHERE individual_id = ?",
+                    "SELECT individual_id FROM captured_pokemon WHERE individual_id = ?",
                     (individual_id,)
                 )
                 if cursor.fetchone():
@@ -2174,11 +2165,26 @@ class AnkimonItemsWeb(QDialog):
             
             db = services.db
             with db._get_connection() as conn:
+                # Use the correct table name and clean up team slots
                 cursor = conn.execute(
-                    "DELETE FROM pokemon WHERE individual_id = ?",
+                    "DELETE FROM captured_pokemon WHERE individual_id = ?",
                     (individual_id,)
                 )
                 removed = cursor.rowcount > 0
+                
+                # Also clean up team references
+                conn.execute(
+                    "UPDATE team SET individual_id = NULL WHERE individual_id = ?",
+                    (individual_id,)
+                )
+                conn.execute(
+                    "UPDATE user_data SET value = NULL WHERE key = 'companion_id' AND value = ?",
+                    (individual_id,)
+                )
+                conn.execute(
+                    "UPDATE user_data SET value = NULL WHERE key = 'xp_share_id' AND value = ?",
+                    (individual_id,)
+                )
                 
                 # Update status in same transaction
                 conn.execute(

--- a/src/Ankimon/ankimon_items_web/shop_obj.py
+++ b/src/Ankimon/ankimon_items_web/shop_obj.py
@@ -1435,15 +1435,8 @@ class AnkimonItemsWeb(QDialog):
                 js = f"if (window.initializeMonthlyChallenge) window.initializeMonthlyChallenge({json.dumps(result_data)});"
                 self.webview_monthly.page().runJavaScript(js)
             
-            if self._monthly_challenge_cache:
-                push_with_data(self._monthly_challenge_cache)
-            else:
-                # Push loading state immediately
-                loading_data = {"ok": False, "loading": True, "message": "Loading monthly challenge data..."}
-                js = f"if (window.initializeMonthlyChallenge) window.initializeMonthlyChallenge({json.dumps(loading_data)});"
-                self.webview_monthly.page().runJavaScript(js)
-                # Then fetch the real data in the background
-                self._fetch_monthly_challenge_async(push_with_data)
+            # Always call _fetch_monthly_challenge_async - it handles cache internally
+            self._fetch_monthly_challenge_async(push_with_data)
 
     def get_profile_payload(self):
         """Profile data + a one-shot UI action ('sprite' opens the picker,
@@ -1570,10 +1563,8 @@ class AnkimonItemsWeb(QDialog):
             js = f"if (window.liveRefreshMonthly) window.liveRefreshMonthly({json.dumps(result_data)});"
             self.webview_monthly.page().runJavaScript(js)
         
-        if self._monthly_challenge_cache:
-            push(self._monthly_challenge_cache)
-        else:
-            self._fetch_monthly_challenge_async(push)
+        # Always call _fetch_monthly_challenge_async - it handles cache internally
+        self._fetch_monthly_challenge_async(push)
 
     def _get_ankidex_data(self):
         # Reuse the existing Ankidex singleton's data getter — keeps the
@@ -1843,18 +1834,41 @@ class AnkimonItemsWeb(QDialog):
             if current_individual_id:
                 collection_pokemon = db.get_pokemon(current_individual_id)
             
-            # Pre-fetch all Pokémon in the user's collection by individual_id for quick lookup
+            # Fetch only the Pokémon we need for the challenge list - avoid loading full collection
+            # Collect all individual_ids we need to check
+            needed_ids = []
+            for c in all_challenges:
+                pokemon = c.get("pokemon", {})
+                individual_id = pokemon.get("individual_id")
+                if individual_id:
+                    needed_ids.append(individual_id)
+            
+            # Also add next month's IDs for the result logic
+            for i, c in enumerate(all_challenges):
+                if i + 1 < len(all_challenges):
+                    next_pokemon = all_challenges[i + 1].get("pokemon", {})
+                    next_id = next_pokemon.get("individual_id")
+                    if next_id:
+                        needed_ids.append(next_id)
+            
+            # Fetch only needed Pokémon in one query
             all_pokemon_in_collection = {}
-            try:
-                all_pokemon = db.get_all_pokemon() or []
-                for p in all_pokemon:
-                    ind_id = p.get("individual_id")
-                    if ind_id:
-                        all_pokemon_in_collection[ind_id] = p
-            except Exception as e:
-                logger = services.logger
-                if logger:
-                    logger.log("error", f"Failed to fetch all Pokémon: {e}")
+            if needed_ids:
+                try:
+                    # Use a targeted query with IN clause
+                    placeholders = ','.join(['?'] * len(needed_ids))
+                    query = f"SELECT * FROM pokemon WHERE individual_id IN ({placeholders})"
+                    cursor = db.execute(query, needed_ids)
+                    for row in cursor.fetchall():
+                        # Convert row to dict based on column names
+                        row_dict = dict(row)
+                        ind_id = row_dict.get("individual_id")
+                        if ind_id:
+                            all_pokemon_in_collection[ind_id] = row_dict
+                except Exception as e:
+                    logger = services.logger
+                    if logger:
+                        logger.log("error", f"Failed to fetch Pokémon by IDs: {e}")
             
             # Build the challenge list
             challenges_list = []
@@ -1921,11 +1935,12 @@ class AnkimonItemsWeb(QDialog):
                 month_pokemon_in_collection = all_pokemon_in_collection.get(pokemon_id) if pokemon_id else None
                 
                 if is_current and pokemon_id:
-                    # CURRENT month - determine Status
+                    # CURRENT month - use current_status from DB
+                    entry["status"] = current_status
+                    entry["in_collection"] = (collection_pokemon is not None)
+                    
                     if collection_pokemon:
-                        # Pokémon is in collection - Status: Accepted
-                        entry["status"] = 1  # Accepted
-                        entry["in_collection"] = True
+                        # Pokémon is in collection
                         entry["collection_level"] = collection_pokemon.get("level", level)
                         entry["collection_pokedex_id"] = collection_pokemon.get("id", pokedex_id)
                         entry["collection_shiny"] = collection_pokemon.get("shiny", False)
@@ -1963,9 +1978,7 @@ class AnkimonItemsWeb(QDialog):
                         
                         entry["has_evolved"] = (evolved_id != pokedex_id)
                     else:
-                        # Pokémon not in collection - Status: Rejected
-                        entry["status"] = 2  # Rejected
-                        entry["in_collection"] = False
+                        # Pokémon not in collection
                         entry["collection_level"] = level
                         entry["collection_pokedex_id"] = pokedex_id
                         entry["collection_shiny"] = shiny_template
@@ -2086,7 +2099,8 @@ class AnkimonItemsWeb(QDialog):
                 pokemon_data.get('held_item'),
                 pokemon_data.get('nickname'),
                 pokemon_data.get('cp'),
-                json.dumps(pokemon_data.get('ivs', {}))
+                # Fix: Use 'iv' field, not 'ivs' - create_monthly_challenge_pokemon returns "iv"
+                json.dumps(pokemon_data.get('iv', {}))
             )
         )
 

--- a/src/Ankimon/ankimon_items_web/shop_obj.py
+++ b/src/Ankimon/ankimon_items_web/shop_obj.py
@@ -1,6 +1,7 @@
-"""Unified shell window — Items (Mart + Bag) and Ankidex live in one QDialog.
+"""Unified shell window — Items (Mart + Bag), Ankidex, Profile, Team, Settings, 
+Monthly Challenge, and Mobile all live in one QDialog.
 
-The same QWebEngineView swaps between two screens by changing its URL. No
+The same QWebEngineView swaps between screens by changing its URL. No
 window close/open flicker; the dropdown switcher in either screen calls back
 through QWebChannel to swap content in place.
 """
@@ -14,9 +15,10 @@ import traceback
 import threading
 import base64
 from datetime import datetime
+import requests
 from aqt import QDialog, QVBoxLayout, QWebEngineView, QWebEnginePage, mw
 from aqt.qt import Qt, QUrl, QFrame, QWebEngineProfile
-from PyQt6.QtCore import QObject, pyqtSlot, QTimer, QByteArray
+from PyQt6.QtCore import QObject, pyqtSlot, QTimer, QByteArray, QVariant
 from PyQt6.QtGui import QColor
 from PyQt6.QtWebChannel import QWebChannel
 from PyQt6.QtWidgets import QStackedWidget
@@ -32,7 +34,7 @@ except ImportError:  # dev helper not landed yet (thread-reload-and-misc-utils u
         return False
 
 
-from ..resources import items_path, csv_file_items_cost, csv_file_descriptions
+from ..resources import items_path, csv_file_items_cost, csv_file_descriptions, icon_path
 
 
 class SafeWebEnginePage(QWebEnginePage):
@@ -86,8 +88,8 @@ from ..events import events
 # NOTE: functions/mobile_sync.py is a later (mobile) unit and is intentionally
 # NOT a module-load dependency of the web-shell host. The MobileBridge slots
 # lazy-import it in-method and degrade to a benign/neutral payload when it is
-# absent, so the host, shop, settings, profile and team screens all work with
-# mobile not yet installed.
+# absent, so the host, shop, settings, profile, team, and monthly challenge 
+# screens all work with mobile not yet installed.
 
 
 SCREEN_ITEMS = "items"
@@ -97,6 +99,7 @@ SCREEN_PROFILE = "profile"
 SCREEN_TEAM = "team"
 SCREEN_MOBILE = "mobile"
 SCREEN_HISTORY = "history"
+SCREEN_MONTHLY = "monthly"
 
 SPRITE_VISIBILITY_SCREENS = (
     SCREEN_ITEMS,
@@ -104,6 +107,7 @@ SPRITE_VISIBILITY_SCREENS = (
     SCREEN_SETTINGS,
     SCREEN_PROFILE,
     SCREEN_TEAM,
+    SCREEN_MONTHLY,
 )
 
 
@@ -149,6 +153,10 @@ class NavBridge(QObject):
     @pyqtSlot()
     def openHistory(self):
         self._w.load_screen(SCREEN_HISTORY)
+    
+    @pyqtSlot()
+    def openMonthly(self):
+        self._w.load_screen(SCREEN_MONTHLY)
 
 
 class TrainerBridge(QObject):
@@ -1023,6 +1031,28 @@ class MobileBridge(QObject):
         except Exception as e:
             return {"success": False, "error": str(e)}
 
+class MonthlyBridge(QObject):
+    """Monthly Challenge screen data and collection actions."""
+
+    def __init__(self, window):
+        super().__init__()
+        self._w = window
+
+    @pyqtSlot(result="QVariant")
+    def getMonthlyChallenge(self):
+        return self._w.get_monthly_challenge_data()
+
+    @pyqtSlot(result="QVariant")
+    def receiveMon(self):
+        result = self._w.receive_monthly_challenge_mon()
+        self._w.push_screen_data()
+        return result
+
+    @pyqtSlot(result="QVariant")
+    def removeMon(self):
+        result = self._w.remove_monthly_challenge_mon()
+        self._w.push_screen_data()
+        return result
 
 class AnkimonItemsWeb(QDialog):
     def __init__(
@@ -1070,6 +1100,7 @@ class AnkimonItemsWeb(QDialog):
             SCREEN_PROFILE: self._push_profile_live,
             SCREEN_MOBILE: self._push_mobile_live,
             SCREEN_HISTORY: self._push_history_live,
+            SCREEN_MONTHLY: self._push_monthly_live,
         }
         self._live_refresh_pending = False
         self.current_screen = None
@@ -1150,6 +1181,13 @@ class AnkimonItemsWeb(QDialog):
                 self.profile, SCREEN_HISTORY, logger, self.webview_history
             )
         )
+
+        self.webview_monthly = QWebEngineView()
+        self.webview_monthly.setPage(
+            SafeWebEnginePage(
+                self.profile, SCREEN_MONTHLY, logger, self.webview_monthly
+            )
+        )
         self._views = {
             SCREEN_ITEMS: self.webview_items,
             SCREEN_ANKIDEX: self.webview_ankidex,
@@ -1158,6 +1196,7 @@ class AnkimonItemsWeb(QDialog):
             SCREEN_TEAM: self.webview_team,
             SCREEN_MOBILE: self.webview_mobile,
             SCREEN_HISTORY: self.webview_history,
+            SCREEN_MONTHLY: self.webview_monthly,
         }
 
         self.bridge = ItemsBridge(self)
@@ -1166,6 +1205,7 @@ class AnkimonItemsWeb(QDialog):
         self.trainer_bridge = TrainerBridge(self)
         self.team_bridge = TeamBridge(self)
         self._mobile_bridge = MobileBridge(self)
+        self.monthly_bridge = MonthlyBridge(self)
 
         # Each screen gets its own channel, but every channel registers the
         # same bridge objects so any page can navigate / call any action.
@@ -1180,6 +1220,7 @@ class AnkimonItemsWeb(QDialog):
             channel.registerObject("settings", self.settings_bridge)
             channel.registerObject("trainer", self.trainer_bridge)
             channel.registerObject("team", self.team_bridge)
+            channel.registerObject("monthly", self.monthly_bridge)
             if screen in (SCREEN_MOBILE, SCREEN_HISTORY):
                 channel.registerObject("mobile", self._mobile_bridge)
             view.page().setWebChannel(channel)
@@ -1239,6 +1280,10 @@ class AnkimonItemsWeb(QDialog):
                 title = "Ankimon — Mobile History"
                 target_view = self.webview_history
                 path = self.addon_dir / "ankimon_mobile_web" / "history.html"
+            elif screen == SCREEN_MONTHLY:
+                title = "Ankimon — Monthly Challenge"
+                target_view = self.webview_monthly
+                path = self.addon_dir / "ankimon_monthly_challenge_web" / "monthly.html"
             else:
                 return
 
@@ -1362,6 +1407,10 @@ class AnkimonItemsWeb(QDialog):
             data = db.get_mobile_history() if db is not None else []
             js = f"if (window.initializeHistory) window.initializeHistory({json.dumps(data)});"
             self.webview_history.page().runJavaScript(js)
+        elif self.current_screen == SCREEN_MONTHLY:
+            data = self.get_monthly_challenge_data()
+            js = f"if (window.initializeMonthlyChallenge) window.initializeMonthlyChallenge({json.dumps(data)});"
+            self.webview_monthly.page().runJavaScript(js)
 
     def get_profile_payload(self):
         """Profile data + a one-shot UI action ('sprite' opens the picker,
@@ -1480,6 +1529,15 @@ class AnkimonItemsWeb(QDialog):
             f"window.liveRefreshHistory({json.dumps(history_data)});"
         )
         self.webview_history.page().runJavaScript(js)
+
+    def _push_monthly_live(self):
+        """Push a live refresh to the Monthly Challenge screen."""
+        data = self.get_monthly_challenge_data()
+        js = (
+            "if (window.liveRefreshMonthly) "
+            f"window.liveRefreshMonthly({json.dumps(data)});"
+        )
+        self.webview_monthly.page().runJavaScript(js)
 
     def _get_ankidex_data(self):
         # Reuse the existing Ankidex singleton's data getter — keeps the
@@ -1610,6 +1668,342 @@ class AnkimonItemsWeb(QDialog):
         # Sort by name alphabetically
         results.sort(key=lambda r: r["name"].lower())
         return {"results": results}
+
+    def _get_monthly_challenge_context(self):
+        month = datetime.now().strftime("%B %Y")
+        url = "https://raw.githubusercontent.com/h0tp-ftw/ankimon/refs/heads/main/assets/challenges/monthly_challenges.json"
+        response = requests.get(url, timeout=2)
+        response.raise_for_status()
+        challenge = next((item for item in response.json() if item.get("month") == month), None)
+        if not challenge or not challenge.get("pokemon"):
+            raise ValueError(f"No monthly challenge found for {month}")
+
+        pokemon_data = challenge["pokemon"]
+        individual_id = pokemon_data.get("individual_id")
+        if not individual_id:
+            raise ValueError("Monthly challenge Pokémon is missing individual_id")
+
+        db = services.db
+        last_id = db.get_user_data("monthly_challenge_id")
+        if str(last_id) != str(individual_id):
+            db.set_user_data("monthly_challenge_id", individual_id)
+            db.set_user_data("monthly_challenge", 0)
+        try:
+            status = int(db.get_user_data("monthly_challenge", 0))
+        except (TypeError, ValueError):
+            status = 0
+        return challenge, pokemon_data, individual_id, status
+
+    def get_monthly_challenge_data(self):
+        """Fetch monthly challenge data from the live JSON file and compute results."""
+        try:
+            from ..functions.sprite_functions import get_relative_sprite_path
+            from datetime import datetime
+            import requests
+            import json
+            
+            # Fetch the live monthly challenges JSON
+            url = "https://raw.githubusercontent.com/h0tp-ftw/ankimon/refs/heads/main/assets/challenges/monthly_challenges.json"
+            response = requests.get(url, timeout=5)
+            response.raise_for_status()
+            all_challenges = response.json()
+            
+            # Get current month
+            current_month = datetime.now().strftime("%B %Y")
+            
+            # Get current challenge status from DB
+            db = services.db
+            current_individual_id = None
+            current_status = 0
+            
+            # Find the current month's challenge
+            current_challenge = next((c for c in all_challenges if c.get("month") == current_month), None)
+            if current_challenge and current_challenge.get("pokemon"):
+                current_individual_id = current_challenge["pokemon"].get("individual_id")
+                if current_individual_id:
+                    last_id = db.get_user_data("monthly_challenge_id")
+                    if str(last_id) != str(current_individual_id):
+                        db.set_user_data("monthly_challenge_id", current_individual_id)
+                        db.set_user_data("monthly_challenge", 0)
+                    try:
+                        current_status = int(db.get_user_data("monthly_challenge", 0))
+                    except (TypeError, ValueError):
+                        current_status = 0
+            
+            # Get sprite visibility setting
+            show_sprites = True
+            try:
+                settings_obj = services.settings
+                if settings_obj is not None:
+                    show_sprites = settings_obj.get("gui.show_sprites_across_ankimon", True)
+            except Exception:
+                pass
+            
+            # Query the database for the current month's Pokémon if it exists
+            collection_pokemon = None
+            if current_individual_id:
+                collection_pokemon = db.get_pokemon(current_individual_id)
+            
+            # Pre-fetch all Pokémon in the user's collection by individual_id for quick lookup
+            all_pokemon_in_collection = {}
+            try:
+                all_pokemon = db.get_all_pokemon() or []
+                for p in all_pokemon:
+                    ind_id = p.get("individual_id")
+                    if ind_id:
+                        all_pokemon_in_collection[ind_id] = p
+            except Exception as e:
+                logger = services.logger
+                if logger:
+                    logger.log("error", f"Failed to fetch all Pokémon: {e}")
+            
+            # Build the challenge list
+            challenges_list = []
+            logger = services.logger
+            
+            for idx, c in enumerate(all_challenges):
+                month = c.get("month", "")
+                pokemon = c.get("pokemon", {})
+                pokemon_id = pokemon.get("individual_id")
+                name = pokemon.get("name", "Unknown")
+                description = c.get("description", "")
+                pokedex_id = pokemon.get("id", 0)
+                shiny_template = bool(pokemon.get("shiny", False))
+                gender = pokemon.get("gender", "N")
+                level = pokemon.get("level", 1)
+                stats = pokemon.get("stats", {})
+                types = pokemon.get("type", ["Normal"])
+                defeated = pokemon.get("pokemon_defeated", 0)
+                
+                is_current = (month == current_month)
+                
+                # Get sprites - only if show_sprites is True
+                sprite_png = None
+                sprite_gif = None
+                if show_sprites:
+                    try:
+                        sprite_png = get_relative_sprite_path(
+                            pokedex_id,
+                            shiny_template,
+                            gender,
+                            name,
+                            "png",
+                        )
+                        sprite_gif = get_relative_sprite_path(
+                            pokedex_id,
+                            shiny_template,
+                            gender,
+                            name,
+                            "gif",
+                        )
+                    except Exception:
+                        sprite_png = f"../user_files/sprites/front_default/{pokedex_id}.png"
+                        sprite_gif = f"../user_files/sprites/front_default/{pokedex_id}.gif"
+                
+                entry = {
+                    "month": month,
+                    "name": name,
+                    "individual_id": pokemon_id,
+                    "pokedex_id": pokedex_id,
+                    "sprite": sprite_png,
+                    "sprite_gif": sprite_gif,
+                    "description": description or "",
+                    "is_current": is_current,
+                    "show_sprites": show_sprites,
+                    "shiny": shiny_template,
+                    "gender": gender,
+                    "level": level,
+                    "stats": stats,
+                    "type": types,
+                    "pokemon_defeated": defeated,
+                }
+                
+                # Check if this month's Pokémon is in the user's collection
+                month_pokemon_in_collection = all_pokemon_in_collection.get(pokemon_id) if pokemon_id else None
+                
+                if is_current and pokemon_id:
+                    # CURRENT month - determine Status
+                    if collection_pokemon:
+                        # Pokémon is in collection - Status: Accepted
+                        entry["status"] = 1  # Accepted
+                        entry["in_collection"] = True
+                        entry["collection_level"] = collection_pokemon.get("level", level)
+                        entry["collection_pokedex_id"] = collection_pokemon.get("id", pokedex_id)
+                        entry["collection_shiny"] = collection_pokemon.get("shiny", False)
+                        entry["collection_gender"] = collection_pokemon.get("gender", gender)
+                        entry["collection_name"] = collection_pokemon.get("name", name)
+                        entry["collection_stats"] = collection_pokemon.get("stats", stats)
+                        entry["collection_types"] = collection_pokemon.get("type", types)
+                        entry["collection_defeated"] = collection_pokemon.get("pokemon_defeated", 0)
+                        
+                        # Get evolved sprite if applicable
+                        evolved_id = collection_pokemon.get("id", pokedex_id)
+                        evolved_shiny = collection_pokemon.get("shiny", False)
+                        evolved_gender = collection_pokemon.get("gender", gender)
+                        evolved_name = collection_pokemon.get("name", name)
+                        
+                        if show_sprites:
+                            try:
+                                entry["collection_sprite_gif"] = get_relative_sprite_path(
+                                    evolved_id,
+                                    evolved_shiny,
+                                    evolved_gender,
+                                    evolved_name,
+                                    "gif",
+                                )
+                                entry["collection_sprite_png"] = get_relative_sprite_path(
+                                    evolved_id,
+                                    evolved_shiny,
+                                    evolved_gender,
+                                    evolved_name,
+                                    "png",
+                                )
+                            except Exception:
+                                entry["collection_sprite_gif"] = f"../user_files/sprites/front_default/{evolved_id}.gif"
+                                entry["collection_sprite_png"] = f"../user_files/sprites/front_default/{evolved_id}.png"
+                        
+                        entry["has_evolved"] = (evolved_id != pokedex_id)
+                    else:
+                        # Pokémon not in collection - Status: Rejected
+                        entry["status"] = 2  # Rejected
+                        entry["in_collection"] = False
+                        entry["collection_level"] = level
+                        entry["collection_pokedex_id"] = pokedex_id
+                        entry["collection_shiny"] = shiny_template
+                        entry["collection_gender"] = gender
+                        entry["collection_name"] = name
+                        entry["collection_stats"] = stats
+                        entry["collection_types"] = types
+                        entry["collection_defeated"] = 0
+                        entry["collection_sprite_gif"] = sprite_gif
+                        entry["collection_sprite_png"] = sprite_png
+                        entry["has_evolved"] = False
+                else:
+                    # PAST challenges - determine Result
+                    # Check if this month's Pokémon is in the collection
+                    is_collected = month_pokemon_in_collection is not None
+                    
+                    # Check if next month's Pokémon exists
+                    next_challenge = all_challenges[idx + 1] if idx + 1 < len(all_challenges) else None
+                    next_individual_id = next_challenge.get("pokemon", {}).get("individual_id") if next_challenge else None
+                    next_pokemon_in_db = all_pokemon_in_collection.get(next_individual_id) if next_individual_id else None
+                    
+                    if is_collected and next_pokemon_in_db is None:
+                        # Month A's ID is present, Month B's ID is NOT present → Pending: Accepted
+                        entry["result"] = "pending_accepted"
+                        if logger:
+                            logger.log("debug", f"[Monthly] {month}: → Pending: Accepted")
+                    elif not is_collected and next_pokemon_in_db is None:
+                        # Month A's ID is NOT present, Month B's ID is NOT present → Pending: Rejected
+                        entry["result"] = "pending_rejected"
+                        if logger:
+                            logger.log("debug", f"[Monthly] {month}: → Pending: Rejected")
+                    elif not is_collected:
+                        # ID not in collection → Rejected
+                        entry["result"] = "rejected"
+                        if logger:
+                            logger.log("debug", f"[Monthly] {month}: NOT in collection → Rejected")
+                    else:
+                        # ID IS in collection → Check if next month's Pokémon is shiny
+                        next_is_shiny = False
+                        if next_pokemon_in_db:
+                            raw_shiny = next_pokemon_in_db.get("shiny", False)
+                            # Handle both boolean and integer storage
+                            if isinstance(raw_shiny, bool):
+                                next_is_shiny = raw_shiny
+                            elif isinstance(raw_shiny, int):
+                                next_is_shiny = raw_shiny == 1
+                            elif isinstance(raw_shiny, str):
+                                next_is_shiny = raw_shiny.lower() in ("true", "1")
+                            else:
+                                next_is_shiny = bool(raw_shiny)
+                        
+                        # CRITICAL: Log everything for debugging
+                        if logger:
+                            next_month_name = next_challenge.get("month", "None") if next_challenge else "None"
+                            logger.log("debug", f"[Monthly] ===== CHECKING {month} =====")
+                            logger.log("debug", f"[Monthly] current_month_in_db: {is_collected}")
+                            logger.log("debug", f"[Monthly] next_month: {next_month_name}")
+                            logger.log("debug", f"[Monthly] next_individual_id: {next_individual_id}")
+                            logger.log("debug", f"[Monthly] next_pokemon_in_db: {next_pokemon_in_db is not None}")
+                            if next_pokemon_in_db:
+                                logger.log("debug", f"[Monthly] next_pokemon shiny raw value: {next_pokemon_in_db.get('shiny', 'NOT FOUND')}")
+                                logger.log("debug", f"[Monthly] next_pokemon name: {next_pokemon_in_db.get('name', 'UNKNOWN')}")
+                            logger.log("debug", f"[Monthly] next_is_shiny: {next_is_shiny}")
+                        
+                        if next_pokemon_in_db and next_is_shiny:
+                            # Current month's ID is in collection AND next month's Mon is in collection AND shiny → Succeeded!
+                            entry["result"] = "success"
+                            if logger:
+                                logger.log("debug", f"[Monthly] {month}: → SUCCEEDED!")
+                        elif next_pokemon_in_db and not next_is_shiny:
+                            # Current month's ID is in collection AND next month's Mon is in collection BUT NOT shiny → Next time's a charm!
+                            entry["result"] = "next_time"
+                            if logger:
+                                logger.log("debug", f"[Monthly] {month}: → NEXT TIME'S A CHARM!")
+                        else:
+                            # Current month's ID is in collection but next month's Mon is not collected → Accepted
+                            entry["result"] = "accepted"
+                            if logger:
+                                logger.log("debug", f"[Monthly] {month}: → Accepted")
+                
+                challenges_list.append(entry)
+            
+            return {
+                "ok": True,
+                "current_month": current_month,
+                "current_individual_id": current_individual_id,
+                "current_status": current_status,
+                "show_sprites": show_sprites,
+                "challenges": challenges_list,
+            }
+            
+        except requests.exceptions.RequestException as e:
+            return {"ok": False, "message": f"Could not fetch monthly challenges: {e}"}
+        except Exception as e:
+            import traceback
+            logger = services.logger
+            if logger:
+                logger.log("error", f"get_monthly_challenge_data failed: {e}\n{traceback.format_exc()}")
+            return {"ok": False, "message": str(e)}
+
+    def _build_monthly_pokemon(self, challenge, pokemon_data):
+        make_shiny = False
+        previous_id = challenge.get("previous_challenge_individual_id")
+        threshold = challenge.get("defeat_threshold")
+        if previous_id and threshold:
+            previous = services.db.get_pokemon(previous_id)
+            if previous:
+                try:
+                    make_shiny = int(previous.get("pokemon_defeated", 0)) >= int(threshold)
+                except (TypeError, ValueError):
+                    pass
+        from ..pyobj.pokemon_trade import create_monthly_challenge_pokemon
+        return create_monthly_challenge_pokemon(pokemon_data, make_shiny=make_shiny)
+
+    def receive_monthly_challenge_mon(self):
+        try:
+            challenge, pokemon_data, individual_id, status = self._get_monthly_challenge_context()
+            db = services.db
+            if status == 1 and db.get_pokemon(individual_id) is not None:
+                return {"ok": True, "message": "Your Monthly Challenge Pokémon is already in your collection."}
+            if db.get_pokemon(individual_id) is None:
+                db.save_pokemon(self._build_monthly_pokemon(challenge, pokemon_data))
+            db.set_user_data("monthly_challenge", 1)
+            return {"ok": True}
+        except Exception as e:
+            return {"ok": False, "message": str(e)}
+
+    def remove_monthly_challenge_mon(self):
+        try:
+            _, _, individual_id, status = self._get_monthly_challenge_context()
+            if status != 1:
+                return {"ok": False, "message": "The Monthly Challenge Pokémon is not currently accepted."}
+            removed = services.db.delete_pokemon(individual_id)
+            services.db.set_user_data("monthly_challenge", 2)
+            return {"ok": True, "removed": removed}
+        except Exception as e:
+            return {"ok": False, "message": str(e)}
 
     def get_inventory_data(self):
         sm = self.shop_manager

--- a/src/Ankimon/ankimon_items_web/shop_obj.py
+++ b/src/Ankimon/ankimon_items_web/shop_obj.py
@@ -18,6 +18,7 @@ from datetime import datetime
 import requests
 from aqt import QDialog, QVBoxLayout, QWebEngineView, QWebEnginePage, mw
 from aqt.qt import Qt, QUrl, QFrame, QWebEngineProfile
+from aqt.operations import QueryOp
 from PyQt6.QtCore import QObject, pyqtSlot, QTimer, QByteArray, QVariant
 from PyQt6.QtGui import QColor
 from PyQt6.QtWebChannel import QWebChannel
@@ -520,7 +521,6 @@ class MobileBridge(QObject):
                     estimates_loading = False
                     battle_count = estimates["encounters"]
                 else:
-                    from aqt.operations import QueryOp
 
                     QueryOp(
                         parent=self._w, op=run_sim, success=on_sim_success
@@ -850,7 +850,6 @@ class MobileBridge(QObject):
                     return res["result"]
                 return res
             else:
-                from aqt.operations import QueryOp
 
                 def run_sim(col):
                     return resolve_next(
@@ -1103,6 +1102,11 @@ class AnkimonItemsWeb(QDialog):
             SCREEN_MONTHLY: self._push_monthly_live,
         }
         self._live_refresh_pending = False
+
+        # Monthly challenge cache - prevents blocking HTTP on GUI thread
+        self._monthly_challenge_cache = None
+        self._monthly_challenge_cache_time = None
+
         self.current_screen = None
         self.setWindowTitle("Ankimon")
 
@@ -1408,9 +1412,20 @@ class AnkimonItemsWeb(QDialog):
             js = f"if (window.initializeHistory) window.initializeHistory({json.dumps(data)});"
             self.webview_history.page().runJavaScript(js)
         elif self.current_screen == SCREEN_MONTHLY:
-            data = self.get_monthly_challenge_data()
-            js = f"if (window.initializeMonthlyChallenge) window.initializeMonthlyChallenge({json.dumps(data)});"
-            self.webview_monthly.page().runJavaScript(js)
+            def push_with_data(data):
+                result_data = self.get_monthly_challenge_data(data)
+                js = f"if (window.initializeMonthlyChallenge) window.initializeMonthlyChallenge({json.dumps(result_data)});"
+                self.webview_monthly.page().runJavaScript(js)
+            
+            if self._monthly_challenge_cache:
+                push_with_data(self._monthly_challenge_cache)
+            else:
+                # Push loading state immediately
+                loading_data = {"ok": False, "loading": True, "message": "Loading monthly challenge data..."}
+                js = f"if (window.initializeMonthlyChallenge) window.initializeMonthlyChallenge({json.dumps(loading_data)});"
+                self.webview_monthly.page().runJavaScript(js)
+                # Then fetch the real data in the background
+                self._fetch_monthly_challenge_async(push_with_data)
 
     def get_profile_payload(self):
         """Profile data + a one-shot UI action ('sprite' opens the picker,
@@ -1532,12 +1547,15 @@ class AnkimonItemsWeb(QDialog):
 
     def _push_monthly_live(self):
         """Push a live refresh to the Monthly Challenge screen."""
-        data = self.get_monthly_challenge_data()
-        js = (
-            "if (window.liveRefreshMonthly) "
-            f"window.liveRefreshMonthly({json.dumps(data)});"
-        )
-        self.webview_monthly.page().runJavaScript(js)
+        def push(data):
+            result_data = self.get_monthly_challenge_data(data)
+            js = f"if (window.liveRefreshMonthly) window.liveRefreshMonthly({json.dumps(result_data)});"
+            self.webview_monthly.page().runJavaScript(js)
+        
+        if self._monthly_challenge_cache:
+            push(self._monthly_challenge_cache)
+        else:
+            self._fetch_monthly_challenge_async(push)
 
     def _get_ankidex_data(self):
         # Reuse the existing Ankidex singleton's data getter — keeps the
@@ -1669,20 +1687,68 @@ class AnkimonItemsWeb(QDialog):
         results.sort(key=lambda r: r["name"].lower())
         return {"results": results}
 
-    def _get_monthly_challenge_context(self):
-        month = datetime.now().strftime("%B %Y")
-        url = "https://raw.githubusercontent.com/h0tp-ftw/ankimon/refs/heads/main/assets/challenges/monthly_challenges.json"
-        response = requests.get(url, timeout=2)
-        response.raise_for_status()
-        challenge = next((item for item in response.json() if item.get("month") == month), None)
-        if not challenge or not challenge.get("pokemon"):
-            raise ValueError(f"No monthly challenge found for {month}")
+    def _fetch_monthly_challenge_async(self, callback=None):
+        """Fetch monthly challenge data in background thread."""
+        # If cache is fresh (within 5 minutes), use it
+        if self._monthly_challenge_cache and self._monthly_challenge_cache_time:
+            if time.time() - self._monthly_challenge_cache_time < 300:
+                if callback:
+                    callback(self._monthly_challenge_cache)
+                return
+        
+        def run_fetch(col):
+            try:
+                url = "https://raw.githubusercontent.com/h0tp-ftw/ankimon/refs/heads/main/assets/challenges/monthly_challenges.json"
+                response = requests.get(url, timeout=5)
+                response.raise_for_status()
+                data = response.json()
+                # Ensure the data is wrapped in the expected format
+                if isinstance(data, list):
+                    return {"challenges": data}
+                return data
+            except Exception as e:
+                return {"error": str(e)}
+        
+        def on_success(data):
+            if data and (not isinstance(data, dict) or "error" not in data):
+                self._monthly_challenge_cache = data
+                self._monthly_challenge_cache_time = time.time()
+            if callback:
+                callback(data)
+        
+        QueryOp(parent=self, op=run_fetch, success=on_success).without_collection().run_in_background()
 
+    def _get_monthly_challenge_context(self):
+        """Get current monthly challenge context from cache."""
+        if self._monthly_challenge_cache is None:
+            return None, None, None, 0
+        
+        # Handle both dict and list formats
+        raw_data = self._monthly_challenge_cache
+        if isinstance(raw_data, list):
+            all_challenges = raw_data
+        else:
+            all_challenges = raw_data.get("challenges", [])
+        
+        month = datetime.now().strftime("%B %Y")
+        
+        # Parse and sort by month
+        def parse_month(month_str):
+            try:
+                return datetime.strptime(month_str, "%B %Y")
+            except ValueError:
+                return datetime.min
+        all_challenges.sort(key=lambda c: parse_month(c.get("month", "")))
+        
+        challenge = next((item for item in all_challenges if item.get("month") == month), None)
+        if not challenge or not challenge.get("pokemon"):
+            return None, None, None, 0
+        
         pokemon_data = challenge["pokemon"]
         individual_id = pokemon_data.get("individual_id")
         if not individual_id:
-            raise ValueError("Monthly challenge Pokémon is missing individual_id")
-
+            return None, None, None, 0
+        
         db = services.db
         last_id = db.get_user_data("monthly_challenge_id")
         if str(last_id) != str(individual_id):
@@ -1694,20 +1760,35 @@ class AnkimonItemsWeb(QDialog):
             status = 0
         return challenge, pokemon_data, individual_id, status
 
-    def get_monthly_challenge_data(self):
-        """Fetch monthly challenge data from the live JSON file and compute results."""
+    def get_monthly_challenge_data(self, raw_data=None):
+        """Fetch monthly challenge data from the live JSON file."""
         try:
-            from ..functions.sprite_functions import get_relative_sprite_path
-            from datetime import datetime
-            import requests
-            import json
+            # If raw_data not provided, use cache
+            if raw_data is None:
+                raw_data = self._monthly_challenge_cache
+                if raw_data is None:
+                    # Return loading state instead of error
+                    return {"ok": False, "loading": True, "message": "Loading monthly challenge data..."}
             
-            # Fetch the live monthly challenges JSON
-            url = "https://raw.githubusercontent.com/h0tp-ftw/ankimon/refs/heads/main/assets/challenges/monthly_challenges.json"
-            response = requests.get(url, timeout=5)
-            response.raise_for_status()
-            all_challenges = response.json()
+            if isinstance(raw_data, dict) and "error" in raw_data:
+                return {"ok": False, "message": raw_data["error"]}
             
+            # Handle both dict and list formats
+            if isinstance(raw_data, list):
+                all_challenges = raw_data
+            else:
+                all_challenges = raw_data.get("challenges", [])
+            
+            # Parse and sort challenges by month
+            def parse_month(month_str):
+                try:
+                    return datetime.strptime(month_str, "%B %Y")
+                except ValueError:
+                    return datetime.min
+            
+            # Sort by parsed month before processing
+            all_challenges.sort(key=lambda c: parse_month(c.get("month", "")))
+
             # Get current month
             current_month = datetime.now().strftime("%B %Y")
             
@@ -1967,6 +2048,30 @@ class AnkimonItemsWeb(QDialog):
                 logger.log("error", f"get_monthly_challenge_data failed: {e}\n{traceback.format_exc()}")
             return {"ok": False, "message": str(e)}
 
+    def _save_pokemon_in_transaction(self, conn, pokemon_data):
+        """Save a Pokémon using an existing transaction connection."""
+        conn.execute(
+            """INSERT OR REPLACE INTO pokemon 
+               (individual_id, id, name, level, gender, shiny, type, stats, 
+                pokemon_defeated, held_item, nickname, cp, ivs)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            (
+                pokemon_data.get('individual_id'),
+                pokemon_data.get('id'),
+                pokemon_data.get('name'),
+                pokemon_data.get('level'),
+                pokemon_data.get('gender'),
+                pokemon_data.get('shiny'),
+                json.dumps(pokemon_data.get('type', [])),
+                json.dumps(pokemon_data.get('stats', {})),
+                pokemon_data.get('pokemon_defeated', 0),
+                pokemon_data.get('held_item'),
+                pokemon_data.get('nickname'),
+                pokemon_data.get('cp'),
+                json.dumps(pokemon_data.get('ivs', {}))
+            )
+        )
+
     def _build_monthly_pokemon(self, challenge, pokemon_data):
         make_shiny = False
         previous_id = challenge.get("previous_challenge_individual_id")
@@ -1984,25 +2089,77 @@ class AnkimonItemsWeb(QDialog):
     def receive_monthly_challenge_mon(self):
         try:
             challenge, pokemon_data, individual_id, status = self._get_monthly_challenge_context()
+            if not challenge:
+                return {"ok": False, "message": "No monthly challenge available."}
+            
             db = services.db
-            if status == 1 and db.get_pokemon(individual_id) is not None:
-                return {"ok": True, "message": "Your Monthly Challenge Pokémon is already in your collection."}
-            if db.get_pokemon(individual_id) is None:
-                db.save_pokemon(self._build_monthly_pokemon(challenge, pokemon_data))
-            db.set_user_data("monthly_challenge", 1)
+            if status == 1:
+                # Check if already collected
+                existing = db.get_pokemon(individual_id)
+                if existing:
+                    return {"ok": True, "message": "Your Monthly Challenge Pokémon is already in your collection."}
+            
+            # Use a single transaction
+            with db._get_connection() as conn:
+                # Check if already collected within the transaction
+                cursor = conn.execute(
+                    "SELECT individual_id FROM pokemon WHERE individual_id = ?",
+                    (individual_id,)
+                )
+                if cursor.fetchone():
+                    return {"ok": True, "message": "Your Monthly Challenge Pokémon is already in your collection."}
+                
+                # Save Pokémon
+                pokemon = self._build_monthly_pokemon(challenge, pokemon_data)
+                self._save_pokemon_in_transaction(conn, pokemon)
+                
+                # Set status in same transaction
+                conn.execute(
+                    "INSERT OR REPLACE INTO user_data (key, value) VALUES (?, ?)",
+                    ("monthly_challenge", "1")
+                )
+                conn.execute(
+                    "INSERT OR REPLACE INTO user_data (key, value) VALUES (?, ?)",
+                    ("monthly_challenge_id", individual_id)
+                )
+            
             return {"ok": True}
         except Exception as e:
+            import traceback
+            logger = services.logger
+            if logger:
+                logger.log("error", f"receive_monthly_challenge_mon failed: {e}\n{traceback.format_exc()}")
             return {"ok": False, "message": str(e)}
 
     def remove_monthly_challenge_mon(self):
         try:
             _, _, individual_id, status = self._get_monthly_challenge_context()
+            if not individual_id:
+                return {"ok": False, "message": "No monthly challenge Pokémon found."}
+            
             if status != 1:
                 return {"ok": False, "message": "The Monthly Challenge Pokémon is not currently accepted."}
-            removed = services.db.delete_pokemon(individual_id)
-            services.db.set_user_data("monthly_challenge", 2)
+            
+            db = services.db
+            with db._get_connection() as conn:
+                cursor = conn.execute(
+                    "DELETE FROM pokemon WHERE individual_id = ?",
+                    (individual_id,)
+                )
+                removed = cursor.rowcount > 0
+                
+                # Update status in same transaction
+                conn.execute(
+                    "INSERT OR REPLACE INTO user_data (key, value) VALUES (?, ?)",
+                    ("monthly_challenge", "2")
+                )
+            
             return {"ok": True, "removed": removed}
         except Exception as e:
+            import traceback
+            logger = services.logger
+            if logger:
+                logger.log("error", f"remove_monthly_challenge_mon failed: {e}\n{traceback.format_exc()}")
             return {"ok": False, "message": str(e)}
 
     def get_inventory_data(self):

--- a/src/Ankimon/ankimon_items_web/shop_obj.py
+++ b/src/Ankimon/ankimon_items_web/shop_obj.py
@@ -1803,6 +1803,8 @@ class AnkimonItemsWeb(QDialog):
     def get_monthly_challenge_data(self, raw_data=None):
         """Fetch monthly challenge data from the live JSON file."""
         try:
+            db = services.db
+            
             # If raw_data not provided, use cache
             if raw_data is None:
                 raw_data = self._monthly_challenge_cache

--- a/src/Ankimon/ankimon_items_web/shop_obj.py
+++ b/src/Ankimon/ankimon_items_web/shop_obj.py
@@ -1071,6 +1071,13 @@ class MonthlyBridge(QObject):
         self._w.push_screen_data()
         return result
 
+    @pyqtSlot(result="QVariant")
+    def rejectMon(self):
+        """Reject the current monthly challenge without claiming the Pokémon."""
+        result = self._w.reject_monthly_challenge_mon()
+        self._w.push_screen_data()
+        return result
+
 class AnkimonItemsWeb(QDialog):
     def __init__(
         self,
@@ -2073,27 +2080,20 @@ class AnkimonItemsWeb(QDialog):
 
     def _save_pokemon_in_transaction(self, conn, pokemon_data):
         """Save a Pokémon using an existing transaction connection."""
-        # Normalize name: lowercase and strip hyphens
-        name = pokemon_data.get('name', '').lower().replace('-', '')
+        # Get the individual_id from the data
+        individual_id = pokemon_data.get('individual_id')
+        if not individual_id:
+            raise ValueError("Missing individual_id in pokemon_data")
+        
+        # Serialize the entire pokemon_data as JSON in the 'data' column
+        # This matches the DatabaseManager.save_pokemon pattern
         conn.execute(
-            """INSERT OR REPLACE INTO captured_pokemon 
-               (individual_id, id, name, level, gender, shiny, type, stats, 
-                pokemon_defeated, held_item, nickname, cp, ivs)
-               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            """INSERT OR REPLACE INTO captured_pokemon (individual_id, data, is_main)
+               VALUES (?, ?, ?)""",
             (
-                pokemon_data.get('individual_id'),
-                pokemon_data.get('id'),
-                name,
-                pokemon_data.get('level'),
-                pokemon_data.get('gender'),
-                pokemon_data.get('shiny'),
-                json.dumps(pokemon_data.get('type', [])),
-                json.dumps(pokemon_data.get('stats', {})),
-                pokemon_data.get('pokemon_defeated', 0),
-                pokemon_data.get('held_item'),
-                pokemon_data.get('nickname'),
-                pokemon_data.get('cp'),
-                json.dumps(pokemon_data.get('iv', {}))
+                individual_id,
+                json.dumps(pokemon_data),
+                0  # is_main = 0 for monthly challenge Pokémon
             )
         )
 
@@ -2200,6 +2200,27 @@ class AnkimonItemsWeb(QDialog):
             logger = services.logger
             if logger:
                 logger.log("error", f"remove_monthly_challenge_mon failed: {e}\n{traceback.format_exc()}")
+            return {"ok": False, "message": str(e)}
+
+    def reject_monthly_challenge_mon(self):
+        """Reject the current monthly challenge without claiming the Pokémon."""
+        try:
+            challenge, pokemon_data, individual_id, status = self._get_monthly_challenge_context()
+            if not challenge:
+                return {"ok": False, "message": "No monthly challenge available."}
+            
+            if status != 0:
+                return {"ok": False, "message": "Can only reject a challenge that hasn't been claimed yet."}
+            
+            db = services.db
+            db.set_user_data("monthly_challenge", 2)
+            
+            return {"ok": True, "message": "Challenge rejected."}
+        except Exception as e:
+            import traceback
+            logger = services.logger
+            if logger:
+                logger.log("error", f"reject_monthly_challenge_mon failed: {e}\n{traceback.format_exc()}")
             return {"ok": False, "message": str(e)}
 
     def get_inventory_data(self):

--- a/src/Ankimon/ankimon_mobile_web/history.html
+++ b/src/Ankimon/ankimon_mobile_web/history.html
@@ -57,6 +57,13 @@
                 <span class="nav-menu-desc">Configure Ankimon</span>
               </div>
             </button>
+            <button class="nav-menu-item" role="menuitem" data-screen="monthly">
+              <span class="nav-menu-icon"><img src="../user_files/sprites/items/lucky-punch.png" class="icon-item-sprite" alt=""></span>
+              <div class="nav-menu-text">
+                <span class="nav-menu-title">Monthly Challenge</span>
+                <span class="nav-menu-desc">Claim your monthly Pokémon</span>
+              </div>
+            </button>
             <button class="nav-menu-item active" role="menuitem" data-screen="mobile">
               <span class="nav-menu-icon"><img src="../user_files/sprites/items/elixir.png" class="icon-item-sprite" alt=""></span>
               <div class="nav-menu-text">

--- a/src/Ankimon/ankimon_mobile_web/history.html
+++ b/src/Ankimon/ankimon_mobile_web/history.html
@@ -57,7 +57,7 @@
                 <span class="nav-menu-desc">Configure Ankimon</span>
               </div>
             </button>
-            <button class="nav-menu-item" role="menuitem" data-screen="monthly">
+            <button type="button" class="nav-menu-item" role="menuitem" data-screen="monthly">
               <span class="nav-menu-icon"><img src="../user_files/sprites/items/lucky-punch.png" class="icon-item-sprite" alt=""></span>
               <div class="nav-menu-text">
                 <span class="nav-menu-title">Monthly Challenge</span>

--- a/src/Ankimon/ankimon_mobile_web/mobile.html
+++ b/src/Ankimon/ankimon_mobile_web/mobile.html
@@ -57,6 +57,13 @@
                 <span class="nav-menu-desc">Configure Ankimon</span>
               </div>
             </button>
+            <button class="nav-menu-item" role="menuitem" data-screen="monthly">
+              <span class="nav-menu-icon"><img src="../user_files/sprites/items/lucky-punch.png" class="icon-item-sprite" alt=""></span>
+              <div class="nav-menu-text">
+                <span class="nav-menu-title">Monthly Challenge</span>
+                <span class="nav-menu-desc">Claim your monthly Pokémon</span>
+              </div>
+            </button>
             <button class="nav-menu-item active" role="menuitem" data-screen="mobile">
               <span class="nav-menu-icon"><img src="../user_files/sprites/items/elixir.png" class="icon-item-sprite" alt=""></span>
               <div class="nav-menu-text">

--- a/src/Ankimon/ankimon_mobile_web/mobile.html
+++ b/src/Ankimon/ankimon_mobile_web/mobile.html
@@ -57,7 +57,7 @@
                 <span class="nav-menu-desc">Configure Ankimon</span>
               </div>
             </button>
-            <button class="nav-menu-item" role="menuitem" data-screen="monthly">
+            <button type="button" class="nav-menu-item" role="menuitem" data-screen="monthly">
               <span class="nav-menu-icon"><img src="../user_files/sprites/items/lucky-punch.png" class="icon-item-sprite" alt=""></span>
               <div class="nav-menu-text">
                 <span class="nav-menu-title">Monthly Challenge</span>

--- a/src/Ankimon/ankimon_monthly_challenge_web/monthly.css
+++ b/src/Ankimon/ankimon_monthly_challenge_web/monthly.css
@@ -1,0 +1,1051 @@
+/* Monthly Challenge screen — styled to match Settings/Shop UI theme */
+
+:root {
+    /* Color Palette (matching shop.css) */
+    --bg-darker: #080a0c;
+    --bg-dark: #0d1117;
+    --bg-card: #161b22;
+    --bg-card-hover: #21262d;
+    --border-main: #30363d;
+    --text-main: #c9d1d9;
+    --text-muted: #8b949e;
+    --text-bright: #ffffff;
+    --accent-blue: #58a6ff;
+    --accent-red: #f85149;
+    --accent-gold: #d29922;
+    --accent-green: #3fb950;
+    --accent-blue-deep: #2474a8;
+    --accent-purple: #a855f7;
+    --accent-dark-orange: #c2410c;
+    
+    /* Sizing */
+    --sidebar-width: 260px;
+    --header-height: 70px;
+    --transition-fast: 0.15s ease;
+    --transition-mid: 0.25s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+* {
+    box-sizing: border-box;
+    margin: 0;
+    padding: 0;
+    -webkit-user-select: none;
+    user-select: none;
+}
+
+body {
+    font-family: 'Outfit', sans-serif;
+    background: transparent;
+    color: var(--text-main);
+    height: 100vh;
+    overflow: hidden;
+}
+
+.app-container {
+    display: flex;
+    width: 100vw;
+    height: 100vh;
+    background: var(--bg-dark);
+    border-radius: 0;
+    overflow: hidden;
+    box-shadow: 0 20px 50px rgba(0,0,0,0.5);
+}
+
+/* Sidebar - matching Shop/Settings */
+.sidebar {
+    width: var(--sidebar-width);
+    background: var(--bg-darker);
+    border-right: 1px solid var(--border-main);
+    display: flex;
+    flex-direction: column;
+    flex-shrink: 0;
+    min-width: var(--sidebar-width);
+    max-width: var(--sidebar-width);
+    height: 100vh;
+    overflow: hidden;
+}
+
+.sidebar-header {
+    padding: 24px 24px 16px;
+    flex-shrink: 0;
+}
+
+.sidebar-header h1 {
+    font-size: 1.2rem;
+    font-weight: 800;
+    letter-spacing: -0.5px;
+    background: linear-gradient(to bottom, #fff, #ccc);
+    -webkit-background-clip: text;
+    background-clip: text;
+    -webkit-text-fill-color: transparent;
+    margin: 0;
+}
+
+/* Nav switcher inside sidebar header */
+#nav-switcher {
+    width: 100%;
+}
+
+.nav-trigger {
+    width: 100%;
+    background: transparent;
+    border: 1px solid transparent;
+    color: inherit;
+    padding: 6px 10px;
+    border-radius: 10px;
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    cursor: pointer;
+    transition: 0.15s ease;
+    text-align: left;
+    font-family: inherit;
+}
+
+.nav-trigger h1 {
+    flex: 1;
+    margin: 0;
+    font-size: 1.2rem;
+    font-weight: 800;
+    letter-spacing: -0.5px;
+    background: linear-gradient(to bottom, #fff, #ccc);
+    -webkit-background-clip: text;
+    background-clip: text;
+    -webkit-text-fill-color: transparent;
+}
+
+.nav-trigger .app-logo {
+    flex-shrink: 0;
+    width: 32px;
+    height: 32px;
+    filter: drop-shadow(0 0 10px rgba(255, 255, 255, 0.2));
+}
+
+.nav-chevron {
+    font-size: 0.9rem;
+    color: var(--text-muted);
+    transition: transform 0.2s ease;
+    margin-right: 2px;
+}
+
+.nav-trigger[aria-expanded="true"] .nav-chevron {
+    transform: rotate(180deg);
+    color: var(--accent-blue);
+}
+
+.nav-menu {
+    position: absolute;
+    top: calc(100% + 8px);
+    left: 0;
+    right: 0;
+    z-index: 200;
+    background: linear-gradient(180deg, var(--bg-card), var(--bg-darker));
+    border: 1px solid var(--border-main);
+    border-radius: 12px;
+    padding: 6px;
+    box-shadow: 0 14px 32px rgba(0, 0, 0, 0.55);
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    animation: navMenuPop 0.16s cubic-bezier(0.22, 1, 0.36, 1);
+    transform-origin: top left;
+}
+
+.nav-menu.hidden {
+    display: none;
+}
+
+@keyframes navMenuPop {
+    0%   { opacity: 0; transform: translateY(-6px) scale(0.97); }
+    100% { opacity: 1; transform: translateY(0)    scale(1); }
+}
+
+.nav-menu-item {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    width: 100%;
+    background: transparent;
+    border: 1px solid transparent;
+    color: var(--text-main);
+    padding: 8px 12px;
+    border-radius: 8px;
+    cursor: pointer;
+    font-family: inherit;
+    text-align: left;
+    transition: 0.15s ease;
+    font-size: 0.85rem;
+}
+
+.nav-menu-item:hover {
+    background: var(--bg-card-hover);
+    border-color: var(--border-main);
+    color: var(--text-bright);
+}
+
+.nav-menu-item.active {
+    background: rgba(88, 166, 255, 0.08);
+    border-color: rgba(88, 166, 255, 0.4);
+    color: var(--text-bright);
+}
+
+.nav-menu-icon {
+    width: 28px;
+    height: 28px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--accent-blue);
+    flex-shrink: 0;
+}
+
+.nav-menu-icon img {
+    width: 24px;
+    height: 24px;
+    object-fit: contain;
+}
+
+.nav-menu-text {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    gap: 1px;
+    min-width: 0;
+}
+
+.nav-menu-title {
+    font-size: 0.82rem;
+    font-weight: 700;
+    line-height: 1.15;
+    word-wrap: break-word;
+    white-space: normal;
+}
+
+.nav-menu-desc {
+    font-size: 0.65rem;
+    color: var(--text-muted);
+    letter-spacing: 0.3px;
+    line-height: 1.2;
+}
+
+/* Current Month Box - Large Blue Box with Badges at Bottom */
+.current-mon-box {
+    margin: 12px 16px 8px;
+    padding: 0;
+    background: linear-gradient(150deg, #bde7fb, #83c6e8);
+    border-radius: 12px;
+    min-height: 120px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    overflow: hidden;
+    flex-shrink: 0;
+    position: relative;
+}
+
+.current-mon-sprite-container {
+    width: 100%;
+    height: 120px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    position: relative;
+}
+
+.current-mon-sprite-container img {
+    width: 80%;
+    height: 80%;
+    object-fit: contain;
+    image-rendering: auto;
+    filter: drop-shadow(0 4px 12px rgba(18, 48, 71, .2));
+}
+
+/* Badges container - fixed at bottom of the sprite box */
+.current-mon-badges {
+    position: absolute;
+    bottom: 6px;
+    left: 50%;
+    transform: translateX(-50%);
+    display: flex;
+    gap: 5px;
+    align-items: center;
+    justify-content: center;
+    width: auto;
+    max-width: 92%;
+    z-index: 2;
+    pointer-events: none;
+}
+
+/* Individual badge styles */
+.badge {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 0.55rem;
+    font-weight: 700;
+    padding: 1px 7px;
+    border-radius: 5px;
+    backdrop-filter: blur(4px);
+    border: 1px solid rgba(255, 255, 255, 0.25);
+    text-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
+    white-space: nowrap;
+    flex-shrink: 0;
+}
+
+.type-badge {
+    color: #ffffff;
+    background-color: #888888;
+    text-transform: uppercase;
+    letter-spacing: 0.3px;
+}
+
+.level-badge {
+    color: #0d1117;
+    background: rgba(255, 255, 255, 0.85);
+}
+
+.defeated-badge {
+    color: #0d1117;
+    background: rgba(255, 255, 255, 0.85);
+}
+
+/* Hide sprites when setting is disabled - badges remain visible and centered */
+.current-mon-sprite-container.sprites-hidden img {
+    display: none !important;
+}
+
+.current-mon-sprite-container.sprites-hidden .current-mon-badges {
+    position: absolute;
+    bottom: 50%;
+    transform: translate(-50%, 50%);
+    left: 50%;
+    right: auto;
+}
+
+/* Stats Summary Box */
+.stats-summary {
+    margin: 4px 16px 8px;
+    padding: 10px 12px;
+    background: var(--bg-card);
+    border: 1px solid var(--border-main);
+    border-radius: 10px;
+    flex-shrink: 0;
+}
+
+.stats-summary-header {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 0.55rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    color: var(--text-muted);
+    letter-spacing: 1.5px;
+    margin-bottom: 6px;
+    opacity: 0.7;
+}
+
+#stats-summary-content {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+}
+
+.stats-summary-loading {
+    font-size: 0.7rem;
+    color: var(--text-muted);
+    text-align: center;
+    padding: 8px 0;
+    font-style: italic;
+}
+
+.stats-summary-empty {
+    font-size: 0.7rem;
+    color: var(--text-muted);
+    text-align: center;
+    padding: 8px 0;
+    font-style: italic;
+}
+
+.stats-row {
+    display: grid;
+    grid-template-columns: 28px 1fr 24px;
+    gap: 6px;
+    align-items: center;
+    height: 16px;
+}
+
+.stats-label {
+    font-size: 0.55rem;
+    font-weight: 700;
+    color: var(--text-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.3px;
+}
+
+.stats-bar-bg {
+    height: 4px;
+    background: var(--bg-darker);
+    border-radius: 2px;
+    overflow: hidden;
+}
+
+.stats-bar-fill {
+    height: 100%;
+    background: linear-gradient(90deg, var(--accent-blue), var(--accent-blue-deep));
+    border-radius: 2px;
+    transition: width 0.4s ease;
+}
+
+.stats-value {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 0.55rem;
+    font-weight: 700;
+    color: var(--text-bright);
+    text-align: right;
+}
+
+/* Sidebar Footer - Tip */
+.sidebar-footer {
+    padding: 12px 16px 16px;
+    border-top: 1px solid var(--border-main);
+    flex-shrink: 0;
+    margin-top: auto;
+}
+
+.footer-tip {
+    display: flex;
+    align-items: flex-start;
+    gap: 10px;
+    padding: 10px 12px;
+    background: rgba(22, 27, 34, 0.6);
+    border: 1px solid var(--border-main);
+    border-radius: 10px;
+    font-size: 0.7rem;
+    color: var(--text-muted);
+    line-height: 1.4;
+}
+
+.footer-tip-icon {
+    font-size: 0.9rem;
+    flex-shrink: 0;
+    margin-top: 1px;
+}
+
+.footer-tip-text {
+    flex: 1;
+}
+
+.sidebar-nav {
+    flex: 1;
+    overflow-y: auto;
+    padding: 8px 16px 16px;
+}
+
+.nav-group {
+    margin-bottom: 20px;
+}
+
+.nav-group label {
+    display: block;
+    font-size: 0.65rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    color: var(--text-muted);
+    letter-spacing: 1px;
+    margin-bottom: 8px;
+    margin-left: 8px;
+}
+
+.nav-item {
+    width: 100%;
+    text-align: left;
+    background: transparent;
+    border: none;
+    color: var(--text-main);
+    padding: 8px 12px;
+    border-radius: 8px;
+    font-size: 0.85rem;
+    font-weight: 500;
+    cursor: pointer;
+    transition: var(--transition-fast);
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    margin-bottom: 2px;
+    font-family: 'Outfit', sans-serif;
+}
+
+.nav-item:hover {
+    background: var(--bg-card);
+    color: var(--text-bright);
+}
+
+.nav-item.active {
+    background: var(--bg-card-hover);
+    color: var(--accent-blue);
+    font-weight: 600;
+}
+
+.nav-item:disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
+}
+
+.nav-icon {
+    display: inline-flex;
+    width: 14px;
+    justify-content: center;
+    font-size: 0.7rem;
+    color: var(--accent-blue);
+    flex-shrink: 0;
+}
+
+/* Main Content */
+.main-content {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    min-width: 0;
+    overflow: hidden;
+}
+
+.top-bar {
+    height: var(--header-height);
+    padding: 0 24px;
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    border-bottom: 1px solid var(--border-main);
+    flex-shrink: 0;
+}
+
+.content-scroll {
+    flex: 1;
+    overflow-y: auto;
+    padding: 16px 24px 32px;
+}
+
+/* Monthly Challenge List */
+.monthly-list {
+    display: flex;
+    flex-direction: column;
+    gap: 0;
+    background: var(--bg-card);
+    border: 1px solid var(--border-main);
+    border-radius: 16px;
+    overflow: hidden;
+}
+
+.monthly-entry {
+    display: grid;
+    grid-template-columns: 100px 1fr;
+    gap: 20px;
+    padding: 20px 24px;
+    background: var(--bg-card);
+    transition: background 0.15s ease;
+    min-height: 120px;
+}
+
+.monthly-entry:hover {
+    background: var(--bg-card-hover);
+}
+
+.monthly-entry.is-current {
+    border-left: 3px solid var(--accent-gold);
+    background: rgba(210, 153, 34, 0.03);
+}
+
+.monthly-entry.is-current:hover {
+    background: rgba(210, 153, 34, 0.06);
+}
+
+.monthly-entry-sprite {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: linear-gradient(150deg, #bde7fb, #83c6e8);
+    border-radius: 12px;
+    padding: 12px;
+    min-height: 80px;
+    aspect-ratio: 1;
+}
+
+.monthly-entry-sprite img {
+    width: 80%;
+    height: 80%;
+    object-fit: contain;
+    image-rendering: auto;
+    filter: drop-shadow(0 4px 8px rgba(18, 48, 71, .2));
+}
+
+.monthly-entry-sprite.sprites-hidden img {
+    display: none !important;
+}
+
+.monthly-entry-sprite.sprites-hidden {
+    background: linear-gradient(150deg, #bde7fb, #83c6e8);
+    min-height: 80px;
+}
+
+.monthly-entry-info {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    gap: 4px;
+    min-width: 0;
+}
+
+.monthly-entry-month {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 0.7rem;
+    font-weight: 700;
+    color: var(--accent-blue);
+    letter-spacing: 0.5px;
+    text-transform: uppercase;
+}
+
+.monthly-entry-month.current {
+    color: var(--accent-gold);
+}
+
+.monthly-entry-name {
+    font-size: 1.1rem;
+    font-weight: 800;
+    color: var(--text-bright);
+    text-transform: capitalize;
+}
+
+.monthly-entry-desc {
+    font-size: 0.85rem;
+    color: var(--text-muted);
+    line-height: 1.4;
+}
+
+.monthly-entry-result {
+    display: flex;
+    align-items: center;
+    gap: 16px;
+    margin-top: 4px;
+    flex-wrap: wrap;
+}
+
+.monthly-entry-status {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 0.75rem;
+    font-weight: 700;
+    padding: 2px 10px;
+    border-radius: 4px;
+}
+
+.monthly-entry-status.accepted {
+    color: var(--accent-green);
+    background: rgba(63, 185, 80, 0.12);
+    border: 1px solid rgba(63, 185, 80, 0.3);
+}
+
+.monthly-entry-status.rejected {
+    color: var(--accent-red);
+    background: rgba(248, 81, 73, 0.12);
+    border: 1px solid rgba(248, 81, 73, 0.3);
+}
+
+.monthly-entry-status.unknown {
+    color: var(--accent-gold);
+    background: rgba(210, 153, 34, 0.12);
+    border: 1px solid rgba(210, 153, 34, 0.3);
+}
+
+.monthly-entry-result-label {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 0.75rem;
+    font-weight: 700;
+    padding: 2px 10px;
+    border-radius: 4px;
+}
+
+/* Result: Succeeded! - Gold/Yellow */
+.monthly-entry-result-label.success {
+    color: var(--accent-gold);
+    background: rgba(210, 153, 34, 0.15);
+    border: 1px solid rgba(210, 153, 34, 0.4);
+}
+
+/* Result: Next time's a charm! - Purple */
+.monthly-entry-result-label.next-time {
+    color: var(--accent-purple);
+    background: rgba(168, 85, 247, 0.12);
+    border: 1px solid rgba(168, 85, 247, 0.3);
+}
+
+/* Pending: Accepted / Pending: Rejected - Grey */
+.monthly-entry-result-label.pending {
+    color: var(--text-muted);
+    background: rgba(139, 148, 158, 0.08);
+    border: 1px solid rgba(139, 148, 158, 0.25);
+}
+
+/* Result: Accepted - Blue */
+.monthly-entry-result-label.accepted {
+    color: var(--accent-blue);
+    background: rgba(88, 166, 255, 0.12);
+    border: 1px solid rgba(88, 166, 255, 0.3);
+}
+
+/* Result: Not Joined - Dark Orange */
+.monthly-entry-result-label.rejected {
+    color: var(--accent-dark-orange);
+    background: rgba(194, 65, 12, 0.12);
+    border: 1px solid rgba(194, 65, 12, 0.3);
+}
+
+.monthly-entry-result-label.unknown {
+    color: var(--text-muted);
+    background: rgba(139, 148, 158, 0.12);
+    border: 1px solid rgba(139, 148, 158, 0.3);
+}
+
+.monthly-entry-actions {
+    display: flex;
+    gap: 8px;
+}
+
+.monthly-entry-actions .button {
+    padding: 4px 14px;
+    font-size: 0.75rem;
+    min-width: 60px;
+}
+
+.monthly-divider {
+    border-bottom: 1px solid var(--border-main);
+    margin: 0 24px;
+}
+
+/* Buttons */
+.button {
+    border: 1px solid transparent;
+    border-radius: 8px;
+    padding: 10px 18px;
+    font: 700 13px 'Outfit', sans-serif;
+    cursor: pointer;
+    transition: var(--transition-fast);
+    min-width: 100px;
+}
+
+.button:hover:not(:disabled) {
+    transform: translateY(-1px);
+    filter: brightness(1.08);
+}
+
+.button:disabled {
+    cursor: not-allowed;
+    opacity: 0.35;
+}
+
+.button-primary {
+    background: var(--accent-blue-deep);
+    color: white;
+}
+
+.button-primary:hover:not(:disabled) {
+    background: #2a8ac0;
+}
+
+.button-danger {
+    background: var(--accent-red);
+    color: white;
+}
+
+.button-danger:hover:not(:disabled) {
+    background: #d63a33;
+}
+
+.button-quiet {
+    background: var(--bg-card);
+    color: var(--text-main);
+    border-color: var(--border-main);
+}
+
+.button-quiet:hover:not(:disabled) {
+    background: var(--bg-card-hover);
+}
+
+/* Loading state for modal buttons */
+.button.loading {
+    opacity: 0.7;
+    cursor: wait;
+    position: relative;
+    padding-right: 36px;
+}
+
+.button.loading::after {
+    content: '';
+    position: absolute;
+    top: 50%;
+    right: 10px;
+    width: 16px;
+    height: 16px;
+    margin-top: -8px;
+    border: 2px solid rgba(255, 255, 255, 0.3);
+    border-top-color: #ffffff;
+    border-radius: 50%;
+    animation: button-spin 0.8s linear infinite;
+}
+
+@keyframes button-spin {
+    to { transform: rotate(360deg); }
+}
+
+.button-primary.loading::after {
+    border-color: rgba(255, 255, 255, 0.3);
+    border-top-color: #ffffff;
+}
+
+.button-danger.loading::after {
+    border-color: rgba(255, 255, 255, 0.3);
+    border-top-color: #ffffff;
+}
+
+/* Modal */
+.modal {
+    position: fixed;
+    inset: 0;
+    z-index: 1500;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    animation: fadeIn 0.18s ease-out;
+}
+
+.modal.hidden {
+    display: none;
+}
+
+.modal-backdrop {
+    position: absolute;
+    inset: 0;
+    background: rgba(8, 10, 12, 0.7);
+}
+
+.modal-card {
+    position: relative;
+    background: linear-gradient(160deg, var(--bg-card), var(--bg-darker));
+    border: 1px solid var(--border-main);
+    border-radius: 16px;
+    padding: 24px 28px 20px;
+    width: 380px;
+    max-width: calc(100vw - 40px);
+    box-shadow: 0 24px 60px rgba(0, 0, 0, 0.6);
+    animation: modalPop 0.22s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+@keyframes modalPop {
+    0% { transform: scale(0.92); opacity: 0; }
+    100% { transform: scale(1); opacity: 1; }
+}
+
+.modal-mark {
+    font: 700 28px 'JetBrains Mono', monospace;
+    color: var(--accent-blue);
+    text-align: center;
+    margin-bottom: 6px;
+}
+
+.modal-card h2 {
+    font-size: 1.05rem;
+    font-weight: 800;
+    color: var(--text-bright);
+    margin: 0 0 6px;
+    text-align: center;
+    letter-spacing: -0.3px;
+}
+
+.modal-card p {
+    color: var(--text-muted);
+    line-height: 1.5;
+    text-align: center;
+    font-size: 0.88rem;
+}
+
+.modal-card p strong {
+    color: var(--accent-red);
+}
+
+.modal-actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 10px;
+    margin-top: 20px;
+}
+
+/* Toast */
+.toast {
+    position: fixed;
+    bottom: 28px;
+    left: 50%;
+    transform: translateX(-50%) translateY(20px);
+    background: linear-gradient(135deg, var(--bg-card), var(--bg-card-hover));
+    color: var(--text-bright);
+    border: 1px solid var(--accent-green);
+    border-radius: 10px;
+    padding: 10px 20px;
+    font-size: 0.85rem;
+    font-weight: 600;
+    box-shadow: 0 10px 30px rgba(0, 0, 0, 0.5);
+    opacity: 0;
+    transition: opacity 0.25s ease, transform 0.25s ease;
+    pointer-events: none;
+    z-index: 2000;
+    letter-spacing: 0.3px;
+}
+
+.toast.visible {
+    opacity: 1;
+    transform: translateX(-50%) translateY(0);
+}
+
+.toast.error {
+    border-color: var(--accent-red);
+    box-shadow: 0 10px 30px rgba(248, 81, 73, 0.25);
+}
+
+/* Error and Empty States */
+.monthly-error {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    padding: 60px 40px;
+    background: var(--bg-card);
+    border: 1px solid var(--border-main);
+    border-radius: 16px;
+    min-height: 300px;
+    text-align: center;
+}
+
+.monthly-error-icon {
+    font-size: 48px;
+    margin-bottom: 16px;
+    opacity: 0.6;
+}
+
+.monthly-error-text {
+    font-size: 1rem;
+    color: var(--text-muted);
+    max-width: 400px;
+    line-height: 1.5;
+}
+
+.monthly-empty {
+    padding: 40px 20px;
+    text-align: center;
+    color: var(--text-muted);
+    font-size: 0.95rem;
+}
+
+/* Scrollbar */
+::-webkit-scrollbar {
+    width: 6px;
+}
+
+::-webkit-scrollbar-track {
+    background: transparent;
+}
+
+::-webkit-scrollbar-thumb {
+    background: var(--border-main);
+    border-radius: 8px;
+}
+
+::-webkit-scrollbar-thumb:hover {
+    background: var(--text-muted);
+}
+
+/* Animations */
+@keyframes fadeIn {
+    from { opacity: 0; }
+    to { opacity: 1; }
+}
+
+/* Responsive */
+@media (max-width: 650px) {
+    .monthly-entry {
+        grid-template-columns: 70px 1fr;
+        gap: 12px;
+        padding: 14px 16px;
+        min-height: 90px;
+    }
+    .monthly-entry-sprite {
+        min-height: 60px;
+    }
+    .monthly-entry-name {
+        font-size: 0.95rem;
+    }
+    .monthly-entry-desc {
+        font-size: 0.75rem;
+    }
+    .monthly-entry-result {
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 8px;
+    }
+    .monthly-divider {
+        margin: 0 16px;
+    }
+    .sidebar {
+        width: 200px;
+        min-width: 200px;
+        max-width: 200px;
+    }
+    .current-mon-box {
+        min-height: 90px;
+        margin: 8px 12px 4px;
+    }
+    .current-mon-sprite-container {
+        height: 90px;
+    }
+    .badge {
+        font-size: 0.5rem;
+        padding: 1px 5px;
+    }
+    .modal-card {
+        padding: 20px 20px 16px;
+        width: 320px;
+    }
+}
+
+@media (max-width: 480px) {
+    .sidebar {
+        width: 56px;
+        min-width: 56px;
+        max-width: 56px;
+    }
+    .sidebar-header h1,
+    .nav-trigger h1,
+    .nav-trigger .app-logo,
+    .nav-chevron,
+    .sidebar-nav .nav-group label,
+    .sidebar-nav .nav-item span:not(.nav-icon),
+    .stats-summary {
+        display: none;
+    }
+    .sidebar-nav .nav-item {
+        justify-content: center;
+        padding: 8px;
+    }
+    .current-mon-box {
+        min-height: 60px;
+        margin: 6px 6px 2px;
+        border-radius: 8px;
+    }
+    .current-mon-sprite-container {
+        height: 60px;
+    }
+    .current-mon-sprite-container img {
+        width: 70%;
+        height: 70%;
+    }
+    .badge {
+        font-size: 0.4rem;
+        padding: 0 3px;
+    }
+    .sidebar-footer {
+        display: none;
+    }
+}

--- a/src/Ankimon/ankimon_monthly_challenge_web/monthly.css
+++ b/src/Ankimon/ankimon_monthly_challenge_web/monthly.css
@@ -1018,7 +1018,8 @@ body {
     }
     .sidebar-header h1,
     .nav-trigger h1,
-    .nav-trigger .app-logo,
+    .sidebar-header h1,
+    .nav-trigger h1,
     .nav-chevron,
     .sidebar-nav .nav-group label,
     .sidebar-nav .nav-item span:not(.nav-icon),

--- a/src/Ankimon/ankimon_monthly_challenge_web/monthly.html
+++ b/src/Ankimon/ankimon_monthly_challenge_web/monthly.html
@@ -82,13 +82,6 @@
                                 <span class="nav-menu-desc">Claim your monthly Pokémon</span>
                             </div>
                         </button>
-                        <button class="nav-menu-item" role="menuitem" data-screen="update">
-                            <span class="nav-menu-icon"><img src="../user_files/sprites/items/x-speed.png?v=20260901" class="icon-item-sprite" alt=""></span>
-                            <div class="nav-menu-text">
-                                <span class="nav-menu-title">Updates</span>
-                                <span class="nav-menu-desc">Update Ankimon &amp; sprites</span>
-                            </div>
-                        </button>
                         <button class="nav-menu-item" role="menuitem" data-screen="mobile">
                             <span class="nav-menu-icon"><img src="../user_files/sprites/items/elixir.png?v=20260901" class="icon-item-sprite" alt=""></span>
                             <div class="nav-menu-text">

--- a/src/Ankimon/ankimon_monthly_challenge_web/monthly.html
+++ b/src/Ankimon/ankimon_monthly_challenge_web/monthly.html
@@ -1,0 +1,180 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Ankimon — Monthly Challenge</title>
+    <!-- Inline dark bg so the first paint is dark -->
+    <style>
+        html { background: #0d1117; }
+        .skeleton {
+            background: #161b22;
+            border: 1px solid #30363d;
+            border-radius: 14px;
+            opacity: 0.5;
+            animation: skeleton-pulse 1.5s ease-in-out infinite;
+        }
+        .skeleton-hero { height: 400px; }
+        @keyframes skeleton-pulse {
+            0%, 100% { opacity: 0.35; }
+            50%      { opacity: 0.6; }
+        }
+    </style>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700;800;900&family=JetBrains+Mono:wght@500;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="monthly.css?v=20260901">
+    <link rel="stylesheet" href="../ankimon_items_web/nav-switcher.css?v=20260901">
+    <script src="qrc:///qtwebchannel/qwebchannel.js"></script>
+</head>
+<body class="dark-mode">
+    <div class="app-container">
+
+        <!-- Sidebar -->
+        <aside class="sidebar">
+            <div class="sidebar-header">
+                <div id="nav-switcher" class="nav-switcher">
+                    <button id="nav-trigger" class="nav-trigger" type="button" aria-haspopup="true" aria-expanded="false">
+                        <img src="../user_files/sprites/items/lucky-punch.png?v=20260901" class="app-logo icon-item-sprite" alt="">
+                        <h1>MONTHLY</h1>
+                        <span class="nav-chevron">▾</span>
+                    </button>
+                    <div id="nav-menu" class="nav-menu hidden" role="menu">
+                        <button class="nav-menu-item" role="menuitem" data-screen="items">
+                            <span class="nav-menu-icon"><img src="../user_files/sprites/items/max-potion.png?v=20260901" class="icon-item-sprite" alt=""></span>
+                            <div class="nav-menu-text">
+                                <span class="nav-menu-title">Items</span>
+                                <span class="nav-menu-desc">Your inventory and today's Mart</span>
+                            </div>
+                        </button>
+                        <button class="nav-menu-item" role="menuitem" data-screen="ankidex">
+                            <span class="nav-menu-icon"><img src="../user_files/sprites/items/poke-ball.png?v=20260901" alt=""></span>
+                            <div class="nav-menu-text">
+                                <span class="nav-menu-title">Ankidex</span>
+                                <span class="nav-menu-desc">Browse caught Pokémon</span>
+                            </div>
+                        </button>
+                        <button class="nav-menu-item" role="menuitem" data-screen="team">
+                            <span class="nav-menu-icon"><img src="../user_files/sprites/items/great-ball.png?v=20260901" class="icon-item-sprite" alt=""></span>
+                            <div class="nav-menu-text">
+                                <span class="nav-menu-title">Team</span>
+                                <span class="nav-menu-desc">Your active 6 Pokémon</span>
+                            </div>
+                        </button>
+                        <button class="nav-menu-item" role="menuitem" data-screen="profile">
+                            <span class="nav-menu-icon"><img src="../user_files/sprites/items/water-gem.png?v=20260901" class="icon-item-sprite" alt=""></span>
+                            <div class="nav-menu-text">
+                                <span class="nav-menu-title">Profile</span>
+                                <span class="nav-menu-desc">Card, badges &amp; avatar</span>
+                            </div>
+                        </button>
+                        <button class="nav-menu-item" role="menuitem" data-screen="settings">
+                            <span class="nav-menu-icon"><img src="../user_files/sprites/items/x-speed.png?v=20260901" class="icon-item-sprite" alt=""></span>
+                            <div class="nav-menu-text">
+                                <span class="nav-menu-title">Settings</span>
+                                <span class="nav-menu-desc">Configure Ankimon</span>
+                            </div>
+                        </button>
+                        <button class="nav-menu-item active" role="menuitem" data-screen="monthly">
+                            <span class="nav-menu-icon"><img src="../user_files/sprites/items/lucky-punch.png?v=20260901" class="icon-item-sprite" alt=""></span>
+                            <div class="nav-menu-text">
+                                <span class="nav-menu-title">Monthly Challenge</span>
+                                <span class="nav-menu-desc">Claim your monthly Pokémon</span>
+                            </div>
+                        </button>
+                        <button class="nav-menu-item" role="menuitem" data-screen="update">
+                            <span class="nav-menu-icon"><img src="../user_files/sprites/items/x-speed.png?v=20260901" class="icon-item-sprite" alt=""></span>
+                            <div class="nav-menu-text">
+                                <span class="nav-menu-title">Updates</span>
+                                <span class="nav-menu-desc">Update Ankimon &amp; sprites</span>
+                            </div>
+                        </button>
+                        <button class="nav-menu-item" role="menuitem" data-screen="mobile">
+                            <span class="nav-menu-icon"><img src="../user_files/sprites/items/elixir.png?v=20260901" class="icon-item-sprite" alt=""></span>
+                            <div class="nav-menu-text">
+                                <span class="nav-menu-title">Mobile &amp; Web Reviews</span>
+                                <span class="nav-menu-desc">Pending mobile/web battles</span>
+                            </div>
+                        </button>
+                    </div>
+                </div>
+            </div>
+
+            <!-- Current Month's Mon Box - Large Blue Box with Badges -->
+            <div id="current-mon-box" class="current-mon-box">
+                <div id="current-mon-sprite-container" class="current-mon-sprite-container">
+                    <img id="current-mon-img" src="../user_files/sprites/front_default/0.png" alt="">
+                    <div id="current-mon-badges" class="current-mon-badges">
+                        <span id="current-mon-types" class="badge type-badge">—</span>
+                        <span id="current-mon-level" class="badge level-badge">Lv.—</span>
+                        <span id="current-mon-defeated" class="badge defeated-badge">Df. —</span>
+                    </div>
+                </div>
+            </div>
+
+            <!-- Stats Summary Box -->
+            <div id="stats-summary" class="stats-summary">
+                <div class="stats-summary-header">STATS</div>
+                <div id="stats-summary-content">
+                    <div class="stats-summary-loading">Loading stats...</div>
+                </div>
+            </div>
+
+            <!-- Sidebar Footer - Tip -->
+            <div class="sidebar-footer">
+                <div class="footer-tip">
+                    <span class="footer-tip-icon">Tip:</span>
+                    <span class="footer-tip-text">Accept the current month's challenge to view previous month's results before it slips away!</span>
+                </div>
+            </div>
+        </aside>
+
+        <!-- Main Content -->
+        <main class="main-content">
+            <header class="top-bar">
+                <!-- Empty header - no stats chips -->
+            </header>
+
+            <div class="content-scroll">
+                <div id="monthly-content">
+                    <!-- Skeleton placeholder -->
+                    <div class="skeleton skeleton-hero" style="min-height: 400px; border-radius: 16px;"></div>
+                </div>
+            </div>
+        </main>
+    </div>
+
+    <!-- Confirm Modal (Receive) -->
+    <div id="confirm-modal" class="modal hidden" role="dialog" aria-modal="true" aria-labelledby="confirm-title">
+        <div class="modal-backdrop"></div>
+        <div class="modal-card">
+            <div id="confirm-mark" class="modal-mark">?</div>
+            <h2 id="confirm-title">Receive this Mon?</h2>
+            <p id="confirm-copy">Add this month's challenge Mon to your collection?</p>
+            <div class="modal-actions">
+                <button id="confirm-cancel" class="button button-quiet" type="button">Cancel</button>
+                <button id="confirm-action" class="button button-primary" type="button">Accept Challenge</button>
+            </div>
+        </div>
+    </div>
+
+    <!-- Remove Confirmation Modal -->
+    <div id="remove-modal" class="modal hidden" role="dialog" aria-modal="true" aria-labelledby="remove-title">
+        <div class="modal-backdrop"></div>
+        <div class="modal-card">
+            <div id="remove-mark" class="modal-mark">!</div>
+            <h2 id="remove-title">Remove this Pokémon?</h2>
+            <p id="remove-copy">This removes this Mon from your collection. <strong>All progress will be reset</strong> — if you receive it again, its level and number of Pokémon defeated will return to their defaults.</p>
+            <div class="modal-actions">
+                <button id="remove-cancel" class="button button-quiet" type="button">Cancel</button>
+                <button id="remove-confirm" class="button button-danger" type="button">Reject Challenge</button>
+            </div>
+        </div>
+    </div>
+
+    <div id="toast" class="toast" role="status"></div>
+
+    <script src="../ankimon_items_web/nav-switcher.js?v=20260901"></script>
+    <script src="monthly.js?v=20260901"></script>
+</body>
+</html>

--- a/src/Ankimon/ankimon_monthly_challenge_web/monthly.js
+++ b/src/Ankimon/ankimon_monthly_challenge_web/monthly.js
@@ -1,0 +1,653 @@
+// Monthly Challenge screen — unified Ankimon shell.
+// Talks to Python via QWebChannel (window.monthly) for data and actions.
+
+(function () {
+    'use strict';
+
+    let bridge = null;
+    let nav = null;
+    let pendingAction = null;
+    let latest = null;
+    let dataLoaded = false;
+    let allChallenges = [];
+    let currentMonth = '';
+    let currentMonId = null;
+    let currentStatus = 0;
+    let currentMonData = null;
+    let showSprites = true;
+
+    // Type color mapping
+    const TYPE_COLORS = {
+        normal: '#A8A77A', fire: '#EE8130', water: '#6390F0',
+        electric: '#F7D02C', grass: '#7AC74C', ice: '#96D9D6',
+        fighting: '#C22E28', poison: '#A33EA1', ground: '#E2BF65',
+        flying: '#A98FF3', psychic: '#F95587', bug: '#A6B91A',
+        rock: '#B6A136', ghost: '#735797', dragon: '#6F35FC',
+        dark: '#705746', steel: '#B7B7CE', fairy: '#D685AD',
+        stellar: '#40C0E0', unknown: '#68A090'
+    };
+
+    function getTypeColor(type) {
+        return TYPE_COLORS[type.toLowerCase()] || '#888888';
+    }
+
+    function initChannel(callback) {
+        if (typeof qt === 'undefined' || !qt.webChannelTransport) {
+            console.warn('qt.webChannelTransport unavailable — standalone mode');
+            callback(null);
+            return;
+        }
+        new QWebChannel(qt.webChannelTransport, function (channel) {
+            bridge = channel.objects && channel.objects.monthly;
+            nav = channel.objects && channel.objects.nav;
+            window.bridge = bridge;
+            window.nav = nav;
+            callback(bridge);
+        });
+    }
+
+    function statusLabel(value) {
+        if (Number(value) === 1) return ['Accepted', 'accepted'];
+        if (Number(value) === 2) return ['Rejected', 'rejected'];
+        return ['Unknown', 'unknown'];
+    }
+
+    function render(data) {
+        latest = data || {};
+        
+        if (!latest.ok) {
+            const container = document.getElementById('monthly-content');
+            container.innerHTML = `
+                <div class="monthly-error">
+                    <div class="monthly-error-icon">⚠️</div>
+                    <div class="monthly-error-text">${latest.message || 'Monthly Challenge is unavailable.'}</div>
+                </div>
+            `;
+            showToast(latest.message || 'Monthly Challenge is unavailable.', true);
+            return;
+        }
+
+        dataLoaded = true;
+        allChallenges = latest.challenges || [];
+        currentMonth = latest.current_month || '';
+        currentMonId = latest.current_individual_id || null;
+        currentStatus = latest.current_status || 0;
+        showSprites = latest.show_sprites !== undefined ? latest.show_sprites : true;
+
+        // Find current month's data for the sidebar box
+        currentMonData = allChallenges.find(c => c.is_current) || null;
+
+        // Update current month box (left sidebar - shows user's current Mon)
+        updateCurrentMonBox(currentMonData);
+
+        // Update stats summary (left sidebar - shows user's current Mon stats)
+        updateStatsSummary(currentMonData);
+
+        // Build the challenge list (right side - challenge history)
+        const container = document.getElementById('monthly-content');
+        container.innerHTML = '';
+        container.appendChild(buildChallengeList(allChallenges));
+        
+        // Remove any loading states after render completes
+        removeLoadingStates();
+    }
+
+    function updateCurrentMonBox(data) {
+        const img = document.getElementById('current-mon-img');
+        const container = document.getElementById('current-mon-sprite-container');
+        const typeBadge = document.getElementById('current-mon-types');
+        const levelBadge = document.getElementById('current-mon-level');
+        const defeatedBadge = document.getElementById('current-mon-defeated');
+        
+        if (data) {
+            // Check if the Pokémon is in the user's collection
+            const inCollection = data.in_collection || false;
+            
+            // Get types
+            let types = data.type || ['Normal'];
+            if (inCollection && data.collection_types) {
+                types = data.collection_types;
+            }
+            
+            // Update type badge
+            if (typeBadge) {
+                if (inCollection && data.collection_types) {
+                    const typeStr = types.join('/');
+                    typeBadge.textContent = typeStr;
+                    const color = getTypeColor(types[0] || 'Normal');
+                    typeBadge.style.backgroundColor = color;
+                    typeBadge.style.color = '#ffffff';
+                } else {
+                    typeBadge.textContent = '—';
+                    typeBadge.style.backgroundColor = '#888888';
+                    typeBadge.style.color = '#ffffff';
+                }
+            }
+            
+            // Update level badge
+            if (levelBadge) {
+                if (inCollection && data.collection_level) {
+                    levelBadge.textContent = 'Lv.' + data.collection_level;
+                } else {
+                    levelBadge.textContent = 'Lv.—';
+                }
+            }
+            
+            // Update defeated badge
+            if (defeatedBadge) {
+                if (inCollection && data.collection_defeated !== undefined) {
+                    defeatedBadge.textContent = 'Df. ' + data.collection_defeated;
+                } else {
+                    defeatedBadge.textContent = 'Df. —';
+                }
+            }
+            
+            // Update sprite - LEFT SIDE uses user's current Mon (evolved if applicable)
+            if (showSprites) {
+                container.classList.remove('sprites-hidden');
+                img.style.display = 'block';
+                
+                let spriteSrc = null;
+                // Use collection sprite (evolved) if available, otherwise base
+                if (inCollection && data.collection_sprite_gif) {
+                    spriteSrc = data.collection_sprite_gif;
+                } else if (data.sprite_gif) {
+                    spriteSrc = data.sprite_gif;
+                } else if (data.sprite) {
+                    spriteSrc = data.sprite;
+                }
+                
+                if (spriteSrc) {
+                    img.src = spriteSrc;
+                } else {
+                    img.src = '../user_files/sprites/front_default/0.png';
+                }
+                img.alt = data.name || 'Pokémon';
+                img.onerror = function() {
+                    this.src = '../user_files/sprites/front_default/0.png';
+                };
+            } else {
+                container.classList.add('sprites-hidden');
+                img.style.display = 'none';
+            }
+        } else {
+            // No data - show dashes
+            if (typeBadge) {
+                typeBadge.textContent = '—';
+                typeBadge.style.backgroundColor = '#888888';
+                typeBadge.style.color = '#ffffff';
+            }
+            if (levelBadge) {
+                levelBadge.textContent = 'Lv.—';
+            }
+            if (defeatedBadge) {
+                defeatedBadge.textContent = 'Df. —';
+            }
+            img.src = '../user_files/sprites/front_default/0.png';
+            if (!showSprites) {
+                container.classList.add('sprites-hidden');
+                img.style.display = 'none';
+            } else {
+                container.classList.remove('sprites-hidden');
+                img.style.display = 'block';
+            }
+        }
+    }
+
+    function updateStatsSummary(data) {
+        const container = document.getElementById('stats-summary-content');
+        
+        if (!data) {
+            container.innerHTML = '<div class="stats-summary-empty">No stats available</div>';
+            return;
+        }
+
+        // Use collection stats if available (evolved form), otherwise use base stats
+        let stats;
+        
+        if (data.in_collection && data.collection_stats) {
+            stats = data.collection_stats;
+        } else {
+            stats = data.stats || {};
+        }
+
+        const statKeys = ['hp', 'atk', 'def', 'spa', 'spd', 'spe'];
+        const statLabels = {
+            'hp': 'HP',
+            'atk': 'Atk',
+            'def': 'Def',
+            'spa': 'SpA',
+            'spd': 'SpD',
+            'spe': 'Spe'
+        };
+
+        const values = statKeys.map(key => stats[key] || 0);
+        const maxVal = Math.max(...values, 1);
+
+        let html = '';
+
+        statKeys.forEach(key => {
+            const val = stats[key] || 0;
+            const pct = Math.max(0, Math.min(100, (val / maxVal) * 100));
+            html += `
+                <div class="stats-row">
+                    <span class="stats-label">${statLabels[key]}</span>
+                    <div class="stats-bar-bg">
+                        <div class="stats-bar-fill" style="width: ${pct}%;"></div>
+                    </div>
+                    <span class="stats-value">${val}</span>
+                </div>
+            `;
+        });
+
+        container.innerHTML = html;
+    }
+
+    function buildChallengeList(challenges) {
+        const wrapper = document.createElement('div');
+        wrapper.className = 'monthly-list';
+
+        // Filter out challenges from months AFTER the current month
+        const currentDate = new Date(currentMonth + ' 1, 2000');
+        const filteredChallenges = challenges.filter(c => {
+            const challengeDate = new Date(c.month + ' 1, 2000');
+            return challengeDate <= currentDate;
+        });
+
+        // Sort by month (newest first - reverse chronological)
+        const sortedChallenges = [...filteredChallenges].sort((a, b) => {
+            const dateA = new Date(a.month + ' 1, 2000');
+            const dateB = new Date(b.month + ' 1, 2000');
+            return dateB - dateA;
+        });
+
+        if (sortedChallenges.length === 0) {
+            const empty = document.createElement('div');
+            empty.className = 'monthly-empty';
+            empty.textContent = 'No monthly challenges available yet. Check back next month!';
+            wrapper.appendChild(empty);
+            return wrapper;
+        }
+
+        const show = showSprites;
+
+        // Build each challenge entry
+        sortedChallenges.forEach((challenge, index) => {
+            const entry = document.createElement('div');
+            entry.className = 'monthly-entry';
+            if (challenge.is_current) {
+                entry.classList.add('is-current');
+            }
+
+            // Left: Sprite - ALWAYS use base sprite from challenge data (static)
+            const spriteBox = document.createElement('div');
+            spriteBox.className = 'monthly-entry-sprite';
+            
+            if (show) {
+                const img = document.createElement('img');
+                let spriteSrc = null;
+                if (challenge.sprite_gif) {
+                    spriteSrc = challenge.sprite_gif;
+                } else if (challenge.sprite) {
+                    spriteSrc = challenge.sprite;
+                }
+                
+                if (spriteSrc) {
+                    img.src = spriteSrc;
+                } else {
+                    img.src = '../user_files/sprites/front_default/0.png';
+                }
+                img.alt = challenge.name || 'Pokémon';
+                img.onerror = function() {
+                    this.src = '../user_files/sprites/front_default/0.png';
+                };
+                spriteBox.appendChild(img);
+            } else {
+                spriteBox.classList.add('sprites-hidden');
+            }
+            
+            entry.appendChild(spriteBox);
+
+            // Right: Info
+            const infoBox = document.createElement('div');
+            infoBox.className = 'monthly-entry-info';
+
+            // Month/Year
+            const monthLabel = document.createElement('div');
+            monthLabel.className = 'monthly-entry-month';
+            if (challenge.is_current) {
+                monthLabel.textContent = challenge.month || 'Current Month';
+                monthLabel.classList.add('current');
+            } else {
+                monthLabel.textContent = challenge.month || 'Unknown';
+            }
+            infoBox.appendChild(monthLabel);
+
+            // Pokémon name - ALWAYS use base name from challenge JSON
+            let displayName = challenge.name || 'Unknown Pokémon';
+            
+            // If evolved, add arrow indicator to the right
+            if (challenge.is_current && challenge.has_evolved) {
+                displayName += ' ⬆';
+            }
+            
+            const nameLabel = document.createElement('div');
+            nameLabel.className = 'monthly-entry-name';
+            nameLabel.textContent = displayName;
+            infoBox.appendChild(nameLabel);
+
+            // Description
+            if (challenge.description) {
+                const descLabel = document.createElement('div');
+                descLabel.className = 'monthly-entry-desc';
+                descLabel.textContent = challenge.description;
+                infoBox.appendChild(descLabel);
+            }
+
+            // Result / Status
+            const resultBox = document.createElement('div');
+            resultBox.className = 'monthly-entry-result';
+
+            const isCurrent = challenge.is_current;
+
+            if (isCurrent) {
+                // STATUS for current month
+                const status = document.createElement('span');
+                status.className = 'monthly-entry-status';
+                let statusText = '';
+                if (challenge.status === 1) {
+                    statusText = 'Status: Accepted';
+                    status.classList.add('accepted');
+                } else if (challenge.status === 2) {
+                    statusText = 'Status: Rejected';
+                    status.classList.add('rejected');
+                } else {
+                    statusText = 'Status: Unknown';
+                    status.classList.add('unknown');
+                }
+                status.textContent = statusText;
+                resultBox.appendChild(status);
+
+                // Action buttons for current month
+                // If status is 0 (Unknown): Show both Accept and Reject buttons
+                // If status is 1 (Accepted): Show only Remove button
+                // If status is 2 (Rejected): Show only Accept button
+                const actionBtns = document.createElement('div');
+                actionBtns.className = 'monthly-entry-actions';
+
+                if (challenge.status === 0) {
+                    // Unknown - show both Accept and Reject
+                    const acceptBtn = document.createElement('button');
+                    acceptBtn.className = 'button button-primary';
+                    acceptBtn.textContent = 'Accept';
+                    acceptBtn.addEventListener('click', function(e) {
+                        e.stopPropagation();
+                        openConfirm('receive');
+                    });
+                    actionBtns.appendChild(acceptBtn);
+
+                    const rejectBtn = document.createElement('button');
+                    rejectBtn.className = 'button button-danger';
+                    rejectBtn.textContent = 'Reject';
+                    rejectBtn.addEventListener('click', function(e) {
+                        e.stopPropagation();
+                        openConfirm('reject');
+                    });
+                    actionBtns.appendChild(rejectBtn);
+                } else if (challenge.status === 1) {
+                    // Accepted - show only Remove button
+                    const removeBtn = document.createElement('button');
+                    removeBtn.className = 'button button-danger';
+                    removeBtn.textContent = 'Remove';
+                    removeBtn.addEventListener('click', function(e) {
+                        e.stopPropagation();
+                        openConfirm('reject');
+                    });
+                    actionBtns.appendChild(removeBtn);
+                } else if (challenge.status === 2) {
+                    // Rejected - show only Accept button
+                    const acceptBtn = document.createElement('button');
+                    acceptBtn.className = 'button button-primary';
+                    acceptBtn.textContent = 'Accept';
+                    acceptBtn.addEventListener('click', function(e) {
+                        e.stopPropagation();
+                        openConfirm('receive');
+                    });
+                    actionBtns.appendChild(acceptBtn);
+                }
+
+                resultBox.appendChild(actionBtns);
+            } else {
+                // RESULT for past challenges
+                const result = document.createElement('span');
+                result.className = 'monthly-entry-result-label';
+                const resultText = challenge.result || 'unknown';
+                let displayText = '';
+                if (resultText === 'success') {
+                    displayText = 'Result: Succeeded!';
+                    result.classList.add('success');
+                } else if (resultText === 'next_time') {
+                    displayText = 'Result: Next time\'s a charm!';
+                    result.classList.add('next-time');
+                } else if (resultText === 'pending_accepted') {
+                    displayText = 'Pending: Accepted';
+                    result.classList.add('pending');
+                } else if (resultText === 'pending_rejected') {
+                    displayText = 'Pending: Rejected';
+                    result.classList.add('pending');
+                } else if (resultText === 'accepted') {
+                    displayText = 'Result: Accepted';
+                    result.classList.add('accepted');
+                } else if (resultText === 'rejected') {
+                    displayText = 'Result: Not Joined';
+                    result.classList.add('rejected');
+                } else {
+                    displayText = 'Result: Unknown';
+                    result.classList.add('unknown');
+                }
+                result.textContent = displayText;
+                resultBox.appendChild(result);
+            }
+
+            infoBox.appendChild(resultBox);
+            entry.appendChild(infoBox);
+
+            wrapper.appendChild(entry);
+
+            // Divider (except after last)
+            if (index < sortedChallenges.length - 1) {
+                const divider = document.createElement('div');
+                divider.className = 'monthly-divider';
+                wrapper.appendChild(divider);
+            }
+        });
+
+        return wrapper;
+    }
+
+    // --- Loading State Management ---
+    let loadingButton = null;
+
+    function setLoadingState(button) {
+        if (!button) return;
+        loadingButton = button;
+        button._originalText = button.textContent;
+        button.textContent = 'Processing...';
+        button.disabled = true;
+        button.classList.add('loading');
+    }
+
+    function removeLoadingStates() {
+        if (loadingButton) {
+            loadingButton.textContent = loadingButton._originalText || loadingButton.textContent;
+            loadingButton.disabled = false;
+            loadingButton.classList.remove('loading');
+            loadingButton = null;
+        }
+    }
+
+    // --- Modal Functions ---
+
+    function getPokemonDisplayInfo() {
+        let pokemonName = 'this Mon';
+        let pokemonLevel = '';
+        
+        if (currentMonData) {
+            // Check if the Pokémon is in the user's collection
+            const inCollection = currentMonData.in_collection || false;
+            
+            if (inCollection) {
+                // Use collection data (what the user actually has)
+                pokemonName = currentMonData.collection_name || currentMonData.name || 'this Mon';
+                pokemonLevel = currentMonData.collection_level || '';
+            } else {
+                // Fall back to template data if not in collection
+                pokemonName = currentMonData.name || 'this Mon';
+                pokemonLevel = currentMonData.level || '';
+            }
+        }
+        
+        return { name: pokemonName, level: pokemonLevel };
+    }
+
+    function openConfirm(action) {
+        const info = getPokemonDisplayInfo();
+        const levelText = info.level ? ` Lvl. ${info.level}` : '';
+        
+        if (action === 'reject') {
+            // SHOW REMOVE MODAL
+            const removeTitle = document.getElementById('remove-title');
+            const removeCopy = document.getElementById('remove-copy');
+            
+            removeTitle.textContent = `Remove this month's Pokémon?`;
+            removeCopy.innerHTML = `This removes ${info.name}${levelText} from your collection. <strong>All progress will be reset</strong> — if you receive it again, its level and number of Pokémon defeated will return to their defaults.`;
+            
+            document.getElementById('remove-modal').classList.remove('hidden');
+            return;
+        }
+
+        // SHOW RECEIVE MODAL (action === 'receive')
+        pendingAction = action;
+        document.getElementById('confirm-mark').textContent = '?';
+        document.getElementById('confirm-title').textContent = 'Receive this month\'s Pokémon?';
+        document.getElementById('confirm-copy').textContent = `Add ${info.name}${levelText} to your collection?`;
+        
+        const confirmBtn = document.getElementById('confirm-action');
+        confirmBtn.textContent = 'Accept Challenge';
+        confirmBtn.className = 'button button-primary';
+        document.getElementById('confirm-modal').classList.remove('hidden');
+    }
+
+    function closeConfirm() {
+        document.getElementById('confirm-modal').classList.add('hidden');
+        pendingAction = null;
+    }
+
+    function closeRemoveModal() {
+        document.getElementById('remove-modal').classList.add('hidden');
+    }
+
+    function runAction() {
+        if (!bridge || !pendingAction) return;
+        const action = pendingAction;
+        
+        // Set loading state on the confirm button
+        const confirmBtn = document.getElementById('confirm-action');
+        setLoadingState(confirmBtn);
+        
+        closeConfirm();
+
+        const callback = function(result) {
+            if (result && result.ok) {
+                bridge.getMonthlyChallenge(render);
+                showToast('Pokémon received!');
+            } else {
+                showToast((result && result.message) || 'The action could not be completed.', true);
+                removeLoadingStates();
+            }
+        };
+
+        if (action === 'receive') {
+            bridge.receiveMon(callback);
+        }
+    }
+
+    function confirmRemove() {
+        if (!bridge) return;
+        
+        // Set loading state on the remove confirm button
+        const removeBtn = document.getElementById('remove-confirm');
+        setLoadingState(removeBtn);
+        
+        closeRemoveModal();
+        bridge.removeMon(function(result) {
+            if (result && result.ok) {
+                bridge.getMonthlyChallenge(render);
+                showToast('Monthly challenge removed.');
+            } else {
+                showToast((result && result.message) || 'Could not remove.', true);
+                removeLoadingStates();
+            }
+        });
+    }
+
+    function showToast(text, isError) {
+        if (!text) return;
+        const toast = document.getElementById('toast');
+        toast.textContent = text;
+        toast.classList.toggle('error', !!isError);
+        toast.classList.add('visible');
+        clearTimeout(toast._timer);
+        toast._timer = setTimeout(function() {
+            toast.classList.remove('visible');
+        }, 2800);
+    }
+
+    // Live refresh support
+    window.liveRefreshMonthly = function(data) {
+        if (!data) return;
+        render(data);
+    };
+
+    // Initialize from Python
+    window.initializeMonthlyChallenge = function(data) {
+        render(data);
+    };
+
+    // ----- UI Binding -----
+    document.addEventListener('DOMContentLoaded', function() {
+        document.getElementById('confirm-cancel').addEventListener('click', closeConfirm);
+        document.getElementById('confirm-action').addEventListener('click', runAction);
+
+        document.getElementById('remove-cancel').addEventListener('click', closeRemoveModal);
+        document.getElementById('remove-confirm').addEventListener('click', confirmRemove);
+
+        document.getElementById('confirm-modal').addEventListener('click', function(e) {
+            if (e.target.classList.contains('modal-backdrop')) closeConfirm();
+        });
+        document.getElementById('remove-modal').addEventListener('click', function(e) {
+            if (e.target.classList.contains('modal-backdrop')) closeRemoveModal();
+        });
+
+        document.addEventListener('keydown', function(e) {
+            if (e.key === 'Escape') {
+                const confirmModal = document.getElementById('confirm-modal');
+                const removeModal = document.getElementById('remove-modal');
+                if (!confirmModal.classList.contains('hidden')) {
+                    closeConfirm();
+                } else if (!removeModal.classList.contains('hidden')) {
+                    closeRemoveModal();
+                }
+            }
+        });
+
+        initChannel(function() {
+            if (window.wireNavSwitcher) {
+                window.wireNavSwitcher(nav);
+            }
+            if (bridge && bridge.getMonthlyChallenge) {
+                bridge.getMonthlyChallenge(render);
+            }
+        });
+    });
+})();

--- a/src/Ankimon/ankimon_monthly_challenge_web/monthly.js
+++ b/src/Ankimon/ankimon_monthly_challenge_web/monthly.js
@@ -52,18 +52,43 @@
         return ['Unknown', 'unknown'];
     }
 
+    function escapeText(text) {
+        if (!text) return '';
+        const div = document.createElement('div');
+        div.textContent = text;
+        return div.innerHTML;
+    }
+
     function render(data) {
         latest = data || {};
         
+        // Check if this is a loading state
+        if (data && data.loading === true) {
+            // Show skeleton - the HTML already has it
+            const container = document.getElementById('monthly-content');
+            container.innerHTML = `
+                <div class="skeleton skeleton-hero" style="min-height: 400px; border-radius: 16px;"></div>
+            `;
+            return;
+        }
+        
         if (!latest.ok) {
             const container = document.getElementById('monthly-content');
+            const errorMessage = latest.message || 'Monthly Challenge is unavailable.';
+            // Use textContent to avoid XSS
             container.innerHTML = `
                 <div class="monthly-error">
                     <div class="monthly-error-icon">⚠️</div>
-                    <div class="monthly-error-text">${latest.message || 'Monthly Challenge is unavailable.'}</div>
+                    <div class="monthly-error-text"></div>
                 </div>
             `;
-            showToast(latest.message || 'Monthly Challenge is unavailable.', true);
+            const errorTextEl = container.querySelector('.monthly-error-text');
+            if (errorTextEl) {
+                errorTextEl.textContent = errorMessage;
+            }
+            showToast(errorMessage, true);
+            // Clear any loading state on error path
+            removeLoadingStates();
             return;
         }
 
@@ -520,7 +545,16 @@
             const removeCopy = document.getElementById('remove-copy');
             
             removeTitle.textContent = `Remove this month's Pokémon?`;
-            removeCopy.innerHTML = `This removes ${info.name}${levelText} from your collection. <strong>All progress will be reset</strong> — if you receive it again, its level and number of Pokémon defeated will return to their defaults.`;
+            // Use textContent for the display name to prevent XSS
+            const displayName = info.name || 'this Mon';
+            // Clear and rebuild with safe DOM nodes
+            removeCopy.innerHTML = '';
+            removeCopy.appendChild(document.createTextNode(`This removes ${displayName}${levelText} from your collection. `));
+            const warningSpan = document.createElement('strong');
+            warningSpan.textContent = 'All progress will be reset';
+            removeCopy.appendChild(warningSpan);
+            const suffixSpan = document.createTextNode(` — if you receive it again, its level and number of Pokémon defeated will return to their defaults.`);
+            removeCopy.appendChild(suffixSpan);
             
             document.getElementById('remove-modal').classList.remove('hidden');
             return;
@@ -530,7 +564,8 @@
         pendingAction = action;
         document.getElementById('confirm-mark').textContent = '?';
         document.getElementById('confirm-title').textContent = 'Receive this month\'s Pokémon?';
-        document.getElementById('confirm-copy').textContent = `Add ${info.name}${levelText} to your collection?`;
+        const displayName = info.name || 'this Mon';
+        document.getElementById('confirm-copy').textContent = `Add ${displayName}${levelText} to your collection?`;
         
         const confirmBtn = document.getElementById('confirm-action');
         confirmBtn.textContent = 'Accept Challenge';
@@ -559,6 +594,8 @@
 
         const callback = function(result) {
             if (result && result.ok) {
+                // Clear loading state before refresh so the button isn't stuck if the refresh fails
+                removeLoadingStates();
                 bridge.getMonthlyChallenge(render);
                 showToast('Pokémon received!');
             } else {
@@ -582,6 +619,8 @@
         closeRemoveModal();
         bridge.removeMon(function(result) {
             if (result && result.ok) {
+                // Clear loading state before refresh so the button isn't stuck if the refresh fails
+                removeLoadingStates();
                 bridge.getMonthlyChallenge(render);
                 showToast('Monthly challenge removed.');
             } else {
@@ -594,6 +633,7 @@
     function showToast(text, isError) {
         if (!text) return;
         const toast = document.getElementById('toast');
+        // Use textContent to prevent XSS
         toast.textContent = text;
         toast.classList.toggle('error', !!isError);
         toast.classList.add('visible');

--- a/src/Ankimon/ankimon_monthly_challenge_web/monthly.js
+++ b/src/Ankimon/ankimon_monthly_challenge_web/monthly.js
@@ -263,43 +263,73 @@
             'spe': 'Spe'
         };
 
-        const values = statKeys.map(key => stats[key] || 0);
+        // Coerce all values to safe numbers to prevent XSS
+        const values = statKeys.map(key => {
+            const val = stats[key];
+            return typeof val === 'number' && !isNaN(val) ? val : 0;
+        });
         const maxVal = Math.max(...values, 1);
 
-        let html = '';
+        // Clear container
+        container.innerHTML = '';
 
-        statKeys.forEach(key => {
-            const val = stats[key] || 0;
+        statKeys.forEach((key, index) => {
+            const val = values[index];
             const pct = Math.max(0, Math.min(100, (val / maxVal) * 100));
-            html += `
-                <div class="stats-row">
-                    <span class="stats-label">${statLabels[key]}</span>
-                    <div class="stats-bar-bg">
-                        <div class="stats-bar-fill" style="width: ${pct}%;"></div>
-                    </div>
-                    <span class="stats-value">${val}</span>
-                </div>
-            `;
+            
+            const row = document.createElement('div');
+            row.className = 'stats-row';
+            
+            const label = document.createElement('span');
+            label.className = 'stats-label';
+            label.textContent = statLabels[key];
+            row.appendChild(label);
+            
+            const barBg = document.createElement('div');
+            barBg.className = 'stats-bar-bg';
+            
+            const barFill = document.createElement('div');
+            barFill.className = 'stats-bar-fill';
+            barFill.style.width = pct + '%';
+            barBg.appendChild(barFill);
+            row.appendChild(barBg);
+            
+            const valueSpan = document.createElement('span');
+            valueSpan.className = 'stats-value';
+            valueSpan.textContent = val;
+            row.appendChild(valueSpan);
+            
+            container.appendChild(row);
         });
-
-        container.innerHTML = html;
     }
 
     function buildChallengeList(challenges) {
         const wrapper = document.createElement('div');
         wrapper.className = 'monthly-list';
 
-        // Filter out challenges from months AFTER the current month
-        const currentDate = new Date(currentMonth + ' 1, 2000');
+        // Parse current month properly
+        const currentDate = new Date(currentMonth);
+        // If currentMonth is "September 2026", this will parse correctly
+        
         const filteredChallenges = challenges.filter(c => {
-            const challengeDate = new Date(c.month + ' 1, 2000');
+            const challengeDate = new Date(c.month);
+            // If c.month is like "September 2026", this works
+            // Fallback: if invalid, check string comparison
+            if (isNaN(challengeDate.getTime())) {
+                // Fallback: compare month strings alphabetically
+                return c.month <= currentMonth;
+            }
             return challengeDate <= currentDate;
         });
 
         // Sort by month (newest first - reverse chronological)
         const sortedChallenges = [...filteredChallenges].sort((a, b) => {
-            const dateA = new Date(a.month + ' 1, 2000');
-            const dateB = new Date(b.month + ' 1, 2000');
+            const dateA = new Date(a.month);
+            const dateB = new Date(b.month);
+            // If either date is invalid, fall back to string comparison
+            if (isNaN(dateA.getTime()) || isNaN(dateB.getTime())) {
+                return a.month.localeCompare(b.month);
+            }
             return dateB - dateA;
         });
 

--- a/src/Ankimon/ankimon_monthly_challenge_web/monthly.js
+++ b/src/Ankimon/ankimon_monthly_challenge_web/monthly.js
@@ -28,7 +28,12 @@
     };
 
     function getTypeColor(type) {
-        return TYPE_COLORS[type.toLowerCase()] || '#888888';
+        // Coerce type to string and handle various input types safely
+        if (type === null || type === undefined) {
+            return '#888888';
+        }
+        const typeStr = String(type).toLowerCase();
+        return TYPE_COLORS[typeStr] || '#888888';
     }
 
     function initChannel(callback) {
@@ -64,7 +69,7 @@
         
         // Check if this is a loading state
         if (data && data.loading === true) {
-            // Show skeleton - the HTML already has it
+            // Show skeleton - the HTML already has it, but we need to make sure it's visible
             const container = document.getElementById('monthly-content');
             container.innerHTML = `
                 <div class="skeleton skeleton-hero" style="min-height: 400px; border-radius: 16px;"></div>
@@ -128,18 +133,30 @@
             // Check if the Pokémon is in the user's collection
             const inCollection = data.in_collection || false;
             
-            // Get types
-            let types = data.type || ['Normal'];
+            // Get types - safely handle non-string, non-array values
+            let types = ['Normal'];
             if (inCollection && data.collection_types) {
-                types = data.collection_types;
+                if (Array.isArray(data.collection_types)) {
+                    types = data.collection_types;
+                } else if (typeof data.collection_types === 'string') {
+                    types = [data.collection_types];
+                }
+            } else if (data.type) {
+                if (Array.isArray(data.type)) {
+                    types = data.type;
+                } else if (typeof data.type === 'string') {
+                    types = [data.type];
+                }
             }
             
             // Update type badge
             if (typeBadge) {
-                if (inCollection && data.collection_types) {
+                if (types && types.length > 0) {
                     const typeStr = types.join('/');
                     typeBadge.textContent = typeStr;
-                    const color = getTypeColor(types[0] || 'Normal');
+                    // Safely get color - coerce first type to string
+                    const firstType = types[0];
+                    const color = getTypeColor(firstType);
                     typeBadge.style.backgroundColor = color;
                     typeBadge.style.color = '#ffffff';
                 } else {

--- a/src/Ankimon/ankimon_monthly_challenge_web/monthly.js
+++ b/src/Ankimon/ankimon_monthly_challenge_web/monthly.js
@@ -473,7 +473,7 @@
                     removeBtn.textContent = 'Remove';
                     removeBtn.addEventListener('click', function(e) {
                         e.stopPropagation();
-                        openConfirm('reject');
+                        openConfirm('remove');
                     });
                     actionBtns.appendChild(removeBtn);
                 } else if (challenge.status === 2) {
@@ -586,8 +586,8 @@
         const info = getPokemonDisplayInfo();
         const levelText = info.level ? ` Lvl. ${info.level}` : '';
         
-        if (action === 'reject') {
-            // SHOW REMOVE MODAL
+        if (action === 'remove') {
+            // SHOW REMOVE MODAL (for status 1 - Remove button)
             const removeTitle = document.getElementById('remove-title');
             const removeCopy = document.getElementById('remove-copy');
             
@@ -602,6 +602,23 @@
             removeCopy.appendChild(warningSpan);
             const suffixSpan = document.createTextNode(` — if you receive it again, its level and number of Pokémon defeated will return to their defaults.`);
             removeCopy.appendChild(suffixSpan);
+            
+            document.getElementById('remove-modal').classList.remove('hidden');
+            return;
+        }
+
+        if (action === 'reject') {
+            // SHOW REJECT MODAL (for status 0 - Reject button)
+            const removeTitle = document.getElementById('remove-title');
+            const removeCopy = document.getElementById('remove-copy');
+            
+            removeTitle.textContent = `Reject this month's challenge?`;
+            const displayName = info.name || 'this Mon';
+            removeCopy.innerHTML = '';
+            removeCopy.appendChild(document.createTextNode(`You will not receive ${displayName}${levelText}. `));
+            const warningSpan = document.createElement('strong');
+            warningSpan.textContent = 'You can still accept it later if you change your mind.';
+            removeCopy.appendChild(warningSpan);
             
             document.getElementById('remove-modal').classList.remove('hidden');
             return;
@@ -627,6 +644,10 @@
 
     function closeRemoveModal() {
         document.getElementById('remove-modal').classList.add('hidden');
+        // Clear pending action if it was set for this modal
+        if (pendingAction === 'reject' || pendingAction === 'remove') {
+            pendingAction = null;
+        }
     }
 
     function runAction() {
@@ -663,18 +684,31 @@
         const removeBtn = document.getElementById('remove-confirm');
         setLoadingState(removeBtn);
         
+        // Determine which action to call based on current status
+        // If status is 0, this is a Reject action; if status is 1, this is a Remove action
+        const isReject = (currentStatus === 0);
+        const actionName = isReject ? 'reject' : 'remove';
+        
         closeRemoveModal();
-        bridge.removeMon(function(result) {
+        
+        const callback = function(result) {
             if (result && result.ok) {
                 // Clear loading state before refresh so the button isn't stuck if the refresh fails
                 removeLoadingStates();
                 bridge.getMonthlyChallenge(render);
-                showToast('Monthly challenge removed.');
+                const message = isReject ? 'Challenge rejected.' : 'Monthly challenge removed.';
+                showToast(message);
             } else {
-                showToast((result && result.message) || 'Could not remove.', true);
+                showToast((result && result.message) || 'Could not complete action.', true);
                 removeLoadingStates();
             }
-        });
+        };
+
+        if (isReject) {
+            bridge.rejectMon(callback);
+        } else {
+            bridge.removeMon(callback);
+        }
     }
 
     function showToast(text, isError) {

--- a/src/Ankimon/ankimon_profile_web/profile.html
+++ b/src/Ankimon/ankimon_profile_web/profile.html
@@ -62,7 +62,7 @@
                                 <span class="nav-menu-desc">Configure Ankimon</span>
                             </div>
                         </button>
-                        <button class="nav-menu-item" role="menuitem" data-screen="monthly">
+                        <button type="button" class="nav-menu-item" role="menuitem" data-screen="monthly">
                             <span class="nav-menu-icon"><img src="../user_files/sprites/items/lucky-punch.png" class="icon-item-sprite" alt=""></span>
                             <div class="nav-menu-text">
                                 <span class="nav-menu-title">Monthly Challenge</span>

--- a/src/Ankimon/ankimon_profile_web/profile.html
+++ b/src/Ankimon/ankimon_profile_web/profile.html
@@ -62,6 +62,13 @@
                                 <span class="nav-menu-desc">Configure Ankimon</span>
                             </div>
                         </button>
+                        <button class="nav-menu-item" role="menuitem" data-screen="monthly">
+                            <span class="nav-menu-icon"><img src="../user_files/sprites/items/lucky-punch.png" class="icon-item-sprite" alt=""></span>
+                            <div class="nav-menu-text">
+                                <span class="nav-menu-title">Monthly Challenge</span>
+                                <span class="nav-menu-desc">Claim your monthly Pokémon</span>
+                            </div>
+                        </button>
                         <button class="nav-menu-item" role="menuitem" data-screen="mobile">
                             <span class="nav-menu-icon"><img src="../user_files/sprites/items/elixir.png" class="icon-item-sprite" alt=""></span>
                             <div class="nav-menu-text">

--- a/src/Ankimon/ankimon_profile_web/team.html
+++ b/src/Ankimon/ankimon_profile_web/team.html
@@ -62,7 +62,7 @@
                                 <span class="nav-menu-desc">Configure Ankimon</span>
                             </div>
                         </button>
-                        <button class="nav-menu-item" role="menuitem" data-screen="monthly">
+                        <button type="button" class="nav-menu-item" role="menuitem" data-screen="monthly">
                             <span class="nav-menu-icon"><img src="../user_files/sprites/items/lucky-punch.png" class="icon-item-sprite" alt=""></span>
                             <div class="nav-menu-text">
                                 <span class="nav-menu-title">Monthly Challenge</span>

--- a/src/Ankimon/ankimon_profile_web/team.html
+++ b/src/Ankimon/ankimon_profile_web/team.html
@@ -62,6 +62,13 @@
                                 <span class="nav-menu-desc">Configure Ankimon</span>
                             </div>
                         </button>
+                        <button class="nav-menu-item" role="menuitem" data-screen="monthly">
+                            <span class="nav-menu-icon"><img src="../user_files/sprites/items/lucky-punch.png" class="icon-item-sprite" alt=""></span>
+                            <div class="nav-menu-text">
+                                <span class="nav-menu-title">Monthly Challenge</span>
+                                <span class="nav-menu-desc">Claim your monthly Pokémon</span>
+                            </div>
+                        </button>
                         <button class="nav-menu-item" role="menuitem" data-screen="mobile">
                             <span class="nav-menu-icon"><img src="../user_files/sprites/items/elixir.png" class="icon-item-sprite" alt=""></span>
                             <div class="nav-menu-text">

--- a/src/Ankimon/lang/ch_text.json
+++ b/src/Ankimon/lang/ch_text.json
@@ -33,6 +33,7 @@
   "open_ankimon_window_button": "打开 Ankimon 窗口",
   "itembag_button": "道具包",
   "achievements_button": "成就",
+  "monthly_challenge_button": "每月挑战",
   "open_showdown_teambuilder_button": "打开 Pokemon Showdown 队伍编辑器",
   "export_main_pokemon_button": "导出主宝可梦到 PkmnShowdown",
   "export_all_pokemon_button": "导出所有宝可梦到 PkmnShowdown",

--- a/src/Ankimon/lang/cz_text.json
+++ b/src/Ankimon/lang/cz_text.json
@@ -33,6 +33,7 @@
   "open_ankimon_window_button": "Otevřít Ankimon okno",
   "itembag_button": "Taška s předměty",
   "achievements_button": "Úspěchy",
+  "monthly_challenge_button": "Měsíční výzva",
   "open_showdown_teambuilder_button": "Otevřít Pokemon Showdown Teambuilder",
   "export_main_pokemon_button": "Exportovat hlavního Pokémona do PkmnShowdown",
   "export_all_pokemon_button": "Exportovat všechny Pokemony do PkmnShowdown",

--- a/src/Ankimon/lang/de_text.json
+++ b/src/Ankimon/lang/de_text.json
@@ -33,6 +33,7 @@
   "open_ankimon_window_button": "Ankimon-Fenster öffnen",
   "itembag_button": "Itemtasche",
   "achievements_button": "Errungenschaften",
+  "monthly_challenge_button": "Monatliche Herausforderung",
   "open_showdown_teambuilder_button": "Pokémon Showdown Teambuilder öffnen",
   "export_main_pokemon_button": "Haupt-Pokémon zu PkmnShowdown exportieren",
   "export_all_pokemon_button": "Alle Pokémon zu PkmnShowdown exportieren",

--- a/src/Ankimon/lang/en_text.json
+++ b/src/Ankimon/lang/en_text.json
@@ -33,6 +33,7 @@
   "open_ankimon_window_button": "Open Ankimon Window",
   "itembag_button": "Itembag",
   "achievements_button": "Achievements",
+  "monthly_challenge_button": "Monthly Challenge",
   "open_showdown_teambuilder_button": "Open Pokemon Showdown Teambuilder",
   "export_main_pokemon_button": "Export Main Pokemon to PkmnShowdown",
   "export_all_pokemon_button": "Export All Pokemon to PkmnShowdown",

--- a/src/Ankimon/lang/es_latam_text.json
+++ b/src/Ankimon/lang/es_latam_text.json
@@ -33,6 +33,7 @@
   "open_ankimon_window_button": "Abrir ventana de Ankimon",
   "itembag_button": "Bolsa de objetos",
   "achievements_button": "Logros",
+  "monthly_challenge_button": "Desafío Mensual",
   "open_showdown_teambuilder_button": "Abrir Creador de Equipos de Pokémon Showdown",
   "export_main_pokemon_button": "Exportar Pokémon principal a PkmnShowdown",
   "export_all_pokemon_button": "Exportar todos los Pokémon a PkmnShowdown",

--- a/src/Ankimon/lang/fr_text.json
+++ b/src/Ankimon/lang/fr_text.json
@@ -33,6 +33,7 @@
   "open_ankimon_window_button": "Ouvrir la fenêtre Ankimon",
   "itembag_button": "Sac d'objets",
   "achievements_button": "Succès",
+  "monthly_challenge_button": "Défi Mensuel",
   "open_showdown_teambuilder_button": "Ouvrir le créateur d'équipe de Pokémon Showdown",
   "export_main_pokemon_button": "Exporter le Pokémon principal vers PkmnShowdown",
   "export_all_pokemon_button": "Exporter tous les Pokémon vers PkmnShowdown",

--- a/src/Ankimon/lang/it_text.json
+++ b/src/Ankimon/lang/it_text.json
@@ -33,6 +33,7 @@
   "open_ankimon_window_button": "Apri Finestra Ankimon",
   "itembag_button": "Borsa Oggetti",
   "achievements_button": "Obiettivi",
+  "monthly_challenge_button": "Sfida Mensile",
   "open_showdown_teambuilder_button": "Apri Pokemon Showdown Teambuilder",
   "export_main_pokemon_button": "Esporta Pokémon principale su PkmnShowdown",
   "export_all_pokemon_button": "Esporta tutti i Pokémon su PkmnShowdown",

--- a/src/Ankimon/lang/jp_text.json
+++ b/src/Ankimon/lang/jp_text.json
@@ -33,6 +33,7 @@
   "open_ankimon_window_button": "Ankimonウィンドウを開く",
   "itembag_button": "アイテムバッグ",
   "achievements_button": "実績",
+  "monthly_challenge_button": "月間チャレンジ",
   "open_showdown_teambuilder_button": "ポケモンショーダウンのチームビルダーを開く",
   "export_main_pokemon_button": "メインポケモンをPkmnShowdownへエクスポート",
   "export_all_pokemon_button": "すべてのポケモンをPkmnShowdownへエクスポート",

--- a/src/Ankimon/lang/kr_text.json
+++ b/src/Ankimon/lang/kr_text.json
@@ -33,6 +33,7 @@
   "open_ankimon_window_button": "Ankimon 창 열기",
   "itembag_button": "아이템 가방",
   "achievements_button": "업적",
+  "monthly_challenge_button": "월간 챌린지",
   "open_showdown_teambuilder_button": "포켓몬 쇼다운 팀 빌더 열기",
   "export_main_pokemon_button": "메인 포켓몬을 PkmnShowdown으로 내보내기",
   "export_all_pokemon_button": "모든 포켓몬을 PkmnShowdown으로 내보내기",

--- a/src/Ankimon/lang/po_text.json
+++ b/src/Ankimon/lang/po_text.json
@@ -33,6 +33,7 @@
   "open_ankimon_window_button": "Abrir Janela do Ankimon",
   "itembag_button": "Bolsa de Itens",
   "achievements_button": "Conquistas",
+  "monthly_challenge_button": "Desafio Mensal",
   "open_showdown_teambuilder_button": "Abrir Construtor de Equipe do Pokémon Showdown",
   "export_main_pokemon_button": "Exportar Pokémon Principal para o PkmnShowdown",
   "export_all_pokemon_button": "Exportar Todos os Pokémon para o PkmnShowdown",

--- a/src/Ankimon/lang/sp_text.json
+++ b/src/Ankimon/lang/sp_text.json
@@ -33,6 +33,7 @@
   "open_ankimon_window_button": "Abrir ventana de Ankimon",
   "itembag_button": "Bolsa de objetos",
   "achievements_button": "Logros",
+  "monthly_challenge_button": "Desafío Mensual",
   "open_showdown_teambuilder_button": "Abrir Creador de Equipos de Pokémon Showdown",
   "export_main_pokemon_button": "Exportar Pokémon principal a PkmnShowdown",
   "export_all_pokemon_button": "Exportar todos los Pokémon a PkmnShowdown",

--- a/src/Ankimon/menu_buttons.py
+++ b/src/Ankimon/menu_buttons.py
@@ -184,6 +184,12 @@ def create_menu_actions(
         )
         profile_menu.addAction(achievement_bag_action)
 
+        # Monthly Challenge
+        monthly_challenge_action = QAction("Monthly Challenge", mw)
+        monthly_challenge_action.setMenuRole(QAction.MenuRole.NoRole)
+        qconnect(monthly_challenge_action.triggered, lambda: _open_shell_at("monthly"))
+        profile_menu.addAction(monthly_challenge_action)
+        
         # Showdown Teambuilder
         pokemon_showdown_action = QAction(mw.translator.translate("open_showdown_teambuilder_button"), mw)
         pokemon_showdown_action.setMenuRole(QAction.MenuRole.NoRole)

--- a/src/Ankimon/menu_buttons.py
+++ b/src/Ankimon/menu_buttons.py
@@ -185,7 +185,7 @@ def create_menu_actions(
         profile_menu.addAction(achievement_bag_action)
 
         # Monthly Challenge
-        monthly_challenge_action = QAction("Monthly Challenge", mw)
+        monthly_challenge_action = QAction(mw.translator.translate("monthly_challenge_button"), mw)
         monthly_challenge_action.setMenuRole(QAction.MenuRole.NoRole)
         qconnect(monthly_challenge_action.triggered, lambda: _open_shell_at("monthly"))
         profile_menu.addAction(monthly_challenge_action)


### PR DESCRIPTION
### At A Glance, This PR 2 of 2
Adds a dedicated **window** for Ankimon's **Monthly Challenges**. 

### What This PR Does
This is the second and last (so far) PR to improve trainers' experience with the Ankimon Monthly Challenges and their presentation.
- Adds a **Monthly Challenge window** in **Ankimon > Profile > Monthly Challenge**
- Notable features/functionality of the new window:
  - Modern **view** of **past challenges and their results** (synced according to the live GitHub JSON). The results of a particular month **depend on the Shiny status of the following month**. Instead of considering the number of Mons defeated (which was the milestone set for the latest challenges), a Mon's Shiny status is chosen as the guideline in case the required milestone changes over time. 
  - Allows users to view the **current status** (Accepted/Rejected) of the **current month's challenge**. Users can **re-accept** and/or **re-reject** the monthly challenge in the window.
  - There's a quick **overview** of the **current month's Mon**, its stats, and if the challenge was accepted, key data that determine the challenge's success (or the journey so far): the Mon's level and number of defeated Mons. 

### What Each File Does

#### Files Modified:
1. **`ankidex.html`**, **`settings.html`**, **`shop.html`**, **`history.html`**, **`mobile.html`**, **`profile.html`**, and **`team.html`**: add Monthly Challenge to the **navigation bar** of every Web UI window
3. **`shop_obj.py`**: where the logic/code to **extract monthly challenge data** from the raw GitHub file resides
4. **`menu_buttons.py`**: adds the new "**Monthly Challenge" menu button** in Ankimon > Profile > Monthly Challenge

#### Files Created:
A new folder was created at the src root - `ankimon_monthly_challenge_web/` with the following files
1. **`monthly.css`**: styling
2. **`monthly.html`**: structure
3. **`monthly.js`**: logic

### Expected Behaviour
Trainers can view the Monthly Challenge window via Ankimon > Profile > Monthly Challenge and access it via other Web UI windows through the nav switcher.

#### Example View
<img width="1280" height="720" alt="20260902204559" src="https://github.com/user-attachments/assets/ec0f5dc3-31d2-4241-b6ce-6177d1875d31" />

### Related PR
 This PR **depends** on the **successful merge** of **#827**, which controls the accept/reject state of the monthly Mon. **Without** #827, the **Accept/Reject buttons** in the window **will not work** as the state is **not saved** in the database, `ankimon.db`. 

### Fixes
Special thanks for the suggestions in Discord for an option to reject Monthly Challenges, which inspired this window!

### Checklist
- [x] My code and commit messages follow the code style and guidelines of this project.
- [x] I have personally viewed the Monthly Challenge window, and it works as intended.