### PR TITLE
fix(evolve): grant level-0 moves on evolution, and normalize battle_status

### DIFF
--- a/src/Ankimon/functions/battle_functions.py
+++ b/src/Ankimon/functions/battle_functions.py
@@ -595,7 +595,13 @@ def validate_pokemon_status(pokemon):
         "fighting",
     }
 
-    current_status = str(getattr(pokemon, "battle_status", None) or "fighting").lower()
+    # Mirror PokemonObject._normalize_battle_status: strip + lower, None/blank
+    # means healthy. A padded "  par  " must stay "par", not fall through the
+    # invalid-status branch and be silently reset to "fighting".
+    current_status = (
+        str(getattr(pokemon, "battle_status", None) or "").strip().lower()
+        or "fighting"
+    )
 
     # Ensure volatile_status exists
     if not hasattr(pokemon, "volatile_status"):

--- a/src/Ankimon/functions/battle_functions.py
+++ b/src/Ankimon/functions/battle_functions.py
@@ -595,7 +595,7 @@ def validate_pokemon_status(pokemon):
         "fighting",
     }
 
-    current_status = getattr(pokemon, "battle_status", "fighting")
+    current_status = str(getattr(pokemon, "battle_status", None) or "fighting").lower()
 
     # Ensure volatile_status exists
     if not hasattr(pokemon, "volatile_status"):

--- a/src/Ankimon/functions/learnset_retrieval.py
+++ b/src/Ankimon/functions/learnset_retrieval.py
@@ -255,3 +255,16 @@ def get_levelup_move_for_pokemon(pokemon_name, pokemon_level, generation=9):
     return [
         move for move, learn_level in all_moves.items() if learn_level == pokemon_level
     ]
+
+
+def get_evolution_moves_for_pokemon(pokemon_name, pokemon_level, generation=9):
+    """Return the moves this species learns *on evolution* (never None).
+
+    Showdown encodes those as level 0 ("9L0"), which is not a level any Pokemon
+    ever reaches, so they can only be granted by evolving. Keep them out of
+    get_levelup_move_for_pokemon: that one runs on every single level-up, and a
+    move that is never "learned at this level" would be re-offered forever.
+    """
+    all_moves = _get_learnset_moves(pokemon_name, pokemon_level, generation)
+
+    return [move for move, learn_level in all_moves.items() if learn_level == 0]

--- a/src/Ankimon/functions/pokemon_functions.py
+++ b/src/Ankimon/functions/pokemon_functions.py
@@ -262,3 +262,4 @@ def save_fossil_pokemon(pokemon_id):
     db.save_pokemon(caught_pokemon)
 
 from .learnset_retrieval import get_levelup_move_for_pokemon  # noqa: F401,E303 — re-export for backwards compat
+from .learnset_retrieval import get_evolution_moves_for_pokemon  # noqa: F401,E303 — re-export for backwards compat

--- a/src/Ankimon/pyobj/evolution_window.py
+++ b/src/Ankimon/pyobj/evolution_window.py
@@ -635,7 +635,9 @@ class EvoWindow(QWidget):
             # Add logic to learn new moves
             attacks = pokemon_to_update.get("attacks", [])
             level = pokemon_to_update.get("level", 1)
-            new_attacks = _moves_gained_on_evolution(prevo_name.lower(), int(level))
+            # Level-up moves only: the Pokemon stays as prevo_name, so the
+            # evolution-only ("9L0") moves must not be granted here.
+            new_attacks = get_levelup_move_for_pokemon(prevo_name.lower(), int(level))
 
             for new_attack in new_attacks:
                 if new_attack not in attacks:

--- a/src/Ankimon/pyobj/evolution_window.py
+++ b/src/Ankimon/pyobj/evolution_window.py
@@ -26,7 +26,10 @@ from ..functions.pokedex_functions import (
     return_name_for_id,
     search_pokedex,
 )
-from ..functions.pokemon_functions import get_random_moves_for_pokemon
+from ..functions.pokemon_functions import (
+    get_evolution_moves_for_pokemon,
+    get_levelup_move_for_pokemon,
+)
 from ..functions.battle_functions import calculate_hp
 from ..functions.update_main_pokemon import (
     update_main_pokemon,
@@ -46,6 +49,16 @@ from ..resources import (
     frontdefault,
     evolve_image_path,
 )
+
+
+def _moves_gained_on_evolution(species_name, level):
+    """Level-up moves for *level* plus the moves granted by evolving, deduped."""
+    moves = get_levelup_move_for_pokemon(species_name, level)
+    for move in get_evolution_moves_for_pokemon(species_name, level):
+        if move not in moves:
+            moves.append(move)
+
+    return moves
 
 
 class EvoWindow(QWidget):
@@ -394,7 +407,7 @@ class EvoWindow(QWidget):
             pokemon["id"] = evo_id
             pokemon["type"] = search_pokedex(evo_name.lower(), "types")
             attacks = pokemon["attacks"]
-            new_attacks = get_random_moves_for_pokemon(
+            new_attacks = _moves_gained_on_evolution(
                 evo_name.lower(), int(pokemon["level"])
             )
             for new_attack in new_attacks:
@@ -455,7 +468,9 @@ class EvoWindow(QWidget):
             ev = pokemon["ev"]
             level = pokemon["level"]
             hp = calculate_hp(hp_stat, level, ev, iv)
+            pokemon["hp"] = int(hp)
             pokemon["current_hp"] = int(hp)
+            pokemon["battle_status"] = "fighting"
             try:
                 pokemon["growth_rate"] = get_growth_rate(int(evo_id))
             except (ValueError, TypeError):
@@ -620,7 +635,7 @@ class EvoWindow(QWidget):
             # Add logic to learn new moves
             attacks = pokemon_to_update.get("attacks", [])
             level = pokemon_to_update.get("level", 1)
-            new_attacks = get_random_moves_for_pokemon(prevo_name.lower(), int(level))
+            new_attacks = _moves_gained_on_evolution(prevo_name.lower(), int(level))
 
             for new_attack in new_attacks:
                 if new_attack not in attacks:

--- a/src/Ankimon/pyobj/pokemon_obj.py
+++ b/src/Ankimon/pyobj/pokemon_obj.py
@@ -619,7 +619,7 @@ class PokemonObject:
                     ["hp", "atk", "def", "spa", "spd", "spe"], engine_data["ivs"]
                 )
             },
-            battlestatus=engine_data.get("status", "fighting"),
+            battle_status=engine_data.get("status", "fighting"),
             moves=engine_data["moves"],
             stat_stages={
                 "atk": engine_data["stat_stages"]["attack"],

--- a/src/Ankimon/pyobj/pokemon_obj.py
+++ b/src/Ankimon/pyobj/pokemon_obj.py
@@ -117,7 +117,7 @@ class PokemonObject:
         self.friendship = friendship
 
         # Battle and status
-        self.battle_status = str(battle_status)
+        self.battle_status = self._normalize_battle_status(battle_status)
         self.position = (
             tuple(position) if isinstance(position, (list, tuple)) else (0, 0)
         )
@@ -465,6 +465,21 @@ class PokemonObject:
     })
 
     @staticmethod
+    def _normalize_battle_status(value):
+        """Return a lowercase status string; None/blank means healthy.
+
+        Every comparison in the codebase is against lowercase literals
+        ("fighting", "fainted", ...), and update_stats() writes whatever the
+        database row holds — including None for older records — straight onto
+        the attribute. Normalising here keeps validate_pokemon_status() and
+        to_engine_format() from seeing a None or a capitalised "Fighting".
+        """
+        if value is None:
+            return "fighting"
+
+        return str(value).strip().lower() or "fighting"
+
+    @staticmethod
     def _normalize_hp(value, fallback, max_hp):
         """Return an integer HP value constrained to the Pokemon's valid range."""
         try:
@@ -498,12 +513,15 @@ class PokemonObject:
         hp_fallback = raw_current_hp if raw_current_hp is not None else self.max_hp
         self.hp = self._normalize_hp(raw_hp, hp_fallback, self.max_hp)
         self.current_hp = self._normalize_hp(raw_current_hp, self.hp, self.max_hp)
+        self.battle_status = self._normalize_battle_status(
+            getattr(self, "battle_status", None)
+        )
         self._update_battle_stats()  # Update battle stats
 
     def reset_stats(self):
         """Reset the stats of the Pokémon to default values."""
         self.hp = self.max_hp
-        self.battle_status = "Fighting"
+        self.battle_status = "fighting"
         self._update_battle_stats()
 
     def _update_battle_stats(self):

--- a/tests/test_battle_functions.py
+++ b/tests/test_battle_functions.py
@@ -40,3 +40,18 @@ def test_validate_pokemon_status_healed():
 def test_validate_pokemon_status_normal():
     poke = MockPokemon(50, "fighting")
     assert validate_pokemon_status(poke) == "fighting"
+
+
+@pytest.mark.parametrize("raw", [None, "", "Fighting", "  FIGHTING  "])
+def test_validate_pokemon_status_tolerates_unnormalized_status(raw):
+    """PokemonObject.update_stats() writes the database row straight onto the
+    attribute, so battle_status can arrive as None or capitalised. battle_loop
+    calls this every turn, so it must not raise."""
+    assert validate_pokemon_status(MockPokemon(50, raw)) == "fighting"
+
+
+def test_validate_pokemon_status_without_the_attribute():
+    class Bare:
+        hp = 50
+
+    assert validate_pokemon_status(Bare()) == "fighting"

--- a/tests/test_battle_functions.py
+++ b/tests/test_battle_functions.py
@@ -50,6 +50,14 @@ def test_validate_pokemon_status_tolerates_unnormalized_status(raw):
     assert validate_pokemon_status(MockPokemon(50, raw)) == "fighting"
 
 
+@pytest.mark.parametrize("raw, expected", [("  PAR  ", "par"), ("Fainted", "fainted")])
+def test_validate_pokemon_status_preserves_padded_or_capitalised_real_status(raw, expected):
+    """Normalising must not turn a real status into "fighting": a padded "  par  "
+    is still paralysed, and a capitalised "Fainted" at 0 HP is still fainted."""
+    hp = 0 if expected == "fainted" else 50
+    assert validate_pokemon_status(MockPokemon(hp, raw)) == expected
+
+
 def test_validate_pokemon_status_without_the_attribute():
     class Bare:
         hp = 50

--- a/tests/test_evolution_item_consumption.py
+++ b/tests/test_evolution_item_consumption.py
@@ -145,7 +145,7 @@ def _apply_common_patches():
     p = "Ankimon.pyobj.evolution_window."
     handles = {
         "search": patch(p + "search_pokedex").start(),
-        "moves": patch(p + "get_random_moves_for_pokemon").start(),
+        "moves": patch(p + "_moves_gained_on_evolution").start(),
         "hp": patch(p + "calculate_hp").start(),
         "growth": patch(p + "get_growth_rate").start(),
         "base_exp": patch(p + "get_base_experience").start(),
@@ -430,7 +430,7 @@ def test_cancel_evolution_establishes_modality_before_foregrounding_move_dialog(
     events = _install_dialog_order_probe(evo_mod)
 
     with patch(
-        "Ankimon.pyobj.evolution_window.get_random_moves_for_pokemon",
+        "Ankimon.pyobj.evolution_window._moves_gained_on_evolution",
         return_value=["quick-attack"],
     ):
         win = _make_evo_window(evo_mod)

--- a/tests/test_evolution_item_consumption.py
+++ b/tests/test_evolution_item_consumption.py
@@ -430,7 +430,7 @@ def test_cancel_evolution_establishes_modality_before_foregrounding_move_dialog(
     events = _install_dialog_order_probe(evo_mod)
 
     with patch(
-        "Ankimon.pyobj.evolution_window._moves_gained_on_evolution",
+        "Ankimon.pyobj.evolution_window.get_levelup_move_for_pokemon",
         return_value=["quick-attack"],
     ):
         win = _make_evo_window(evo_mod)
@@ -438,3 +438,93 @@ def test_cancel_evolution_establishes_modality_before_foregrounding_move_dialog(
         win.cancel_evolution("some-uuid", "eevee")
 
     assert events == ["scheduled", "exec", "raise", "activate", "delete"]
+
+
+def test_moves_gained_on_evolution_unions_levelup_and_evolution_moves():
+    """Evolving grants this level's level-up moves plus the species' "9L0"
+    on-evolution moves, deduped and level-up first."""
+    evo_mod, _ = _load_evo_window()
+
+    p = "Ankimon.pyobj.evolution_window."
+    with (
+        patch(p + "get_levelup_move_for_pokemon", return_value=["tackle", "vinewhip"]),
+        patch(
+            p + "get_evolution_moves_for_pokemon",
+            return_value=["petalblizzard", "tackle"],
+        ),
+    ):
+        assert evo_mod._moves_gained_on_evolution("venusaur", 32) == [
+            "tackle",
+            "vinewhip",
+            "petalblizzard",
+        ]
+
+
+def test_evolve_pokemon_persists_evolution_only_move():
+    """A "9L0" move granted on evolution must land in the saved attack list."""
+    evo_mod, _ = _load_evo_window()
+    mock_db = MagicMock()
+    evo_mod.services.db = mock_db
+
+    handles = _apply_common_patches()
+    try:
+        handles["search"].side_effect = lambda name, key: (
+            ["Grass"] if key == "types" else {"hp": 80} if key == "baseStats" else {}
+        )
+        handles["moves"].return_value = ["petalblizzard"]
+        mock_db.get_pokemon.return_value = {
+            "id": 2,
+            "name": "Ivysaur",
+            "level": 32,
+            "attacks": ["tackle"],
+            "iv": {},
+            "ev": {},
+            "xp": 100,
+        }
+
+        win = _make_evo_window(evo_mod)
+        win.evolve_pokemon(
+            individual_id="some-uuid",
+            prevo_id=2,
+            prevo_name="ivysaur",
+            evo_id=3,
+            evo_name="venusaur",
+            main_pokemon=None,
+        )
+
+        handles["moves"].assert_called_once_with("venusaur", 32)
+        saved = mock_db.save_pokemon.call_args[0][0]
+        assert saved["attacks"] == ["tackle", "petalblizzard"]
+        assert saved["battle_status"] == "fighting"
+    finally:
+        patch.stopall()
+
+
+def test_cancel_evolution_grants_levelup_moves_but_not_evolution_moves():
+    """Declining keeps the Pokemon as its pre-evolution, so it may still learn
+    this level's ordinary move, but never the evolution-only "9L0" move."""
+    evo_mod, _ = _load_evo_window()
+    mock_db = MagicMock()
+    mock_db.get_pokemon.return_value = {
+        "id": 2,
+        "name": "Ivysaur",
+        "level": 32,
+        "attacks": ["tackle"],
+    }
+    evo_mod.services.db = mock_db
+
+    p = "Ankimon.pyobj.evolution_window."
+    with (
+        patch(p + "get_levelup_move_for_pokemon", return_value=["sleeppowder"]),
+        patch(
+            p + "get_evolution_moves_for_pokemon", return_value=["petalblizzard"]
+        ) as evo_moves,
+    ):
+        win = _make_evo_window(evo_mod)
+        win.main_pokemon = None
+        win.cancel_evolution("some-uuid", "ivysaur")
+
+    evo_moves.assert_not_called()
+    saved = mock_db.save_pokemon.call_args[0][0]
+    assert saved["attacks"] == ["tackle", "sleeppowder"]
+    assert saved["evolution_rejected"] is True

--- a/tests/test_learnset_retrieval.py
+++ b/tests/test_learnset_retrieval.py
@@ -54,6 +54,7 @@ _spec.loader.exec_module(_lr)
 from Ankimon.functions.learnset_retrieval import (
     _get_learnset_moves,
     get_all_pokemon_moves,
+    get_evolution_moves_for_pokemon,
     get_levelup_move_for_pokemon,
     get_random_moves_for_pokemon,
 )
@@ -116,6 +117,14 @@ FAKE_LEARNSET = {
         "learnset": {
             "ember": ["9L1"],
             "flareblitz": ["9L62", "9S11"],
+        }
+    },
+    # "9L0" is Showdown's code for a move learned ON EVOLUTION, not one learned
+    # at level 0 (no Pokemon is ever level 0).
+    "venusaur": {
+        "learnset": {
+            "tackle": ["9L1"],
+            "petalblizzard": ["9L0"],
         }
     },
 }
@@ -222,6 +231,30 @@ class TestGetLevelupMove:
     def test_no_match_returns_empty_list(self):
         result = get_levelup_move_for_pokemon("slowpoke", 13, 9)
         assert result == []
+
+
+class TestEvolutionMovesAreNotLevelupMoves:
+    """A "9L0" move is granted by evolving, not by reaching a level.
+
+    get_levelup_move_for_pokemon runs on every single level-up, so a move that is
+    never "learned at this level" must not surface from it — otherwise it is
+    re-offered at every level for the rest of the Pokemon's life.
+    """
+
+    def test_levelup_never_returns_an_evolution_move(self):
+        for level in (1, 2, 20, 50, 100):
+            assert "petalblizzard" not in get_levelup_move_for_pokemon(
+                "venusaur", level, 9
+            )
+
+    def test_levelup_still_returns_the_exact_level_move(self):
+        assert get_levelup_move_for_pokemon("venusaur", 1, 9) == ["tackle"]
+
+    def test_evolution_helper_returns_the_evolution_move(self):
+        assert get_evolution_moves_for_pokemon("venusaur", 32, 9) == ["petalblizzard"]
+
+    def test_evolution_helper_excludes_ordinary_levelup_moves(self):
+        assert get_evolution_moves_for_pokemon("slowpoke", 50, 9) == []
 
 
 class TestEventSCodesExcluded:

--- a/tests/test_pokemon_obj_persistence.py
+++ b/tests/test_pokemon_obj_persistence.py
@@ -143,6 +143,44 @@ def test_pokemon_object_normalizes_explicit_hp(hp):
     assert pokemon.current_hp == expected_hp
 
 
+@pytest.mark.parametrize(
+    "raw, expected",
+    [
+        (None, "fighting"),
+        ("", "fighting"),
+        ("Fighting", "fighting"),
+        ("  FAINTED  ", "fainted"),
+        ("fainted", "fainted"),
+    ],
+)
+def test_battle_status_normalized_by_constructor(raw, expected):
+    _services, _AnkimonDB, PokemonObject = _load_seam_and_pokemon_obj()
+
+    assert _make_pokemon(PokemonObject, battle_status=raw).battle_status == expected
+
+
+@pytest.mark.parametrize(
+    "raw, expected",
+    [
+        (None, "fighting"),
+        ("", "fighting"),
+        ("Fighting", "fighting"),
+        ("  FAINTED  ", "fainted"),
+    ],
+)
+def test_battle_status_normalized_by_update_stats(raw, expected):
+    """update_stats() bypasses __init__ and writes the database row straight
+    onto the attribute, so a record holding None used to leave battle_status as
+    None — and validate_pokemon_status() then raised AttributeError on .lower().
+    """
+    _services, _AnkimonDB, PokemonObject = _load_seam_and_pokemon_obj()
+    pokemon = _make_pokemon(PokemonObject)
+
+    pokemon.update_stats(battle_status=raw)
+
+    assert pokemon.battle_status == expected
+
+
 # --------------------------------------------------------------------------- #
 # Held-item persistence (re-fit of exp tests/test_held_items.py onto the seam) #
 # --------------------------------------------------------------------------- #
@@ -428,6 +466,7 @@ def _load_pokemon_functions_with_stubs(base_stats):
     lr = types.ModuleType("Ankimon.functions.learnset_retrieval")
     lr.get_random_moves_for_pokemon = lambda name, level: ["Tackle"]
     lr.get_levelup_move_for_pokemon = lambda *a, **k: []
+    lr.get_evolution_moves_for_pokemon = lambda *a, **k: []
     sys.modules["Ankimon.functions.learnset_retrieval"] = lr
     setattr(sys.modules["Ankimon.functions"], "learnset_retrieval", lr)
 


### PR DESCRIPTION
Redo of #817, which I reverted in 4553984e. Same feature, with the two regressions that reached `main` fixed and pinned by tests.

### What happened to #817

I merged it against a branch head that had moved — the review fixes were reverted on the PR branch shortly before the merge, so the squash landed the original implementation while its message claimed the corrections were in it. My mistake; I should have re-checked the head SHA at merge time. Both regressions went live on `main` until the revert.

### 1. Level-0 moves leaked into every level-up

Showdown encodes a move learned **on evolution** as `9L0` — not a level any Pokemon reaches. #817 taught the shared `get_levelup_move_for_pokemon` to match it, but that helper also drives ordinary level-ups (`encounter_functions.save_main_pokemon_progress`) and mobile-sync level-ups. So the move qualified at *every* level and was re-offered forever: once a Pokemon held four moves and the player declined, the replace-move dialog came back on every single level-up. **247 species** carry such a move.

A dedicated `get_evolution_moves_for_pokemon` now returns them, and only the real evolution path (`evolve_pokemon`) uses it, unioned with the level-up moves. Declining an evolution (`cancel_evolution`) keeps the Pokemon as its pre-evolution, so that path grants this level's ordinary level-up move only and never a `9L0` move (CodeRabbit's point on this PR). Measured with an identical seeded save (Charizard 40→46, declining every prompt):

| | replace-move dialogs |
|---|---|
| before #817 | 1 `{firespin}` |
| #817 | 7 `{airslash ×6, firespin}` |
| this PR | 1 `{firespin}` |

### 2. A null `battle_status` crashed the battle loop

Lowercasing it is right — a stored `"Fighting"` used to leak into the poke-engine payload as a status condition instead of `None`. But #817 put `.lower()` at the point of use, and `PokemonObject.update_stats()` bypasses `__init__` to write the database row straight onto the attribute. A record holding `null` left it `None`, and `battle_loop` calls `validate_pokemon_status` **every turn**:

```
before #817   validate_pokemon_status(...) -> 'fighting'
#817          AttributeError: 'NoneType' object has no attribute 'lower'
this PR       -> 'fighting'
```

Normalized in one place and applied at both ingestion points — the constructor and `update_stats`. `validate_pokemon_status` is hardened too, since it accepts any object and a bare one may carry no attribute at all.

Also persists `hp` alongside `current_hp` after evolution, per the contract in `_normalize_loaded_hp` ("New records store the live value in both").

### 3. Validator strip (added while fixing up)

`PokemonObject._normalize_battle_status` strips and lowercases, but `validate_pokemon_status` only lowercased. A padded real status like `"  par  "` was not in the valid set and fell through the invalid-status branch, silently resetting a paralysed Pokemon to `"fighting"`. Both entry points now agree; a test pins that padding never erases a real status.

### 4. `from_engine_format` keyword typo (CodeRabbit, outside the diff)

`PokemonObject.from_engine_format()` passed `battlestatus=`; the constructor takes `battle_status`, so the engine's status was swallowed by `**kwargs` and replaced with the default. One-word fix. The method has no callers today and would still need the constructor's required positional arguments before it can be used, so no test was added for it.

### Verification

Branch merged up to current `main` (a2eb5a36, #770).

- `harness/check.py` — 9/9 green.
- Full suite, PyQt6 present: **1204 passed, 40 skipped, 0 failed, 0 errors**.
- 23 regression tests cover the L0/level-up split (including a persisted `9L0` move on a real evolution and its absence on a declined one), `battle_status` normalization through both paths, and `validate_pokemon_status` against `None`, `""`, `"Fighting"`, padded input and a bare object.

Pre-existing and unrelated, verified identical on `main`: running `test_pokemon_obj_persistence.py` before `test_evolution_item_consumption.py` in the same session errors because the former stubs `Ankimon.functions.learnset_retrieval` in `sys.modules`; the alphabetical full run is unaffected. Three touched files were already not `ruff format`-clean on `main`; left as-is to keep the diff readable (CI only runs `ruff check`).

### Not addressed

CodeRabbit's third point on #817 — warming the learnset cache at startup — is a pre-existing perf nit: the previous `get_random_moves_for_pokemon` hit the same disk I/O. Worth its own PR.

Separately, `harness/fixtures.py` seeds species names lowercase while the level-up branch is gated on `mainpkmndata["name"] == main_pokemon.name.capitalize()`. That guard is False for every seeded save, so the level-up move path never executes in any harness run — which is why #817 cleared all 10 checks. Also worth its own fix.

