### PR TITLE
bug(settings): settings launching back to top with every setting change

### DIFF
--- a/src/Ankimon/ankimon_items_web/settings.js
+++ b/src/Ankimon/ankimon_items_web/settings.js
@@ -600,11 +600,23 @@
                     }
                     setEdit(setting.key, nextValue);
                 }
-                renderAll();  // refresh control + dirty pip
+                updateToggleButtons(wrap, setting.key);
+                updateDirtyUI();
+                markRowDirty(setting.key);
             });
             wrap.appendChild(btn);
         });
         return wrap;
+    }
+
+    function updateToggleButtons(wrap, key) {
+        const value = getSettingValue(key);
+        const btns = wrap.querySelectorAll('.setting-toggle-option');
+        btns.forEach((btn, idx) => {
+            const isOn = (idx === 0 && value) || (idx === 1 && !value);
+            btn.classList.toggle('active', isOn);
+            btn.classList.toggle('off', idx === 1);
+        });
     }
 
     function syncHudTogglesForSpriteVisibility() {
@@ -636,7 +648,8 @@
         sel.addEventListener('change', () => {
             const raw = sel.value === '__null__' ? null : sel.value;
             setEdit(setting.key, raw);
-            renderAll();
+            updateDirtyUI();
+            markRowDirty(setting.key);
         });
         return sel;
     }

--- a/src/Ankimon/ankimon_items_web/settings.js
+++ b/src/Ankimon/ankimon_items_web/settings.js
@@ -594,12 +594,7 @@
                     state.explicitHudOverrides.clear();
                     setEdit(setting.key, nextValue);
                     syncHudTogglesForSpriteVisibility();
-                    HUD_TOGGLE_AUTO_SYNC_KEYS.forEach((key) => {
-                        const row = Array.from(document.querySelectorAll('.setting-row'))
-                            .find((candidate) => candidate.dataset.key === key);
-                        const toggle = row && row.querySelector('.setting-toggle');
-                        if (toggle) updateToggleButtons(toggle, key);
-                    });
+                    HUD_TOGGLE_AUTO_SYNC_KEYS.forEach(refreshBooleanControl);
                 } else {
                     if (HUD_TOGGLE_AUTO_SYNC_KEYS.includes(setting.key)) {
                         state.explicitHudOverrides.add(setting.key);
@@ -613,6 +608,22 @@
             wrap.appendChild(btn);
         });
         return wrap;
+    }
+
+    /**
+     * Repaints whichever control currently renders `key` after its value was
+     * changed programmatically. Every HUD element ships as a `.setting-chip`
+     * inside one shared chip row rather than as its own boolean row, so a
+     * `.setting-row`-only lookup would silently refresh nothing; the toggle
+     * branch keeps working if a key is ever promoted to a row of its own.
+     */
+    function refreshBooleanControl(key) {
+        const value = !!getSettingValue(key);
+        const selector = cssEscape(key);
+        document.querySelectorAll(`.setting-chip[data-key="${selector}"]`)
+            .forEach((chip) => chip.classList.toggle('active', value));
+        document.querySelectorAll(`.setting-row[data-key="${selector}"] .setting-toggle`)
+            .forEach((toggle) => updateToggleButtons(toggle, key));
     }
 
     function updateToggleButtons(wrap, key) {

--- a/src/Ankimon/ankimon_items_web/settings.js
+++ b/src/Ankimon/ankimon_items_web/settings.js
@@ -594,6 +594,12 @@
                     state.explicitHudOverrides.clear();
                     setEdit(setting.key, nextValue);
                     syncHudTogglesForSpriteVisibility();
+                    HUD_TOGGLE_AUTO_SYNC_KEYS.forEach((key) => {
+                        const row = Array.from(document.querySelectorAll('.setting-row'))
+                            .find((candidate) => candidate.dataset.key === key);
+                        const toggle = row && row.querySelector('.setting-toggle');
+                        if (toggle) updateToggleButtons(toggle, key);
+                    });
                 } else {
                     if (HUD_TOGGLE_AUTO_SYNC_KEYS.includes(setting.key)) {
                         state.explicitHudOverrides.add(setting.key);

--- a/tests/test_settings_plumbing_f28.py
+++ b/tests/test_settings_plumbing_f28.py
@@ -33,6 +33,7 @@ Runs Qt-free (Tier-1 / venv_t1): ``Settings`` imports only ``json``/``os``/
 """
 
 import importlib.util
+import re
 import sys
 import types
 from pathlib import Path
@@ -396,3 +397,62 @@ def test_sprite_visibility_web_override_metadata_and_scope_are_wired():
     assert "SCREEN_TEAM" in allowlist
     assert "SCREEN_MOBILE" not in allowlist
     assert "SCREEN_HISTORY" not in allowlist
+
+
+def _load_settings_schema():
+    schema_path = _src / "Ankimon" / "ankimon_items_web" / "settings_schema.py"
+    spec = importlib.util.spec_from_file_location(
+        "_ankimon_settings_schema_f28", schema_path
+    )
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _schema_chip_keys(schema):
+    keys = set()
+    for group in schema.GROUPS:
+        containers = [group, *group.get("subgroups", [])]
+        for container in containers:
+            chip_def = container.get("chip_group")
+            if not chip_def:
+                continue
+            keys.update(key for key, _label in chip_def["keys"])
+    return keys
+
+
+def test_sprite_visibility_sync_repaints_the_chip_controls():
+    """The HUD auto-sync keys are chips, so the post-sync repaint must find them.
+
+    Toggling "Show Sprites Across Ankimon" rewrites every HUD element key in
+    ``state.edits``. Each of those keys is rendered as a ``.setting-chip``
+    button inside one shared chip row, never as its own ``.setting-row`` with a
+    ``.setting-toggle``, so a repaint that only walks setting rows matches
+    nothing and leaves the whole HUD block visually stale while the dirty
+    counter climbs.
+    """
+    settings_js = (
+        _src / "Ankimon" / "ankimon_items_web" / "settings.js"
+    ).read_text(encoding="utf-8")
+    schema = _load_settings_schema()
+
+    js_keys = set(
+        re.findall(
+            r"'([\w.]+)'",
+            settings_js.split("HUD_TOGGLE_AUTO_SYNC_KEYS = [", 1)[1].split("]", 1)[0],
+        )
+    )
+    assert js_keys, "HUD_TOGGLE_AUTO_SYNC_KEYS is empty or unparseable"
+    assert js_keys <= _schema_chip_keys(schema), (
+        "auto-synced HUD keys must be chip keys — if one ever becomes a "
+        "standalone row, revisit the repaint helper below"
+    )
+
+    repaint = re.search(
+        r"HUD_TOGGLE_AUTO_SYNC_KEYS\.forEach\((\w+)\)", settings_js
+    )
+    assert repaint, "master toggle no longer repaints the synced HUD controls"
+    helper = settings_js.split(f"function {repaint.group(1)}(", 1)[1]
+    assert ".setting-chip[data-key=" in helper.split("\n    }", 1)[0], (
+        "the repaint helper must target chip buttons, not setting rows alone"
+    )


### PR DESCRIPTION
### At A Glance, This PR
Fixes the bug where **Settings** kept **launching to the top** of the list - right back to General - with **every setting change**, including but not limited to changes in sections like Sound and Styling. This interrupts UX and makes it nearly impossible for trainers to experience a smooth customisation experience.

### Cause of Bug
In the original code, the `buildToggle` and `buildSelect` functions **called `renderAll()`** after **every user interaction**. The renderAll() function calls renderContent(), which:
- **Destroys** the entire **DOM tree** of all setting rows
- **Rebuilds** every single **setting row** from scratch using `buildSettingRow()` and its children
- And when the **DOM is completely replaced**, the browser resets the scroll position to the top of the container

#### To Fix the Bug
**`renderAll()` calls were removed** and replaced with targeted updates.

### Expected Behaviour
Freely toggle any setting in Settings and nothing launches or jumps. 

#### Bugged
<img width="400" height="225" alt="20260904110152" src="https://github.com/user-attachments/assets/076fb0a7-d078-4655-bce5-139b5dec11b8" />

#### Fixed
<img width="400" height="225" alt="20260904105709" src="https://github.com/user-attachments/assets/2b5dbd8a-af9e-4f10-97d6-150d6d751ebc" />

### Related Issues
Special thanks to Ouranos for enlightening this bug!

### Checklist
- [x] My code and commit messages follow the code style and guidelines of this project.
- [x] I have personally tested the fixed Settings window and verified that it no longer jigs. 