### PR TITLE
Fix Poké Dolls and remove catching items from useless list

### DIFF
--- a/src/Ankimon/functions/encounter_functions.py
+++ b/src/Ankimon/functions/encounter_functions.py
@@ -2166,7 +2166,9 @@ def handle_main_pokemon_faint(
     Handles what happens when the main Pokémon faints.
     """
     msg = translator.translate(
-        "pokemon_fainted", enemy_pokemon_name=main_pokemon.name.capitalize()
+        "own_pokemon_fainted",
+        main_pokemon_name=main_pokemon.name.capitalize(),
+        enemy_pokemon_name=get_pretty_name_for_name(enemy_pokemon.name)
     )
     tooltipWithColour(msg, "#E12939")
     events.emit("faint", who="main", pokemon=main_pokemon.name)

--- a/src/Ankimon/pyobj/item_window.py
+++ b/src/Ankimon/pyobj/item_window.py
@@ -120,6 +120,12 @@ class ItemWindow(QWidget):
             "ultra-ball": 13,  # Increased catch rate (original was 10, now 13)
         }
 
+        self.escape_items = {
+            "poke-doll": True,
+            "smoke-ball": True,
+            "fluffy-tail": True,
+        }
+
         self.evolution_items = set()
         self.load_evolution_items()
 
@@ -405,6 +411,9 @@ class ItemWindow(QWidget):
             use_item_button.clicked.connect(
                 lambda: self.Evolve_Fossil(item_name, fossil_id, fossil_pokemon_name)
             )
+        elif item_name in self.escape_items:
+            use_item_button = QPushButton("Escape from battle")
+            use_item_button.clicked.connect(lambda: self.Handle_EscapeItem(item_name))
         elif item_name in self.pokeball_chances:
             use_item_button = QPushButton("Try catching wild Pokemon")
             use_item_button.clicked.connect(lambda: self.Handle_Pokeball(item_name))
@@ -496,6 +505,9 @@ class ItemWindow(QWidget):
                     "ok": False,
                     "message": f"Failed to revive {fossil_pokemon_name}.",
                 }
+            if name in self.escape_items:
+                self.Handle_EscapeItem(name)
+                return {"ok": True, "message": f"Escaped using {name}."}
             if name in self.pokeball_chances:
                 self.Handle_Pokeball(name)
                 return {"ok": True, "message": f"Threw {name}."}
@@ -644,6 +656,36 @@ class ItemWindow(QWidget):
             self.logger.log("game", f"{item_name} gets a bonus for Water-type Pokémon!")
 
         return catch_chance
+
+    def Handle_EscapeItem(self, item_name: str):
+        # Notify the user
+        self.logger.log_and_showinfo(
+            "info", f"You used the {item_name} and successfully escaped the battle!"
+        )
+        self.delete_item(item_name)  # Consume the item
+
+        # Log to mobile sync history if enabled
+        from ..services import services
+        from ..functions.mobile_sync import save_encounter_history
+        save_encounter_history(
+            None,
+            None,
+            None,
+            {"enemy_name": self.enemy_pokemon.name, "companion_name": self.main_pokemon.name},
+            "escaped"
+        )
+
+        # Reset the wild pokemon directly and update the window
+        from ..functions.encounter_functions import new_pokemon
+        from ..singletons import get_test_window, reviewer_obj
+
+        new_pokemon(
+            self.enemy_pokemon,
+            get_test_window(),
+            services.ankimon_tracker_obj,
+            reviewer_obj,
+            update_hud=True,
+        )
 
     def Handle_Pokeball(self, item_name: str):
         # Check if the item exists in the pokeball chances

--- a/src/Ankimon/utils.py
+++ b/src/Ankimon/utils.py
@@ -274,23 +274,6 @@ USELESS_ITEMS = {
     "relic-gold",
     "tiny-mushroom",
     # catching / escape / encounter rate items
-    "dive-ball",
-    "dusk-ball",
-    "great-ball",
-    "heal-ball",
-    "luxury-ball",
-    "master-ball",
-    "nest-ball",
-    "net-ball",
-    "poke-ball",
-    "premier-ball",
-    "quick-ball",
-    "repeat-ball",
-    "safari-ball",
-    "timer-ball",
-    "ultra-ball",
-    "smoke-ball",  # escape from wild battles
-    "fluffy-tail",  # escape from wild battles
     "repel",
     "max-repel",
     "super-repel",
@@ -312,7 +295,6 @@ USELESS_ITEMS = {
     "yellow-shard",
     # Contest / Grooming / Friendship items outside battle
     "soothe-bell",
-    "luxury-ball",
     "pretty-wing",
     # Miscellaneous items for info
     "heart-scale",


### PR DESCRIPTION
Fix Poké Dolls and remove catching items from useless list

This change removes Pokeballs and escape items from the `USELESS_ITEMS` list in `utils.py` so they can spawn in the daily shop.
It also introduces the `Handle_EscapeItem` function for `ItemWindow` to correctly handle `poke-doll`, `fluffy-tail`, and `smoke-ball` so players can flee from battles properly.

---
*PR created automatically by Jules for task [13042078883822876772](https://jules.google.com/task/13042078883822876772) started by @h0tp-ftw*