### PR TITLE
fix(db): prevent database corruption on backup restore and prevent repair crashes

### DIFF
--- a/debug_test.py
+++ b/debug_test.py
@@ -1,0 +1,8 @@
+import pytest
+from pathlib import Path
+from src.Ankimon.pyobj.database_manager import AnkimonDB
+from src.Ankimon.pyobj.backup_manager import BackupManager
+from src.Ankimon.services import services
+
+def test_debug(tmp_path):
+    pass

--- a/src/Ankimon/pyobj/backup_manager.py
+++ b/src/Ankimon/pyobj/backup_manager.py
@@ -390,6 +390,16 @@ class BackupManager:
             active_db = services.db.db_path.name
             backup_file = backup_path / active_db
             if backup_file.exists():
+                # We MUST close all database connections before overwriting the file.
+                # Otherwise, replacing an active DB file causes SQLite to enter a
+                # malformed state, preventing successful loading on the next boot.
+                try:
+                    services.db.close(wait_seconds=2.0)
+                except Exception as e:
+                    self.logger.log("error", f"Failed to gracefully close connections before restore: {e}")
+                    showWarning(f"Failed to gracefully close the database. Aborting restore to prevent corruption: {e}")
+                    return
+
                 shutil.copy2(backup_file, self.user_files_path / active_db)
             else:
                 showWarning(

--- a/src/Ankimon/pyobj/database_manager.py
+++ b/src/Ankimon/pyobj/database_manager.py
@@ -652,10 +652,22 @@ class AnkimonDB:
                 except Exception:
                     pass
                     
-            # Dump current database safely
+            # Dump current database safely, recovering what we can
             src_conn = sqlite3.connect(str(db_file))
+            lines = []
             try:
-                lines = list(src_conn.iterdump())
+                iterator = src_conn.iterdump()
+                while True:
+                    try:
+                        lines.append(next(iterator))
+                    except StopIteration:
+                        break
+                    except sqlite3.DatabaseError as e:
+                        self._log("warning", f"iterdump encountered corruption, saving partial dump: {e}")
+                        break
+            except Exception as e:
+                self._log("error", f"Could not initialize database dump: {e}")
+                # Fallback to empty dump to allow initialization
             finally:
                 src_conn.close()
             


### PR DESCRIPTION
Fixes an issue where restoring a backup while Ankimon was running would overwrite the active database file, corrupting the SQLite disk image. Also prevents the subsequent auto-repair loop from crashing Anki entirely if it encounters unreadable sectors during the SQL dump.

---
*PR created automatically by Jules for task [16525047403627761542](https://jules.google.com/task/16525047403627761542) started by @h0tp-ftw*