### PR TITLE
fix: preserve saves across import restarts and media sync

### DIFF
--- a/.github/workflows/harness.yml
+++ b/.github/workflows/harness.yml
@@ -66,6 +66,7 @@ jobs:
           xvfb-run -a python3 -m harness.checks.probe_real_boot
           xvfb-run -a python3 -m harness.checks.probe_real_play
           xvfb-run -a python3 -m harness.checks.probe_real_move_selection
+          xvfb-run -a python3 -m harness.checks.probe_real_save_import
           xvfb-run -a python3 -m harness.checks.probe_real_tm_learnsets
 
   tier2_webengine:

--- a/docs/save_transfer_safety.md
+++ b/docs/save_transfer_safety.md
@@ -149,3 +149,22 @@ A second review round raised four further findings, all accepted:
   that the source held still while they were read, and only a capture bound to
   one observed revision releases the sync guard.
 - The worker/GUI-thread sentence above names preservation work as its subject.
+
+A third review round raised four further findings, all accepted:
+
+- Media capture is bound to a source revision observed both before and after
+  the copy. Verifying the copy's own bytes never established that the source
+  held still while they were read, so a writer landing mid-capture left a
+  recovery copy of the old version described by the new version's signature —
+  and the callback, comparing new against new, released the sync guard over
+  progress that had never been preserved.
+- Staging is split at its publication commit point. Once `pending.json` is in
+  place the import installs at the next full start whatever fails afterwards,
+  so Import, Rescue and Backup Restore report it as pending and name the cancel
+  action instead of announcing an abort with the current save unchanged.
+- A media sync the capture guard turned away is re-requested once capture
+  succeeds. Anki reads the gate only as a sync starts, so clearing it merely
+  permitted the next attempt while the suppressed request was gone.
+- The shutdown backup's single budget now also covers summary generation, which
+  fell back to reading the live database — and its own busy timeout — whenever
+  the required snapshot had not been taken.

--- a/docs/save_transfer_safety.md
+++ b/docs/save_transfer_safety.md
@@ -168,3 +168,24 @@ A third review round raised four further findings, all accepted:
 - The shutdown backup's single budget now also covers summary generation, which
   fell back to reading the live database — and its own busy timeout — whenever
   the required snapshot had not been taken.
+
+Verifying those four fixes surfaced five more, all accepted:
+
+- The media-sync guard stands aside for Anki's Preferences dialog. That dialog
+  reads the same gate only to tick "Synchronize audio and images too" and
+  writes whatever the box shows back into the profile on OK, so a blocked
+  answer there would have silently switched the user's real AnkiWeb media-sync
+  preference off for good. The guard delays a sync; it never edits a setting.
+- Recording a turned-away sync and replaying it happen under one lock. Anki
+  evaluates the gate on a background thread, so without it a request could be
+  remembered just after the release that would have replayed it.
+- The success notices for Import, Rescue and Backup Restore are guarded. They
+  reach into Qt in a shutdown-adjacent state, and a failure there used to
+  surface as "aborted, nothing was replaced" over a save that was staged.
+- A second import attempt while one is pending has its own message naming the
+  pending import, instead of an abort notice that is true of the attempt and
+  misleading about the session.
+- Cancelling a pending import is committed by removing the manifest. A failure
+  of the durability flush that follows no longer reports "could not be
+  cancelled, try again", which the retry immediately contradicted with "there
+  is no pending save import".

--- a/docs/save_transfer_safety.md
+++ b/docs/save_transfer_safety.md
@@ -43,7 +43,8 @@ storage. Only sanitised bytes enter the destination directory, including its
 temporary file. Completion statistics come from the actual exported snapshot.
 
 At profile open, both `ankimon.db` and `ankimonDEV.db` in `collection.media` are
-captured before Anki can start automatic media sync. Verified copies include
+guarded before Anki can start automatic media sync, then captured on a background
+worker. Media sync resumes only after capture completes. Verified copies include
 committed WAL contents and use content-derived filenames under
 `ankimon-media-recovery/` beside `collection.media`, not inside the media folder.
 That keeps newly-created recovery databases out of AnkiWeb media sync while
@@ -59,8 +60,11 @@ sync pauses for that profile in memory until capture succeeds. Sync preferences
 are not changed. Close anything locking the files and restart Anki to retry.
 
 Preservation status is separate from the feature-removal announcement. Worker
-or dispatch failures remain retryable and visible; they do not start a full
-comparison scan on the GUI thread. Recovery paths are recorded in the Ankimon
+or dispatch failures remain retryable and visible; they do not copy, archive, or
+compare saves on the GUI thread. Unchanged unreadable saves have a 30-second
+retry delay; changed files, permissions, or SQLite sidecars re-arm immediately.
+Moving an uncaptured save out of the media folder also clears its sync guard.
+Recovery paths are recorded in the Ankimon
 log. No original media file is deleted.
 
 ## Review disposition and validation limits
@@ -85,3 +89,30 @@ remained writable; a subsequent full process loaded the imported trainer and
 retained the final old progress in recovery. Dialog choices were automated;
 Anki's actual editor and close lifecycle ran. Authenticated AnkiWeb conflict
 resolution and Windows file locking remain outside this validation.
+
+## CodeRabbit review of #850
+
+All ten inline findings and the failed User Data Safety pre-merge check were
+accepted after checking the implementation. The fixes preserve the existing
+restart-only import behavior:
+
+- Failed backups never enter retention. A backup stays in a hidden staging
+  directory until its required SQLite snapshot and summary are complete; even
+  a failed cleanup cannot cause that directory to evict an older valid backup.
+- Restore and import callers request observable shutdown errors and report that
+  their prepared save remains pending. Cancellation filesystem errors and
+  recovery-folder access failures receive actionable menu warnings.
+- Errors after atomic replacement are reported separately: the imported save
+  is active, and final disk sync/cleanup can retry without reinstalling it over
+  newer progress. Failures before replacement still leave the old save active.
+- File fsync uses a writable handle for Windows. Existing pre-import recovery
+  directories are restricted before access, including those opened by browsing.
+- Preservation and raw archive writes run once on the guarded worker. Repeated
+  sync-stop notifications cannot immediately repeat an unchanged failed capture.
+- The locked-source timing test pins its probe budget; the permission test skips
+  root; the digest-collision test uses a valid source and a damaged copy in the
+  actual recovery directory and checks that a numbered copy preserves both.
+
+The optional 80% docstring-coverage warning was not adopted as a blanket rewrite
+of the transfer tests and existing helpers. Behavioral contracts and the new
+failure/scheduling paths are documented where they need explanation.

--- a/docs/save_transfer_safety.md
+++ b/docs/save_transfer_safety.md
@@ -50,7 +50,13 @@ temporary file. Completion statistics come from the actual exported snapshot.
 
 At profile open, both `ankimon.db` and `ankimonDEV.db` in `collection.media` are
 guarded before Anki can start automatic media sync, then captured on a background
-worker. Media sync resumes only after capture completes. Verified copies include
+worker. Media sync resumes only after capture completes. Anki reads that gate
+once, when a sync starts, so clearing the guard would otherwise only permit the
+*next* attempt: a collection sync that began during the capture finishes without
+media and is never re-requested. Ankimon therefore remembers a sync its guard
+turned away and asks Anki's media syncer for it once the capture succeeds. That
+restart still honours the user's own media-sync preference, sign-in and profile
+state, and a scan that suppressed nothing starts nothing. Verified copies include
 committed WAL contents and use content-derived filenames under
 `ankimon-media-recovery/` beside `collection.media`, not inside the media folder.
 That keeps newly-created recovery databases out of AnkiWeb media sync while

--- a/docs/save_transfer_safety.md
+++ b/docs/save_transfer_safety.md
@@ -409,6 +409,21 @@ CodeRabbit:
   0.27 seconds, and the 30-second budget is a ceiling for a locked save, after
   which the import stays pending.
 
+After CodeRabbit re-reviewed that push:
+
+- The notice that Anki could not close after an import or a restore was staged is
+  guarded like every other notice about an armed import. Its own failure reached
+  `import_save`'s "Import aborted ... Nothing was replaced" handler.
+- Backup Manager's warnings about an armed restore go through `services.ui`, as
+  new popups should. In Anki that presenter shows the same `showWarning` dialog.
+- *The missing-save probes in `pending_import_is_installed` can freeze the GUI
+  thread on a disconnected network profile.* Not changed. `pending_import_info`
+  runs first in the same call: it resolves the save's path and opens
+  `pending.json` beside it synchronously, so a dead mount blocks there before
+  either probe. The callers have just done synchronous file work on that volume by
+  design, and the two-second budget bounds SQLite's wait on a locked save, not a
+  mount that has gone away.
+
 Tests only: the prune test checks that the superseded copy it keeps is the newest,
 a staged save swapped for another valid save now reaches the digest refusal
 instead of the size check, the shutdown-budget test covers a developer-mode active

--- a/docs/save_transfer_safety.md
+++ b/docs/save_transfer_safety.md
@@ -22,7 +22,9 @@ Publishing `pending.json` is staging's commit point. Anything that fails after
 it — the directory syncs, the read-back — leaves an import that WILL install at
 the next full start, so it is reported as pending with the cancel instruction
 rather than as an abort. Only failures before publication say the current save
-is unchanged, and they leave nothing staged.
+is unchanged, and they leave nothing staged. The one exception after publication
+is a manifest that has vanished by read-back: then nothing will install, so
+staging removes its staged copy and fails as an ordinary abort.
 
 Recovery copies live in `ankimon_recovery/pre-import-<token>/` beside the active
 database. The preparation message displays the reserved location, and
@@ -161,7 +163,9 @@ A third review round raised four further findings, all accepted:
 - Staging is split at its publication commit point. Once `pending.json` is in
   place the import installs at the next full start whatever fails afterwards,
   so Import, Rescue and Backup Restore report it as pending and name the cancel
-  action instead of announcing an abort with the current save unchanged.
+  action instead of announcing an abort with the current save unchanged. The
+  exception is a manifest that has vanished by read-back, which leaves nothing
+  to install and is reported as an abort.
 - A media sync the capture guard turned away is re-requested once capture
   succeeds. Anki reads the gate only as a sync starts, so clearing it merely
   permitted the next attempt while the suppressed request was gone.
@@ -185,10 +189,11 @@ Verifying those four fixes surfaced five more, all accepted:
 - A second import attempt while one is pending has its own message naming the
   pending import, instead of an abort notice that is true of the attempt and
   misleading about the session.
-- Cancelling a pending import is committed by removing the manifest. A failure
+- Cancelling a pending import is committed before anything is removed. A failure
   of the durability flush that follows no longer reports "could not be
   cancelled, try again", which the retry immediately contradicted with "there
-  is no pending save import".
+  is no pending save import". The fifth round moved that commit onto a synced
+  rewrite of the record, so a crash cannot undo it either.
 
 An external review of the branch's own fixes found no surviving instance of the
 four findings it re-checked. Verifying them adversarially instead surfaced
@@ -248,3 +253,61 @@ the real add-on: stage over the live save, keep editing, exit, start again, and
 check that the runtime is on the imported save with the final pre-import
 progress in the recovery copy and nothing left staged. Windows file locking and
 authenticated AnkiWeb behaviour remain outside this validation.
+
+A fifth round left ten review threads open, and the User Data Safety pre-merge
+check failed on two claims. Nine threads led to changes. The `-shm` thread and
+the retention half of the pre-merge check were refuted on the source, the second
+with a regression test.
+
+Cancellation and the pending record:
+
+- Cancelling is durable before it is reported. `pending.json` is rewritten in
+  place as a cancelled record and synced as a file, and only then unlinked. A
+  file sync needs no directory sync, which is the step whose failure the third
+  round had to tolerate, so a crash that undoes the unlink or the staged copy's
+  removal brings back a record that installs nothing. If the rewrite itself
+  cannot be synced, Cancel reports failure and puts the original record back, so
+  the retry it asks for still finds the import. A separate tombstone file was not
+  used: its directory entry would need the very sync that failed.
+- Whether a pending record describes an already-installed import has three
+  answers. The check runs on the GUI thread only to choose wording, so the save
+  gets two seconds rather than SQLite's 30-second busy timeout. A locked or
+  unreadable save answers "unknown", and Import, Backup Restore and Cancel word
+  that as neither pending nor installed; the cancellation event carries
+  `installed=None`.
+- A cancellation that succeeds for one save mode and fails for the other names
+  both outcomes.
+- A manifest that has vanished by read-back is the one failure after publication
+  that stays an ordinary abort: nothing will install, and the staged copy goes.
+
+Startup and shutdown budgets:
+
+- The startup install checks its shared budget between blocks of the digest and
+  of the copy into place, and before each file sync. An fsync already in flight
+  cannot be abandoned, and nothing is checked after the atomic replacement.
+- Retention, and the removal of a failed backup attempt, delete one entry at a
+  time under the shutdown deadline instead of calling `shutil.rmtree`.
+- Retention renames a doomed directory out of the `backup_` namespace before
+  deleting anything in it, and a later pass finishes what is left. Deleting
+  entries restamps a directory's mtime and retention orders by mtime, so a
+  removal cut short in place, by the deadline or by one locked file, left remains
+  that sorted as the newest backup and evicted a good one on the next pass. This
+  turned up while checking the refuted claim below.
+
+Refuted:
+
+- *A backup that fails to delete lets retention evict a newer one.* Retention only
+  ever attempts the oldest directories beyond `MAX_BACKUPS`, and a failure adds no
+  attempt, so nothing in the kept set is touched. Stopping at the first failure,
+  as suggested, would let one permanently locked directory grow the backup folder
+  without bound. The test locks the oldest backup and checks that exactly the next
+  one goes and the newest five stay.
+- *The `-shm` assertion can fail on other SQLite builds.* The last connection
+  `get_db_stats` closes is read-only. SQLite removes `-wal` and `-shm` on close
+  only after a checkpoint, which a read-only connection cannot run, so the sidecar
+  is still there on every build.
+
+Also: a deferred media sync that cannot be restarted is logged (the request itself
+has been kept since the fourth round), each phase of the Tier-2 import probe is
+bounded at 300 seconds, and the preference-off guard test now drives the user's
+preference through the installed wrapper instead of replacing it.

--- a/docs/save_transfer_safety.md
+++ b/docs/save_transfer_safety.md
@@ -9,7 +9,8 @@ Import prepares a private, verified save for the next **full Anki restart**.
 It never replaces the database used by the current game objects. Choosing
 **Keep Editing** during shutdown, a shutdown exception, and shutdown-triggered
 sync therefore leave the current runtime and save together. The menu action
-**Cancel Pending Save Import** discards a prepared import for the active mode.
+**Cancel Pending Save Import** discards prepared imports for both save modes
+(`ankimon.db` and `ankimonDEV.db`).
 
 Before constructing database managers or game objects at the next process
 start, Ankimon captures the final current save using SQLite's backup API,
@@ -30,7 +31,8 @@ Recovery copies live in `ankimon_recovery/pre-import-<token>/` beside the active
 database. The preparation message displays the reserved location, and
 **Browse Pre-import Recovery Saves…** opens the folder. Routine backup retention
 does not delete these copies. Import a recovery `.db` through the same import
-flow to restore it. Failed installation retries retain earlier recovery copies.
+flow to restore it. A failed installation retry keeps the newest snapshot under
+the advertised name, plus the one it superseded; older retry copies are pruned.
 
 Imports require leaderboard sign-in again. Incoming current and legacy
 credentials are removed; explicit empty authentication settings prevent legacy
@@ -66,12 +68,16 @@ still leaving old underscore-prefixed migration copies readable for backwards
 compatibility. Only saves in the active mode are compared for recovery.
 
 If SQLite cannot read a source, Ankimon retains a labelled **unverified** ZIP of
-the raw database and its available sidecars in the same local recovery
-directory. This is recovery material, not a guarantee that the archive contains
-a consistent save. Existing copies and raw archives must match their content
-before reuse. Damaged files remain untouched. If even raw capture fails, media
-sync pauses for that profile in memory until capture succeeds. Sync preferences
-are not changed. Close anything locking the files and restart Anki to retry.
+the raw database and its WAL or rollback journal in the same local recovery
+directory. `-shm` is left out: it is a rebuildable index, and every read-only
+open restamps it, which gave an unchanged save a new archive on every pass. This
+is recovery material, not a guarantee that the archive contains a consistent
+save. Existing copies and raw archives must match their content before reuse.
+Damaged files remain untouched. If even raw capture fails, media sync pauses for
+that profile in memory until capture succeeds. Sync preferences are not changed.
+Close anything locking the files. After a completed scan, Ankimon retries about
+every 30 seconds while Anki is open; if the scan itself could not run, restart Anki
+to retry.
 
 Preservation status is separate from the feature-removal announcement. Worker
 and dispatch failures remain retryable and visible. Preservation work runs on
@@ -309,9 +315,11 @@ Refuted:
   without bound. The test locks the oldest backup and checks that exactly the next
   one goes and the newest five stay.
 - *The `-shm` assertion can fail on other SQLite builds.* The last connection
-  `get_db_stats` closes is read-only. SQLite removes `-wal` and `-shm` on close
-  only after a checkpoint, which a read-only connection cannot run, so the sidecar
-  is still there on every build.
+  `get_db_stats` closes is read-only, and SQLite removes `-wal` and `-shm` on
+  close only after a checkpoint, which a read-only connection cannot run. That
+  holds for the builds it was checked against, but it is not a guarantee for
+  every build or VFS; since the sixth round the test skips where the index is
+  gone instead of asserting that it never is.
 
 Also: a deferred media sync that cannot be restarted is logged (the request itself
 has been kept since the fourth round), each phase of the Tier-2 import probe is
@@ -325,3 +333,106 @@ truncate, the Delete button's in-place removal, a linked backup being walked, an
 no test driving the digest and recovery-sync budget checks through the install
 itself. The `-shm` refutation was re-checked against SQLite 3.46.1's Windows VFS,
 which also refuses a read-only handle the exclusive lock a checkpoint needs.
+
+A sixth round came from a quality pass over the whole branch, two further
+CodeRabbit threads, and its Anki and PyQt compatibility check. Each fix below has
+a test that fails without it.
+
+Media sync:
+
+- Reopening a profile that was already captured this session left media sync
+  paused until Anki restarted. `guard_media_saves_now` only stats files, so the
+  reopen re-armed the guard, and the settled scan that followed returned before
+  the one call that lifts it.
+- A retry that the throttle turned away scheduled nothing. Qt rounds a 30-second
+  timer to whole seconds and can fire it half a second early, and a timer armed
+  for an earlier pass can land after a later failed pass moved the throttle on.
+  Either way the guard stayed up with no retry left. A pass the throttle turns
+  away now asks for a timer covering what is left of it.
+- A rerun requested during a scan ran even when the profile had closed meanwhile,
+  and put its warnings and the rescue prompt over the profile manager.
+- A raw archive no longer includes `-shm`, so an unreadable WAL-mode save is
+  archived once rather than once per pass, with a warning each time.
+- The pause notice says Ankimon retries by itself about every 30 seconds when a
+  retry timer is armed. A scan that failed or could not be dispatched arms none, so
+  there it still says to restart Anki: a timer would repeat that path's own warning
+  every 30 seconds.
+- A reopen inside the 30-second throttle puts the earlier pass's verdict back over
+  the re-armed guard, so a save that was archived but not verified does not leave
+  media sync paused either.
+
+Import and recovery:
+
+- SQLite opens work on a Windows network path. `Path.as_uri` puts a UNC server in
+  the URI authority, and SQLite refuses every authority but an empty one or
+  `localhost`, so a profile on a redirected AppData folder could not back up,
+  restore, import, export or compare saves. That case now percent-encodes the
+  whole native path into `file:` with no authority, which SQLite decodes to
+  exactly the filename a plain open would use, with `mode=ro` still applied. The
+  same helper covers the two opens in `save_transfer` and `ankimon_sync` that
+  predate this branch. It was exercised on Linux with `as_uri` answering the way it
+  does on Windows, not on a real share.
+- A filesystem that cannot sync a directory (EINVAL, ENOTSUP) no longer blocks an
+  install at every start. Nor does a recovery folder on a volume that refuses
+  chmod, provided this user owns it. A real I/O error, and a folder owned by
+  another account, still stop the install before anything is replaced.
+- An accepted rescue that could not quiet the live save did nothing and said
+  nothing. It now reports why, as `main` did, and that the rescue will be offered
+  again after the next sync or restart.
+- Cancel over a record whose save no longer exists says the import was cancelled,
+  not that Ankimon could not tell whether it had installed. The exception is a
+  record with a recovery copy beside it: an install got as far as replacing that
+  save, so the answer stays unknown and points at the copy.
+- Every menu path the import and recovery notices name exists. One pointed at
+  "Browse Recovered Saves",
+  which never existed, and all of them left out the Game submenu the actions live
+  in. A test reads the menu to keep it that way.
+- The startup failure notice no longer says that no save was replaced. `get_db`
+  tries both save modes, and the other one may have installed in the same start.
+
+CodeRabbit:
+
+- `_remove_tree` checks the shutdown deadline before listing a directory as well
+  as between entries. Iterating `iterdir()` lazily does not help on its own:
+  `Path.iterdir` reads the whole listing before it yields anything, through
+  `os.listdir` on Python 3.12 and `list(os.scandir(...))` on 3.14. Past the
+  deadline an empty directory is still removed, since `rmdir` needs no listing;
+  a failed shutdown attempt's staging folder is empty, and a test pins that it
+  does not outlive the attempt.
+- The `-shm` test skips where the index is gone after the read-only close, and the
+  refutation above no longer claims every build.
+- The compatibility check objected to installing synchronously while the add-on
+  loads. It has to: the install must finish before any database manager or game
+  object opens the save, or the runtime writes into a save that is being replaced,
+  which is the #797 defect. An ordinary start pays one failed open of
+  `pending.json` per save mode. A 100 MB save installed in 1.15 seconds in testing, 10 MB in
+  0.27 seconds, and the 30-second budget is a ceiling for a locked save, after
+  which the import stays pending.
+
+Tests only: the prune test checks that the superseded copy it keeps is the newest,
+a staged save swapped for another valid save now reaches the digest refusal
+instead of the size check, the shutdown-budget test covers a developer-mode active
+save, and the sync-hardening stub of `cleanup_backups` takes its real signature.
+
+Deferred, with reasons:
+
+- Windows lock retries for the backup's publishing rename and the import's
+  `os.replace` calls (#636). These are real regressions from `main` in that
+  environment, but a fix needs the lock-retry helpers in a module the stdlib-only
+  import code can load, and a Windows runner to exercise them. That is its own
+  change.
+- A current save that fails `quick_check` but still works blocks imports and
+  Backup Restore, because the safety snapshot of it fails verification. Repairing
+  the snapshot changes what gets retained, so it needs its own review.
+- Retention orders backups by directory mtime, which a read of a WAL-mode backup
+  restamps. Ordering by the timestamp in the name has to handle legacy names.
+- A staged import for `ankimon.db` whose file is deleted before the next start is
+  reported as impossible to install. `get_db` then creates a fresh save, and the
+  following start installs the import over it without a notice; only the recovery
+  copy keeps what was played in between. Which save should win is a product
+  decision.
+- Smaller items: a staged rescue can be offered again by a later scan in the same
+  session; the unverified-archive warning repeats at every start for a permanently
+  damaged file; temporary copies left by a force-quit install or an interrupted
+  cancel are not swept; the import lifecycle is thinly logged; and a handful of
+  paths are covered only indirectly by tests.

--- a/docs/save_transfer_safety.md
+++ b/docs/save_transfer_safety.md
@@ -189,3 +189,62 @@ Verifying those four fixes surfaced five more, all accepted:
   of the durability flush that follows no longer reports "could not be
   cancelled, try again", which the retry immediately contradicted with "there
   is no pending save import".
+
+An external review of the branch's own fixes found no surviving instance of the
+four findings it re-checked. Verifying them adversarially instead surfaced
+thirteen residual gaps, all accepted; eight further claims were refuted on the
+source and not acted on.
+
+Capture and the media-sync guard:
+
+- The capture signature no longer counts the scan's own `-shm` churn as somebody
+  else writing. Every read-only SQLite open the scan performs on a WAL-mode media
+  save creates or restamps that save's `-shm`, so the before/after pair could
+  never agree: the guard would never release and the scan would re-dispatch for
+  as long as the profile was open. The add-on's own exporter writes single-file
+  DELETE-mode saves, so this is a file that arrived some other way, not the
+  common path.
+- A sync the guard turned away is held rather than dropped when the replay
+  stands down. During a backup restore Anki keeps `restoring_backup` set for the
+  whole session and switches its own unattended syncs off, so the request that
+  was discarded there was gone for good.
+- A pass that leaves the guard up schedules its own rescan. The only recurring
+  trigger was the media-sync hook, and `MediaSyncer.start` returns before firing
+  it when the gate says no, so the guard suppressed its own retry. That timer is
+  requested unconditionally: Anki's collection gate drops rather than defers.
+- The gate reads the user's preference before the profile folder, and fails open
+  if the folder cannot be resolved. Anki's own `media_syncing_enabled` is a dict
+  lookup that cannot raise, and three callers assume as much.
+
+Import lifecycle:
+
+- Every notice that reports an armed import is guarded, not just the success
+  one. An exception from Qt in the staged or already-pending branch unwound into
+  the caller's "aborted, nothing was replaced" handler.
+- The menu can tell a pending import from one that has already installed. A
+  failed post-install cleanup leaves the record beside a replaced save, and both
+  answers were the wrong way round: Cancel claimed the save was unchanged, and a
+  second attempt was told the first would install at the next restart.
+- The advertised recovery path always holds the newest pre-install snapshot. A
+  retried install used to redirect the new snapshot and leave the stale one under
+  the name the user was given.
+- Superseded recovery snapshots are pruned to one. An install that cannot finish
+  is retried on every start and each attempt snapshots the save again.
+- The whole startup installation shares one 30-second budget. It runs during
+  add-on import, before Anki has a window or a progress dialog.
+- A record whose target no longer exists says so, and Cancel Pending Save Import
+  covers both save modes, since startup reports failures for both.
+
+Shutdown and scheduling:
+
+- Retention cannot take Anki's close down with it, and it stops when the
+  shutdown budget is gone. Abandoned staging directories are swept after an hour.
+- The media scan is dispatched as the last act of profile-open again. Its
+  main-thread callback would otherwise be delivered inside the modal dialogs
+  that follow, and the rescue it can offer reaches `close_anki` from there.
+
+A Tier-2 probe now plays the whole import contract out across a real restart of
+the real add-on: stage over the live save, keep editing, exit, start again, and
+check that the runtime is on the imported save with the final pre-import
+progress in the recovery copy and nothing left staged. Windows file locking and
+authenticated AnkiWeb behaviour remain outside this validation.

--- a/docs/save_transfer_safety.md
+++ b/docs/save_transfer_safety.md
@@ -31,6 +31,11 @@ does not run over an imported save. The review watermark is rebased when the
 destination collection opens, before mobile detection, including reviews that
 arrived during shutdown sync.
 
+Backup Manager restore uses the same staged, next-process installation path and
+captures the final current save before replacement. Because a Backup Manager
+snapshot is private local recovery material rather than a portable import, its
+leaderboard credentials are retained.
+
 ## Export and media preservation
 
 Export snapshots, removes credentials, vacuums, and verifies in private temporary
@@ -39,16 +44,19 @@ temporary file. Completion statistics come from the actual exported snapshot.
 
 At profile open, both `ankimon.db` and `ankimonDEV.db` in `collection.media` are
 captured before Anki can start automatic media sync. Verified copies include
-committed WAL contents and use underscore-prefixed, content-derived filenames.
-Only saves in the active mode are compared for recovery.
+committed WAL contents and use content-derived filenames under
+`ankimon-media-recovery/` beside `collection.media`, not inside the media folder.
+That keeps newly-created recovery databases out of AnkiWeb media sync while
+still leaving old underscore-prefixed migration copies readable for backwards
+compatibility. Only saves in the active mode are compared for recovery.
 
 If SQLite cannot read a source, Ankimon retains a labelled **unverified** ZIP of
-the raw database and its available sidecars. This is recovery material, not a
-guarantee that the archive contains a consistent save. Existing copies and raw
-archives must match their content before reuse. Damaged files remain untouched.
-If even raw capture fails, media sync pauses for that profile in memory until
-capture succeeds. Sync preferences are not changed. Close anything locking the
-files and restart Anki to retry.
+the raw database and its available sidecars in the same local recovery
+directory. This is recovery material, not a guarantee that the archive contains
+a consistent save. Existing copies and raw archives must match their content
+before reuse. Damaged files remain untouched. If even raw capture fails, media
+sync pauses for that profile in memory until capture succeeds. Sync preferences
+are not changed. Close anything locking the files and restart Anki to retry.
 
 Preservation status is separate from the feature-removal announcement. Worker
 or dispatch failures remain retryable and visible; they do not start a full
@@ -68,8 +76,8 @@ progress UI remain separate UX work. Aggregate counters never establish that
 one collection contains another.
 
 Regression coverage uses real SQLite files, WAL transactions, injected filesystem
-failures, and fresh subprocesses. Validation passed with 1,536 tests, 40 skips,
-9 subtests, all 13 Tier-1 checks, and the Tier-2 real-Qt play probe.
+failures, fresh subprocesses, malformed pending metadata, custom database paths,
+and assertions that new recovery files stay outside `collection.media`.
 
 A real Anki 25.09.2 session with a temporary profile also exercised an unfinished
 Add Cards note and **Keep Editing** during import shutdown. The original save

--- a/docs/save_transfer_safety.md
+++ b/docs/save_transfer_safety.md
@@ -18,6 +18,12 @@ retry through an add-on reload in that process. A token in the installed save
 prevents a crash immediately after replacement from repeating the import over
 later progress.
 
+Publishing `pending.json` is staging's commit point. Anything that fails after
+it — the directory syncs, the read-back — leaves an import that WILL install at
+the next full start, so it is reported as pending with the cancel instruction
+rather than as an abort. Only failures before publication say the current save
+is unchanged, and they leave nothing staged.
+
 Recovery copies live in `ankimon_recovery/pre-import-<token>/` beside the active
 database. The preparation message displays the reserved location, and
 **Browse Pre-import Recovery Saves…** opens the folder. Routine backup retention

--- a/docs/save_transfer_safety.md
+++ b/docs/save_transfer_safety.md
@@ -268,15 +268,18 @@ Cancellation and the pending record:
   removal brings back a record that installs nothing. If the rewrite itself
   cannot be synced, Cancel reports failure and puts the original record back, so
   the retry it asks for still finds the import. A separate tombstone file was not
-  used: its directory entry would need the very sync that failed.
+  used: its directory entry would need the very sync that failed. The record is
+  padded to the old one's length, so no truncate follows the write for a crash to
+  split from it.
 - Whether a pending record describes an already-installed import has three
   answers. The check runs on the GUI thread only to choose wording, so the save
-  gets two seconds rather than SQLite's 30-second busy timeout. A locked or
-  unreadable save answers "unknown", and Import, Backup Restore and Cancel word
-  that as neither pending nor installed; the cancellation event carries
-  `installed=None`.
-- A cancellation that succeeds for one save mode and fails for the other names
-  both outcomes.
+  gets two seconds rather than SQLite's 30-second busy timeout. A damaged record
+  or a locked or unreadable save answers "unknown", and Import, Backup Restore
+  and Cancel word that as neither pending nor installed, without guessing which
+  of the two could not be read; the cancellation event carries `installed=None`.
+- Cancel reports one line per save. A cancellation that succeeds for one save and
+  fails for the other names both outcomes, and an import that had already
+  installed on one save is no longer described as if it were the other's.
 - A manifest that has vanished by read-back is the one failure after publication
   that stays an ordinary abort: nothing will install, and the staged copy goes.
 
@@ -292,7 +295,10 @@ Startup and shutdown budgets:
   entries restamps a directory's mtime and retention orders by mtime, so a
   removal cut short in place, by the deadline or by one locked file, left remains
   that sorted as the newest backup and evicted a good one on the next pass. This
-  turned up while checking the refuted claim below.
+  turned up while checking the refuted claim below. Backup Manager's Delete
+  button had the same problem and now renames first too. A linked backup is
+  removed as a link: walking it would delete the files it points at, which
+  `shutil.rmtree` refused to do.
 
 Refuted:
 
@@ -311,3 +317,11 @@ Also: a deferred media sync that cannot be restarted is logged (the request itse
 has been kept since the fourth round), each phase of the Tier-2 import probe is
 bounded at 300 seconds, and the preference-off guard test now drives the user's
 preference through the installed wrapper instead of replacing it.
+
+These changes were checked adversarially before they were pushed. That found seven
+gaps in them, each now fixed with a test: three ways Cancel's wording could be
+wrong across two saves, a record rewrite that a crash could split from its
+truncate, the Delete button's in-place removal, a linked backup being walked, and
+no test driving the digest and recovery-sync budget checks through the install
+itself. The `-shm` refutation was re-checked against SQLite 3.46.1's Windows VFS,
+which also refuses a read-only handle the exclusive lock a checkpoint needs.

--- a/docs/save_transfer_safety.md
+++ b/docs/save_transfer_safety.md
@@ -138,4 +138,8 @@ A second review round raised four further findings, all accepted:
   a save that is already gone, and the next pass rescans with sync still paused.
   The comparison uses the state the worker observed, so a transient metadata
   failure while the scan was being dispatched no longer costs an extra pass.
+  The worker reads that state both before and after the capture, so a writer
+  landing *during* the copy is caught too: the copy verifies its own bytes, not
+  that the source held still while they were read, and only a capture bound to
+  one observed revision releases the sync guard.
 - The worker/GUI-thread sentence above names preservation work as its subject.

--- a/docs/save_transfer_safety.md
+++ b/docs/save_transfer_safety.md
@@ -1,0 +1,79 @@
+# Save transfer safety after #797
+
+This follow-up addresses the transfer and migration review of #797, including
+the inherited backup defect tracked in #798.
+
+## Import and recovery
+
+Import prepares a private, verified save for the next **full Anki restart**.
+It never replaces the database used by the current game objects. Choosing
+**Keep Editing** during shutdown, a shutdown exception, and shutdown-triggered
+sync therefore leave the current runtime and save together. The menu action
+**Cancel Pending Save Import** discards a prepared import for the active mode.
+
+Before constructing database managers or game objects at the next process
+start, Ankimon captures the final current save using SQLite's backup API,
+verifies it, and installs the prepared snapshot. Failed startup attempts cannot
+retry through an add-on reload in that process. A token in the installed save
+prevents a crash immediately after replacement from repeating the import over
+later progress.
+
+Recovery copies live in `ankimon_recovery/pre-import-<token>/` beside the active
+database. The preparation message displays the reserved location, and
+**Browse Pre-import Recovery Saves…** opens the folder. Routine backup retention
+does not delete these copies. Import a recovery `.db` through the same import
+flow to restore it. Failed installation retries retain earlier recovery copies.
+
+Imports require leaderboard sign-in again. Incoming current and legacy
+credentials are removed; explicit empty authentication settings prevent legacy
+local configuration from restoring another account. Destination JSON migration
+does not run over an imported save. The review watermark is rebased when the
+destination collection opens, before mobile detection, including reviews that
+arrived during shutdown sync.
+
+## Export and media preservation
+
+Export snapshots, removes credentials, vacuums, and verifies in private temporary
+storage. Only sanitised bytes enter the destination directory, including its
+temporary file. Completion statistics come from the actual exported snapshot.
+
+At profile open, both `ankimon.db` and `ankimonDEV.db` in `collection.media` are
+captured before Anki can start automatic media sync. Verified copies include
+committed WAL contents and use underscore-prefixed, content-derived filenames.
+Only saves in the active mode are compared for recovery.
+
+If SQLite cannot read a source, Ankimon retains a labelled **unverified** ZIP of
+the raw database and its available sidecars. This is recovery material, not a
+guarantee that the archive contains a consistent save. Existing copies and raw
+archives must match their content before reuse. Damaged files remain untouched.
+If even raw capture fails, media sync pauses for that profile in memory until
+capture succeeds. Sync preferences are not changed. Close anything locking the
+files and restart Anki to retry.
+
+Preservation status is separate from the feature-removal announcement. Worker
+or dispatch failures remain retryable and visible; they do not start a full
+comparison scan on the GUI thread. Recovery paths are recorded in the Ankimon
+log. No original media file is deleted.
+
+## Review disposition and validation limits
+
+All seven safety findings were accepted: import lifecycle, export credentials,
+pre-sync capture, consistent safety backups, accurate notices, both save modes,
+and WAL-aware preservation. General backups also use verified SQLite snapshots
+of the exact active path. No compatibility workaround for `uses_collection=False`
+was needed.
+
+A richer recovery browser with trainer/count summaries and cancellable transfer
+progress UI remain separate UX work. Aggregate counters never establish that
+one collection contains another.
+
+Regression coverage uses real SQLite files, WAL transactions, injected filesystem
+failures, and fresh subprocesses. Validation passed with 1,536 tests, 40 skips,
+9 subtests, all 13 Tier-1 checks, and the Tier-2 real-Qt play probe.
+
+A real Anki 25.09.2 session with a temporary profile also exercised an unfinished
+Add Cards note and **Keep Editing** during import shutdown. The original save
+remained writable; a subsequent full process loaded the imported trainer and
+retained the final old progress in recovery. Dialog choices were automated;
+Anki's actual editor and close lifecycle ran. Authenticated AnkiWeb conflict
+resolution and Windows file locking remain outside this validation.

--- a/docs/save_transfer_safety.md
+++ b/docs/save_transfer_safety.md
@@ -192,8 +192,8 @@ Verifying those four fixes surfaced five more, all accepted:
 
 An external review of the branch's own fixes found no surviving instance of the
 four findings it re-checked. Verifying them adversarially instead surfaced
-thirteen residual gaps, all accepted; eight further claims were refuted on the
-source and not acted on.
+fifteen residual gaps in this branch, all accepted; eight further claims were
+refuted on the source and not acted on.
 
 Capture and the media-sync guard:
 

--- a/docs/save_transfer_safety.md
+++ b/docs/save_transfer_safety.md
@@ -60,9 +60,10 @@ sync pauses for that profile in memory until capture succeeds. Sync preferences
 are not changed. Close anything locking the files and restart Anki to retry.
 
 Preservation status is separate from the feature-removal announcement. Worker
-or dispatch failures remain retryable and visible; they do not copy, archive, or
-compare saves on the GUI thread. Unchanged unreadable saves have a 30-second
-retry delay; changed files, permissions, or SQLite sidecars re-arm immediately.
+and dispatch failures remain retryable and visible. Preservation work runs on
+the guarded worker and does not copy, archive, or compare saves on the GUI
+thread. Unchanged unreadable saves have a 30-second retry delay; changed files,
+permissions, or SQLite sidecars re-arm immediately.
 Moving an uncaptured save out of the media folder also clears its sync guard.
 Recovery paths are recorded in the Ankimon
 log. No original media file is deleted.
@@ -116,3 +117,19 @@ restart-only import behavior:
 The optional 80% docstring-coverage warning was not adopted as a blanket rewrite
 of the transfer tests and existing helpers. Behavioral contracts and the new
 failure/scheduling paths are documented where they need explanation.
+
+A second review round raised four further findings, all accepted:
+
+- Import outcome warnings are delivered inside their own guard, and each list is
+  cleared only after the user has actually been shown it. A presenter failure no
+  longer discards the notice or prevents the AnkiWeb sync hooks from registering.
+- The automatic shutdown backup spends a single 30-second budget across every
+  database it snapshots, starting with the one the result depends on, so two
+  locked saves cannot delay closing Anki for a full timeout each. Manual and
+  pre-overwrite backups keep the per-file default.
+- A media scan whose source changed after the worker captured it is discarded
+  whole rather than applied. Its comparison figures and rescue snapshot describe
+  a save that is already gone, and the next pass rescans with sync still paused.
+  The comparison uses the state the worker observed, so a transient metadata
+  failure while the scan was being dispatched no longer costs an extra pass.
+- The worker/GUI-thread sentence above names preservation work as its subject.

--- a/harness/checks/probe_real_save_import.py
+++ b/harness/checks/probe_real_save_import.py
@@ -1,0 +1,183 @@
+"""Tier-2 probe: a staged save import survives a real restart of the real add-on.
+
+The unit tests around ``save_import`` drive the module with a faked Anki host and
+a database nobody else has open. The guarantee users actually depend on spans two
+processes and the real boot order, so this probe plays it out for real:
+
+  1. boot the genuine add-on, mark the live save, stage an import of a different
+     save while the runtime holds that database open, then KEEP EDITING -- the
+     case the dialog explicitly invites, and the one where a wrongly reported
+     abort would cost progress;
+  2. exit, and boot the add-on again on the same user path, exactly as a user
+     restarting Anki does.
+
+Then it checks what the dialog promised: the imported save is what the runtime is
+now playing, the final progress from step 1 (post-staging edits included) is in the
+retained recovery copy, and nothing is left staged to install a second time.
+
+Run (after sourcing the Tier-2 env file):
+    python -m harness.checks.probe_real_save_import
+"""
+
+import json
+import os
+import pathlib
+import shutil
+import sqlite3
+import subprocess
+import sys
+import tempfile
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[2]))
+
+# Config keys this probe writes. Real keys are avoided deliberately: the add-on
+# rewrites its own settings during boot, and a marker it owns could be restored
+# from somewhere else and pass the check for the wrong reason.
+BEFORE = "ankimon.probe.save_import.before"
+AFTER = "ankimon.probe.save_import.after"
+INCOMING = "ankimon.probe.save_import.incoming"
+
+HANDOFF = "probe_save_import_handoff.json"
+
+
+def _boot(user_path):
+    from harness.real_env import start_real_session
+
+    return start_real_session(user_path=str(user_path))
+
+
+def _phase_one(user_path: pathlib.Path) -> int:
+    """Mark the save, stage an import over it, then keep playing."""
+    session = _boot(user_path)
+    db = session.services.db
+    target = pathlib.Path(db.db_path)
+    db.set_config_value(BEFORE, "progress-before-the-import")
+
+    # The incoming save is a copy of the live one carrying a different marker, so
+    # it passes the importer's validity checks the way a real exported save does.
+    incoming = user_path / "incoming-save.db"
+    source = sqlite3.connect(target.as_uri() + "?mode=ro", uri=True, timeout=30)
+    try:
+        destination = sqlite3.connect(str(incoming), timeout=30)
+        try:
+            source.backup(destination)
+        finally:
+            destination.close()
+    finally:
+        source.close()
+    stamp = sqlite3.connect(str(incoming), timeout=30)
+    try:
+        stamp.execute("INSERT OR REPLACE INTO config (key, value) VALUES (?, ?)",
+                      (INCOMING, "the-imported-save"))
+        stamp.commit()
+    finally:
+        stamp.close()
+
+    from Ankimon.save_import import stage_import
+
+    pending = stage_import(incoming, target)
+
+    # "If you keep editing, this import stays pending" -- so edit. This is the
+    # progress the recovery copy has to hold after the restart.
+    db.set_config_value(AFTER, "progress-after-staging")
+
+    # The import must be PENDING, not applied: the live save carries on unchanged
+    # until the next full start. Without this the restart check below could pass
+    # for the wrong reason, on an import that never waited at all.
+    from Ankimon.save_import import pending_import_info
+
+    assert db.get_config_value(INCOMING) is None, "the import replaced the live save in place"
+    assert db.get_config_value(AFTER) == "progress-after-staging"
+    assert pending_import_info(target) is not None, "nothing was left staged to install"
+
+    (user_path / HANDOFF).write_text(json.dumps({
+        "target": str(target),
+        "recovery_path": str(pending["recovery_path"]),
+        "token": pending["token"],
+    }), encoding="utf-8")
+    print(f"  phase 1: staged {pending['token'][:12]} over {target.name}, kept editing")
+    return 0
+
+
+def _config(path: pathlib.Path, key: str):
+    conn = sqlite3.connect(path.as_uri() + "?mode=ro", uri=True, timeout=30)
+    try:
+        row = conn.execute("SELECT value FROM config WHERE key = ?", (key,)).fetchone()
+        return None if row is None else row[0]
+    finally:
+        conn.close()
+
+
+def _phase_two(user_path: pathlib.Path) -> int:
+    """Restart, and check the promise the import dialog made."""
+    handoff = json.loads((user_path / HANDOFF).read_text(encoding="utf-8"))
+    target = pathlib.Path(handoff["target"])
+    recovery = pathlib.Path(handoff["recovery_path"])
+
+    session = _boot(user_path)
+    db = session.services.db
+
+    # 1. The runtime is playing the imported save, read through the add-on's own
+    #    database object rather than the file, because that is what the game uses.
+    assert db.get_config_value(INCOMING) == "the-imported-save", (
+        "the staged import did not install on restart")
+    assert db.get_config_value(AFTER) is None, (
+        "the runtime is still on the pre-import save")
+
+    # 2. The final pre-import progress is retained, including what was played
+    #    after staging. Losing this is the failure the recovery copy exists for.
+    assert recovery.is_file(), f"no recovery copy at {recovery}"
+    assert _config(recovery, BEFORE) == "progress-before-the-import", (
+        "the recovery copy is missing progress from before staging")
+    assert _config(recovery, AFTER) == "progress-after-staging", (
+        "the recovery copy predates the play that followed staging")
+
+    # 3. Nothing is left armed to install a second time over the new save.
+    from Ankimon.save_import import pending_import_info
+
+    assert pending_import_info(target) is None, "an import is still pending after install"
+    staging = target.parent / f".ankimon-import-{target.name}"
+    leftovers = sorted(p.name for p in staging.glob("*")) if staging.is_dir() else []
+    assert not leftovers, f"staging directory still holds {leftovers}"
+
+    print(f"  phase 2: installed, recovery verified at {recovery.name}")
+    return 0
+
+
+def main() -> int:
+    phase = None
+    user_path = None
+    for argument in sys.argv[1:]:
+        if argument.startswith("--phase="):
+            phase = argument.split("=", 1)[1]
+        elif argument.startswith("--user="):
+            user_path = pathlib.Path(argument.split("=", 1)[1])
+
+    if phase == "1":
+        return _phase_one(user_path)
+    if phase == "2":
+        return _phase_two(user_path)
+
+    # Orchestrator. Each phase is a separate process because that is the thing
+    # being tested: the install runs before any runtime exists, and the module
+    # singletons an in-process reload would keep are exactly what it refuses.
+    user_path = pathlib.Path(tempfile.mkdtemp(prefix="ankimon_import_probe_"))
+    environment = dict(os.environ)
+    environment.setdefault("QT_QPA_PLATFORM", "offscreen")
+    for step in ("1", "2"):
+        result = subprocess.run(
+            [sys.executable, "-m", "harness.checks.probe_real_save_import",
+             f"--phase={step}", f"--user={user_path}"],
+            cwd=str(pathlib.Path(__file__).resolve().parents[2]),
+            env=environment,
+        )
+        if result.returncode != 0:
+            print(f"probe_real_save_import: phase {step} FAILED", file=sys.stderr)
+            return result.returncode
+    shutil.rmtree(user_path, ignore_errors=True)
+    print("probe_real_save_import: OK")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/harness/checks/probe_real_save_import.py
+++ b/harness/checks/probe_real_save_import.py
@@ -144,6 +144,11 @@ def _phase_two(user_path: pathlib.Path) -> int:
     return 0
 
 
+# Each phase boots the real add-on once; CI finishes both in well under a
+# minute. A startup that hangs must fail this probe, not occupy the job.
+PHASE_TIMEOUT = 300
+
+
 def main() -> int:
     phase = None
     user_path = None
@@ -165,12 +170,18 @@ def main() -> int:
     environment = dict(os.environ)
     environment.setdefault("QT_QPA_PLATFORM", "offscreen")
     for step in ("1", "2"):
-        result = subprocess.run(
-            [sys.executable, "-m", "harness.checks.probe_real_save_import",
-             f"--phase={step}", f"--user={user_path}"],
-            cwd=str(pathlib.Path(__file__).resolve().parents[2]),
-            env=environment,
-        )
+        try:
+            result = subprocess.run(
+                [sys.executable, "-m", "harness.checks.probe_real_save_import",
+                 f"--phase={step}", f"--user={user_path}"],
+                cwd=str(pathlib.Path(__file__).resolve().parents[2]),
+                env=environment,
+                timeout=PHASE_TIMEOUT,
+            )
+        except subprocess.TimeoutExpired:
+            print(f"probe_real_save_import: phase {step} did not finish within "
+                  f"{PHASE_TIMEOUT}s", file=sys.stderr)
+            return 1
         if result.returncode != 0:
             print(f"probe_real_save_import: phase {step} FAILED", file=sys.stderr)
             return result.returncode

--- a/src/Ankimon/functions/mobile_sync.py
+++ b/src/Ankimon/functions/mobile_sync.py
@@ -378,6 +378,9 @@ def process_mobile_reviews_after_sync(col, ankimon_db, settings_obj, logger) -> 
         return 0
 
     try:
+        from ..save_import import rebase_after_import
+
+        rebase_after_import(ankimon_db, col)
         watermark = ankimon_db.get_mobile_watermark()
         desktop_ids = get_desktop_session_revlog_ids()
 

--- a/src/Ankimon/menu_buttons.py
+++ b/src/Ankimon/menu_buttons.py
@@ -25,7 +25,9 @@ from .pokedex.pokedex_obj import Pokedex
 from .pyobj.achievement_window import AchievementWindow
 from .pyobj.ankimon_tracker_window import AnkimonTrackerWindow
 from .pyobj.backup_manager import BackupManager
-from .pyobj.save_transfer import export_save, import_save
+from .pyobj.save_transfer import (
+    export_save, import_save, cancel_pending_save_import, browse_recovered_saves,
+)
 from .gui_classes.backup_manager_dialog import BackupManagerDialog
 from .gui_entities import (
     License,
@@ -234,6 +236,16 @@ def create_menu_actions(
     import_save_action.setMenuRole(QAction.MenuRole.NoRole)
     import_save_action.triggered.connect(lambda: import_save(mw))
     game_menu.addAction(import_save_action)
+
+    cancel_import_action = QAction("Cancel Pending Save Import", mw)
+    cancel_import_action.setMenuRole(QAction.MenuRole.NoRole)
+    cancel_import_action.triggered.connect(cancel_pending_save_import)
+    game_menu.addAction(cancel_import_action)
+
+    recovery_action = QAction("Browse Pre-import Recovery Saves…", mw)
+    recovery_action.setMenuRole(QAction.MenuRole.NoRole)
+    recovery_action.triggered.connect(browse_recovered_saves)
+    game_menu.addAction(recovery_action)
 
     # Effectiveness chart
     eff_chart_action = QAction(mw.translator.translate("eff_chart_button"), mw)

--- a/src/Ankimon/profile_hooks.py
+++ b/src/Ankimon/profile_hooks.py
@@ -56,9 +56,8 @@ def _on_profile_close():
 
 def _on_profile_did_open(online_connectivity):
     def handler():
-        # Capture bare media saves before any dialog can pump the event loop,
-        # and before Anki starts automatic sync after profile_did_open returns.
-        # Only preservation is synchronous; comparisons run in the background.
+        # Guard startup sync before any dialog can pump the event loop, then
+        # preserve bare media saves in the background before sync may proceed.
         try:
             register_media_migration_hooks(settings_obj, logger)
         except Exception as e:
@@ -133,9 +132,19 @@ def _on_profile_did_open(online_connectivity):
         if failures:
             services._save_import_errors = []
             services.ui.warn(
-                "Ankimon could not install a pending import. Your current save remains active. "
-                "It will retry on a full restart, or use Cancel Pending Save Import.\n\n" +
+                "Ankimon could not install the pending imports listed below. "
+                "The previous save for each listed file remains active. "
+                "They will retry on a full restart, or use Cancel Pending Save Import.\n\n" +
                 "\n".join(failures)
+            )
+        warnings = getattr(services, "_save_import_warnings", [])
+        if warnings:
+            services._save_import_warnings = []
+            services.ui.warn(
+                "Ankimon installed the imported saves listed below, and they are active. "
+                "A final disk sync or cleanup step failed. Any remaining pending "
+                "work will retry on a full restart without applying the import again.\n\n" +
+                "\n".join(warnings)
             )
 
         # Register the AnkiWeb sync hooks SYNCHRONOUSLY here — not in the

--- a/src/Ankimon/profile_hooks.py
+++ b/src/Ankimon/profile_hooks.py
@@ -10,7 +10,10 @@ from .services import services
 from .singletons import settings_obj, logger
 from .utils import test_online_connectivity
 from .pyobj.ankimon_sync import setup_ankimon_sync_hooks
-from .pyobj.save_transfer import register_media_migration_hooks
+from .pyobj.save_transfer import (
+    guard_media_saves_now,
+    register_media_migration_hooks,
+)
 from .pyobj.tip_of_the_day import show_tip_of_the_day
 from .pyobj.pokemon_trade import check_and_award_monthly_pokemon
 from .pyobj.error_handler import show_warning_with_traceback
@@ -56,12 +59,11 @@ def _on_profile_close():
 
 def _on_profile_did_open(online_connectivity):
     def handler():
-        # Guard startup sync before any dialog can pump the event loop, then
-        # preserve bare media saves in the background before sync may proceed.
-        try:
-            register_media_migration_hooks(settings_obj, logger)
-        except Exception as e:
-            logger.log("error", f"AnkiWeb sync-removal migration failed: {e}")
+        # Pause media sync for any uncaptured original BEFORE the first dialog
+        # below can pump the event loop. Stat calls only; the scan that can
+        # release this guard is dispatched at the very end of this handler,
+        # where nothing runs after it to deliver its callback re-entrantly.
+        guard_media_saves_now(logger)
 
         # Re-warm the static evolution table _on_profile_close just dropped.
         # The boot warm (startup.run_startup_background_checks) runs once per
@@ -216,6 +218,30 @@ def _on_profile_did_open(online_connectivity):
                 )
 
         mw.taskman.run_in_background(check_connectivity_bg, on_done)
+
+        # One-shot per-profile cleanup after the removal of the AnkiWeb
+        # file-sync: protect whatever that feature left in collection.media from
+        # Anki's "Delete Unused Files", and offer to rescue it if it holds more
+        # progress than the local save.
+        #
+        # LAST in this handler, deliberately. The scan runs on mw.taskman and
+        # its decisions come back through a main-thread callback, which a nested
+        # event loop -- any modal dialog above -- would deliver in the middle of
+        # that dialog. Nothing after this line pumps the loop, so the callback
+        # lands on a clean stack, which is what _offer_rescue_later's zero-delay
+        # timer relies on to defer a shutdown until profile-open has returned.
+        # The guard itself is already up, from the top of this handler.
+        #
+        # This registers a media-sync-completion hook AND starts one scan now.
+        # Both are needed: Anki fires profile_did_open one line BEFORE it starts
+        # its own sync (aqt/main.py:568-569), so on a second device this first
+        # scan sees a media folder the peer's save has not reached yet, and only
+        # the post-sync pass can find it. Local files only, no network, never
+        # raises.
+        try:
+            register_media_migration_hooks(settings_obj, logger)
+        except Exception as e:
+            logger.log("error", f"AnkiWeb sync-removal migration failed: {e}")
 
     return handler
 

--- a/src/Ankimon/profile_hooks.py
+++ b/src/Ankimon/profile_hooks.py
@@ -56,6 +56,14 @@ def _on_profile_close():
 
 def _on_profile_did_open(online_connectivity):
     def handler():
+        # Capture bare media saves before any dialog can pump the event loop,
+        # and before Anki starts automatic sync after profile_did_open returns.
+        # Only preservation is synchronous; comparisons run in the background.
+        try:
+            register_media_migration_hooks(settings_obj, logger)
+        except Exception as e:
+            logger.log("error", f"AnkiWeb sync-removal migration failed: {e}")
+
         # Re-warm the static evolution table _on_profile_close just dropped.
         # The boot warm (startup.run_startup_background_checks) runs once per
         # Anki PROCESS, so a profile SWITCH leaves pokemon_evolution.csv
@@ -81,6 +89,12 @@ def _on_profile_did_open(online_connectivity):
             if db is not None and col is not None:
                 from .functions.mobile_sync import clear_desktop_session
                 from .menu_buttons import update_mobile_badge
+                from .save_import import rebase_after_import
+
+                # Addon construction precedes opening the Anki collection.
+                # Rebase an installed import now, including shutdown-sync reviews,
+                # before any old reviews can be queued as mobile battles.
+                rebase_after_import(db, col)
 
                 watermark = db.get_mobile_watermark()
                 if watermark == 0:
@@ -114,6 +128,15 @@ def _on_profile_did_open(online_connectivity):
                 update_mobile_badge(pending)
         except Exception as e:
             logger.log("error", f"Failed to initialize mobile watermark: {e}")
+
+        failures = getattr(services, "_save_import_errors", [])
+        if failures:
+            services._save_import_errors = []
+            services.ui.warn(
+                "Ankimon could not install a pending import. Your current save remains active. "
+                "It will retry on a full restart, or use Cancel Pending Save Import.\n\n" +
+                "\n".join(failures)
+            )
 
         # Register the AnkiWeb sync hooks SYNCHRONOUSLY here — not in the
         # backgrounded connectivity callback below. Anki fires profile_did_open
@@ -173,28 +196,6 @@ def _on_profile_did_open(online_connectivity):
                 )
 
         mw.taskman.run_in_background(check_connectivity_bg, on_done)
-
-        # One-shot per-profile cleanup after the removal of the AnkiWeb
-        # file-sync: protect whatever that feature left in collection.media from
-        # Anki's "Delete Unused Files", and offer to rescue it if it holds more
-        # progress than the local save.
-        #
-        # This registers a media-sync-completion hook AND starts one scan now.
-        # Both are needed: Anki fires profile_did_open one line BEFORE it starts
-        # its own sync (aqt/main.py:568-569), so on a second device this first
-        # scan sees a media folder the peer's save has not reached yet, and only
-        # the post-sync pass can find it. Local files only, no network, never
-        # raises.
-        #
-        # The scan itself runs on a background thread (mw.taskman): it opens
-        # SQLite saves, and a locked or oversized one must not be waited on here,
-        # where the wait is a frozen startup. Only the decisions come back to
-        # this thread. A profile that has already resolved its media folder is a
-        # handful of stat calls and starts no thread at all.
-        try:
-            register_media_migration_hooks(settings_obj, logger)
-        except Exception as e:
-            logger.log("error", f"AnkiWeb sync-removal migration failed: {e}")
 
     return handler
 

--- a/src/Ankimon/profile_hooks.py
+++ b/src/Ankimon/profile_hooks.py
@@ -140,8 +140,9 @@ def _on_profile_did_open(online_connectivity):
             try:
                 services.ui.warn(
                     "Ankimon could not install the pending imports listed below. "
-                    "The previous save for each listed file remains active. "
-                    "They will retry on a full restart, or use Cancel Pending Save Import.\n\n" +
+                    "No save was replaced. They will retry on a full restart, or "
+                    "use Cancel Pending Save Import, which now covers both save "
+                    "modes.\n\n" +
                     "\n".join(failures)
                 )
                 services._save_import_errors = []

--- a/src/Ankimon/profile_hooks.py
+++ b/src/Ankimon/profile_hooks.py
@@ -138,11 +138,14 @@ def _on_profile_did_open(online_connectivity):
         failures = getattr(services, "_save_import_errors", [])
         if failures:
             try:
+                # Only the listed saves were left alone. get_db tries both save
+                # modes at every start, so the other one may have been replaced
+                # in this same start; "no save was replaced" denied that.
                 services.ui.warn(
-                    "Ankimon could not install the pending imports listed below. "
-                    "No save was replaced. They will retry on a full restart, or "
-                    "use Cancel Pending Save Import, which now covers both save "
-                    "modes.\n\n" +
+                    "Ankimon could not install the pending imports listed below, "
+                    "so those saves were not replaced. They will retry on a full "
+                    "restart, or use Ankimon → Game → Cancel Pending Save Import, "
+                    "which covers both save modes.\n\n" +
                     "\n".join(failures)
                 )
                 services._save_import_errors = []

--- a/src/Ankimon/profile_hooks.py
+++ b/src/Ankimon/profile_hooks.py
@@ -128,24 +128,35 @@ def _on_profile_did_open(online_connectivity):
         except Exception as e:
             logger.log("error", f"Failed to initialize mobile watermark: {e}")
 
+        # Delivery goes through QtPresenter.warn -> showWarning in production, so
+        # it can raise. Report each list in its own guarded block and clear it
+        # only once the user has actually been told: a lost warning would leave
+        # the import outcome invisible, and an escaping one would take the sync
+        # hook registration below down with it.
         failures = getattr(services, "_save_import_errors", [])
         if failures:
-            services._save_import_errors = []
-            services.ui.warn(
-                "Ankimon could not install the pending imports listed below. "
-                "The previous save for each listed file remains active. "
-                "They will retry on a full restart, or use Cancel Pending Save Import.\n\n" +
-                "\n".join(failures)
-            )
+            try:
+                services.ui.warn(
+                    "Ankimon could not install the pending imports listed below. "
+                    "The previous save for each listed file remains active. "
+                    "They will retry on a full restart, or use Cancel Pending Save Import.\n\n" +
+                    "\n".join(failures)
+                )
+                services._save_import_errors = []
+            except Exception as e:
+                logger.log("error", f"Failed to report pending save import failures: {e}")
         warnings = getattr(services, "_save_import_warnings", [])
         if warnings:
-            services._save_import_warnings = []
-            services.ui.warn(
-                "Ankimon installed the imported saves listed below, and they are active. "
-                "A final disk sync or cleanup step failed. Any remaining pending "
-                "work will retry on a full restart without applying the import again.\n\n" +
-                "\n".join(warnings)
-            )
+            try:
+                services.ui.warn(
+                    "Ankimon installed the imported saves listed below, and they are active. "
+                    "A final disk sync or cleanup step failed. Any remaining pending "
+                    "work will retry on a full restart without applying the import again.\n\n" +
+                    "\n".join(warnings)
+                )
+                services._save_import_warnings = []
+            except Exception as e:
+                logger.log("error", f"Failed to report save import finalization warnings: {e}")
 
         # Register the AnkiWeb sync hooks SYNCHRONOUSLY here — not in the
         # backgrounded connectivity callback below. Anki fires profile_did_open

--- a/src/Ankimon/pyobj/ankimon_sync.py
+++ b/src/Ankimon/pyobj/ankimon_sync.py
@@ -508,6 +508,7 @@ def setup_ankimon_sync_hooks(settings_obj, logger):
                     MOBILE_QUEUE_CAP,
                 )
                 from ..menu_buttons import update_mobile_badge
+                from ..save_import import rebase_after_import
 
                 dev_db_path = user_path / "ankimonDEV.db"
                 original_db_name = db.db_path.name
@@ -548,6 +549,7 @@ def setup_ankimon_sync_hooks(settings_obj, logger):
                         # 1. Queue to ankimon.db
                         if db.db_path.name != "ankimon.db":
                             db.switch_database("ankimon.db")
+                        rebase_after_import(db, col)
                         watermark_normal = db.get_mobile_watermark()
                         all_mobile_normal = detect_mobile_reviews(col, watermark_normal, desktop_ids)
                         if all_mobile_normal:
@@ -565,6 +567,7 @@ def setup_ankimon_sync_hooks(settings_obj, logger):
                         if dev_db_path.is_file():
                             if db.db_path.name != "ankimonDEV.db":
                                 db.switch_database("ankimonDEV.db")
+                            rebase_after_import(db, col)
                             watermark_dev = db.get_mobile_watermark()
                             all_mobile_dev = detect_mobile_reviews(col, watermark_dev, desktop_ids)
                             if all_mobile_dev:

--- a/src/Ankimon/pyobj/ankimon_sync.py
+++ b/src/Ankimon/pyobj/ankimon_sync.py
@@ -225,11 +225,13 @@ def _verify_sqlite_integrity(db_file: Path, timeout: float = 30.0) -> bool:
         if not db_file.is_file() or db_file.stat().st_size < 512:
             return False
         import sqlite3
-        # Build the read-only URI via as_uri() so a profile path with spaces
-        # or unicode (e.g. C:\Users\John Doe\...) is percent-encoded correctly
-        # — a raw f-string URI would fail to open a perfectly valid DB and
-        # wrongly refuse the import.
-        uri = db_file.resolve().as_uri() + "?mode=ro"
+        from ..save_import import _sqlite_uri
+        # A percent-encoded read-only URI, so a profile path with spaces or
+        # unicode (e.g. C:\Users\John Doe\...) or on a network share
+        # (\\server\share\...) opens — a raw f-string URI, or as_uri()'s
+        # server-in-the-authority form, would fail to open a perfectly valid
+        # DB and wrongly refuse the import.
+        uri = _sqlite_uri(db_file, "ro")
         conn = sqlite3.connect(uri, uri=True, timeout=timeout)
         # connect(timeout=) bounds only the wait for a LOCK. PRAGMA quick_check
         # scans the whole database, so on a big enough save it can run well past

--- a/src/Ankimon/pyobj/backup_manager.py
+++ b/src/Ankimon/pyobj/backup_manager.py
@@ -31,6 +31,8 @@ class BackupManager:
     # profile_will_close runs the automatic backup synchronously, so the whole
     # shutdown gets this budget once -- not one full SQLite timeout per file.
     SHUTDOWN_BACKUP_BUDGET = 30.0
+    # How old an abandoned staging directory must be before retention sweeps it.
+    STALE_STAGING_AGE = 3600.0
 
     def __init__(self, logger, settings_obj):
         self.logger = logger
@@ -213,7 +215,17 @@ class BackupManager:
                 showWarning(f"Failed to create backup: {e}")
 
         if success:
-            self.cleanup_backups()
+            # Retention is housekeeping, and this runs on Anki's synchronous
+            # profile_will_close hook, which does not catch what its handlers
+            # raise. An unremovable old backup -- a Windows lock, an antivirus
+            # scan, a permission change -- must not abort the close, and must
+            # not throw away the backup that was just published either. It also
+            # gets what is left of the shutdown budget: deleting directories is
+            # not work to do while the user waits for Anki to exit.
+            try:
+                self.cleanup_backups(deadline=deadline)
+            except Exception as error:
+                self.logger.log("error", f"Backup retention did not finish: {error}")
         elif created_directory:
             # Failed attempts stay outside listings and retention even if a
             # locked file prevents deletion. Remove only staging directories
@@ -230,7 +242,14 @@ class BackupManager:
 
         A checkpoint can return busy while leaving committed pages in WAL, so
         copying the main file is never sufficient. Read-only online backup also
-        works for an inactive database without mutating or creating its source.
+        works for an inactive database, and never writes to the save itself.
+
+        It is not, however, inert: reading a WAL-mode source through SQLite
+        materialises that source's ``-shm`` (and an empty ``-wal`` when none is
+        there) beside it, because a WAL reader needs the shared index. Nothing
+        in the save changes, but anything comparing stat signatures across such
+        a read has to expect it -- ``_pending_media_protection`` in
+        ``save_transfer`` leaves ``-shm`` out for exactly this reason.
         """
         deadline = time.monotonic() + timeout
         fd, name = tempfile.mkstemp(prefix=".snapshot-", suffix=".db", dir=destination_path.parent)
@@ -580,7 +599,24 @@ class BackupManager:
             self.logger.log("error", f"Failed to delete backup: {e}")
             showWarning(f"Failed to delete backup: {e}")
 
-    def cleanup_backups(self):
+    def _discard(self, directory: Path, what: str, deadline) -> bool:
+        """Remove one directory. Never raise, and never overrun the deadline.
+
+        Retention has no deadline of its own to defend: every removal it skips
+        is simply retried by the next backup. What it must not do is fail the
+        call that published a good backup, or keep Anki's close waiting.
+        """
+        if deadline is not None and time.monotonic() >= deadline:
+            return False
+        try:
+            shutil.rmtree(directory)
+        except Exception as error:
+            self.logger.log("error", f"Failed to delete {what} {directory.name}: {error}")
+            return True
+        self.logger.log("info", f"Deleted {what}: {directory.name}")
+        return True
+
+    def cleanup_backups(self, deadline: float = None):
         """Deletes old backups based on retention policy."""
         # Only published backups enter retention. Failed or interrupted staging
         # directories must not displace recoverable saves even if they remain.
@@ -594,8 +630,8 @@ class BackupManager:
         for backup_dir in backups:
             backup_time = datetime.datetime.fromtimestamp(os.path.getmtime(backup_dir))
             if (datetime.datetime.now() - backup_time).days > self.MAX_BACKUP_AGE_DAYS:
-                shutil.rmtree(backup_dir)
-                self.logger.log("info", f"Deleted old backup: {backup_dir.name}")
+                if not self._discard(backup_dir, "old backup", deadline):
+                    return
             else:
                 backups_to_keep.append(backup_dir)
 
@@ -603,8 +639,25 @@ class BackupManager:
         if not self.settings_obj.get("misc.developer_mode"):
             while len(backups_to_keep) > self.MAX_BACKUPS:
                 oldest_backup = backups_to_keep.pop(0)
-                shutil.rmtree(oldest_backup)
-                self.logger.log("info", f"Deleted oldest backup to maintain max count: {oldest_backup.name}")
+                if not self._discard(oldest_backup, "oldest backup", deadline):
+                    return
+
+        # An attempt whose own rmtree failed leaves a dot-prefixed staging
+        # directory holding a full copy of the save. Listing and retention both
+        # filter on "backup_", by design -- an incomplete attempt must never
+        # displace a recoverable one -- so nothing else would ever remove it.
+        # Age-gated because the name is only reserved while an attempt is live,
+        # and a snapshot takes seconds, never an hour.
+        for staging in self.backups_path.glob(".backup_*"):
+            try:
+                if not staging.is_dir():
+                    continue
+                if time.time() - os.path.getmtime(staging) < self.STALE_STAGING_AGE:
+                    continue
+            except OSError:
+                continue
+            if not self._discard(staging, "incomplete backup", deadline):
+                return
 
     def on_anki_close(self):
         """Creates a backup when Anki is about to close.

--- a/src/Ankimon/pyobj/backup_manager.py
+++ b/src/Ankimon/pyobj/backup_manager.py
@@ -451,6 +451,16 @@ class BackupManager:
 
         return summary
 
+    def _warn_about_pending_import(self, message: str) -> None:
+        """Report an armed import without letting Qt's failure escape."""
+        try:
+            showWarning(message)
+        except Exception as error:
+            self.logger.log(
+                "error",
+                f"A pending save import could not be reported to the user: {error}",
+            )
+
     def restore_backup(self, backup_path_str: str):
         """Stage the selected backup for the next full process start.
 
@@ -486,14 +496,29 @@ class BackupManager:
                 return
 
             from ..save_import import (
-                ImportAlreadyPendingError, ImportStagedError, stage_import,
+                ImportAlreadyPendingError, ImportStagedError,
+                pending_import_is_installed, stage_import,
             )
 
             pending = stage_import(
                 backup_file, target, sanitize_credentials=False
             )
         except ImportAlreadyPendingError:
-            showWarning(
+            # Guarded like the success notice below: showWarning reaches into
+            # Qt, and an exception raised inside an except clause is not caught
+            # by its siblings -- it would leave restore_backup entirely, with
+            # an import armed and nothing said about it.
+            if pending_import_is_installed(target):
+                # The record outlived the import; that replacement has already
+                # happened and no restart will repeat it.
+                self._warn_about_pending_import(
+                    "The previous save import has ALREADY installed and is the "
+                    "save you are playing now. Only its leftover record could "
+                    "not be cleared.\n\nUse Ankimon → Cancel Pending Save Import "
+                    "to clear that record, then restore this backup again."
+                )
+                return
+            self._warn_about_pending_import(
                 "A save import is already pending and will install at the next "
                 "full Anki restart.\n\nUse Ankimon → Cancel Pending Save Import "
                 "first if you want to restore this backup instead."
@@ -503,7 +528,7 @@ class BackupManager:
             # The restore is published and will install; calling it a failure
             # to prepare would hide an armed replacement from the user.
             self.logger.log("error", f"Backup restore staged but unfinished: {e}")
-            showWarning(
+            self._warn_about_pending_import(
                 f"The backup restore could not be finished cleanly: {e}.\n\n"
                 "Your current save is still active, but the restore is now "
                 "PENDING and will install at the next full Anki restart. Use "

--- a/src/Ankimon/pyobj/backup_manager.py
+++ b/src/Ankimon/pyobj/backup_manager.py
@@ -480,9 +480,9 @@ class BackupManager:
         return summary
 
     def _warn_about_pending_import(self, message: str) -> None:
-        """Report an armed import without letting Qt's failure escape."""
+        """Report an armed import without letting the presenter's failure escape."""
         try:
-            showWarning(message)
+            services.ui.warn(message)
         except Exception as error:
             self.logger.log(
                 "error",
@@ -600,7 +600,8 @@ class BackupManager:
         try:
             close_anki(raise_on_error=True)
         except Exception as error:
-            showWarning(
+            # The restore is staged by now; report it like any other armed import.
+            self._warn_about_pending_import(
                 f"Anki could not close: {error}. Your current save is still "
                 "active and the prepared restore remains pending."
             )

--- a/src/Ankimon/pyobj/backup_manager.py
+++ b/src/Ankimon/pyobj/backup_manager.py
@@ -2,7 +2,6 @@
 import base64
 import json
 import os
-import shutil
 import datetime
 import sqlite3
 import tempfile
@@ -547,11 +546,12 @@ class BackupManager:
                 )
                 return
             if installed is None:
-                # The save could not be read in time to tell, so claim neither.
+                # The record or the save could not be read in time to tell, so
+                # claim neither.
                 self._warn_about_pending_import(
                     "A save import is already recorded for this save, and Ankimon "
-                    "could not read the save to tell whether it has already "
-                    "installed.\n\nUse Ankimon → Cancel Pending Save Import to "
+                    "could not tell whether it has already installed."
+                    "\n\nUse Ankimon → Cancel Pending Save Import to "
                     "clear that record, then restore this backup again."
                 )
                 return
@@ -604,18 +604,42 @@ class BackupManager:
             )
 
     def delete_backup(self, backup_path_str: str):
-        """Deletes a selected backup."""
+        """Deletes a selected backup.
+
+        Renamed out of the ``backup_`` namespace first, as retention does. A
+        removal that failed part-way in place restamped the directory's mtime,
+        and retention, which orders by mtime, then kept those hidden remains as
+        the newest backup and evicted a good one to make room for them.
+        """
         backup_path = Path(backup_path_str)
         if not backup_path.is_dir():
             showWarning("Selected backup path does not exist.")
             return
         try:
-            shutil.rmtree(backup_path)
-            self.logger.log("info", f"Deleted backup: {backup_path.name}")
-            showInfo("Backup deleted successfully.")
+            doomed = backup_path.rename(self._discard_name(backup_path))
         except Exception as e:
             self.logger.log("error", f"Failed to delete backup: {e}")
             showWarning(f"Failed to delete backup: {e}")
+            return
+        try:
+            self._remove_tree(doomed, None)
+            self.logger.log("info", f"Deleted backup: {backup_path.name}")
+        except Exception as e:
+            # Out of the listing and the count already; retention finishes it.
+            self.logger.log("error", f"Backup {backup_path.name} is deleted, but some "
+                            f"of its files remain until the next backup: {e}")
+        showInfo("Backup deleted successfully.")
+
+    def _discard_name(self, directory: Path) -> Path:
+        return directory.with_name(
+            f"{self.DISCARD_PREFIX}{uuid.uuid4().hex[:8]}_{directory.name.lstrip('.')}")
+
+    @staticmethod
+    def _is_link(path: Path) -> bool:
+        # A Windows junction is not a symlink to pathlib, and walking one deletes
+        # what it points at; shutil.rmtree guards against both.
+        isjunction = getattr(os.path, "isjunction", None)
+        return path.is_symlink() or bool(isjunction and isjunction(path))
 
     def _remove_tree(self, directory: Path, deadline) -> bool:
         """Delete a directory one entry at a time, stopping at the deadline.
@@ -625,11 +649,18 @@ class BackupManager:
         the shutdown budget had run out. Checking between entries bounds the
         overrun to the single unlink already in flight. Returns False when the
         deadline stopped it; filesystem errors propagate.
+
+        A link, the root included, is removed as a link. ``shutil.rmtree``
+        refuses one; walking it would delete the files it points at, outside
+        the backups folder.
         """
+        if self._is_link(directory):
+            directory.unlink()
+            return True
         for entry in list(directory.iterdir()):
             if deadline is not None and time.monotonic() >= deadline:
                 return False
-            if entry.is_dir() and not entry.is_symlink():
+            if entry.is_dir() and not self._is_link(entry):
                 if not self._remove_tree(entry, deadline):
                     return False
             else:
@@ -659,8 +690,7 @@ class BackupManager:
             return False
         doomed = directory
         if not directory.name.startswith(self.DISCARD_PREFIX):
-            doomed = directory.with_name(
-                f"{self.DISCARD_PREFIX}{uuid.uuid4().hex[:8]}_{directory.name.lstrip('.')}")
+            doomed = self._discard_name(directory)
             try:
                 directory.rename(doomed)
             except Exception as error:
@@ -679,8 +709,9 @@ class BackupManager:
         """Deletes old backups based on retention policy."""
         # Taken before this pass renames anything, so a removal that fails now
         # is retried by the next pass rather than twice in this one.
+        # A link counts even when dangling: _remove_tree removes the link itself.
         leftovers = [p for p in self.backups_path.glob(f"{self.DISCARD_PREFIX}*")
-                     if p.is_dir()]
+                     if p.is_dir() or p.is_symlink()]
         # Only published backups enter retention. Failed or interrupted staging
         # directories must not displace recoverable saves even if they remain.
         backups = sorted(

--- a/src/Ankimon/pyobj/backup_manager.py
+++ b/src/Ankimon/pyobj/backup_manager.py
@@ -78,7 +78,7 @@ class BackupManager:
             return backups
         active_db = services.db.db_path.name
         for backup_dir in sorted(self.backups_path.iterdir(), reverse=True):
-            if backup_dir.is_dir():
+            if backup_dir.name.startswith("backup_") and backup_dir.is_dir():
                 # Only show a backup if it contains the database for the active mode.
                 if not (backup_dir / active_db).exists():
                     continue
@@ -119,10 +119,15 @@ class BackupManager:
         isolated below)."""
         timestamp = datetime.datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
         backup_dir = self.backups_path / f"backup_{timestamp}"
+        staging_dir = self.backups_path / f".{backup_dir.name}"
 
         success = False
+        created_directory = False
         try:
-            backup_dir.mkdir()
+            if backup_dir.exists():
+                raise FileExistsError(f"Backup already exists: {backup_dir.name}")
+            staging_dir.mkdir()
+            created_directory = True
 
             active_path = Path(services.db.db_path) if services.db is not None else None
             # For manual backups, only back up the currently active database.
@@ -142,22 +147,26 @@ class BackupManager:
                     # a successful ankimon.db backup as failed (which would
                     # needlessly abort a safe import), and vice versa.
                     try:
-                        self._snapshot_database(source_path, backup_dir / filename)
+                        self._snapshot_database(source_path, staging_dir / filename)
                         completed.add(filename)
                     except Exception as e:
                         self.logger.log("error", f"Failed to back up {filename}: {e}")
 
-            summary = self._generate_summary(backup_dir)
+            summary = self._generate_summary(staging_dir)
+            summary['date'] = timestamp.replace("_", " ")
             summary['manual'] = manual
-            with open(backup_dir / "summary.json", 'w', encoding='utf-8') as f:
+            with open(staging_dir / "summary.json", 'w', encoding='utf-8') as f:
                 json.dump(summary, f, indent=4)
-
-            self.logger.log("info", f"Created backup: {backup_dir.name}")
 
             # A failed snapshot can leave a partial temporary file; only a
             # completed, verified snapshot authorizes a destructive overwrite.
             needed = required_file or (active_path.name if active_path else "ankimon.db")
-            success = needed in completed and (backup_dir / needed).is_file()
+            if needed in completed and (staging_dir / needed).is_file():
+                if backup_dir.exists():
+                    raise FileExistsError(f"Backup already exists: {backup_dir.name}")
+                staging_dir.rename(backup_dir)
+                success = True
+                self.logger.log("info", f"Created backup: {backup_dir.name}")
 
             # Report manual feedback based on the ACTUAL outcome — never claim
             # success when the DB copy failed (per-file copy errors are logged,
@@ -176,7 +185,16 @@ class BackupManager:
             if manual:
                 showWarning(f"Failed to create backup: {e}")
 
-        self.cleanup_backups()
+        if success:
+            self.cleanup_backups()
+        elif created_directory:
+            # Failed attempts stay outside listings and retention even if a
+            # locked file prevents deletion. Remove only staging directories
+            # created by this attempt, never a pre-existing timestamp collision.
+            try:
+                shutil.rmtree(staging_dir)
+            except OSError as error:
+                self.logger.log("error", f"Failed to remove incomplete backup: {error}")
         return success
 
     @staticmethod
@@ -455,7 +473,7 @@ class BackupManager:
                 "the next full restart."
             )
             try:
-                close_anki()
+                close_anki(raise_on_error=True)
             except Exception as error:
                 showWarning(
                     f"Anki could not close: {error}. Your current save is still "
@@ -482,8 +500,13 @@ class BackupManager:
 
     def cleanup_backups(self):
         """Deletes old backups based on retention policy."""
-        # Get only directories and sort them by modification time
-        backups = sorted([p for p in self.backups_path.iterdir() if p.is_dir()], key=os.path.getmtime)
+        # Only published backups enter retention. Failed or interrupted staging
+        # directories must not displace recoverable saves even if they remain.
+        backups = sorted(
+            [p for p in self.backups_path.iterdir()
+             if p.name.startswith("backup_") and p.is_dir()],
+            key=os.path.getmtime,
+        )
 
         backups_to_keep = []
         for backup_dir in backups:

--- a/src/Ankimon/pyobj/backup_manager.py
+++ b/src/Ankimon/pyobj/backup_manager.py
@@ -28,6 +28,9 @@ class BackupManager:
     ]
     MAX_BACKUPS = 5
     MAX_BACKUP_AGE_DAYS = 14
+    # profile_will_close runs the automatic backup synchronously, so the whole
+    # shutdown gets this budget once -- not one full SQLite timeout per file.
+    SHUTDOWN_BACKUP_BUDGET = 30.0
 
     def __init__(self, logger, settings_obj):
         self.logger = logger
@@ -106,8 +109,14 @@ class BackupManager:
                     backups.append(summary)
         return backups
 
-    def create_backup(self, manual=False, required_file: str = None) -> bool:
+    def create_backup(self, manual=False, required_file: str = None,
+                      deadline: float = None) -> bool:
         """Creates a new backup.
+
+        ``deadline`` is an absolute ``time.monotonic()`` instant that bounds the
+        WHOLE call rather than each file. Shutdown passes one so two locked
+        databases cannot hold Anki open for a full timeout each; every other
+        caller leaves it unset and keeps the per-file default.
 
         Returns ``True`` only if the backup directory contains a verified
         snapshot of the file the caller depends on. ``required_file`` names it (the
@@ -141,13 +150,28 @@ class BackupManager:
                     sources[active_path.name] = active_path
 
             completed = set()
-            for filename, source_path in sources.items():
+            needed = required_file or (active_path.name if active_path else "ankimon.db")
+            # A shared budget is spent on the file `success` depends on first,
+            # so a locked companion database cannot starve the one that matters.
+            order = sorted(sources, key=lambda name: name != needed) if deadline else sources
+            for filename in order:
+                source_path = sources[filename]
                 if source_path.exists():
                     # Isolate each snapshot: a failure on ankimonDEV.db must not mark
                     # a successful ankimon.db backup as failed (which would
                     # needlessly abort a safe import), and vice versa.
                     try:
-                        self._snapshot_database(source_path, staging_dir / filename)
+                        if deadline is None:
+                            self._snapshot_database(source_path, staging_dir / filename)
+                        else:
+                            remaining = deadline - time.monotonic()
+                            if remaining <= 0:
+                                # Refuse rather than start a snapshot whose own
+                                # deadline check would fail it after the copy.
+                                raise TimeoutError(
+                                    "the shutdown backup budget expired before this file")
+                            self._snapshot_database(source_path, staging_dir / filename,
+                                                    timeout=remaining)
                         completed.add(filename)
                     except Exception as e:
                         self.logger.log("error", f"Failed to back up {filename}: {e}")
@@ -160,7 +184,6 @@ class BackupManager:
 
             # A failed snapshot can leave a partial temporary file; only a
             # completed, verified snapshot authorizes a destructive overwrite.
-            needed = required_file or (active_path.name if active_path else "ankimon.db")
             if needed in completed and (staging_dir / needed).is_file():
                 if backup_dir.exists():
                     raise FileExistsError(f"Backup already exists: {backup_dir.name}")
@@ -525,6 +548,12 @@ class BackupManager:
                 self.logger.log("info", f"Deleted oldest backup to maintain max count: {oldest_backup.name}")
 
     def on_anki_close(self):
-        """Creates a backup when Anki is about to close."""
+        """Creates a backup when Anki is about to close.
+
+        One deadline covers every database this call snapshots: shutdown is
+        synchronous, so a per-file timeout would let two locked saves stall the
+        close for twice as long.
+        """
         # This logic can be expanded with the developer mode setting
-        self.create_backup(manual=False)
+        self.create_backup(manual=False,
+                           deadline=time.monotonic() + self.SHUTDOWN_BACKUP_BUDGET)

--- a/src/Ankimon/pyobj/backup_manager.py
+++ b/src/Ankimon/pyobj/backup_manager.py
@@ -176,15 +176,19 @@ class BackupManager:
                     except Exception as e:
                         self.logger.log("error", f"Failed to back up {filename}: {e}")
 
-            summary = self._generate_summary(staging_dir)
-            summary['date'] = timestamp.replace("_", " ")
-            summary['manual'] = manual
-            with open(staging_dir / "summary.json", 'w', encoding='utf-8') as f:
-                json.dump(summary, f, indent=4)
-
             # A failed snapshot can leave a partial temporary file; only a
             # completed, verified snapshot authorizes a destructive overwrite.
+            # Summarise INSIDE that check: with no snapshot in staging,
+            # _generate_summary falls back to the live database, and its own
+            # busy timeout would re-enter the very lock wait `deadline` exists
+            # to bound — describing a backup that is about to be discarded.
             if needed in completed and (staging_dir / needed).is_file():
+                summary = self._generate_summary(staging_dir)
+                summary['date'] = timestamp.replace("_", " ")
+                summary['manual'] = manual
+                with open(staging_dir / "summary.json", 'w', encoding='utf-8') as f:
+                    json.dump(summary, f, indent=4)
+
                 if backup_dir.exists():
                     raise FileExistsError(f"Backup already exists: {backup_dir.name}")
                 staging_dir.rename(backup_dir)

--- a/src/Ankimon/pyobj/backup_manager.py
+++ b/src/Ankimon/pyobj/backup_manager.py
@@ -485,7 +485,7 @@ class BackupManager:
                 )
                 return
 
-            from ..save_import import stage_import
+            from ..save_import import ImportStagedError, stage_import
 
             pending = stage_import(
                 backup_file, target, sanitize_credentials=False
@@ -507,6 +507,16 @@ class BackupManager:
                     "active and the prepared restore remains pending."
                 )
 
+        except ImportStagedError as e:
+            # The restore is published and will install; calling it a failure
+            # to prepare would hide an armed replacement from the user.
+            self.logger.log("error", f"Backup restore staged but unfinished: {e}")
+            showWarning(
+                f"The backup restore could not be finished cleanly: {e}.\n\n"
+                "Your current save is still active, but the restore is now "
+                "PENDING and will install at the next full Anki restart. Use "
+                "Ankimon → Cancel Pending Save Import if you do not want it."
+            )
         except Exception as e:
             self.logger.log("error", f"Failed to prepare backup restore: {e}")
             showWarning(f"Failed to prepare backup restore: {e}")

--- a/src/Ankimon/pyobj/backup_manager.py
+++ b/src/Ankimon/pyobj/backup_manager.py
@@ -7,6 +7,7 @@ import datetime
 import sqlite3
 import tempfile
 import time
+import uuid
 from contextlib import closing
 from pathlib import Path
 from typing import List, Dict, Any, Optional
@@ -33,6 +34,9 @@ class BackupManager:
     SHUTDOWN_BACKUP_BUDGET = 30.0
     # How old an abandoned staging directory must be before retention sweeps it.
     STALE_STAGING_AGE = 3600.0
+    # Retention renames a directory to this prefix before deleting inside it,
+    # taking it out of the listing and the count; a later pass finishes it.
+    DISCARD_PREFIX = ".discard_"
 
     def __init__(self, logger, settings_obj):
         self.logger = logger
@@ -230,8 +234,12 @@ class BackupManager:
             # Failed attempts stay outside listings and retention even if a
             # locked file prevents deletion. Remove only staging directories
             # created by this attempt, never a pre-existing timestamp collision.
+            # Entry by entry under the shutdown deadline, as retention is: the
+            # attempt may hold a whole companion save.
             try:
-                shutil.rmtree(staging_dir)
+                if not self._remove_tree(staging_dir, deadline):
+                    self.logger.log("error", "The shutdown budget ran out removing an "
+                                    "incomplete backup; retention sweeps it once stale")
             except OSError as error:
                 self.logger.log("error", f"Failed to remove incomplete backup: {error}")
         return success
@@ -527,7 +535,8 @@ class BackupManager:
             # Qt, and an exception raised inside an except clause is not caught
             # by its siblings -- it would leave restore_backup entirely, with
             # an import armed and nothing said about it.
-            if pending_import_is_installed(target):
+            installed = pending_import_is_installed(target)
+            if installed:
                 # The record outlived the import; that replacement has already
                 # happened and no restart will repeat it.
                 self._warn_about_pending_import(
@@ -535,6 +544,15 @@ class BackupManager:
                     "save you are playing now. Only its leftover record could "
                     "not be cleared.\n\nUse Ankimon → Cancel Pending Save Import "
                     "to clear that record, then restore this backup again."
+                )
+                return
+            if installed is None:
+                # The save could not be read in time to tell, so claim neither.
+                self._warn_about_pending_import(
+                    "A save import is already recorded for this save, and Ankimon "
+                    "could not read the save to tell whether it has already "
+                    "installed.\n\nUse Ankimon → Cancel Pending Save Import to "
+                    "clear that record, then restore this backup again."
                 )
                 return
             self._warn_about_pending_import(
@@ -599,25 +617,70 @@ class BackupManager:
             self.logger.log("error", f"Failed to delete backup: {e}")
             showWarning(f"Failed to delete backup: {e}")
 
+    def _remove_tree(self, directory: Path, deadline) -> bool:
+        """Delete a directory one entry at a time, stopping at the deadline.
+
+        ``shutil.rmtree`` cannot be interrupted, and a backup holds whole save
+        copies, so one large or stalled deletion could keep Anki closing after
+        the shutdown budget had run out. Checking between entries bounds the
+        overrun to the single unlink already in flight. Returns False when the
+        deadline stopped it; filesystem errors propagate.
+        """
+        for entry in list(directory.iterdir()):
+            if deadline is not None and time.monotonic() >= deadline:
+                return False
+            if entry.is_dir() and not entry.is_symlink():
+                if not self._remove_tree(entry, deadline):
+                    return False
+            else:
+                entry.unlink()
+        directory.rmdir()
+        return True
+
     def _discard(self, directory: Path, what: str, deadline) -> bool:
         """Remove one directory. Never raise, and never overrun the deadline.
 
-        Retention has no deadline of its own to defend: every removal it skips
-        is simply retried by the next backup. What it must not do is fail the
-        call that published a good backup, or keep Anki's close waiting.
+        Returns False only when the deadline has passed, telling the caller to
+        stop: every removal it skips is simply retried by the next backup. A
+        removal that fails is logged and retention carries on. Every removal a
+        pass attempts was due regardless of the others, so a directory that
+        cannot be deleted costs one extra retained copy -- never the eviction
+        of a backup the policy keeps.
+
+        The directory leaves the ``backup_`` namespace by rename before anything
+        inside it is deleted. Deleting entries updates a directory's mtime, and
+        retention orders by mtime, so a removal cut short in place -- by the
+        deadline, or by one locked file -- would leave remains that sort as the
+        NEWEST backup and displace a good one at the next pass. A failed rename
+        changes nothing; after a successful one, the worst left behind is a
+        hidden ``.discard_`` directory that a later pass finishes.
         """
         if deadline is not None and time.monotonic() >= deadline:
             return False
+        doomed = directory
+        if not directory.name.startswith(self.DISCARD_PREFIX):
+            doomed = directory.with_name(
+                f"{self.DISCARD_PREFIX}{uuid.uuid4().hex[:8]}_{directory.name.lstrip('.')}")
+            try:
+                directory.rename(doomed)
+            except Exception as error:
+                self.logger.log("error", f"Failed to delete {what} {directory.name}: {error}")
+                return True
         try:
-            shutil.rmtree(directory)
+            finished = self._remove_tree(doomed, deadline)
         except Exception as error:
-            self.logger.log("error", f"Failed to delete {what} {directory.name}: {error}")
+            self.logger.log("error", f"Failed to finish deleting {what} {directory.name}: {error}")
             return True
-        self.logger.log("info", f"Deleted {what}: {directory.name}")
-        return True
+        if finished:
+            self.logger.log("info", f"Deleted {what}: {directory.name}")
+        return finished
 
     def cleanup_backups(self, deadline: float = None):
         """Deletes old backups based on retention policy."""
+        # Taken before this pass renames anything, so a removal that fails now
+        # is retried by the next pass rather than twice in this one.
+        leftovers = [p for p in self.backups_path.glob(f"{self.DISCARD_PREFIX}*")
+                     if p.is_dir()]
         # Only published backups enter retention. Failed or interrupted staging
         # directories must not displace recoverable saves even if they remain.
         backups = sorted(
@@ -657,6 +720,12 @@ class BackupManager:
             except OSError:
                 continue
             if not self._discard(staging, "incomplete backup", deadline):
+                return
+
+        # What an earlier pass renamed out of the listing but could not finish
+        # deleting -- stopped by the deadline, or by a locked file -- ends here.
+        for leftover in leftovers:
+            if not self._discard(leftover, "discarded backup", deadline):
                 return
 
     def on_anki_close(self):

--- a/src/Ankimon/pyobj/backup_manager.py
+++ b/src/Ankimon/pyobj/backup_manager.py
@@ -407,40 +407,64 @@ class BackupManager:
         return summary
 
     def restore_backup(self, backup_path_str: str):
-        """Restores a selected backup (only the currently active database)."""
+        """Stage the selected backup for the next full process start.
+
+        Never copy over a database that the current runtime still has open.
+        Restore uses the same crash-safe installation gate as manual Import,
+        while retaining credentials because Backup Manager snapshots are private
+        local recovery material rather than portable exports.
+        """
         backup_path = Path(backup_path_str)
         if not backup_path.is_dir():
             showWarning("Selected backup path does not exist.")
             return
 
         if not askUser(
-            "Are you sure you want to restore this backup? This will overwrite your current Ankimon data. Anki will be closed to apply the changes."
+            "Prepare this backup for restore? It will replace the current Ankimon "
+            "save on the next full Anki restart. The final current save will be "
+            "retained as a separate recovery copy first."
         ):
             return
 
         try:
-            # Without an initialized database service we cannot tell which mode
-            # (normal vs dev) is active, so refuse the destructive restore rather
-            # than guessing or crashing on ``None.db_path``.
             if services.db is None:
                 showWarning("The Ankimon database is not initialized yet; cannot restore a backup.")
                 return
-            active_db = services.db.db_path.name
-            backup_file = backup_path / active_db
-            if backup_file.exists():
-                shutil.copy2(backup_file, self.user_files_path / active_db)
-            else:
+
+            target = Path(services.db.db_path)
+            backup_file = backup_path / target.name
+            if not backup_file.is_file():
                 showWarning(
-                    f"The selected backup does not contain a backup for the active database ({active_db})."
+                    "The selected backup does not contain a backup for the active "
+                    f"database ({target.name})."
                 )
                 return
 
-            showInfo("Backup restored successfully. Anki will now close. Please restart Anki to see the changes.")
-            close_anki()
+            from ..save_import import stage_import
+
+            pending = stage_import(
+                backup_file, target, sanitize_credentials=False
+            )
+            showInfo(
+                "Backup restore prepared for the next full Anki restart.\n\n"
+                "Your current save stays active until Anki exits. At the next "
+                "start, its final state will be retained here before the selected "
+                "backup is installed:\n"
+                f"{pending['recovery_path']}\n\n"
+                "If you choose Keep Editing, the restore remains pending until "
+                "the next full restart."
+            )
+            try:
+                close_anki()
+            except Exception as error:
+                showWarning(
+                    f"Anki could not close: {error}. Your current save is still "
+                    "active and the prepared restore remains pending."
+                )
 
         except Exception as e:
-            self.logger.log("error", f"Failed to restore backup: {e}")
-            showWarning(f"Failed to restore backup: {e}")
+            self.logger.log("error", f"Failed to prepare backup restore: {e}")
+            showWarning(f"Failed to prepare backup restore: {e}")
 
     def delete_backup(self, backup_path_str: str):
         """Deletes a selected backup."""

--- a/src/Ankimon/pyobj/backup_manager.py
+++ b/src/Ankimon/pyobj/backup_manager.py
@@ -485,28 +485,20 @@ class BackupManager:
                 )
                 return
 
-            from ..save_import import ImportStagedError, stage_import
+            from ..save_import import (
+                ImportAlreadyPendingError, ImportStagedError, stage_import,
+            )
 
             pending = stage_import(
                 backup_file, target, sanitize_credentials=False
             )
-            showInfo(
-                "Backup restore prepared for the next full Anki restart.\n\n"
-                "Your current save stays active until Anki exits. At the next "
-                "start, its final state will be retained here before the selected "
-                "backup is installed:\n"
-                f"{pending['recovery_path']}\n\n"
-                "If you choose Keep Editing, the restore remains pending until "
-                "the next full restart."
+        except ImportAlreadyPendingError:
+            showWarning(
+                "A save import is already pending and will install at the next "
+                "full Anki restart.\n\nUse Ankimon → Cancel Pending Save Import "
+                "first if you want to restore this backup instead."
             )
-            try:
-                close_anki(raise_on_error=True)
-            except Exception as error:
-                showWarning(
-                    f"Anki could not close: {error}. Your current save is still "
-                    "active and the prepared restore remains pending."
-                )
-
+            return
         except ImportStagedError as e:
             # The restore is published and will install; calling it a failure
             # to prepare would hide an armed replacement from the user.
@@ -517,9 +509,37 @@ class BackupManager:
                 "PENDING and will install at the next full Anki restart. Use "
                 "Ankimon → Cancel Pending Save Import if you do not want it."
             )
+            return
         except Exception as e:
             self.logger.log("error", f"Failed to prepare backup restore: {e}")
             showWarning(f"Failed to prepare backup restore: {e}")
+            return
+
+        # Past staging, and outside the guard above: the restore is committed,
+        # so a failure to announce it must never be reported as one to prepare
+        # it. Import keeps its own notice outside its guard for the same reason.
+        try:
+            showInfo(
+                "Backup restore prepared for the next full Anki restart.\n\n"
+                "Your current save stays active until Anki exits. At the next "
+                "start, its final state will be retained here before the selected "
+                "backup is installed:\n"
+                f"{pending['recovery_path']}\n\n"
+                "If you choose Keep Editing, the restore remains pending until "
+                "the next full restart."
+            )
+        except Exception as error:
+            self.logger.log(
+                "error",
+                f"Backup restore is staged, but its notice could not be shown: {error}",
+            )
+        try:
+            close_anki(raise_on_error=True)
+        except Exception as error:
+            showWarning(
+                f"Anki could not close: {error}. Your current save is still "
+                "active and the prepared restore remains pending."
+            )
 
     def delete_backup(self, backup_path_str: str):
         """Deletes a selected backup."""

--- a/src/Ankimon/pyobj/backup_manager.py
+++ b/src/Ankimon/pyobj/backup_manager.py
@@ -4,6 +4,10 @@ import json
 import os
 import shutil
 import datetime
+import sqlite3
+import tempfile
+import time
+from contextlib import closing
 from pathlib import Path
 from typing import List, Dict, Any, Optional
 
@@ -105,43 +109,41 @@ class BackupManager:
     def create_backup(self, manual=False, required_file: str = None) -> bool:
         """Creates a new backup.
 
-        Returns ``True`` only if the backup directory was written AND contains
-        the file the caller depends on. ``required_file`` names that file (the
+        Returns ``True`` only if the backup directory contains a verified
+        snapshot of the file the caller depends on. ``required_file`` names it (the
         one a pre-overwrite caller is protecting, e.g. ``ankimon.db``); when
         omitted, the active-mode database is used. Callers that back up *before*
         a destructive overwrite rely on this to refuse the overwrite when no
         recoverable backup of THAT file was actually made — so one unrelated
-        file's copy failure must not blank another file's success (each copy is
+        file's snapshot failure must not blank another file's success (each file is
         isolated below)."""
         timestamp = datetime.datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
         backup_dir = self.backups_path / f"backup_{timestamp}"
 
         success = False
         try:
-            # Checkpoint the active database first to flush all WAL changes to disk,
-            # so the single-file copy below captures the latest committed state.
-            if services.db is not None:
-                try:
-                    services.db.execute("PRAGMA wal_checkpoint(TRUNCATE);")
-                    self.logger.log("info", "Checkpoint database before backup.")
-                except Exception as e:
-                    self.logger.log("error", f"Failed to checkpoint database before backup: {e}")
-
             backup_dir.mkdir()
 
+            active_path = Path(services.db.db_path) if services.db is not None else None
             # For manual backups, only back up the currently active database.
-            files_to_copy = self.FILES_TO_BACKUP
-            if manual and services.db is not None:
-                files_to_copy = [services.db.db_path.name]
+            sources = {name: self.user_files_path / name for name in self.FILES_TO_BACKUP}
+            if active_path is not None:
+                # Profiles can choose a different directory or filename. Never
+                # substitute the default save for the active file being protected.
+                if manual:
+                    sources = {active_path.name: active_path}
+                else:
+                    sources[active_path.name] = active_path
 
-            for filename in files_to_copy:
-                source_path = self.user_files_path / filename
+            completed = set()
+            for filename, source_path in sources.items():
                 if source_path.exists():
-                    # Isolate each copy: a failure on ankimonDEV.db must not mark
+                    # Isolate each snapshot: a failure on ankimonDEV.db must not mark
                     # a successful ankimon.db backup as failed (which would
                     # needlessly abort a safe import), and vice versa.
                     try:
-                        shutil.copy2(source_path, backup_dir / filename)
+                        self._snapshot_database(source_path, backup_dir / filename)
+                        completed.add(filename)
                     except Exception as e:
                         self.logger.log("error", f"Failed to back up {filename}: {e}")
 
@@ -152,12 +154,10 @@ class BackupManager:
 
             self.logger.log("info", f"Created backup: {backup_dir.name}")
 
-            # Success = the SPECIFIC file the caller relies on landed in the
-            # backup dir. Defaults to the active-mode DB when unspecified.
-            needed = required_file or (
-                services.db.db_path.name if services.db is not None else "ankimon.db"
-            )
-            success = (backup_dir / needed).is_file()
+            # A failed snapshot can leave a partial temporary file; only a
+            # completed, verified snapshot authorizes a destructive overwrite.
+            needed = required_file or (active_path.name if active_path else "ankimon.db")
+            success = needed in completed and (backup_dir / needed).is_file()
 
             # Report manual feedback based on the ACTUAL outcome — never claim
             # success when the DB copy failed (per-file copy errors are logged,
@@ -178,6 +178,43 @@ class BackupManager:
 
         self.cleanup_backups()
         return success
+
+    @staticmethod
+    def _snapshot_database(source_path: Path, destination_path: Path, timeout: float = 30.0):
+        """Publish a verified standalone snapshot, including committed WAL pages.
+
+        A checkpoint can return busy while leaving committed pages in WAL, so
+        copying the main file is never sufficient. Read-only online backup also
+        works for an inactive database without mutating or creating its source.
+        """
+        deadline = time.monotonic() + timeout
+        fd, name = tempfile.mkstemp(prefix=".snapshot-", suffix=".db", dir=destination_path.parent)
+        os.close(fd)
+        temporary = Path(name)
+        try:
+            uri = source_path.resolve().as_uri() + "?mode=ro"
+            with closing(sqlite3.connect(uri, uri=True, timeout=timeout)) as source, \
+                 closing(sqlite3.connect(temporary, timeout=timeout)) as snapshot:
+                def check_deadline(status, remaining, total):
+                    # backup() retries SQLITE_BUSY beyond connect's timeout.
+                    if time.monotonic() > deadline:
+                        raise TimeoutError("Timed out taking a database backup")
+
+                source.backup(snapshot, pages=256, progress=check_deadline, sleep=0.05)
+                snapshot.set_progress_handler(lambda: int(time.monotonic() > deadline), 2000)
+                if snapshot.execute("PRAGMA quick_check").fetchall() != [("ok",)]:
+                    raise ValueError("Database backup failed its integrity check")
+                if not snapshot.execute(
+                    "SELECT 1 FROM sqlite_master WHERE type='table' AND name='captured_pokemon'"
+                ).fetchone():
+                    raise ValueError("Database backup is not an Ankimon save")
+                # A backup is a single file: do not require WAL sidecars on restore.
+                snapshot.execute("PRAGMA journal_mode=DELETE")
+                check_deadline(0, 0, 0)
+            os.replace(temporary, destination_path)
+        finally:
+            for suffix in ("", "-wal", "-shm", "-journal"):
+                Path(str(temporary) + suffix).unlink(missing_ok=True)
 
     def _get_db_file_stats(self, db_file_path: Path) -> Dict[str, Any]:
         """Reads summary stats directly from one Ankimon SQLite backup file.
@@ -262,10 +299,11 @@ class BackupManager:
         )
 
         # Read stats from the database files stored inside this backup directory.
-        normal_stats = self._get_db_file_stats(backup_dir / "ankimon.db")
+        normal_name = "ankimon.db" if active_db_name == "ankimonDEV.db" else active_db_name
+        normal_stats = self._get_db_file_stats(backup_dir / normal_name)
         dev_stats = self._get_db_file_stats(backup_dir / "ankimonDEV.db")
 
-        normal_exists = (backup_dir / "ankimon.db").exists()
+        normal_exists = (backup_dir / normal_name).exists()
         dev_exists = (backup_dir / "ankimonDEV.db").exists()
 
         # If the backup folder has no DB files yet (e.g. a freshly-created dummy

--- a/src/Ankimon/pyobj/backup_manager.py
+++ b/src/Ankimon/pyobj/backup_manager.py
@@ -263,7 +263,9 @@ class BackupManager:
         os.close(fd)
         temporary = Path(name)
         try:
-            uri = source_path.resolve().as_uri() + "?mode=ro"
+            from ..save_import import _sqlite_uri
+
+            uri = _sqlite_uri(source_path, "ro")
             with closing(sqlite3.connect(uri, uri=True, timeout=timeout)) as source, \
                  closing(sqlite3.connect(temporary, timeout=timeout)) as snapshot:
                 def check_deadline(status, remaining, total):
@@ -541,7 +543,7 @@ class BackupManager:
                 self._warn_about_pending_import(
                     "The previous save import has ALREADY installed and is the "
                     "save you are playing now. Only its leftover record could "
-                    "not be cleared.\n\nUse Ankimon → Cancel Pending Save Import "
+                    "not be cleared.\n\nUse Ankimon → Game → Cancel Pending Save Import "
                     "to clear that record, then restore this backup again."
                 )
                 return
@@ -551,13 +553,13 @@ class BackupManager:
                 self._warn_about_pending_import(
                     "A save import is already recorded for this save, and Ankimon "
                     "could not tell whether it has already installed."
-                    "\n\nUse Ankimon → Cancel Pending Save Import to "
+                    "\n\nUse Ankimon → Game → Cancel Pending Save Import to "
                     "clear that record, then restore this backup again."
                 )
                 return
             self._warn_about_pending_import(
                 "A save import is already pending and will install at the next "
-                "full Anki restart.\n\nUse Ankimon → Cancel Pending Save Import "
+                "full Anki restart.\n\nUse Ankimon → Game → Cancel Pending Save Import "
                 "first if you want to restore this backup instead."
             )
             return
@@ -569,7 +571,7 @@ class BackupManager:
                 f"The backup restore could not be finished cleanly: {e}.\n\n"
                 "Your current save is still active, but the restore is now "
                 "PENDING and will install at the next full Anki restart. Use "
-                "Ankimon → Cancel Pending Save Import if you do not want it."
+                "Ankimon → Game → Cancel Pending Save Import if you do not want it."
             )
             return
         except Exception as e:
@@ -657,7 +659,18 @@ class BackupManager:
         if self._is_link(directory):
             directory.unlink()
             return True
-        for entry in list(directory.iterdir()):
+        if deadline is not None and time.monotonic() >= deadline:
+            # Past the deadline, list nothing: iterdir reads the whole directory
+            # before it yields the first entry, so a check inside the loop only
+            # runs after that read. An empty directory -- a failed attempt's
+            # staging folder, typically -- still goes, in the one call that needs
+            # no listing.
+            try:
+                directory.rmdir()
+            except OSError:
+                return False
+            return True
+        for entry in directory.iterdir():
             if deadline is not None and time.monotonic() >= deadline:
                 return False
             if entry.is_dir() and not self._is_link(entry):

--- a/src/Ankimon/pyobj/database_manager.py
+++ b/src/Ankimon/pyobj/database_manager.py
@@ -2647,23 +2647,30 @@ def get_db(logger=None, db_path=None) -> AnkimonDB:
         # Pending transfers are installed before opening a connection or building
         # settings/game objects. A process identity gate refuses addon reloads
         # and profile switches in the process that staged the import.
-        from ..save_import import commit_pending_import
+        from ..save_import import ImportInstalledError, commit_pending_import
         from ..services import services
 
         targets = ([Path(db_path)] if db_path is not None else
                    [user_path / "ankimon.db", user_path / "ankimonDEV.db"])
         for target in targets:
+            installed = False
             try:
-                if commit_pending_import(target, logger):
-                    from ..events import events
-
-                    events.emit("save_import_installed", target=str(target))
+                installed = commit_pending_import(target, logger)
+            except ImportInstalledError as warning:
+                installed = True
+                warnings = getattr(services, "_save_import_warnings", [])
+                warnings.append(f"{target}: {warning}")
+                services._save_import_warnings = warnings
             except Exception as error:
                 failures = getattr(services, "_save_import_errors", [])
                 failures.append(f"{target}: {error}")
                 services._save_import_errors = failures
                 if logger is not None:
                     logger.log("error", f"Pending save import could not be installed: {error}")
+            if installed:
+                from ..events import events
+
+                events.emit("save_import_installed", target=str(target))
         _db_instance = AnkimonDB(logger, db_path=db_path)
     return _db_instance
 

--- a/src/Ankimon/pyobj/database_manager.py
+++ b/src/Ankimon/pyobj/database_manager.py
@@ -2647,15 +2647,23 @@ def get_db(logger=None, db_path=None) -> AnkimonDB:
         # Pending transfers are installed before opening a connection or building
         # settings/game objects. A process identity gate refuses addon reloads
         # and profile switches in the process that staged the import.
-        from ..save_import import ImportInstalledError, commit_pending_import
+        from ..save_import import (
+            STARTUP_IMPORT_BUDGET, ImportInstalledError, commit_pending_import,
+        )
         from ..services import services
 
         targets = ([Path(db_path)] if db_path is not None else
                    [user_path / "ankimon.db", user_path / "ankimonDEV.db"])
+        # One budget for the whole installation. This runs inside add-on import,
+        # which Anki performs in AnkiQt.__init__ -- before any window exists, let
+        # alone a progress dialog -- so a locked save here is Anki looking hung
+        # with nothing on screen and no way to cancel. Anything not installed in
+        # time stays pending and is retried on the next start.
+        deadline = time.monotonic() + STARTUP_IMPORT_BUDGET
         for target in targets:
             installed = False
             try:
-                installed = commit_pending_import(target, logger)
+                installed = commit_pending_import(target, logger, deadline)
             except ImportInstalledError as warning:
                 installed = True
                 warnings = getattr(services, "_save_import_warnings", [])

--- a/src/Ankimon/pyobj/database_manager.py
+++ b/src/Ankimon/pyobj/database_manager.py
@@ -2644,6 +2644,26 @@ def get_db(logger=None, db_path=None) -> AnkimonDB:
     """
     global _db_instance
     if _db_instance is None:
+        # Pending transfers are installed before opening a connection or building
+        # settings/game objects. A process identity gate refuses addon reloads
+        # and profile switches in the process that staged the import.
+        from ..save_import import commit_pending_import
+        from ..services import services
+
+        targets = ([Path(db_path)] if db_path is not None else
+                   [user_path / "ankimon.db", user_path / "ankimonDEV.db"])
+        for target in targets:
+            try:
+                if commit_pending_import(target, logger):
+                    from ..events import events
+
+                    events.emit("save_import_installed", target=str(target))
+            except Exception as error:
+                failures = getattr(services, "_save_import_errors", [])
+                failures.append(f"{target}: {error}")
+                services._save_import_errors = failures
+                if logger is not None:
+                    logger.log("error", f"Pending save import could not be installed: {error}")
         _db_instance = AnkimonDB(logger, db_path=db_path)
     return _db_instance
 

--- a/src/Ankimon/pyobj/save_transfer.py
+++ b/src/Ankimon/pyobj/save_transfer.py
@@ -1339,15 +1339,21 @@ def _resume_deferred_media_sync() -> None:
     media and nothing re-requests it. Clearing the guard only makes the NEXT
     attempt permissible, and Anki's own next attempt is a profile close or a
     periodic tick whose clock the skipped sync has just reset. Ask for one now
-    instead. ``MediaSyncer.start`` re-checks the user's preference and sign-in
-    and returns immediately if a media sync is already running, so this cannot
-    sync for a user who turned media sync off.
+    instead. ``MediaSyncer.start`` re-checks the user's preference and sign-in,
+    so this cannot sync for a user who turned media sync off.
+
+    Ask for it the way Anki's own unattended timer does. Nobody clicked for
+    this request, and MediaSyncer only keeps a failed one out of a dialog when
+    it is marked periodic. That timer's other condition, a backup restore in
+    progress, is the one thing ``start`` does not check for itself.
     """
     try:
         syncer = getattr(mw, "media_syncer", None)
         if syncer is None or getattr(mw, "col", None) is None:
             return
-        syncer.start()
+        if getattr(mw, "restoring_backup", False):
+            return
+        syncer.start(True)
     except Exception:
         # Never let a restart attempt keep the guard from being released.
         pass

--- a/src/Ankimon/pyobj/save_transfer.py
+++ b/src/Ankimon/pyobj/save_transfer.py
@@ -719,8 +719,14 @@ def _replace_active_save(source: Path, target: Path, what: str, *, collection,
     try:
         close_anki(raise_on_error=True)
     except Exception as error:
-        showWarning(f"Anki could not close: {error}. Your current save is still active. "
-                    "The prepared import will run on the next full restart, or you can cancel it.")
+        # The import is published by now, so this notice is guarded like every
+        # other one about an armed import: its own failure would otherwise reach
+        # the caller's "aborted, nothing was replaced" handler.
+        _warn_about_pending_import(
+            f"Anki could not close: {error}. Your current save is still active. "
+            "The prepared import will run on the next full restart, or you can cancel it.",
+            f"{what} is staged and Anki could not close, but the notice could not be shown",
+        )
     return True
 
 

--- a/src/Ankimon/pyobj/save_transfer.py
+++ b/src/Ankimon/pyobj/save_transfer.py
@@ -1331,6 +1331,28 @@ def _protect_bare_saves(media_dir: Path) -> Dict[str, Any]:
     return result
 
 
+def _resume_deferred_media_sync() -> None:
+    """Re-request one media sync the guard turned away.
+
+    Anki reads ``media_syncing_enabled()`` once, when a sync starts, and passes
+    it into the backend call; a collection sync that saw False finishes without
+    media and nothing re-requests it. Clearing the guard only makes the NEXT
+    attempt permissible, and Anki's own next attempt is a profile close or a
+    periodic tick whose clock the skipped sync has just reset. Ask for one now
+    instead. ``MediaSyncer.start`` re-checks the user's preference and sign-in
+    and returns immediately if a media sync is already running, so this cannot
+    sync for a user who turned media sync off.
+    """
+    try:
+        syncer = getattr(mw, "media_syncer", None)
+        if syncer is None or getattr(mw, "col", None) is None:
+            return
+        syncer.start()
+    except Exception:
+        # Never let a restart attempt keep the guard from being released.
+        pass
+
+
 def _guard_uncaptured_media(media_dir: Path, protection: Dict[str, Any]) -> None:
     """Pause media sync for this profile only while original bytes are at risk.
 
@@ -1338,6 +1360,9 @@ def _guard_uncaptured_media(media_dir: Path, protection: Dict[str, Any]) -> None
     Keep its preference untouched; the in-memory guard clears on a successful
     capture and automatically allows other profiles. Anchor it on the profile
     manager so an addon module reload cannot stack wrappers or lose the guard.
+
+    A sync turned away while the guard was up is remembered and re-requested
+    when the guard clears, because Anki keeps no deferred request of its own.
     """
     uncaptured = set(protection["unprotected"]) - set(protection["archived_sources"])
     pm = mw.pm
@@ -1346,18 +1371,28 @@ def _guard_uncaptured_media(media_dir: Path, protection: Dict[str, Any]) -> None
         if not uncaptured:
             return
         original = pm.media_syncing_enabled
-        state = {"blocked": set()}
+        state = {"blocked": set(), "deferred": set()}
 
         def enabled():
             folder = Path(pm.profileFolder()) / "collection.media"
-            return folder not in state["blocked"] and original()
+            allowed = original()
+            if allowed and folder in state["blocked"]:
+                # Only a sync the user's own preference would have permitted
+                # counts as deferred; nothing else may be restarted later.
+                state["deferred"].add(folder)
+                return False
+            return allowed
 
         pm.media_syncing_enabled = enabled
         pm._ankimon_media_protection_guard = state
+    state.setdefault("deferred", set())
     if uncaptured:
         state["blocked"].add(media_dir)
     else:
         state["blocked"].discard(media_dir)
+        if media_dir in state["deferred"]:
+            state["deferred"].discard(media_dir)
+            _resume_deferred_media_sync()
 
 
 _LAST_PROTECTION_NOTICE = None

--- a/src/Ankimon/pyobj/save_transfer.py
+++ b/src/Ankimon/pyobj/save_transfer.py
@@ -1841,6 +1841,36 @@ def _pending_media_protection(media_dir: Path, target: Optional[Path]):
     return protection, (tuple(signature), tuple(sorted(entries.items())))
 
 
+def guard_media_saves_now(logger) -> None:
+    """Pause media sync for uncaptured originals, synchronously and cheaply.
+
+    Split out of ``start_media_migration`` so profile-open can arm the guard as
+    its very first act while leaving the SCAN where it has to be: last, after
+    everything in that handler which opens a modal dialog.
+
+    A modal spins a nested event loop, which delivers taskman's queued main-
+    thread callbacks. Dispatching the scan early therefore let its completion
+    run re-entrantly inside those dialogs -- nesting its own warnings and rescue
+    prompt inside them, and, if the user accepted, reaching ``close_anki`` while
+    Anki's ``loadProfile`` was still on the stack. ``_offer_rescue_later`` posts
+    its work with a zero-delay timer precisely to get off that stack, which only
+    works if nothing after the dispatch pumps the loop.
+
+    Only stat calls: no SQLite, no thread, nothing that can block a profile open.
+    """
+    try:
+        media_dir = _media_dir()
+        if media_dir is None or not media_dir.is_dir():
+            return
+        protection, _ = _pending_media_protection(media_dir, _active_db_path())
+        _guard_uncaptured_media(media_dir, protection)
+    except Exception as e:
+        try:
+            logger.log("error", f"Could not pause media sync for uncaptured saves: {e}")
+        except Exception:
+            pass
+
+
 def start_media_migration(settings_obj, logger) -> None:
     """Scan on a background worker, then apply decisions on the main thread.
 

--- a/src/Ankimon/pyobj/save_transfer.py
+++ b/src/Ankimon/pyobj/save_transfer.py
@@ -97,7 +97,8 @@ def get_db_stats(db_path: Path, timeout: float = 30.0) -> Optional[Dict[str, Any
     that actually holds their progress.
 
     Opened read-only through a percent-encoded URI so a profile path containing
-    spaces or non-ASCII characters still resolves, with an explicit busy timeout
+    spaces or non-ASCII characters, or on a Windows network share, still
+    resolves, with an explicit busy timeout
     — the default 5 s is easy to exceed while the live connection is mid-write,
     and a timeout here would otherwise look like a corrupt file.
 
@@ -108,7 +109,9 @@ def get_db_stats(db_path: Path, timeout: float = 30.0) -> Optional[Dict[str, Any
     try:
         if not Path(db_path).is_file():
             return None
-        uri = Path(db_path).resolve().as_uri() + "?mode=ro"
+        from ..save_import import _sqlite_uri
+
+        uri = _sqlite_uri(db_path, "ro")
         conn = sqlite3.connect(uri, uri=True, timeout=timeout)
         # Same wall-clock bound as _verify_sqlite_integrity: connect(timeout=)
         # covers lock waiting only, and the COUNT(*)s below scan whole tables.
@@ -264,9 +267,11 @@ def _sqlite_backup(source: Path, dest: Path, timeout: float = 30.0) -> None:
     read-only prevents creating a missing file or recovering its journal in
     place. Both lock retries and copying are bounded by ``timeout``.
     """
+    from ..save_import import _sqlite_uri
+
     # Imports and migration candidates are external files. A read-only source
     # must neither create a missing file nor recover a hot journal in place.
-    uri = Path(source).resolve().as_uri() + "?mode=ro"
+    uri = _sqlite_uri(source, "ro")
     src_conn = sqlite3.connect(uri, uri=True, timeout=timeout)
     try:
         dest_conn = sqlite3.connect(str(dest), timeout=timeout)
@@ -472,7 +477,7 @@ def export_save(parent=None) -> bool:
     showInfo(
         f"Save exported to:\n{dest}\n\n{_format_stats(stats)}\n\n"
         "Copy this file to your other computer and use "
-        "Ankimon → Import Save File… there."
+        "Ankimon → Game → Import Save File… there."
     )
     return True
 
@@ -609,7 +614,16 @@ def _replace_active_save(source: Path, target: Path, what: str, *, collection,
             return False
         if local_digest is not None:
             with get_ankimon_sync()._quiesce_live_db_connection(target) as closed:
-                if not closed or _save_snapshot_digest(target) != local_digest:
+                if not closed:
+                    # Not a changed save, which the caller rescans for. The user
+                    # said yes, so a silent False left them with no rescue, no
+                    # message, and the same question at the next launch.
+                    raise RuntimeError(
+                        "Ankimon was still writing to your save and did not stop "
+                        "in time; the rescue will be offered again after the next "
+                        "sync or restart"
+                    )
+                if _save_snapshot_digest(target) != local_digest:
                     return False
                 pending = stage_import(source, target)
         else:
@@ -637,7 +651,7 @@ def _replace_active_save(source: Path, target: Path, what: str, *, collection,
                 f"{what} not started: the previous import has ALREADY installed "
                 "and is the save you are playing now. Only its leftover record "
                 "could not be cleared.\n\n"
-                "Use Ankimon → Cancel Pending Save Import to clear that record, "
+                "Use Ankimon → Game → Cancel Pending Save Import to clear that record, "
                 "then try again. Nothing will be installed a second time.",
                 f"{what} was refused over an already-installed import, "
                 "but the notice could not be shown",
@@ -650,7 +664,7 @@ def _replace_active_save(source: Path, target: Path, what: str, *, collection,
                 f"{what} not started: a save import is already recorded for this "
                 "save, and Ankimon could not tell whether it has already "
                 "installed.\n\n"
-                "Use Ankimon → Cancel Pending Save Import to clear that record, "
+                "Use Ankimon → Game → Cancel Pending Save Import to clear that record, "
                 "then try again.",
                 f"{what} was refused over an import record of unknown state, "
                 "but the notice could not be shown",
@@ -659,7 +673,7 @@ def _replace_active_save(source: Path, target: Path, what: str, *, collection,
         _warn_about_pending_import(
             f"{what} not started: a save import is already pending and will "
             "install at the next full Anki restart.\n\n"
-            "Use Ankimon → Cancel Pending Save Import first if you want to "
+            "Use Ankimon → Game → Cancel Pending Save Import first if you want to "
             "choose a different save instead.",
             f"{what} was refused because an import is already pending, "
             "but the notice could not be shown",
@@ -673,7 +687,7 @@ def _replace_active_save(source: Path, target: Path, what: str, *, collection,
             f"{what} could not be finished cleanly: {error}.\n\n"
             "Your current save is still active, but this import is now PENDING "
             "and will install at the next full Anki restart. Its final progress "
-            "will still be retained in a recovery copy first. Use Ankimon → "
+            "will still be retained in a recovery copy first. Use Ankimon → Game → "
             "Cancel Pending Save Import if you do not want it.",
             f"{what} is staged but unfinished, and the notice could not be shown",
         )
@@ -694,7 +708,7 @@ def _replace_active_save(source: Path, target: Path, what: str, *, collection,
             "before the imported save is installed:\n"
             f"{pending['recovery_path']}\n\n"
             "Please reopen Anki after it closes. If you keep editing, this import "
-            "stays pending; use Ankimon → Cancel Pending Save Import to discard it.\n\n"
+            "stays pending; use Ankimon → Game → Cancel Pending Save Import to discard it.\n\n"
             "Leaderboard credentials are not imported. Sign in again after restart."
         )
     except Exception as error:
@@ -766,14 +780,15 @@ def cancel_pending_save_import() -> None:
             outcomes.append(
                 f"{target.name}: that import had ALREADY installed, so this save IS "
                 "the imported one. Only its leftover record was cleared, and nothing "
-                "will be installed again. The save it replaced was retained first — "
-                "see Ankimon → Browse Recovered Saves.")
+                "will be installed again. The save it replaced was retained first; find "
+                "it under Ankimon → Game → Browse Pre-import Recovery Saves…")
         elif target in undetermined:
             outcomes.append(
                 f"{target.name}: the import record was cleared, so nothing will be "
                 "installed from it. Ankimon could not tell whether that import had "
                 "already installed; if it had, the save it replaced was retained "
-                "first — see Ankimon → Browse Recovered Saves.")
+                "first; find it under Ankimon → Game → Browse Pre-import Recovery "
+                "Saves…")
         else:
             outcomes.append(f"{target.name}: the pending import was cancelled. "
                             "This save is unchanged.")
@@ -803,7 +818,12 @@ def browse_recovered_saves() -> None:
     try:
         recovery.mkdir(mode=0o700, parents=True, exist_ok=True)
         if os.name != "nt":
-            recovery.chmod(0o700)
+            try:
+                recovery.chmod(0o700)
+            except OSError:
+                # A volume mounted with fixed permissions refuses chmod, and
+                # showing the folder does not depend on tightening it.
+                pass
         openFolder(str(recovery))
     except OSError as error:
         showWarning(f"The recovery folder could not be opened: {error}. "
@@ -1164,7 +1184,7 @@ def _notify_affected_user(logger) -> None:
             "Your save on this computer is untouched. Media-save protection "
             "is checked separately; any files that could not be verified are "
             "reported and retried.\n\n"
-            "To move a save between computers now, use Ankimon → Export Save "
+            "To move a save between computers now, use Ankimon → Game → Export Save "
             "File… on one and Import Save File… on the other."
         )
         try:
@@ -1456,7 +1476,11 @@ def _protect_bare_saves(media_dir: Path) -> Dict[str, Any]:
             archive = Path(temporary)
             with zipfile.ZipFile(archive, "w", compression=zipfile.ZIP_STORED) as bundle:
                 bundle.write(source, source.name)
-                for suffix in ("-wal", "-shm", "-journal"):
+                # Not -shm: it is a rebuildable index rather than save content,
+                # and every read-only open restamps it. Archiving it gave an
+                # unchanged save a new digest on every pass, so every pass wrote
+                # another full archive and showed the warning again.
+                for suffix in ("-wal", "-journal"):
                     sidecar = Path(str(source) + suffix)
                     if sidecar.exists():
                         bundle.write(sidecar, sidecar.name)
@@ -1640,9 +1664,19 @@ def _report_protection(result: Dict[str, Any], logger) -> None:
                          "\n".join(map(str, result["archives"])))
         lines.append("Ankimon will retry. Keep these files until you have verified your progress.")
         if set(result["unprotected"]) - set(result["archived_sources"]):
+            # Promise the automatic retry only while a timer is armed. A scan that
+            # failed, or could not be dispatched, schedules none: those paths show
+            # a warning of their own, and a timer there would repeat it every 30
+            # seconds for as long as the failure lasted.
+            if _MIGRATION_SCAN_STATE.get("retry_scheduled"):
+                retry = ("Close anything locking those files: Ankimon retries about "
+                         "every 30 seconds while Anki is open, and at the next sync or "
+                         "restart.")
+            else:
+                retry = "Close anything locking those files and restart Anki to retry."
             lines.append("Media sync is paused for this profile because some original files "
-                         "could not be copied at all. Close anything locking those files and "
-                         "restart Anki to retry. Your Anki sync preferences have not changed.")
+                         f"could not be copied at all. {retry} Your Anki sync preferences "
+                         "have not changed.")
         showWarning("\n\n".join(lines))
     else:
         # Paths remain available in the Ankimon log without a popup every boot.
@@ -1775,7 +1809,7 @@ def _apply_migration_decision(result: Dict[str, Any], logger) -> None:
             f"ON THIS COMPUTER\n{_format_stats(local_stats)}\n\n"
             "Nothing has been changed and nothing has been deleted. If you want "
             "the recovered copy, load the recovery file shown above with "
-            "Ankimon → Import Save File… — your current save is backed up before "
+            "Ankimon → Game → Import Save File… — your current save is backed up before "
             "it is replaced."
         )
         _set_profile_flag(_MIGRATION_ANSWERED_FLAG, answer_identity)
@@ -1838,7 +1872,7 @@ _MIGRATION_SCAN_STATE = {"running": False, "rerun": False}
 _MIGRATION_RETRY_DELAY = 30.0
 
 
-def _schedule_migration_retry(settings_obj, logger) -> None:
+def _schedule_migration_retry(settings_obj, logger, delay: Optional[float] = None) -> None:
     """Ask for another pass later, without going through a media-sync hook.
 
     The add-on's only recurring rescan trigger is
@@ -1851,7 +1885,9 @@ def _schedule_migration_retry(settings_obj, logger) -> None:
     user synced by hand or closed the profile, with media sync off throughout.
 
     One timer at a time, cleared when it fires. A capture that succeeds releases
-    the guard and stops the cycle; nothing reschedules from here.
+    the guard and stops the cycle; nothing reschedules from here. ``delay``
+    defaults to the full throttle; a pass the throttle turned away asks for only
+    what is left of it.
     """
     if _MIGRATION_SCAN_STATE.get("retry_scheduled"):
         return
@@ -1874,7 +1910,9 @@ def _schedule_migration_retry(settings_obj, logger) -> None:
         # the very retry_at that scheduled it. requires_collection is False and
         # the check lives in _retry instead: Anki's own gate DROPS the call when
         # the collection is gone, and a dropped call never clears the flag.
-        mw.progress.single_shot(int(_MIGRATION_RETRY_DELAY * 1000) + 250, _retry, False)
+        if delay is None:
+            delay = _MIGRATION_RETRY_DELAY
+        mw.progress.single_shot(int(delay * 1000) + 250, _retry, False)
         _MIGRATION_SCAN_STATE["retry_scheduled"] = True
     except Exception:
         # No timer is a missed retry, not a failure: a manual sync and the next
@@ -1971,10 +2009,27 @@ def start_media_migration(settings_obj, logger) -> None:
         key = (media_dir, target)
         previous = completed.get(key)
         if previous is not None and previous["signature"] == signature:
-            if previous["protection"]["unprotected"]:
-                if time.monotonic() < previous["retry_at"]:
+            earlier = previous["protection"]
+            if earlier["unprotected"]:
+                remaining = previous["retry_at"] - time.monotonic()
+                if remaining > 0:
+                    # Nothing has changed since that pass, so its verdict holds:
+                    # put it back over the stat-only guard a profile open arms,
+                    # and keep a retry coming for what it could not capture. The
+                    # retry timer itself can land here -- Qt fires a 30 s timer
+                    # up to half a second early -- as can a timer armed for an
+                    # earlier pass, and returning with nothing scheduled left
+                    # the guard up with no retry left to lift it.
+                    _guard_uncaptured_media(media_dir, earlier)
+                    if set(earlier["unprotected"]) - set(earlier["archived_sources"]):
+                        _schedule_migration_retry(settings_obj, logger, delay=remaining)
                     return
             elif _migration_done():
+                # Settled, and unchanged since. A profile reopened in this
+                # process had its guard re-armed by guard_media_saves_now, which
+                # only stats files, and nothing runs after this return to lift
+                # it: media sync stayed paused until Anki restarted.
+                _guard_uncaptured_media(media_dir, earlier)
                 return
         elif not protection["unprotected"] and _migration_done():
             return
@@ -2039,7 +2094,12 @@ def start_media_migration(settings_obj, logger) -> None:
                 _MIGRATION_SCAN_STATE["running"] = False
                 if _MIGRATION_SCAN_STATE["rerun"]:
                     _MIGRATION_SCAN_STATE["rerun"] = False
-                    start_media_migration(settings_obj, logger)
+                    # As the retry timer does: a profile closed mid-scan still
+                    # resolves its media folder by name, and a pass for it put
+                    # the rescue prompt over the profile manager. Its next open
+                    # rescans.
+                    if _active_collection() is not None:
+                        start_media_migration(settings_obj, logger)
 
         _MIGRATION_SCAN_STATE["running"] = True
         try:

--- a/src/Ankimon/pyobj/save_transfer.py
+++ b/src/Ankimon/pyobj/save_transfer.py
@@ -1692,13 +1692,24 @@ _MIGRATION_RETRY_DELAY = 30.0
 
 
 def _pending_media_protection(media_dir: Path, target: Optional[Path]):
-    """Stat both bare saves and sidecars without opening or copying their bytes."""
+    """Stat both bare saves and sidecars without opening or copying their bytes.
+
+    SHM is left out for the reason ``_local_save_revision`` leaves it out: it is
+    a rebuildable index rather than save content, and merely reading updates it.
+    This scan is one of those readers. Every read-only open it performs on a
+    WAL-mode media save -- ``get_db_stats``, ``_sqlite_backup`` under
+    ``_protect_bare_saves``, ``_snapshot_save`` -- creates that save's ``-shm``
+    or restamps the existing one. Counting that as a source change would make
+    the before/after pair in ``_migration_scan`` disagree on every single pass:
+    ``stable`` would never be true, so the media-sync guard would never release
+    and ``_done`` would re-dispatch the scan forever.
+    """
     protection = {"protected": {}, "unprotected": [], "archives": [],
                   "archived_sources": [], "log": []}
     signature = []
     for name in _SAVE_PREFIX:
         source = media_dir / name
-        for suffix in ("", "-wal", "-shm", "-journal"):
+        for suffix in ("", "-wal", "-journal"):
             path = Path(str(source) + suffix)
             try:
                 stat = path.stat()

--- a/src/Ankimon/pyobj/save_transfer.py
+++ b/src/Ankimon/pyobj/save_transfer.py
@@ -696,35 +696,68 @@ def _replace_active_save(source: Path, target: Path, what: str, *, collection,
     return True
 
 
+def _import_targets() -> list:
+    """Every save an install is attempted against on a start, active first.
+
+    ``get_db`` tries both modes on every start and reports a failure for either,
+    naming Cancel Pending Save Import as the remedy. Resolving only the active
+    save made that remedy answer "there is no pending save import" to a user
+    looking at a warning about the other one, on every start, forever.
+    """
+    targets = []
+    for candidate in (_active_db_path(), user_path / "ankimon.db",
+                      user_path / "ankimonDEV.db"):
+        if candidate is None:
+            continue
+        try:
+            resolved = Path(candidate).resolve()
+        except Exception:
+            continue
+        if resolved not in targets:
+            targets.append(resolved)
+    return targets
+
+
 def cancel_pending_save_import() -> None:
-    """Cancel a staged import and report filesystem failures through the menu."""
+    """Cancel staged imports for either save mode, and report what was found."""
+    from ..events import events
     from ..save_import import cancel_pending_import, pending_import_is_installed
 
-    target = _active_db_path()
-    try:
-        # Asked BEFORE cancelling: removing the manifest is what makes the two
-        # states indistinguishable afterwards.
-        installed = target is not None and pending_import_is_installed(target)
-        cancelled = target is not None and cancel_pending_import(target)
-    except OSError as error:
-        showWarning(f"The pending save import could not be cancelled: {error}. "
-                    "Close anything using the Ankimon folder and try again.")
+    cancelled, already_installed, failures = [], [], []
+    for target in _import_targets():
+        try:
+            # Asked BEFORE cancelling: removing the manifest is what makes the
+            # two states indistinguishable afterwards.
+            installed = pending_import_is_installed(target)
+            if not cancel_pending_import(target):
+                continue
+        except OSError as error:
+            failures.append(f"{target.name}: {error}")
+            continue
+        cancelled.append(target)
+        if installed:
+            already_installed.append(target)
+        events.emit("save_import_cancelled", target=str(target),
+                    installed=installed)
+
+    if failures:
+        showWarning("The pending save import could not be cancelled:\n\n"
+                    + "\n".join(failures)
+                    + "\n\nClose anything using the Ankimon folder and try again.")
         return
-    if cancelled and installed:
-        from ..events import events
-
-        events.emit("save_import_cancelled", target=str(target), installed=True)
-        showInfo("That import had already installed: the save you are playing IS the "
-                 "imported one. Only its leftover record was cleared, so nothing will "
-                 "be installed again.\n\nYour previous save was retained before the "
-                 "replacement — see Ankimon → Browse Recovered Saves.")
-    elif cancelled:
-        from ..events import events
-
-        events.emit("save_import_cancelled", target=str(target))
-        showInfo("The pending save import was cancelled. Your current save is unchanged.")
+    if not cancelled:
+        showInfo("There is no pending save import for either save mode.")
+        return
+    named = ", ".join(target.name for target in cancelled)
+    if already_installed:
+        showInfo(f"That import ({', '.join(t.name for t in already_installed)}) had "
+                 "already installed: the save you are playing IS the imported one. "
+                 "Only its leftover record was cleared, so nothing will be installed "
+                 "again.\n\nYour previous save was retained before the replacement — "
+                 "see Ankimon → Browse Recovered Saves.")
     else:
-        showInfo("There is no pending save import for the active mode.")
+        showInfo(f"The pending save import was cancelled ({named}). "
+                 "Your current save is unchanged.")
 
 
 def browse_recovered_saves() -> None:

--- a/src/Ankimon/pyobj/save_transfer.py
+++ b/src/Ankimon/pyobj/save_transfer.py
@@ -2,8 +2,8 @@
 
 Exports use SQLite snapshots with local credentials removed. Imports and rescues
 require a verified snapshot, explicit confirmation, a safety backup and atomic
-replacement. The migration preserves bare media saves under underscore-prefixed
-names, which Anki excludes from Delete Unused Files. Progress counters select a
+replacement. The migration preserves bare media saves in a private profile-local
+recovery directory outside ``collection.media``. Progress counters select a
 candidate for comparison; they do not prove one save contains another.
 
 The automatic file sync was removed because Anki media downloads have local
@@ -29,10 +29,25 @@ from PyQt6.QtWidgets import QFileDialog
 from ..resources import user_path
 from ..utils import close_anki
 
-# Leading underscores protect saves from Anki's Delete Unused Files. Keep
-# normal/developer partitions separate and name each distinct save by content.
-# Existing names must be verified before reuse; damaged copies keep their names.
+# Keep normal/developer partitions separate and name each distinct save by
+# content. Older revisions wrote underscore-prefixed copies into
+# ``collection.media`` to protect them from Delete Unused Files; new recovery
+# material lives outside that directory so Anki media sync cannot upload it.
 _SAVE_PREFIX = {"ankimon.db": "_ankimon_save_", "ankimonDEV.db": "_ankimon_save_dev_"}
+
+
+def _recovery_store(media_dir: Path, *, create: bool = False) -> Path:
+    """Profile-local media-save recovery storage that Anki does not sync."""
+    recovery = Path(media_dir).parent / "ankimon-media-recovery"
+    if create:
+        recovery.mkdir(mode=0o700, parents=True, exist_ok=True)
+        if os.name != "nt":
+            try:
+                recovery.chmod(0o700)
+            except OSError:
+                pass
+    return recovery
+
 
 # Use 128 bits of SHA-256 for compact protected filenames.
 _DIGEST_CHARS = 32
@@ -699,9 +714,8 @@ def _media_fingerprint_entries(media_dir: Path, target_db: str) -> Dict[str, str
     other candidates are readable. An unreadable newcomer must not match a
     previously settled empty folder or subset of saves.
 
-    Returned as a dict so the scan can amend it with only the files it wrote
-    ITSELF — which is what separates "the folder the scan resolved" from "the
-    folder as it stands after an unrelated download".
+    Only sync-visible media paths belong here. Private recovery copies are
+    scanned separately and cannot re-arm or settle a media-sync fingerprint.
     """
     entries: Dict[str, str] = {}
     for path in _media_candidate_paths(media_dir, target_db):
@@ -818,20 +832,20 @@ def _rescan_local_save(logger) -> None:
 
 
 def _media_candidate_paths(media_dir: Path, target_db: str) -> list:
-    """Every path in ``media_dir`` that could hold a save for ``target_db``.
+    """Every sync-visible path that could hold a save for ``target_db``.
 
-    ONE definition, shared by the scanner and by the settle fingerprint. If
-    those two ever drift, the fingerprint stops noticing a file the scanner
-    would have acted on — which silently re-opens the stale-settle hole the
-    fingerprint exists to close.
+    ONE definition is shared by the media fingerprint and the media side of the
+    scanner. Private recovery copies are intentionally excluded: they must not
+    affect the fingerprint that answers "did collection.media change?"
 
-    Three kinds of name: the bare one the removed feature wrote; the
-    content-addressed copies this migration writes; and the pre-2024 legacy
-    names, which are GLOBBED rather than reconstructed. The old code built them
-    from ``Path(__file__).parents[2].name``, which is ``addons21`` in a normal
-    install and ``src`` in a git checkout, and real profiles have been seen
-    carrying the numeric package id instead — so the exact prefix cannot be
-    computed after the fact, only matched.
+    Three kinds of sync-visible name may already exist: the bare one the removed
+    feature wrote; underscore/content-addressed copies written by older
+    migration revisions; and the pre-2024 legacy names, which are GLOBBED rather
+    than reconstructed. The old code built them from
+    ``Path(__file__).parents[2].name``, which is ``addons21`` in a normal install
+    and ``src`` in a git checkout, and real profiles have been seen carrying the
+    numeric package id instead — so the exact prefix cannot be computed after
+    the fact, only matched.
     """
     paths = [media_dir / target_db]
     try:
@@ -848,13 +862,30 @@ def _media_candidate_paths(media_dir: Path, target_db: str) -> list:
     return paths
 
 
-def _find_media_saves(media_dir: Path, target_db: str) -> tuple:
-    """Every Ankimon save in collection.media belonging to ``target_db``.
+def _recovery_candidate_paths(media_dir: Path, target_db: str) -> list:
+    """Verified local recovery copies for ``target_db``, outside media sync."""
+    recovery = _recovery_store(media_dir)
+    if not recovery.is_dir():
+        return []
+    try:
+        return [
+            path
+            for path in sorted(recovery.glob(_SAVE_PREFIX[target_db] + "*.db"))
+            if _target_db_for(path) == target_db
+        ]
+    except Exception:
+        return []
 
-    Returns ``(candidates, unreadable)``. A file that exists but will not open
-    lands in ``unreadable`` rather than being silently dropped: it may be a real
-    save merely locked by another process this second, and the caller must stay
-    armed and rescan rather than settle as though the folder held nothing.
+
+def _find_media_saves(media_dir: Path, target_db: str) -> tuple:
+    """Every recoverable media save belonging to ``target_db``.
+
+    This includes sync-visible legacy files in ``collection.media`` and verified
+    local copies retained beside it. Returns ``(candidates, unreadable)``. A file
+    that exists but will not open lands in ``unreadable`` rather than being
+    silently dropped: it may be a real save merely locked by another process
+    this second, and the caller must stay armed and rescan rather than settle as
+    though the folder held nothing.
     """
     from .ankimon_sync import _verify_sqlite_integrity
 
@@ -862,7 +893,10 @@ def _find_media_saves(media_dir: Path, target_db: str) -> tuple:
     unreadable = []
     seen = set()
 
-    for path in _media_candidate_paths(media_dir, target_db):
+    for path in (
+        _media_candidate_paths(media_dir, target_db)
+        + _recovery_candidate_paths(media_dir, target_db)
+    ):
         try:
             resolved = path.resolve()
         except Exception:
@@ -984,10 +1018,9 @@ def _migration_scan(media_dir: Path, target: Optional[Path]) -> Dict[str, Any]:
     written: list = []
     target_db = Path(target).name if target else "ankimon.db"
 
-    # Taken BEFORE anything is read or written, and amended below with only the
-    # files this scan wrote itself, so the settle describes the folder this pass
-    # actually examined — a peer's save landing mid-scan is not recorded as
-    # resolved.
+    # Taken BEFORE anything is read or written. This fingerprint deliberately
+    # describes only collection.media: private recovery copies are outside Anki
+    # media sync and must not make a settled media state look changed.
     entries = _media_fingerprint_entries(media_dir, target_db)
 
     protection = _protect_bare_saves(media_dir)
@@ -1000,12 +1033,6 @@ def _migration_scan(media_dir: Path, target: Optional[Path]) -> Dict[str, Any]:
     unreadable.extend(integrity_failures)
 
     def _result(outcome: str, **extra) -> Dict[str, Any]:
-        for path in written:
-            entry = _fingerprint_entry(path)
-            if entry is None:
-                entries.pop(path.name, None)
-            else:
-                entries[path.name] = entry
         base = {
             "outcome": outcome,
             "notify": False,
@@ -1151,9 +1178,11 @@ def _preserve(at_risk: Path, media_dir: Path, target_db: str,
     tmp = None
     dest = None
     try:
+        recovery_dir = _recovery_store(media_dir, create=True)
+
         def destination(digest):
             """Find an identical copy or an unused name, skipping damaged copies."""
-            base = media_dir / _protected_copy_name(target_db, digest)
+            base = recovery_dir / _protected_copy_name(target_db, digest)
             candidate, suffix = base, 0
             while candidate.exists() or candidate.is_symlink():
                 if _content_digest(candidate) == digest:
@@ -1178,9 +1207,9 @@ def _preserve(at_risk: Path, media_dir: Path, target_db: str,
         written.append(dest)
         notes.append((
             "info",
-            f"Ankimon: preserved {at_risk.name} as {dest.name} "
-            "(protected from Anki's Delete Unused Files). Nothing was deleted "
-            "or overwritten.",
+            f"Ankimon: preserved {at_risk.name} as {dest} "
+            "outside collection.media so Anki media sync cannot upload it. "
+            "Nothing was deleted or overwritten.",
         ))
         return dest
     except Exception as e:
@@ -1228,7 +1257,8 @@ def _protect_bare_saves(media_dir: Path) -> Dict[str, Any]:
             digest = _content_digest(archive)
             if digest is None:
                 raise OSError("Could not verify the raw archive bytes")
-            destination = media_dir / f"_ankimon_unverified_{name}_{digest}.zip"
+            recovery_dir = _recovery_store(media_dir, create=True)
+            destination = recovery_dir / f"_ankimon_unverified_{name}_{digest}.zip"
             base, suffix = destination, 0
             while destination.exists() or destination.is_symlink():
                 if _content_digest(destination) == digest:
@@ -1378,19 +1408,19 @@ def _apply_migration_decision(result: Dict[str, Any], logger) -> None:
             "Ankimon's automatic AnkiWeb save-sync has been removed — it "
             "could not tell reliably which device's save was newer, and "
             "sometimes overwrote the wrong one.\n\n"
-            "A save left in your Anki media folder (synced from AnkiWeb, if "
-            "media sync is on) is further along than the save on this computer "
-            "on every count Ankimon can compare:\n\n"
-            f"IN YOUR MEDIA FOLDER\n{_format_stats(media_stats)}\n\n"
+            "A save recovered from your Anki media folder (synced from AnkiWeb, "
+            "if media sync is on) is further along than the save on this "
+            "computer on every count Ankimon can compare:\n\n"
+            f"RECOVERED MEDIA SAVE\n{_format_stats(media_stats)}\n\n"
             f"ON THIS COMPUTER\n{_format_stats(local_stats)}\n\n"
-            "Load the media-folder copy? Compare the two above first — Ankimon "
+            "Load the recovered copy? Compare the two above first — Ankimon "
             "counts what each save holds, it cannot tell whether one contains "
             "the other. Your current save will be backed up before anything is "
             "replaced, and Anki will close so the copy can be loaded cleanly."
             "\n\n"
-            "If you say no, nothing changes — the copy stays in your media "
-            "folder either way, and you will not be asked about it again "
-            "unless a different copy arrives there.",
+            "If you say no, nothing changes — the recovery copy stays preserved "
+            "locally, and you will not be asked about it again unless a "
+            "different media save arrives.",
             parent=mw,
             defaultno=True,
         ):
@@ -1428,16 +1458,16 @@ def _apply_migration_decision(result: Dict[str, Any], logger) -> None:
         showInfo(
             "Ankimon's automatic AnkiWeb save-sync has been removed — it "
             "could not tell reliably which device's save was newer.\n\n"
-            "There is a save in your Anki media folder that has DIVERGED from "
-            "the one on this computer: each contains progress the other does "
-            "not, so neither can simply replace the other.\n\n"
-            f"IN YOUR MEDIA FOLDER ({Path(result['media_path']).name})\n"
+            "There is a save recovered from your Anki media folder that has "
+            "DIVERGED from the one on this computer: each contains progress the "
+            "other does not, so neither can simply replace the other.\n\n"
+            f"RECOVERED MEDIA SAVE ({result['media_path']})\n"
             f"{_format_stats(media_stats)}\n\n"
             f"ON THIS COMPUTER\n{_format_stats(local_stats)}\n\n"
             "Nothing has been changed and nothing has been deleted. If you want "
-            "the media-folder copy, copy it out of your collection.media folder "
-            "and load it with Ankimon → Import Save File… — your current save is "
-            "backed up before it is replaced."
+            "the recovered copy, load the recovery file shown above with "
+            "Ankimon → Import Save File… — your current save is backed up before "
+            "it is replaced."
         )
         _set_profile_flag(_MIGRATION_ANSWERED_FLAG, answer_identity)
 

--- a/src/Ankimon/pyobj/save_transfer.py
+++ b/src/Ankimon/pyobj/save_transfer.py
@@ -18,6 +18,7 @@ import shutil
 import sqlite3
 import tempfile
 import time
+import zipfile
 from pathlib import Path
 from typing import Any, Dict, Optional
 
@@ -400,23 +401,26 @@ def export_save(parent=None) -> bool:
     ):
         return False
 
-    # Build into a temp file beside the destination and move it into place only
-    # after it verifies, so an interrupted or failed export can never leave a
-    # half-written file the user might later import over a good save.
+    # The destination may be shared/cloud-synced. Only sanitised bytes may ever
+    # enter that directory, including temporary files and interrupted exports.
     tmp = None
+    private = None
     try:
-        fd, tmp_name = tempfile.mkstemp(prefix="ankimon-export-", suffix=".db", dir=str(dest.parent))
-        os.close(fd)
-        tmp = Path(tmp_name)
-        _sqlite_backup(source, tmp)
-        _strip_local_secrets(tmp)
+        private = _snapshot_save(source)
+        _strip_local_secrets(private)
 
-        if not _verify_sqlite_integrity(tmp):
+        if not _verify_sqlite_integrity(private):
             showWarning(
                 "Export failed: the exported file did not pass an integrity "
                 "check, so it was discarded. Your save is unchanged."
             )
             return False
+
+        stats = get_db_stats(private)
+        fd, tmp_name = tempfile.mkstemp(prefix="ankimon-export-", suffix=".db", dir=str(dest.parent))
+        os.close(fd)
+        tmp = Path(tmp_name)
+        shutil.copyfile(private, tmp)
 
         # Same lock ladder the import path uses. Exporting over an existing
         # file inside a OneDrive/Dropbox folder is the obvious thing a
@@ -445,11 +449,8 @@ def export_save(parent=None) -> bool:
             showWarning(f"Export failed: {e}\n\nYour save is unchanged.")
         return False
     finally:
-        if tmp is not None:
-            try:
-                tmp.unlink(missing_ok=True)
-            except Exception:
-                pass
+        _discard_snapshot(private)
+        _discard_snapshot(tmp)
 
     showInfo(
         f"Save exported to:\n{dest}\n\n{_format_stats(stats)}\n\n"
@@ -492,8 +493,8 @@ def import_save(parent=None) -> bool:
             "Replace your current Ankimon save with this file?\n\n"
             f"FILE YOU CHOSE\n{_format_stats(incoming)}\n\n"
             f"YOUR CURRENT SAVE\n{_format_stats(current)}\n\n"
-            "Your current save will be backed up first, and Anki will close so the "
-            "new save is loaded cleanly.",
+            "The import takes effect on the next full Anki restart. Your final current "
+            "save will be backed up before replacement. Leaderboard sign-in will be required.",
             parent=parent,
             defaultno=True,
         ):
@@ -543,75 +544,74 @@ def _rebase_import_watermark(snapshot: Path, col) -> None:
 
 def _replace_active_save(source: Path, target: Path, what: str, *, collection,
                          local_revision=None, local_digest=None) -> bool:
-    """Back up, then install the private snapshot the caller showed the user.
+    """Prepare the approved save for a fresh process; never replace live state.
 
-    ``source`` must be a caller-owned snapshot, never the original external
-    pathname. Rebase its review watermark and verify it before the backup; a
-    failed backup REFUSES the replacement — never overwrite the live save with
-    no recovery path. The replace itself goes through ``_atomic_replace``, which
-    closes the live connection, writes a temp on the same volume,
-    ``os.replace``s it into place (retrying a transient OneDrive/antivirus lock)
-    and reaps stale ``-wal`` / ``-shm`` sidecars belonging to the old file.
-
-    Rescue validates the local content again after active writers drain. Its
-    snapshot digest ignores harmless WAL checkpoints performed by the backup.
-    Anki then closes to reload live objects; the watermark is already rebased.
+    Cancellation of Anki's asynchronous shutdown leaves the original runtime
+    and database together. Installation and the final recovery snapshot happen
+    before any database manager or game objects exist on the next full start.
     """
-    from .ankimon_sync import (
-        get_ankimon_sync, _handle_manual_sync_error, _verify_sqlite_integrity,
-    )
+    from ..save_import import stage_import
+    from .ankimon_sync import get_ankimon_sync
 
     try:
         if _active_db_path() != Path(target) or _active_collection() is not collection:
             raise RuntimeError("The active profile or save changed; please try the import again")
         _rebase_import_watermark(source, collection)
-    except Exception as e:
-        showWarning(f"{what} aborted: {e}. Your save is unchanged.")
-        return False
-
-    if not _verify_sqlite_integrity(Path(source)):
-        showWarning(
-            f"{what} aborted: the save file no longer passes an integrity check "
-            "(it may have changed since it was checked), so nothing was "
-            "replaced. Your save is unchanged."
-        )
-        return False
-
-    sync = get_ankimon_sync()
-    if local_revision is not None and _local_save_revision(target) != local_revision:
-        return False
-    if not sync._backup_before_overwrite(Path(target).name):
-        showWarning(
-            f"{what} aborted: a safety backup of your current save could not be "
-            "created, so nothing was replaced. Your save is unchanged."
-        )
-        return False
-
-    local_changed = False
-
-    def validate_target():
-        """Check content after active writers drain, tolerating WAL checkpoints."""
-        nonlocal local_changed
-        if _save_snapshot_digest(target) != local_digest:
-            local_changed = True
-            raise RuntimeError("The local save changed after rescue confirmation")
-
-    try:
-        if local_digest is None:
-            sync._atomic_replace(Path(source), Path(target))
-        else:
-            sync._atomic_replace(Path(source), Path(target), validate_target=validate_target)
-    except Exception as e:
-        if local_changed:
+        if local_revision is not None and _local_save_revision(target) != local_revision:
             return False
-        return _handle_manual_sync_error(e, f"{what} failed")
+        if local_digest is not None:
+            with get_ankimon_sync()._quiesce_live_db_connection(target) as closed:
+                if not closed or _save_snapshot_digest(target) != local_digest:
+                    return False
+                pending = stage_import(source, target)
+        else:
+            pending = stage_import(source, target)
+    except Exception as error:
+        showWarning(f"{what} aborted: {error}. Your current save is unchanged.")
+        return False
 
     showInfo(
-        f"{what} complete. Anki will now close — please reopen it to start "
-        "playing with the restored save."
+        f"{what} prepared for the next full Anki restart.\n\n"
+        "Your current save stays active until Anki exits. At the next start, "
+        "its final progress will be saved in a separately retained recovery copy "
+        "before the imported save is installed:\n"
+        f"{pending['recovery_path']}\n\n"
+        "Please reopen Anki after it closes. If you keep editing, this import "
+        "stays pending; use Ankimon → Cancel Pending Save Import to discard it.\n\n"
+        "Leaderboard credentials are not imported. Sign in again after restart."
     )
-    close_anki()
+    from ..events import events
+
+    events.emit("save_import_prepared", target=str(target), recovery_path=str(pending["recovery_path"]))
+    try:
+        close_anki()
+    except Exception as error:
+        showWarning(f"Anki could not close: {error}. Your current save is still active. "
+                    "The prepared import will run on the next full restart, or you can cancel it.")
     return True
+
+
+def cancel_pending_save_import() -> None:
+    from ..save_import import cancel_pending_import
+
+    target = _active_db_path()
+    if target is not None and cancel_pending_import(target):
+        from ..events import events
+
+        events.emit("save_import_cancelled", target=str(target))
+        showInfo("The pending save import was cancelled. Your current save is unchanged.")
+    else:
+        showInfo("There is no pending save import for the active mode.")
+
+
+def browse_recovered_saves() -> None:
+    """Open the separately retained pre-import recovery folder."""
+    target = _active_db_path()
+    recovery = Path(target).parent / "ankimon_recovery" if target else user_path / "ankimon_recovery"
+    from aqt.utils import openFolder
+
+    recovery.mkdir(parents=True, exist_ok=True)
+    openFolder(str(recovery))
 
 
 # ---------------------------------------------------------------------------
@@ -946,8 +946,9 @@ def _notify_affected_user(logger) -> None:
             "could pick the wrong one and overwrite newer progress. It could not "
             "be made reliable, so it has been taken out rather than left to lose "
             "data.\n\n"
-            "Your save on this computer is untouched, and any copy in your media "
-            "folder has been preserved.\n\n"
+            "Your save on this computer is untouched. Media-save protection "
+            "is checked separately; any files that could not be verified are "
+            "reported and retried.\n\n"
             "To move a save between computers now, use Ankimon → Export Save "
             "File… on one and Import Save File… on the other."
         )
@@ -989,6 +990,12 @@ def _migration_scan(media_dir: Path, target: Optional[Path]) -> Dict[str, Any]:
     # resolved.
     entries = _media_fingerprint_entries(media_dir, target_db)
 
+    protection = _protect_bare_saves(media_dir)
+    notes.extend(protection["log"])
+    unreadable.extend(protection["unprotected"])
+    written.extend(path for path in protection["protected"].values()
+                   if _target_db_for(path) == target_db)
+
     saves, integrity_failures = _find_media_saves(media_dir, target_db)
     unreadable.extend(integrity_failures)
 
@@ -1010,6 +1017,7 @@ def _migration_scan(media_dir: Path, target: Optional[Path]) -> Dict[str, Any]:
             "media_stats": None,
             "local_stats": None,
             "fingerprint": _join_fingerprint(entries),
+            "protection": protection,
         }
         base.update(extra)
         return base
@@ -1050,17 +1058,8 @@ def _migration_scan(media_dir: Path, target: Optional[Path]) -> Dict[str, Any]:
         ))
         return _result("armed")
 
-    # PROTECT. Exactly ONE file in this partition can be taken by Anki's "Delete
-    # Unused Files": the bare ``ankimon.db`` / ``ankimonDEV.db``. Every other
-    # candidate already begins with an underscore. So the protect step has one
-    # job, on one file, and it is unconditional: it does not rank, does not
-    # compare, and does not write over anything.
     at_risk = media_dir / target_db
-    preserved = (
-        _preserve(at_risk, media_dir, target_db, notes, unreadable, written)
-        if at_risk in stats
-        else None
-    )
+    preserved = protection["protected"].get(at_risk)
 
     local_revision = _local_save_revision(target) if target else None
     local_stats = (
@@ -1143,9 +1142,9 @@ def _preserve(at_risk: Path, media_dir: Path, target_db: str,
     """Keep a verified protected copy without changing any existing media file.
 
     Reuse a digest-named copy only when its bytes still match. If that name is
-    occupied by damaged or different content, try numbered alternatives. Copy
-    the static media file as bytes to avoid SQLite recovering its journal in
-    place; verify the temporary copy before publishing it atomically.
+    occupied by damaged or different content, try numbered alternatives. Read
+    via SQLite's backup API so committed WAL pages are included. Read-only
+    source access refuses to recover an external rollback journal in place.
     """
     from .ankimon_sync import _atomic_write_over, _verify_sqlite_integrity
 
@@ -1163,24 +1162,18 @@ def _preserve(at_risk: Path, media_dir: Path, target_db: str,
                 candidate = base.with_name(f"{base.stem}-{suffix}.db")
             return candidate
 
-        probe = _content_digest(at_risk)
-        if probe is not None:
-            settled = destination(probe)
-            if settled.is_file():
-                return settled
-
         fd, name = tempfile.mkstemp(prefix="ankimon-protect-", suffix=".db")
         os.close(fd)
         tmp = Path(name)
-        shutil.copy2(at_risk, tmp)
+        _sqlite_backup(at_risk, tmp, timeout=MIGRATION_PROBE_TIMEOUT)
+        if not _verify_sqlite_integrity(tmp, timeout=MIGRATION_PROBE_TIMEOUT):
+            raise OSError(f"the copy of {at_risk.name} did not verify")
         digest = _content_digest(tmp)
         if digest is None:
             raise OSError(f"could not read back the copy of {at_risk.name}")
         dest = destination(digest)
         if dest.is_file():
             return dest
-        if not _verify_sqlite_integrity(tmp, timeout=MIGRATION_PROBE_TIMEOUT):
-            raise OSError(f"the copy of {at_risk.name} did not verify")
         _atomic_write_over(tmp, dest)
         written.append(dest)
         notes.append((
@@ -1197,11 +1190,124 @@ def _preserve(at_risk: Path, media_dir: Path, target_db: str,
         unreadable.append(dest if dest is not None else at_risk)
         return None
     finally:
-        if tmp is not None:
-            try:
-                tmp.unlink(missing_ok=True)
-            except Exception:
-                pass
+        _discard_snapshot(tmp)
+
+
+def _protect_bare_saves(media_dir: Path) -> Dict[str, Any]:
+    """Capture both modes before Anki can start replacing media files.
+
+    Only this preservation step is synchronous. A locked/corrupt SQLite source
+    gets a labelled raw archive including sidecars, never a claimed valid save.
+    Validation, ranking and recovery decisions remain eligible for retry.
+    """
+    result = {"protected": {}, "unprotected": [], "archives": [], "archived_sources": [], "log": []}
+    for name in _SAVE_PREFIX:
+        source = media_dir / name
+        try:
+            source.stat()
+        except FileNotFoundError:
+            continue
+        except OSError:
+            pass  # Unknown/unreadable is not the same as an absent file.
+        protected = _preserve(source, media_dir, name, result["log"], [], [])
+        if protected is not None:
+            result["protected"][source] = protected
+            continue
+        result["unprotected"].append(source)
+        archive = None
+        try:
+            fd, temporary = tempfile.mkstemp(prefix="ankimon-unverified-", suffix=".zip")
+            os.close(fd)
+            archive = Path(temporary)
+            with zipfile.ZipFile(archive, "w", compression=zipfile.ZIP_STORED) as bundle:
+                bundle.write(source, source.name)
+                for suffix in ("-wal", "-shm", "-journal"):
+                    sidecar = Path(str(source) + suffix)
+                    if sidecar.exists():
+                        bundle.write(sidecar, sidecar.name)
+            digest = _content_digest(archive)
+            if digest is None:
+                raise OSError("Could not verify the raw archive bytes")
+            destination = media_dir / f"_ankimon_unverified_{name}_{digest}.zip"
+            base, suffix = destination, 0
+            while destination.exists() or destination.is_symlink():
+                if _content_digest(destination) == digest:
+                    break
+                suffix += 1
+                destination = base.with_name(f"{base.stem}-{suffix}.zip")
+            from .ankimon_sync import _atomic_write_over
+            if not destination.exists():
+                _atomic_write_over(archive, destination)
+            result["archives"].append(destination)
+            result["archived_sources"].append(source)
+        except Exception as error:
+            result["log"].append(("error", f"Could not archive {source}: {error}"))
+        finally:
+            _discard_snapshot(archive)
+    return result
+
+
+def _guard_uncaptured_media(media_dir: Path, protection: Dict[str, Any]) -> None:
+    """Pause media sync for this profile only while original bytes are at risk.
+
+    Anki checks this method for collection-triggered and periodic media sync.
+    Keep its preference untouched; the in-memory guard clears on a successful
+    capture and automatically allows other profiles. Anchor it on the profile
+    manager so an addon module reload cannot stack wrappers or lose the guard.
+    """
+    uncaptured = set(protection["unprotected"]) - set(protection["archived_sources"])
+    pm = mw.pm
+    state = getattr(pm, "_ankimon_media_protection_guard", None)
+    if not isinstance(state, dict):
+        if not uncaptured:
+            return
+        original = pm.media_syncing_enabled
+        state = {"blocked": set()}
+
+        def enabled():
+            folder = Path(pm.profileFolder()) / "collection.media"
+            return folder not in state["blocked"] and original()
+
+        pm.media_syncing_enabled = enabled
+        pm._ankimon_media_protection_guard = state
+    if uncaptured:
+        state["blocked"].add(media_dir)
+    else:
+        state["blocked"].discard(media_dir)
+
+
+_LAST_PROTECTION_NOTICE = None
+
+
+def _report_protection(result: Dict[str, Any], logger) -> None:
+    """Keep the removal announcement separate from verified preservation."""
+    global _LAST_PROTECTION_NOTICE
+    for level, message in result["log"]:
+        logger.log(level, message)
+    identity = (tuple(map(str, result["protected"].values())),
+                tuple(map(str, result["unprotected"])), tuple(map(str, result["archives"])))
+    if identity == _LAST_PROTECTION_NOTICE or not any(identity):
+        return
+    _LAST_PROTECTION_NOTICE = identity
+    lines = []
+    if result["protected"]:
+        lines.append("Verified recovery copies:\n" + "\n".join(map(str, result["protected"].values())))
+    if result["unprotected"]:
+        lines.append("Could not create a verified recovery save for:\n" +
+                     "\n".join(map(str, result["unprotected"])))
+        if result["archives"]:
+            lines.append("Raw files were archived with their SQLite sidecars. These archives "
+                         "are unverified and may require recovery:\n" +
+                         "\n".join(map(str, result["archives"])))
+        lines.append("Ankimon will retry. Keep these files until you have verified your progress.")
+        if set(result["unprotected"]) - set(result["archived_sources"]):
+            lines.append("Media sync is paused for this profile because some original files "
+                         "could not be copied at all. Close anything locking those files and "
+                         "restart Anki to retry. Your Anki sync preferences have not changed.")
+        showWarning("\n\n".join(lines))
+    else:
+        # Paths remain available in the Ankimon log without a popup every boot.
+        logger.log("info", "\n\n".join(lines))
 
 
 def _apply_migration_result(result: Dict[str, Any], logger) -> None:
@@ -1224,6 +1330,8 @@ def _apply_migration_decision(result: Dict[str, Any], logger) -> None:
         except Exception:
             pass
 
+    if result.get("protection"):
+        _report_protection(result["protection"], logger)
     if result.get("notify"):
         _notify_affected_user(logger)
 
@@ -1361,7 +1469,7 @@ def run_media_migration(settings_obj, logger) -> None:
     """Protect, and offer to rescue, whatever the removed sync left in media.
 
     The SYNCHRONOUS form: scan and act on the calling thread. Used directly by
-    tests, and as the fallback when Anki's task manager is unavailable. Anki's
+    tests. Anki's
     own callers go through ``start_media_migration``, which keeps the file work
     off the profile-open stack.
 
@@ -1399,10 +1507,14 @@ def start_media_migration(settings_obj, logger) -> None:
     coalesced into a later pass, and profile changes invalidate its result.
     """
     try:
-        if _migration_done():
-            return
         media_dir = _media_dir()
         if media_dir is None or not media_dir.is_dir():
+            return
+        # Anki starts automatic media sync immediately after profile_did_open.
+        # Complete capture BEFORE returning or queueing the expensive scan.
+        protection = _protect_bare_saves(media_dir)
+        _guard_uncaptured_media(media_dir, protection)
+        if _migration_done() and not protection["unprotected"]:
             return
         target = _active_db_path()
         collection = _active_collection()
@@ -1417,16 +1529,23 @@ def start_media_migration(settings_obj, logger) -> None:
         def _done(future) -> None:
             result = None
             try:
+                if _media_dir() == media_dir and _active_collection() is collection:
+                    _report_protection(protection, logger)
                 result = future.result()
                 # A profile switch during the scan would leave us applying one
                 # profile's media folder to another's flag and another's save.
                 # mw.pm has already moved on by the time this runs, so compare.
                 if (result is not None and _media_dir() == media_dir
                         and _active_collection() is collection):
+                    if result.get("protection"):
+                        _guard_uncaptured_media(media_dir, result["protection"])
                     _apply_migration_result(result, logger)
             except Exception as e:
                 try:
                     logger.log("error", f"AnkiWeb sync-removal migration failed: {e}")
+                    if _media_dir() == media_dir and _active_collection() is collection:
+                        showWarning("Ankimon's media recovery comparison failed and will be retried "
+                                    "after the next sync or restart. See the Ankimon log for details.")
                 except Exception:
                     pass
             finally:
@@ -1440,10 +1559,12 @@ def start_media_migration(settings_obj, logger) -> None:
         _MIGRATION_SCAN_STATE["running"] = True
         try:
             mw.taskman.run_in_background(_scan, _done, uses_collection=False)
-        except Exception:
-            # No task manager (or it refused): correctness beats responsiveness.
+        except Exception as error:
             _MIGRATION_SCAN_STATE["running"] = False
-            run_media_migration(settings_obj, logger)
+            _report_protection(protection, logger)
+            logger.log("error", f"Could not schedule media recovery scan: {error}")
+            showWarning("Ankimon could not start its media recovery scan. "
+                        "Recovery comparison will be retried after the next sync or restart.")
     except Exception as e:
         try:
             logger.log("error", f"AnkiWeb sync-removal migration failed: {e}")

--- a/src/Ankimon/pyobj/save_transfer.py
+++ b/src/Ankimon/pyobj/save_transfer.py
@@ -627,7 +627,8 @@ def _replace_active_save(source: Path, target: Path, what: str, *, collection,
         # into import_save's "Import aborted: ... Nothing was replaced" handler
         # over a published, armed import. That is the mis-report this branch
         # exists to prevent.
-        if pending_import_is_installed(Path(target)):
+        installed = pending_import_is_installed(Path(target))
+        if installed:
             # The record outlived the import it describes. Telling the user it
             # "will install at the next restart" describes a replacement that
             # has already happened, to somebody deciding what to do about the
@@ -639,6 +640,19 @@ def _replace_active_save(source: Path, target: Path, what: str, *, collection,
                 "Use Ankimon → Cancel Pending Save Import to clear that record, "
                 "then try again. Nothing will be installed a second time.",
                 f"{what} was refused over an already-installed import, "
+                "but the notice could not be shown",
+            )
+            return True
+        if installed is None:
+            # The save could not be read in time to tell. Either confident
+            # answer could be the wrong way round, so claim neither.
+            _warn_about_pending_import(
+                f"{what} not started: a save import is already recorded for this "
+                "save, and Ankimon could not read the save to tell whether it "
+                "has already installed.\n\n"
+                "Use Ankimon → Cancel Pending Save Import to clear that record, "
+                "then try again.",
+                f"{what} was refused over an import record of unknown state, "
                 "but the notice could not be shown",
             )
             return True
@@ -723,7 +737,7 @@ def cancel_pending_save_import() -> None:
     from ..events import events
     from ..save_import import cancel_pending_import, pending_import_is_installed
 
-    cancelled, already_installed, failures = [], [], []
+    cancelled, already_installed, undetermined, failures = [], [], [], []
     for target in _import_targets():
         try:
             # Asked BEFORE cancelling: removing the manifest is what makes the
@@ -737,12 +751,20 @@ def cancel_pending_save_import() -> None:
         cancelled.append(target)
         if installed:
             already_installed.append(target)
+        elif installed is None:
+            undetermined.append(target)
         events.emit("save_import_cancelled", target=str(target),
                     installed=installed)
 
     if failures:
-        showWarning("The pending save import could not be cancelled:\n\n"
-                    + "\n".join(failures)
+        message = ("The pending save import could not be cancelled:\n\n"
+                   + "\n".join(failures))
+        if cancelled:
+            # The other save mode may already be cancelled, its event emitted.
+            # Naming only the failure would tell the user that did not happen.
+            message += ("\n\nCancelled successfully: "
+                        + ", ".join(target.name for target in cancelled))
+        showWarning(message
                     + "\n\nClose anything using the Ankimon folder and try again.")
         return
     if not cancelled:
@@ -755,6 +777,11 @@ def cancel_pending_save_import() -> None:
                  "Only its leftover record was cleared, so nothing will be installed "
                  "again.\n\nYour previous save was retained before the replacement — "
                  "see Ankimon → Browse Recovered Saves.")
+    elif undetermined:
+        showInfo(f"The pending save import record was cleared ({named}), so nothing "
+                 "will be installed from it. Ankimon could not read the save to tell "
+                 "whether that import had already installed; if it had, your previous "
+                 "save was retained first — see Ankimon → Browse Recovered Saves.")
     else:
         showInfo(f"The pending save import was cancelled ({named}). "
                  "Your current save is unchanged.")
@@ -1480,8 +1507,10 @@ def _resume_deferred_media_sync() -> bool:
             return False
         syncer.start(True)
         return True
-    except Exception:
-        # Never let a restart attempt keep the guard from being released.
+    except Exception as error:
+        # Never let a restart attempt keep the guard from being released. The
+        # caller keeps the request for a later release; the log says why.
+        _log_transfer_failure("could not re-request the deferred media sync", error)
         return False
 
 

--- a/src/Ankimon/pyobj/save_transfer.py
+++ b/src/Ankimon/pyobj/save_transfer.py
@@ -599,7 +599,7 @@ def _replace_active_save(source: Path, target: Path, what: str, *, collection,
 
     events.emit("save_import_prepared", target=str(target), recovery_path=str(pending["recovery_path"]))
     try:
-        close_anki()
+        close_anki(raise_on_error=True)
     except Exception as error:
         showWarning(f"Anki could not close: {error}. Your current save is still active. "
                     "The prepared import will run on the next full restart, or you can cancel it.")
@@ -607,10 +607,17 @@ def _replace_active_save(source: Path, target: Path, what: str, *, collection,
 
 
 def cancel_pending_save_import() -> None:
+    """Cancel a staged import and report filesystem failures through the menu."""
     from ..save_import import cancel_pending_import
 
     target = _active_db_path()
-    if target is not None and cancel_pending_import(target):
+    try:
+        cancelled = target is not None and cancel_pending_import(target)
+    except OSError as error:
+        showWarning(f"The pending save import could not be cancelled: {error}. "
+                    "Close anything using the Ankimon folder and try again.")
+        return
+    if cancelled:
         from ..events import events
 
         events.emit("save_import_cancelled", target=str(target))
@@ -625,8 +632,14 @@ def browse_recovered_saves() -> None:
     recovery = Path(target).parent / "ankimon_recovery" if target else user_path / "ankimon_recovery"
     from aqt.utils import openFolder
 
-    recovery.mkdir(parents=True, exist_ok=True)
-    openFolder(str(recovery))
+    try:
+        recovery.mkdir(mode=0o700, parents=True, exist_ok=True)
+        if os.name != "nt":
+            recovery.chmod(0o700)
+        openFolder(str(recovery))
+    except OSError as error:
+        showWarning(f"The recovery folder could not be opened: {error}. "
+                    "Check access to the Ankimon folder and try again.")
 
 
 # ---------------------------------------------------------------------------
@@ -1223,9 +1236,9 @@ def _preserve(at_risk: Path, media_dir: Path, target_db: str,
 
 
 def _protect_bare_saves(media_dir: Path) -> Dict[str, Any]:
-    """Capture both modes before Anki can start replacing media files.
+    """Capture both modes on the worker while media sync is paused.
 
-    Only this preservation step is synchronous. A locked/corrupt SQLite source
+    A locked/corrupt SQLite source
     gets a labelled raw archive including sidecars, never a claimed valid save.
     Validation, ranking and recovery decisions remain eligible for retry.
     """
@@ -1526,6 +1539,32 @@ def run_media_migration(settings_obj, logger) -> None:
 # pass whenever the boot scan is still running when the download lands, which is
 # exactly the ordering the post-sync pass exists to cover.
 _MIGRATION_SCAN_STATE = {"running": False, "rerun": False}
+_MIGRATION_RETRY_DELAY = 30.0
+
+
+def _pending_media_protection(media_dir: Path, target: Optional[Path]):
+    """Stat both bare saves and sidecars without opening or copying their bytes."""
+    protection = {"protected": {}, "unprotected": [], "archives": [],
+                  "archived_sources": [], "log": []}
+    signature = []
+    for name in _SAVE_PREFIX:
+        source = media_dir / name
+        for suffix in ("", "-wal", "-shm", "-journal"):
+            path = Path(str(source) + suffix)
+            try:
+                stat = path.stat()
+            except FileNotFoundError:
+                continue
+            except OSError:
+                signature.append((path.name, "unknown"))
+            else:
+                signature.append((path.name, stat.st_size, stat.st_mtime_ns,
+                                  stat.st_ctime_ns, stat.st_ino, stat.st_mode))
+            if not suffix:
+                protection["unprotected"].append(source)
+    # A newly downloaded candidate must also bypass an unreadable-file delay.
+    entries = _media_fingerprint_entries(media_dir, target.name if target else "ankimon.db")
+    return protection, (tuple(signature), tuple(sorted(entries.items())))
 
 
 def start_media_migration(settings_obj, logger) -> None:
@@ -1540,14 +1579,29 @@ def start_media_migration(settings_obj, logger) -> None:
         media_dir = _media_dir()
         if media_dir is None or not media_dir.is_dir():
             return
-        # Anki starts automatic media sync immediately after profile_did_open.
-        # Complete capture BEFORE returning or queueing the expensive scan.
-        protection = _protect_bare_saves(media_dir)
-        _guard_uncaptured_media(media_dir, protection)
-        if _migration_done() and not protection["unprotected"]:
-            return
         target = _active_db_path()
         collection = _active_collection()
+        protection, signature = _pending_media_protection(media_dir, target)
+        if not protection["unprotected"]:
+            # A user may move an uncaptured save out of media. Release its old
+            # guard even when the folder now matches a previously settled scan.
+            _guard_uncaptured_media(media_dir, protection)
+        completed = _MIGRATION_SCAN_STATE.setdefault("completed", {})
+        key = (media_dir, target)
+        previous = completed.get(key)
+        if previous is not None and previous["signature"] == signature:
+            if previous["protection"]["unprotected"]:
+                if time.monotonic() < previous["retry_at"]:
+                    return
+            elif _migration_done():
+                return
+        elif not protection["unprotected"] and _migration_done():
+            return
+
+        # Anki checks this gate before startup/periodic media sync. Pause it
+        # before dispatch so neither SQLite backups nor raw ZIP writes block
+        # profile-open. Only a completed capture can release the guard.
+        _guard_uncaptured_media(media_dir, protection)
 
         if _MIGRATION_SCAN_STATE["running"]:
             _MIGRATION_SCAN_STATE["rerun"] = True
@@ -1559,21 +1613,28 @@ def start_media_migration(settings_obj, logger) -> None:
         def _done(future) -> None:
             result = None
             try:
-                if _media_dir() == media_dir and _active_collection() is collection:
-                    _report_protection(protection, logger)
                 result = future.result()
                 # A profile switch during the scan would leave us applying one
                 # profile's media folder to another's flag and another's save.
                 # mw.pm has already moved on by the time this runs, so compare.
                 if (result is not None and _media_dir() == media_dir
                         and _active_collection() is collection):
-                    if result.get("protection"):
+                    _, current_signature = _pending_media_protection(media_dir, target)
+                    if current_signature != signature:
+                        # A download or external writer changed the source
+                        # during capture. Keep sync paused until the next pass.
+                        _MIGRATION_SCAN_STATE["rerun"] = True
+                    elif result.get("protection"):
+                        completed[key] = {"signature": signature,
+                                          "protection": result["protection"],
+                                          "retry_at": time.monotonic() + _MIGRATION_RETRY_DELAY}
                         _guard_uncaptured_media(media_dir, result["protection"])
                     _apply_migration_result(result, logger)
             except Exception as e:
                 try:
                     logger.log("error", f"AnkiWeb sync-removal migration failed: {e}")
                     if _media_dir() == media_dir and _active_collection() is collection:
+                        _report_protection(protection, logger)
                         showWarning("Ankimon's media recovery comparison failed and will be retried "
                                     "after the next sync or restart. See the Ankimon log for details.")
                 except Exception:
@@ -1594,7 +1655,8 @@ def start_media_migration(settings_obj, logger) -> None:
             _report_protection(protection, logger)
             logger.log("error", f"Could not schedule media recovery scan: {error}")
             showWarning("Ankimon could not start its media recovery scan. "
-                        "Recovery comparison will be retried after the next sync or restart.")
+                        "It will be retried after the next sync or restart. "
+                        "Media sync stays paused while original save files remain uncaptured.")
     except Exception as e:
         try:
             logger.log("error", f"AnkiWeb sync-removal migration failed: {e}")

--- a/src/Ankimon/pyobj/save_transfer.py
+++ b/src/Ankimon/pyobj/save_transfer.py
@@ -1821,16 +1821,24 @@ def _schedule_migration_retry(settings_obj, logger) -> None:
         return
 
     def _retry() -> None:
+        # Cleared first, on every path. This flag is the only thing stopping a
+        # second timer from being scheduled, so a return that leaves it set
+        # costs the profile its retries for the rest of the process.
         _MIGRATION_SCAN_STATE["retry_scheduled"] = False
         try:
+            if getattr(mw, "col", None) is None:
+                # The profile closed inside the delay. Its own open rescans.
+                return
             start_media_migration(settings_obj, logger)
         except Exception:
             pass
 
     try:
         # A little past the throttle, so the pass it asks for is not refused by
-        # the very retry_at that scheduled it.
-        mw.progress.single_shot(int(_MIGRATION_RETRY_DELAY * 1000) + 250, _retry, True)
+        # the very retry_at that scheduled it. requires_collection is False and
+        # the check lives in _retry instead: Anki's own gate DROPS the call when
+        # the collection is gone, and a dropped call never clears the flag.
+        mw.progress.single_shot(int(_MIGRATION_RETRY_DELAY * 1000) + 250, _retry, False)
         _MIGRATION_SCAN_STATE["retry_scheduled"] = True
     except Exception:
         # No timer is a missed retry, not a failure: a manual sync and the next

--- a/src/Ankimon/pyobj/save_transfer.py
+++ b/src/Ankimon/pyobj/save_transfer.py
@@ -569,6 +569,20 @@ def _log_transfer_failure(context: str, error: Exception) -> None:
         pass
 
 
+def _warn_about_pending_import(message: str, context: str) -> None:
+    """Show a staged-import warning that cannot unwind into an abort handler.
+
+    Every caller of this is reporting an import that IS armed. Letting Qt's
+    failure travel up would hand that report to a generic ``except Exception``
+    which says nothing was replaced -- the one thing that must never be said
+    about a published import.
+    """
+    try:
+        showWarning(message)
+    except Exception as error:
+        _log_transfer_failure(context, error)
+
+
 def _replace_active_save(source: Path, target: Path, what: str, *, collection,
                          local_revision=None, local_digest=None) -> bool:
     """Prepare the approved save for a fresh process; never replace live state.
@@ -582,7 +596,8 @@ def _replace_active_save(source: Path, target: Path, what: str, *, collection,
     rather than aborted and must not lead a caller to offer another save.
     """
     from ..save_import import (
-        ImportAlreadyPendingError, ImportStagedError, stage_import,
+        ImportAlreadyPendingError, ImportStagedError,
+        pending_import_is_installed, stage_import,
     )
     from .ankimon_sync import get_ankimon_sync
 
@@ -604,23 +619,49 @@ def _replace_active_save(source: Path, target: Path, what: str, *, collection,
         # this attempt and false of the session, which is the confusing half:
         # the rescue offer can return after a staging failure, and answering it
         # again must not read as though no import were coming.
-        showWarning(
+        #
+        # Both notices below are guarded for the reason the success notice is,
+        # and more sharply: showWarning reaches into Qt through
+        # mw.app.activeWindow(), this runs in a shutdown-adjacent state, and an
+        # exception escaping here does not merely lose a message -- it unwinds
+        # into import_save's "Import aborted: ... Nothing was replaced" handler
+        # over a published, armed import. That is the mis-report this branch
+        # exists to prevent.
+        if pending_import_is_installed(Path(target)):
+            # The record outlived the import it describes. Telling the user it
+            # "will install at the next restart" describes a replacement that
+            # has already happened, to somebody deciding what to do about the
+            # save they are looking at.
+            _warn_about_pending_import(
+                f"{what} not started: the previous import has ALREADY installed "
+                "and is the save you are playing now. Only its leftover record "
+                "could not be cleared.\n\n"
+                "Use Ankimon → Cancel Pending Save Import to clear that record, "
+                "then try again. Nothing will be installed a second time.",
+                f"{what} was refused over an already-installed import, "
+                "but the notice could not be shown",
+            )
+            return True
+        _warn_about_pending_import(
             f"{what} not started: a save import is already pending and will "
             "install at the next full Anki restart.\n\n"
             "Use Ankimon → Cancel Pending Save Import first if you want to "
-            "choose a different save instead."
+            "choose a different save instead.",
+            f"{what} was refused because an import is already pending, "
+            "but the notice could not be shown",
         )
         return True
     except ImportStagedError as error:
         # Publication already happened, so this is not an abort: the save will
         # install at the next full start. Saying otherwise would leave the user
         # playing on towards a replacement they were told could not happen.
-        showWarning(
+        _warn_about_pending_import(
             f"{what} could not be finished cleanly: {error}.\n\n"
             "Your current save is still active, but this import is now PENDING "
             "and will install at the next full Anki restart. Its final progress "
             "will still be retained in a recovery copy first. Use Ankimon → "
-            "Cancel Pending Save Import if you do not want it."
+            "Cancel Pending Save Import if you do not want it.",
+            f"{what} is staged but unfinished, and the notice could not be shown",
         )
         return True
     except Exception as error:
@@ -657,16 +698,27 @@ def _replace_active_save(source: Path, target: Path, what: str, *, collection,
 
 def cancel_pending_save_import() -> None:
     """Cancel a staged import and report filesystem failures through the menu."""
-    from ..save_import import cancel_pending_import
+    from ..save_import import cancel_pending_import, pending_import_is_installed
 
     target = _active_db_path()
     try:
+        # Asked BEFORE cancelling: removing the manifest is what makes the two
+        # states indistinguishable afterwards.
+        installed = target is not None and pending_import_is_installed(target)
         cancelled = target is not None and cancel_pending_import(target)
     except OSError as error:
         showWarning(f"The pending save import could not be cancelled: {error}. "
                     "Close anything using the Ankimon folder and try again.")
         return
-    if cancelled:
+    if cancelled and installed:
+        from ..events import events
+
+        events.emit("save_import_cancelled", target=str(target), installed=True)
+        showInfo("That import had already installed: the save you are playing IS the "
+                 "imported one. Only its leftover record was cleared, so nothing will "
+                 "be installed again.\n\nYour previous save was retained before the "
+                 "replacement — see Ankimon → Browse Recovered Saves.")
+    elif cancelled:
         from ..events import events
 
         events.emit("save_import_cancelled", target=str(target))

--- a/src/Ankimon/pyobj/save_transfer.py
+++ b/src/Ankimon/pyobj/save_transfer.py
@@ -1416,8 +1416,15 @@ def _protect_bare_saves(media_dir: Path) -> Dict[str, Any]:
     return result
 
 
-def _resume_deferred_media_sync() -> None:
-    """Re-request one media sync the guard turned away.
+def _resume_deferred_media_sync() -> bool:
+    """Re-request one media sync the guard turned away; say whether it went.
+
+    The answer matters because every "no" here is a stand-down, not a refusal:
+    the request is still owed, and the caller puts it back rather than dropping
+    it. Anki has no deferred request of its own to fall back on, and in the one
+    state this most often declines for -- a backup restore in progress -- it has
+    switched its own unattended sync off too, so a dropped request is simply
+    gone for the session.
 
     Anki reads ``media_syncing_enabled()`` once, when a sync starts, and passes
     it into the backend call; a collection sync that saw False finishes without
@@ -1435,13 +1442,14 @@ def _resume_deferred_media_sync() -> None:
     try:
         syncer = getattr(mw, "media_syncer", None)
         if syncer is None or getattr(mw, "col", None) is None:
-            return
+            return False
         if getattr(mw, "restoring_backup", False):
-            return
+            return False
         syncer.start(True)
+        return True
     except Exception:
         # Never let a restart attempt keep the guard from being released.
-        pass
+        return False
 
 
 def _reading_to_display_the_preference() -> bool:
@@ -1491,10 +1499,22 @@ def _guard_uncaptured_media(media_dir: Path, protection: Dict[str, Any]) -> None
         state = {"blocked": set(), "deferred": set(), "lock": threading.Lock()}
 
         def enabled():
-            folder = Path(pm.profileFolder()) / "collection.media"
+            # The preference first: Anki's own media_syncing_enabled is a dict
+            # lookup that cannot fail, and a user who has media sync off needs
+            # no answer from the disk at all.
             allowed = original()
             if not allowed or _reading_to_display_the_preference():
                 return allowed
+            try:
+                folder = Path(pm.profileFolder()) / "collection.media"
+            except Exception:
+                # profileFolder(create=True) makes directories, so a base on a
+                # volume that went away raises here. Three callers read this --
+                # the Preferences dialog, the periodic timer's Qt slot, and the
+                # sync worker -- and none of them expect it to. Fail open: the
+                # guard only ever delays a sync, so answering "allowed" costs at
+                # most one unprotected pass, which the next scan re-arms.
+                return True
             with state["lock"]:
                 if folder not in state["blocked"]:
                     return True
@@ -1516,8 +1536,14 @@ def _guard_uncaptured_media(media_dir: Path, protection: Dict[str, Any]) -> None
             deferred = media_dir in state["deferred"]
             state["deferred"].discard(media_dir)
     # Outside the lock: restarting a sync re-enters Anki, which reads the gate.
-    if deferred:
-        _resume_deferred_media_sync()
+    if deferred and not _resume_deferred_media_sync():
+        # Standing down is not the same as being done. Put the request back so a
+        # later release -- or the next profile open, which is where Anki clears
+        # restoring_backup -- can still replay it. Dropping it here left the
+        # user who restored a backup and then synced by hand with no media sync
+        # for the rest of the session.
+        with lock:
+            state["deferred"].add(media_dir)
 
 
 _LAST_PROTECTION_NOTICE = None
@@ -1743,6 +1769,42 @@ _MIGRATION_SCAN_STATE = {"running": False, "rerun": False}
 _MIGRATION_RETRY_DELAY = 30.0
 
 
+def _schedule_migration_retry(settings_obj, logger) -> None:
+    """Ask for another pass later, without going through a media-sync hook.
+
+    The add-on's only recurring rescan trigger is
+    ``gui_hooks.media_sync_did_start_or_stop``, and ``MediaSyncer.start``
+    returns before ``start_monitoring`` when the gate says no. So exactly while
+    the guard is up, the 5-minute periodic media sync that would have fired that
+    hook fires nothing at all -- the guard suppresses its own retry. The
+    ``retry_at`` delay recorded after a failed capture had no clock behind it,
+    and a file that stopped being locked mid-session went unnoticed until the
+    user synced by hand or closed the profile, with media sync off throughout.
+
+    One timer at a time, cleared when it fires. A capture that succeeds releases
+    the guard and stops the cycle; nothing reschedules from here.
+    """
+    if _MIGRATION_SCAN_STATE.get("retry_scheduled"):
+        return
+
+    def _retry() -> None:
+        _MIGRATION_SCAN_STATE["retry_scheduled"] = False
+        try:
+            start_media_migration(settings_obj, logger)
+        except Exception:
+            pass
+
+    try:
+        # A little past the throttle, so the pass it asks for is not refused by
+        # the very retry_at that scheduled it.
+        mw.progress.single_shot(int(_MIGRATION_RETRY_DELAY * 1000) + 250, _retry, True)
+        _MIGRATION_SCAN_STATE["retry_scheduled"] = True
+    except Exception:
+        # No timer is a missed retry, not a failure: a manual sync and the next
+        # profile open still rescan.
+        pass
+
+
 def _pending_media_protection(media_dir: Path, target: Optional[Path]):
     """Stat both bare saves and sidecars without opening or copying their bytes.
 
@@ -1848,6 +1910,12 @@ def start_media_migration(settings_obj, logger) -> None:
                                               "protection": result["protection"],
                                               "retry_at": time.monotonic() + _MIGRATION_RETRY_DELAY}
                             _guard_uncaptured_media(media_dir, result["protection"])
+                            if (set(result["protection"]["unprotected"])
+                                    - set(result["protection"]["archived_sources"])):
+                                # The guard stays up, so Anki's media-sync hook
+                                # -- this scan's only other trigger -- is the
+                                # one thing that cannot bring the retry around.
+                                _schedule_migration_retry(settings_obj, logger)
                         _apply_migration_result(result, logger)
             except Exception as e:
                 try:

--- a/src/Ankimon/pyobj/save_transfer.py
+++ b/src/Ankimon/pyobj/save_transfer.py
@@ -1038,6 +1038,14 @@ def _migration_scan(media_dir: Path, target: Optional[Path]) -> Dict[str, Any]:
 
     protection = _protect_bare_saves(media_dir)
     notes.extend(protection["log"])
+    # The state this result actually describes. The caller's dispatch-time
+    # signature is not it: a transient stat failure there reads as "unknown",
+    # and comparing that against a readable file later would discard a sound
+    # scan. Taken after protection, so a change during ranking or snapshotting
+    # still invalidates the result; changes during protection itself are
+    # caught by _preserve's content verification.
+    _, captured_signature = _pending_media_protection(media_dir, target)
+
     unreadable.extend(protection["unprotected"])
     written.extend(path for path in protection["protected"].values()
                    if _target_db_for(path) == target_db)
@@ -1058,6 +1066,7 @@ def _migration_scan(media_dir: Path, target: Optional[Path]) -> Dict[str, Any]:
             "local_stats": None,
             "fingerprint": _join_fingerprint(entries),
             "protection": protection,
+            "signature": captured_signature,
         }
         base.update(extra)
         return base
@@ -1620,16 +1629,21 @@ def start_media_migration(settings_obj, logger) -> None:
                 if (result is not None and _media_dir() == media_dir
                         and _active_collection() is collection):
                     _, current_signature = _pending_media_protection(media_dir, target)
-                    if current_signature != signature:
-                        # A download or external writer changed the source
-                        # during capture. Keep sync paused until the next pass.
+                    baseline = result.get("signature", signature)
+                    if current_signature != baseline:
+                        # A download or external writer changed the source after
+                        # the worker captured it. Keep sync paused until the next
+                        # pass and drop this result whole: its comparison figures
+                        # and its rescue snapshot describe a save that is already
+                        # gone, so offering either would stage stale bytes.
                         _MIGRATION_SCAN_STATE["rerun"] = True
-                    elif result.get("protection"):
-                        completed[key] = {"signature": signature,
-                                          "protection": result["protection"],
-                                          "retry_at": time.monotonic() + _MIGRATION_RETRY_DELAY}
-                        _guard_uncaptured_media(media_dir, result["protection"])
-                    _apply_migration_result(result, logger)
+                    else:
+                        if result.get("protection"):
+                            completed[key] = {"signature": baseline,
+                                              "protection": result["protection"],
+                                              "retry_at": time.monotonic() + _MIGRATION_RETRY_DELAY}
+                            _guard_uncaptured_media(media_dir, result["protection"])
+                        _apply_migration_result(result, logger)
             except Exception as e:
                 try:
                     logger.log("error", f"AnkiWeb sync-removal migration failed: {e}")

--- a/src/Ankimon/pyobj/save_transfer.py
+++ b/src/Ankimon/pyobj/save_transfer.py
@@ -1041,6 +1041,10 @@ def _migration_scan(media_dir: Path, target: Optional[Path]) -> Dict[str, Any]:
     regardless of ranking, verifying any existing protected copy before reuse.
     Rank candidates for display and freeze the chosen save in a private
     snapshot. The local revision lets the UI reject an outdated comparison.
+
+    The source signature is read before AND after the capture, and ``stable``
+    says whether they agreed. Only a capture bound to one observed revision can
+    release the media-sync guard.
     """
     notes: list = []
     unreadable: list = []
@@ -1052,15 +1056,26 @@ def _migration_scan(media_dir: Path, target: Optional[Path]) -> Dict[str, Any]:
     # media sync and must not make a settled media state look changed.
     entries = _media_fingerprint_entries(media_dir, target_db)
 
+    # The revision the capture is BOUND to, read before anything is copied.
+    # _preserve verifies the bytes it wrote, not that the source held still
+    # while it read them, so without this a writer landing mid-capture would
+    # leave a recovery copy of the old version described by the new version's
+    # signature — and the callback, comparing new against new, would release
+    # the sync guard over bytes that were never preserved.
+    _, before_protection = _pending_media_protection(media_dir, target)
+
     protection = _protect_bare_saves(media_dir)
     notes.extend(protection["log"])
     # The state this result actually describes. The caller's dispatch-time
     # signature is not it: a transient stat failure there reads as "unknown",
     # and comparing that against a readable file later would discard a sound
     # scan. Taken after protection, so a change during ranking or snapshotting
-    # still invalidates the result; changes during protection itself are
-    # caught by _preserve's content verification.
+    # still invalidates the result.
     _, captured_signature = _pending_media_protection(media_dir, target)
+    # Protection only ever reads collection.media (read-only SQLite opens; its
+    # copies and archives are written outside the folder), so an unequal pair
+    # means somebody else wrote, not that we did.
+    stable_capture = before_protection == captured_signature
 
     unreadable.extend(protection["unprotected"])
     written.extend(path for path in protection["protected"].values()
@@ -1083,6 +1098,7 @@ def _migration_scan(media_dir: Path, target: Optional[Path]) -> Dict[str, Any]:
             "fingerprint": _join_fingerprint(entries),
             "protection": protection,
             "signature": captured_signature,
+            "stable": stable_capture,
         }
         base.update(extra)
         return base
@@ -1646,12 +1662,14 @@ def start_media_migration(settings_obj, logger) -> None:
                         and _active_collection() is collection):
                     _, current_signature = _pending_media_protection(media_dir, target)
                     baseline = result.get("signature", signature)
-                    if current_signature != baseline:
-                        # A download or external writer changed the source after
-                        # the worker captured it. Keep sync paused until the next
-                        # pass and drop this result whole: its comparison figures
-                        # and its rescue snapshot describe a save that is already
-                        # gone, so offering either would stage stale bytes.
+                    if current_signature != baseline or not result.get("stable", True):
+                        # A download or external writer changed the source
+                        # during or after the capture. Keep sync paused until
+                        # the next pass and drop this result whole: its
+                        # comparison figures and its rescue snapshot describe a
+                        # save that is already gone, and the protected copy is
+                        # not of the version sitting there now, so releasing
+                        # the guard would expose unpreserved progress.
                         _MIGRATION_SCAN_STATE["rerun"] = True
                     else:
                         if result.get("protection"):

--- a/src/Ankimon/pyobj/save_transfer.py
+++ b/src/Ankimon/pyobj/save_transfer.py
@@ -564,8 +564,12 @@ def _replace_active_save(source: Path, target: Path, what: str, *, collection,
     Cancellation of Anki's asynchronous shutdown leaves the original runtime
     and database together. Installation and the final recovery snapshot happen
     before any database manager or game objects exist on the next full start.
+
+    True means an import is pending — including the case where staging
+    published one but could not finish cleanly, which is reported as pending
+    rather than aborted and must not lead a caller to offer another save.
     """
-    from ..save_import import stage_import
+    from ..save_import import ImportStagedError, stage_import
     from .ankimon_sync import get_ankimon_sync
 
     try:
@@ -581,6 +585,18 @@ def _replace_active_save(source: Path, target: Path, what: str, *, collection,
                 pending = stage_import(source, target)
         else:
             pending = stage_import(source, target)
+    except ImportStagedError as error:
+        # Publication already happened, so this is not an abort: the save will
+        # install at the next full start. Saying otherwise would leave the user
+        # playing on towards a replacement they were told could not happen.
+        showWarning(
+            f"{what} could not be finished cleanly: {error}.\n\n"
+            "Your current save is still active, but this import is now PENDING "
+            "and will install at the next full Anki restart. Its final progress "
+            "will still be retained in a recovery copy first. Use Ankimon → "
+            "Cancel Pending Save Import if you do not want it."
+        )
+        return True
     except Exception as error:
         showWarning(f"{what} aborted: {error}. Your current save is unchanged.")
         return False

--- a/src/Ankimon/pyobj/save_transfer.py
+++ b/src/Ankimon/pyobj/save_transfer.py
@@ -644,12 +644,12 @@ def _replace_active_save(source: Path, target: Path, what: str, *, collection,
             )
             return True
         if installed is None:
-            # The save could not be read in time to tell. Either confident
-            # answer could be the wrong way round, so claim neither.
+            # The record or the save could not be read in time to tell. Either
+            # confident answer could be the wrong way round, so claim neither.
             _warn_about_pending_import(
                 f"{what} not started: a save import is already recorded for this "
-                "save, and Ankimon could not read the save to tell whether it "
-                "has already installed.\n\n"
+                "save, and Ankimon could not tell whether it has already "
+                "installed.\n\n"
                 "Use Ankimon → Cancel Pending Save Import to clear that record, "
                 "then try again.",
                 f"{what} was refused over an import record of unknown state, "
@@ -756,35 +756,42 @@ def cancel_pending_save_import() -> None:
         events.emit("save_import_cancelled", target=str(target),
                     installed=installed)
 
+    # One line per save. Their outcomes can differ -- one import may already
+    # have installed while the other was only pending, or one may cancel while
+    # the other fails -- and a sentence chosen for one reads as the answer for
+    # both, including "the save you are playing" about a save nobody is playing.
+    outcomes = []
+    for target in cancelled:
+        if target in already_installed:
+            outcomes.append(
+                f"{target.name}: that import had ALREADY installed, so this save IS "
+                "the imported one. Only its leftover record was cleared, and nothing "
+                "will be installed again. The save it replaced was retained first — "
+                "see Ankimon → Browse Recovered Saves.")
+        elif target in undetermined:
+            outcomes.append(
+                f"{target.name}: the import record was cleared, so nothing will be "
+                "installed from it. Ankimon could not tell whether that import had "
+                "already installed; if it had, the save it replaced was retained "
+                "first — see Ankimon → Browse Recovered Saves.")
+        else:
+            outcomes.append(f"{target.name}: the pending import was cancelled. "
+                            "This save is unchanged.")
+
     if failures:
         message = ("The pending save import could not be cancelled:\n\n"
                    + "\n".join(failures))
-        if cancelled:
-            # The other save mode may already be cancelled, its event emitted.
-            # Naming only the failure would tell the user that did not happen.
-            message += ("\n\nCancelled successfully: "
-                        + ", ".join(target.name for target in cancelled))
+        if outcomes:
+            # Another save may already be settled, its event emitted. Naming only
+            # the failure would tell the user that did not happen.
+            message += "\n\nMeanwhile:\n\n" + "\n\n".join(outcomes)
         showWarning(message
                     + "\n\nClose anything using the Ankimon folder and try again.")
         return
-    if not cancelled:
+    if not outcomes:
         showInfo("There is no pending save import for either save mode.")
         return
-    named = ", ".join(target.name for target in cancelled)
-    if already_installed:
-        showInfo(f"That import ({', '.join(t.name for t in already_installed)}) had "
-                 "already installed: the save you are playing IS the imported one. "
-                 "Only its leftover record was cleared, so nothing will be installed "
-                 "again.\n\nYour previous save was retained before the replacement — "
-                 "see Ankimon → Browse Recovered Saves.")
-    elif undetermined:
-        showInfo(f"The pending save import record was cleared ({named}), so nothing "
-                 "will be installed from it. Ankimon could not read the save to tell "
-                 "whether that import had already installed; if it had, your previous "
-                 "save was retained first — see Ankimon → Browse Recovered Saves.")
-    else:
-        showInfo(f"The pending save import was cancelled ({named}). "
-                 "Your current save is unchanged.")
+    showInfo("\n\n".join(outcomes))
 
 
 def browse_recovered_saves() -> None:

--- a/src/Ankimon/pyobj/save_transfer.py
+++ b/src/Ankimon/pyobj/save_transfer.py
@@ -16,7 +16,9 @@ import hashlib
 import os
 import shutil
 import sqlite3
+import sys
 import tempfile
+import threading
 import time
 import zipfile
 from pathlib import Path
@@ -557,6 +559,16 @@ def _rebase_import_watermark(snapshot: Path, col) -> None:
         conn.close()
 
 
+def _log_transfer_failure(context: str, error: Exception) -> None:
+    """Record a non-fatal transfer problem without needing a logger argument."""
+    try:
+        from ..services import services
+
+        services.logger.log("error", f"Ankimon: {context}: {error}")
+    except Exception:
+        pass
+
+
 def _replace_active_save(source: Path, target: Path, what: str, *, collection,
                          local_revision=None, local_digest=None) -> bool:
     """Prepare the approved save for a fresh process; never replace live state.
@@ -569,7 +581,9 @@ def _replace_active_save(source: Path, target: Path, what: str, *, collection,
     published one but could not finish cleanly, which is reported as pending
     rather than aborted and must not lead a caller to offer another save.
     """
-    from ..save_import import ImportStagedError, stage_import
+    from ..save_import import (
+        ImportAlreadyPendingError, ImportStagedError, stage_import,
+    )
     from .ankimon_sync import get_ankimon_sync
 
     try:
@@ -585,6 +599,18 @@ def _replace_active_save(source: Path, target: Path, what: str, *, collection,
                 pending = stage_import(source, target)
         else:
             pending = stage_import(source, target)
+    except ImportAlreadyPendingError:
+        # An earlier choice is still staged. "Nothing was replaced" is true of
+        # this attempt and false of the session, which is the confusing half:
+        # the rescue offer can return after a staging failure, and answering it
+        # again must not read as though no import were coming.
+        showWarning(
+            f"{what} not started: a save import is already pending and will "
+            "install at the next full Anki restart.\n\n"
+            "Use Ankimon → Cancel Pending Save Import first if you want to "
+            "choose a different save instead."
+        )
+        return True
     except ImportStagedError as error:
         # Publication already happened, so this is not an abort: the save will
         # install at the next full start. Saying otherwise would leave the user
@@ -601,16 +627,23 @@ def _replace_active_save(source: Path, target: Path, what: str, *, collection,
         showWarning(f"{what} aborted: {error}. Your current save is unchanged.")
         return False
 
-    showInfo(
-        f"{what} prepared for the next full Anki restart.\n\n"
-        "Your current save stays active until Anki exits. At the next start, "
-        "its final progress will be saved in a separately retained recovery copy "
-        "before the imported save is installed:\n"
-        f"{pending['recovery_path']}\n\n"
-        "Please reopen Anki after it closes. If you keep editing, this import "
-        "stays pending; use Ankimon → Cancel Pending Save Import to discard it.\n\n"
-        "Leaderboard credentials are not imported. Sign in again after restart."
-    )
+    # Announcing the import is the last thing that can go wrong, and it can:
+    # showInfo reaches into Qt, and this runs in a shutdown-adjacent state.
+    # A torn-down parent widget must not travel back up to the caller's
+    # "aborted, nothing was replaced" handler over a save that is staged.
+    try:
+        showInfo(
+            f"{what} prepared for the next full Anki restart.\n\n"
+            "Your current save stays active until Anki exits. At the next start, "
+            "its final progress will be saved in a separately retained recovery copy "
+            "before the imported save is installed:\n"
+            f"{pending['recovery_path']}\n\n"
+            "Please reopen Anki after it closes. If you keep editing, this import "
+            "stays pending; use Ankimon → Cancel Pending Save Import to discard it.\n\n"
+            "Leaderboard credentials are not imported. Sign in again after restart."
+        )
+    except Exception as error:
+        _log_transfer_failure(f"{what} was prepared but its notice could not be shown", error)
     from ..events import events
 
     events.emit("save_import_prepared", target=str(target), recovery_path=str(pending["recovery_path"]))
@@ -1359,6 +1392,29 @@ def _resume_deferred_media_sync() -> None:
         pass
 
 
+def _reading_to_display_the_preference() -> bool:
+    """Is this gate being read by Anki's Preferences dialog rather than a sync?
+
+    ``Preferences.setup_network`` reads ``media_syncing_enabled()`` only to tick
+    its "Synchronize audio and images too" box, and ``update_network`` writes
+    whatever that box shows straight back into ``pm.profile`` on OK. Answering
+    False there would turn the user's real AnkiWeb preference off for good, and
+    they would never see it happen. The guard exists to delay a sync, never to
+    edit a setting, so it stands aside for that reader.
+
+    Failing open is the safe direction: Preferences starts no sync.
+    """
+    try:
+        frame = sys._getframe(1)
+        while frame is not None:
+            if frame.f_globals.get("__name__") == "aqt.preferences":
+                return True
+            frame = frame.f_back
+    except Exception:
+        pass
+    return False
+
+
 def _guard_uncaptured_media(media_dir: Path, protection: Dict[str, Any]) -> None:
     """Pause media sync for this profile only while original bytes are at risk.
 
@@ -1369,6 +1425,9 @@ def _guard_uncaptured_media(media_dir: Path, protection: Dict[str, Any]) -> None
 
     A sync turned away while the guard was up is remembered and re-requested
     when the guard clears, because Anki keeps no deferred request of its own.
+    Anki reads the gate on a background thread, so the record-and-release pair
+    is taken under a lock: without it a request could be remembered just after
+    the release that would have replayed it, and be dropped after all.
     """
     uncaptured = set(protection["unprotected"]) - set(protection["archived_sources"])
     pm = mw.pm
@@ -1377,28 +1436,36 @@ def _guard_uncaptured_media(media_dir: Path, protection: Dict[str, Any]) -> None
         if not uncaptured:
             return
         original = pm.media_syncing_enabled
-        state = {"blocked": set(), "deferred": set()}
+        state = {"blocked": set(), "deferred": set(), "lock": threading.Lock()}
 
         def enabled():
             folder = Path(pm.profileFolder()) / "collection.media"
             allowed = original()
-            if allowed and folder in state["blocked"]:
+            if not allowed or _reading_to_display_the_preference():
+                return allowed
+            with state["lock"]:
+                if folder not in state["blocked"]:
+                    return True
                 # Only a sync the user's own preference would have permitted
                 # counts as deferred; nothing else may be restarted later.
                 state["deferred"].add(folder)
-                return False
-            return allowed
+            return False
 
         pm.media_syncing_enabled = enabled
         pm._ankimon_media_protection_guard = state
     state.setdefault("deferred", set())
-    if uncaptured:
-        state["blocked"].add(media_dir)
-    else:
-        state["blocked"].discard(media_dir)
-        if media_dir in state["deferred"]:
+    lock = state.setdefault("lock", threading.Lock())
+    with lock:
+        if uncaptured:
+            state["blocked"].add(media_dir)
+            deferred = False
+        else:
+            state["blocked"].discard(media_dir)
+            deferred = media_dir in state["deferred"]
             state["deferred"].discard(media_dir)
-            _resume_deferred_media_sync()
+    # Outside the lock: restarting a sync re-enters Anki, which reads the gate.
+    if deferred:
+        _resume_deferred_media_sync()
 
 
 _LAST_PROTECTION_NOTICE = None

--- a/src/Ankimon/save_import.py
+++ b/src/Ankimon/save_import.py
@@ -8,6 +8,7 @@ game objects. This module deliberately has no Anki, Qt, or services imports.
 
 from __future__ import annotations
 
+import errno
 import hashlib
 import json
 import os
@@ -17,6 +18,7 @@ import sqlite3
 import sys
 import tempfile
 import time
+import urllib.parse
 import uuid
 
 
@@ -70,6 +72,16 @@ def _fsync_file(path: Path) -> None:
         os.fsync(handle.fileno())
 
 
+# What a filesystem that cannot sync a directory answers: a VirtualBox shared
+# folder, some network mounts. SQLite ignores these in its own directory sync.
+# Raising on them left a staged import that could never install on that volume.
+_NO_DIRECTORY_SYNC = frozenset(
+    code for code in (errno.EINVAL, getattr(errno, "ENOTSUP", None),
+                      getattr(errno, "EOPNOTSUPP", None))
+    if code is not None
+)
+
+
 def _fsync_directory(path: Path) -> None:
     # Windows does not allow opening directories this way. File fsync and the
     # same-volume replace still apply there.
@@ -78,6 +90,10 @@ def _fsync_directory(path: Path) -> None:
     descriptor = os.open(path, os.O_RDONLY | getattr(os, "O_DIRECTORY", 0))
     try:
         os.fsync(descriptor)
+    except OSError as error:
+        # A real I/O failure (EIO, ENOSPC) still stops the import.
+        if error.errno not in _NO_DIRECTORY_SYNC:
+            raise
     finally:
         os.close(descriptor)
 
@@ -96,9 +112,29 @@ def _budget(deadline: float | None) -> float:
     return min(_TIMEOUT, remaining)
 
 
+def _sqlite_uri(path, mode: str) -> str:
+    """A SQLite URI for ``path`` that a Windows network path can use too.
+
+    ``as_uri`` percent-encodes spaces and non-ASCII names, which a bare f-string
+    URI gets wrong. For a UNC path, though, it puts the server in the URI
+    authority (``file://server/share/...``), and SQLite refuses every authority
+    but an empty one or ``localhost``: "invalid uri authority". That is any
+    profile on a redirected AppData folder, or on a mapped drive ``resolve``
+    rewrites to UNC. SQLite's URI syntax has no network-path form, so that case
+    percent-encodes the whole native path into ``file:`` with no authority.
+    SQLite decodes it back to exactly the filename a plain ``connect`` would
+    open, and ``mode`` still applies.
+    """
+    resolved = Path(path).resolve()
+    uri = resolved.as_uri()
+    if not uri.startswith("file:///"):
+        uri = "file:" + urllib.parse.quote(str(resolved), safe="")
+    return f"{uri}?mode={mode}"
+
+
 def _connect_readonly(path: Path, deadline: float = None):
     timeout = _budget(deadline)
-    conn = sqlite3.connect(path.resolve().as_uri() + "?mode=ro", uri=True, timeout=timeout)
+    conn = sqlite3.connect(_sqlite_uri(path, "ro"), uri=True, timeout=timeout)
     limit = time.monotonic() + timeout
     conn.set_progress_handler(lambda: int(time.monotonic() > limit), 2000)
     return conn
@@ -469,6 +505,13 @@ def pending_import_is_installed(target: Path) -> bool | None:
         info = pending_import_info(target)
         if info is None:
             return False
+        if not Path(target).is_file():
+            # No save on disk can be the imported one. The recovery copy is written
+            # just before replacement, so without one no install ever got that
+            # far, and "unknown" would send the user after a copy that was never
+            # made. With one, an install may have replaced the save before it went
+            # missing, and only "unknown" points the user at that copy.
+            return None if info["recovery_path"].is_file() else False
         deadline = time.monotonic() + _WORDING_BUDGET
         return _installed_token(target, deadline) == info["token"]
     except Exception:
@@ -481,6 +524,33 @@ def _log(logger, level: str, message: str) -> None:
             logger.log(level, message)
         except Exception:
             pass
+
+
+# A volume whose permissions are fixed by how it is mounted (FAT or exFAT, some
+# network shares) refuses chmod outright. Nothing can ever tighten a folder
+# there, so refusing the install over it refused it at every start.
+_FIXED_PERMISSIONS = frozenset(
+    code for code in (errno.EPERM, getattr(errno, "ENOTSUP", None),
+                      getattr(errno, "EOPNOTSUPP", None))
+    if code is not None
+)
+
+
+def _restrict_directory(path: Path, logger=None) -> None:
+    """Make a recovery folder private to this user where the volume allows it.
+
+    Tolerated only for a folder this user owns. EPERM is also the answer for a
+    folder that belongs to another account, and a copy of the save, credentials
+    included, does not go into a folder somebody else controls.
+    """
+    try:
+        path.chmod(0o700)
+    except OSError as error:
+        getuid = getattr(os, "getuid", None)
+        owned = getuid is None or path.stat().st_uid == getuid()
+        if error.errno not in _FIXED_PERMISSIONS or not owned:
+            raise
+        _log(logger, "warning", f"Could not restrict access to {path}: {error}")
 
 
 def _finish_installed_import(target, recovery, logger, install_temp=None) -> None:
@@ -565,7 +635,8 @@ def commit_pending_import(target: Path, logger=None, deadline: float = None) -> 
         # save is never recreated, so that is forever.
         raise FileNotFoundError(
             f"{target.name} no longer exists, so the save import prepared for it "
-            "cannot be installed. Use Ankimon \u2192 Cancel Pending Save Import to "
+            "cannot be installed. Use Ankimon \u2192 Game \u2192 Cancel Pending Save "
+            "Import to "
             "discard it."
         )
 
@@ -581,9 +652,9 @@ def commit_pending_import(target: Path, logger=None, deadline: float = None) -> 
     # mkdir(mode=...) does not tighten pre-existing directories. Restrict both
     # levels before inspecting or writing private recovery material.
     recovery.parent.parent.mkdir(mode=0o700, exist_ok=True)
-    recovery.parent.parent.chmod(0o700)
+    _restrict_directory(recovery.parent.parent, logger)
     recovery.parent.mkdir(mode=0o700, exist_ok=True)
-    recovery.parent.chmod(0o700)
+    _restrict_directory(recovery.parent, logger)
     if recovery.is_file():
         # A failed previous replacement may be followed by more local play, so
         # the snapshot taken now is the one holding everything. Move the older
@@ -616,7 +687,7 @@ def commit_pending_import(target: Path, logger=None, deadline: float = None) -> 
     # Let SQLite merge and remove the OLD database's journals itself. Never
     # delete a WAL before replacement: a crash in that gap would lose committed
     # progress. A busy external connection refuses the mode change and import.
-    conn = sqlite3.connect(target.as_uri() + "?mode=rw", uri=True, timeout=_budget(deadline))
+    conn = sqlite3.connect(_sqlite_uri(target, "rw"), uri=True, timeout=_budget(deadline))
     try:
         mode = conn.execute("PRAGMA journal_mode=DELETE").fetchone()[0]
         if str(mode).lower() != "delete":

--- a/src/Ankimon/save_import.py
+++ b/src/Ankimon/save_import.py
@@ -320,14 +320,19 @@ def _write_cancelled_record(manifest: Path, target: Path) -> None:
     only needs its file synced. If the write or its sync fails, the original
     bytes are put back before raising, so this session still sees the import
     its caller is about to report could not be cancelled.
+
+    The record is padded with whitespace, which JSON ignores, to the original
+    length, so no truncate follows the write. A crash between a shorter write
+    and its truncate left the new record followed by the old one's tail, which
+    parses as neither -- and after an install, that made every later start
+    report a replacement that had already happened as one that had failed.
     """
     record = json.dumps({"version": 1, "target": str(target), "cancelled": True})
     with manifest.open("r+b") as handle:
         original = handle.read()
         try:
             handle.seek(0)
-            handle.write(record.encode("utf-8"))
-            handle.truncate()
+            handle.write(record.encode("utf-8").ljust(len(original), b" "))
             handle.flush()
             os.fsync(handle.fileno())
         except Exception:

--- a/src/Ankimon/save_import.py
+++ b/src/Ankimon/save_import.py
@@ -25,6 +25,10 @@ _TIMEOUT = 30.0
 _PROCESS_ATTRIBUTE = "_ankimon_save_import_process"
 
 
+class ImportInstalledError(RuntimeError):
+    """The imported save is active, but its final sync or cleanup failed."""
+
+
 def _process_identity() -> str:
     # sys survives add-on module purges. Include the PID so a subprocess/fork
     # cannot inherit the parent's identity while a reload keeps its identity.
@@ -41,7 +45,8 @@ def _paths(target: Path) -> tuple[Path, Path]:
 
 
 def _fsync_file(path: Path) -> None:
-    with path.open("rb") as handle:
+    # Windows FlushFileBuffers requires write access to the file handle.
+    with path.open("r+b") as handle:
         os.fsync(handle.fileno())
 
 
@@ -298,17 +303,34 @@ def _log(logger, level: str, message: str) -> None:
             pass
 
 
+def _finish_installed_import(target, recovery, logger, install_temp=None) -> None:
+    _log(logger, "info", f"Ankimon import installed. Previous save: {recovery}")
+    try:
+        # Retry this sync after a prior crash too, before retiring the manifest.
+        _fsync_directory(target.parent)
+        if install_temp is not None:
+            _remove_owned_copy(install_temp)
+        cancel_pending_import(target)
+    except Exception as error:
+        # The installed token prevents a later launch from reinstalling over
+        # new progress. Surface this separately from a refused replacement.
+        message = f"Imported save is active; final sync or cleanup did not finish: {error}"
+        _log(logger, "warning", message)
+        raise ImportInstalledError(message) from error
+
+
 def commit_pending_import(target: Path, logger=None) -> bool:
     """Install before any runtime exists, refusing work staged in this process.
 
     Returns True if installed (or a prior crash installed it); False if there is
-    nothing to do yet. Failures raise while leaving pending work available for
-    retry or explicit cancellation. The installed token prevents a crash after
-    replacement from reapplying the old import over subsequent game progress.
+    nothing to do yet. Failures before replacement leave pending work available
+    for retry or explicit cancellation. ImportInstalledError means replacement
+    succeeded but final sync or cleanup failed. The installed token prevents a
+    retry from reapplying the old import over subsequent game progress.
     """
     target, _ = _paths(target)
-    # A failed attempt is followed by construction of the OLD runtime. Retrying
-    # after reset_db or a module purge must wait for another full process start.
+    # Any attempt may be followed by construction of a runtime. Retrying after
+    # reset_db or a module purge must wait for another full process start.
     attribute = "_ankimon_import_startup_attempts"
     identity = _process_identity()
     saved = getattr(sys, attribute, None)
@@ -323,7 +345,7 @@ def commit_pending_import(target: Path, logger=None) -> bool:
         return False
 
     if _installed_token(target) == info["token"]:
-        cancel_pending_import(target)
+        _finish_installed_import(target, info["recovery_path"], logger)
         return True
 
     incoming = info["pending_path"]
@@ -331,10 +353,12 @@ def commit_pending_import(target: Path, logger=None) -> bool:
     if _digest(incoming) != info["digest"]:
         raise ValueError("The pending save changed after it was confirmed")
     recovery = info["recovery_path"]
-    # parents=True applies mode only to the final directory, which would leave
-    # the shared recovery root readable under a permissive umask.
+    # mkdir(mode=...) does not tighten pre-existing directories. Restrict both
+    # levels before inspecting or writing private recovery material.
     recovery.parent.parent.mkdir(mode=0o700, exist_ok=True)
+    recovery.parent.parent.chmod(0o700)
     recovery.parent.mkdir(mode=0o700, exist_ok=True)
+    recovery.parent.chmod(0o700)
     if recovery.exists():
         # A failed previous replacement may be followed by more local play.
         # Retain that attempt's backup and capture the current save again.
@@ -372,16 +396,10 @@ def commit_pending_import(target: Path, logger=None) -> bool:
         shutil.copyfile(incoming, install_temp)
         _fsync_file(install_temp)
         os.replace(install_temp, target)
-        _fsync_directory(target.parent)
-    finally:
+    except Exception:
         _remove_owned_copy(install_temp)
-    _log(logger, "info", f"Ankimon import installed. Previous save: {recovery}")
-    try:
-        cancel_pending_import(target)
-    except OSError as exc:
-        # Installation succeeded. The token makes cleanup safe to retry on the
-        # next launch without overwriting game progress.
-        _log(logger, "warning", f"Import installed; pending-file cleanup will retry: {exc}")
+        raise
+    _finish_installed_import(target, recovery, logger, install_temp)
     return True
 
 

--- a/src/Ankimon/save_import.py
+++ b/src/Ankimon/save_import.py
@@ -29,6 +29,17 @@ class ImportInstalledError(RuntimeError):
     """The imported save is active, but its final sync or cleanup failed."""
 
 
+class ImportStagedError(RuntimeError):
+    """The import is published and WILL install, but staging did not finish.
+
+    Publishing ``pending.json`` is the commit point: after it, the next full
+    start installs the save whether or not the durability and read-back steps
+    that follow succeed. Callers must not report that as an abort — the user
+    would keep playing believing a replacement they were told had failed
+    cannot happen. Cancelling is the only way to stop it.
+    """
+
+
 def _process_identity() -> str:
     # sys survives add-on module purges. Include the PID so a subprocess/fork
     # cannot inherit the parent's identity while a reload keeps its identity.
@@ -201,6 +212,10 @@ def stage_import(
     ``sanitize_credentials`` is True for portable imports/rescues. Backup
     Manager restores may set it False because their source is already private
     local recovery material owned by this installation.
+
+    Raises ``ImportStagedError`` when publication succeeded but a later step
+    did not: the import is armed for the next start and can only be stopped by
+    cancelling it. Every other failure leaves nothing staged.
     """
     target, directory = _paths(target)
     if pending_import_info(target) is not None:
@@ -226,13 +241,26 @@ def stage_import(
             os.fsync(handle.fileno())
         os.replace(temp_manifest, directory / "pending.json")
         published = True
-        _fsync_directory(directory)
-        _fsync_directory(target.parent)
-        return pending_import_info(target)
     finally:
         temp_manifest.unlink(missing_ok=True)
         if not published:
             _remove_owned_copy(incoming)
+
+    # Past the commit point. Everything below is durability and read-back, and
+    # none of it can un-arm the install, so a failure here is reported as a
+    # staged import the user can cancel — never as "nothing was replaced".
+    try:
+        _fsync_directory(directory)
+        _fsync_directory(target.parent)
+        info = pending_import_info(target)
+    except Exception as error:
+        raise ImportStagedError(str(error)) from error
+    if info is None:
+        # The manifest vanished between publishing and reading it back, so
+        # nothing will install after all; do not strand the staged copy.
+        _remove_owned_copy(incoming)
+        raise OSError("The published pending import disappeared before it could be read back")
+    return info
 
 
 def cancel_pending_import(target: Path) -> bool:

--- a/src/Ankimon/save_import.py
+++ b/src/Ankimon/save_import.py
@@ -22,6 +22,12 @@ import uuid
 
 
 _TIMEOUT = 30.0
+# get_db installs pending work during add-on import, which Anki runs inside
+# AnkiQt.__init__ -- before setupProfile, before any window is shown and before
+# a progress dialog exists. A locked save there is Anki looking hung with
+# nothing on screen, so the WHOLE installation gets one budget, the way the
+# shutdown backup does, rather than a full SQLite timeout per file per step.
+STARTUP_IMPORT_BUDGET = 30.0
 _PROCESS_ATTRIBUTE = "_ankimon_save_import_process"
 
 
@@ -77,17 +83,32 @@ def _fsync_directory(path: Path) -> None:
         os.close(descriptor)
 
 
-def _connect_readonly(path: Path):
-    conn = sqlite3.connect(path.resolve().as_uri() + "?mode=ro", uri=True, timeout=_TIMEOUT)
-    deadline = time.monotonic() + _TIMEOUT
-    conn.set_progress_handler(lambda: int(time.monotonic() > deadline), 2000)
+def _budget(deadline: float | None) -> float:
+    """What one step may spend: its own timeout, or what is left of a shared one.
+
+    Raises rather than starting a step that has no time to finish in, so a
+    caller with an expired budget fails now instead of after another full wait.
+    """
+    if deadline is None:
+        return _TIMEOUT
+    remaining = deadline - time.monotonic()
+    if remaining <= 0:
+        raise TimeoutError("the save import budget expired")
+    return min(_TIMEOUT, remaining)
+
+
+def _connect_readonly(path: Path, deadline: float = None):
+    timeout = _budget(deadline)
+    conn = sqlite3.connect(path.resolve().as_uri() + "?mode=ro", uri=True, timeout=timeout)
+    limit = time.monotonic() + timeout
+    conn.set_progress_handler(lambda: int(time.monotonic() > limit), 2000)
     return conn
 
 
-def _verify_save(path: Path) -> None:
+def _verify_save(path: Path, deadline: float = None) -> None:
     if not path.is_file() or path.stat().st_size < 512:
         raise ValueError("The pending save is missing or truncated")
-    conn = _connect_readonly(path)
+    conn = _connect_readonly(path, deadline)
     try:
         if conn.execute("PRAGMA quick_check").fetchall() != [("ok",)]:
             raise ValueError("The save failed its SQLite integrity check")
@@ -104,16 +125,17 @@ def _remove_owned_copy(path: Path) -> None:
         Path(str(path) + suffix).unlink(missing_ok=True)
 
 
-def _snapshot(source: Path, dest: Path) -> None:
+def _snapshot(source: Path, dest: Path, deadline: float = None) -> None:
     """Build a verified single-file copy, including committed WAL contents."""
-    source_conn = _connect_readonly(source)
+    source_conn = _connect_readonly(source, deadline)
     try:
-        dest_conn = sqlite3.connect(dest, timeout=_TIMEOUT)
+        timeout = _budget(deadline)
+        dest_conn = sqlite3.connect(dest, timeout=timeout)
         try:
-            deadline = time.monotonic() + _TIMEOUT
+            limit = time.monotonic() + timeout
 
             def progress(status, remaining, total):
-                if time.monotonic() > deadline:
+                if time.monotonic() > limit:
                     raise TimeoutError("Timed out taking the import safety snapshot")
 
             source_conn.backup(dest_conn, pages=256, progress=progress, sleep=0.05)
@@ -122,7 +144,7 @@ def _snapshot(source: Path, dest: Path) -> None:
             dest_conn.close()
     finally:
         source_conn.close()
-    _verify_save(dest)
+    _verify_save(dest, deadline)
     _fsync_file(dest)
 
 
@@ -326,8 +348,8 @@ def cancel_pending_import(target: Path) -> bool:
     return True
 
 
-def _installed_token(target: Path) -> str | None:
-    conn = _connect_readonly(target)
+def _installed_token(target: Path, deadline: float = None) -> str | None:
+    conn = _connect_readonly(target, deadline)
     try:
         if conn.execute(
             "SELECT 1 FROM sqlite_master WHERE type='table' AND name='metadata'"
@@ -419,7 +441,7 @@ def _prune_superseded_recovery(directory: Path, name: str, keep: int = 1) -> Non
             pass
 
 
-def commit_pending_import(target: Path, logger=None) -> bool:
+def commit_pending_import(target: Path, logger=None, deadline: float = None) -> bool:
     """Install before any runtime exists, refusing work staged in this process.
 
     Returns True if installed (or a prior crash installed it); False if there is
@@ -427,6 +449,11 @@ def commit_pending_import(target: Path, logger=None) -> bool:
     for retry or explicit cancellation. ImportInstalledError means replacement
     succeeded but final sync or cleanup failed. The installed token prevents a
     retry from reapplying the old import over subsequent game progress.
+
+    ``deadline`` is an absolute ``time.monotonic()`` instant bounding the WHOLE
+    installation rather than each SQLite step. The caller runs during add-on
+    import, before Anki has a window to say what it is waiting for, so a locked
+    save must not be waited on twice over.
     """
     target, _ = _paths(target)
     # Any attempt may be followed by construction of a runtime. Retrying after
@@ -444,12 +471,22 @@ def commit_pending_import(target: Path, logger=None) -> bool:
     if info is None or info["process"] == _process_identity():
         return False
 
-    if _installed_token(target) == info["token"]:
+    if not target.is_file():
+        # Every step below reads the save, so without this the user gets a bare
+        # SQLite "unable to open database file" on every start. The developer
+        # save is never recreated, so that is forever.
+        raise FileNotFoundError(
+            f"{target.name} no longer exists, so the save import prepared for it "
+            "cannot be installed. Use Ankimon \u2192 Cancel Pending Save Import to "
+            "discard it."
+        )
+
+    if _installed_token(target, deadline) == info["token"]:
         _finish_installed_import(target, info["recovery_path"], logger)
         return True
 
     incoming = info["pending_path"]
-    _verify_save(incoming)
+    _verify_save(incoming, deadline)
     if _digest(incoming) != info["digest"]:
         raise ValueError("The pending save changed after it was confirmed")
     recovery = info["recovery_path"]
@@ -480,7 +517,7 @@ def commit_pending_import(target: Path, logger=None) -> bool:
     os.close(fd)
     backup_temp = Path(name)
     try:
-        _snapshot(target, backup_temp)
+        _snapshot(target, backup_temp, deadline)
         os.replace(backup_temp, recovery)
         _fsync_directory(recovery.parent)
         _fsync_directory(recovery.parent.parent)
@@ -491,7 +528,7 @@ def commit_pending_import(target: Path, logger=None) -> bool:
     # Let SQLite merge and remove the OLD database's journals itself. Never
     # delete a WAL before replacement: a crash in that gap would lose committed
     # progress. A busy external connection refuses the mode change and import.
-    conn = sqlite3.connect(target.as_uri() + "?mode=rw", uri=True, timeout=_TIMEOUT)
+    conn = sqlite3.connect(target.as_uri() + "?mode=rw", uri=True, timeout=_budget(deadline))
     try:
         mode = conn.execute("PRAGMA journal_mode=DELETE").fetchone()[0]
         if str(mode).lower() != "delete":

--- a/src/Ankimon/save_import.py
+++ b/src/Ankimon/save_import.py
@@ -29,6 +29,10 @@ class ImportInstalledError(RuntimeError):
     """The imported save is active, but its final sync or cleanup failed."""
 
 
+class ImportAlreadyPendingError(RuntimeError):
+    """Another import is staged for this save and has not been cancelled."""
+
+
 class ImportStagedError(RuntimeError):
     """The import is published and WILL install, but staging did not finish.
 
@@ -219,7 +223,8 @@ def stage_import(
     """
     target, directory = _paths(target)
     if pending_import_info(target) is not None:
-        raise RuntimeError("An import is already pending; cancel it before choosing another save")
+        raise ImportAlreadyPendingError(
+            "An import is already pending; cancel it before choosing another save")
     token = uuid.uuid4().hex
     directory.mkdir(mode=0o700, parents=True, exist_ok=True)
     incoming = directory / f"{token}.db"
@@ -270,11 +275,13 @@ def stage_import(
 def cancel_pending_import(target: Path) -> bool:
     """Cancel staged work even if its manifest is damaged.
 
-    Removing and fsyncing the manifest is the cancellation commit point. Once
-    that succeeds, failure to delete an orphaned private staged copy must not
-    make the UI claim cancellation failed: without ``pending.json`` no startup
-    can install it. Invalid manifests are deliberately not trusted for paths;
-    only locally-generated 32-hex-token database names are cleaned up.
+    Removing the manifest is the cancellation commit point. Once that
+    succeeds, neither the durability flush nor a failure to delete an orphaned
+    private staged copy may make the UI claim cancellation failed: without
+    ``pending.json`` no startup can install it, and a caller told to "try
+    again" would be told on the retry that there was nothing pending. Invalid
+    manifests are deliberately not trusted for paths; only locally-generated
+    32-hex-token database names are cleaned up.
     """
     target, directory = _paths(target)
     manifest = directory / "pending.json"
@@ -288,7 +295,12 @@ def cancel_pending_import(target: Path) -> bool:
 
     # Commit cancellation before touching any staged data.
     manifest.unlink()
-    _fsync_directory(directory)
+    try:
+        _fsync_directory(directory)
+    except Exception:
+        # The manifest is already gone, so nothing can install. Only the
+        # crash-durability of that removal is in question here.
+        pass
 
     if info is not None:
         candidates = [info["pending_path"]]

--- a/src/Ankimon/save_import.py
+++ b/src/Ankimon/save_import.py
@@ -242,14 +242,18 @@ def stage_import(
         os.replace(temp_manifest, directory / "pending.json")
         published = True
     finally:
-        temp_manifest.unlink(missing_ok=True)
         if not published:
+            temp_manifest.unlink(missing_ok=True)
             _remove_owned_copy(incoming)
 
-    # Past the commit point. Everything below is durability and read-back, and
-    # none of it can un-arm the install, so a failure here is reported as a
-    # staged import the user can cancel — never as "nothing was replaced".
+    # Past the commit point. Everything below is cleanup, durability and
+    # read-back, and none of it can un-arm the install, so a failure here is
+    # reported as a staged import the user can cancel — never as "nothing was
+    # replaced". The leftover manifest is removed here rather than in the
+    # finally above for that reason: missing_ok hides only a missing file, and
+    # a locked directory would otherwise abort over an already-published save.
     try:
+        temp_manifest.unlink(missing_ok=True)
         _fsync_directory(directory)
         _fsync_directory(target.parent)
         info = pending_import_info(target)

--- a/src/Ankimon/save_import.py
+++ b/src/Ankimon/save_import.py
@@ -389,6 +389,36 @@ def _finish_installed_import(target, recovery, logger, install_temp=None) -> Non
         raise ImportInstalledError(message) from error
 
 
+def _prune_superseded_recovery(directory: Path, name: str, keep: int = 1) -> None:
+    """Keep the canonical snapshot and the newest superseded one, no more.
+
+    An install that cannot finish -- on Windows, any process holding the save
+    open is enough -- is retried on every start, and each attempt snapshots the
+    live save again before trying. Unbounded, that is a full extra copy of the
+    save in user_files per restart, for as long as the lock lasts, while the
+    failure notice says only that it will retry. Nothing else prunes this
+    directory: Backup Manager's retention works on a different tree entirely.
+
+    One superseded copy is kept because the newest snapshot is taken before the
+    install is attempted, so the one before it is the last state captured under
+    a different set of conditions. Older ones describe the same save with less
+    of the user's progress in it.
+    """
+    try:
+        superseded = sorted(
+            (path for path in directory.glob(f"retry-*-{name}") if path.is_file()),
+            key=lambda path: path.stat().st_mtime,
+        )
+    except OSError:
+        return
+    for stale in superseded[:-keep] if keep else superseded:
+        try:
+            stale.unlink()
+        except OSError:
+            # Retaining one copy too many is not worth failing an install over.
+            pass
+
+
 def commit_pending_import(target: Path, logger=None) -> bool:
     """Install before any runtime exists, refusing work staged in this process.
 
@@ -440,6 +470,7 @@ def commit_pending_import(target: Path, logger=None) -> bool:
         # a name nobody had been given.
         os.replace(recovery, recovery.with_name(f"retry-{uuid.uuid4().hex}-{target.name}"))
         _fsync_directory(recovery.parent)
+        _prune_superseded_recovery(recovery.parent, target.name)
     elif recovery.exists():
         # Something that is not a snapshot holds the name. Write beside it, as
         # this has always done: replacing it would fail the install outright.

--- a/src/Ankimon/save_import.py
+++ b/src/Ankimon/save_import.py
@@ -339,6 +339,32 @@ def _installed_token(target: Path) -> str | None:
         conn.close()
 
 
+def pending_import_is_installed(target: Path) -> bool:
+    """True when the pending record describes an import that ALREADY installed.
+
+    ``_finish_installed_import`` retires the manifest after replacement, so this
+    is only reachable when that last step failed: the save on disk IS the
+    imported one and a stale ``pending.json`` is still sitting beside it, which
+    the next full start clears by itself.
+
+    ``commit_pending_import`` discriminates this state (it checks the installed
+    token before doing anything), but the menu did not, and answered for the
+    ordinary pending case: Cancel said the current save was unchanged when the
+    import had already replaced it, and a second import attempt was told the
+    first one "will install at the next full Anki restart". Both are the wrong
+    way round for a user deciding what to do about their save.
+    """
+    try:
+        info = pending_import_info(target)
+        if info is None:
+            return False
+        return _installed_token(target) == info["token"]
+    except Exception:
+        # An unreadable manifest or save is not evidence of an install, and this
+        # only ever chooses wording. Fall back to the ordinary pending case.
+        return False
+
+
 def _log(logger, level: str, message: str) -> None:
     if logger is not None:
         try:
@@ -403,9 +429,20 @@ def commit_pending_import(target: Path, logger=None) -> bool:
     recovery.parent.parent.chmod(0o700)
     recovery.parent.mkdir(mode=0o700, exist_ok=True)
     recovery.parent.chmod(0o700)
-    if recovery.exists():
-        # A failed previous replacement may be followed by more local play.
-        # Retain that attempt's backup and capture the current save again.
+    if recovery.is_file():
+        # A failed previous replacement may be followed by more local play, so
+        # the snapshot taken now is the one holding everything. Move the older
+        # attempt aside rather than redirecting this one: the canonical name is
+        # the only recovery filename the user is ever shown -- the staging
+        # notice quotes it once, before Anki closes, and nothing names the file
+        # again afterwards. Redirecting left that advertised path holding the
+        # stale first attempt while the genuinely final save sat beside it under
+        # a name nobody had been given.
+        os.replace(recovery, recovery.with_name(f"retry-{uuid.uuid4().hex}-{target.name}"))
+        _fsync_directory(recovery.parent)
+    elif recovery.exists():
+        # Something that is not a snapshot holds the name. Write beside it, as
+        # this has always done: replacing it would fail the install outright.
         recovery = recovery.with_name(f"retry-{uuid.uuid4().hex}-{target.name}")
 
     fd, name = tempfile.mkstemp(prefix=".backup-", suffix=".db", dir=recovery.parent)

--- a/src/Ankimon/save_import.py
+++ b/src/Ankimon/save_import.py
@@ -1,0 +1,363 @@
+"""Durable save imports applied before the next process builds its game state.
+
+Staging never replaces a running session's database. A cancelled Anki close or
+an add-on reload therefore leaves that session usable. The composition root
+may commit pending work only before it opens any Ankimon database or creates
+game objects. This module deliberately has no Anki, Qt, or services imports.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from pathlib import Path
+import re
+import shutil
+import sqlite3
+import sys
+import tempfile
+import time
+import uuid
+
+
+_TIMEOUT = 30.0
+_PROCESS_ATTRIBUTE = "_ankimon_save_import_process"
+
+
+def _process_identity() -> str:
+    # sys survives add-on module purges. Include the PID so a subprocess/fork
+    # cannot inherit the parent's identity while a reload keeps its identity.
+    identity = getattr(sys, _PROCESS_ATTRIBUTE, None)
+    if identity is None or identity[0] != os.getpid():
+        identity = (os.getpid(), uuid.uuid4().hex)
+        setattr(sys, _PROCESS_ATTRIBUTE, identity)
+    return f"{identity[0]}:{identity[1]}"
+
+
+def _paths(target: Path) -> tuple[Path, Path]:
+    target = Path(target).resolve()
+    return target, target.parent / f".ankimon-import-{target.name}"
+
+
+def _fsync_file(path: Path) -> None:
+    with path.open("rb") as handle:
+        os.fsync(handle.fileno())
+
+
+def _fsync_directory(path: Path) -> None:
+    # Windows does not allow opening directories this way. File fsync and the
+    # same-volume replace still apply there.
+    if os.name == "nt":
+        return
+    descriptor = os.open(path, os.O_RDONLY | getattr(os, "O_DIRECTORY", 0))
+    try:
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
+
+
+def _connect_readonly(path: Path):
+    conn = sqlite3.connect(path.resolve().as_uri() + "?mode=ro", uri=True, timeout=_TIMEOUT)
+    deadline = time.monotonic() + _TIMEOUT
+    conn.set_progress_handler(lambda: int(time.monotonic() > deadline), 2000)
+    return conn
+
+
+def _verify_save(path: Path) -> None:
+    if not path.is_file() or path.stat().st_size < 512:
+        raise ValueError("The pending save is missing or truncated")
+    conn = _connect_readonly(path)
+    try:
+        if conn.execute("PRAGMA quick_check").fetchall() != [("ok",)]:
+            raise ValueError("The save failed its SQLite integrity check")
+        if conn.execute(
+            "SELECT 1 FROM sqlite_master WHERE type='table' AND name='captured_pokemon'"
+        ).fetchone() is None:
+            raise ValueError("The file is not an Ankimon save")
+    finally:
+        conn.close()
+
+
+def _remove_owned_copy(path: Path) -> None:
+    for suffix in ("", "-wal", "-shm", "-journal"):
+        Path(str(path) + suffix).unlink(missing_ok=True)
+
+
+def _snapshot(source: Path, dest: Path) -> None:
+    """Build a verified single-file copy, including committed WAL contents."""
+    source_conn = _connect_readonly(source)
+    try:
+        dest_conn = sqlite3.connect(dest, timeout=_TIMEOUT)
+        try:
+            deadline = time.monotonic() + _TIMEOUT
+
+            def progress(status, remaining, total):
+                if time.monotonic() > deadline:
+                    raise TimeoutError("Timed out taking the import safety snapshot")
+
+            source_conn.backup(dest_conn, pages=256, progress=progress, sleep=0.05)
+            dest_conn.execute("PRAGMA journal_mode=DELETE")
+        finally:
+            dest_conn.close()
+    finally:
+        source_conn.close()
+    _verify_save(dest)
+    _fsync_file(dest)
+
+
+def _digest(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for block in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def _prepare_incoming(path: Path, token: str) -> None:
+    conn = sqlite3.connect(path, timeout=_TIMEOUT)
+    try:
+        tables = {row[0] for row in conn.execute("SELECT name FROM sqlite_master WHERE type='table'")}
+        conn.execute("PRAGMA secure_delete=ON")
+        with conn:
+            # Explicit empty auth rows also prevent Settings from falling back
+            # to this installation's legacy config.obf when an old save has no
+            # config. An imported SQLite save never inherits local credentials.
+            conn.execute("CREATE TABLE IF NOT EXISTS config (key TEXT PRIMARY KEY, value TEXT)")
+            conn.executemany("INSERT OR REPLACE INTO config VALUES (?, '')", [
+                ("leaderboard.username",), ("leaderboard.api_key",),
+            ])
+            if "user_data" in tables:
+                conn.execute("DELETE FROM user_data WHERE key IN ('username', 'api_key')")
+            conn.execute("CREATE TABLE IF NOT EXISTS metadata (key TEXT PRIMARY KEY, value TEXT)")
+            conn.executemany("INSERT OR REPLACE INTO metadata VALUES (?, ?)", [
+                ("import_token", token), ("import_rebase_pending", "1"),
+                # Do not merge destination legacy JSON into a whole-save import.
+                # Ordinary schema upgrades still run in AnkimonDB construction.
+                ("migrated", "true"), ("migrated_phase2", "true"),
+            ])
+        # Eliminate credentials from free pages as well as live rows. New game
+        # state will require this device's user to sign in again.
+        conn.execute("VACUUM")
+    finally:
+        conn.close()
+    _verify_save(path)
+    _fsync_file(path)
+
+
+def pending_import_info(target: Path) -> dict | None:
+    """Read pending work for exactly this target; paths come from local code.
+
+    Invalid metadata raises instead of silently treating a failed import as
+    absent. No pathname from the manifest can redirect a write or deletion.
+    """
+    target, directory = _paths(target)
+    try:
+        with (directory / "pending.json").open(encoding="utf-8") as handle:
+            record = json.load(handle)
+    except FileNotFoundError:
+        return None
+    if not isinstance(record, dict):
+        raise ValueError("The pending import record is damaged")
+    token = record.get("token", "")
+    if (record.get("version") != 1 or record.get("target") != str(target)
+            or not isinstance(token, str) or re.fullmatch(r"[0-9a-f]{32}", token) is None
+            or not isinstance(record.get("process"), str)
+            or not isinstance(record.get("digest"), str)):
+        raise ValueError("The pending import record does not match this save")
+    return {
+        **record,
+        "pending_path": directory / f"{token}.db",
+        "recovery_path": target.parent / "ankimon_recovery" / f"pre-import-{token}" / target.name,
+    }
+
+
+def stage_import(snapshot: Path, target: Path) -> dict:
+    """Durably retain the chosen save without touching the runtime database.
+
+    Returns pending_path, recovery_path and token. Recovery is reserved now and
+    written from the final local save immediately before installation. Existing
+    pending work must be cancelled explicitly before choosing another import.
+    """
+    target, directory = _paths(target)
+    if pending_import_info(target) is not None:
+        raise RuntimeError("An import is already pending; cancel it before choosing another save")
+    token = uuid.uuid4().hex
+    directory.mkdir(mode=0o700, parents=True, exist_ok=True)
+    incoming = directory / f"{token}.db"
+    temp_manifest = directory / f"{token}.json"
+    published = False
+    try:
+        # mkstemp permissions are private even if the user's umask is broad.
+        fd = os.open(incoming, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
+        os.close(fd)
+        _snapshot(Path(snapshot), incoming)
+        _prepare_incoming(incoming, token)
+        record = {
+            "version": 1, "target": str(target), "token": token,
+            "process": _process_identity(), "digest": _digest(incoming),
+        }
+        with temp_manifest.open("x", encoding="utf-8") as handle:
+            json.dump(record, handle)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temp_manifest, directory / "pending.json")
+        published = True
+        _fsync_directory(directory)
+        _fsync_directory(target.parent)
+        return pending_import_info(target)
+    finally:
+        temp_manifest.unlink(missing_ok=True)
+        if not published:
+            _remove_owned_copy(incoming)
+
+
+def cancel_pending_import(target: Path) -> bool:
+    """Cancel only staged work; all completed recovery copies remain intact."""
+    info = pending_import_info(target)
+    if info is None:
+        return False
+    _, directory = _paths(target)
+    (directory / "pending.json").unlink()
+    _fsync_directory(directory)
+    _remove_owned_copy(info["pending_path"])
+    _fsync_directory(directory)
+    return True
+
+
+def _installed_token(target: Path) -> str | None:
+    conn = _connect_readonly(target)
+    try:
+        if conn.execute(
+            "SELECT 1 FROM sqlite_master WHERE type='table' AND name='metadata'"
+        ).fetchone() is None:
+            return None
+        row = conn.execute("SELECT value FROM metadata WHERE key='import_token'").fetchone()
+        return row[0] if row else None
+    finally:
+        conn.close()
+
+
+def _log(logger, level: str, message: str) -> None:
+    if logger is not None:
+        try:
+            logger.log(level, message)
+        except Exception:
+            pass
+
+
+def commit_pending_import(target: Path, logger=None) -> bool:
+    """Install before any runtime exists, refusing work staged in this process.
+
+    Returns True if installed (or a prior crash installed it); False if there is
+    nothing to do yet. Failures raise while leaving pending work available for
+    retry or explicit cancellation. The installed token prevents a crash after
+    replacement from reapplying the old import over subsequent game progress.
+    """
+    target, _ = _paths(target)
+    # A failed attempt is followed by construction of the OLD runtime. Retrying
+    # after reset_db or a module purge must wait for another full process start.
+    attribute = "_ankimon_import_startup_attempts"
+    identity = _process_identity()
+    saved = getattr(sys, attribute, None)
+    if saved is None or saved[0] != identity:
+        saved = (identity, set())
+        setattr(sys, attribute, saved)
+    if str(target) in saved[1]:
+        return False
+    saved[1].add(str(target))
+    info = pending_import_info(target)
+    if info is None or info["process"] == _process_identity():
+        return False
+
+    if _installed_token(target) == info["token"]:
+        cancel_pending_import(target)
+        return True
+
+    incoming = info["pending_path"]
+    _verify_save(incoming)
+    if _digest(incoming) != info["digest"]:
+        raise ValueError("The pending save changed after it was confirmed")
+    recovery = info["recovery_path"]
+    # parents=True applies mode only to the final directory, which would leave
+    # the shared recovery root readable under a permissive umask.
+    recovery.parent.parent.mkdir(mode=0o700, exist_ok=True)
+    recovery.parent.mkdir(mode=0o700, exist_ok=True)
+    if recovery.exists():
+        # A failed previous replacement may be followed by more local play.
+        # Retain that attempt's backup and capture the current save again.
+        recovery = recovery.with_name(f"retry-{uuid.uuid4().hex}-{target.name}")
+
+    fd, name = tempfile.mkstemp(prefix=".backup-", suffix=".db", dir=recovery.parent)
+    os.close(fd)
+    backup_temp = Path(name)
+    try:
+        _snapshot(target, backup_temp)
+        os.replace(backup_temp, recovery)
+        _fsync_directory(recovery.parent)
+        _fsync_directory(recovery.parent.parent)
+        _fsync_directory(target.parent)
+    finally:
+        _remove_owned_copy(backup_temp)
+
+    # Let SQLite merge and remove the OLD database's journals itself. Never
+    # delete a WAL before replacement: a crash in that gap would lose committed
+    # progress. A busy external connection refuses the mode change and import.
+    conn = sqlite3.connect(target.as_uri() + "?mode=rw", uri=True, timeout=_TIMEOUT)
+    try:
+        mode = conn.execute("PRAGMA journal_mode=DELETE").fetchone()[0]
+        if str(mode).lower() != "delete":
+            raise RuntimeError("Could not safely close the old save's journal")
+    finally:
+        conn.close()
+    if any(Path(str(target) + suffix).exists() for suffix in ("-wal", "-shm", "-journal")):
+        raise RuntimeError("The old save still has SQLite journals; import remains pending")
+
+    fd, name = tempfile.mkstemp(prefix=".ankimon-install-", suffix=".db", dir=target.parent)
+    os.close(fd)
+    install_temp = Path(name)
+    try:
+        shutil.copyfile(incoming, install_temp)
+        _fsync_file(install_temp)
+        os.replace(install_temp, target)
+        _fsync_directory(target.parent)
+    finally:
+        _remove_owned_copy(install_temp)
+    _log(logger, "info", f"Ankimon import installed. Previous save: {recovery}")
+    try:
+        cancel_pending_import(target)
+    except OSError as exc:
+        # Installation succeeded. The token makes cleanup safe to retry on the
+        # next launch without overwriting game progress.
+        _log(logger, "warning", f"Import installed; pending-file cleanup will retry: {exc}")
+    return True
+
+
+def rebase_after_import(db, col) -> bool:
+    """Exclude existing destination reviews before any mobile detection runs.
+
+    The next profile open sees reviews pulled by the previous shutdown sync.
+    Retire the marker and set that collection's exact watermark in one database
+    transaction. Failures propagate so callers can skip detection and retry;
+    the source save's watermark must never be used while the marker remains.
+    """
+    conn = db._get_connection()
+    with conn:
+        marker = conn.execute(
+            "SELECT value FROM metadata WHERE key='import_rebase_pending'"
+        ).fetchone()
+        if marker is None or str(marker[0]) != "1":
+            return False
+        if col is None:
+            raise RuntimeError("The Anki collection is not available to finish the import")
+        watermark = col.db.scalar("SELECT MAX(id) FROM revlog")
+        if watermark is None:
+            watermark = 0
+        if type(watermark) is not int or watermark < 0:
+            raise ValueError("Could not read the collection's review watermark")
+        conn.execute(
+            "INSERT OR REPLACE INTO metadata (key, value) VALUES ('mobile_revlog_watermark', ?)",
+            (str(watermark),),
+        )
+        conn.execute("DELETE FROM metadata WHERE key='import_rebase_pending'")
+    return True

--- a/src/Ankimon/save_import.py
+++ b/src/Ankimon/save_import.py
@@ -13,7 +13,6 @@ import json
 import os
 from pathlib import Path
 import re
-import shutil
 import sqlite3
 import sys
 import tempfile
@@ -145,15 +144,27 @@ def _snapshot(source: Path, dest: Path, deadline: float = None) -> None:
     finally:
         source_conn.close()
     _verify_save(dest, deadline)
+    # An fsync in flight cannot be abandoned, so the budget is checked before
+    # one starts rather than trusted to cover it.
+    _budget(deadline)
     _fsync_file(dest)
 
 
-def _digest(path: Path) -> str:
+def _digest(path: Path, deadline: float = None) -> str:
     digest = hashlib.sha256()
     with path.open("rb") as handle:
         for block in iter(lambda: handle.read(1024 * 1024), b""):
+            _budget(deadline)
             digest.update(block)
     return digest.hexdigest()
+
+
+def _copy_within(source: Path, dest: Path, deadline: float = None) -> None:
+    """``shutil.copyfile`` that checks a shared budget between blocks."""
+    with source.open("rb") as reader, dest.open("wb") as writer:
+        for block in iter(lambda: reader.read(1024 * 1024), b""):
+            _budget(deadline)
+            writer.write(block)
 
 
 def _prepare_incoming(
@@ -211,6 +222,10 @@ def pending_import_info(target: Path) -> dict | None:
             record = json.load(handle)
     except FileNotFoundError:
         return None
+    if _is_cancelled_record(record):
+        # What a crash can bring back after Cancel: it installs nothing, and a
+        # new import may publish over it.
+        return None
     if not isinstance(record, dict):
         raise ValueError("The pending import record is damaged")
     token = record.get("token", "")
@@ -241,7 +256,10 @@ def stage_import(
 
     Raises ``ImportStagedError`` when publication succeeded but a later step
     did not: the import is armed for the next start and can only be stopped by
-    cancelling it. Every other failure leaves nothing staged.
+    cancelling it. Every other failure leaves nothing staged -- including the
+    one after publication that is not ``ImportStagedError``: a manifest gone
+    by read-back raises plain ``OSError``, because then nothing will install,
+    and the staged copy is removed with it.
     """
     target, directory = _paths(target)
     if pending_import_info(target) is not None:
@@ -294,14 +312,62 @@ def stage_import(
     return info
 
 
+def _write_cancelled_record(manifest: Path, target: Path) -> None:
+    """Overwrite the manifest in place with a record that installs nothing.
+
+    In place rather than by rename: a new directory entry would need the very
+    directory sync whose failure this has to survive, while the existing entry
+    only needs its file synced. If the write or its sync fails, the original
+    bytes are put back before raising, so this session still sees the import
+    its caller is about to report could not be cancelled.
+    """
+    record = json.dumps({"version": 1, "target": str(target), "cancelled": True})
+    with manifest.open("r+b") as handle:
+        original = handle.read()
+        try:
+            handle.seek(0)
+            handle.write(record.encode("utf-8"))
+            handle.truncate()
+            handle.flush()
+            os.fsync(handle.fileno())
+        except Exception:
+            try:
+                handle.seek(0)
+                handle.write(original)
+                handle.truncate()
+                handle.flush()
+            except Exception:
+                pass
+            raise
+
+
+def _is_cancelled_record(record) -> bool:
+    return isinstance(record, dict) and record.get("cancelled") is True
+
+
+def _manifest_is_cancelled(manifest: Path) -> bool:
+    try:
+        with manifest.open(encoding="utf-8") as handle:
+            return _is_cancelled_record(json.load(handle))
+    except Exception:
+        return False
+
+
 def cancel_pending_import(target: Path) -> bool:
     """Cancel staged work even if its manifest is damaged.
 
-    Removing the manifest is the cancellation commit point. Once that
-    succeeds, neither the durability flush nor a failure to delete an orphaned
-    private staged copy may make the UI claim cancellation failed: without
-    ``pending.json`` no startup can install it, and a caller told to "try
-    again" would be told on the retry that there was nothing pending. Invalid
+    The commit point is ``pending.json`` rewritten in place as a cancelled
+    record and synced as a FILE. Its directory entry already exists, so that
+    is durable even where the directory itself cannot be synced, and a crash
+    that undoes the unlink below brings back a record that installs nothing --
+    not the import the user was told had been cancelled. If the rewrite or its
+    sync fails this raises with the pending import left as it was, so the
+    caller can say cancellation failed and a retry still finds it to cancel.
+
+    Past that commit, neither the unlink, the directory sync nor a failure to
+    delete an orphaned private staged copy may make the UI claim cancellation
+    failed. A cancelled record that an earlier call committed but could not
+    remove is synced again, removed, and reported as nothing pending. Invalid
     manifests are deliberately not trusted for paths; only locally-generated
     32-hex-token database names are cleaned up.
     """
@@ -314,14 +380,22 @@ def cancel_pending_import(target: Path) -> bool:
         info = pending_import_info(target)
     except Exception:
         info = None
+    already_cancelled = info is None and _manifest_is_cancelled(manifest)
 
     # Commit cancellation before touching any staged data.
-    manifest.unlink()
     try:
+        if already_cancelled:
+            _fsync_file(manifest)
+        else:
+            _write_cancelled_record(manifest, target)
+    except FileNotFoundError:
+        return False
+    try:
+        manifest.unlink()
         _fsync_directory(directory)
     except Exception:
-        # The manifest is already gone, so nothing can install. Only the
-        # crash-durability of that removal is in question here.
+        # The synced cancelled record already stops every install, including
+        # one after a crash that brings this directory entry back.
         pass
 
     if info is not None:
@@ -336,16 +410,16 @@ def cancel_pending_import(target: Path) -> bool:
         try:
             _remove_owned_copy(path)
         except OSError:
-            # The manifest is already durably gone, so this is only an orphaned
+            # The cancellation is already on disk, so this is only an orphaned
             # private file. A later cleanup/stage can retry without any chance
             # of installing it.
             pass
     try:
         _fsync_directory(directory)
     except OSError:
-        # The cancellation itself was already fsynced above.
+        # Only the durability of those orphan removals is in question here.
         pass
-    return True
+    return not already_cancelled
 
 
 def _installed_token(target: Path, deadline: float = None) -> str | None:
@@ -361,10 +435,15 @@ def _installed_token(target: Path, deadline: float = None) -> str | None:
         conn.close()
 
 
-def pending_import_is_installed(target: Path) -> bool:
-    """True when the pending record describes an import that ALREADY installed.
+# Choosing a message is not worth freezing the menu for: a save something else
+# holds locked answers "unknown" within this long, not after SQLite's full timeout.
+_WORDING_BUDGET = 2.0
 
-    ``_finish_installed_import`` retires the manifest after replacement, so this
+
+def pending_import_is_installed(target: Path) -> bool | None:
+    """Whether the pending record describes an import that ALREADY installed.
+
+    ``_finish_installed_import`` retires the manifest after replacement, so True
     is only reachable when that last step failed: the save on disk IS the
     imported one and a stale ``pending.json`` is still sitting beside it, which
     the next full start clears by itself.
@@ -375,16 +454,20 @@ def pending_import_is_installed(target: Path) -> bool:
     import had already replaced it, and a second import attempt was told the
     first one "will install at the next full Anki restart". Both are the wrong
     way round for a user deciding what to do about their save.
+
+    None means the answer could not be read -- a damaged record, or a save that
+    is locked or unreadable -- and callers word it as unknown rather than as
+    either case. Callers run on the GUI thread, so the save gets
+    ``_WORDING_BUDGET`` rather than SQLite's 30-second busy timeout.
     """
     try:
         info = pending_import_info(target)
         if info is None:
             return False
-        return _installed_token(target) == info["token"]
+        deadline = time.monotonic() + _WORDING_BUDGET
+        return _installed_token(target, deadline) == info["token"]
     except Exception:
-        # An unreadable manifest or save is not evidence of an install, and this
-        # only ever chooses wording. Fall back to the ordinary pending case.
-        return False
+        return None
 
 
 def _log(logger, level: str, message: str) -> None:
@@ -487,7 +570,7 @@ def commit_pending_import(target: Path, logger=None, deadline: float = None) -> 
 
     incoming = info["pending_path"]
     _verify_save(incoming, deadline)
-    if _digest(incoming) != info["digest"]:
+    if _digest(incoming, deadline) != info["digest"]:
         raise ValueError("The pending save changed after it was confirmed")
     recovery = info["recovery_path"]
     # mkdir(mode=...) does not tighten pre-existing directories. Restrict both
@@ -542,7 +625,8 @@ def commit_pending_import(target: Path, logger=None, deadline: float = None) -> 
     os.close(fd)
     install_temp = Path(name)
     try:
-        shutil.copyfile(incoming, install_temp)
+        _copy_within(incoming, install_temp, deadline)
+        _budget(deadline)
         _fsync_file(install_temp)
         os.replace(install_temp, target)
     except Exception:

--- a/src/Ankimon/save_import.py
+++ b/src/Ankimon/save_import.py
@@ -114,21 +114,32 @@ def _digest(path: Path) -> str:
     return digest.hexdigest()
 
 
-def _prepare_incoming(path: Path, token: str) -> None:
+def _prepare_incoming(
+    path: Path, token: str, *, sanitize_credentials: bool = True
+) -> None:
+    """Prepare a staged save for installation.
+
+    Portable imports must never carry another installation's leaderboard
+    credentials. A Backup Manager restore is different: it restores the user's
+    own private local snapshot, so callers can explicitly retain credentials.
+    """
     conn = sqlite3.connect(path, timeout=_TIMEOUT)
     try:
         tables = {row[0] for row in conn.execute("SELECT name FROM sqlite_master WHERE type='table'")}
-        conn.execute("PRAGMA secure_delete=ON")
+        if sanitize_credentials:
+            conn.execute("PRAGMA secure_delete=ON")
         with conn:
-            # Explicit empty auth rows also prevent Settings from falling back
-            # to this installation's legacy config.obf when an old save has no
-            # config. An imported SQLite save never inherits local credentials.
-            conn.execute("CREATE TABLE IF NOT EXISTS config (key TEXT PRIMARY KEY, value TEXT)")
-            conn.executemany("INSERT OR REPLACE INTO config VALUES (?, '')", [
-                ("leaderboard.username",), ("leaderboard.api_key",),
-            ])
-            if "user_data" in tables:
-                conn.execute("DELETE FROM user_data WHERE key IN ('username', 'api_key')")
+            if sanitize_credentials:
+                # Explicit empty auth rows also prevent Settings from falling
+                # back to this installation's legacy config.obf when an old save
+                # has no config. A portable imported save never inherits local
+                # credentials.
+                conn.execute("CREATE TABLE IF NOT EXISTS config (key TEXT PRIMARY KEY, value TEXT)")
+                conn.executemany("INSERT OR REPLACE INTO config VALUES (?, '')", [
+                    ("leaderboard.username",), ("leaderboard.api_key",),
+                ])
+                if "user_data" in tables:
+                    conn.execute("DELETE FROM user_data WHERE key IN ('username', 'api_key')")
             conn.execute("CREATE TABLE IF NOT EXISTS metadata (key TEXT PRIMARY KEY, value TEXT)")
             conn.executemany("INSERT OR REPLACE INTO metadata VALUES (?, ?)", [
                 ("import_token", token), ("import_rebase_pending", "1"),
@@ -136,9 +147,10 @@ def _prepare_incoming(path: Path, token: str) -> None:
                 # Ordinary schema upgrades still run in AnkimonDB construction.
                 ("migrated", "true"), ("migrated_phase2", "true"),
             ])
-        # Eliminate credentials from free pages as well as live rows. New game
-        # state will require this device's user to sign in again.
-        conn.execute("VACUUM")
+        if sanitize_credentials:
+            # Eliminate credentials from free pages as well as live rows. New
+            # game state will require this device's user to sign in again.
+            conn.execute("VACUUM")
     finally:
         conn.close()
     _verify_save(path)
@@ -172,12 +184,18 @@ def pending_import_info(target: Path) -> dict | None:
     }
 
 
-def stage_import(snapshot: Path, target: Path) -> dict:
+def stage_import(
+    snapshot: Path, target: Path, *, sanitize_credentials: bool = True
+) -> dict:
     """Durably retain the chosen save without touching the runtime database.
 
     Returns pending_path, recovery_path and token. Recovery is reserved now and
     written from the final local save immediately before installation. Existing
     pending work must be cancelled explicitly before choosing another import.
+
+    ``sanitize_credentials`` is True for portable imports/rescues. Backup
+    Manager restores may set it False because their source is already private
+    local recovery material owned by this installation.
     """
     target, directory = _paths(target)
     if pending_import_info(target) is not None:
@@ -192,7 +210,7 @@ def stage_import(snapshot: Path, target: Path) -> dict:
         fd = os.open(incoming, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
         os.close(fd)
         _snapshot(Path(snapshot), incoming)
-        _prepare_incoming(incoming, token)
+        _prepare_incoming(incoming, token, sanitize_credentials=sanitize_credentials)
         record = {
             "version": 1, "target": str(target), "token": token,
             "process": _process_identity(), "digest": _digest(incoming),
@@ -213,15 +231,49 @@ def stage_import(snapshot: Path, target: Path) -> dict:
 
 
 def cancel_pending_import(target: Path) -> bool:
-    """Cancel only staged work; all completed recovery copies remain intact."""
-    info = pending_import_info(target)
-    if info is None:
+    """Cancel staged work even if its manifest is damaged.
+
+    Removing and fsyncing the manifest is the cancellation commit point. Once
+    that succeeds, failure to delete an orphaned private staged copy must not
+    make the UI claim cancellation failed: without ``pending.json`` no startup
+    can install it. Invalid manifests are deliberately not trusted for paths;
+    only locally-generated 32-hex-token database names are cleaned up.
+    """
+    target, directory = _paths(target)
+    manifest = directory / "pending.json"
+    if not manifest.exists():
         return False
-    _, directory = _paths(target)
-    (directory / "pending.json").unlink()
+
+    try:
+        info = pending_import_info(target)
+    except Exception:
+        info = None
+
+    # Commit cancellation before touching any staged data.
+    manifest.unlink()
     _fsync_directory(directory)
-    _remove_owned_copy(info["pending_path"])
-    _fsync_directory(directory)
+
+    if info is not None:
+        candidates = [info["pending_path"]]
+    else:
+        candidates = [
+            path
+            for path in directory.glob("*.db")
+            if re.fullmatch(r"[0-9a-f]{32}\.db", path.name) is not None
+        ]
+    for path in candidates:
+        try:
+            _remove_owned_copy(path)
+        except OSError:
+            # The manifest is already durably gone, so this is only an orphaned
+            # private file. A later cleanup/stage can retry without any chance
+            # of installing it.
+            pass
+    try:
+        _fsync_directory(directory)
+    except OSError:
+        # The cancellation itself was already fsynced above.
+        pass
     return True
 
 

--- a/src/Ankimon/utils.py
+++ b/src/Ankimon/utils.py
@@ -1150,14 +1150,17 @@ def png_to_base64(path: str) -> str:
         return "data:image/png;base64," + base64.b64encode(f.read()).decode("utf-8")
 
 
-def close_anki():
-    # Guarded: only meaningful inside Anki. No-op headless.
+def close_anki(*, raise_on_error=False):
+    """Request shutdown, optionally exposing failures to callers with pending work."""
+    # Legacy callers remain guarded and do nothing headless. Restore/import
+    # callers opt in so they can explain that their prepared change is pending.
     try:
         from aqt import mw
 
         mw.close()
     except Exception:
-        pass
+        if raise_on_error:
+            raise
 
 
 # --- Thread / Qt-liveness helpers (Stage A scaffolding) ---------------------

--- a/tests/test_backup_manager.py
+++ b/tests/test_backup_manager.py
@@ -319,9 +319,10 @@ def test_restore_stays_pending_when_real_close_helper_cannot_exit(mock_env, clos
     try:
         with patch.dict(sys.modules, {"aqt": aqt}), \
              patch.object(_bm_mod, "close_anki", close_anki), \
-             patch.object(_bm_mod, "showWarning") as warning:
+             patch.object(services, "ui", MagicMock()) as ui:
             bm.restore_backup(str(backup_dir))
 
+        warning = ui.warn
         assert pending_import_info(db.db_path) is not None
         assert db.get_config_value("trainer.name") == "Red"
         if close_error is not None:
@@ -891,9 +892,9 @@ def test_restore_over_an_import_of_unknown_state_claims_neither_answer(mock_env,
     assert save_import.pending_import_info(db.db_path) is not None
     monkeypatch.setattr(save_import, "pending_import_is_installed", lambda target: None)
     try:
-        with patch.object(_bm_mod, "showWarning") as warning:
+        with patch.object(services, "ui", MagicMock()) as ui:
             bm.restore_backup(str(backup_dir))
-        message = warning.call_args.args[0]
+        message = ui.warn.call_args.args[0]
         assert "could not tell whether" in message
         assert "will install at the next" not in message
         assert "is the save you are playing" not in message
@@ -964,3 +965,31 @@ def test_an_abandoned_staging_directory_is_swept_once_it_is_stale(mock_env, monk
 
     assert not stale.exists()
     assert live.is_dir(), "a staging directory an attempt may still be using was removed"
+
+
+def test_a_restore_close_failure_notice_that_cannot_be_shown_does_not_escape(mock_env):
+    """The restore is staged before Anki is asked to close.
+
+    Its warning goes through the presenter port like the other notices about an
+    armed restore, and a presenter that fails is logged rather than raised.
+    """
+    bm, db, _, _ = mock_env
+    from Ankimon import save_import
+
+    backup_dir = bm.backups_path / "backup_2026-06-04_12-00-00"
+    backup_dir.mkdir(parents=True, exist_ok=True)
+    _seed_db(backup_dir / "ankimon.db", "Blue", 999)
+    shown = []
+
+    def broken(message):
+        shown.append(message)
+        raise RuntimeError("wrapped C/C++ object has been deleted")
+
+    try:
+        with patch.object(services, "ui", types.SimpleNamespace(warn=broken)), \
+             patch.object(_bm_mod, "close_anki", side_effect=RuntimeError("no main window")):
+            bm.restore_backup(str(backup_dir))
+        assert [message.split(":")[0] for message in shown] == ["Anki could not close"]
+        assert save_import.pending_import_info(db.db_path) is not None
+    finally:
+        save_import.cancel_pending_import(db.db_path)

--- a/tests/test_backup_manager.py
+++ b/tests/test_backup_manager.py
@@ -870,11 +870,60 @@ def test_restore_over_an_import_of_unknown_state_claims_neither_answer(mock_env,
         with patch.object(_bm_mod, "showWarning") as warning:
             bm.restore_backup(str(backup_dir))
         message = warning.call_args.args[0]
-        assert "could not read the save" in message
+        assert "could not tell whether" in message
         assert "will install at the next" not in message
         assert "is the save you are playing" not in message
     finally:
         save_import.cancel_pending_import(db.db_path)
+
+
+def test_a_manual_delete_that_fails_part_way_cannot_pose_as_the_newest_backup(mock_env):
+    """The Delete button had the same restamped-remains problem as retention."""
+    bm, _, _, _ = mock_env
+    made = _fake_backups(bm, bm.MAX_BACKUPS)
+    for name in ("ankimon.db", "ankimonDEV.db", "summary.json"):
+        (made[1] / name).write_bytes(b"x")
+    unlink, calls = os.unlink, []
+
+    def second_file_locked(path, *args, **kwargs):
+        calls.append(path)
+        if len(calls) == 2:
+            raise PermissionError("simulated lock on one file of the backup")
+        return unlink(path, *args, **kwargs)
+
+    with patch.object(os, "unlink", side_effect=second_file_locked), \
+         patch.object(_bm_mod, "showInfo"), patch.object(_bm_mod, "showWarning"):
+        bm.delete_backup(str(made[1]))
+    assert len(calls) == 2, "the removal was not cut short part-way"
+
+    newest = bm.backups_path / "backup_2020-01-01_00-01-00"
+    newest.mkdir()
+    bm.cleanup_backups()
+
+    kept = sorted(path.name for path in bm.backups_path.glob("backup_*"))
+    assert kept == sorted([made[0].name] + [path.name for path in made[2:]] + [newest.name])
+    assert not list(bm.backups_path.glob(".discard_*")), "retention should finish the removal"
+
+
+@pytest.mark.skipif(os.name == "nt", reason="creating symlinks needs privileges on Windows")
+def test_retention_removes_a_linked_backup_without_emptying_what_it_points_at(mock_env, tmp_path):
+    """shutil.rmtree refuses a link; walking one deletes files outside the folder."""
+    bm, _, _, _ = mock_env
+    elsewhere = tmp_path / "backup-on-another-drive"
+    elsewhere.mkdir()
+    (elsewhere / "ankimon.db").write_bytes(b"a save the user moved and linked back")
+    stamp = time.time() - 3600
+    os.utime(elsewhere, (stamp, stamp))
+    made = _fake_backups(bm, bm.MAX_BACKUPS)
+    link = bm.backups_path / "backup_2019-01-01_00-00-00"
+    link.symlink_to(elsewhere, target_is_directory=True)
+
+    bm.cleanup_backups()
+
+    assert (elsewhere / "ankimon.db").is_file()
+    assert not link.exists() and not link.is_symlink()
+    assert all(path.is_dir() for path in made)
+    assert not list(bm.backups_path.glob(".discard_*"))
 
 
 def test_an_abandoned_staging_directory_is_swept_once_it_is_stale(mock_env, monkeypatch):

--- a/tests/test_backup_manager.py
+++ b/tests/test_backup_manager.py
@@ -2,6 +2,9 @@ import os
 import sys
 import json
 import sqlite3
+import threading
+import time
+from contextlib import closing
 import pytest
 import importlib.util
 from pathlib import Path
@@ -129,7 +132,10 @@ def mock_env(tmp_path):
         # replaces exp's direct mw.ankimon_db access, so backup_manager reads
         # services.db instead of a mocked mw.
         with patch.object(services, "db", db):
-            yield bm, db, user_files_dir, addon_dir
+            try:
+                yield bm, db, user_files_dir, addon_dir
+            finally:
+                db.close()
 
 def test_backup_summary_trainer_info(mock_env):
     bm, db, user_files_dir, addon_dir = mock_env
@@ -229,3 +235,145 @@ def test_restore_only_active_db(mock_env):
     assert restored.exists()
     assert restored.read_bytes() == b"NORMAL_DB_CONTENT"
     assert not (user_files_dir / "ankimonDEV.db").exists()
+
+
+@pytest.mark.parametrize("filename", ["ankimon.db", "ankimonDEV.db"])
+def test_backup_contains_committed_wal_while_reader_blocks_checkpoint(mock_env, filename):
+    """Copying the main file after a busy checkpoint loses committed cash."""
+    bm, db, user_files_dir, _ = mock_env
+    source = user_files_dir / filename
+    if filename == "ankimonDEV.db":
+        _seed_db(source, "Dev", 5000)
+    db.execute("PRAGMA busy_timeout=1")
+
+    with closing(sqlite3.connect(source, timeout=0.01)) as writer, \
+         closing(sqlite3.connect(source)) as reader:
+        writer.execute("PRAGMA journal_mode=WAL")
+        writer.execute("PRAGMA wal_autocheckpoint=0")
+        assert writer.execute("PRAGMA wal_checkpoint(TRUNCATE)").fetchone()[0] == 0
+        reader.execute("BEGIN")
+        assert reader.execute(
+            "SELECT value FROM config WHERE key='trainer.cash'"
+        ).fetchone()[0] == "5000"
+        writer.execute("UPDATE config SET value='12345' WHERE key='trainer.cash'")
+        writer.commit()
+        busy, pages, checkpointed = writer.execute("PRAGMA wal_checkpoint(TRUNCATE)").fetchone()
+        assert busy == 1 and pages > checkpointed
+
+        assert bm.create_backup(required_file=filename) is True
+        backup = next(bm.backups_path.glob("backup_*")) / filename
+        # Read only the published file, without allowing a companion WAL to
+        # supply missing pages: this is what a restored backup can recover.
+        with closing(sqlite3.connect(backup.as_uri() + "?immutable=1", uri=True)) as saved:
+            assert saved.execute(
+                "SELECT value FROM config WHERE key='trainer.cash'"
+            ).fetchone()[0] == "12345"
+        reader.rollback()
+
+
+@pytest.mark.parametrize("manual", [False, True])
+@pytest.mark.parametrize("filename", ["ankimon.db", "profile-save.db"])
+def test_backup_uses_active_database_at_custom_path(mock_env, tmp_path, manual, filename):
+    """A same-named default save must never stand in for the active profile."""
+    bm, _, _, _ = mock_env
+    custom_dir = tmp_path / "profile with spaces #?"
+    custom_dir.mkdir()
+    active = AnkimonDB(MockLogger(), db_path=custom_dir / filename)
+    active.set_config_value("trainer.cash", 76543)
+    try:
+        with patch.object(services, "db", active):
+            assert bm.create_backup(manual=manual, required_file=filename) is True
+        backup = next(bm.backups_path.glob("backup_*")) / filename
+        with closing(sqlite3.connect(backup)) as saved:
+            assert saved.execute(
+                "SELECT value FROM config WHERE key='trainer.cash'"
+            ).fetchone()[0] == "76543"
+    finally:
+        active.close()
+
+
+@pytest.mark.parametrize("contents", [b"not a database", b""])
+def test_backup_rejects_invalid_required_database(mock_env, contents):
+    """A file's existence alone cannot establish a recoverable backup."""
+    bm, _, user_files_dir, _ = mock_env
+    (user_files_dir / "ankimonDEV.db").write_bytes(contents)
+
+    assert bm.create_backup(required_file="ankimonDEV.db") is False
+    backup_dir = next(bm.backups_path.glob("backup_*"))
+    assert not (backup_dir / "ankimonDEV.db").exists()
+
+
+def test_snapshot_timeout_does_not_publish_partial_backup(mock_env, tmp_path):
+    """A locked source must stop within its deadline and leave no usable backup."""
+    bm, _, _, _ = mock_env
+    source = tmp_path / "locked.db"
+    destination = tmp_path / "saved.db"
+    _seed_db(source, "Locked", 10)
+    with closing(sqlite3.connect(source, check_same_thread=False)) as locker:
+        locker.execute("PRAGMA journal_mode=DELETE")
+        locker.execute("BEGIN EXCLUSIVE")
+        # Release even if a regression removes the timeout, so a failed test
+        # cannot hang the test runner indefinitely inside sqlite3.backup().
+        release = threading.Timer(1.0, locker.rollback)
+        release.start()
+        started = time.monotonic()
+        try:
+            with pytest.raises(TimeoutError):
+                bm._snapshot_database(source, destination, timeout=0.05)
+            assert time.monotonic() - started < 0.75
+        finally:
+            release.cancel()
+            release.join()
+            locker.rollback()
+    assert not destination.exists()
+    assert not list(tmp_path.glob(".snapshot-*"))
+
+
+def test_snapshot_missing_source_is_not_created(mock_env, tmp_path):
+    bm, _, _, _ = mock_env
+    source = tmp_path / "missing.db"
+    with pytest.raises(sqlite3.OperationalError):
+        bm._snapshot_database(source, tmp_path / "saved.db")
+    assert not source.exists()
+    assert not (tmp_path / "saved.db").exists()
+    assert not list(tmp_path.glob(".snapshot-*"))
+
+
+def test_backup_rejects_corruption_that_sqlite_can_copy(mock_env):
+    """Online backup copies pages without verifying their logical consistency."""
+    bm, _, user_files_dir, _ = mock_env
+    source = user_files_dir / "ankimonDEV.db"
+    with closing(sqlite3.connect(source)) as conn:
+        conn.executescript(
+            "CREATE TABLE captured_pokemon(id INTEGER, data TEXT);"
+            "CREATE TABLE scratch(data BLOB);"
+            "INSERT INTO scratch VALUES (zeroblob(10000));"
+            "DROP TABLE scratch;"
+        )
+    damaged = bytearray(source.read_bytes())
+    # The freelist still has pages, but its SQLite header count falsely says
+    # zero. Online backup succeeds; quick_check detects the inconsistency.
+    damaged[36:40] = (0).to_bytes(4, "big")
+    source.write_bytes(damaged)
+
+    assert bm.create_backup(required_file="ankimonDEV.db") is False
+    backup_dir = next(bm.backups_path.glob("backup_*"))
+    assert not (backup_dir / "ankimonDEV.db").exists()
+    assert not list(backup_dir.glob(".snapshot-*"))
+    assert source.read_bytes() == damaged
+
+
+def test_custom_active_filename_summary_describes_its_snapshot(mock_env, tmp_path):
+    bm, _, _, _ = mock_env
+    active = AnkimonDB(MockLogger(), db_path=tmp_path / "profile.db")
+    active.set_config_value("trainer.name", "Custom profile")
+    active.set_config_value("trainer.cash", 54321)
+    try:
+        with patch.object(services, "db", active):
+            assert bm.create_backup() is True
+            active.set_config_value("trainer.cash", 1)
+            summary = bm.get_backups()[0]
+            assert summary["trainer_name"] == "Custom profile"
+            assert summary["trainer_cash"] == 54321
+    finally:
+        active.close()

--- a/tests/test_backup_manager.py
+++ b/tests/test_backup_manager.py
@@ -605,10 +605,14 @@ def test_custom_active_filename_summary_describes_its_snapshot(mock_env, tmp_pat
         active.close()
 
 
-def test_shutdown_backup_spends_one_budget_across_both_databases(mock_env, monkeypatch):
+@pytest.mark.parametrize("active_name", ["ankimon.db", "ankimonDEV.db"])
+def test_shutdown_backup_spends_one_budget_across_both_databases(mock_env, monkeypatch, active_name):
     """Two locked saves must not each hold the close for a full timeout."""
-    bm, _, user_files_dir, _ = mock_env
+    bm, db, user_files_dir, _ = mock_env
     _seed_db(user_files_dir / "ankimonDEV.db", "Dev", 1)
+    # FILES_TO_BACKUP lists ankimon.db first anyway, so only a developer-mode
+    # active save shows that the active save really is the one tried first.
+    monkeypatch.setattr(db, "db_path", user_files_dir / active_name)
     clock = [100.0]
     monkeypatch.setattr(_bm_mod.time, "monotonic", lambda: clock[0])
     attempts = []
@@ -624,7 +628,7 @@ def test_shutdown_backup_spends_one_budget_across_both_databases(mock_env, monke
 
     # The active save goes first and consumes the whole shutdown budget; the
     # companion database is refused rather than given a second full timeout.
-    assert [name for name, _ in attempts] == ["ankimon.db"]
+    assert [name for name, _ in attempts] == [active_name]
     assert attempts[0][1] == pytest.approx(bm.SHUTDOWN_BACKUP_BUDGET)
     assert clock[0] - 100.0 <= bm.SHUTDOWN_BACKUP_BUDGET
 
@@ -853,6 +857,26 @@ def test_a_removal_stops_between_entries_once_the_shutdown_budget_is_spent(mock_
     assert len(list(leftover.iterdir())) == 2
     bm.cleanup_backups()
     assert not leftover.exists()
+
+
+def test_a_removal_that_starts_after_the_budget_does_not_list_the_directory(mock_env):
+    """iterdir reads the whole listing before it yields the first entry.
+
+    So a deadline checked only inside the loop is checked after that read.
+    """
+    bm, _, _, _ = mock_env
+    doomed = bm.backups_path / ".discard_00000000_backup_2020-01-01_00-00-00"
+    doomed.mkdir(parents=True)
+    (doomed / "ankimon.db").write_bytes(b"x")
+
+    with patch.object(_bm_mod.time, "monotonic", return_value=10.0), \
+         patch.object(Path, "iterdir", side_effect=AssertionError("listed after the deadline")):
+        assert bm._remove_tree(doomed, deadline=5.0) is False
+        assert (doomed / "ankimon.db").exists()
+        # An empty one needs no listing, so it still goes.
+        (doomed / "ankimon.db").unlink()
+        assert bm._remove_tree(doomed, deadline=5.0) is True
+    assert not doomed.exists()
 
 
 def test_restore_over_an_import_of_unknown_state_claims_neither_answer(mock_env, monkeypatch):

--- a/tests/test_backup_manager.py
+++ b/tests/test_backup_manager.py
@@ -633,3 +633,77 @@ def test_shutdown_backup_spends_one_budget_across_both_databases(mock_env, monke
     assert bm.create_backup(required_file="ankimon.db") is False
     assert [name for name, _ in attempts] == ["ankimon.db", "ankimonDEV.db"]
     assert {timeout for _, timeout in attempts} == {30.0}
+
+
+class _LockedLiveDatabase:
+    """A live handle with the accessors the backup summary reads.
+
+    Behaves like ``AnkimonDB`` towards ``backup_manager``, but every read opens
+    a real connection to a genuinely locked file, so its own busy timeout —
+    not a mocked clock — is what the shutdown budget has to keep out.
+    """
+
+    def __init__(self, path: Path, timeout: float):
+        self.db_path = path
+        self._timeout = timeout
+        self.live_reads = 0
+
+    def _read(self, statement, *parameters):
+        self.live_reads += 1
+        with closing(sqlite3.connect(self.db_path, timeout=self._timeout)) as conn:
+            return conn.execute(statement, parameters).fetchone()
+
+    def get_stats(self):
+        return {"pokemon": self._read("SELECT COUNT(*) FROM captured_pokemon")[0], "items": 0}
+
+    def get_config_value(self, key, default=None):
+        row = self._read("SELECT value FROM config WHERE key=?", key)
+        return row[0] if row else default
+
+    def get_main_pokemon(self):
+        return None
+
+    def close(self):
+        pass
+
+
+def test_failed_shutdown_backup_does_not_read_the_locked_live_database(mock_env, monkeypatch, tmp_path):
+    """The shutdown budget bounds the WHOLE call, summary generation included.
+
+    A summary is only ever published alongside a verified snapshot, so when the
+    required snapshot times out there is nothing to describe. Generating one
+    anyway sends ``_generate_summary`` down its live-database fallback and into
+    the same lock the deadline just gave up on, for a second full timeout.
+    """
+    bm, _, _, _ = mock_env
+    source = tmp_path / "profile" / "ankimon.db"
+    source.parent.mkdir()
+    _seed_db(source, "Locked", 7)
+    with closing(sqlite3.connect(source)) as setup:
+        # A rollback journal is what makes one writer exclude every reader,
+        # including the read-only connection the snapshot opens.
+        setup.execute("PRAGMA journal_mode=DELETE")
+
+    live = _LockedLiveDatabase(source, timeout=2.0)
+    monkeypatch.setattr(services, "db", live)
+    monkeypatch.setattr(bm, "SHUTDOWN_BACKUP_BUDGET", 0.1)
+
+    with closing(sqlite3.connect(source, check_same_thread=False)) as locker:
+        locker.execute("BEGIN EXCLUSIVE")
+        # Release even if a regression removes the bound, so a failing test
+        # cannot wedge the runner inside a multi-second busy wait.
+        release = threading.Timer(10.0, locker.rollback)
+        release.start()
+        started = time.monotonic()
+        try:
+            bm.on_anki_close()
+            elapsed = time.monotonic() - started
+        finally:
+            release.cancel()
+            release.join()
+            locker.rollback()
+
+    assert live.live_reads == 0
+    assert elapsed < 1.0
+    assert not list(bm.backups_path.glob("backup_*"))
+    assert not list(bm.backups_path.glob(".backup_*"))

--- a/tests/test_backup_manager.py
+++ b/tests/test_backup_manager.py
@@ -707,3 +707,75 @@ def test_failed_shutdown_backup_does_not_read_the_locked_live_database(mock_env,
     assert elapsed < 1.0
     assert not list(bm.backups_path.glob("backup_*"))
     assert not list(bm.backups_path.glob(".backup_*"))
+
+
+def _fake_backups(bm, count):
+    """Published-looking backup directories, oldest first and all within the
+    age limit, so only the MAX_BACKUPS count rule decides what goes."""
+    made = []
+    now = time.time()
+    for index in range(count):
+        directory = bm.backups_path / f"backup_2020-01-01_00-00-{index:02d}"
+        directory.mkdir()
+        stamp = now - (count - index)
+        os.utime(directory, (stamp, stamp))
+        made.append(directory)
+    return made
+
+
+def test_retention_failure_cannot_abort_anki_closing(mock_env, monkeypatch):
+    """profile_will_close does not catch what its handlers raise.
+
+    Retention runs after a backup has already been published, and deleting an
+    old directory can fail for reasons that have nothing to do with it -- a
+    Windows lock, an antivirus scan, a permission change. Letting that escape
+    would take Anki's close down over housekeeping, and throw away the backup
+    the call had just made.
+    """
+    bm, _, _, _ = mock_env
+    _fake_backups(bm, bm.MAX_BACKUPS + 3)
+
+    def refuse(path, *args, **kwargs):
+        raise OSError("simulated lock on an old backup")
+
+    monkeypatch.setattr(_bm_mod.shutil, "rmtree", refuse)
+
+    bm.on_anki_close()
+
+    published = [p for p in bm.backups_path.iterdir()
+                 if p.name.startswith("backup_") and (p / "ankimon.db").is_file()]
+    assert len(published) == 1, "the shutdown backup was lost to a retention failure"
+    assert len(list(bm.backups_path.glob("backup_*"))) == bm.MAX_BACKUPS + 4
+
+
+def test_retention_does_not_spend_a_shutdown_budget_it_no_longer_has(mock_env, monkeypatch):
+    """Deleting directories is not work to do while the user waits to exit."""
+    bm, _, _, _ = mock_env
+    _fake_backups(bm, bm.MAX_BACKUPS + 3)
+    removed = []
+    monkeypatch.setattr(_bm_mod.shutil, "rmtree", lambda path, *a, **k: removed.append(Path(path)))
+
+    clock = [500.0]
+    monkeypatch.setattr(_bm_mod.time, "monotonic", lambda: clock[0])
+    bm.cleanup_backups(deadline=clock[0] - 1)
+    assert removed == []
+
+    # With budget left it does the same work as before.
+    bm.cleanup_backups(deadline=clock[0] + 60)
+    assert len(removed) == 3
+
+
+def test_an_abandoned_staging_directory_is_swept_once_it_is_stale(mock_env, monkeypatch):
+    """Nothing else can remove it: listing and retention both filter on backup_."""
+    bm, _, _, _ = mock_env
+    stale = bm.backups_path / ".backup_2020-01-01_00-00-00"
+    stale.mkdir()
+    (stale / "ankimon.db").write_bytes(b"a whole save copy")
+    os.utime(stale, (1_600_000_000, 1_600_000_000))
+    live = bm.backups_path / ".backup_2020-01-01_00-00-01"
+    live.mkdir()
+
+    bm.cleanup_backups()
+
+    assert not stale.exists()
+    assert live.is_dir(), "a staging directory an attempt may still be using was removed"

--- a/tests/test_backup_manager.py
+++ b/tests/test_backup_manager.py
@@ -602,3 +602,34 @@ def test_custom_active_filename_summary_describes_its_snapshot(mock_env, tmp_pat
             assert summary["trainer_cash"] == 54321
     finally:
         active.close()
+
+
+def test_shutdown_backup_spends_one_budget_across_both_databases(mock_env, monkeypatch):
+    """Two locked saves must not each hold the close for a full timeout."""
+    bm, _, user_files_dir, _ = mock_env
+    _seed_db(user_files_dir / "ankimonDEV.db", "Dev", 1)
+    clock = [100.0]
+    monkeypatch.setattr(_bm_mod.time, "monotonic", lambda: clock[0])
+    attempts = []
+
+    def exhaust(source_path, destination_path, timeout=30.0):
+        # A locked source spends everything it is given, then fails.
+        attempts.append((Path(source_path).name, timeout))
+        clock[0] += timeout
+        raise TimeoutError("Timed out taking a database backup")
+
+    monkeypatch.setattr(bm, "_snapshot_database", exhaust)
+    bm.on_anki_close()
+
+    # The active save goes first and consumes the whole shutdown budget; the
+    # companion database is refused rather than given a second full timeout.
+    assert [name for name, _ in attempts] == ["ankimon.db"]
+    assert attempts[0][1] == pytest.approx(bm.SHUTDOWN_BACKUP_BUDGET)
+    assert clock[0] - 100.0 <= bm.SHUTDOWN_BACKUP_BUDGET
+
+    # A pre-overwrite backup is not a shutdown: every file keeps the per-file
+    # default, and the call shape stays positional for callers that patch it.
+    attempts.clear()
+    assert bm.create_backup(required_file="ankimon.db") is False
+    assert [name for name, _ in attempts] == ["ankimon.db", "ankimonDEV.db"]
+    assert {timeout for _, timeout in attempts} == {30.0}

--- a/tests/test_backup_manager.py
+++ b/tests/test_backup_manager.py
@@ -471,7 +471,8 @@ def test_incomplete_backup_survives_failed_removal_without_evicting_valid_backup
     with patch.object(_bm_mod.datetime, "datetime", wraps=datetime.datetime) as clock, \
          patch.object(db, "db_path", source):
         clock.now.return_value = now
-        with patch.object(_bm_mod.shutil, "rmtree", side_effect=PermissionError("file locked")):
+        with patch.object(_bm_mod.BackupManager, "_remove_tree",
+                          side_effect=PermissionError("file locked")):
             assert bm.create_backup() is False
 
         assert all(path.read_bytes() == content for path, content in prior.items())
@@ -735,10 +736,14 @@ def test_retention_failure_cannot_abort_anki_closing(mock_env, monkeypatch):
     bm, _, _, _ = mock_env
     _fake_backups(bm, bm.MAX_BACKUPS + 3)
 
-    def refuse(path, *args, **kwargs):
-        raise OSError("simulated lock on an old backup")
+    rename = Path.rename
 
-    monkeypatch.setattr(_bm_mod.shutil, "rmtree", refuse)
+    def refuse(path, *args, **kwargs):
+        if path.name.startswith("backup_2020"):
+            raise OSError("simulated lock on an old backup")
+        return rename(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "rename", refuse)
 
     bm.on_anki_close()
 
@@ -753,16 +758,123 @@ def test_retention_does_not_spend_a_shutdown_budget_it_no_longer_has(mock_env, m
     bm, _, _, _ = mock_env
     _fake_backups(bm, bm.MAX_BACKUPS + 3)
     removed = []
-    monkeypatch.setattr(_bm_mod.shutil, "rmtree", lambda path, *a, **k: removed.append(Path(path)))
+    monkeypatch.setattr(_bm_mod.BackupManager, "_remove_tree",
+                        lambda self, path, deadline: removed.append(Path(path)) or True)
 
     clock = [500.0]
     monkeypatch.setattr(_bm_mod.time, "monotonic", lambda: clock[0])
     bm.cleanup_backups(deadline=clock[0] - 1)
     assert removed == []
+    assert not list(bm.backups_path.glob(".discard_*"))
 
     # With budget left it does the same work as before.
     bm.cleanup_backups(deadline=clock[0] + 60)
     assert len(removed) == 3
+
+
+def test_a_backup_that_cannot_be_removed_never_costs_one_the_policy_keeps(mock_env, monkeypatch):
+    """Only removals that were due are attempted, and a failure adds none.
+
+    The oldest backup is locked and the next one is not. Stopping at the lock
+    would let one stuck directory grow the folder without bound; carrying on
+    removes only what lay outside the newest MAX_BACKUPS anyway.
+    """
+    bm, _, _, _ = mock_env
+    made = _fake_backups(bm, bm.MAX_BACKUPS + 2)
+    rename = Path.rename
+
+    def oldest_locked(path, *args, **kwargs):
+        if path == made[0]:
+            raise PermissionError("simulated lock on the oldest backup")
+        return rename(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "rename", oldest_locked)
+    bm.cleanup_backups()
+
+    assert made[0].is_dir(), "the locked backup should simply remain"
+    assert not made[1].exists()
+    assert all(path.is_dir() for path in made[2:])
+    assert not list(bm.backups_path.glob(".discard_*"))
+
+
+def test_a_removal_that_fails_part_way_cannot_pose_as_the_newest_backup(mock_env):
+    """Deleting inside a directory restamps its mtime, and retention sorts by mtime.
+
+    Emptied in place, what a failed removal leaves behind would sort as the
+    newest backup, and the next pass would evict a good one to keep it.
+    """
+    bm, _, _, _ = mock_env
+    made = _fake_backups(bm, bm.MAX_BACKUPS + 1)
+    for name in ("ankimon.db", "ankimonDEV.db", "summary.json"):
+        (made[0] / name).write_bytes(b"x")
+    stamp = time.time() - 3600
+    os.utime(made[0], (stamp, stamp))
+    unlink, calls = os.unlink, []
+
+    def second_file_locked(path, *args, **kwargs):
+        calls.append(path)
+        if len(calls) == 2:
+            raise PermissionError("simulated lock on one file of the oldest backup")
+        return unlink(path, *args, **kwargs)
+
+    with patch.object(os, "unlink", side_effect=second_file_locked):
+        bm.cleanup_backups()
+    assert len(calls) == 2, "the removal was not cut short part-way"
+
+    newest = bm.backups_path / "backup_2020-01-01_00-01-00"
+    newest.mkdir()
+    bm.cleanup_backups()
+
+    kept = sorted(path.name for path in bm.backups_path.glob("backup_*"))
+    assert kept == sorted([path.name for path in made[2:]] + [newest.name])
+
+
+def test_a_removal_stops_between_entries_once_the_shutdown_budget_is_spent(mock_env):
+    """shutil.rmtree cannot be interrupted; one entry at a time can."""
+    bm, _, _, _ = mock_env
+    doomed = bm.backups_path / "backup_2020-01-01_00-00-00"
+    doomed.mkdir()
+    for name in ("ankimon.db", "ankimonDEV.db", "summary.json"):
+        (doomed / name).write_bytes(b"x")
+    clock = [0.0]
+    unlink = os.unlink
+
+    def slow_disk(path, *args, **kwargs):
+        clock[0] += 10  # every deletion outlasts the whole budget
+        return unlink(path, *args, **kwargs)
+
+    with patch.object(_bm_mod.time, "monotonic", side_effect=lambda: clock[0]), \
+         patch.object(os, "unlink", side_effect=slow_disk):
+        assert bm._discard(doomed, "old backup", deadline=5.0) is False
+
+    # Out of the listing at once, one entry gone, the rest left for later.
+    assert not doomed.exists()
+    [leftover] = bm.backups_path.glob(".discard_*")
+    assert len(list(leftover.iterdir())) == 2
+    bm.cleanup_backups()
+    assert not leftover.exists()
+
+
+def test_restore_over_an_import_of_unknown_state_claims_neither_answer(mock_env, monkeypatch):
+    """A locked save gives no answer in time; neither confident message is safe."""
+    bm, db, _, _ = mock_env
+    from Ankimon import save_import
+
+    backup_dir = bm.backups_path / "backup_2026-06-02_12-00-00"
+    backup_dir.mkdir(parents=True, exist_ok=True)
+    _seed_db(backup_dir / "ankimon.db", "Blue", 999)
+    bm.restore_backup(str(backup_dir))
+    assert save_import.pending_import_info(db.db_path) is not None
+    monkeypatch.setattr(save_import, "pending_import_is_installed", lambda target: None)
+    try:
+        with patch.object(_bm_mod, "showWarning") as warning:
+            bm.restore_backup(str(backup_dir))
+        message = warning.call_args.args[0]
+        assert "could not read the save" in message
+        assert "will install at the next" not in message
+        assert "is the save you are playing" not in message
+    finally:
+        save_import.cancel_pending_import(db.db_path)
 
 
 def test_an_abandoned_staging_directory_is_swept_once_it_is_stale(mock_env, monkeypatch):

--- a/tests/test_backup_manager.py
+++ b/tests/test_backup_manager.py
@@ -222,19 +222,78 @@ def test_get_backups_active_db_filtering(mock_env):
 
 def test_restore_only_active_db(mock_env):
     bm, db, user_files_dir, addon_dir = mock_env
+    from Ankimon.save_import import cancel_pending_import, pending_import_info
 
     backup_dir = bm.backups_path / "backup_2026-06-02_09-00-00"
     backup_dir.mkdir(parents=True, exist_ok=True)
-    (backup_dir / "ankimon.db").write_bytes(b"NORMAL_DB_CONTENT")
-    (backup_dir / "ankimonDEV.db").write_bytes(b"DEV_DB_CONTENT")
+    _seed_db(backup_dir / "ankimon.db", "Blue", 999)
+    _seed_db(backup_dir / "ankimonDEV.db", "DevGuy", 111)
+    with closing(sqlite3.connect(backup_dir / "ankimon.db")) as conn:
+        conn.execute(
+            "INSERT OR REPLACE INTO config VALUES "
+            "('leaderboard.api_key', 'private-local-backup-key')"
+        )
+        conn.commit()
 
-    # Active DB is ankimon.db -> only that file is restored; the dev DB is untouched.
+    # Restore is staged: the current runtime keeps its original live DB until
+    # a fresh process can safely install the selected backup.
     bm.restore_backup(str(backup_dir))
 
-    restored = user_files_dir / "ankimon.db"
-    assert restored.exists()
-    assert restored.read_bytes() == b"NORMAL_DB_CONTENT"
+    assert db.get_config_value("trainer.name") == "Red"
+    assert db.get_config_value("trainer.cash") == 5000
+    pending = pending_import_info(db.db_path)
+    assert pending is not None
+    with closing(sqlite3.connect(pending["pending_path"])) as staged:
+        assert staged.execute(
+            "SELECT value FROM config WHERE key='trainer.name'"
+        ).fetchone()[0] == "Blue"
+        # Local Backup Manager restores retain this installation's credentials.
+        assert staged.execute(
+            "SELECT value FROM config WHERE key='leaderboard.api_key'"
+        ).fetchone()[0] == "private-local-backup-key"
     assert not (user_files_dir / "ankimonDEV.db").exists()
+    assert cancel_pending_import(db.db_path) is True
+
+
+def test_restore_targets_the_actual_custom_active_path(mock_env, tmp_path):
+    bm, _, user_files_dir, _ = mock_env
+    from Ankimon.save_import import cancel_pending_import, pending_import_info
+
+    custom_dir = tmp_path / "custom-profile"
+    custom_dir.mkdir()
+    active = AnkimonDB(MockLogger(), db_path=custom_dir / "profile-save.db")
+    active.set_config_value("trainer.name", "Current custom")
+    backup_dir = bm.backups_path / "backup_2026-06-02_10-00-00"
+    backup_dir.mkdir(parents=True, exist_ok=True)
+    _seed_db(backup_dir / "profile-save.db", "Restored custom", 4242)
+    try:
+        with patch.object(services, "db", active):
+            bm.restore_backup(str(backup_dir))
+            pending = pending_import_info(active.db_path)
+            assert pending is not None
+            assert pending["target"] == str(active.db_path.resolve())
+            assert not (user_files_dir / active.db_path.name).exists()
+            with closing(sqlite3.connect(pending["pending_path"])) as staged:
+                assert staged.execute(
+                    "SELECT value FROM config WHERE key='trainer.name'"
+                ).fetchone()[0] == "Restored custom"
+            assert cancel_pending_import(active.db_path) is True
+    finally:
+        active.close()
+
+
+def test_restore_rejects_a_corrupt_backup_without_touching_live_save(mock_env):
+    bm, db, _, _ = mock_env
+    from Ankimon.save_import import pending_import_info
+
+    backup_dir = bm.backups_path / "backup_2026-06-02_11-00-00"
+    backup_dir.mkdir(parents=True, exist_ok=True)
+    (backup_dir / db.db_path.name).write_bytes(b"not a database")
+
+    bm.restore_backup(str(backup_dir))
+
+    assert db.get_config_value("trainer.name") == "Red"
+    assert pending_import_info(db.db_path) is None
 
 
 @pytest.mark.parametrize("filename", ["ankimon.db", "ankimonDEV.db"])

--- a/tests/test_backup_manager.py
+++ b/tests/test_backup_manager.py
@@ -1,6 +1,7 @@
 import os
 import sys
 import json
+import datetime
 import sqlite3
 import threading
 import time
@@ -296,6 +297,45 @@ def test_restore_rejects_a_corrupt_backup_without_touching_live_save(mock_env):
     assert pending_import_info(db.db_path) is None
 
 
+@pytest.mark.parametrize("close_error", [RuntimeError("shutdown failed"), None])
+def test_restore_stays_pending_when_real_close_helper_cannot_exit(mock_env, close_error):
+    """Use the real shutdown helper so swallowed exceptions cannot hide a warning."""
+    bm, db, _, _ = mock_env
+    from Ankimon.save_import import cancel_pending_import, pending_import_info
+    from Ankimon.utils import close_anki
+
+    backup_dir = bm.backups_path / "backup_to_restore"
+    backup_dir.mkdir()
+    _seed_db(backup_dir / "ankimon.db", "Restored", 42)
+
+    def close():
+        if close_error is not None:
+            raise close_error
+        # Anki can refuse to close when the user chooses Keep Editing.
+        return False
+
+    aqt = types.ModuleType("aqt")
+    aqt.mw = types.SimpleNamespace(close=close)
+    try:
+        with patch.dict(sys.modules, {"aqt": aqt}), \
+             patch.object(_bm_mod, "close_anki", close_anki), \
+             patch.object(_bm_mod, "showWarning") as warning:
+            bm.restore_backup(str(backup_dir))
+
+        assert pending_import_info(db.db_path) is not None
+        assert db.get_config_value("trainer.name") == "Red"
+        if close_error is not None:
+            assert warning.call_count == 1
+            message = warning.call_args.args[0]
+            assert "shutdown failed" in message
+            assert "current save is still active" in message
+            assert "restore remains pending" in message
+        else:
+            warning.assert_not_called()
+    finally:
+        cancel_pending_import(db.db_path)
+
+
 @pytest.mark.parametrize("filename", ["ankimon.db", "ankimonDEV.db"])
 def test_backup_contains_committed_wal_while_reader_blocks_checkpoint(mock_env, filename):
     """Copying the main file after a busy checkpoint loses committed cash."""
@@ -358,7 +398,135 @@ def test_backup_rejects_invalid_required_database(mock_env, contents):
     (user_files_dir / "ankimonDEV.db").write_bytes(contents)
 
     assert bm.create_backup(required_file="ankimonDEV.db") is False
+    assert not list(bm.backups_path.iterdir())
+
+
+def _seed_prior_backups(bm):
+    backups = {}
+    for index in range(5):
+        backup_dir = bm.backups_path / f"backup_prior_{index}"
+        backup_dir.mkdir()
+        database = backup_dir / "ankimonDEV.db"
+        _seed_db(database, f"Prior {index}", index)
+        backups[database] = database.read_bytes()
+        (backup_dir / "summary.json").write_text(json.dumps({
+            "date": f"Prior {index}",
+            "dev_stats": {"trainer_name": f"Prior {index}", "trainer_cash": index},
+        }), encoding="utf-8")
+        modified = time.time() - (5 - index) * 60
+        os.utime(backup_dir, (modified, modified))
+    return backups
+
+
+@pytest.mark.parametrize("manual", [False, True])
+def test_failed_required_backup_preserves_all_five_prior_backups(mock_env, manual):
+    """Neither an empty attempt nor another mode's snapshot may evict recovery data."""
+    bm, db, user_files_dir, _ = mock_env
+    prior = _seed_prior_backups(bm)
+    source = user_files_dir / "ankimonDEV.db"
+    source.write_bytes(b"not a database")
+
+    with patch.object(db, "db_path", source):
+        assert bm.create_backup(manual=manual) is False
+
+    assert set(bm.backups_path.iterdir()) == {path.parent for path in prior}
+    assert all(path.read_bytes() == content for path, content in prior.items())
+
+
+def test_locked_required_backup_preserves_all_five_prior_backups(mock_env):
+    bm, _, user_files_dir, _ = mock_env
+    prior = _seed_prior_backups(bm)
+    source = user_files_dir / "ankimonDEV.db"
+    _seed_db(source, "Locked", 10)
+    snapshot = bm._snapshot_database
+
+    def quick_snapshot(source_path, destination_path):
+        return snapshot(source_path, destination_path, timeout=0.05)
+
+    with closing(sqlite3.connect(source, check_same_thread=False)) as locker:
+        locker.execute("PRAGMA journal_mode=DELETE")
+        locker.execute("BEGIN EXCLUSIVE")
+        release = threading.Timer(1.0, locker.rollback)
+        release.start()
+        try:
+            with patch.object(bm, "_snapshot_database", side_effect=quick_snapshot):
+                assert bm.create_backup(required_file="ankimonDEV.db") is False
+        finally:
+            release.cancel()
+            release.join()
+            locker.rollback()
+
+    assert set(bm.backups_path.iterdir()) == {path.parent for path in prior}
+    assert all(path.read_bytes() == content for path, content in prior.items())
+
+
+def test_incomplete_backup_survives_failed_removal_without_evicting_valid_backups(mock_env):
+    """A leftover failed attempt must not occupy a retention slot on the next success."""
+    bm, db, user_files_dir, _ = mock_env
+    prior = _seed_prior_backups(bm)
+    source = user_files_dir / "ankimonDEV.db"
+    source.write_bytes(b"not a database")
+    now = datetime.datetime.now()
+
+    with patch.object(_bm_mod.datetime, "datetime", wraps=datetime.datetime) as clock, \
+         patch.object(db, "db_path", source):
+        clock.now.return_value = now
+        with patch.object(_bm_mod.shutil, "rmtree", side_effect=PermissionError("file locked")):
+            assert bm.create_backup() is False
+
+        assert all(path.read_bytes() == content for path, content in prior.items())
+        failed_directories = set(bm.backups_path.iterdir()) - {path.parent for path in prior}
+        assert len(failed_directories) == 1
+
+        source.unlink()
+        _seed_db(source, "Next success", 100)
+        clock.now.return_value = now + datetime.timedelta(seconds=1)
+        assert bm.create_backup() is True
+
+        # Only the oldest of the five valid copies should rotate out. The
+        # unreadable attempt must neither count nor be listed as a backup.
+        surviving_prior = list(prior.items())[1:]
+        assert all(path.exists() for path, _ in surviving_prior)
+        assert all(path.read_bytes() == content for path, content in surviving_prior)
+        assert len(bm.get_backups()) == 5
+        assert not {Path(backup["path"]) for backup in bm.get_backups()} & failed_directories
+
+    # The failed attempt captured the other mode, which must not make it
+    # visible when that mode is active either.
+    assert not {Path(backup["path"]) for backup in bm.get_backups()} & failed_directories
+
+
+@pytest.mark.parametrize("prefix", ["backup_", ".backup_"])
+def test_failed_backup_mkdir_preserves_existing_same_timestamp_directory(mock_env, prefix):
+    bm, _, _, _ = mock_env
+    now = datetime.datetime.now()
+    backup_dir = bm.backups_path / f"{prefix}{now:%Y-%m-%d_%H-%M-%S}"
+    backup_dir.mkdir()
+    database = backup_dir / "ankimon.db"
+    _seed_db(database, "Existing", 123)
+    original = database.read_bytes()
+    # Even an expired existing backup must survive a failed creation attempt.
+    expired = time.time() - 30 * 24 * 3600
+    os.utime(backup_dir, (expired, expired))
+
+    with patch.object(_bm_mod.datetime, "datetime", wraps=datetime.datetime) as clock:
+        clock.now.return_value = now
+        assert bm.create_backup() is False
+
+    assert database.read_bytes() == original
+
+
+def test_failed_other_mode_snapshot_keeps_successful_required_backup(mock_env):
+    bm, _, user_files_dir, _ = mock_env
+    (user_files_dir / "ankimonDEV.db").write_bytes(b"not a database")
+
+    assert bm.create_backup(required_file="ankimon.db") is True
+
     backup_dir = next(bm.backups_path.glob("backup_*"))
+    with closing(sqlite3.connect(backup_dir / "ankimon.db")) as saved:
+        assert saved.execute(
+            "SELECT value FROM config WHERE key='trainer.cash'"
+        ).fetchone()[0] == "5000"
     assert not (backup_dir / "ankimonDEV.db").exists()
 
 
@@ -416,9 +584,7 @@ def test_backup_rejects_corruption_that_sqlite_can_copy(mock_env):
     source.write_bytes(damaged)
 
     assert bm.create_backup(required_file="ankimonDEV.db") is False
-    backup_dir = next(bm.backups_path.glob("backup_*"))
-    assert not (backup_dir / "ankimonDEV.db").exists()
-    assert not list(backup_dir.glob(".snapshot-*"))
+    assert not list(bm.backups_path.iterdir())
     assert source.read_bytes() == damaged
 
 

--- a/tests/test_pr797_repros.py
+++ b/tests/test_pr797_repros.py
@@ -323,14 +323,19 @@ def test_migration_does_not_block_profile_open_on_a_locked_save(
     holder.execute("BEGIN EXCLUSIVE;")
     holder.execute("INSERT INTO items VALUES ('lockholder', 1)")
     monkeypatch.setattr(st, "askUser", lambda *a, **k: False)
+    queued = []
+    monkeypatch.setattr(st.mw.taskman, "run_in_background",
+                        lambda scan, done, **kwargs: queued.append(scan))
 
     try:
         t0 = time.monotonic()
-        st.run_media_migration(MagicMock(), logger)
+        st.start_media_migration(MagicMock(), logger)
         elapsed = time.monotonic() - t0
         assert elapsed < 1.0, (
             f"profile-open path blocked for {elapsed:.1f}s on a locked media save"
         )
+        assert len(queued) == 1
+        assert list(media.glob("_ankimon_unverified_*.zip"))
     finally:
         holder.close()
 
@@ -991,11 +996,10 @@ def test_a_profile_switch_during_the_scan_discards_the_result(
     settled.assert_not_called()
 
 
-def test_start_falls_back_to_a_synchronous_run_without_a_task_manager(
+def test_start_preserves_and_retries_without_a_task_manager(
     real_flag_media, live_db, logger, monkeypatch
 ):
-    """Correctness beats responsiveness: if the dispatch is refused, do the work
-    rather than skip it."""
+    """Capture survives failed dispatch; the comparison remains asynchronous."""
     folder, _profile = real_flag_media
     _make_save(folder / "ankimon.db", pokemon=42, badges=8, history=99)
     ask = MagicMock(return_value=False)
@@ -1009,7 +1013,8 @@ def test_start_falls_back_to_a_synchronous_run_without_a_task_manager(
 
     st.start_media_migration(MagicMock(), logger)
 
-    ask.assert_called_once()
+    ask.assert_not_called()
+    assert st.get_db_stats(_protected(folder)[0])["pokemon"] == 42
     assert st._MIGRATION_SCAN_STATE["running"] is False
 
 
@@ -1153,7 +1158,10 @@ def test_equal_counters_do_not_mean_the_save_is_already_preserved(
 
     copies = _protected(media)
     assert len(copies) == 1, "the equal-but-different bare save was left exposed"
-    assert copies[0].read_bytes() == (media / "ankimon.db").read_bytes()
+    with sqlite3.connect(copies[0]) as conn:
+        assert [row[0] for row in conn.execute(
+            "SELECT individual_id FROM captured_pokemon ORDER BY individual_id"
+        )] == ["theirs-0", "theirs-1", "theirs-2", "theirs-3"]
 
 
 def test_two_devices_converge_on_one_name_for_one_save(tmp_path, live_db, logger, monkeypatch):

--- a/tests/test_pr797_repros.py
+++ b/tests/test_pr797_repros.py
@@ -335,7 +335,8 @@ def test_migration_does_not_block_profile_open_on_a_locked_save(
             f"profile-open path blocked for {elapsed:.1f}s on a locked media save"
         )
         assert len(queued) == 1
-        assert list(media.glob("_ankimon_unverified_*.zip"))
+        assert list(st._recovery_store(media).glob("_ankimon_unverified_*.zip"))
+        assert not list(media.glob("_ankimon_unverified_*.zip"))
     finally:
         holder.close()
 

--- a/tests/test_pr797_repros.py
+++ b/tests/test_pr797_repros.py
@@ -322,6 +322,7 @@ def test_migration_does_not_block_profile_open_on_a_locked_save(
     holder.execute("PRAGMA locking_mode = EXCLUSIVE;")
     holder.execute("BEGIN EXCLUSIVE;")
     holder.execute("INSERT INTO items VALUES ('lockholder', 1)")
+    monkeypatch.setattr(st, "MIGRATION_PROBE_TIMEOUT", 0.01)
     monkeypatch.setattr(st, "askUser", lambda *a, **k: False)
     queued = []
     monkeypatch.setattr(st.mw.taskman, "run_in_background",
@@ -335,6 +336,9 @@ def test_migration_does_not_block_profile_open_on_a_locked_save(
             f"profile-open path blocked for {elapsed:.1f}s on a locked media save"
         )
         assert len(queued) == 1
+        assert not list(st._recovery_store(media).glob("_ankimon_unverified_*.zip"))
+        assert media in st.mw.pm._ankimon_media_protection_guard["blocked"]
+        queued[0]()
         assert list(st._recovery_store(media).glob("_ankimon_unverified_*.zip"))
         assert not list(media.glob("_ankimon_unverified_*.zip"))
     finally:
@@ -997,10 +1001,10 @@ def test_a_profile_switch_during_the_scan_discards_the_result(
     settled.assert_not_called()
 
 
-def test_start_preserves_and_retries_without_a_task_manager(
+def test_start_guards_and_retries_without_a_task_manager(
     real_flag_media, live_db, logger, monkeypatch
 ):
-    """Capture survives failed dispatch; the comparison remains asynchronous."""
+    """Failed dispatch keeps the sync guard and never runs inline recovery."""
     folder, _profile = real_flag_media
     _make_save(folder / "ankimon.db", pokemon=42, badges=8, history=99)
     ask = MagicMock(return_value=False)
@@ -1015,7 +1019,9 @@ def test_start_preserves_and_retries_without_a_task_manager(
     st.start_media_migration(MagicMock(), logger)
 
     ask.assert_not_called()
-    assert st.get_db_stats(_protected(folder)[0])["pokemon"] == 42
+    assert st.get_db_stats(folder / "ankimon.db")["pokemon"] == 42
+    assert _protected(folder) == []
+    assert folder in st.mw.pm._ankimon_media_protection_guard["blocked"]
     assert st._MIGRATION_SCAN_STATE["running"] is False
 
 

--- a/tests/test_pr850_media_review.py
+++ b/tests/test_pr850_media_review.py
@@ -392,12 +392,18 @@ def test_the_gate_and_the_release_cannot_interleave(
     _make_save(media_host.media / "ankimon.db", pokemon=5)
     st.start_media_migration(None, _Logger())
     state = media_host.pm._ankimon_media_protection_guard
-    answers = []
+    answers, about_to_read = [], threading.Event()
+
+    def anki_sync_worker():
+        about_to_read.set()
+        answers.append(media_host.pm.media_syncing_enabled())
 
     with state["lock"]:
-        worker = threading.Thread(
-            target=lambda: answers.append(media_host.pm.media_syncing_enabled()))
+        worker = threading.Thread(target=anki_sync_worker)
         worker.start()
+        # Wait for the worker to reach the gate, so an empty `answers` below
+        # means it is blocked on the lock rather than simply not scheduled yet.
+        assert about_to_read.wait(5)
         worker.join(0.25)
         # A release is mid-flight, so the gate may not answer yet.
         assert worker.is_alive()

--- a/tests/test_pr850_media_review.py
+++ b/tests/test_pr850_media_review.py
@@ -1,0 +1,163 @@
+"""Regression coverage for PR #850's recovery scheduling and menu failures."""
+
+from concurrent.futures import ThreadPoolExecutor
+import os
+from pathlib import Path
+import threading
+import sys
+from types import SimpleNamespace
+
+import pytest
+
+from test_save_transfer import _Logger, _make_save, st
+from test_save_transfer_safety import transfer
+
+
+@pytest.fixture
+def media_host(transfer, tmp_path, monkeypatch):
+    """Queue workers explicitly while retaining the real profile sync guard."""
+    media = tmp_path / "collection.media"
+    media.mkdir()
+    queued = []
+    pm = SimpleNamespace(profile={}, profileFolder=lambda: str(tmp_path),
+                         media_syncing_enabled=lambda: True, save=lambda: None)
+    monkeypatch.setattr(st.mw, "pm", pm)
+    monkeypatch.setattr(st, "_MIGRATION_SCAN_STATE", {"running": False, "rerun": False})
+    monkeypatch.setattr(st.mw.taskman, "run_in_background",
+                        lambda work, done, **kwargs: queued.append((work, done)))
+
+    def finish():
+        work, done = queued.pop(0)
+        with ThreadPoolExecutor(max_workers=1) as executor:
+            future = executor.submit(work)
+            future.result()
+        done(future)
+
+    return SimpleNamespace(media=media, pm=pm, queued=queued, finish=finish)
+
+
+@pytest.mark.parametrize("readable", [False, True])
+def test_preservation_io_runs_on_worker_with_sync_guard(transfer, media_host, monkeypatch, readable):
+    """Neither SQLite copying nor full raw ZIP writes may run on profile-open."""
+    host = media_host
+    source = host.media / "ankimon.db"
+    if readable:
+        _make_save(source, pokemon=2)
+    else:
+        source.write_bytes(b"unreadable database" * 100)
+    gui_thread = threading.get_ident()
+    preserve = st._protect_bare_saves
+    seen = []
+
+    def checked_preserve(media):
+        seen.append(threading.get_ident())
+        assert threading.get_ident() != gui_thread
+        assert host.pm.media_syncing_enabled() is False
+        return preserve(media)
+
+    monkeypatch.setattr(st, "_protect_bare_saves", checked_preserve)
+    st.start_media_migration(None, _Logger())
+    assert not seen
+    assert host.pm.media_syncing_enabled() is False
+    host.finish()
+    assert len(seen) == 1
+    assert host.pm.media_syncing_enabled() is True
+    copies = list(st._recovery_store(host.media).iterdir())
+    assert len(copies) == 1
+    assert copies[0].suffix == (".db" if readable else ".zip")
+
+
+def test_unchanged_unreadable_save_has_retry_delay_but_changes_rearm(transfer, media_host, monkeypatch):
+    """Repeated sync stops cannot repeatedly archive the same corrupt file."""
+    source = media_host.media / "ankimon.db"
+    source.write_bytes(b"corrupt" * 100)
+    now = [100.0]
+    monkeypatch.setattr(st.time, "monotonic", lambda: now[0])
+    st.start_media_migration(None, _Logger())
+    media_host.finish()
+    for _ in range(5):
+        st.start_media_migration(None, _Logger())
+    assert media_host.queued == []
+    assert media_host.pm.media_syncing_enabled() is True
+
+    now[0] += 61
+    st.start_media_migration(None, _Logger())
+    assert len(media_host.queued) == 1
+    media_host.finish()
+    source.write_bytes(b"different corrupt save" * 100)
+    st.start_media_migration(None, _Logger())
+    assert len(media_host.queued) == 1
+    assert media_host.pm.media_syncing_enabled() is False
+    media_host.finish()
+
+
+def test_dispatch_failure_keeps_guard_and_can_retry(transfer, media_host, monkeypatch):
+    """A stopped executor leaves original files protected by the sync gate."""
+    source = _make_save(media_host.media / "ankimon.db", pokemon=17)
+    enqueue = st.mw.taskman.run_in_background
+
+    def refused(*args, **kwargs):
+        raise RuntimeError("executor stopped")
+
+    monkeypatch.setattr(st.mw.taskman, "run_in_background", refused)
+    st.start_media_migration(None, _Logger())
+    assert media_host.pm.media_syncing_enabled() is False
+    assert st.get_db_stats(source)["pokemon"] == 17
+    assert not st._recovery_store(media_host.media).exists()
+    assert "paused" in st.showWarning.call_args.args[0].lower()
+    monkeypatch.setattr(st.mw.taskman, "run_in_background", enqueue)
+    st.start_media_migration(None, _Logger())
+    media_host.finish()
+    assert media_host.pm.media_syncing_enabled() is True
+
+
+def test_removing_uncaptured_save_releases_guard_on_previously_settled_folder(
+    transfer, media_host, monkeypatch,
+):
+    """Moving a failed save elsewhere must not leave media sync paused forever."""
+    st.start_media_migration(None, _Logger())
+    media_host.finish()
+    assert st._migration_done()
+    source = _make_save(media_host.media / "ankimon.db", pokemon=17)
+
+    def refused(*args, **kwargs):
+        raise RuntimeError("executor stopped")
+
+    monkeypatch.setattr(st.mw.taskman, "run_in_background", refused)
+    st.start_media_migration(None, _Logger())
+    assert media_host.pm.media_syncing_enabled() is False
+    source.rename(source.parent.parent / "moved-save.db")
+    st.start_media_migration(None, _Logger())
+    assert media_host.pm.media_syncing_enabled() is True
+
+
+def test_cancel_menu_reports_manifest_lock_without_losing_pending_import(transfer, monkeypatch):
+    """A locked manifest keeps the staged save and produces an actionable warning."""
+    from Ankimon import save_import
+
+    info = save_import.stage_import(transfer.incoming, transfer.active)
+    unlink = Path.unlink
+
+    def locked(path, *args, **kwargs):
+        if path.name == "pending.json":
+            raise PermissionError("manifest locked")
+        return unlink(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "unlink", locked)
+    st.cancel_pending_save_import()
+    assert save_import.pending_import_info(transfer.active)["token"] == info["token"]
+    assert "could not be cancelled" in st.showWarning.call_args.args[0]
+    assert "try again" in st.showWarning.call_args.args[0]
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX directory permissions")
+def test_browse_tightens_existing_recovery_directory(transfer, monkeypatch):
+    """Opening the browser cannot leave local credential backups world-readable."""
+
+    recovery = transfer.active.parent / "ankimon_recovery"
+    recovery.mkdir(mode=0o755)
+    opened = []
+    monkeypatch.setattr(sys.modules["aqt.utils"], "openFolder", lambda path: opened.append(path), raising=False)
+    st.browse_recovered_saves()
+    assert recovery.stat().st_mode & 0o777 == 0o700
+    assert opened == [str(recovery)]

--- a/tests/test_pr850_media_review.py
+++ b/tests/test_pr850_media_review.py
@@ -570,3 +570,47 @@ def test_the_gate_fails_open_when_the_profile_folder_cannot_be_read(
     monkeypatch.setattr(media_host.pm, "media_syncing_enabled", lambda: False,
                         raising=False)
     assert media_host.pm.media_syncing_enabled() is False
+
+
+def test_a_retry_that_cannot_run_still_lets_another_be_scheduled(
+    transfer, media_host, monkeypatch,
+):
+    """The scheduled flag is the only thing stopping a second timer.
+
+    Anki's own timer gate drops a call outright when the collection is gone
+    rather than deferring it, so a retry that returns without clearing the flag
+    would cost the profile every later retry for the life of the process.
+    """
+    source = media_host.media / "ankimon.db"
+    _make_save(source, pokemon=5)
+
+    def captures_nothing(media_dir):
+        return {"protected": {}, "unprotected": [source], "archives": [],
+                "archived_sources": [], "log": []}
+
+    monkeypatch.setattr(st, "_protect_bare_saves", captures_nothing)
+    timers = []
+    monkeypatch.setattr(st.mw.progress, "single_shot",
+                        lambda ms, func, *args: timers.append((ms, func, args)))
+    now = [100.0]
+    monkeypatch.setattr(st.time, "monotonic", lambda: now[0])
+
+    st.start_media_migration(None, _Logger())
+    media_host.finish()
+    retries = [entry for entry in timers
+               if entry[0] > st._MIGRATION_RETRY_DELAY * 1000]
+    assert len(retries) == 1
+    # Asked for unconditionally, because Anki's own condition would drop it.
+    assert retries[0][2] == (False,)
+
+    # The profile closes inside the delay.
+    monkeypatch.setattr(st.mw, "col", None)
+    now[0] += st._MIGRATION_RETRY_DELAY + 1
+    retries[0][1]()
+    assert media_host.queued == []
+    assert st._MIGRATION_SCAN_STATE.get("retry_scheduled") is False
+
+    # A later pass can still arm one.
+    st._schedule_migration_retry(None, _Logger())
+    assert len([entry for entry in timers
+                if entry[0] > st._MIGRATION_RETRY_DELAY * 1000]) == 2

--- a/tests/test_pr850_media_review.py
+++ b/tests/test_pr850_media_review.py
@@ -161,3 +161,31 @@ def test_browse_tightens_existing_recovery_directory(transfer, monkeypatch):
     st.browse_recovered_saves()
     assert recovery.stat().st_mode & 0o777 == 0o700
     assert opened == [str(recovery)]
+
+
+def test_scan_result_is_discarded_when_the_media_save_changes_mid_scan(
+    transfer, media_host, monkeypatch,
+):
+    """A save rewritten during capture must not be compared or offered."""
+    source = _make_save(media_host.media / "ankimon.db", pokemon=9)
+    applied = []
+    monkeypatch.setattr(st, "_apply_migration_result",
+                        lambda result, logger: applied.append(result))
+
+    st.start_media_migration(None, _Logger())
+    work, done = media_host.queued.pop(0)
+    with ThreadPoolExecutor(max_workers=1) as executor:
+        future = executor.submit(work)
+        future.result()
+    # A download lands between the worker finishing and its callback running.
+    source.unlink()
+    _make_save(source, pokemon=40)
+    done(future)
+
+    # Nothing from the obsolete pass reaches the user, sync stays paused, and
+    # the coalesced rerun is what finally applies a result.
+    assert applied == []
+    assert media_host.pm.media_syncing_enabled() is False
+    assert len(media_host.queued) == 1
+    media_host.finish()
+    assert len(applied) == 1

--- a/tests/test_pr850_media_review.py
+++ b/tests/test_pr850_media_review.py
@@ -256,11 +256,16 @@ def test_an_untouched_capture_still_settles_in_one_pass(transfer, media_host, mo
 
 @pytest.fixture
 def media_syncer(monkeypatch):
-    """Record what Ankimon asks Anki's media syncer to do."""
+    """Record what Ankimon asks Anki's media syncer to do.
+
+    ``mw`` is a MagicMock, so every unset attribute reads as truthy. Pin the
+    host state the resume actually consults instead of letting the mock decide.
+    """
     started = []
     monkeypatch.setattr(st.mw, "media_syncer",
                         SimpleNamespace(start=lambda *args: started.append(args)))
     monkeypatch.setattr(st.mw, "col", object())
+    monkeypatch.setattr(st.mw, "restoring_backup", False)
     return started
 
 
@@ -283,7 +288,10 @@ def test_a_sync_turned_away_by_the_guard_is_restarted_after_capture(
 
     media_host.finish()
     assert media_host.pm.media_syncing_enabled() is True
-    assert len(media_syncer) == 1
+    # Marked periodic, like Anki's own unattended timer: nobody clicked for
+    # this request, and MediaSyncer only keeps a failure out of a dialog when
+    # the request says it is periodic.
+    assert media_syncer == [(True,)]
 
 
 def test_capture_does_not_start_a_sync_nobody_asked_for(
@@ -312,16 +320,31 @@ def test_media_sync_switched_off_by_the_user_is_never_resumed(
     assert media_syncer == []
 
 
+def test_a_restore_in_progress_suppresses_the_resumed_sync(
+    transfer, media_host, media_syncer, monkeypatch,
+):
+    """Anki's own unattended sync stands down during a backup restore."""
+    monkeypatch.setattr(st.mw, "restoring_backup", True)
+    _make_save(media_host.media / "ankimon.db", pokemon=5)
+    st.start_media_migration(None, _Logger())
+    assert media_host.pm.media_syncing_enabled() is False
+
+    media_host.finish()
+    # The guard still lifts; only the extra request we would have made is held.
+    assert media_host.pm.media_syncing_enabled() is True
+    assert media_syncer == []
+
+
 def test_a_deferred_sync_is_resumed_only_once(transfer, media_host, media_syncer):
     """A later settled pass must not re-request the sync it already restarted."""
     _make_save(media_host.media / "ankimon.db", pokemon=5)
     st.start_media_migration(None, _Logger())
     assert media_host.pm.media_syncing_enabled() is False
     media_host.finish()
-    assert len(media_syncer) == 1
+    assert media_syncer == [(True,)]
 
     (media_host.media / "ankimon.db").unlink()
     st.start_media_migration(None, _Logger())
     if media_host.queued:
         media_host.finish()
-    assert len(media_syncer) == 1
+    assert media_syncer == [(True,)]

--- a/tests/test_pr850_media_review.py
+++ b/tests/test_pr850_media_review.py
@@ -348,3 +348,65 @@ def test_a_deferred_sync_is_resumed_only_once(transfer, media_host, media_syncer
     if media_host.queued:
         media_host.finish()
     assert media_syncer == [(True,)]
+
+
+def test_opening_preferences_does_not_report_media_sync_as_switched_off(
+    transfer, media_host, media_syncer, monkeypatch,
+):
+    """The guard delays a sync; it must never edit the user's setting.
+
+    Anki's Preferences dialog reads this same gate to tick "Synchronize audio
+    and images too", then writes whatever the box shows back into the profile
+    when the user presses OK. A blocked answer there would silently turn real
+    AnkiWeb media sync off for good.
+    """
+    _make_save(media_host.media / "ankimon.db", pokemon=5)
+    st.start_media_migration(None, _Logger())
+    # Read the guard's own state, not the gate: calling the gate is what a
+    # sync request does, and this test is about a caller that is not one.
+    assert media_host.media in media_host.pm._ankimon_media_protection_guard["blocked"]
+
+    # A function whose module really is aqt.preferences, the way the dialog's
+    # setup_network is, doing exactly what it does to draw the checkbox.
+    dialog = {"__name__": "aqt.preferences", "pm": media_host.pm}
+    exec("def setup_network():\n    return pm.media_syncing_enabled()\n", dialog)
+    assert dialog["setup_network"]() is True
+
+    # Drawing a checkbox is not a request, so nothing is replayed either.
+    media_host.finish()
+    assert media_syncer == []
+
+
+def test_the_gate_and_the_release_cannot_interleave(
+    transfer, media_host, media_syncer,
+):
+    """Anki reads the gate on a worker thread while release runs on the GUI.
+
+    aqt's sync_collection evaluates media_syncing_enabled() inside the lambda
+    it hands to the task manager, so the read lands on a background thread
+    while _guard_uncaptured_media runs on the main one. Unless recording a
+    turned-away request and replaying it are one atomic step, a request can be
+    remembered just after the release that would have replayed it and be
+    dropped anyway -- the same lost sync, reached through a race.
+    """
+    _make_save(media_host.media / "ankimon.db", pokemon=5)
+    st.start_media_migration(None, _Logger())
+    state = media_host.pm._ankimon_media_protection_guard
+    answers = []
+
+    with state["lock"]:
+        worker = threading.Thread(
+            target=lambda: answers.append(media_host.pm.media_syncing_enabled()))
+        worker.start()
+        worker.join(0.25)
+        # A release is mid-flight, so the gate may not answer yet.
+        assert worker.is_alive()
+        assert answers == []
+
+    worker.join(5)
+    assert answers == [False]
+    assert media_host.media in state["deferred"]
+
+    # And the request that was recorded under that lock is the one replayed.
+    media_host.finish()
+    assert media_syncer == [(True,)]

--- a/tests/test_pr850_media_review.py
+++ b/tests/test_pr850_media_review.py
@@ -480,3 +480,93 @@ def test_wal_media_save_settles_instead_of_rescanning_forever(transfer, media_ho
     # which is a real content sidecar and stays in the signature.
     assert passes <= 2
     assert media_host.pm.media_syncing_enabled() is True
+
+
+def test_a_deferral_the_resume_stands_down_from_is_kept_for_later(
+    transfer, media_host, media_syncer, monkeypatch,
+):
+    """Standing down is not being done: the request is still owed.
+
+    During a backup restore Anki has switched its own unattended sync off, so a
+    request dropped here is gone for the session -- and that is precisely when
+    the user has just synced by hand to get their media back.
+    """
+    monkeypatch.setattr(st.mw, "restoring_backup", True)
+    _make_save(media_host.media / "ankimon.db", pokemon=5)
+    st.start_media_migration(None, _Logger())
+    assert media_host.pm.media_syncing_enabled() is False
+
+    media_host.finish()
+    assert media_host.pm.media_syncing_enabled() is True
+    assert media_syncer == []
+
+    # The restore finishes (Anki clears this on the next profile open) and the
+    # guard is released again: the request that was held now goes.
+    monkeypatch.setattr(st.mw, "restoring_backup", False)
+    (media_host.media / "ankimon.db").unlink()
+    st.start_media_migration(None, _Logger())
+    assert media_syncer == [(True,)]
+
+
+def test_a_guard_that_stays_up_schedules_its_own_rescan(
+    transfer, media_host, monkeypatch,
+):
+    """The guard suppresses the only hook that would have brought the retry.
+
+    MediaSyncer.start returns before start_monitoring when the gate says no, so
+    no media_sync_did_start_or_stop fires while the guard is up -- and that hook
+    is this scan's only recurring trigger. Without a clock of its own the
+    recorded retry delay never arrives.
+    """
+    source = media_host.media / "ankimon.db"
+    _make_save(source, pokemon=5)
+
+    def captures_nothing(media_dir):
+        return {"protected": {}, "unprotected": [source], "archives": [],
+                "archived_sources": [], "log": []}
+
+    monkeypatch.setattr(st, "_protect_bare_saves", captures_nothing)
+    timers = []
+    monkeypatch.setattr(st.mw.progress, "single_shot",
+                        lambda ms, func, *args: timers.append((ms, func)))
+    now = [100.0]
+    monkeypatch.setattr(st.time, "monotonic", lambda: now[0])
+
+    st.start_media_migration(None, _Logger())
+    media_host.finish()
+
+    assert media_host.pm.media_syncing_enabled() is False, "the guard should still be up"
+    # A rescue offer also uses this timer, at zero delay; the retry is the one
+    # scheduled past the throttle it has to outlast.
+    retries = [entry for entry in timers
+               if entry[0] > st._MIGRATION_RETRY_DELAY * 1000]
+    assert len(retries) == 1
+
+    # Firing it asks for the pass the throttle was waiting for.
+    now[0] += st._MIGRATION_RETRY_DELAY + 1
+    retries[0][1]()
+    assert media_host.queued, "the scheduled retry did not dispatch a scan"
+
+
+def test_the_gate_fails_open_when_the_profile_folder_cannot_be_read(
+    transfer, media_host, monkeypatch,
+):
+    """Anki's own media_syncing_enabled is a dict lookup and cannot raise.
+
+    Three callers read this gate -- the Preferences dialog, the periodic timer's
+    Qt slot and the sync worker -- and none of them expect an exception from it.
+    """
+    _make_save(media_host.media / "ankimon.db", pokemon=5)
+    st.start_media_migration(None, _Logger())
+    assert media_host.pm.media_syncing_enabled() is False
+
+    def gone():
+        raise OSError("the profile volume went away")
+
+    monkeypatch.setattr(media_host.pm, "profileFolder", gone)
+    assert media_host.pm.media_syncing_enabled() is True
+
+    # A user who has media sync switched off is answered without touching disk.
+    monkeypatch.setattr(media_host.pm, "media_syncing_enabled", lambda: False,
+                        raising=False)
+    assert media_host.pm.media_syncing_enabled() is False

--- a/tests/test_pr850_media_review.py
+++ b/tests/test_pr850_media_review.py
@@ -252,3 +252,76 @@ def test_an_untouched_capture_still_settles_in_one_pass(transfer, media_host, mo
     assert applied[0]["stable"] is True
     assert media_host.queued == []
     assert media_host.pm.media_syncing_enabled() is True
+
+
+@pytest.fixture
+def media_syncer(monkeypatch):
+    """Record what Ankimon asks Anki's media syncer to do."""
+    started = []
+    monkeypatch.setattr(st.mw, "media_syncer",
+                        SimpleNamespace(start=lambda *args: started.append(args)))
+    monkeypatch.setattr(st.mw, "col", object())
+    return started
+
+
+def test_a_sync_turned_away_by_the_guard_is_restarted_after_capture(
+    transfer, media_host, media_syncer, monkeypatch,
+):
+    """Clearing the guard only permits the NEXT sync; the skipped one is lost.
+
+    Anki reads media_syncing_enabled() once, as a collection sync starts, and
+    passes that answer into the backend call. A request that saw False finishes
+    without media, and its later start_monitoring() call only watches; nothing
+    re-requests media for it.
+    """
+    _make_save(media_host.media / "ankimon.db", pokemon=5)
+    st.start_media_migration(None, _Logger())
+
+    # Anki asks as its startup collection sync begins, and is turned away.
+    assert media_host.pm.media_syncing_enabled() is False
+    assert media_syncer == []
+
+    media_host.finish()
+    assert media_host.pm.media_syncing_enabled() is True
+    assert len(media_syncer) == 1
+
+
+def test_capture_does_not_start_a_sync_nobody_asked_for(
+    transfer, media_host, media_syncer,
+):
+    """Only a suppressed request is resumed, not every completed scan."""
+    _make_save(media_host.media / "ankimon.db", pokemon=5)
+    st.start_media_migration(None, _Logger())
+    media_host.finish()
+
+    assert media_host.pm.media_syncing_enabled() is True
+    assert media_syncer == []
+
+
+def test_media_sync_switched_off_by_the_user_is_never_resumed(
+    transfer, media_host, media_syncer, monkeypatch,
+):
+    """The guard defers requests; it must not manufacture one."""
+    monkeypatch.setattr(media_host.pm, "media_syncing_enabled", lambda: False)
+    _make_save(media_host.media / "ankimon.db", pokemon=5)
+    st.start_media_migration(None, _Logger())
+
+    assert media_host.pm.media_syncing_enabled() is False
+    media_host.finish()
+    assert media_host.pm.media_syncing_enabled() is False
+    assert media_syncer == []
+
+
+def test_a_deferred_sync_is_resumed_only_once(transfer, media_host, media_syncer):
+    """A later settled pass must not re-request the sync it already restarted."""
+    _make_save(media_host.media / "ankimon.db", pokemon=5)
+    st.start_media_migration(None, _Logger())
+    assert media_host.pm.media_syncing_enabled() is False
+    media_host.finish()
+    assert len(media_syncer) == 1
+
+    (media_host.media / "ankimon.db").unlink()
+    st.start_media_migration(None, _Logger())
+    if media_host.queued:
+        media_host.finish()
+    assert len(media_syncer) == 1

--- a/tests/test_pr850_media_review.py
+++ b/tests/test_pr850_media_review.py
@@ -20,8 +20,10 @@ def media_host(transfer, tmp_path, monkeypatch):
     media = tmp_path / "collection.media"
     media.mkdir()
     queued = []
+    # The user's own preference, read through whatever guard gets installed.
+    preference = [True]
     pm = SimpleNamespace(profile={}, profileFolder=lambda: str(tmp_path),
-                         media_syncing_enabled=lambda: True, save=lambda: None)
+                         media_syncing_enabled=lambda: preference[0], save=lambda: None)
     monkeypatch.setattr(st.mw, "pm", pm)
     monkeypatch.setattr(st, "_MIGRATION_SCAN_STATE", {"running": False, "rerun": False})
     monkeypatch.setattr(st.mw.taskman, "run_in_background",
@@ -34,7 +36,8 @@ def media_host(transfer, tmp_path, monkeypatch):
             future.result()
         done(future)
 
-    return SimpleNamespace(media=media, pm=pm, queued=queued, finish=finish)
+    return SimpleNamespace(media=media, pm=pm, queued=queued, finish=finish,
+                           preference=preference)
 
 
 @pytest.mark.parametrize("readable", [False, True])
@@ -137,14 +140,22 @@ def test_cancel_menu_reports_manifest_lock_without_losing_pending_import(transfe
     from Ankimon import save_import
 
     info = save_import.stage_import(transfer.incoming, transfer.active)
-    unlink = Path.unlink
+    unlink, open_path = Path.unlink, Path.open
 
-    def locked(path, *args, **kwargs):
+    # A lock that keeps the cancellation from being written keeps it from
+    # happening at all, so it must hold the writer out as well as the unlink.
+    def locked_unlink(path, *args, **kwargs):
         if path.name == "pending.json":
             raise PermissionError("manifest locked")
         return unlink(path, *args, **kwargs)
 
-    monkeypatch.setattr(Path, "unlink", locked)
+    def locked_open(path, mode="r", *args, **kwargs):
+        if path.name == "pending.json" and mode != "r":
+            raise PermissionError("manifest locked")
+        return open_path(path, mode, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "unlink", locked_unlink)
+    monkeypatch.setattr(Path, "open", locked_open)
     st.cancel_pending_save_import()
     assert save_import.pending_import_info(transfer.active)["token"] == info["token"]
     assert "could not be cancelled" in st.showWarning.call_args.args[0]
@@ -560,16 +571,42 @@ def test_the_gate_fails_open_when_the_profile_folder_cannot_be_read(
     st.start_media_migration(None, _Logger())
     assert media_host.pm.media_syncing_enabled() is False
 
+    folder_reads = []
+
     def gone():
+        folder_reads.append(True)
         raise OSError("the profile volume went away")
 
     monkeypatch.setattr(media_host.pm, "profileFolder", gone)
     assert media_host.pm.media_syncing_enabled() is True
+    assert folder_reads == [True]
 
-    # A user who has media sync switched off is answered without touching disk.
-    monkeypatch.setattr(media_host.pm, "media_syncing_enabled", lambda: False,
-                        raising=False)
+    # A user who has media sync switched off is answered without touching disk,
+    # by the guard that is installed rather than by a replacement for it.
+    media_host.preference[0] = False
     assert media_host.pm.media_syncing_enabled() is False
+    assert folder_reads == [True]
+
+
+def test_a_deferred_sync_that_cannot_be_restarted_is_logged_and_kept(
+    transfer, media_host, media_syncer, monkeypatch,
+):
+    """The request stays owed for a later release; the log is the only trace why."""
+    from Ankimon.services import services
+
+    def refuse(*args):
+        raise RuntimeError("the media syncer is shutting down")
+
+    monkeypatch.setattr(st.mw.media_syncer, "start", refuse)
+    _make_save(media_host.media / "ankimon.db", pokemon=5)
+    st.start_media_migration(None, _Logger())
+    assert media_host.pm.media_syncing_enabled() is False
+
+    media_host.finish()
+
+    assert media_host.media in media_host.pm._ankimon_media_protection_guard["deferred"]
+    assert any("deferred media sync" in message and "shutting down" in message
+               for message in services.logger.errors)
 
 
 def test_a_retry_that_cannot_run_still_lets_another_be_scheduled(

--- a/tests/test_pr850_media_review.py
+++ b/tests/test_pr850_media_review.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import sqlite3
 import threading
 import sys
+import zipfile
 from types import SimpleNamespace
 
 import pytest
@@ -173,6 +174,25 @@ def test_browse_tightens_existing_recovery_directory(transfer, monkeypatch):
     st.browse_recovered_saves()
     assert recovery.stat().st_mode & 0o777 == 0o700
     assert opened == [str(recovery)]
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX directory permissions")
+def test_browse_still_opens_a_folder_whose_permissions_cannot_change(transfer, monkeypatch):
+    """A FAT or exFAT volume refuses chmod; the folder can still be shown."""
+    import errno
+
+    recovery = transfer.active.parent / "ankimon_recovery"
+    recovery.mkdir()
+    opened = []
+    monkeypatch.setattr(sys.modules["aqt.utils"], "openFolder", lambda path: opened.append(path), raising=False)
+
+    def fixed_permissions(self, mode, *args, **kwargs):
+        raise PermissionError(errno.EPERM, "Operation not permitted", str(self))
+
+    monkeypatch.setattr(Path, "chmod", fixed_permissions)
+    st.browse_recovered_saves()
+    assert opened == [str(recovery)]
+    st.showWarning.assert_not_called()
 
 
 def test_scan_result_is_discarded_when_the_media_save_changes_mid_scan(
@@ -458,7 +478,10 @@ def test_capture_signature_ignores_reader_created_shm(transfer, media_host):
     # clean close. Settle that before measuring a reader's ongoing effect.
     assert st.get_db_stats(source, timeout=5) is not None
     shm = Path(str(source) + "-shm")
-    assert shm.is_file()
+    if not shm.is_file():
+        # A build or VFS that removes the index when the reader closes cannot
+        # restamp it, so the churn this test guards against cannot happen there.
+        pytest.skip("this SQLite build removes -shm when a read-only reader closes")
     before_shm = shm.stat()
     _, before = st._pending_media_protection(media_host.media, source)
 
@@ -651,3 +674,205 @@ def test_a_retry_that_cannot_run_still_lets_another_be_scheduled(
     st._schedule_migration_retry(None, _Logger())
     assert len([entry for entry in timers
                 if entry[0] > st._MIGRATION_RETRY_DELAY * 1000]) == 2
+
+
+def test_reopening_a_profile_captured_earlier_this_session_resumes_media_sync(
+    transfer, media_host,
+):
+    """guard_media_saves_now only stats files, so a reopen re-arms the guard.
+
+    The scan that follows finds the folder already settled and returns early.
+    Nothing after that return lifted the guard, and while it is up no media-sync
+    hook fires to bring a rescan: media sync stayed paused until Anki restarted.
+    """
+    _make_save(media_host.media / "ankimon.db", pokemon=1)
+    log = _Logger()
+    st.guard_media_saves_now(log)
+    st.start_media_migration(None, log)
+    media_host.finish()
+    assert st._migration_done()
+    assert media_host.pm.media_syncing_enabled() is True
+
+    # File > Switch Profile, and back to this one.
+    st.guard_media_saves_now(log)
+    assert media_host.pm.media_syncing_enabled() is False
+    st.start_media_migration(None, log)
+
+    assert media_host.queued == []
+    assert media_host.pm.media_syncing_enabled() is True
+
+
+def test_a_retry_that_fires_before_the_throttle_ends_arms_another(
+    transfer, media_host, monkeypatch,
+):
+    """Qt rounds a 30 s timer to whole seconds and can fire it half a second early.
+
+    The throttle turns that retry away, as it does a timer armed for an earlier
+    pass after a later failed pass moved retry_at on. The return scheduled
+    nothing, so the guard stayed up with no retry left to lift it.
+    """
+    source = media_host.media / "ankimon.db"
+    _make_save(source, pokemon=5)
+
+    def captures_nothing(media_dir):
+        return {"protected": {}, "unprotected": [source], "archives": [],
+                "archived_sources": [], "log": []}
+
+    monkeypatch.setattr(st, "_protect_bare_saves", captures_nothing)
+    timers = []
+    monkeypatch.setattr(st.mw.progress, "single_shot",
+                        lambda ms, func, *args: timers.append((ms, func)))
+    now = [100.0]
+    monkeypatch.setattr(st.time, "monotonic", lambda: now[0])
+
+    st.start_media_migration(None, _Logger())
+    media_host.finish()
+    [(_, retry)] = [entry for entry in timers
+                    if entry[0] > st._MIGRATION_RETRY_DELAY * 1000]
+
+    now[0] += st._MIGRATION_RETRY_DELAY - 0.5
+    timers.clear()
+    retry()
+    assert media_host.queued == []
+    assert media_host.pm.media_syncing_enabled() is False
+    # One more timer, for what is left of the throttle rather than a full delay.
+    [(delay, retry)] = timers
+    assert 500 <= delay < st._MIGRATION_RETRY_DELAY * 1000
+
+    now[0] += delay / 1000
+    retry()
+    assert len(media_host.queued) == 1, "the re-armed retry did not dispatch a scan"
+
+
+def test_a_rerun_for_a_profile_that_closed_mid_scan_is_dropped(
+    transfer, media_host, monkeypatch,
+):
+    """File > Switch Profile during a scan leaves the profile manager showing.
+
+    The media folder still resolves by profile name, so a pass dispatched then
+    put its warnings and the rescue prompt over the profile picker.
+    """
+    from Ankimon.services import services
+
+    _make_save(media_host.media / "ankimon.db", pokemon=5)
+    st.start_media_migration(None, _Logger())
+    st.start_media_migration(None, _Logger())  # a media-sync stop during the scan
+    assert st._MIGRATION_SCAN_STATE["rerun"] is True
+
+    monkeypatch.setattr(services, "col", None)
+    monkeypatch.setattr(st.mw, "col", None, raising=False)
+    media_host.finish()
+
+    assert media_host.queued == []
+    assert st._MIGRATION_SCAN_STATE["rerun"] is False
+
+
+def test_an_unreadable_wal_save_is_archived_once_however_often_it_is_read(
+    transfer, media_host,
+):
+    """Every read-only open restamps -shm, so archiving it made each pass new.
+
+    Each pass then wrote another full-size archive and showed the warning again.
+    """
+    source = media_host.media / "ankimon.db"
+    source.write_bytes(b"unreadable database" * 100)
+    Path(str(source) + "-wal").write_bytes(b"wal frames" * 10)
+    shm = Path(str(source) + "-shm")
+    shm.write_bytes(b"index" * 10)
+    first = st._protect_bare_saves(media_host.media)
+    shm.write_bytes(b"rebuilt index" * 10)
+    stamp = shm.stat().st_mtime_ns + 5_000_000_000
+    os.utime(shm, ns=(stamp, stamp))
+    second = st._protect_bare_saves(media_host.media)
+
+    assert first["archives"] == second["archives"]
+    [archive] = first["archives"]
+    with zipfile.ZipFile(archive) as bundle:
+        assert sorted(bundle.namelist()) == ["ankimon.db", "ankimon.db-wal"]
+
+
+def _pause_notice():
+    [text] = [call.args[0] for call in st.showWarning.call_args_list
+              if "Media sync is paused" in call.args[0]]
+    return text
+
+
+def test_the_pause_notice_promises_a_timed_retry_when_one_is_armed(
+    transfer, media_host, monkeypatch,
+):
+    """The guard rescans by itself; a restart mid-review is what its timer avoids."""
+    source = media_host.media / "ankimon.db"
+    _make_save(source, pokemon=1)
+
+    def captures_nothing(media_dir):
+        return {"protected": {}, "unprotected": [source], "archives": [],
+                "archived_sources": [], "log": []}
+
+    monkeypatch.setattr(st, "_protect_bare_saves", captures_nothing)
+    monkeypatch.setattr(st, "_LAST_PROTECTION_NOTICE", None)
+    monkeypatch.setattr(st.mw.progress, "single_shot", lambda *args: None)
+    st.start_media_migration(None, _Logger())
+    media_host.finish()
+
+    assert st._MIGRATION_SCAN_STATE.get("retry_scheduled") is True
+    text = _pause_notice()
+    assert "about every 30 seconds" in text
+    assert "restart Anki to retry" not in text
+
+
+def test_a_scan_that_could_not_be_dispatched_promises_no_timed_retry(
+    transfer, media_host, monkeypatch,
+):
+    """No timer is armed there, and arming one would repeat its own warning.
+
+    The dispatch failure shows a second warning of its own, so a 30-second timer
+    would bring both back every 30 seconds for as long as the executor refused.
+    """
+    _make_save(media_host.media / "ankimon.db", pokemon=17)
+
+    def refused(*args, **kwargs):
+        raise RuntimeError("executor stopped")
+
+    monkeypatch.setattr(st.mw.taskman, "run_in_background", refused)
+    monkeypatch.setattr(st, "_LAST_PROTECTION_NOTICE", None)
+    st.start_media_migration(None, _Logger())
+
+    assert not st._MIGRATION_SCAN_STATE.get("retry_scheduled")
+    text = _pause_notice()
+    assert "restart Anki to retry" in text
+    assert "about every 30 seconds" not in text
+
+
+def test_reopening_within_the_throttle_restores_a_verdict_that_released_the_guard(
+    transfer, media_host, monkeypatch,
+):
+    """An archived but unverified save leaves nothing uncaptured and arms no retry.
+
+    A reopen inside the 30-second throttle re-arms the stat-only guard, and the
+    throttled return is all that runs next. Only putting that pass's verdict
+    back lifts the guard: without it media sync stayed paused with no timer.
+    """
+    source = media_host.media / "ankimon.db"
+    _make_save(source, pokemon=1)
+    archive = media_host.media.parent / "ankimon-media-recovery" / "unverified.zip"
+
+    def archives_without_verifying(media_dir):
+        return {"protected": {}, "unprotected": [source], "archives": [archive],
+                "archived_sources": [source], "log": []}
+
+    monkeypatch.setattr(st, "_protect_bare_saves", archives_without_verifying)
+    monkeypatch.setattr(st.time, "monotonic", lambda: 100.0)
+    log = _Logger()
+    st.guard_media_saves_now(log)
+    st.start_media_migration(None, log)
+    media_host.finish()
+    assert media_host.pm.media_syncing_enabled() is True
+    assert not st._MIGRATION_SCAN_STATE.get("retry_scheduled")
+
+    # File > Switch Profile and back, well inside the throttle.
+    st.guard_media_saves_now(log)
+    assert media_host.pm.media_syncing_enabled() is False
+    st.start_media_migration(None, log)
+
+    assert media_host.queued == []
+    assert media_host.pm.media_syncing_enabled() is True

--- a/tests/test_pr850_media_review.py
+++ b/tests/test_pr850_media_review.py
@@ -189,3 +189,66 @@ def test_scan_result_is_discarded_when_the_media_save_changes_mid_scan(
     assert len(media_host.queued) == 1
     media_host.finish()
     assert len(applied) == 1
+
+
+def test_capture_is_bound_to_a_revision_observed_across_the_copy(
+    transfer, media_host, monkeypatch,
+):
+    """A writer landing INSIDE the capture must not look like a settled scan.
+
+    _preserve verifies the bytes it wrote, not that the source held still while
+    it read them. Recording the source signature only afterwards described the
+    new version while the recovery copy held the old one, so the callback
+    compared new against new, agreed, and released the sync guard over progress
+    that had never been preserved.
+    """
+    source = _make_save(media_host.media / "ankimon.db", pokemon=2)
+    applied = []
+    monkeypatch.setattr(st, "_apply_migration_result",
+                        lambda result, logger: applied.append(result))
+    preserve, overwritten = st._preserve, []
+
+    def preserve_then_overwrite(at_risk, *args, **kwargs):
+        protected = preserve(at_risk, *args, **kwargs)
+        if Path(at_risk) == source and not overwritten:
+            overwritten.append(True)
+            source.unlink()
+            _make_save(source, pokemon=9)
+        return protected
+
+    monkeypatch.setattr(st, "_preserve", preserve_then_overwrite)
+    st.start_media_migration(None, _Logger())
+    media_host.finish()
+
+    # What is in the folder now was never captured, so nothing from this pass
+    # may be offered and media sync stays paused.
+    assert overwritten == [True]
+    assert applied == []
+    assert media_host.pm.media_syncing_enabled() is False
+    recovery = st._recovery_store(media_host.media)
+    assert [st.get_db_stats(copy)["pokemon"] for copy in recovery.glob("*.db")] == [2]
+    assert st.get_db_stats(source)["pokemon"] == 9
+
+    # The coalesced rerun captures what is actually there, and only that
+    # releases the guard.
+    assert len(media_host.queued) == 1
+    media_host.finish()
+    assert len(applied) == 1
+    assert media_host.pm.media_syncing_enabled() is True
+    assert sorted(st.get_db_stats(copy)["pokemon"] for copy in recovery.glob("*.db")) == [2, 9]
+
+
+def test_an_untouched_capture_still_settles_in_one_pass(transfer, media_host, monkeypatch):
+    """The stability check must not cost an extra pass on the normal path."""
+    _make_save(media_host.media / "ankimon.db", pokemon=2)
+    applied = []
+    monkeypatch.setattr(st, "_apply_migration_result",
+                        lambda result, logger: applied.append(result))
+
+    st.start_media_migration(None, _Logger())
+    media_host.finish()
+
+    assert len(applied) == 1
+    assert applied[0]["stable"] is True
+    assert media_host.queued == []
+    assert media_host.pm.media_syncing_enabled() is True

--- a/tests/test_pr850_media_review.py
+++ b/tests/test_pr850_media_review.py
@@ -3,6 +3,7 @@
 from concurrent.futures import ThreadPoolExecutor
 import os
 from pathlib import Path
+import sqlite3
 import threading
 import sys
 from types import SimpleNamespace
@@ -416,3 +417,66 @@ def test_the_gate_and_the_release_cannot_interleave(
     # And the request that was recorded under that lock is the one replayed.
     media_host.finish()
     assert media_syncer == [(True,)]
+
+
+def _make_wal_save(path: Path, **kwargs) -> None:
+    """A save in WAL journal mode, as a peer's synced copy can easily be.
+
+    Closed cleanly, so no sidecar is on disk: the next reader materialises them.
+    """
+    _make_save(path, **kwargs)
+    conn = sqlite3.connect(str(path))
+    try:
+        conn.execute("PRAGMA journal_mode=WAL")
+        conn.execute("INSERT INTO items VALUES ('elixir', 1)")
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def test_capture_signature_ignores_reader_created_shm(transfer, media_host):
+    """Reading a WAL save restamps its -shm; that is not somebody else writing.
+
+    The capture signature is compared before and after preservation to decide
+    whether a writer landed mid-copy. Counting the scan's own -shm churn as a
+    change would make every pass over a WAL-mode media save look unstable.
+    """
+    source = media_host.media / "ankimon.db"
+    _make_wal_save(source, pokemon=2)
+    # The first reader materialises -wal and -shm; both are absent after a
+    # clean close. Settle that before measuring a reader's ongoing effect.
+    assert st.get_db_stats(source, timeout=5) is not None
+    shm = Path(str(source) + "-shm")
+    assert shm.is_file()
+    before_shm = shm.stat()
+    _, before = st._pending_media_protection(media_host.media, source)
+
+    assert st.get_db_stats(source, timeout=5) is not None
+    # A read's own restamp is not reliably observable inside one test run, so
+    # apply the change a reader makes explicitly as well.
+    stamp = before_shm.st_mtime_ns + 5_000_000_000
+    os.utime(shm, ns=(stamp, stamp))
+    assert shm.stat().st_mtime_ns != before_shm.st_mtime_ns
+
+    _, after = st._pending_media_protection(media_host.media, source)
+    assert after == before
+
+
+def test_wal_media_save_settles_instead_of_rescanning_forever(transfer, media_host):
+    """A WAL save must not re-arm the scan on its own sidecars, pass after pass.
+
+    ``stable`` gates the guard release, so a signature the scan perturbs itself
+    would keep dispatching workers and keep media sync paused indefinitely.
+    """
+    source = media_host.media / "ankimon.db"
+    _make_wal_save(source, pokemon=2)
+    st.start_media_migration(None, _Logger())
+    passes = 0
+    while media_host.queued and passes < 8:
+        media_host.finish()
+        passes += 1
+    assert not media_host.queued, "the scan never stopped re-dispatching itself"
+    # One extra pass is expected and bounded: the first reader creates -wal,
+    # which is a real content sidecar and stays in the signature.
+    assert passes <= 2
+    assert media_host.pm.media_syncing_enabled() is True

--- a/tests/test_profile_hooks.py
+++ b/tests/test_profile_hooks.py
@@ -105,7 +105,9 @@ def _exec_profile_hooks(monkeypatch, gui_hooks):
     monkeypatch.setitem(
         sys.modules,
         "Ankimon.pyobj.save_transfer",
-        _stub_module("Ankimon.pyobj.save_transfer", register_media_migration_hooks=MagicMock()),
+        _stub_module("Ankimon.pyobj.save_transfer",
+                     register_media_migration_hooks=MagicMock(),
+                     guard_media_saves_now=MagicMock()),
     )
     monkeypatch.setitem(
         sys.modules,
@@ -262,7 +264,8 @@ class _Future:
         return self._value
 
 
-def _fire_profile_did_open(monkeypatch, *, mobile_enabled=True, warm_error=None):
+def _fire_profile_did_open(monkeypatch, *, mobile_enabled=True, warm_error=None,
+                           record=None):
     """Register hooks, then fire the profile_did_open handler with the given
     settings.
 
@@ -274,6 +277,16 @@ def _fire_profile_did_open(monkeypatch, *, mobile_enabled=True, warm_error=None)
     profile_hooks = _exec_profile_hooks(monkeypatch, gui_hooks)
     if warm_error is not None:
         profile_hooks._warm.side_effect = warm_error
+    if record is not None:
+        # side_effect rather than replacement: profile_hooks binds these names
+        # at import time, so the mock objects themselves have to stay.
+        for module_name, attribute in (
+            ("Ankimon.pyobj.save_transfer", "guard_media_saves_now"),
+            ("Ankimon.pyobj.tip_of_the_day", "show_tip_of_the_day"),
+            ("Ankimon.pyobj.save_transfer", "register_media_migration_hooks"),
+        ):
+            mock = getattr(sys.modules[module_name], attribute)
+            mock.side_effect = (lambda name: lambda *a, **k: record.append(name))(attribute)
 
     def _get(key, default=None):
         return {
@@ -319,6 +332,30 @@ def test_media_migration_hooks_registered_on_profile_open(monkeypatch):
     _, _, transfer_mod = _fire_profile_did_open(monkeypatch)
 
     transfer_mod.register_media_migration_hooks.assert_called_once()
+    transfer_mod.guard_media_saves_now.assert_called_once()
+
+
+def test_the_media_guard_precedes_every_dialog_and_the_scan_follows_them(monkeypatch):
+    """A modal spins a nested event loop, which delivers taskman callbacks.
+
+    So the scan must be dispatched with nothing left in this handler that can
+    pump the loop -- otherwise its completion runs re-entrantly inside a dialog,
+    and the rescue it may offer reaches close_anki while Anki's loadProfile is
+    still on the stack. The guard is the opposite case: it has to be up before
+    the first of those dialogs, so it is called separately, first.
+    """
+    order = []
+    profile_hooks, _, transfer_mod = _fire_profile_did_open(
+        monkeypatch,
+        record=order,
+    )
+
+    assert order, "no ordered calls were recorded"
+    assert order[0] == "guard_media_saves_now"
+    assert order[-1] == "register_media_migration_hooks"
+    assert "show_tip_of_the_day" in order
+    assert order.index("guard_media_saves_now") < order.index("show_tip_of_the_day")
+    assert order.index("show_tip_of_the_day") < order.index("register_media_migration_hooks")
 
 
 # --- Static-data re-warm on profile open ------------------------------------

--- a/tests/test_save_import.py
+++ b/tests/test_save_import.py
@@ -9,6 +9,7 @@ import sqlite3
 import stat
 import subprocess
 import sys
+import time
 from types import SimpleNamespace
 
 import pytest
@@ -369,6 +370,7 @@ def test_post_install_failure_reports_installed_and_retries_without_losing_progr
         "token = module.pending_import_info(target)['token']\n"
         "failure = sys.argv[3]\n"
         "sync, cleanup, unlink = module._fsync_directory, module._remove_owned_copy, Path.unlink\n"
+        "open_path = Path.open\n"
         "def fail_sync(path):\n"
         "    if path == target.parent and module._installed_token(target) == token:\n"
         "        raise OSError('injected directory sync failure')\n"
@@ -381,9 +383,15 @@ def test_post_install_failure_reports_installed_and_retries_without_losing_progr
         "    if path.name == 'pending.json':\n"
         "        raise OSError('injected manifest cleanup failure')\n"
         "    return unlink(path, *args, **kwargs)\n"
+        # Retiring the record is committed by rewriting it, so a lock has to
+        # hold the writer out, not only the unlink, to leave it unretired.
+        "def fail_retire(path, mode='r', *args, **kwargs):\n"
+        "    if path.name == 'pending.json' and mode != 'r':\n"
+        "        raise OSError('injected manifest cleanup failure')\n"
+        "    return open_path(path, mode, *args, **kwargs)\n"
         "if failure == 'directory_sync': module._fsync_directory = fail_sync\n"
         "elif failure == 'temporary_cleanup': module._remove_owned_copy = fail_cleanup\n"
-        "else: Path.unlink = fail_unlink\n"
+        "else: Path.unlink, Path.open = fail_unlink, fail_retire\n"
         "try:\n"
         "    module.commit_pending_import(target)\n"
         "except Exception as error:\n"
@@ -639,12 +647,105 @@ def test_a_manifest_that_vanishes_before_read_back_leaves_nothing_staged(tmp_pat
     assert names(target) == ["local"]
 
 
-def test_cancellation_holds_even_when_its_durability_flush_fails(tmp_path, monkeypatch):
-    """Removing the manifest is what stops the install, so say so.
+def test_a_cancellation_survives_a_crash_that_undoes_its_removals(tmp_path, monkeypatch):
+    """Cancel is committed on disk before anything is removed.
 
-    Reporting "could not be cancelled, try again" after the manifest is gone
+    Without a directory sync, a crash can bring back both ``pending.json`` and
+    the staged copy, and the next start would install over progress made after
+    the user was told the import was cancelled. The record is rewritten in place
+    and synced as a file first, so what a crash brings back installs nothing.
+    """
+    importer = load_module()
+    target = make_save(tmp_path / "ankimon.db", "local")
+    source = make_save(tmp_path / "source.db", "incoming")
+    staged = importer.stage_import(source, target)
+    manifest = staged["pending_path"].parent / "pending.json"
+    unlink = Path.unlink
+
+    def undone_by_the_crash(path, *args, **kwargs):
+        if path == manifest:
+            return None
+        return unlink(path, *args, **kwargs)
+
+    def failing_sync(path):
+        raise OSError("injected cancellation flush failure")
+
+    monkeypatch.setattr(importer, "_fsync_directory", failing_sync)
+    monkeypatch.setattr(importer, "_remove_owned_copy", lambda path: None)
+    monkeypatch.setattr(Path, "unlink", undone_by_the_crash)
+    assert importer.cancel_pending_import(target) is True
+    monkeypatch.undo()
+
+    # The crash left both files in place, and play went on afterwards.
+    assert manifest.is_file() and staged["pending_path"].is_file()
+    with sqlite3.connect(target) as conn:
+        conn.execute("INSERT INTO captured_pokemon VALUES ('after-cancel', '{}')")
+    assert importer.pending_import_info(target) is None
+    assert json.loads(commit_in_new_process(target).stdout)["installed"] is False
+    assert names(target) == ["after-cancel", "local"]
+
+    # Finishing off the leftover is not reported as a second cancellation.
+    assert importer.cancel_pending_import(target) is False
+    assert not manifest.exists()
+    assert not staged["pending_path"].exists()
+
+
+def test_a_cancellation_that_cannot_reach_the_disk_is_reported_and_kept(tmp_path, monkeypatch):
+    """If the commit itself cannot be synced, the import has not been cancelled.
+
+    A crash could bring it back as it was, so "cancelled" would be a promise
+    nobody kept. The record is put back for this session too: the retry that
+    the warning asks for must find something to cancel.
+    """
+    importer = load_module()
+    target = make_save(tmp_path / "ankimon.db", "local")
+    source = make_save(tmp_path / "source.db", "incoming")
+    staged = importer.stage_import(source, target)
+
+    def failing_fsync(descriptor):
+        raise OSError("injected file sync failure")
+
+    monkeypatch.setattr(importer.os, "fsync", failing_fsync)
+    with pytest.raises(OSError, match="injected file sync failure"):
+        importer.cancel_pending_import(target)
+    monkeypatch.undo()
+
+    assert importer.pending_import_info(target)["token"] == staged["token"]
+    assert staged["pending_path"].is_file()
+    assert importer.cancel_pending_import(target) is True
+    assert json.loads(commit_in_new_process(target).stdout)["installed"] is False
+    assert names(target) == ["local"]
+
+
+def test_a_new_import_can_be_staged_over_a_cancelled_record(tmp_path, monkeypatch):
+    """A cancelled record that could not be removed blocks nothing."""
+    importer = load_module()
+    target = make_save(tmp_path / "ankimon.db", "local")
+    first = make_save(tmp_path / "first.db", "first")
+    second = make_save(tmp_path / "second.db", "second")
+    staged = importer.stage_import(first, target)
+    manifest = staged["pending_path"].parent / "pending.json"
+    unlink = Path.unlink
+    monkeypatch.setattr(
+        Path, "unlink",
+        lambda path, *args, **kwargs: None if path == manifest else unlink(path, *args, **kwargs),
+    )
+    assert importer.cancel_pending_import(target) is True
+    monkeypatch.undo()
+    assert manifest.is_file()
+
+    importer.stage_import(second, target)
+    assert json.loads(commit_in_new_process(target).stdout)["installed"] is True
+    assert names(target) == ["second"]
+
+
+def test_cancellation_holds_even_when_its_directory_flush_fails(tmp_path, monkeypatch):
+    """The synced cancelled record is what stops the install, so say so.
+
+    Reporting "could not be cancelled, try again" once that record is on disk
     earns a "there is no pending save import" on the retry, and the user cannot
-    tell from Ankimon which of the two to believe.
+    tell from Ankimon which of the two to believe. Some network and FUSE mounts
+    refuse a directory sync outright, which would fail every cancellation.
     """
     importer = load_module()
     target = make_save(tmp_path / "ankimon.db", "local")
@@ -788,3 +889,72 @@ def test_a_spent_startup_budget_refuses_rather_than_waiting_again(tmp_path):
     )
     assert names(target) == ["local"]
     assert importer.pending_import_info(target) is not None
+
+
+def test_whole_file_reads_and_copies_check_the_budget_between_blocks(tmp_path, monkeypatch):
+    """One large save must not carry a startup install past its budget."""
+    importer = load_module()
+    source = tmp_path / "large.db"
+    source.write_bytes(b"\0" * (3 * 1024 * 1024))
+    clock = [0.0]
+
+    def tick():
+        clock[0] += 1
+        return clock[0]
+
+    monkeypatch.setattr(importer.time, "monotonic", tick)
+    with pytest.raises(TimeoutError):
+        importer._digest(source, deadline=2.5)
+    clock[0] = 0.0
+    with pytest.raises(TimeoutError):
+        importer._copy_within(source, tmp_path / "copy.db", deadline=2.5)
+    assert (tmp_path / "copy.db").stat().st_size < source.stat().st_size
+
+
+def test_a_budget_spent_during_the_install_copy_leaves_the_old_save_pending(tmp_path):
+    """Copying the save into place is the largest step, and the last one checked."""
+    importer = load_module()
+    target = make_save(tmp_path / "ankimon.db", "local")
+    source = make_save(tmp_path / "source.db", "incoming")
+    importer.stage_import(source, target)
+
+    child(
+        "import time\n"
+        "copy = module._copy_within\n"
+        "def slow_disk(source, dest, deadline=None):\n"
+        "    module.time.monotonic = lambda: deadline + 1\n"
+        "    return copy(source, dest, deadline)\n"
+        "module._copy_within = slow_disk\n"
+        "try:\n"
+        "    module.commit_pending_import(target, deadline=time.monotonic() + 60)\n"
+        "except TimeoutError:\n"
+        "    pass\n"
+        "else:\n"
+        "    raise AssertionError('the install copy ignored its budget')\n",
+        target,
+    )
+    assert names(target) == ["local"]
+    assert importer.pending_import_info(target) is not None
+    assert not list(tmp_path.glob(".ankimon-install-*"))
+
+
+def test_a_locked_save_answers_unknown_within_the_wording_budget(tmp_path):
+    """The menu asks this on the GUI thread, only to choose its wording.
+
+    SQLite's own busy timeout here would be 30 seconds of a frozen Anki, and a
+    save that cannot be read is evidence of neither answer.
+    """
+    importer = load_module()
+    target = make_save(tmp_path / "ankimon.db", "local")
+    source = make_save(tmp_path / "source.db", "incoming")
+    importer.stage_import(source, target)
+    locker = sqlite3.connect(target, isolation_level=None)
+    try:
+        locker.execute("BEGIN EXCLUSIVE")
+        started = time.monotonic()
+        assert importer.pending_import_is_installed(target) is None
+        assert time.monotonic() - started < importer._WORDING_BUDGET + 3
+    finally:
+        locker.execute("ROLLBACK")
+        locker.close()
+    assert importer.pending_import_is_installed(target) is False

--- a/tests/test_save_import.py
+++ b/tests/test_save_import.py
@@ -520,3 +520,103 @@ def test_rebase_rolls_back_watermark_if_marker_cannot_be_retired(tmp_path):
         }
     finally:
         conn.close()
+
+
+@pytest.mark.parametrize("failure", ["staging_directory", "target_directory", "read_back"])
+def test_publication_failure_reports_a_pending_import_rather_than_an_abort(
+    tmp_path, monkeypatch, failure,
+):
+    """Replacing pending.json is the commit point; later steps cannot undo it.
+
+    Durability and read-back run after publication and deliberately keep the
+    staged copy when they fail. A caller told only "aborted" would leave the
+    user playing on into a replacement they believe cannot happen, so staging
+    reports this state with its own exception.
+    """
+    importer = load_module()
+    target = make_save(tmp_path / "ankimon.db", "local")
+    source = make_save(tmp_path / "source.db", "incoming")
+    _, directory = importer._paths(target)
+    injecting = [True]
+    fsync_directory, read_back = importer._fsync_directory, importer.pending_import_info
+
+    def failing_sync(path):
+        if injecting[0] and Path(path) == (
+            directory if failure == "staging_directory" else target.parent
+        ):
+            raise OSError(f"injected {failure} sync failure")
+        return fsync_directory(path)
+
+    published = []
+
+    def failing_read_back(path):
+        # The guard read at the start of staging must still work: only the
+        # read-back of what this call published is broken.
+        if injecting[0] and failure == "read_back" and published:
+            raise OSError("injected read-back failure")
+        published.append(path)
+        return read_back(path)
+
+    monkeypatch.setattr(importer, "_fsync_directory", failing_sync)
+    monkeypatch.setattr(importer, "pending_import_info", failing_read_back)
+
+    with pytest.raises(importer.ImportStagedError):
+        importer.stage_import(source, target)
+
+    injecting[0] = False
+    staged = importer.pending_import_info(target)
+    assert staged is not None and staged["pending_path"].is_file()
+    # Nothing was replaced yet, and the next full start still installs it.
+    assert names(target) == ["local"]
+    assert json.loads(commit_in_new_process(target).stdout)["installed"] is True
+    assert names(target) == ["incoming"]
+
+
+def test_publication_failure_can_still_be_cancelled(tmp_path, monkeypatch):
+    """The reported remedy has to work: cancelling stops the pending install."""
+    importer = load_module()
+    target = make_save(tmp_path / "ankimon.db", "local")
+    source = make_save(tmp_path / "source.db", "incoming")
+    fsync_directory = importer._fsync_directory
+    injecting = [True]
+
+    def failing_sync(path):
+        if injecting[0] and Path(path) == target.parent:
+            raise OSError("injected sync failure")
+        return fsync_directory(path)
+
+    monkeypatch.setattr(importer, "_fsync_directory", failing_sync)
+    with pytest.raises(importer.ImportStagedError):
+        importer.stage_import(source, target)
+
+    injecting[0] = False
+    assert importer.cancel_pending_import(target) is True
+    assert importer.pending_import_info(target) is None
+    assert json.loads(commit_in_new_process(target).stdout)["installed"] is False
+    assert names(target) == ["local"]
+
+
+def test_a_manifest_that_vanishes_before_read_back_leaves_nothing_staged(tmp_path, monkeypatch):
+    """Nothing will install, so this really is an abort — and must not litter."""
+    importer = load_module()
+    target = make_save(tmp_path / "ankimon.db", "local")
+    source = make_save(tmp_path / "source.db", "incoming")
+    _, directory = importer._paths(target)
+    read_back = importer.pending_import_info
+    published = []
+
+    def vanishing(path):
+        if published:
+            (directory / "pending.json").unlink(missing_ok=True)
+        published.append(path)
+        return read_back(path)
+
+    monkeypatch.setattr(importer, "pending_import_info", vanishing)
+    with pytest.raises(OSError) as raised:
+        importer.stage_import(source, target)
+    assert not isinstance(raised.value, importer.ImportStagedError)
+
+    monkeypatch.undo()
+    assert importer.pending_import_info(target) is None
+    assert list(directory.glob("*.db")) == []
+    assert names(target) == ["local"]

--- a/tests/test_save_import.py
+++ b/tests/test_save_import.py
@@ -439,7 +439,7 @@ def test_existing_recovery_directories_are_private_before_snapshot_access(tmp_pa
     child(
         "import stat\n"
         "snapshot = module._snapshot\n"
-        "def inspect_access(source, dest):\n"
+        "def inspect_access(source, dest, deadline=None):\n"
         "    assert stat.S_IMODE(dest.parent.stat().st_mode) == 0o700\n"
         "    assert stat.S_IMODE(dest.parent.parent.stat().st_mode) == 0o700\n"
         "    snapshot(source, dest)\n"
@@ -740,3 +740,51 @@ def test_repeated_failed_installs_do_not_grow_the_recovery_folder_forever(tmp_pa
     assert names(staged["recovery_path"]) == [
         "local", "run-0", "run-1", "run-2",
     ]
+
+
+def test_an_import_for_a_save_that_no_longer_exists_says_so(tmp_path):
+    """Every step below the check reads the target; a bare SQLite error does not.
+
+    get_db tries both modes on every start and never recreates the developer
+    save, so an unactionable message here repeats for as long as the record does.
+    """
+    importer = load_module()
+    target = make_save(tmp_path / "ankimonDEV.db", "local")
+    source = make_save(tmp_path / "source.db", "incoming")
+    importer.stage_import(source, target)
+    target.unlink()
+
+    child(
+        "try:\n"
+        "    module.commit_pending_import(target)\n"
+        "except FileNotFoundError as error:\n"
+        "    assert 'no longer exists' in str(error), error\n"
+        "    assert 'Cancel Pending Save Import' in str(error), error\n"
+        "else:\n"
+        "    raise AssertionError('a missing target should be reported, not opened')\n",
+        target,
+    )
+    assert importer.pending_import_info(target) is not None
+
+
+def test_a_spent_startup_budget_refuses_rather_than_waiting_again(tmp_path):
+    """The install runs before Anki has a window to say what it is waiting for."""
+    importer = load_module()
+    target = make_save(tmp_path / "ankimon.db", "local")
+    source = make_save(tmp_path / "source.db", "incoming")
+    importer.stage_import(source, target)
+
+    child(
+        "import time\n"
+        "started = time.monotonic()\n"
+        "try:\n"
+        "    module.commit_pending_import(target, deadline=started - 1)\n"
+        "except TimeoutError as error:\n"
+        "    assert 'budget expired' in str(error), error\n"
+        "else:\n"
+        "    raise AssertionError('an expired budget should refuse the install')\n"
+        "assert time.monotonic() - started < 5, 'it waited anyway'\n",
+        target,
+    )
+    assert names(target) == ["local"]
+    assert importer.pending_import_info(target) is not None

--- a/tests/test_save_import.py
+++ b/tests/test_save_import.py
@@ -706,3 +706,37 @@ def test_a_record_left_over_from_an_installed_import_is_recognised(tmp_path):
     with sqlite3.connect(target) as conn:
         conn.execute("UPDATE metadata SET value = 'another-token' WHERE key = 'import_token'")
     assert importer.pending_import_is_installed(target) is False
+
+
+def test_repeated_failed_installs_do_not_grow_the_recovery_folder_forever(tmp_path):
+    """Every attempt snapshots the live save again before it tries to install.
+
+    A lock that does not clear -- the Windows case -- means one attempt per
+    restart, indefinitely, and nothing else prunes this directory: Backup
+    Manager's retention works on a different tree.
+    """
+    importer = load_module()
+    target = make_save(tmp_path / "ankimon.db", "local")
+    source = make_save(tmp_path / "source.db", "incoming")
+    staged = importer.stage_import(source, target)
+
+    refuse_install = (
+        "real_replace = os.replace\n"
+        "def fail_install(source, dest):\n"
+        "    if Path(dest) == target:\n"
+        "        raise PermissionError('simulated antivirus lock')\n"
+        "    return real_replace(source, dest)\n"
+        "module.os.replace = fail_install\n"
+        "module.commit_pending_import(target)\n"
+    )
+    for attempt in range(4):
+        child(refuse_install, target, expected=1)
+        with sqlite3.connect(target) as conn:
+            conn.execute("INSERT INTO captured_pokemon VALUES (?, '{}')", (f"run-{attempt}",))
+
+    copies = list(staged["recovery_path"].parent.glob("*.db"))
+    assert len(copies) == 2, sorted(path.name for path in copies)
+    # The advertised path still holds the most recent attempt's progress.
+    assert names(staged["recovery_path"]) == [
+        "local", "run-0", "run-1", "run-2",
+    ]

--- a/tests/test_save_import.py
+++ b/tests/test_save_import.py
@@ -157,6 +157,41 @@ def test_cancellation_discards_only_pending_import(tmp_path):
     assert names(source) == ["incoming"]
 
 
+def test_cancellation_recovers_from_a_damaged_pending_manifest(tmp_path):
+    importer = load_module()
+    target = make_save(tmp_path / "ankimon.db", "local")
+    source = make_save(tmp_path / "source.db", "incoming")
+    staged = importer.stage_import(source, target)
+    manifest = staged["pending_path"].parent / "pending.json"
+    manifest.write_text("{ definitely-not-json", encoding="utf-8")
+
+    with pytest.raises(json.JSONDecodeError):
+        importer.pending_import_info(target)
+    assert importer.cancel_pending_import(target) is True
+    assert not manifest.exists()
+    assert not staged["pending_path"].exists()
+    assert names(target) == ["local"]
+
+
+def test_cancellation_is_committed_even_if_staged_copy_cleanup_is_locked(
+    tmp_path, monkeypatch
+):
+    importer = load_module()
+    target = make_save(tmp_path / "ankimon.db", "local")
+    source = make_save(tmp_path / "source.db", "incoming")
+    staged = importer.stage_import(source, target)
+    manifest = staged["pending_path"].parent / "pending.json"
+
+    def locked(_path):
+        raise PermissionError("simulated antivirus lock")
+
+    monkeypatch.setattr(importer, "_remove_owned_copy", locked)
+    assert importer.cancel_pending_import(target) is True
+    assert not manifest.exists()
+    assert importer.pending_import_info(target) is None
+    assert names(target) == ["local"]
+
+
 def test_pending_import_applies_only_to_the_explicit_target(tmp_path):
     importer = load_module()
     target = make_save(tmp_path / "ankimonDEV.db", "local")

--- a/tests/test_save_import.py
+++ b/tests/test_save_import.py
@@ -112,6 +112,23 @@ def test_staged_copy_requires_reauthentication_without_exporting_source_secrets(
     assert b"private-legacy-key" not in staged["pending_path"].read_bytes()
 
 
+def test_file_sync_uses_descriptor_that_can_flush_on_windows(tmp_path, monkeypatch):
+    importer = load_module()
+    path = tmp_path / "snapshot.db"
+    path.write_bytes(b"snapshot contents")
+    real_fsync = os.fsync
+
+    def require_write_access(descriptor):
+        # Windows FlushFileBuffers requires a handle with write access. A
+        # zero-byte write exercises that requirement on the host platform too.
+        os.write(descriptor, b"")
+        real_fsync(descriptor)
+
+    monkeypatch.setattr(importer.os, "fsync", require_write_access)
+    importer._fsync_file(path)
+    assert path.read_bytes() == b"snapshot contents"
+
+
 def test_next_process_installs_and_recovers_commits_made_after_staging(tmp_path):
     importer = load_module()
     target = make_save(tmp_path / "ankimon.db", "local")
@@ -320,6 +337,67 @@ def test_crash_after_atomic_install_never_reapplies_import_over_new_progress(tmp
     assert importer.pending_import_info(target) is None
 
 
+@pytest.mark.parametrize("already_installed,failure", [
+    (False, "directory_sync"), (False, "temporary_cleanup"),
+    (False, "manifest_cleanup"), (True, "directory_sync"), (True, "manifest_cleanup"),
+])
+def test_post_install_failure_reports_installed_and_retries_without_losing_progress(
+    tmp_path, failure, already_installed
+):
+    importer = load_module()
+    target = make_save(tmp_path / "ankimon.db", "local")
+    source = make_save(tmp_path / "source.db", "incoming")
+    staged = importer.stage_import(source, target)
+    if already_installed:
+        child(
+            "replace = os.replace\n"
+            "def crash_after_install(source, dest):\n"
+            "    replace(source, dest)\n"
+            "    if Path(dest) == target:\n"
+            "        os._exit(37)\n"
+            "module.os.replace = crash_after_install\n"
+            "module.commit_pending_import(target)\n", target, expected=37,
+        )
+
+    child(
+        "token = module.pending_import_info(target)['token']\n"
+        "failure = sys.argv[3]\n"
+        "sync, cleanup, unlink = module._fsync_directory, module._remove_owned_copy, Path.unlink\n"
+        "def fail_sync(path):\n"
+        "    if path == target.parent and module._installed_token(target) == token:\n"
+        "        raise OSError('injected directory sync failure')\n"
+        "    return sync(path)\n"
+        "def fail_cleanup(path):\n"
+        "    if path.name.startswith('.ankimon-install-'):\n"
+        "        raise OSError('injected temporary cleanup failure')\n"
+        "    return cleanup(path)\n"
+        "def fail_unlink(path, *args, **kwargs):\n"
+        "    if path.name == 'pending.json':\n"
+        "        raise OSError('injected manifest cleanup failure')\n"
+        "    return unlink(path, *args, **kwargs)\n"
+        "if failure == 'directory_sync': module._fsync_directory = fail_sync\n"
+        "elif failure == 'temporary_cleanup': module._remove_owned_copy = fail_cleanup\n"
+        "else: Path.unlink = fail_unlink\n"
+        "try:\n"
+        "    module.commit_pending_import(target)\n"
+        "except Exception as error:\n"
+        "    assert type(error).__name__ == 'ImportInstalledError', repr(error)\n"
+        "    assert 'injected' in str(error)\n"
+        "else:\n"
+        "    raise AssertionError('Expected an installed-with-warning result')\n"
+        "assert module._installed_token(target) == token\n"
+        "assert module.commit_pending_import(target) is False\n", target, failure,
+    )
+    assert names(target) == ["incoming"]
+    assert importer.pending_import_info(target)["token"] == staged["token"]
+    with sqlite3.connect(target) as conn:
+        conn.execute("INSERT INTO captured_pokemon VALUES ('new-progress', '{}')")
+    commit_in_new_process(target)
+    assert names(target) == ["incoming", "new-progress"]
+    assert names(staged["recovery_path"]) == ["local"]
+    assert importer.pending_import_info(target) is None
+
+
 def test_staging_twice_requires_explicit_cancellation(tmp_path):
     importer = load_module()
     target = make_save(tmp_path / "ankimon.db", "local")
@@ -340,6 +418,29 @@ def test_new_recovery_directories_are_private_even_with_permissive_umask(tmp_pat
         assert stat.S_IMODE(staged["recovery_path"].parent.parent.stat().st_mode) == 0o700
         assert stat.S_IMODE(staged["recovery_path"].parent.stat().st_mode) == 0o700
         assert stat.S_IMODE(staged["recovery_path"].stat().st_mode) == 0o600
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX directory permissions")
+def test_existing_recovery_directories_are_private_before_snapshot_access(tmp_path):
+    importer = load_module()
+    target = make_save(tmp_path / "ankimon.db", "local")
+    source = make_save(tmp_path / "source.db", "incoming")
+    staged = importer.stage_import(source, target)
+    recovery_directory = staged["recovery_path"].parent
+    recovery_directory.mkdir(parents=True)
+    recovery_directory.chmod(0o777)
+    recovery_directory.parent.chmod(0o777)
+    child(
+        "import stat\n"
+        "snapshot = module._snapshot\n"
+        "def inspect_access(source, dest):\n"
+        "    assert stat.S_IMODE(dest.parent.stat().st_mode) == 0o700\n"
+        "    assert stat.S_IMODE(dest.parent.parent.stat().st_mode) == 0o700\n"
+        "    snapshot(source, dest)\n"
+        "module._snapshot = inspect_access\n"
+        "assert module.commit_pending_import(target) is True\n", target,
+    )
+    assert names(staged["recovery_path"]) == ["local"]
 
 
 def rebase_state(path, *, marker="1"):

--- a/tests/test_save_import.py
+++ b/tests/test_save_import.py
@@ -4,6 +4,7 @@ import importlib.util
 import json
 import os
 from pathlib import Path
+import shutil
 import sqlite3
 import stat
 import subprocess
@@ -280,6 +281,11 @@ def test_failed_replace_keeps_backup_and_retry_backs_up_latest_progress(tmp_path
     assert names(target) == ["incoming"]
     backups = list(staged["recovery_path"].parent.glob("*.db"))
     assert sorted(names(path) for path in backups) == [["after-failure", "local"], ["local"]]
+    # The advertised path is the only recovery filename the user is ever shown,
+    # so it must hold the LATEST pre-install save, not the first attempt's.
+    assert names(staged["recovery_path"]) == ["after-failure", "local"]
+    superseded = [path for path in backups if path != staged["recovery_path"]]
+    assert [names(path) for path in superseded] == [["local"]]
 
 
 def test_failed_startup_install_cannot_retry_after_runtime_and_module_reload(tmp_path):
@@ -675,3 +681,28 @@ def test_a_second_import_names_the_pending_one_it_is_refusing_for(tmp_path):
     assert json.loads(commit_in_new_process(target).stdout)["installed"] is True
     assert names(target) == ["incoming"]
 
+
+
+def test_a_record_left_over_from_an_installed_import_is_recognised(tmp_path):
+    """The manifest outlives the import when the final cleanup fails.
+
+    ``_finish_installed_import`` retires it after replacement, so what survives
+    that failure describes a save that has ALREADY been replaced. Nothing in the
+    menu could tell the two apart, and both its answers were the wrong way round.
+    """
+    importer = load_module()
+    target = make_save(tmp_path / "ankimon.db", "local")
+    source = make_save(tmp_path / "source.db", "incoming")
+    staged = importer.stage_import(source, target)
+    assert importer.pending_import_is_installed(target) is False
+
+    # Exactly what installation does, without the cleanup that follows it.
+    shutil.copyfile(staged["pending_path"], target)
+    assert names(target) == ["incoming"]
+    assert importer.pending_import_info(target)["token"] == staged["token"]
+    assert importer.pending_import_is_installed(target) is True
+
+    # A record for a DIFFERENT import is still ordinary pending work.
+    with sqlite3.connect(target) as conn:
+        conn.execute("UPDATE metadata SET value = 'another-token' WHERE key = 'import_token'")
+    assert importer.pending_import_is_installed(target) is False

--- a/tests/test_save_import.py
+++ b/tests/test_save_import.py
@@ -1,0 +1,386 @@
+"""Exercise staged imports across real process and SQLite boundaries."""
+
+import importlib.util
+import json
+import os
+from pathlib import Path
+import sqlite3
+import stat
+import subprocess
+import sys
+from types import SimpleNamespace
+
+import pytest
+
+
+MODULE = Path(__file__).resolve().parents[1] / "src/Ankimon/save_import.py"
+
+
+def load_module():
+    assert MODULE.is_file(), "The staged import helper has not been implemented"
+    spec = importlib.util.spec_from_file_location("save_import_under_test", MODULE)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def make_save(path, name):
+    with sqlite3.connect(path) as conn:
+        conn.executescript(
+            "CREATE TABLE captured_pokemon (individual_id TEXT PRIMARY KEY, data TEXT);"
+            "CREATE TABLE config (key TEXT PRIMARY KEY, value TEXT);"
+            "CREATE TABLE user_data (key TEXT PRIMARY KEY, value TEXT);"
+        )
+        conn.execute("INSERT INTO captured_pokemon VALUES (?, '{}')", (name,))
+        conn.executemany("INSERT INTO config VALUES (?, ?)", [
+            ("leaderboard.username", "source-account"),
+            ("leaderboard.api_key", "private-source-api-key"),
+            ("trainer.name", name),
+        ])
+        conn.executemany("INSERT INTO user_data VALUES (?, ?)", [
+            ("username", "legacy-account"), ("api_key", "private-legacy-key"),
+        ])
+    return path
+
+
+def names(path):
+    with sqlite3.connect(path) as conn:
+        return [row[0] for row in conn.execute(
+            "SELECT individual_id FROM captured_pokemon ORDER BY individual_id"
+        )]
+
+
+def child(body, *args, expected=0):
+    setup = (
+        "import importlib.util, json, os, sqlite3, sys\n"
+        "from pathlib import Path\n"
+        "spec = importlib.util.spec_from_file_location('save_import_child', sys.argv[1])\n"
+        "module = importlib.util.module_from_spec(spec)\n"
+        "spec.loader.exec_module(module)\n"
+        "target = Path(sys.argv[2])\n"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", setup + body, str(MODULE), *(str(a) for a in args)],
+        text=True, capture_output=True, timeout=20,
+    )
+    assert result.returncode == expected, result.stdout + result.stderr
+    return result
+
+
+def commit_in_new_process(target, *, expected=0):
+    """Run the real pending-import gate without constructing the Anki host.
+
+    Integration tests can inspect returncode and the JSON ``installed`` value
+    on stdout. Exceptions retain their normal nonzero process exit status.
+    """
+    return child(
+        "print(json.dumps({'installed': module.commit_pending_import(target)}))\n",
+        target, expected=expected,
+    )
+
+
+def test_staging_keeps_runtime_and_source_unchanged_and_requires_fresh_process(tmp_path):
+    importer = load_module()
+    target = make_save(tmp_path / "ankimon.db", "local")
+    source = make_save(tmp_path / "source.db", "incoming")
+    original = source.read_bytes()
+    staged = importer.stage_import(source, target)
+
+    assert names(target) == ["local"]
+    assert source.read_bytes() == original
+    assert staged["pending_path"].is_file()
+    assert not staged["recovery_path"].exists()
+    assert importer.commit_pending_import(target) is False
+    # A module purge/reload is not a new process, even if get_db is reset.
+    assert load_module().commit_pending_import(target) is False
+    assert names(target) == ["local"]
+    assert importer.pending_import_info(target)["token"] == staged["token"]
+
+
+def test_staged_copy_requires_reauthentication_without_exporting_source_secrets(tmp_path):
+    importer = load_module()
+    target = make_save(tmp_path / "ankimon.db", "local")
+    source = make_save(tmp_path / "source.db", "incoming")
+    staged = importer.stage_import(source, target)
+
+    with sqlite3.connect(staged["pending_path"]) as conn:
+        assert dict(conn.execute("SELECT key, value FROM config WHERE key LIKE 'leaderboard.%'")) == {"leaderboard.username": "", "leaderboard.api_key": ""}
+        assert conn.execute("SELECT key FROM user_data").fetchall() == []
+        assert conn.execute("SELECT value FROM config WHERE key='trainer.name'").fetchone()[0] == "incoming"
+        assert conn.execute("SELECT value FROM metadata WHERE key='import_rebase_pending'").fetchone()[0] == "1"
+    assert b"private-source-api-key" not in staged["pending_path"].read_bytes()
+    assert b"private-legacy-key" not in staged["pending_path"].read_bytes()
+
+
+def test_next_process_installs_and_recovers_commits_made_after_staging(tmp_path):
+    importer = load_module()
+    target = make_save(tmp_path / "ankimon.db", "local")
+    source = make_save(tmp_path / "source.db", "incoming")
+    staged = importer.stage_import(source, target)
+    # A killed writer leaves committed data in the WAL. No Anki runtime remains.
+    child(
+        "conn = sqlite3.connect(target)\n"
+        "conn.execute('PRAGMA journal_mode=WAL')\n"
+        "conn.execute('PRAGMA wal_autocheckpoint=0')\n"
+        "conn.execute(\"INSERT INTO captured_pokemon VALUES ('late-commit', '{}')\")\n"
+        "conn.commit()\n"
+        "os._exit(0)\n", target,
+    )
+    assert Path(str(target) + "-wal").exists()
+    result = commit_in_new_process(target)
+    assert json.loads(result.stdout)["installed"] is True
+
+    assert names(target) == ["incoming"]
+    assert names(staged["recovery_path"]) == ["late-commit", "local"]
+    assert importer.pending_import_info(target) is None
+    assert not staged["pending_path"].exists()
+    child("assert module.commit_pending_import(target) is False\n", target)
+
+    # Recovery uses the same supported import path and restores every committed
+    # row, including the one that was present only in the previous WAL.
+    rollback = importer.stage_import(staged["recovery_path"], target)
+    commit_in_new_process(target)
+    assert names(target) == ["late-commit", "local"]
+    assert names(rollback["recovery_path"]) == ["incoming"]
+
+
+def test_cancellation_discards_only_pending_import(tmp_path):
+    importer = load_module()
+    target = make_save(tmp_path / "ankimon.db", "local")
+    source = make_save(tmp_path / "source.db", "incoming")
+    staged = importer.stage_import(source, target)
+    assert importer.cancel_pending_import(target) is True
+    assert importer.cancel_pending_import(target) is False
+    assert not staged["pending_path"].exists()
+    child("assert module.commit_pending_import(target) is False\n", target)
+    assert names(target) == ["local"]
+    assert names(source) == ["incoming"]
+
+
+def test_pending_import_applies_only_to_the_explicit_target(tmp_path):
+    importer = load_module()
+    target = make_save(tmp_path / "ankimonDEV.db", "local")
+    normal = make_save(tmp_path / "ankimon.db", "normal")
+    source = make_save(tmp_path / "source.db", "incoming")
+    importer.stage_import(source, target)
+    child("assert module.commit_pending_import(target) is False\n", normal)
+    assert names(normal) == ["normal"]
+    assert names(target) == ["local"]
+    child("assert module.commit_pending_import(target) is True\n", target)
+    assert names(target) == ["incoming"]
+
+
+def test_invalid_source_never_publishes_pending_work(tmp_path):
+    importer = load_module()
+    target = make_save(tmp_path / "ankimon.db", "local")
+    source = tmp_path / "source.db"
+    source.write_bytes(b"not a database")
+    with pytest.raises(Exception):
+        importer.stage_import(source, target)
+    assert importer.pending_import_info(target) is None
+    assert names(target) == ["local"]
+
+
+def test_damaged_pending_snapshot_refuses_install_and_remains_recoverable(tmp_path):
+    importer = load_module()
+    target = make_save(tmp_path / "ankimon.db", "local")
+    source = make_save(tmp_path / "source.db", "incoming")
+    staged = importer.stage_import(source, target)
+    staged["pending_path"].write_bytes(b"truncated")
+    child("module.commit_pending_import(target)\n", target, expected=1)
+    assert names(target) == ["local"]
+    assert importer.pending_import_info(target) is not None
+    assert not staged["recovery_path"].exists()
+
+
+def test_backup_failure_refuses_replacement_and_preserves_pending(tmp_path):
+    importer = load_module()
+    target = make_save(tmp_path / "ankimon.db", "local")
+    source = make_save(tmp_path / "source.db", "incoming")
+    staged = importer.stage_import(source, target)
+    # A real filesystem obstruction, not a mocked successful backup call.
+    staged["recovery_path"].parent.parent.mkdir(parents=True)
+    staged["recovery_path"].parent.write_text("obstruction")
+    child("module.commit_pending_import(target)\n", target, expected=1)
+    assert names(target) == ["local"]
+    assert importer.pending_import_info(target) is not None
+
+
+def test_failed_replace_keeps_backup_and_retry_backs_up_latest_progress(tmp_path):
+    importer = load_module()
+    target = make_save(tmp_path / "ankimon.db", "local")
+    source = make_save(tmp_path / "source.db", "incoming")
+    staged = importer.stage_import(source, target)
+    child(
+        "real_replace = os.replace\n"
+        "def fail_install(source, dest):\n"
+        "    if Path(dest) == target:\n"
+        "        raise PermissionError('simulated antivirus lock')\n"
+        "    return real_replace(source, dest)\n"
+        "module.os.replace = fail_install\n"
+        "module.commit_pending_import(target)\n", target, expected=1,
+    )
+    assert names(target) == ["local"]
+    assert names(staged["recovery_path"]) == ["local"]
+    with sqlite3.connect(target) as conn:
+        conn.execute("INSERT INTO captured_pokemon VALUES ('after-failure', '{}')")
+    child("assert module.commit_pending_import(target) is True\n", target)
+    assert names(target) == ["incoming"]
+    backups = list(staged["recovery_path"].parent.glob("*.db"))
+    assert sorted(names(path) for path in backups) == [["after-failure", "local"], ["local"]]
+
+
+def test_failed_startup_install_cannot_retry_after_runtime_and_module_reload(tmp_path):
+    importer = load_module()
+    target = make_save(tmp_path / "ankimon.db", "local")
+    source = make_save(tmp_path / "source.db", "incoming")
+    staged = importer.stage_import(source, target)
+    staged["recovery_path"].parent.parent.mkdir(parents=True)
+    staged["recovery_path"].parent.write_text("temporary obstruction")
+    child(
+        "try:\n"
+        "    module.commit_pending_import(target)\n"
+        "except OSError:\n"
+        "    pass\n"
+        "else:\n"
+        "    raise AssertionError('initial startup installation should fail')\n"
+        "# get_db would now construct the original runtime.\n"
+        "with sqlite3.connect(target) as runtime:\n"
+        "    runtime.execute(\"INSERT INTO captured_pokemon VALUES ('runtime-progress', '{}')\")\n"
+        "module.pending_import_info(target)['recovery_path'].parent.unlink()\n"
+        "# Reloading the helper must not reopen this process's install gate.\n"
+        "spec = importlib.util.spec_from_file_location('reloaded_save_import', sys.argv[1])\n"
+        "module = importlib.util.module_from_spec(spec)\n"
+        "spec.loader.exec_module(module)\n"
+        "assert module.commit_pending_import(target) is False\n", target,
+    )
+    assert names(target) == ["local", "runtime-progress"]
+    assert importer.pending_import_info(target) is not None
+    # The next actual process can still install, backing up all interim play.
+    commit_in_new_process(target)
+    assert names(target) == ["incoming"]
+    assert names(staged["recovery_path"]) == ["local", "runtime-progress"]
+
+
+def test_crash_after_atomic_install_never_reapplies_import_over_new_progress(tmp_path):
+    importer = load_module()
+    target = make_save(tmp_path / "ankimon.db", "local")
+    source = make_save(tmp_path / "source.db", "incoming")
+    staged = importer.stage_import(source, target)
+    child(
+        "real_replace = os.replace\n"
+        "def crash_after_install(source, dest):\n"
+        "    real_replace(source, dest)\n"
+        "    if Path(dest) == target:\n"
+        "        os._exit(37)\n"
+        "module.os.replace = crash_after_install\n"
+        "module.commit_pending_import(target)\n", target, expected=37,
+    )
+    assert names(target) == ["incoming"]
+    with sqlite3.connect(target) as conn:
+        conn.execute("INSERT INTO captured_pokemon VALUES ('new-progress', '{}')")
+    child("module.commit_pending_import(target)\n", target)
+    assert names(target) == ["incoming", "new-progress"]
+    assert names(staged["recovery_path"]) == ["local"]
+    assert importer.pending_import_info(target) is None
+
+
+def test_staging_twice_requires_explicit_cancellation(tmp_path):
+    importer = load_module()
+    target = make_save(tmp_path / "ankimon.db", "local")
+    source = make_save(tmp_path / "source.db", "incoming")
+    first = importer.stage_import(source, target)
+    with pytest.raises(RuntimeError, match="pending"):
+        importer.stage_import(source, target)
+    assert importer.pending_import_info(target)["token"] == first["token"]
+
+
+def test_new_recovery_directories_are_private_even_with_permissive_umask(tmp_path):
+    importer = load_module()
+    target = make_save(tmp_path / "ankimon.db", "local")
+    source = make_save(tmp_path / "source.db", "incoming")
+    staged = importer.stage_import(source, target)
+    child("os.umask(0)\nmodule.commit_pending_import(target)\n", target)
+    if os.name != "nt":
+        assert stat.S_IMODE(staged["recovery_path"].parent.parent.stat().st_mode) == 0o700
+        assert stat.S_IMODE(staged["recovery_path"].parent.stat().st_mode) == 0o700
+        assert stat.S_IMODE(staged["recovery_path"].stat().st_mode) == 0o600
+
+
+def rebase_state(path, *, marker="1"):
+    conn = sqlite3.connect(path)
+    conn.execute("CREATE TABLE metadata (key TEXT PRIMARY KEY, value TEXT)")
+    conn.execute("INSERT INTO metadata VALUES ('mobile_revlog_watermark', '9999')")
+    if marker is not None:
+        conn.execute("INSERT INTO metadata VALUES ('import_rebase_pending', ?)", (marker,))
+    conn.commit()
+    return conn, SimpleNamespace(_get_connection=lambda: conn)
+
+
+@pytest.mark.parametrize("maximum,expected", [(200, "200"), (None, "0")])
+def test_rebase_reads_post_shutdown_collection_and_can_lower_imported_watermark(tmp_path, maximum, expected):
+    importer = load_module()
+    assert hasattr(importer, "rebase_after_import"), "The import rebase has not been implemented"
+    conn, manager = rebase_state(tmp_path / "save.db")
+    collection = SimpleNamespace(db=SimpleNamespace(scalar=lambda sql: maximum))
+    try:
+        assert importer.rebase_after_import(manager, collection) is True
+        assert conn.execute("SELECT value FROM metadata WHERE key='mobile_revlog_watermark'").fetchone()[0] == expected
+        assert conn.execute("SELECT value FROM metadata WHERE key='import_rebase_pending'").fetchone() is None
+        # Repeated sync hooks must preserve normal future watermark updates.
+        conn.execute("UPDATE metadata SET value='20000' WHERE key='mobile_revlog_watermark'")
+        conn.commit()
+        assert importer.rebase_after_import(manager, None) is False
+        assert conn.execute("SELECT value FROM metadata WHERE key='mobile_revlog_watermark'").fetchone()[0] == "20000"
+    finally:
+        conn.close()
+
+
+@pytest.mark.parametrize("maximum", [-1, True, "123", 12.5])
+def test_rebase_invalid_collection_watermark_leaves_marker_for_retry(tmp_path, maximum):
+    importer = load_module()
+    assert hasattr(importer, "rebase_after_import"), "The import rebase has not been implemented"
+    conn, manager = rebase_state(tmp_path / "save.db")
+    collection = SimpleNamespace(db=SimpleNamespace(scalar=lambda sql: maximum))
+    try:
+        with pytest.raises(ValueError):
+            importer.rebase_after_import(manager, collection)
+        assert dict(conn.execute("SELECT key,value FROM metadata")) == {
+            "mobile_revlog_watermark": "9999", "import_rebase_pending": "1",
+        }
+    finally:
+        conn.close()
+
+
+def test_rebase_requires_collection_only_while_import_marker_exists(tmp_path):
+    importer = load_module()
+    assert hasattr(importer, "rebase_after_import"), "The import rebase has not been implemented"
+    conn, manager = rebase_state(tmp_path / "save.db")
+    try:
+        with pytest.raises(RuntimeError):
+            importer.rebase_after_import(manager, None)
+        conn.execute("DELETE FROM metadata WHERE key='import_rebase_pending'")
+        conn.commit()
+        assert importer.rebase_after_import(manager, None) is False
+    finally:
+        conn.close()
+
+
+def test_rebase_rolls_back_watermark_if_marker_cannot_be_retired(tmp_path):
+    importer = load_module()
+    assert hasattr(importer, "rebase_after_import"), "The import rebase has not been implemented"
+    conn, manager = rebase_state(tmp_path / "save.db")
+    conn.execute(
+        "CREATE TRIGGER reject_marker_delete BEFORE DELETE ON metadata "
+        "WHEN OLD.key='import_rebase_pending' BEGIN SELECT RAISE(ABORT, 'simulated write failure'); END"
+    )
+    conn.commit()
+    collection = SimpleNamespace(db=SimpleNamespace(scalar=lambda sql: 200))
+    try:
+        with pytest.raises(sqlite3.IntegrityError):
+            importer.rebase_after_import(manager, collection)
+        assert dict(conn.execute("SELECT key,value FROM metadata")) == {
+            "mobile_revlog_watermark": "9999", "import_rebase_pending": "1",
+        }
+    finally:
+        conn.close()

--- a/tests/test_save_import.py
+++ b/tests/test_save_import.py
@@ -631,3 +631,47 @@ def test_a_manifest_that_vanishes_before_read_back_leaves_nothing_staged(tmp_pat
     assert importer.pending_import_info(target) is None
     assert list(directory.glob("*.db")) == []
     assert names(target) == ["local"]
+
+
+def test_cancellation_holds_even_when_its_durability_flush_fails(tmp_path, monkeypatch):
+    """Removing the manifest is what stops the install, so say so.
+
+    Reporting "could not be cancelled, try again" after the manifest is gone
+    earns a "there is no pending save import" on the retry, and the user cannot
+    tell from Ankimon which of the two to believe.
+    """
+    importer = load_module()
+    target = make_save(tmp_path / "ankimon.db", "local")
+    source = make_save(tmp_path / "source.db", "incoming")
+    importer.stage_import(source, target)
+    fsync_directory = importer._fsync_directory
+    injecting = [True]
+
+    def failing_sync(path):
+        if injecting[0]:
+            raise OSError("injected cancellation flush failure")
+        return fsync_directory(path)
+
+    monkeypatch.setattr(importer, "_fsync_directory", failing_sync)
+    assert importer.cancel_pending_import(target) is True
+
+    injecting[0] = False
+    assert importer.pending_import_info(target) is None
+    assert json.loads(commit_in_new_process(target).stdout)["installed"] is False
+    assert names(target) == ["local"]
+
+
+def test_a_second_import_names_the_pending_one_it_is_refusing_for(tmp_path):
+    """The refusal has its own type: this is not "nothing is going to happen"."""
+    importer = load_module()
+    target = make_save(tmp_path / "ankimon.db", "local")
+    source = make_save(tmp_path / "source.db", "incoming")
+    other = make_save(tmp_path / "other.db", "second")
+    importer.stage_import(source, target)
+
+    with pytest.raises(importer.ImportAlreadyPendingError):
+        importer.stage_import(other, target)
+    # The refusal leaves the first import exactly as it was.
+    assert json.loads(commit_in_new_process(target).stdout)["installed"] is True
+    assert names(target) == ["incoming"]
+

--- a/tests/test_save_import.py
+++ b/tests/test_save_import.py
@@ -10,6 +10,7 @@ import stat
 import subprocess
 import sys
 import time
+import urllib.parse
 from types import SimpleNamespace
 
 import pytest
@@ -245,6 +246,24 @@ def test_damaged_pending_snapshot_refuses_install_and_remains_recoverable(tmp_pa
     assert names(target) == ["local"]
     assert importer.pending_import_info(target) is not None
     assert not staged["recovery_path"].exists()
+
+
+def test_a_pending_save_swapped_for_another_valid_save_is_refused(tmp_path):
+    """Size and integrity checks pass for any real save; only the digest knows.
+
+    A truncated file never reaches the digest comparison: the size check refuses
+    it first. This one is a complete Ankimon save, just not the confirmed one.
+    """
+    importer = load_module()
+    target = make_save(tmp_path / "ankimon.db", "local")
+    source = make_save(tmp_path / "source.db", "incoming")
+    staged = importer.stage_import(source, target)
+    shutil.copyfile(make_save(tmp_path / "other.db", "other"), staged["pending_path"])
+
+    result = child("module.commit_pending_import(target)\n", target, expected=1)
+    assert "changed after it was confirmed" in result.stderr
+    assert names(target) == ["local"]
+    assert importer.pending_import_info(target) is not None
 
 
 def test_backup_failure_refuses_replacement_and_preserves_pending(tmp_path):
@@ -840,6 +859,9 @@ def test_repeated_failed_installs_do_not_grow_the_recovery_folder_forever(tmp_pa
 
     copies = list(staged["recovery_path"].parent.glob("*.db"))
     assert len(copies) == 2, sorted(path.name for path in copies)
+    # The superseded copy kept is the newest one, not the first attempt's.
+    [retry] = [path for path in copies if path != staged["recovery_path"]]
+    assert names(retry) == ["local", "run-0", "run-1"]
     # The advertised path still holds the most recent attempt's progress.
     assert names(staged["recovery_path"]) == [
         "local", "run-0", "run-1", "run-2",
@@ -1011,3 +1033,153 @@ def test_a_locked_save_answers_unknown_within_the_wording_budget(tmp_path):
         locker.execute("ROLLBACK")
         locker.close()
     assert importer.pending_import_is_installed(target) is False
+
+
+def test_a_record_for_a_save_that_no_longer_exists_was_not_installed(tmp_path):
+    """There is no save on disk, so it is not the imported one.
+
+    Answering "unknown" made Cancel send the user after a recovery copy of a
+    save that was never there to copy. Once a recovery copy exists, an install
+    may have replaced the save before it went missing, and "unknown" is the
+    answer that points at that copy.
+    """
+    importer = load_module()
+    target = make_save(tmp_path / "ankimonDEV.db", "local")
+    source = make_save(tmp_path / "source.db", "incoming")
+    staged = importer.stage_import(source, target)
+    target.unlink()
+    assert importer.pending_import_is_installed(target) is False
+
+    staged["recovery_path"].parent.mkdir(parents=True)
+    shutil.copyfile(source, staged["recovery_path"])
+    assert importer.pending_import_is_installed(target) is None
+
+
+@pytest.mark.skipif(os.name == "nt", reason="Windows never syncs a directory")
+@pytest.mark.parametrize("code, installs", [
+    ("EINVAL", True), ("EOPNOTSUPP", True), ("EIO", False),
+])
+def test_a_volume_that_cannot_sync_directories_still_installs(tmp_path, code, installs):
+    """A VirtualBox shared folder answers a directory fsync with EINVAL.
+
+    SQLite ignores that in its own directory sync. Treating it as fatal left an
+    import that could never install on that volume. A real I/O error still stops
+    the install before anything is replaced.
+    """
+    importer = load_module()
+    target = make_save(tmp_path / "ankimon.db", "local")
+    source = make_save(tmp_path / "source.db", "incoming")
+    importer.stage_import(source, target)
+    child(
+        "import errno, stat\n"
+        "real_fsync = os.fsync\n"
+        "def directory_refuses(fd):\n"
+        "    if stat.S_ISDIR(os.fstat(fd).st_mode):\n"
+        f"        raise OSError(errno.{code}, 'directory fsync refused')\n"
+        "    return real_fsync(fd)\n"
+        "module.os.fsync = directory_refuses\n"
+        "module.commit_pending_import(target)\n",
+        target, expected=0 if installs else 1,
+    )
+    assert names(target) == (["incoming"] if installs else ["local"])
+    assert (importer.pending_import_info(target) is None) is installs
+
+
+REFUSE_CHMOD = (
+    "import errno\n"
+    "def fixed_permissions(self, mode, *args, **kwargs):\n"
+    "    raise PermissionError(errno.EPERM, 'Operation not permitted', str(self))\n"
+    "module.Path.chmod = fixed_permissions\n"
+)
+
+
+@pytest.mark.skipif(not hasattr(os, "getuid"), reason="POSIX ownership")
+def test_a_recovery_folder_that_refuses_chmod_does_not_block_the_install(tmp_path):
+    """FAT and exFAT volumes fix permissions when mounted, and refuse chmod.
+
+    Nothing can ever tighten such a folder, so refusing over it refused the
+    install at every start.
+    """
+    importer = load_module()
+    target = make_save(tmp_path / "ankimon.db", "local")
+    source = make_save(tmp_path / "source.db", "incoming")
+    staged = importer.stage_import(source, target)
+    child(REFUSE_CHMOD + "module.commit_pending_import(target)\n", target)
+    assert names(target) == ["incoming"]
+    assert names(staged["recovery_path"]) == ["local"]
+
+
+@pytest.mark.skipif(not hasattr(os, "getuid"), reason="POSIX ownership")
+def test_a_recovery_folder_owned_by_another_account_is_still_refused(tmp_path):
+    """EPERM is also chmod's answer about somebody else's folder.
+
+    A copy of the save, credentials included, does not go into a folder another
+    account controls.
+    """
+    importer = load_module()
+    target = make_save(tmp_path / "ankimon.db", "local")
+    source = make_save(tmp_path / "source.db", "incoming")
+    staged = importer.stage_import(source, target)
+    result = child(
+        REFUSE_CHMOD
+        + "real_getuid = os.getuid\n"
+        "module.os.getuid = lambda: real_getuid() + 1\n"
+        "module.commit_pending_import(target)\n",
+        target, expected=1,
+    )
+    assert "Operation not permitted" in result.stderr
+    assert names(target) == ["local"]
+    assert not staged["recovery_path"].exists()
+
+
+def unc_as_uri(self):
+    """What Path.as_uri gives a UNC path on Windows: the server as the authority."""
+    return "file://server" + urllib.parse.quote(str(self))
+
+
+def test_a_network_path_gets_a_uri_sqlite_accepts(tmp_path, monkeypatch):
+    """SQLite refuses any URI authority but an empty one or localhost.
+
+    Linux has no UNC paths, so as_uri is made to answer the way it does on
+    Windows for one. The file must still open, read-only, even with URI
+    delimiters in its name, and a missing one must not be created.
+    """
+    importer = load_module()
+    # "?" is not a legal Windows filename character; "#" and "%" still need escaping.
+    folder = tmp_path / ("share #1 %" if os.name == "nt" else "share #1 ?%")
+    folder.mkdir()
+    save = make_save(folder / "ankimon.db", "local")
+    monkeypatch.setattr(importer.Path, "as_uri", unc_as_uri)
+
+    with pytest.raises(sqlite3.OperationalError, match="authority"):
+        sqlite3.connect(save.as_uri() + "?mode=ro", uri=True)
+    conn = sqlite3.connect(importer._sqlite_uri(save, "ro"), uri=True)
+    try:
+        assert conn.execute("SELECT individual_id FROM captured_pokemon").fetchall() == [("local",)]
+        with pytest.raises(sqlite3.OperationalError, match="readonly"):
+            conn.execute("DELETE FROM captured_pokemon")
+    finally:
+        conn.close()
+    missing = folder / "missing.db"
+    with pytest.raises(sqlite3.OperationalError):
+        sqlite3.connect(importer._sqlite_uri(missing, "ro"), uri=True)
+    assert not missing.exists()
+
+
+def test_an_import_stages_and_installs_on_a_network_path(tmp_path, monkeypatch):
+    """Every SQLite open on the import path, staging and startup, takes the helper."""
+    importer = load_module()
+    target = make_save(tmp_path / "ankimon.db", "local")
+    source = make_save(tmp_path / "source.db", "incoming")
+    with monkeypatch.context() as patched:
+        patched.setattr(importer.Path, "as_uri", unc_as_uri)
+        staged = importer.stage_import(source, target)
+
+    child(
+        "import urllib.parse\n"
+        "module.Path.as_uri = lambda self: 'file://server' + urllib.parse.quote(str(self))\n"
+        "assert module.commit_pending_import(target) is True\n",
+        target,
+    )
+    assert names(target) == ["incoming"]
+    assert names(staged["recovery_path"]) == ["local"]

--- a/tests/test_save_import.py
+++ b/tests/test_save_import.py
@@ -660,6 +660,7 @@ def test_a_cancellation_survives_a_crash_that_undoes_its_removals(tmp_path, monk
     source = make_save(tmp_path / "source.db", "incoming")
     staged = importer.stage_import(source, target)
     manifest = staged["pending_path"].parent / "pending.json"
+    original_length = manifest.stat().st_size
     unlink = Path.unlink
 
     def undone_by_the_crash(path, *args, **kwargs):
@@ -676,8 +677,10 @@ def test_a_cancellation_survives_a_crash_that_undoes_its_removals(tmp_path, monk
     assert importer.cancel_pending_import(target) is True
     monkeypatch.undo()
 
-    # The crash left both files in place, and play went on afterwards.
+    # The crash left both files in place, and play went on afterwards. The
+    # record was rewritten at its own length: no truncate, so no torn tail.
     assert manifest.is_file() and staged["pending_path"].is_file()
+    assert manifest.stat().st_size == original_length
     with sqlite3.connect(target) as conn:
         conn.execute("INSERT INTO captured_pokemon VALUES ('after-cancel', '{}')")
     assert importer.pending_import_info(target) is None
@@ -909,6 +912,56 @@ def test_whole_file_reads_and_copies_check_the_budget_between_blocks(tmp_path, m
     with pytest.raises(TimeoutError):
         importer._copy_within(source, tmp_path / "copy.db", deadline=2.5)
     assert (tmp_path / "copy.db").stat().st_size < source.stat().st_size
+
+
+@pytest.mark.parametrize("step", ["digest", "recovery_sync"])
+def test_the_startup_budget_reaches_the_digest_and_the_recovery_sync(tmp_path, step):
+    """The install passes its budget into each whole-file step, not just the copy.
+
+    Checked by where the TimeoutError is raised: a call site that dropped the
+    deadline would let the step finish and fail later, somewhere else.
+    """
+    importer = load_module()
+    target = make_save(tmp_path / "ankimon.db", "local")
+    source = make_save(tmp_path / "source.db", "incoming")
+    with sqlite3.connect(source) as conn:
+        # More than one digest block, so a check between blocks can fire.
+        conn.execute("CREATE TABLE ballast (data BLOB)")
+        conn.execute("INSERT INTO ballast VALUES (?)", (os.urandom(3 * 1024 * 1024),))
+    staged = importer.stage_import(source, target)
+
+    child(
+        "import time, traceback\n"
+        "step = sys.argv[3]\n"
+        "deadline = time.monotonic() + 60\n"
+        "def expire():\n"
+        "    module.time.monotonic = lambda: deadline + 1\n"
+        "if step == 'digest':\n"
+        "    real_sha = module.hashlib.sha256\n"
+        "    class SlowDisk:\n"
+        "        def __init__(self): self.inner = real_sha()\n"
+        "        def update(self, block): expire(); self.inner.update(block)\n"
+        "        def hexdigest(self): return self.inner.hexdigest()\n"
+        "    module.hashlib.sha256 = SlowDisk\n"
+        "    expected = '_digest'\n"
+        "else:\n"
+        "    verify = module._verify_save\n"
+        "    def verify_then_stall(path, deadline=None):\n"
+        "        verify(path, deadline)\n"
+        "        if Path(path).name.startswith('.backup-'): expire()\n"
+        "    module._verify_save = verify_then_stall\n"
+        "    expected = '_snapshot'\n"
+        "try:\n"
+        "    module.commit_pending_import(target, deadline=deadline)\n"
+        "except TimeoutError as error:\n"
+        "    frames = [frame.name for frame in traceback.extract_tb(error.__traceback__)]\n"
+        "    assert frames[-2:] == [expected, '_budget'], frames\n"
+        "else:\n"
+        "    raise AssertionError('the budget was not checked at ' + step)\n",
+        target, step,
+    )
+    assert names(target) == ["local"]
+    assert importer.pending_import_info(target)["token"] == staged["token"]
 
 
 def test_a_budget_spent_during_the_install_copy_leaves_the_old_save_pending(tmp_path):

--- a/tests/test_save_import.py
+++ b/tests/test_save_import.py
@@ -522,16 +522,21 @@ def test_rebase_rolls_back_watermark_if_marker_cannot_be_retired(tmp_path):
         conn.close()
 
 
-@pytest.mark.parametrize("failure", ["staging_directory", "target_directory", "read_back"])
+@pytest.mark.parametrize(
+    "failure", ["manifest_cleanup", "staging_directory", "target_directory", "read_back"],
+)
 def test_publication_failure_reports_a_pending_import_rather_than_an_abort(
     tmp_path, monkeypatch, failure,
 ):
     """Replacing pending.json is the commit point; later steps cannot undo it.
 
-    Durability and read-back run after publication and deliberately keep the
-    staged copy when they fail. A caller told only "aborted" would leave the
-    user playing on into a replacement they believe cannot happen, so staging
-    reports this state with its own exception.
+    Cleanup, durability and read-back all run after publication and
+    deliberately keep the staged copy when they fail. A caller told only
+    "aborted" would leave the user playing on into a replacement they believe
+    cannot happen, so staging reports this state with its own exception.
+
+    Each parameter breaks exactly one of those steps, in the order stage_import
+    performs them, so no two cases exercise the same line.
     """
     importer = load_module()
     target = make_save(tmp_path / "ankimon.db", "local")
@@ -539,11 +544,16 @@ def test_publication_failure_reports_a_pending_import_rather_than_an_abort(
     _, directory = importer._paths(target)
     injecting = [True]
     fsync_directory, read_back = importer._fsync_directory, importer.pending_import_info
+    unlink = Path.unlink
+
+    def failing_unlink(self, *args, **kwargs):
+        if injecting[0] and failure == "manifest_cleanup" and self.suffix == ".json":
+            raise PermissionError("injected manifest cleanup failure")
+        return unlink(self, *args, **kwargs)
 
     def failing_sync(path):
-        if injecting[0] and Path(path) == (
-            directory if failure == "staging_directory" else target.parent
-        ):
+        broken = {"staging_directory": directory, "target_directory": target.parent}
+        if injecting[0] and Path(path) == broken.get(failure):
             raise OSError(f"injected {failure} sync failure")
         return fsync_directory(path)
 
@@ -557,6 +567,7 @@ def test_publication_failure_reports_a_pending_import_rather_than_an_abort(
         published.append(path)
         return read_back(path)
 
+    monkeypatch.setattr(Path, "unlink", failing_unlink)
     monkeypatch.setattr(importer, "_fsync_directory", failing_sync)
     monkeypatch.setattr(importer, "pending_import_info", failing_read_back)
 

--- a/tests/test_save_import_startup.py
+++ b/tests/test_save_import_startup.py
@@ -1,0 +1,89 @@
+"""Import outcome reporting across the database factory and profile hook."""
+
+import importlib
+import os
+from pathlib import Path
+import sqlite3
+from types import SimpleNamespace
+
+import pytest
+
+from test_profile_hooks import _exec_profile_hooks, _fresh_gui_hooks, _fresh_services
+from test_save_import import child, make_save
+
+
+@pytest.mark.parametrize("installed", [False, True])
+def test_startup_reports_the_save_that_is_active(tmp_path, monkeypatch, installed):
+    importer = importlib.import_module("Ankimon.save_import")
+    manager = importlib.import_module("Ankimon.pyobj.database_manager")
+    events_module = importlib.import_module("Ankimon.events")
+    event_bus = events_module._EventBus()
+    event_bus.enable()
+    monkeypatch.setattr(events_module, "events", event_bus)
+    services = _fresh_services(monkeypatch)
+    monkeypatch.setattr(manager, "_db_instance", None)
+    target = make_save(tmp_path / "ankimon.db", "local")
+    source = make_save(tmp_path / "source.db", "incoming")
+    for path in (target, source):
+        # Supply the real database manager's indexed columns and normalization
+        # marker, so constructing it needs no external Pokemon assets.
+        with sqlite3.connect(path) as conn:
+            for column in ("name", "pokedex_id", "shiny", "level", "is_main"):
+                conn.execute(f"ALTER TABLE captured_pokemon ADD COLUMN {column} TEXT")
+            conn.execute("CREATE TABLE metadata (key TEXT PRIMARY KEY, value TEXT)")
+            conn.execute("INSERT INTO metadata VALUES ('base_stats_normalized', 'true')")
+    child("module.stage_import(Path(sys.argv[3]), target)\n", target, source)
+    replace, sync = os.replace, importer._fsync_directory
+
+    def fail_replace(source, destination):
+        if Path(destination) == target:
+            raise OSError("injected replacement failure")
+        return replace(source, destination)
+
+    def fail_sync(path):
+        if path == target.parent and importer._installed_token(target) is not None:
+            raise OSError("injected final sync failure")
+        return sync(path)
+
+    if installed:
+        monkeypatch.setattr(importer, "_fsync_directory", fail_sync)
+    else:
+        monkeypatch.setattr(importer.os, "replace", fail_replace)
+    logs, warnings = [], []
+    logger = SimpleNamespace(log=lambda level, message: logs.append((level, message)))
+    services.ui = SimpleNamespace(warn=warnings.append)
+    runtime = manager.get_db(logger=logger, db_path=target)
+    try:
+        assert runtime.get_config_value("trainer.name") == ("incoming" if installed else "local")
+        failures = getattr(services, "_save_import_errors", [])
+        finalization = getattr(services, "_save_import_warnings", [])
+        assert bool(failures) is not installed
+        assert bool(finalization) is installed
+        import_events = [event for event in event_bus.peek()
+                         if event["type"] == "save_import_installed"]
+        assert len(import_events) == int(installed)
+        if installed:
+            assert import_events[0]["target"] == str(target)
+
+        hooks = _exec_profile_hooks(monkeypatch, _fresh_gui_hooks())
+        hooks.mw.col = None
+        hooks.mw.taskman = SimpleNamespace(run_in_background=lambda *args: None)
+        hooks._on_profile_did_open(False)()
+        assert len(warnings) == 1
+        message = warnings[0].lower()
+        if installed:
+            assert "imported save" in message and "active" in message
+            assert "could not install" not in message
+            assert "injected final sync failure" in message
+            assert any(level == "warning" and "injected final sync failure" in text
+                       for level, text in logs)
+            assert not any("could not be installed" in text for _, text in logs)
+        else:
+            assert "could not install" in message
+            assert "injected replacement failure" in message
+        assert not getattr(services, "_save_import_errors", [])
+        assert not getattr(services, "_save_import_warnings", [])
+        hooks._on_profile_did_open(False)()
+        assert len(warnings) == 1
+    finally:
+        runtime.close()

--- a/tests/test_save_import_startup.py
+++ b/tests/test_save_import_startup.py
@@ -81,6 +81,10 @@ def test_startup_reports_the_save_that_is_active(tmp_path, monkeypatch, installe
         else:
             assert "could not install" in message
             assert "injected replacement failure" in message
+            # Only the listed saves were left alone: get_db tries both modes,
+            # and the other may have been replaced in this same start.
+            assert "no save was replaced" not in message
+            assert "ankimon → game → cancel pending save import" in message
         assert not getattr(services, "_save_import_errors", [])
         assert not getattr(services, "_save_import_warnings", [])
         hooks._on_profile_did_open(False)()

--- a/tests/test_save_import_startup.py
+++ b/tests/test_save_import_startup.py
@@ -87,3 +87,31 @@ def test_startup_reports_the_save_that_is_active(tmp_path, monkeypatch, installe
         assert len(warnings) == 1
     finally:
         runtime.close()
+
+
+def test_failed_warning_delivery_keeps_the_notice_and_registers_sync_hooks(monkeypatch):
+    """A raising presenter must not silence an import outcome or skip the hooks."""
+    services = _fresh_services(monkeypatch)
+    services._save_import_errors = ["ankimon.db: injected replacement failure"]
+    services._save_import_warnings = ["ankimonDEV.db: injected final sync failure"]
+    delivered = []
+
+    def refuse(message):
+        delivered.append(message)
+        raise RuntimeError("the warning dialog could not be shown")
+
+    services.ui = SimpleNamespace(warn=refuse)
+    hooks = _exec_profile_hooks(monkeypatch, _fresh_gui_hooks())
+    hooks.mw.col = None
+    hooks.mw.taskman = SimpleNamespace(run_in_background=lambda *args: None)
+    hooks._on_profile_did_open(False)()
+
+    # Both notices were attempted, both survive for the next profile open
+    # instead of being cleared into nothing, and the AnkiWeb sync hooks that
+    # follow them still registered.
+    assert len(delivered) == 2
+    assert "could not install" in delivered[0].lower()
+    assert "are active" in delivered[1].lower()
+    assert services._save_import_errors == ["ankimon.db: injected replacement failure"]
+    assert services._save_import_warnings == ["ankimonDEV.db: injected final sync failure"]
+    assert hooks.setup_ankimon_sync_hooks.called

--- a/tests/test_save_transfer.py
+++ b/tests/test_save_transfer.py
@@ -112,17 +112,13 @@ def _make_save(path: Path, *, pokemon=0, badges=0, history=0,
 
 
 def _protected(media: Path, target_db: str = "ankimon.db"):
-    """The content-addressed protected copies the migration wrote, by name.
-
-    The migration never writes a FIXED protected name — a fixed name can hold
-    one save, so the second one to arrive forces a choice between overwriting
-    it and leaving the newcomer under the bare, deletable name, and the
-    progress counters cannot make that choice honestly. Each distinct save is
-    preserved as ``_ankimon_save_<digest of its bytes>.db`` instead, so tests
-    ask what is protected rather than assuming one name.
-    """
+    """All verified protected copies, including legacy sync-visible ones."""
+    locations = (media, st._recovery_store(media))
     return sorted(
-        path for path in media.glob(st._SAVE_PREFIX[target_db] + "*.db")
+        path
+        for location in locations
+        if location.is_dir()
+        for path in location.glob(st._SAVE_PREFIX[target_db] + "*.db")
         if st._target_db_for(path) == target_db
     )
 

--- a/tests/test_save_transfer.py
+++ b/tests/test_save_transfer.py
@@ -23,6 +23,7 @@ import types
 import shutil
 import sqlite3
 import tempfile
+from contextlib import nullcontext
 from pathlib import Path
 from unittest.mock import MagicMock
 
@@ -60,6 +61,7 @@ for _n in ("showInfo", "showWarning", "tooltip", "askUser"):
         setattr(_aqt_utils, _n, MagicMock())
 
 import Ankimon.pyobj.save_transfer as st  # noqa: E402
+from test_save_import import commit_in_new_process
 
 
 class _Logger:
@@ -256,6 +258,9 @@ def _stub_sync(monkeypatch, *, backup_ok=True):
     calls = []
 
     class _Sync:
+        def _quiesce_live_db_connection(self, target):
+            return nullcontext(True)
+
         def _backup_before_overwrite(self, name):
             calls.append(("backup", name))
             return backup_ok
@@ -266,6 +271,10 @@ def _stub_sync(monkeypatch, *, backup_ok=True):
             calls.append(("replace", str(src), str(dest)))
             shutil.copy2(src, dest)
 
+    if not backup_ok:
+        def fail_staging(*args):
+            raise OSError("Cannot prepare pending import")
+        monkeypatch.setattr("Ankimon.save_import.stage_import", fail_staging)
     monkeypatch.setattr("Ankimon.pyobj.ankimon_sync.get_ankimon_sync", lambda: _Sync())
     return calls
 
@@ -285,7 +294,7 @@ def test_import_refuses_a_file_that_is_not_an_ankimon_save(tmp_path, live_db, mo
     assert st.get_db_stats(live_db)["pokemon"] == 3
 
 
-def test_import_refuses_when_the_safety_backup_fails(tmp_path, live_db, monkeypatch):
+def test_import_refuses_when_staging_fails(tmp_path, live_db, monkeypatch):
     incoming = _make_save(tmp_path / "incoming.db", pokemon=99)
     monkeypatch.setattr(st.QFileDialog, "getOpenFileName", lambda *a, **k: (str(incoming), ""))
     monkeypatch.setattr(st, "askUser", lambda *a, **k: True)
@@ -296,7 +305,7 @@ def test_import_refuses_when_the_safety_backup_fails(tmp_path, live_db, monkeypa
     calls = _stub_sync(monkeypatch, backup_ok=False)
 
     assert st.import_save() is False
-    assert [c[0] for c in calls] == ["backup"]      # refused BEFORE replacing
+    assert calls == []  # nothing touches the live database
     assert st.get_db_stats(live_db)["pokemon"] == 3
     closed.assert_not_called()
 
@@ -312,7 +321,7 @@ def test_import_declined_by_user_changes_nothing(tmp_path, live_db, monkeypatch)
     assert st.get_db_stats(live_db)["pokemon"] == 3
 
 
-def test_import_backs_up_before_replacing_then_closes_anki(tmp_path, live_db, monkeypatch):
+def test_import_prepares_then_installs_only_after_full_restart(tmp_path, live_db, monkeypatch):
     incoming = _make_save(tmp_path / "incoming.db", pokemon=99, badges=4)
     monkeypatch.setattr(st.QFileDialog, "getOpenFileName", lambda *a, **k: (str(incoming), ""))
     monkeypatch.setattr(st, "askUser", lambda *a, **k: True)
@@ -322,7 +331,9 @@ def test_import_backs_up_before_replacing_then_closes_anki(tmp_path, live_db, mo
     calls = _stub_sync(monkeypatch)
 
     assert st.import_save() is True
-    assert [c[0] for c in calls] == ["backup", "replace"]   # order is the safety
+    assert calls == []
+    assert st.get_db_stats(live_db)["pokemon"] == 3
+    commit_in_new_process(live_db)
     assert st.get_db_stats(live_db)["pokemon"] == 99
     closed.assert_called_once()
 
@@ -446,7 +457,9 @@ def test_migration_rescue_replaces_the_save_when_accepted(media, live_db, logger
 
     st.run_media_migration(MagicMock(), logger)
 
-    assert [c[0] for c in calls] == ["backup", "replace"]
+    assert calls == []
+    assert st.get_db_stats(live_db)["pokemon"] == 3
+    commit_in_new_process(live_db)
     assert st.get_db_stats(live_db)["pokemon"] == 42
 
 
@@ -514,7 +527,8 @@ def test_migration_settles_after_a_successful_rescue(media, live_db, logger, mon
     monkeypatch.setattr(st, "close_anki", MagicMock())
     _stub_sync(monkeypatch)
 
-    st.run_media_migration(MagicMock(), logger)       # rescues, "closes" Anki
+    st.run_media_migration(MagicMock(), logger)       # prepares a rescue
+    commit_in_new_process(live_db)
     assert st.get_db_stats(live_db)["pokemon"] == 42
     st.run_media_migration(MagicMock(), logger)       # the next boot
 
@@ -624,11 +638,11 @@ def test_dev_and_normal_saves_are_not_ranked_against_each_other(media, tmp_path,
 
     st.run_media_migration(MagicMock(), logger)
 
-    # The dev save is not what got preserved, and no rescue was offered from it.
+    # Both modes are protected, but only the active mode is eligible for rescue.
     copies = _protected(media)
     assert len(copies) == 1
     assert st.get_db_stats(copies[0])["pokemon"] == 1
-    assert _protected(media, "ankimonDEV.db") == []
+    assert st.get_db_stats(_protected(media, "ankimonDEV.db")[0])["pokemon"] == 500
     ask.assert_not_called()
 
 
@@ -674,6 +688,8 @@ def test_rescue_is_deferred_off_the_profile_open_stack(media, live_db, logger, m
     assert len(scheduled) == 1                       # deferred, not called inline
     assert st.get_db_stats(live_db)["pokemon"] == 3  # nothing replaced yet
     scheduled[0]()                                   # next event-loop turn
+    assert st.get_db_stats(live_db)["pokemon"] == 3
+    commit_in_new_process(live_db)
     assert st.get_db_stats(live_db)["pokemon"] == 42
 
 
@@ -708,12 +724,11 @@ def test_rescue_keeps_the_verified_snapshot_when_the_media_file_changes(
     bare.write_bytes(bytes(raw))
 
     scheduled[0]()
-
+    assert st.get_db_stats(live_db)["pokemon"] == 3
+    commit_in_new_process(live_db)
     assert st.get_db_stats(live_db)["pokemon"] == 42
-    assert [c[0] for c in calls] == ["backup", "replace"]
-    assert Path(calls[1][1]) != bare
-    assert not Path(calls[1][1]).exists()  # snapshot was released
-    warn.assert_not_called()
+    assert calls == []
+    assert "unverified" in warn.call_args.args[0]
 
 
 # --------------------------------------------------------------------------

--- a/tests/test_save_transfer_migration_answers.py
+++ b/tests/test_save_transfer_migration_answers.py
@@ -128,7 +128,7 @@ def test_eligible_rescue_is_offered_before_a_higher_ranked_diverged_save(
     if diverged_name == "ankimon.db":
         protected = list(m.folder.glob("_ankimon_save_*.db"))
         assert len(protected) == 1
-        assert protected[0].read_bytes() == original
+        assert st.get_db_stats(protected[0]) == st.get_db_stats(diverged)
 
 
 @pytest.mark.parametrize("target_db", ["ankimon.db", "ankimonDEV.db"])
@@ -155,7 +155,7 @@ def test_preservation_verifies_existing_copy_and_keeps_both_files(
 
     protected = [p for p in migration.folder.glob(f"{prefix}*.db") if p != damaged]
     assert len(protected) == 1
-    assert protected[0].read_bytes() == original
+    assert st.get_db_stats(protected[0])["pokemon"] == 4
     assert source.read_bytes() == original
     assert damaged.read_bytes() == damaged_bytes
 

--- a/tests/test_save_transfer_migration_answers.py
+++ b/tests/test_save_transfer_migration_answers.py
@@ -8,7 +8,7 @@ from types import ModuleType, SimpleNamespace
 
 import pytest
 
-from test_save_transfer import _Logger, _make_save, st
+from test_save_transfer import _Logger, _make_save, _protected, st
 from Ankimon.pyobj import ankimon_sync
 from Ankimon.services import services
 
@@ -126,8 +126,10 @@ def test_eligible_rescue_is_offered_before_a_higher_ranked_diverged_save(
     assert len(m.prompts) == 1
     assert diverged.read_bytes() == original
     if diverged_name == "ankimon.db":
-        protected = list(m.folder.glob("_ankimon_save_*.db"))
+        protected = _protected(m.folder)
         assert len(protected) == 1
+        assert protected[0].parent == st._recovery_store(m.folder)
+        assert not list(m.folder.glob("_ankimon_save_*.db"))
         assert st.get_db_stats(protected[0]) == st.get_db_stats(diverged)
 
 
@@ -153,8 +155,9 @@ def test_preservation_verifies_existing_copy_and_keeps_both_files(
     result = st._migration_scan(migration.folder, active)
     st._discard_snapshot(result.get("snapshot_path"))
 
-    protected = [p for p in migration.folder.glob(f"{prefix}*.db") if p != damaged]
+    protected = [p for p in _protected(migration.folder, target_db) if p != damaged]
     assert len(protected) == 1
+    assert protected[0].parent == st._recovery_store(migration.folder)
     assert st.get_db_stats(protected[0])["pokemon"] == 4
     assert source.read_bytes() == original
     assert damaged.read_bytes() == damaged_bytes
@@ -162,4 +165,5 @@ def test_preservation_verifies_existing_copy_and_keeps_both_files(
     written = []
     assert st._preserve(source, migration.folder, target_db, [], [], written) == protected[0]
     assert written == []
-    assert len(list(migration.folder.glob(f"{prefix}*.db"))) == 2
+    assert list(migration.folder.glob(f"{prefix}*.db")) == [damaged]
+    assert len(_protected(migration.folder, target_db)) == 2

--- a/tests/test_save_transfer_safety.py
+++ b/tests/test_save_transfer_safety.py
@@ -608,3 +608,69 @@ def test_busy_snapshot_obeys_migration_budget_and_cleans_up(transfer):
         writer.rollback()
         writer.close()
     assert list(transfer.snapshots.iterdir()) == []
+
+
+def test_import_published_but_unfinished_is_reported_as_pending(transfer, monkeypatch):
+    """A staged import that will install must never be announced as aborted."""
+    from Ankimon import save_import
+
+    fsync_directory = save_import._fsync_directory
+    injecting = [True]
+
+    def failing_sync(path):
+        if injecting[0] and Path(path) == transfer.active.parent:
+            raise OSError("injected directory sync failure")
+        return fsync_directory(path)
+
+    monkeypatch.setattr(save_import, "_fsync_directory", failing_sync)
+    closed = []
+    monkeypatch.setattr(st, "close_anki", lambda **kwargs: closed.append(kwargs))
+
+    assert st.import_save() is True
+    injecting[0] = False
+    message = st.showWarning.call_args.args[0]
+    assert "PENDING" in message
+    assert "Cancel Pending Save Import" in message
+    assert "aborted" not in message.lower()
+    assert "unchanged" not in message.lower()
+    # Anki is not closed on our own initiative after an I/O failure, but the
+    # warning's claim is real: the save is armed for the next full start.
+    assert closed == []
+    assert st.get_db_stats(transfer.active)["pokemon"] == 3
+    commit_in_new_process(transfer.active)
+    assert st.get_db_stats(transfer.active)["pokemon"] == 42
+
+
+def test_backup_restore_published_but_unfinished_is_reported_as_pending(transfer, monkeypatch, tmp_path):
+    """Backup Restore shares the staging path and must share its honesty."""
+    from Ankimon import save_import
+
+    backup_dir = tmp_path / "backup_2026-01-01_00-00-00"
+    backup_dir.mkdir()
+    _make_save(backup_dir / transfer.active.name, pokemon=11, name="Restored")
+    manager = backup_manager.BackupManager(_Logger(), SimpleNamespace(get=lambda *a, **k: None))
+    monkeypatch.setattr(services, "db", SimpleNamespace(db_path=transfer.active))
+    warn = MagicMock()
+    monkeypatch.setattr(backup_manager, "showWarning", warn)
+    monkeypatch.setattr(backup_manager, "showInfo", MagicMock())
+    monkeypatch.setattr(backup_manager, "askUser", lambda *a, **k: True)
+    monkeypatch.setattr(backup_manager, "close_anki", MagicMock())
+
+    fsync_directory = save_import._fsync_directory
+    injecting = [True]
+
+    def failing_sync(path):
+        if injecting[0] and Path(path) == transfer.active.parent:
+            raise OSError("injected directory sync failure")
+        return fsync_directory(path)
+
+    monkeypatch.setattr(save_import, "_fsync_directory", failing_sync)
+    manager.restore_backup(str(backup_dir))
+    injecting[0] = False
+
+    message = warn.call_args.args[0]
+    assert "PENDING" in message
+    assert "Cancel Pending Save Import" in message
+    assert "Failed to prepare" not in message
+    commit_in_new_process(transfer.active)
+    assert st.get_db_stats(transfer.active)["pokemon"] == 11

--- a/tests/test_save_transfer_safety.py
+++ b/tests/test_save_transfer_safety.py
@@ -719,3 +719,23 @@ def test_import_that_cannot_announce_itself_is_not_called_an_abort(transfer, mon
     assert "Nothing was replaced" not in str(warn.call_args_list)
     assert st.get_db_stats(transfer.active)["pokemon"] == 42
 
+
+def test_a_rescue_that_cannot_quiet_the_save_says_why_nothing_happened(transfer):
+    """The user said yes. A silent False left no rescue, no message and no reason,
+    and the same question came back at the next launch."""
+    from Ankimon import save_import
+
+    @contextmanager
+    def still_busy(target):
+        yield False
+
+    transfer.sync._quiesce_live_db_connection = still_busy
+    digest = st._save_snapshot_digest(transfer.active)
+    assert st._replace_active_save(transfer.incoming, transfer.active, "Rescue",
+                                   collection=transfer.col, local_digest=digest) is False
+    message = st.showWarning.call_args.args[0]
+    assert message.startswith("Rescue aborted:")
+    assert "did not stop in time" in message
+    # No menu action starts a rescue; the next scan offers it again.
+    assert "offered again after the next sync or restart" in message
+    assert save_import.pending_import_info(transfer.active) is None

--- a/tests/test_save_transfer_safety.py
+++ b/tests/test_save_transfer_safety.py
@@ -50,7 +50,7 @@ def transfer(tmp_path, monkeypatch):
     monkeypatch.setattr(st, "_active_db_path", lambda: active)
     monkeypatch.setattr(st, "showInfo", MagicMock())
     monkeypatch.setattr(st, "showWarning", MagicMock())
-    def restart():
+    def restart(**kwargs):
         if services.db is not None:
             services.db.close()
         commit_in_new_process(active)
@@ -302,7 +302,7 @@ def test_rescue_recovery_includes_progress_after_staging(transfer, rescue, monke
     st._apply_migration_result(st._migration_scan(rescue.media, transfer.active), _Logger())
     assert len(rescue.callbacks) == 1
 
-    def finish_old_session():
+    def finish_old_session(**kwargs):
         with sqlite3.connect(transfer.active) as conn:
             conn.executemany("INSERT INTO captured_pokemon VALUES (?, 0, '{}')",
                              [(f"mobile-{i}",) for i in range(5)])

--- a/tests/test_save_transfer_safety.py
+++ b/tests/test_save_transfer_safety.py
@@ -652,6 +652,8 @@ def test_backup_restore_published_but_unfinished_is_reported_as_pending(transfer
     monkeypatch.setattr(services, "db", SimpleNamespace(db_path=transfer.active))
     warn = MagicMock()
     monkeypatch.setattr(backup_manager, "showWarning", warn)
+    # Warnings about an armed restore go through the presenter port.
+    monkeypatch.setattr(services, "ui", SimpleNamespace(warn=warn))
     monkeypatch.setattr(backup_manager, "showInfo", MagicMock())
     monkeypatch.setattr(backup_manager, "askUser", lambda *a, **k: True)
     monkeypatch.setattr(backup_manager, "close_anki", MagicMock())
@@ -739,3 +741,27 @@ def test_a_rescue_that_cannot_quiet_the_save_says_why_nothing_happened(transfer)
     # No menu action starts a rescue; the next scan offers it again.
     assert "offered again after the next sync or restart" in message
     assert save_import.pending_import_info(transfer.active) is None
+
+
+def test_a_close_failure_notice_that_cannot_be_shown_is_not_called_an_abort(transfer, monkeypatch):
+    """The import is published before Anki is asked to close.
+
+    A warning about the failed close that raised unwound into import_save's
+    "Import aborted ... Nothing was replaced" handler, over a staged import.
+    """
+    from Ankimon import save_import
+
+    shown = []
+
+    def refuse_close(**kwargs):
+        raise RuntimeError("no main window")
+
+    def broken_warning(message, *args, **kwargs):
+        shown.append(message)
+        raise RuntimeError("wrapped C/C++ object has been deleted")
+
+    monkeypatch.setattr(st, "close_anki", refuse_close)
+    monkeypatch.setattr(st, "showWarning", broken_warning)
+    assert st.import_save() is True
+    assert [message.split(":")[0] for message in shown] == ["Anki could not close"]
+    assert save_import.pending_import_info(transfer.active) is not None

--- a/tests/test_save_transfer_safety.py
+++ b/tests/test_save_transfer_safety.py
@@ -18,6 +18,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from test_save_transfer import _Logger, _make_save, st
+from test_save_import import commit_in_new_process
 from Ankimon.functions import mobile_sync
 from Ankimon.pyobj import ankimon_sync, backup_manager
 from Ankimon.pyobj import settings as settings_module
@@ -49,7 +50,11 @@ def transfer(tmp_path, monkeypatch):
     monkeypatch.setattr(st, "_active_db_path", lambda: active)
     monkeypatch.setattr(st, "showInfo", MagicMock())
     monkeypatch.setattr(st, "showWarning", MagicMock())
-    monkeypatch.setattr(st, "close_anki", MagicMock())
+    def restart():
+        if services.db is not None:
+            services.db.close()
+        commit_in_new_process(active)
+    monkeypatch.setattr(st, "close_anki", restart)
     monkeypatch.setattr(st, "askUser", lambda *a, **k: True)
     monkeypatch.setattr(st.QFileDialog, "getOpenFileName", lambda *a, **k: (str(incoming), ""))
     monkeypatch.setattr(backup_manager, "user_path", tmp_path)
@@ -62,7 +67,7 @@ def transfer(tmp_path, monkeypatch):
     try:
         yield SimpleNamespace(active=active, incoming=incoming, sync=sync,
                               collection=collection, col=col, snapshots=snapshots,
-                              backups=tmp_path / "ankimon_backups")
+                              backups=tmp_path / "ankimon_recovery")
     finally:
         collection.close()
 
@@ -172,14 +177,15 @@ def test_export_removes_legacy_credentials_without_changing_live_save(
 
 
 def test_import_does_not_copy_a_source_changed_after_verification(transfer, monkeypatch):
-    backup = transfer.sync._backup_before_overwrite
+    from Ankimon import save_import
+    stage = save_import.stage_import
 
-    def backup_during_download(required):
-        result = backup(required)
-        transfer.incoming.write_bytes(b"corrupted during backup" * 100)
+    def stage_during_download(snapshot, target):
+        result = stage(snapshot, target)
+        transfer.incoming.write_bytes(b"corrupted after staging" * 100)
         return result
 
-    monkeypatch.setattr(transfer.sync, "_backup_before_overwrite", backup_during_download)
+    monkeypatch.setattr(save_import, "stage_import", stage_during_download)
     assert st.import_save()
     assert ankimon_sync._verify_sqlite_integrity(transfer.active)
     assert st.get_db_stats(transfer.active)["pokemon"] == 42
@@ -292,28 +298,21 @@ def test_deferred_rescue_invalidates_approval_when_local_save_changes(
         writer.close()
 
 
-def test_rescue_rechecks_changes_during_backup(transfer, rescue, monkeypatch):
+def test_rescue_recovery_includes_progress_after_staging(transfer, rescue, monkeypatch):
     st._apply_migration_result(st._migration_scan(rescue.media, transfer.active), _Logger())
     assert len(rescue.callbacks) == 1
-    backup = transfer.sync._backup_before_overwrite
 
-    def backup_then_progress(required):
-        success = backup(required)
-        connection = sqlite3.connect(transfer.active)
-        try:
-            with connection:
-                connection.executemany("INSERT INTO captured_pokemon VALUES (?, 0, '{}')",
-                                       [(f"mobile-{i}",) for i in range(5)])
-        finally:
-            connection.close()
-        return success
+    def finish_old_session():
+        with sqlite3.connect(transfer.active) as conn:
+            conn.executemany("INSERT INTO captured_pokemon VALUES (?, 0, '{}')",
+                             [(f"mobile-{i}",) for i in range(5)])
+        commit_in_new_process(transfer.active)
 
-    monkeypatch.setattr(transfer.sync, "_backup_before_overwrite", backup_then_progress)
+    monkeypatch.setattr(st, "close_anki", finish_old_session)
     rescue.callbacks.pop(0)()
-    rescue.finish_workers()
-
-    assert st.get_db_stats(transfer.active)["pokemon"] == 8
-    assert len(rescue.prompts) == 1
+    assert st.get_db_stats(transfer.active)["pokemon"] == 4
+    backups = list(transfer.backups.glob("*/ankimon.db"))
+    assert len(backups) == 1 and st.get_db_stats(backups[0])["pokemon"] == 8
     assert list(transfer.snapshots.iterdir()) == []
 
 
@@ -546,17 +545,15 @@ def test_confirmation_cannot_follow_a_profile_switch(transfer, tmp_path, monkeyp
     assert list(transfer.snapshots.iterdir()) == []
 
 
-@pytest.mark.parametrize("failure", ["decline", "backup", "replace"])
+@pytest.mark.parametrize("failure", ["decline", "staging"])
 def test_unsuccessful_import_releases_snapshot_and_preserves_live_save(transfer, monkeypatch, failure):
     before = transfer.active.read_bytes()
     if failure == "decline":
         monkeypatch.setattr(st, "askUser", lambda *a, **k: False)
-    elif failure == "backup":
-        monkeypatch.setattr(transfer.sync, "_backup_before_overwrite", lambda *a: False)
     else:
         def disk_failure(*args):
-            raise OSError("cannot replace destination")
-        monkeypatch.setattr(transfer.sync, "_atomic_replace", disk_failure)
+            raise OSError("cannot prepare destination")
+        monkeypatch.setattr("Ankimon.save_import.stage_import", disk_failure)
     assert st.import_save() is False
     assert transfer.active.read_bytes() == before
     assert list(transfer.snapshots.iterdir()) == []

--- a/tests/test_save_transfer_safety.py
+++ b/tests/test_save_transfer_safety.py
@@ -672,5 +672,50 @@ def test_backup_restore_published_but_unfinished_is_reported_as_pending(transfer
     assert "PENDING" in message
     assert "Cancel Pending Save Import" in message
     assert "Failed to prepare" not in message
+    # Like Import, the restore does not close Anki on its own after an I/O
+    # failure; the user decides when to restart.
+    backup_manager.close_anki.assert_not_called()
     commit_in_new_process(transfer.active)
     assert st.get_db_stats(transfer.active)["pokemon"] == 11
+
+
+def test_backup_restore_that_cannot_announce_itself_is_not_called_a_failure(
+    transfer, monkeypatch, tmp_path,
+):
+    """Staging succeeded outright here, so "failed to prepare" is simply false."""
+    backup_dir = tmp_path / "backup_2026-02-02_00-00-00"
+    backup_dir.mkdir()
+    _make_save(backup_dir / transfer.active.name, pokemon=13, name="Restored")
+    manager = backup_manager.BackupManager(_Logger(), SimpleNamespace(get=lambda *a, **k: None))
+    monkeypatch.setattr(services, "db", SimpleNamespace(db_path=transfer.active))
+    warn = MagicMock()
+    monkeypatch.setattr(backup_manager, "showWarning", warn)
+    monkeypatch.setattr(backup_manager, "askUser", lambda *a, **k: True)
+    monkeypatch.setattr(backup_manager, "close_anki", MagicMock())
+
+    def broken_notice(*args, **kwargs):
+        raise RuntimeError("wrapped C/C++ object has been deleted")
+
+    monkeypatch.setattr(backup_manager, "showInfo", broken_notice)
+    manager.restore_backup(str(backup_dir))
+
+    assert "Failed to prepare backup restore" not in str(warn.call_args_list)
+    # And the restore really is staged, whatever the notice did.
+    commit_in_new_process(transfer.active)
+    assert st.get_db_stats(transfer.active)["pokemon"] == 13
+
+
+def test_import_that_cannot_announce_itself_is_not_called_an_abort(transfer, monkeypatch):
+    """The notice is the last thing that can fail, and it is not the import."""
+    def broken_notice(*args, **kwargs):
+        raise RuntimeError("wrapped C/C++ object has been deleted")
+
+    monkeypatch.setattr(st, "showInfo", broken_notice)
+    warn = MagicMock()
+    monkeypatch.setattr(st, "showWarning", warn)
+
+    assert st.import_save() is True
+    assert "aborted" not in str(warn.call_args_list).lower()
+    assert "Nothing was replaced" not in str(warn.call_args_list)
+    assert st.get_db_stats(transfer.active)["pokemon"] == 42
+

--- a/tests/test_sync_hardening.py
+++ b/tests/test_sync_hardening.py
@@ -278,7 +278,11 @@ def _make_backup_manager(tmp_path, monkeypatch):
     monkeypatch.setattr(bm, "backups_path", tmp_path / "backups")
     (tmp_path / "backups").mkdir()
     monkeypatch.setattr(bm, "_generate_summary", lambda d: {})
-    monkeypatch.setattr(bm, "cleanup_backups", lambda: None)
+    # The real signature. create_backup passes the deadline, so a stub that
+    # cannot take it raised, and the retention guard logged that as a failure.
+    bm.retention_calls = []
+    monkeypatch.setattr(bm, "cleanup_backups",
+                        lambda deadline=None: bm.retention_calls.append(deadline))
     return bm
 
 
@@ -297,6 +301,7 @@ def test_backup_required_file_success_isolated_from_other_file_failure(tmp_path,
         services.db = prev
 
     assert ok is True   # ankimon.db was backed up despite the corrupt DEV file
+    assert bm.retention_calls == [None]   # retention ran, with no shutdown deadline
     backup_dir = next(bm.backups_path.glob("backup_*"))
     conn = sqlite3.connect(backup_dir / "ankimon.db")
     try:

--- a/tests/test_sync_hardening.py
+++ b/tests/test_sync_hardening.py
@@ -282,24 +282,12 @@ def _make_backup_manager(tmp_path, monkeypatch):
     return bm
 
 
-def _flaky_copy_factory(fail_substr):
-    real = shutil.copy2
-
-    def flaky(src, dst, *a, **k):
-        if fail_substr in str(src):
-            raise OSError(f"simulated failure copying {src}")
-        return real(src, dst, *a, **k)
-
-    return flaky
-
-
 def test_backup_required_file_success_isolated_from_other_file_failure(tmp_path, monkeypatch):
-    """A failed ankimonDEV.db copy must NOT blank a successful ankimon.db backup
+    """A failed ankimonDEV.db snapshot must NOT blank a successful ankimon.db backup
     — otherwise a perfectly safe import would be needlessly aborted."""
-    (tmp_path / "ankimon.db").write_bytes(b"MAIN" + b"\x00" * 600)
+    _make_ankimon_db(tmp_path / "ankimon.db")
     (tmp_path / "ankimonDEV.db").write_bytes(b"DEV" + b"\x00" * 600)
     bm = _make_backup_manager(tmp_path, monkeypatch)
-    monkeypatch.setattr(shutil, "copy2", _flaky_copy_factory("ankimonDEV.db"))
 
     prev = services.db
     services.db = None   # active-mode default is "ankimon.db"
@@ -308,13 +296,19 @@ def test_backup_required_file_success_isolated_from_other_file_failure(tmp_path,
     finally:
         services.db = prev
 
-    assert ok is True   # ankimon.db was backed up despite the DEV copy failing
+    assert ok is True   # ankimon.db was backed up despite the corrupt DEV file
+    backup_dir = next(bm.backups_path.glob("backup_*"))
+    conn = sqlite3.connect(backup_dir / "ankimon.db")
+    try:
+        assert conn.execute("SELECT * FROM captured_pokemon").fetchall() == [(1, "x")]
+    finally:
+        conn.close()
+    assert not (backup_dir / "ankimonDEV.db").exists()
 
 
 def test_backup_returns_false_when_required_file_not_backed_up(tmp_path, monkeypatch):
     (tmp_path / "ankimon.db").write_bytes(b"MAIN" + b"\x00" * 600)
     bm = _make_backup_manager(tmp_path, monkeypatch)
-    monkeypatch.setattr(shutil, "copy2", _flaky_copy_factory("ankimon.db"))
 
     prev = services.db
     services.db = None

--- a/tests/test_transfer_followup.py
+++ b/tests/test_transfer_followup.py
@@ -90,6 +90,27 @@ def test_both_bare_saves_survive_before_worker_runs(transfer, tmp_path, monkeypa
     assert len(work) == 1
 
 
+def test_verified_recovery_copies_stay_outside_anki_media_sync(transfer, tmp_path):
+    media = tmp_path / "collection.media"
+    media.mkdir()
+    source = _make_save(media / "ankimon.db", pokemon=7)
+    with sqlite3.connect(source) as conn:
+        conn.execute(
+            "INSERT INTO config VALUES ('leaderboard.api_key', 'local-private-key')"
+        )
+
+    result = st._protect_bare_saves(media)
+
+    protected = result["protected"][source]
+    assert protected.parent == st._recovery_store(media)
+    assert protected.parent != media
+    assert not list(media.glob("_ankimon_save_*.db"))
+    with sqlite3.connect(protected) as conn:
+        assert conn.execute(
+            "SELECT value FROM config WHERE key='leaderboard.api_key'"
+        ).fetchone()[0] == "local-private-key"
+
+
 def test_media_preservation_captures_wal(transfer, tmp_path):
     media = tmp_path / "collection.media"
     media.mkdir()
@@ -138,6 +159,8 @@ def test_locked_media_is_archived_before_worker_and_never_claimed_verified(trans
         assert result["protected"] == {}
         assert result["unprotected"] == [source]
         assert len(result["archives"]) == 1
+        assert result["archives"][0].parent == st._recovery_store(media)
+        assert not list(media.glob("_ankimon_unverified_*.zip"))
         with zipfile.ZipFile(result["archives"][0]) as archive:
             assert archive.read("ankimon.db") == original
         monkeypatch.setattr(st, "_LAST_PROTECTION_NOTICE", None)

--- a/tests/test_transfer_followup.py
+++ b/tests/test_transfer_followup.py
@@ -452,3 +452,72 @@ def test_cancel_reaches_an_import_staged_against_the_other_save_mode(
     assert len(shown) == 1
     assert "ankimonDEV.db" in shown[0]
     assert "no pending save import" not in shown[0]
+
+
+def test_a_partial_cancellation_names_what_was_cancelled_as_well_as_what_failed(
+    transfer, tmp_path, monkeypatch
+):
+    """One mode can cancel while the other fails, its event already emitted.
+
+    A warning naming only the failure tells the user nothing was cancelled.
+    """
+    from Ankimon import save_import
+
+    monkeypatch.setattr(st, "user_path", tmp_path)
+    developer = _make_save(tmp_path / "ankimonDEV.db", pokemon=1, name="Dev")
+    save_import.stage_import(transfer.incoming, transfer.active)
+    save_import.stage_import(transfer.incoming, developer)
+    cancel = save_import.cancel_pending_import
+
+    def locked_for_developer(target):
+        if Path(target).name == "ankimonDEV.db":
+            raise PermissionError("manifest locked")
+        return cancel(target)
+
+    monkeypatch.setattr(save_import, "cancel_pending_import", locked_for_developer)
+
+    st.cancel_pending_save_import()
+
+    message = st.showWarning.call_args.args[0]
+    assert "ankimonDEV.db: manifest locked" in message
+    assert "Cancelled successfully: ankimon.db" in message
+    assert save_import.pending_import_info(transfer.active) is None
+    assert save_import.pending_import_info(developer) is not None
+
+
+def test_a_record_whose_install_state_cannot_be_read_is_cancelled_without_guessing(
+    transfer, monkeypatch
+):
+    """A locked save gives no answer in time; neither confident message is safe."""
+    from Ankimon import save_import
+
+    save_import.stage_import(transfer.incoming, transfer.active)
+    monkeypatch.setattr(save_import, "pending_import_is_installed", lambda target: None)
+    shown = []
+    monkeypatch.setattr(st, "showInfo", lambda message: shown.append(message))
+
+    st.cancel_pending_save_import()
+
+    assert save_import.pending_import_info(transfer.active) is None
+    assert len(shown) == 1
+    assert "could not read the save" in shown[0]
+    assert "unchanged" not in shown[0].lower()
+    assert "is the imported one" not in shown[0]
+
+
+def test_a_second_import_over_a_record_of_unknown_state_claims_neither_answer(
+    transfer, monkeypatch
+):
+    from Ankimon import save_import
+
+    save_import.stage_import(transfer.incoming, transfer.active)
+    monkeypatch.setattr(save_import, "pending_import_is_installed", lambda target: None)
+    shown = []
+    monkeypatch.setattr(st, "showWarning", lambda message: shown.append(message))
+
+    assert st.import_save() is True
+
+    assert len(shown) == 1
+    assert "could not read the save" in shown[0]
+    assert "will install at the next" not in shown[0].lower()
+    assert "is the save you are playing" not in shown[0]

--- a/tests/test_transfer_followup.py
+++ b/tests/test_transfer_followup.py
@@ -1,6 +1,8 @@
 """Real-file regressions for the follow-up safety review of #797."""
 import os
+import re
 import sqlite3
+import urllib.parse
 import zipfile
 from pathlib import Path
 from concurrent.futures import Future
@@ -572,3 +574,55 @@ def test_a_second_import_over_a_record_of_unknown_state_claims_neither_answer(
     assert "could not tell whether" in shown[0]
     assert "will install at the next" not in shown[0].lower()
     assert "is the save you are playing" not in shown[0]
+
+
+def test_every_menu_path_an_import_or_recovery_notice_names_exists():
+    """These notices are the only pointer to Cancel and to the recovery copies.
+
+    One named an item that never existed ("Browse Recovered Saves"), and every
+    path left out the Game submenu the actions actually live in.
+    """
+    root = Path(__file__).resolve().parents[1] / "src" / "Ankimon"
+    menu = (root / "menu_buttons.py").read_text(encoding="utf-8")
+    game_items = [label for variable, label in
+                  re.findall(r'(\w+) = QAction\("([^"]+)", mw\)', menu)
+                  if f"game_menu.addAction({variable})" in menu]
+    assert "Cancel Pending Save Import" in game_items
+    assert "Browse Pre-import Recovery Saves…" in game_items
+
+    checked = 0
+    for path in (root / "save_import.py", root / "profile_hooks.py",
+                 root / "pyobj" / "save_transfer.py", root / "pyobj" / "backup_manager.py"):
+        # Join implicitly concatenated literals, so a path split across two
+        # source lines is read the way the user reads it.
+        text = re.sub(r'"\s*\n\s*f?"', "", path.read_text(encoding="utf-8"))
+        text = text.replace("\\u2192", "→")
+        for match in re.finditer("Ankimon → ", text):
+            rest = text[match.end():]
+            assert rest.startswith("Game → ") and any(
+                rest[len("Game → "):].startswith(label) for label in game_items
+            ), f"{path.name}: Ankimon → {rest[:60]!r}"
+            checked += 1
+    assert checked >= 10
+
+
+def test_every_read_only_open_works_on_a_network_path(transfer, tmp_path, monkeypatch):
+    """Path.as_uri gives a UNC path a server authority, and SQLite refuses it.
+
+    On a redirected AppData folder every one of these failed: stats, verification,
+    snapshots and backups alike.
+    """
+    from Ankimon.pyobj.ankimon_sync import _verify_sqlite_integrity
+    from Ankimon.pyobj.backup_manager import BackupManager
+
+    save = _make_save(tmp_path / "shared-ankimon.db", pokemon=4)
+    copy, snapshot = tmp_path / "copy.db", tmp_path / "snapshot.db"
+    with monkeypatch.context() as patched:
+        patched.setattr(Path, "as_uri",
+                        lambda self: "file://server" + urllib.parse.quote(str(self)))
+        assert st.get_db_stats(save)["pokemon"] == 4
+        assert _verify_sqlite_integrity(save) is True
+        st._sqlite_backup(save, copy)
+        BackupManager._snapshot_database(save, snapshot)
+    assert st.get_db_stats(copy)["pokemon"] == 4
+    assert st.get_db_stats(snapshot)["pokemon"] == 4

--- a/tests/test_transfer_followup.py
+++ b/tests/test_transfer_followup.py
@@ -3,6 +3,8 @@ import os
 import sqlite3
 import zipfile
 from pathlib import Path
+from concurrent.futures import Future
+from types import SimpleNamespace
 
 import pytest
 
@@ -70,7 +72,7 @@ def test_export_statistics_describe_snapshot_after_picker(transfer, tmp_path, mo
 
 
 @pytest.mark.parametrize("change", ["replace", "delete"])
-def test_both_bare_saves_survive_before_worker_runs(transfer, tmp_path, monkeypatch, change):
+def test_both_bare_saves_are_guarded_until_worker_captures_them(transfer, tmp_path, monkeypatch, change):
     media = tmp_path / "collection.media"
     media.mkdir()
     for name in ("ankimon.db", "ankimonDEV.db"):
@@ -78,9 +80,20 @@ def test_both_bare_saves_survive_before_worker_runs(transfer, tmp_path, monkeypa
     monkeypatch.setattr(st, "_media_dir", lambda: media)
     monkeypatch.setattr(st, "_migration_done", lambda: False)
     monkeypatch.setattr(st, "_MIGRATION_SCAN_STATE", {"running": False, "rerun": False})
+    pm = SimpleNamespace(profileFolder=lambda: str(tmp_path), media_syncing_enabled=lambda: True)
+    monkeypatch.setattr(st.mw, "pm", pm)
     work = []
-    monkeypatch.setattr(st.mw.taskman, "run_in_background", lambda scan, done, **kw: work.append(scan))
+    monkeypatch.setattr(st.mw.taskman, "run_in_background", lambda scan, done, **kw: work.append((scan, done)))
     st.start_media_migration(None, _Logger())
+    assert pm.media_syncing_enabled() is False
+    assert _protected(media) == []
+    assert len(work) == 1
+    scan, done = work[0]
+    future = Future()
+    future.set_result(scan())
+    assert pm.media_syncing_enabled() is False
+    done(future)
+    assert pm.media_syncing_enabled() is True
     for name in ("ankimon.db", "ankimonDEV.db"):
         (media / name).unlink()
         if change == "replace":
@@ -131,22 +144,23 @@ def test_media_preservation_captures_wal(transfer, tmp_path):
 def test_existing_digest_copy_must_verify_before_being_reported_protected(transfer, tmp_path):
     media = tmp_path / "collection.media"
     media.mkdir()
-    source = media / "ankimon.db"
-    with sqlite3.connect(source) as conn:
-        conn.execute("CREATE TABLE unrelated (id INTEGER)")
+    source = _make_save(media / "ankimon.db", pokemon=17)
     snapshot = tmp_path / "copied.db"
     st._sqlite_backup(source, snapshot)
-    existing = media / st._protected_copy_name(source.name, st._content_digest(snapshot))
-    existing.write_bytes(snapshot.read_bytes())
+    recovery = st._recovery_store(media, create=True)
+    existing = recovery / st._protected_copy_name(source.name, st._content_digest(snapshot))
+    existing.write_bytes(b"damaged existing save")
 
     protection = st._protect_bare_saves(media)
 
-    assert protection["protected"] == {}
-    assert protection["unprotected"] == [source]
-    assert len(protection["archives"]) == 1
+    numbered = existing.with_name(f"{existing.stem}-1.db")
+    assert protection["protected"] == {source: numbered}
+    assert protection["unprotected"] == []
+    assert st.get_db_stats(numbered)["pokemon"] == 17
+    assert existing.read_bytes() == b"damaged existing save"
 
 
-def test_locked_media_is_archived_before_worker_and_never_claimed_verified(transfer, tmp_path, monkeypatch):
+def test_locked_media_archive_is_never_claimed_verified(transfer, tmp_path, monkeypatch):
     media = tmp_path / "collection.media"
     media.mkdir()
     source = _make_save(media / "ankimon.db", pokemon=17)
@@ -197,12 +211,11 @@ def test_damaged_existing_raw_archive_is_not_reported_as_a_retained_copy(transfe
 
 
 @pytest.mark.skipif(os.name == "nt", reason="POSIX unreadable-file reproduction")
+@pytest.mark.skipif(hasattr(os, "geteuid") and os.geteuid() == 0,
+                    reason="root bypasses the mode bits this test relies on")
 def test_uncaptured_original_pauses_only_its_profile_and_successful_retry_restores_sync(
     transfer, tmp_path, monkeypatch,
 ):
-    from concurrent.futures import Future
-    from types import SimpleNamespace
-
     profiles = [tmp_path / "profile-a", tmp_path / "profile-b"]
     for path in profiles:
         (path / "collection.media").mkdir(parents=True)
@@ -218,7 +231,7 @@ def test_uncaptured_original_pauses_only_its_profile_and_successful_retry_restor
     monkeypatch.setattr(st, "_LAST_PROTECTION_NOTICE", None)
     monkeypatch.setattr(st, "_MIGRATION_SCAN_STATE", {"running": False, "rerun": False})
     callbacks = []
-    monkeypatch.setattr(st.mw.taskman, "run_in_background", lambda scan, done, **kw: callbacks.append(done))
+    monkeypatch.setattr(st.mw.taskman, "run_in_background", lambda scan, done, **kw: callbacks.append((scan, done)))
     source = _make_save(profiles[0] / "collection.media" / "ankimon.db", pokemon=17)
     original_mode = source.stat().st_mode
     source.chmod(0)
@@ -232,9 +245,10 @@ def test_uncaptured_original_pauses_only_its_profile_and_successful_retry_restor
         active_profile[0] = profiles[0]
         assert pm.media_syncing_enabled() is False
 
+        scan, done = callbacks.pop(0)
         failed = Future()
-        failed.set_exception(RuntimeError("comparison worker failed"))
-        callbacks[0](failed)
+        failed.set_result(scan())
+        done(failed)
         assert pm.media_syncing_enabled() is False
         assert any("Media sync is paused" in call.args[0] for call in st.showWarning.call_args_list)
     finally:
@@ -242,13 +256,18 @@ def test_uncaptured_original_pauses_only_its_profile_and_successful_retry_restor
 
     st.start_media_migration(None, _Logger())
     assert pm.media_syncing_enabled is guarded_method
+    assert pm.media_syncing_enabled() is False
+    scan, done = callbacks.pop(0)
+    recovered = Future()
+    recovered.set_result(scan())
+    done(recovered)
     assert pm.media_syncing_enabled() is True
     assert preferences == {"syncMedia": True, "autoSync": True}
     preferences["syncMedia"] = False
     assert pm.media_syncing_enabled() is False
 
 
-def test_dispatch_failure_preserves_files_without_running_scan(transfer, tmp_path, monkeypatch):
+def test_dispatch_failure_guards_files_without_running_scan(transfer, tmp_path, monkeypatch):
     media = tmp_path / "collection.media"
     media.mkdir()
     _make_save(media / "ankimon.db", pokemon=17)
@@ -265,7 +284,9 @@ def test_dispatch_failure_preserves_files_without_running_scan(transfer, tmp_pat
     monkeypatch.setattr(st.mw.taskman, "run_in_background", refused)
     monkeypatch.setattr(st, "_migration_scan", forbidden)
     st.start_media_migration(None, _Logger())
-    assert st.get_db_stats(_protected(media)[0])["pokemon"] == 17
+    assert st.get_db_stats(media / "ankimon.db")["pokemon"] == 17
+    assert _protected(media) == []
+    assert media in st.mw.pm._ankimon_media_protection_guard["blocked"]
     assert "retried" in st.showWarning.call_args.args[0]
 
 
@@ -277,7 +298,7 @@ def test_import_keeps_old_runtime_on_original_database(transfer, monkeypatch, sh
 
     monkeypatch.setattr(st, "showInfo", queued_old_write)
 
-    def close():
+    def close(**kwargs):
         if shutdown == "exception":
             raise RuntimeError("shutdown failed")
         if shutdown == "sync":

--- a/tests/test_transfer_followup.py
+++ b/tests/test_transfer_followup.py
@@ -480,15 +480,65 @@ def test_a_partial_cancellation_names_what_was_cancelled_as_well_as_what_failed(
 
     message = st.showWarning.call_args.args[0]
     assert "ankimonDEV.db: manifest locked" in message
-    assert "Cancelled successfully: ankimon.db" in message
+    assert "ankimon.db: the pending import was cancelled" in message
     assert save_import.pending_import_info(transfer.active) is None
     assert save_import.pending_import_info(developer) is not None
+
+
+def test_a_partial_cancellation_does_not_call_an_installed_import_cancelled(
+    transfer, tmp_path, monkeypatch
+):
+    """The side that succeeded may be a record for an import that already installed."""
+    from Ankimon import save_import
+
+    monkeypatch.setattr(st, "user_path", tmp_path)
+    developer = _make_save(tmp_path / "ankimonDEV.db", pokemon=1, name="Dev")
+    _install_without_cleanup(transfer)
+    save_import.stage_import(transfer.incoming, developer)
+    cancel = save_import.cancel_pending_import
+
+    def locked_for_developer(target):
+        if Path(target).name == "ankimonDEV.db":
+            raise PermissionError("manifest locked")
+        return cancel(target)
+
+    monkeypatch.setattr(save_import, "cancel_pending_import", locked_for_developer)
+
+    st.cancel_pending_save_import()
+
+    message = st.showWarning.call_args.args[0]
+    assert "ankimonDEV.db: manifest locked" in message
+    assert "ankimon.db: that import had ALREADY installed" in message
+    assert "ankimon.db: the pending import was cancelled" not in message
+
+
+def test_mixed_outcomes_are_each_named_against_their_own_save(
+    transfer, tmp_path, monkeypatch
+):
+    """An installed record for one save must not speak for the other save's cancel."""
+    import shutil
+
+    from Ankimon import save_import
+
+    monkeypatch.setattr(st, "user_path", tmp_path)
+    developer = _make_save(tmp_path / "ankimonDEV.db", pokemon=1, name="Dev")
+    save_import.stage_import(transfer.incoming, transfer.active)
+    staged = save_import.stage_import(transfer.incoming, developer)
+    shutil.copyfile(staged["pending_path"], developer)
+    shown = []
+    monkeypatch.setattr(st, "showInfo", lambda message: shown.append(message))
+
+    st.cancel_pending_save_import()
+
+    assert len(shown) == 1
+    assert "ankimon.db: the pending import was cancelled. This save is unchanged." in shown[0]
+    assert "ankimonDEV.db: that import had ALREADY installed" in shown[0]
 
 
 def test_a_record_whose_install_state_cannot_be_read_is_cancelled_without_guessing(
     transfer, monkeypatch
 ):
-    """A locked save gives no answer in time; neither confident message is safe."""
+    """A damaged record or a locked save gives no answer in time; neither guess is safe."""
     from Ankimon import save_import
 
     save_import.stage_import(transfer.incoming, transfer.active)
@@ -500,7 +550,8 @@ def test_a_record_whose_install_state_cannot_be_read_is_cancelled_without_guessi
 
     assert save_import.pending_import_info(transfer.active) is None
     assert len(shown) == 1
-    assert "could not read the save" in shown[0]
+    assert "could not tell whether" in shown[0]
+    assert "could not read the save" not in shown[0]
     assert "unchanged" not in shown[0].lower()
     assert "is the imported one" not in shown[0]
 
@@ -518,6 +569,6 @@ def test_a_second_import_over_a_record_of_unknown_state_claims_neither_answer(
     assert st.import_save() is True
 
     assert len(shown) == 1
-    assert "could not read the save" in shown[0]
+    assert "could not tell whether" in shown[0]
     assert "will install at the next" not in shown[0].lower()
     assert "is the save you are playing" not in shown[0]

--- a/tests/test_transfer_followup.py
+++ b/tests/test_transfer_followup.py
@@ -426,3 +426,29 @@ def test_a_second_import_is_not_told_the_installed_one_is_still_coming(
     assert len(shown) == 1
     assert "already installed" in shown[0].lower()
     assert "will install at the next" not in shown[0].lower()
+
+
+def test_cancel_reaches_an_import_staged_against_the_other_save_mode(
+    transfer, tmp_path, monkeypatch
+):
+    """Startup tries both modes and blames Cancel when either fails.
+
+    Resolving only the active save made that advice answer "there is no pending
+    save import" to somebody looking at a warning about the other one.
+    """
+    from Ankimon.save_import import pending_import_info, stage_import
+
+    monkeypatch.setattr(st, "user_path", tmp_path)
+    developer = _make_save(tmp_path / "ankimonDEV.db", pokemon=1, name="Dev")
+    stage_import(transfer.incoming, developer)
+    assert pending_import_info(developer) is not None
+
+    shown = []
+    monkeypatch.setattr(st, "showInfo", lambda message: shown.append(message))
+
+    st.cancel_pending_save_import()
+
+    assert pending_import_info(developer) is None
+    assert len(shown) == 1
+    assert "ankimonDEV.db" in shown[0]
+    assert "no pending save import" not in shown[0]

--- a/tests/test_transfer_followup.py
+++ b/tests/test_transfer_followup.py
@@ -343,3 +343,86 @@ def test_import_without_config_cannot_resurrect_legacy_local_credentials(transfe
         assert loaded.get("leaderboard.api_key") == ""
     finally:
         imported_db.close()
+
+
+@pytest.mark.parametrize("outcome", ["staged", "already_pending"])
+def test_an_armed_import_is_never_reported_as_aborted_when_qt_fails(
+    transfer, monkeypatch, outcome
+):
+    """Losing the notice must not turn a published import into "nothing changed".
+
+    Both of these branches exist to say an import IS coming. They reach Qt
+    through mw.app.activeWindow() from a shutdown-adjacent stack, so the call
+    can raise -- and unguarded it lands in import_save's generic handler, which
+    tells the user nothing was replaced while the save is armed to install.
+    """
+    from Ankimon import save_import as importer
+
+    error = (
+        importer.ImportStagedError("injected durability failure")
+        if outcome == "staged"
+        else importer.ImportAlreadyPendingError("an import is already staged")
+    )
+
+    def refuse(*args, **kwargs):
+        raise error
+
+    monkeypatch.setattr(importer, "stage_import", refuse)
+
+    shown = []
+
+    def torn_down_qt(message):
+        shown.append(message)
+        if len(shown) == 1:
+            raise RuntimeError("wrapped C/C++ object of type AnkiQt has been deleted")
+
+    monkeypatch.setattr(st, "showWarning", torn_down_qt)
+
+    assert st.import_save() is True
+    assert len(shown) == 1, f"a second message followed the lost notice: {shown[1:]}"
+    assert "pending" in shown[0].lower()
+    assert "aborted" not in shown[0].lower()
+
+
+def _install_without_cleanup(transfer):
+    """The state a failed post-install cleanup leaves: installed, record kept."""
+    import shutil
+
+    from Ankimon.save_import import stage_import
+
+    staged = stage_import(transfer.incoming, transfer.active)
+    shutil.copyfile(staged["pending_path"], transfer.active)
+    return staged
+
+
+def test_cancelling_a_record_for_an_installed_import_does_not_claim_nothing_changed(
+    transfer, monkeypatch
+):
+    """The save IS the imported one here, so "unchanged" is the opposite of true."""
+    from Ankimon.save_import import pending_import_info
+
+    _install_without_cleanup(transfer)
+    shown = []
+    monkeypatch.setattr(st, "showInfo", lambda message: shown.append(message))
+
+    st.cancel_pending_save_import()
+
+    assert pending_import_info(transfer.active) is None
+    assert len(shown) == 1
+    assert "already installed" in shown[0].lower()
+    assert "unchanged" not in shown[0].lower()
+
+
+def test_a_second_import_is_not_told_the_installed_one_is_still_coming(
+    transfer, monkeypatch
+):
+    """"Will install at the next restart" describes a replacement already made."""
+    _install_without_cleanup(transfer)
+    shown = []
+    monkeypatch.setattr(st, "showWarning", lambda message: shown.append(message))
+
+    assert st.import_save() is True
+
+    assert len(shown) == 1
+    assert "already installed" in shown[0].lower()
+    assert "will install at the next" not in shown[0].lower()

--- a/tests/test_transfer_followup.py
+++ b/tests/test_transfer_followup.py
@@ -1,0 +1,301 @@
+"""Real-file regressions for the follow-up safety review of #797."""
+import os
+import sqlite3
+import zipfile
+from pathlib import Path
+
+import pytest
+
+from test_save_transfer import _make_save, _Logger, st, _protected
+from test_save_transfer_safety import transfer
+
+
+@pytest.mark.parametrize("failure", [None, "redaction", "publication"])
+def test_export_never_places_secrets_in_destination(transfer, tmp_path, monkeypatch, failure):
+    secret = b"synthetic-secret-destination-observer"
+    with sqlite3.connect(transfer.active) as conn:
+        conn.execute("INSERT INTO config VALUES ('leaderboard.api_key', ?)", (secret.decode(),))
+    destination = tmp_path / "shared"
+    destination.mkdir()
+    exported = destination / "portable.db"
+    monkeypatch.setattr(st.QFileDialog, "getSaveFileName", lambda *a, **k: (str(exported), ""))
+    observed = []
+
+    def observe():
+        for path in destination.iterdir():
+            if path.is_file():
+                observed.append(path.read_bytes())
+
+    backup, redact, replace = st._sqlite_backup, st._strip_local_secrets, os.replace
+
+    def snapshot(*args, **kwargs):
+        backup(*args, **kwargs)
+        observe()
+
+    def sanitise(path):
+        observe()
+        if failure == "redaction":
+            raise OSError("injected redaction failure")
+        redact(path)
+        observe()
+
+    def publish(src, dst):
+        observe()
+        if failure == "publication" and Path(dst) == exported:
+            raise OSError("injected publication failure")
+        replace(src, dst)
+        observe()
+
+    monkeypatch.setattr(st, "_sqlite_backup", snapshot)
+    monkeypatch.setattr(st, "_strip_local_secrets", sanitise)
+    monkeypatch.setattr(st.os, "replace", publish)
+    assert st.export_save() is (failure is None)
+    assert all(secret not in content for content in observed)
+    assert secret in transfer.active.read_bytes()
+    assert list(destination.iterdir()) == ([exported] if failure is None else [])
+
+
+def test_export_statistics_describe_snapshot_after_picker(transfer, tmp_path, monkeypatch):
+    dest = tmp_path / "export.db"
+
+    def picker(*args):
+        with sqlite3.connect(transfer.active) as conn:
+            conn.execute("INSERT INTO captured_pokemon VALUES ('during-picker', 0, '{}')")
+        return str(dest), ""
+
+    monkeypatch.setattr(st.QFileDialog, "getSaveFileName", picker)
+    assert st.export_save()
+    assert st.get_db_stats(dest)["pokemon"] == 4
+    assert "Pokemon: 4" in st.showInfo.call_args.args[0]
+
+
+@pytest.mark.parametrize("change", ["replace", "delete"])
+def test_both_bare_saves_survive_before_worker_runs(transfer, tmp_path, monkeypatch, change):
+    media = tmp_path / "collection.media"
+    media.mkdir()
+    for name in ("ankimon.db", "ankimonDEV.db"):
+        _make_save(media / name, pokemon=10, name=name)
+    monkeypatch.setattr(st, "_media_dir", lambda: media)
+    monkeypatch.setattr(st, "_migration_done", lambda: False)
+    monkeypatch.setattr(st, "_MIGRATION_SCAN_STATE", {"running": False, "rerun": False})
+    work = []
+    monkeypatch.setattr(st.mw.taskman, "run_in_background", lambda scan, done, **kw: work.append(scan))
+    st.start_media_migration(None, _Logger())
+    for name in ("ankimon.db", "ankimonDEV.db"):
+        (media / name).unlink()
+        if change == "replace":
+            _make_save(media / name, pokemon=1)
+        copies = _protected(media, name)
+        assert any(st.get_db_stats(path)["pokemon"] == 10 for path in copies)
+    assert len(work) == 1
+
+
+def test_media_preservation_captures_wal(transfer, tmp_path):
+    media = tmp_path / "collection.media"
+    media.mkdir()
+    source = _make_save(media / "ankimon.db", pokemon=3)
+    writer = sqlite3.connect(source)
+    try:
+        writer.execute("PRAGMA journal_mode=WAL")
+        writer.execute("PRAGMA wal_autocheckpoint=0")
+        with writer:
+            writer.execute("INSERT INTO captured_pokemon VALUES ('wal-only', 0, '{}')")
+        protected = st._preserve(source, media, source.name, [], [], [])
+        assert protected is not None
+        assert st.get_db_stats(protected)["pokemon"] == 4
+    finally:
+        writer.close()
+
+
+def test_existing_digest_copy_must_verify_before_being_reported_protected(transfer, tmp_path):
+    media = tmp_path / "collection.media"
+    media.mkdir()
+    source = media / "ankimon.db"
+    with sqlite3.connect(source) as conn:
+        conn.execute("CREATE TABLE unrelated (id INTEGER)")
+    snapshot = tmp_path / "copied.db"
+    st._sqlite_backup(source, snapshot)
+    existing = media / st._protected_copy_name(source.name, st._content_digest(snapshot))
+    existing.write_bytes(snapshot.read_bytes())
+
+    protection = st._protect_bare_saves(media)
+
+    assert protection["protected"] == {}
+    assert protection["unprotected"] == [source]
+    assert len(protection["archives"]) == 1
+
+
+def test_locked_media_is_archived_before_worker_and_never_claimed_verified(transfer, tmp_path, monkeypatch):
+    media = tmp_path / "collection.media"
+    media.mkdir()
+    source = _make_save(media / "ankimon.db", pokemon=17)
+    original = source.read_bytes()
+    writer = sqlite3.connect(source)
+    writer.execute("BEGIN EXCLUSIVE")
+    try:
+        monkeypatch.setattr(st, "MIGRATION_PROBE_TIMEOUT", 0.01)
+        result = st._protect_bare_saves(media)
+        assert result["protected"] == {}
+        assert result["unprotected"] == [source]
+        assert len(result["archives"]) == 1
+        with zipfile.ZipFile(result["archives"][0]) as archive:
+            assert archive.read("ankimon.db") == original
+        monkeypatch.setattr(st, "_LAST_PROTECTION_NOTICE", None)
+        st._report_protection(result, _Logger())
+        assert "unverified" in st.showWarning.call_args.args[0]
+    finally:
+        writer.rollback()
+        writer.close()
+
+
+def test_damaged_existing_raw_archive_is_not_reported_as_a_retained_copy(transfer, tmp_path, monkeypatch):
+    media = tmp_path / "collection.media"
+    media.mkdir()
+    source = _make_save(media / "ankimon.db", pokemon=17)
+    original = source.read_bytes()
+    writer = sqlite3.connect(source)
+    writer.execute("BEGIN EXCLUSIVE")
+    monkeypatch.setattr(st, "MIGRATION_PROBE_TIMEOUT", 0.01)
+    try:
+        first = st._protect_bare_saves(media)
+        damaged = first["archives"][0]
+        damaged.write_bytes(b"damaged archive")
+
+        retried = st._protect_bare_saves(media)
+
+        assert len(retried["archives"]) == 1
+        assert retried["archives"][0] != damaged
+        assert damaged.read_bytes() == b"damaged archive"
+        with zipfile.ZipFile(retried["archives"][0]) as archive:
+            assert archive.read("ankimon.db") == original
+    finally:
+        writer.rollback()
+        writer.close()
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX unreadable-file reproduction")
+def test_uncaptured_original_pauses_only_its_profile_and_successful_retry_restores_sync(
+    transfer, tmp_path, monkeypatch,
+):
+    from concurrent.futures import Future
+    from types import SimpleNamespace
+
+    profiles = [tmp_path / "profile-a", tmp_path / "profile-b"]
+    for path in profiles:
+        (path / "collection.media").mkdir(parents=True)
+    active_profile = [profiles[0]]
+    preferences = {"syncMedia": True, "autoSync": True}
+    pm = SimpleNamespace(
+        profile=preferences,
+        profileFolder=lambda: str(active_profile[0]),
+        media_syncing_enabled=lambda: preferences["syncMedia"],
+    )
+    monkeypatch.setattr(st.mw, "pm", pm)
+    monkeypatch.setattr(st, "_migration_done", lambda: False)
+    monkeypatch.setattr(st, "_LAST_PROTECTION_NOTICE", None)
+    monkeypatch.setattr(st, "_MIGRATION_SCAN_STATE", {"running": False, "rerun": False})
+    callbacks = []
+    monkeypatch.setattr(st.mw.taskman, "run_in_background", lambda scan, done, **kw: callbacks.append(done))
+    source = _make_save(profiles[0] / "collection.media" / "ankimon.db", pokemon=17)
+    original_mode = source.stat().st_mode
+    source.chmod(0)
+    try:
+        st.start_media_migration(None, _Logger())
+        assert pm.media_syncing_enabled() is False
+        guarded_method = pm.media_syncing_enabled
+        assert preferences == {"syncMedia": True, "autoSync": True}
+        active_profile[0] = profiles[1]
+        assert pm.media_syncing_enabled() is True
+        active_profile[0] = profiles[0]
+        assert pm.media_syncing_enabled() is False
+
+        failed = Future()
+        failed.set_exception(RuntimeError("comparison worker failed"))
+        callbacks[0](failed)
+        assert pm.media_syncing_enabled() is False
+        assert any("Media sync is paused" in call.args[0] for call in st.showWarning.call_args_list)
+    finally:
+        source.chmod(original_mode)
+
+    st.start_media_migration(None, _Logger())
+    assert pm.media_syncing_enabled is guarded_method
+    assert pm.media_syncing_enabled() is True
+    assert preferences == {"syncMedia": True, "autoSync": True}
+    preferences["syncMedia"] = False
+    assert pm.media_syncing_enabled() is False
+
+
+def test_dispatch_failure_preserves_files_without_running_scan(transfer, tmp_path, monkeypatch):
+    media = tmp_path / "collection.media"
+    media.mkdir()
+    _make_save(media / "ankimon.db", pokemon=17)
+    monkeypatch.setattr(st, "_media_dir", lambda: media)
+    monkeypatch.setattr(st, "_migration_done", lambda: False)
+    monkeypatch.setattr(st, "_MIGRATION_SCAN_STATE", {"running": False, "rerun": False})
+
+    def refused(*args, **kwargs):
+        raise RuntimeError("executor stopped")
+
+    def forbidden(*args, **kwargs):
+        pytest.fail("comparison ran on GUI thread")
+
+    monkeypatch.setattr(st.mw.taskman, "run_in_background", refused)
+    monkeypatch.setattr(st, "_migration_scan", forbidden)
+    st.start_media_migration(None, _Logger())
+    assert st.get_db_stats(_protected(media)[0])["pokemon"] == 17
+    assert "retried" in st.showWarning.call_args.args[0]
+
+
+@pytest.mark.parametrize("shutdown", ["keep_editing", "exception", "sync"])
+def test_import_keeps_old_runtime_on_original_database(transfer, monkeypatch, shutdown):
+    def queued_old_write(*args):
+        with sqlite3.connect(transfer.active) as conn:
+            conn.execute("UPDATE config SET value='Old runtime' WHERE key='trainer.name'")
+
+    monkeypatch.setattr(st, "showInfo", queued_old_write)
+
+    def close():
+        if shutdown == "exception":
+            raise RuntimeError("shutdown failed")
+        if shutdown == "sync":
+            with sqlite3.connect(transfer.active) as conn:
+                conn.execute("INSERT INTO captured_pokemon VALUES ('shutdown-sync', 0, '{}')")
+        # Keep Editing never invokes Anki's completion callback.
+
+    monkeypatch.setattr(st, "close_anki", close)
+    st.import_save()
+    assert st.get_db_stats(transfer.active)["pokemon"] == (4 if shutdown == "sync" else 3)
+    assert st.get_db_stats(transfer.active)["trainer_name"] == "Old runtime"
+    from Ankimon.save_import import pending_import_info
+    pending = pending_import_info(transfer.active)
+    assert pending is not None
+    assert st.get_db_stats(pending["pending_path"])["pokemon"] == 42
+    assert st.get_db_stats(pending["pending_path"])["trainer_name"] == "Offered"
+
+
+def test_import_without_config_cannot_resurrect_legacy_local_credentials(transfer, tmp_path, monkeypatch):
+    from Ankimon.pyobj import settings as settings_module
+    from Ankimon.pyobj.ankimon_sync import AnkimonDataSync
+    from Ankimon.pyobj.database_manager import AnkimonDB
+    from Ankimon.services import services
+
+    transfer.incoming.unlink()
+    incoming_db = AnkimonDB(_Logger(), db_path=transfer.incoming)
+    incoming_db.close()
+    with sqlite3.connect(transfer.incoming) as conn:
+        conn.execute("DROP TABLE config")
+    (tmp_path / "config.obf").write_text(AnkimonDataSync()._obfuscate_data({
+        "leaderboard.username": "LegacyLocalAccount",
+        "leaderboard.api_key": "synthetic-legacy-local-api-key",
+    }))
+    monkeypatch.setattr(settings_module, "user_path", tmp_path)
+
+    assert st.import_save()
+    imported_db = AnkimonDB(_Logger(), db_path=transfer.active)
+    monkeypatch.setattr(services, "db", imported_db)
+    try:
+        loaded = settings_module.Settings()
+        assert loaded.get("leaderboard.username") == ""
+        assert loaded.get("leaderboard.api_key") == ""
+    finally:
+        imported_db.close()


### PR DESCRIPTION
### Description

Importing a save could replace the live database before Anki's cancellable shutdown, leaving old game objects able to write into the imported save. Imports now prepare a verified snapshot and install it at the next full process start, before database managers and game objects exist. Choosing **Keep Editing** keeps the original save active. Installation captures the final old progress in a separately retained recovery folder; the menu exposes that folder and lets users cancel pending imports.

This follow-up addresses all seven safety findings from the review of #797:

- Defer import installation until a new process, guard failed retries and interrupted cleanup, and rebase the review watermark before mobile detection. Imports explicitly require leaderboard sign-in again and cannot resurrect credentials from legacy local configuration.
- Redact and verify exports in private staging before any bytes enter the selected destination directory. Report statistics from the actual exported snapshot.
- Capture both normal and developer bare media saves before startup sync, including committed WAL data. Keep recovery comparisons within the active mode. Unreadable saves receive explicitly unverified raw archives; if capture also fails, pause media sync for that profile until preservation succeeds.
- Use verified SQLite backups of the exact active database, retain pre-import recovery copies separately from routine rotation, and preserve the final old progress across cancellation and restart.
- Separate preservation status from the feature-removal notice, verify existing protected copies before reusing them, and keep failed background dispatch retryable without running the full comparison on the GUI thread.

The richer recovery browser with trainer/count summaries and cancellable transfer progress UI remain separate UX work. No `uses_collection=False` compatibility workaround was necessary. See [save transfer safety notes](docs/save_transfer_safety.md) for behavior and review disposition.

### CodeRabbit review follow-up

All ten inline findings and the User Data Safety failure are addressed in `4ded780a`: backup attempts enter retention only after successful publication; media preservation runs once in the background behind a sync guard; unchanged unreadable sources have a bounded retry delay; post-install errors, shutdown failures, cancellation errors, recovery permissions, and Windows fsync access are handled explicitly. Tests now exercise damaged digest collisions and platform-specific permission assumptions. An independent review found no remaining concrete issue. The optional blanket docstring-coverage rewrite was declined; rationale is in the safety notes.

### Later review rounds

Five further rounds followed, each recorded in the [safety notes](docs/save_transfer_safety.md). The third of these was an external review of the branch's own fixes: it found no surviving instance of the four findings it re-checked, and verifying them adversarially surfaced fifteen residual gaps, all fixed here with a failing-first test each. Eight further claims were refuted against the source and not acted on.

The ones worth knowing about from that round:

- **A capture could re-arm itself forever.** The signature that decides whether a writer landed mid-copy stats the save's SQLite sidecars, and every read-only open the scan performs on a WAL-mode media save restamps that save's `-shm`. The before/after pair could never agree, so the guard never released and the scan re-dispatched for as long as the profile stayed open. The add-on's own exporter writes single-file DELETE-mode saves, so this needs a file that arrived some other way.
- **The guard suppressed its own retry.** The only recurring rescan trigger is Anki's media-sync hook, and `MediaSyncer.start` returns before firing it when the gate says no. A pass that leaves the guard up now schedules its own timer.
- **A deferred sync was dropped, not held.** Every stand-down path lost the request, including a backup restore in progress — the one state where Anki has switched its own unattended syncs off too.
- **A published import could still be reported as an abort.** The notices that say an import IS armed reached Qt unguarded, so an exception there unwound into the caller's "nothing was replaced" handler.
- **The menu could not tell a pending import from an installed one.** After a failed post-install cleanup the record outlives a save that has already been replaced, and both answers were the wrong way round.
- **Retention could take Anki's close down with it.** `cleanup_backups` sat outside `create_backup`'s guard on a hook Anki does not protect, and ran unbounded while the user waited to exit.
- **The media scan is dispatched last in profile-open again.** Its main-thread callback would otherwise be delivered inside the modal dialogs that follow it, and the rescue it can offer reaches `close_anki` from there.
- **The startup install is bounded and both save modes are answered.** It runs during add-on import, before Anki has a window; and Cancel Pending Save Import now covers the mode the warning is actually about.

The fifth round answered CodeRabbit's last ten open threads and both claims in its User Data Safety check. Nine threads led to changes; the `-shm` thread was refuted from SQLite's own close path. Before pushing, the changes were checked adversarially. That check found seven gaps in them, each fixed with a failing-first test. The notable changes from that round:

- **Cancelling is durable before it is reported.** `pending.json` is rewritten in place as a cancelled record and synced as a file before it is unlinked. A crash that undoes the removals therefore brings back a record that installs nothing. A separate tombstone file would need the very directory sync whose failure this has to survive. If the rewrite cannot be synced, Cancel says so and the import stays pending.
- **A failed removal could evict a kept backup.** Deleting entries restamps a directory's mtime, and retention orders by mtime, so the remains of a removal cut short sorted as the newest backup. Retention and Backup Manager's Delete now rename a directory out of the `backup_` namespace first, then delete inside it one entry at a time under the shutdown deadline. The pre-merge claim that a failed deletion evicts a newer backup was refuted as stated: retention only ever attempts directories beyond `MAX_BACKUPS`.
- **"Unknown" is its own answer.** Whether a leftover record describes an installed import is read within two seconds instead of SQLite's 30-second timeout. A damaged record or a locked save is worded as unknown. Cancel reports one line per save, so an import that installed on one save no longer speaks for the other save's cancellation.
- **The startup install stays inside its budget.** It checks between blocks of the digest and of the copy into place, and before each file sync.

The sixth round came from a whole-branch quality pass, two further CodeRabbit threads and its compatibility check. Every fix has a test that fails without it; 18 of the 28 new or changed test cases fail on the previous head, and the other 10 pin behaviour that was already correct:

- **Media sync stayed paused after reopening a profile.** Switching away and back re-armed the guard with a stat-only check, and the settled scan that followed returned before the one call that lifts it. Media sync then stayed off until Anki restarted.
- **A throttled retry could leave the guard up for good.** Qt can fire the 30-second timer half a second early, and the throttle then turned the retry away without scheduling another. A turned-away pass now asks for a timer covering what is left of the throttle.
- **Windows network paths.** `Path.as_uri` puts a UNC server in the URI authority, which SQLite refuses. On a redirected AppData folder every backup, restore, import and read-only save check therefore failed. One helper now percent-encodes the native path into an authority-less `file:` URI, which keeps `mode=ro`. This was exercised on Linux with `as_uri` answering the way it does on Windows, not on a real share.
- **Installs that could never finish.** An install hit the same error at every start on a mount that refuses a directory fsync (EINVAL/ENOTSUP), or on a recovery folder whose permissions cannot change. Both are now tolerated. A real I/O error, and a folder owned by another account, still stop the install.
- **Smaller fixes.**
  - An accepted rescue that could not quiet the live save now says why.
  - A rerun requested mid-scan no longer runs for a profile that has since closed.
  - Raw archives leave out `-shm`, so an unreadable WAL-mode save is archived once instead of on every pass.
  - Cancel over a save that no longer exists gives a straight answer.
  - Every menu path the import and recovery notices name now exists; one pointed at "Browse Recovered Saves", and all of them skipped the Game submenu.
  - The startup failure notice no longer says that no save was replaced.
- **CodeRabbit.** `_remove_tree` checks the deadline before listing a directory, since `Path.iterdir` reads the whole listing before yielding. The `-shm` test skips where the index is gone. The compatibility check's objection to the synchronous startup install is answered in a comment: the install has to precede any runtime, and an ordinary start pays one failed open of `pending.json` per save mode. After the re-review, the notice that Anki could not close is guarded like the other armed-import notices, and Backup Manager's armed-restore warnings go through `services.ui`.
- **After CodeRabbit's next review.**
  - Backup Restore reports a failure before staging instead of raising `UnboundLocalError`.
  - An import whose save was deleted before the next start now installs. It used to be refused, `get_db` created a fresh save, and the start after that installed the import over it without a notice. Journals left beside the missing save are moved into the import's recovery folder first. Such an install keeps no recovery copy, so Cancel over its leftover record no longer points at one.
  - Recovery folders, and the staging folder that holds a prepared import, are never written through a symlink or junction. Like the pre-import folders, the media recovery store no longer accepts a folder another account owns when `chmod` fails on it. When the store is refused, nothing is written, media sync stays paused, and the notice names the folder and the reason.
- **After CodeRabbit reviewed `562304bc`.** Recovery saves are never read through a link either: a linked media recovery folder is not searched for rescues, a linked copy inside it is neither read nor adopted when a save is preserved, a linked folder keeps the scan armed instead of settling as empty, and Browse Pre-import Recovery Saves refuses a linked folder. The recovery steps of the startup install check the shared budget before each publish, prune and directory sync, and journals beside a missing save are set aside before anything that can spend it.
- **After CodeRabbit reviewed `e0c08f87`.** Junctions are recognised on Pythons without `os.path.isjunction`, which covers every version before 3.12 and so older Anki builds. A save that is itself a link is still followed, deliberately: play opens the save through the same link.

Deferred items are listed with reasons at the end of the [safety notes](docs/save_transfer_safety.md). The main ones:
- Windows lock retries for the backup publish rename and the import's `os.replace` (#636). They need a shared stdlib-only helper and a Windows runner.
- A damaged-but-working current save blocking imports.
- Retention ordering by mtime.

### Related Issue

Follow-up to #797. Addresses the backup consistency and pre-import recovery retention concerns in #798.

### Validation

- Full `pytest tests/` suite, including integrity imports: **1,675 passed, 40 skipped, 9 subtests passed**.
- Current `main` merged with this branch and tested together: **1,712 passed, 40 skipped, 9 subtests passed**, all 13 Tier-1 checks, and the real-Anki save-import probe.
- `python3 harness/check.py`: **all 13 Tier-1 checks passed**.
- All five Tier-2 real-Anki probes pass on the pushed head: boot, play (including catches, defeat, and trainer progression), move selection, save import, and TM learnsets.
- Tier-2 probe `probe_real_save_import`, wired into the Tier 2 CI job, plays the import contract out across a real restart of the real add-on — stage over the live save, keep editing, exit, start again — and checks that the runtime is on the imported save, the retained recovery copy holds the final pre-import progress including the play that followed staging, and nothing is left armed to install twice.
- Real Anki 25.09.2 with a temporary profile (earlier round): an unfinished Add Cards note exercised **Keep Editing** during import shutdown. The original database remained writable, the prepared import remained pending, and a subsequent full process loaded the imported trainer while recovery retained the progress written after cancellation. Only dialog choices were automated.
- Sixth-round tests were run against the previous head first: 18 of the 28 new or changed test cases fail there, and the other 10 pin behaviour that was already correct. An adversarial review of the round's own changes confirmed eight further gaps before push, all fixed here.
- The tests for CodeRabbit's next review were also run against the previous head first: 11 of the 15 new or changed test cases fail there, and the other 4 pin behaviour that was already correct. An adversarial review of that change confirmed wording and log gaps around installs that keep no recovery copy, a refused media recovery folder that was reported as a lock, and a staging folder with the same link gap as the recovery folders; those are fixed here too.
- The seven test cases added for CodeRabbit's review of `562304bc` all fail on that head. Of the two added for its review of `e0c08f87`, the junction-detection test fails on that head, and the other pins both recovery-store modes and Browse.
- `ruff` on every changed file and `git diff --check`: clean.

Authenticated AnkiWeb conflict resolution, Windows file locking and a real Windows network share were not exercised.

### Checklist

- [x] My code follows the code style and guidelines of this project.
- [x] I have run tests locally (`pytest tests/`, including `tests/test_addon_integrity.py`) and they all pass.
- [ ] **(Optional)** I have added/updated my entry in `.all-contributorsrc`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JnjnXZw1Lq43kJhGKa2Gf5
