### PR TITLE
feat(settings): add Ignore Learning Cards multiplier setting

### DIFF
--- a/src/Ankimon/ankimon_items_web/settings_schema.py
+++ b/src/Ankimon/ankimon_items_web/settings_schema.py
@@ -67,6 +67,7 @@ GROUPS = [
                 "settings": [
                     "Cards per Round",
                     "Review Based Damage",
+                    "Ignore Learning Cards",
                     "Friendship & Time Evolution",
                     "Auto-detect Time Zone",
                     "Time Zone UTC Offset",

--- a/src/Ankimon/card_hooks.py
+++ b/src/Ankimon/card_hooks.py
@@ -28,16 +28,29 @@ def answerCard_before(filter, reviewer, card):
 
 def answerCard_after(rev, card, ease):
     maxEase = rev.mw.col.sched.answerButtons(card)
-    if ease == 1:
-        ankimon_tracker_obj.review("again")
-    elif ease == maxEase - 2:
-        ankimon_tracker_obj.review("hard")
-    elif ease == maxEase - 1:
+
+    # Check if the user wants to ignore learning cards (with safety guard for tests/startup)
+    ignore_learning = False
+    if services.settings is not None:
+        ignore_learning = services.settings.get("battle.ignore_learning_cards", False)
+    # card.type in Anki: 0 is New, 1 is Learning, 2 is Review, 3 is Relearning
+    is_learning_card = getattr(card, "type", 2) in (0, 1)
+
+    if ignore_learning and is_learning_card:
+        # Give the card a neutral/good review multiplier contribution instead of punishing learning
         ankimon_tracker_obj.review("good")
-    elif ease == maxEase:
-        ankimon_tracker_obj.review("easy")
     else:
-        tooltip("Error in ColorConfirmation: Couldn't interpret ease")
+        if ease == 1:
+            ankimon_tracker_obj.review("again")
+        elif ease == maxEase - 2:
+            ankimon_tracker_obj.review("hard")
+        elif ease == maxEase - 1:
+            ankimon_tracker_obj.review("good")
+        elif ease == maxEase:
+            ankimon_tracker_obj.review("easy")
+        else:
+            tooltip("Error in ColorConfirmation: Couldn't interpret ease")
+
     ankimon_tracker_obj.reset_card_timer()
 
     # Mobile-review de-dupe (F29): this review was just turned into battle

--- a/src/Ankimon/lang/setting_description.json
+++ b/src/Ankimon/lang/setting_description.json
@@ -12,6 +12,7 @@
     "battle.daily_average": "Set the amount of Cards you want to review per day.",
     "battle.card_max_time": "Goal of maximum amount of time needed to answer a card in seconds",
     "battle.review_based_damage": "If enabled, your Pokémon's damage will be modified depending on how you graded your last few cards.",
+    "battle.ignore_learning_cards": "If enabled, new and learning cards will not affect the battle multiplier calculation.",
     "evolution.friendship_time_enabled": "Let Pokémon evolve when they reach their friendship requirement at the right time of day (day/night).",
     "evolution.timezone_auto": "Use this device's local time zone to decide day vs night for evolutions. Turn off to set a fixed UTC offset below.",
     "evolution.timezone_offset": "UTC offset in hours used for the day/night cycle when Auto-detect Time Zone is off (e.g. -5 = New York, 1 = Berlin, 5.5 = India, 0 = UTC). Ignored while auto-detect is on.",

--- a/src/Ankimon/lang/setting_name.json
+++ b/src/Ankimon/lang/setting_name.json
@@ -12,6 +12,7 @@
     "battle.daily_average": "Goal of Daily Average Cards",
     "battle.card_max_time": "Card Max Time",
     "battle.review_based_damage": "Review Based Damage",
+    "battle.ignore_learning_cards": "Ignore Learning Cards",
 
     "evolution.friendship_time_enabled": "Friendship & Time Evolution",
     "evolution.timezone_auto": "Auto-detect Time Zone",

--- a/src/Ankimon/pyobj/settings.py
+++ b/src/Ankimon/pyobj/settings.py
@@ -19,6 +19,7 @@ DEFAULT_CONFIG = {
     "battle.daily_average": 100,
     "battle.card_max_time": 60,
     "battle.review_based_damage": True,
+    "battle.ignore_learning_cards": False,
     "evolution.friendship_time_enabled": True,
     "evolution.day_start_hour": 6,
     "evolution.night_start_hour": 18,

--- a/src/Ankimon/pyobj/settings_window.py
+++ b/src/Ankimon/pyobj/settings_window.py
@@ -380,6 +380,7 @@ class SettingsWindow(QMainWindow):
                     "Always Catch: Regional Form",
                     "Cards per Round",
                     "Review Based Damage",
+                    "Ignore Learning Cards",
                     "Friendship & Time Evolution",
                     "Auto-detect Time Zone",
                     "Time Zone UTC Offset",


### PR DESCRIPTION
Adds a new toggle in the Ankimon Settings panel, "Ignore Learning Cards". When enabled, new and learning cards will be automatically graded as a neutral "good" review internally for the sake of the battle damage multiplier, preventing users from tanking their damage output while learning new cards. Does not affect relearning/lapsed cards.

---
*PR created automatically by Jules for task [6182650388774083494](https://jules.google.com/task/6182650388774083494) started by @h0tp-ftw*