### PR TITLE
Fix Anki freeze on startup caused by early QtMultimedia initialization

### DIFF
--- a/src/Ankimon/utils.py
+++ b/src/Ankimon/utils.py
@@ -45,17 +45,31 @@ from .move_names import format_move_name
 # Audio is optional. Under Anki these construct real Qt players; headless (the
 # agent harness / tests) there is no QtMultimedia, so we degrade to "no audio"
 # and play_sound/play_effect_sound become event-only.
+#
+# Constructing QAudioOutput/QMediaPlayer at module scope can hang indefinitely
+# on Linux if the audio backend (e.g. pipewire/pulseaudio dbus) is unresponsive.
+# Instead, we defer instantiation until the first sound is played.
 try:
     from PyQt6.QtMultimedia import QAudioOutput, QMediaPlayer
-
-    audio_output = QAudioOutput()
-    media_player = QMediaPlayer()
-    media_player.setAudioOutput(audio_output)
     _HAVE_AUDIO = True
 except Exception:
-    audio_output = None
-    media_player = None
     _HAVE_AUDIO = False
+
+audio_output = None
+media_player = None
+
+def _get_media_player():
+    global audio_output, media_player
+    if not _HAVE_AUDIO:
+        return None
+    if media_player is None:
+        try:
+            audio_output = QAudioOutput()
+            media_player = QMediaPlayer()
+            media_player.setAudioOutput(audio_output)
+        except Exception:
+            media_player = None
+    return media_player
 
 
 def showInfo(message, *args, **kwargs):
@@ -718,9 +732,11 @@ def play_effect_sound(settings_obj, sound_type):
         if not _HAVE_AUDIO:
             return
         from PyQt6.QtCore import QUrl
-        audio_output.setVolume(settings_obj.get("audio.volume"))
-        media_player.setSource(QUrl.fromLocalFile(str(audio_path)))
-        media_player.play()
+        player = _get_media_player()
+        if player is not None and audio_output is not None:
+            audio_output.setVolume(settings_obj.get("audio.volume"))
+            player.setSource(QUrl.fromLocalFile(str(audio_path)))
+            player.play()
     else:
         pass
 
@@ -814,9 +830,11 @@ def play_sound(enemy_pokemon_id: int, settings_obj: Settings):
             if not _HAVE_AUDIO:
                 return
             from PyQt6.QtCore import QUrl
-            audio_output.setVolume(settings_obj.get("audio.volume"))
-            media_player.setSource(QUrl.fromLocalFile(str(audio_path)))
-            media_player.play()
+            player = _get_media_player()
+            if player is not None and audio_output is not None:
+                audio_output.setVolume(settings_obj.get("audio.volume"))
+                player.setSource(QUrl.fromLocalFile(str(audio_path)))
+                player.play()
 
 
 def load_collected_pokemon_ids() -> set:


### PR DESCRIPTION
Constructing PyQt6 `QAudioOutput` and `QMediaPlayer` components directly at the module scope can cause Anki to freeze indefinitely during startup on Linux environments due to unresponsive audio backends (e.g., PulseAudio/PipeWire dbus issues). This defers audio interface initialization in `utils.py` until a sound actually needs to be played, preventing the deadlock entirely.

---
*PR created automatically by Jules for task [12811587657978061018](https://jules.google.com/task/12811587657978061018) started by @h0tp-ftw*