### PR TITLE
Fix cycle heal bug

### DIFF
--- a/patch_reviewer.sh
+++ b/patch_reviewer.sh
@@ -1,0 +1,1 @@
+sed -i '/main_pokemon.hp = main_pokemon.max_hp/d' src/Ankimon/reviewer_ui.py

--- a/src/Ankimon/reviewer_ui.py
+++ b/src/Ankimon/reviewer_ui.py
@@ -130,7 +130,6 @@ def cycle_team_pokemon():
 
             main_pokemon.update_stats(**pokemon_data)
             main_pokemon.max_hp = main_pokemon.calculate_max_hp()
-            main_pokemon.hp = main_pokemon.max_hp
             main_pokemon.reset_bonuses()
 
             save_main_pokemon(main_pokemon)


### PR DESCRIPTION
Removes the bugged assignment from `src/Ankimon/reviewer_ui.py` that forced HP to max upon team cycle.

---
*PR created automatically by Jules for task [4112992389325968990](https://jules.google.com/task/4112992389325968990) started by @h0tp-ftw*