### PR TITLE
bug(navSwitcher): menu bar unscrollable/clips off-screen

### DIFF
--- a/src/Ankimon/ankimon_items_web/nav-switcher.css
+++ b/src/Ankimon/ankimon_items_web/nav-switcher.css
@@ -72,10 +72,30 @@
     gap: 2px;
     animation: navMenuPop 0.16s cubic-bezier(0.22, 1, 0.36, 1);
     transform-origin: top left;
+    max-height: min(60vh, 400px);
+    overflow-y: auto;
+    overscroll-behavior: contain;
 }
 
 .nav-menu.hidden {
     display: none;
+}
+
+.nav-menu::-webkit-scrollbar {
+    width: 4px;
+}
+
+.nav-menu::-webkit-scrollbar-track {
+    background: transparent;
+}
+
+.nav-menu::-webkit-scrollbar-thumb {
+    background: var(--border-main);
+    border-radius: 4px;
+}
+
+.nav-menu::-webkit-scrollbar-thumb:hover {
+    background: var(--text-muted);
 }
 
 @keyframes navMenuPop {
@@ -97,6 +117,7 @@
     font-family: inherit;
     text-align: left;
     transition: 0.15s ease;
+    flex-shrink: 0;
 }
 
 .nav-menu-item:hover {
@@ -146,6 +167,7 @@
     display: flex;
     flex-direction: column;
     gap: 2px;
+    min-width: 0;
 }
 
 .nav-menu-title {


### PR DESCRIPTION
### At A Glance, This PR
Fixes the **navigation bar** in **Web UI windows** that are **unscrollable** and, as menu buttons increase, freeze menu buttons **off-screen** (thus rendering them unclickable and unusable). 

### Cause of Bug
The **`.nav-menu`** dropdown was **missing several properties**:
- **`max-height`** to limit the menu height
- **`overflow-y: auto`** to enable scrolling when content exceeds the max height
- **`overscroll-behavior: contain`** to prevent scroll from propagating

### What Was Fixed
Adds the listed properties to **`ankimon_items_web/nav-switcher.css`**. Also adds scrollbar styling, `flex-shrink` to prevent content from shrinking, and `min-width` to help with text truncation (where text is tailed with an ellipsis "..." to avoid overflow). 

### Expected Behaviour
Bar now scrolls.

#### Then
<img width="883" height="455" alt="image" src="https://github.com/user-attachments/assets/13c94bbe-1d4b-4a9c-8d6d-f2964b15e63d" />

#### Now
<img width="882" height="457" alt="image" src="https://github.com/user-attachments/assets/76d5a447-4d3b-4b72-aa43-c16ecac04951" />

### Related Issues
This bug was found during ongoing updates to move Ankimon windows to the Web UI group. 

### Checklist
- [x] My code and commit messages follow the code style and guidelines of this project.
- [x] I have personally tested that the navigation bars are scrollable and no longer clip out of view.