### PR TITLE
add(webUI): sets the standard pBall icon as window icons for all Web UI windows

### DIFF
--- a/src/Ankimon/ankimon_items_web/shop_obj.py
+++ b/src/Ankimon/ankimon_items_web/shop_obj.py
@@ -17,7 +17,7 @@ from datetime import datetime
 from aqt import QDialog, QVBoxLayout, QWebEngineView, QWebEnginePage, mw
 from aqt.qt import Qt, QUrl, QFrame, QWebEngineProfile
 from PyQt6.QtCore import QObject, pyqtSlot, QTimer, QByteArray
-from PyQt6.QtGui import QColor
+from PyQt6.QtGui import QColor, QIcon
 from PyQt6.QtWebChannel import QWebChannel
 from PyQt6.QtWidgets import QStackedWidget
 import csv

--- a/src/Ankimon/ankimon_items_web/shop_obj.py
+++ b/src/Ankimon/ankimon_items_web/shop_obj.py
@@ -32,7 +32,7 @@ except ImportError:  # dev helper not landed yet (thread-reload-and-misc-utils u
         return False
 
 
-from ..resources import items_path, csv_file_items_cost, csv_file_descriptions
+from ..resources import items_path, csv_file_items_cost, csv_file_descriptions, icon_path
 
 
 class SafeWebEnginePage(QWebEnginePage):
@@ -1074,6 +1074,7 @@ class AnkimonItemsWeb(QDialog):
         self._live_refresh_pending = False
         self.current_screen = None
         self.setWindowTitle("Ankimon")
+        self.setWindowIcon(QIcon(str(icon_path)))
 
         # Paint the shell dark from the first frame. The web views set their
         # own page background, but the surrounding QDialog/QFrame/QStackedWidget


### PR DESCRIPTION
### At A Glance, This PR
Sets a **Pokéball icon** as the **window icon** for **all Web UI windows** (Settings, Shop, Ankidex, etc.).  

### What This PR Does
A **standard icon** for Ankimon windows allows them to have an **Ankimon-native presentation**. This also provides a consistent impression to users. 

### What Was Changed
Only **`shop_obj.py`**, the file that unites all Web UI windows into one collective window, is modified. The **PBall icon** is **imported** from **`resources`** and set as the **window icon** for the Web UI window(s). 

### Expected Behaviour
The default console/Anki icon is now replaced with a PBall icon.

#### Then
<img width="974" height="588" alt="image" src="https://github.com/user-attachments/assets/3b36cb93-4141-4563-ad48-508beac64373" />

#### Now
<img width="971" height="580" alt="image" src="https://github.com/user-attachments/assets/3492a675-f42f-4a80-9af6-ec1fa58fec8b" />

_(with sprites disabled on my end)_

### Related Issues
_N/A_

### Checklist
- [x] My code and commit messages follow the code style and guidelines of this project.
- [x] I have personally viewed all Web UI windows and verified that the default "console" icon is now replaced with a definitive PBall icon. 