### PR TITLE
fix: hide review multiplier in battle log when setting is disabled

### DIFF
--- a/src/Ankimon/battle_loop.py
+++ b/src/Ankimon/battle_loop.py
@@ -260,6 +260,8 @@ def on_review_card(*args):
             enemy_pokemon.battle_status = validate_pokemon_status(enemy_pokemon)
             main_pokemon.battle_status = validate_pokemon_status(main_pokemon)
 
+            is_review_based_damage_enabled = settings_obj.get("battle.review_based_damage", True)
+
             formatted_battle_log = process_battle_data(
                 battle_info=battle_info,
                 multiplier=multiplier,
@@ -275,6 +277,7 @@ def on_review_card(*args):
                 pokemon_encounter=ankimon_tracker_obj.pokemon_encounter,
                 translator=translator,
                 changes=current_battle_info_changes,
+                review_based_damage=is_review_based_damage_enabled,
             )
 
             tooltipWithColour(formatted_battle_log, color)
@@ -301,12 +304,15 @@ def on_review_card(*args):
             if true_dmg_from_user_move > 0:
                 reviewer_obj.seconds = settings_obj.compute_special_variable("animate_time")
                 tooltipWithColour(f" -{true_dmg_from_user_move} HP ", "#F06060", x=200)
-                if multiplier == 1:
+                if is_review_based_damage_enabled:
+                    if multiplier == 1:
+                        play_effect_sound(settings_obj, "HurtNormal")
+                    elif multiplier < 1:
+                        play_effect_sound(settings_obj, "HurtNotEffective")
+                    elif multiplier > 1:
+                        play_effect_sound(settings_obj, "HurtSuper")
+                else:
                     play_effect_sound(settings_obj, "HurtNormal")
-                elif multiplier < 1:
-                    play_effect_sound(settings_obj, "HurtNotEffective")
-                elif multiplier > 1:
-                    play_effect_sound(settings_obj, "HurtSuper")
             else:
                 reviewer_obj.seconds = 0
 

--- a/src/Ankimon/functions/battle_functions.py
+++ b/src/Ankimon/functions/battle_functions.py
@@ -634,6 +634,7 @@ def process_battle_data(
     pokemon_encounter: int,
     translator,
     changes,
+    review_based_damage: bool = True,
 ) -> str:
     """
     Generate complete battle message from battle data.
@@ -650,12 +651,13 @@ def process_battle_data(
 
     try:
         # 1. Multiplier display
-        formatted_multiplier = f"{multiplier:.1f}"
-        message_parts.append(
-            translator.translate(
-                "battle_multiplier_display", multiplier=formatted_multiplier
+        if review_based_damage:
+            formatted_multiplier = f"{multiplier:.1f}"
+            message_parts.append(
+                translator.translate(
+                    "battle_multiplier_display", multiplier=formatted_multiplier
+                )
             )
-        )
 
         # 2. Enemy attack section
         if enemy_attack and enemy_attack != constants.DO_NOTHING_MOVE:
@@ -721,7 +723,9 @@ def process_battle_data(
             exception=e, message="Critical error generating battle message"
         )
         error_msg = translator.translate("battle_processing_error", error=str(e)[:100])
-        return f"{translator.translate('battle_multiplier_display', multiplier=multiplier)}\n{error_msg}"
+        if review_based_damage:
+            return f"{translator.translate('battle_multiplier_display', multiplier=multiplier)}\n{error_msg}"
+        return error_msg
 
 
 def _handle_special_battle_status(main_pokemon, battle_status: str, translator) -> str:


### PR DESCRIPTION
Resolves an issue where disabling the "Review Based Damage" setting still caused the review multiplier to visually appear in the battle log and incorrectly trigger multiplier-based sound effects.

---
*PR created automatically by Jules for task [15090308768925445833](https://jules.google.com/task/15090308768925445833) started by @h0tp-ftw*