### PR TITLE
feat(battle): implement the Cell Battery held-item effect (supersedes #844)

### DIFF
--- a/src/Ankimon/functions/ankimon_hooks_to_poke_engine.py
+++ b/src/Ankimon/functions/ankimon_hooks_to_poke_engine.py
@@ -20,6 +20,44 @@ from ..pyobj.error_handler import show_warning_with_traceback
 ankimon_tracker_obj = None
 settings_obj = None
 
+# Private key that ``_install_on_hit_boost_items`` stashes on a move dict and the
+# damage wrapper below consumes. It rides on the move instead of the move's
+# ``BOOSTS`` because the engine resolves a boost payload through one elif chain
+# (find_state_instructions) in which a SECONDARY always wins: a top-level BOOSTS is
+# read only for a move that has no secondary effect, which silently drops it for 17
+# of the engine's 37 damaging Electric moves, Thunderbolt included.
+_ON_HIT_BOOSTS_KEY = "_ankimon_on_hit_boosts"
+
+
+def _on_hit_item_triggers(mutator, instruction_set, defender):
+    """Whether an on-hit held item should fire for this one outcome.
+
+    The engine's ``frozen`` flag already covers a miss and an immune hit, but two
+    conditions it does not express are checked here:
+
+      * the defender actually lost HP. A hit absorbed by a Substitute leaves no
+        damage instruction against the defender, and the item's holder was not
+        itself struck.
+      * the defender is still standing afterwards. The engine's own faint check in
+        ``get_instructions_from_damage`` reads HP from before the killing blow is
+        added to the instruction set, so a Pokemon that is about to faint is never
+        frozen and would otherwise collect a boost on its way out.
+    """
+    if not any(
+        instr[0] == constants.MUTATOR_DAMAGE and instr[1] == defender and instr[2] > 0
+        for instr in instruction_set.instructions
+    ):
+        return False
+    # Balanced apply/reverse, exactly as get_instructions_from_boosts does a moment
+    # later, so the state this wrapper was handed is left as it was found.
+    mutator.apply(instruction_set.instructions)
+    try:
+        side = instruction_generator.get_side_from_state(mutator.state, defender)
+        return side.active.hp > 0
+    finally:
+        mutator.reverse(instruction_set.instructions)
+
+
 # --- F37: review-based damage multiplier, applied at the poke-engine level ---
 # poke_engine.find_state_instructions calls
 # ``instruction_generator.get_instructions_from_damage`` via module attribute, so
@@ -28,6 +66,11 @@ settings_obj = None
 # ``simulate_battle_with_poke_engine`` does not double-apply). Guarded against
 # double-wrapping on module reload (reload-safe singletons): capture the pristine
 # original and install the wrapper only once.
+#
+# The same wrapper also fans out the on-hit held-item boosts described above. They
+# belong in this one wrapper rather than a second layer over it: the reload guard is
+# a flag on the installed function, so a wrapper wrapping the wrapper would not carry
+# the flag and the next import would wrap again and scale damage twice.
 if not getattr(
     instruction_generator.get_instructions_from_damage,
     "_ankimon_review_wrapped",
@@ -52,9 +95,28 @@ if not getattr(
             else:
                 damage = math.floor(damage * mutator.review_based_damage_multiplier)
             mutator.review_based_damage_multiplier_applied = True
-        return _original_get_instructions_from_damage(
+        results = _original_get_instructions_from_damage(
             mutator, defender, damage, accuracy, attacking_move, instruction
         )
+
+        # Reaching this call already establishes what an on-hit item needs: the move
+        # survived every ability and item hook as a damaging move, so the Electric
+        # absorbers (Volt Absorb / Lightning Rod / Motor Drive) are out. The engine
+        # then freezes the instruction on a miss, on an immune hit (damage == 0) and
+        # on a faint, and ``get_instructions_from_boosts`` hands a frozen instruction
+        # back untouched -- so none of those need a branch here.
+        on_hit_boosts = attacking_move.get(_ON_HIT_BOOSTS_KEY)
+        if on_hit_boosts:
+            boosted = []
+            for instruction_set in results:
+                if _on_hit_item_triggers(mutator, instruction_set, defender):
+                    boosted += instruction_generator.get_instructions_from_boosts(
+                        mutator, defender, on_hit_boosts, True, instruction_set
+                    )
+                else:
+                    boosted.append(instruction_set)
+            results = boosted
+        return results
 
     _wrapped_get_instructions_from_damage._ankimon_review_wrapped = True
     instruction_generator.get_instructions_from_damage = (
@@ -225,6 +287,77 @@ def _install_stancechange_compat():
     before_move.stancechange = patched_stancechange
 
 
+def _install_on_hit_boost_items():
+    """Give Cell Battery its battle effect: +1 Attack when hit by an Electric move.
+
+    Ankimon sells Cell Battery (items.csv id 589) and lets any Pokemon hold it, and
+    the held item does reach the engine -- ``to_engine_format`` normalizes
+    "cell-battery" to "cellbattery" and passes it to ``Pokemon.item``. The engine
+    just has no entry for it in ``item_modify_attack_against``, so the item sat on
+    its holder doing nothing at all. The engine is a git submodule (edits there are
+    lost on ``git submodule update``), so the effect is registered from this side.
+
+    The engine's own equivalent, ``weaknesspolicy``, sets the move's ``BOOSTS`` and
+    lets find_state_instructions apply them to the defender. That route is not usable
+    here: the boost payload is resolved by one elif chain in which a SECONDARY wins,
+    so a top-level BOOSTS never survives Thunderbolt, Thunder, Spark, Thunder Punch,
+    Discharge or Volt Tackle -- 17 of the 37 damaging Electric moves. (The same
+    shadowing already makes weaknesspolicy and the on-hit abilities Stamina,
+    Justified, Weak Armor and Steam Engine inert against those moves. Repairing the
+    chain would move outcomes for about ten abilities, so it is left alone here.)
+    Instead the boost is stashed on the move under ``_ON_HIT_BOOSTS_KEY`` and fanned
+    out by the damage wrapper at the top of this module, which also means the
+    ability's own ``BOOSTS`` is never touched.
+
+    Like weaknesspolicy (and whiteherb, and airballoon) the item is NOT consumed.
+    ``modify_attack_against`` returns a move dict and has no way to emit a
+    change_item instruction, so single use is not expressible in this hook. Repeat
+    triggers are bounded by MAX_BOOSTS, which is how the engine already models its
+    other one-shot items.
+    """
+    from ..poke_engine.damage_calculator import type_effectiveness_modifier
+    from ..poke_engine.special_effects.items import modify_attack_against
+
+    def _on_hit_boost(move_type, stat, stages):
+        def effect(attacking_move, attacking_pokemon, defending_pokemon):
+            # Requiring a damaging category rules out the Electric-absorbing
+            # abilities (Volt Absorb / Lightning Rod / Motor Drive): they run first
+            # and turn the move into a STATUS move carrying their own boost.
+            if (
+                attacking_move[constants.CATEGORY] not in constants.DAMAGING_CATEGORIES
+                or attacking_move[constants.TYPE] != move_type
+            ):
+                return attacking_move
+            try:
+                if type_effectiveness_modifier(move_type, defending_pokemon.types) == 0:
+                    return attacking_move
+            except KeyError:
+                # Unrecognised type id. The engine's own damage path raises on this
+                # same lookup moments later; an item must not be what breaks first.
+                return attacking_move
+
+            attacking_move = attacking_move.copy()
+            attacking_move[_ON_HIT_BOOSTS_KEY] = {stat: stages}
+            return attacking_move
+
+        return effect
+
+    # item id -> (triggering move type, boosted stat, stages). Absorb Bulb (588),
+    # Snowball (689) and Luminous Moss (688) are the same shape and are also in
+    # Ankimon's item list; they are left for a follow-up so this change stays
+    # reviewable against one item's documented behaviour.
+    on_hit_boosts = {
+        "cellbattery": ("electric", constants.ATTACK, 1),
+    }
+    for item_name, (move_type, stat, stages) in on_hit_boosts.items():
+        effect = _on_hit_boost(move_type, stat, stages)
+        effect.__name__ = item_name
+        # setdefault keeps this idempotent across the reload-safe-singletons module
+        # reload, and lets a future submodule bump that implements the item natively
+        # win over this shim.
+        modify_attack_against.item_lookup.setdefault(item_name, effect)
+
+
 def _apply_engine_patch(patch):
     """Apply one hardening patch, recording a failure without propagating it.
 
@@ -257,6 +390,7 @@ def _apply_engine_patch(patch):
 _apply_engine_patch(_patch_engine_constants)
 _apply_engine_patch(_install_form_tolerant_pokedex)
 _apply_engine_patch(_install_stancechange_compat)
+_apply_engine_patch(_install_on_hit_boost_items)
 
 
 def reset_stat_boosts(pokemon: Pokemon) -> Pokemon:

--- a/src/Ankimon/functions/ankimon_hooks_to_poke_engine.py
+++ b/src/Ankimon/functions/ankimon_hooks_to_poke_engine.py
@@ -387,16 +387,61 @@ def _install_stancechange_compat():
     before_move.stancechange = patched_stancechange
 
 
-# Abilities that do nothing to an incoming boost payload but transform it, and so
-# may be replayed over an on-hit item's boost. The allowlist is load-bearing rather
-# than cautious: most of the engine's defender-ability hooks REPLACE a move's BOOSTS
-# (stamina sets {defense: 1}), which would swallow the item's payload and hand back
-# the ability's own.
+# Abilities the ENGINE implements that do nothing to an incoming boost payload but
+# transform it, and so may be replayed over an on-hit item's boost. The allowlist is
+# load-bearing rather than cautious: most of the engine's defender-ability hooks
+# REPLACE a move's BOOSTS (stamina sets {defense: 1}), which would swallow the item's
+# payload and hand back the ability's own.
 _STAT_STAGE_ABILITIES = frozenset({"contrary"})
 
-# Bumped when the shape of what an on-hit effect stashes on a move changes, so an
-# in-process reload replaces an older shim instead of leaving it registered.
-_ON_HIT_ITEM_VERSION = 1
+# Stage multipliers the engine does NOT implement, mapped to their factor. Replaying
+# a payload through the engine only works for an ability it has a handler for, and
+# 'simple' appears nowhere in its ability hooks -- only in BYPASSABLE_ABILITIES -- so
+# the engine would hand the payload straight back and the battery would be spent on
+# an undoubled +1. These are applied on this side instead, which is why they cannot
+# simply join the allowlist above.
+_STAGE_MULTIPLIER_ABILITIES = {"simple": 2}
+
+# Abilities that switch a held item off. The engine models no item-disabling ability
+# at all -- 'klutz' appears nowhere in it, and ``item_modify_attack_against`` invokes
+# a registered callback unconditionally -- and nothing upstream strips the item
+# either, since ``to_engine_format`` passes ability and held item through side by
+# side. So an on-hit item has to ask this itself before it fires.
+_ITEM_DISABLING_ABILITIES = frozenset({"klutz"})
+
+# Bumped when the shape of what an on-hit effect stashes on a move changes, or when
+# what it stashes it FOR does, so an in-process reload replaces an older shim instead
+# of leaving it registered. Version 2 added the Simple and Klutz interactions: a v1
+# shim stashes a payload this wrapper still understands, but one that is +1 under
+# Simple and present at all under Klutz.
+_ON_HIT_ITEM_VERSION = 2
+
+
+def _ability_suppressed(attacking_pokemon, defending_pokemon):
+    """Whether the engine would treat the defender's ability as switched off.
+
+    Mirrors the guard at the top of the engine's ``ability_modify_attack_against``:
+    Neutralizing Gas on either side turns both abilities off, and a mold-breaker
+    attacker ignores a defender ability the engine lists as bypassable.
+
+    Mirrored rather than read back out of that dispatcher by probing it with an
+    ability it does implement, because such a probe answers this question only for as
+    long as the ability probed with stays implemented AND stays a detectable
+    transform. A submodule bump that renamed Contrary's handler would leave the probe
+    reporting every defender as suppressed -- Simple quietly no longer doubling and,
+    worse, Klutz quietly no longer disabling. Only the three-line structure is copied
+    here: WHICH abilities suppress and which are bypassable is still read from the
+    engine's own constants, so a bump that adds to either set is picked up for free.
+    """
+    if (
+        attacking_pokemon.ability == "neutralizinggas"
+        or defending_pokemon.ability == "neutralizinggas"
+    ):
+        return True
+    return (
+        attacking_pokemon.ability in constants.ABILITIES_THAT_IGNORE_OTHER_ABILITIES
+        and defending_pokemon.ability in constants.BYPASSABLE_ABILITIES
+    )
 
 
 def _install_on_hit_boost_items():
@@ -431,6 +476,12 @@ def _install_on_hit_boost_items():
     scoped to the encounter: the item lives on the engine State, which
     ``simulate_battle_with_poke_engine`` never writes back to the Pokemon object and
     rebuilds from it on every reset.
+
+    Three holder abilities change the outcome here and the engine applies none of
+    them on this path: Contrary inverts the boost, Simple doubles it, and Klutz stops
+    the item firing at all. Each is handled on this side, and each honours the
+    engine's own suppression rules -- so Neutralizing Gas hands a Klutz holder its
+    battery back, and a mold-breaker attacker leaves Simple's doubling off.
     """
     from ..poke_engine.damage_calculator import type_effectiveness_modifier
     from ..poke_engine.special_effects.abilities.modify_attack_against import (
@@ -449,23 +500,47 @@ def _install_on_hit_boost_items():
         mold-breaker-style bypass) stay the engine's rather than a second copy of
         them, and only the abilities on ``_STAT_STAGE_ABILITIES`` are routed through
         it.
+
+        Simple has to be applied on this side instead. It doubles a stage change, but
+        the engine has no handler for it, so replaying the payload would return it
+        unchanged and spend the battery on a +1. No Pokemon has both abilities, so
+        the two branches never compete for one payload. The doubled payload is
+        deliberately NOT clamped here: ``_effective_boost`` already decides whether a
+        partial raise is still worth spending the item on and the engine's boost
+        generator clamps what it emits, so a Simple holder at +5 takes the one stage
+        it has left and a holder at the cap keeps its battery.
         """
-        if defending_pokemon.ability not in _STAT_STAGE_ABILITIES:
-            return boosts
-        probe = ability_modify_attack_against(
-            defending_pokemon.ability,
-            {
-                constants.TARGET: constants.NORMAL,
-                constants.BOOSTS: dict(boosts),
-                constants.SECONDARY: None,
-            },
-            attacking_pokemon,
-            defending_pokemon,
-        )
-        return probe.get(constants.BOOSTS) or boosts
+        if defending_pokemon.ability in _STAT_STAGE_ABILITIES:
+            probe = ability_modify_attack_against(
+                defending_pokemon.ability,
+                {
+                    constants.TARGET: constants.NORMAL,
+                    constants.BOOSTS: dict(boosts),
+                    constants.SECONDARY: None,
+                },
+                attacking_pokemon,
+                defending_pokemon,
+            )
+            return probe.get(constants.BOOSTS) or boosts
+        multiplier = _STAGE_MULTIPLIER_ABILITIES.get(defending_pokemon.ability)
+        if multiplier is not None and not _ability_suppressed(
+            attacking_pokemon, defending_pokemon
+        ):
+            return {stat: stages * multiplier for stat, stages in boosts.items()}
+        return boosts
 
     def _on_hit_boost(move_type, stat, stages):
         def effect(attacking_move, attacking_pokemon, defending_pokemon):
+            # Klutz switches the item off, so the hit lands but the battery neither
+            # boosts nor is spent -- refusing here, before anything is stashed, is
+            # what keeps BOTH of those out of the wrapper's hands. Suppression-aware
+            # on purpose: Neutralizing Gas turns Klutz off as well, and then the
+            # battery works normally, so an unconditional check on the ability name
+            # would be wrong in exactly that matchup.
+            if defending_pokemon.ability in _ITEM_DISABLING_ABILITIES and (
+                not _ability_suppressed(attacking_pokemon, defending_pokemon)
+            ):
+                return attacking_move
             # Requiring a damaging category rules out the Electric-absorbing
             # abilities (Volt Absorb / Lightning Rod / Motor Drive): they run first
             # and turn the move into a STATUS move carrying their own boost.

--- a/src/Ankimon/functions/ankimon_hooks_to_poke_engine.py
+++ b/src/Ankimon/functions/ankimon_hooks_to_poke_engine.py
@@ -20,40 +20,75 @@ from ..pyobj.error_handler import show_warning_with_traceback
 ankimon_tracker_obj = None
 settings_obj = None
 
-# Private key that ``_install_on_hit_boost_items`` stashes on a move dict and the
-# damage wrapper below consumes. It rides on the move instead of the move's
-# ``BOOSTS`` because the engine resolves a boost payload through one elif chain
-# (find_state_instructions) in which a SECONDARY always wins: a top-level BOOSTS is
-# read only for a move that has no secondary effect, which silently drops it for 17
-# of the engine's 37 damaging Electric moves, Thunderbolt included.
+# Private keys that ``_install_on_hit_boost_items`` stashes on a move dict and the
+# damage wrapper below consumes: the boost payload the holder's item is about to
+# add, and the item that is spent adding it. They ride on the move instead of the
+# move's ``BOOSTS`` because the engine resolves a boost payload through one elif
+# chain (find_state_instructions) in which a SECONDARY always wins: a top-level
+# BOOSTS is read only for a move that has no secondary effect, which silently drops
+# it for 17 of the engine's 37 damaging Electric moves, Thunderbolt included.
 _ON_HIT_BOOSTS_KEY = "_ankimon_on_hit_boosts"
+_ON_HIT_ITEM_KEY = "_ankimon_on_hit_item"
 
 
-def _on_hit_item_triggers(mutator, instruction_set, defender):
+def _effective_boost(active, stat, stages):
+    """The stage change the engine's boost generator would actually emit.
+
+    Mirrors ``get_instructions_from_boosts``: a raise clamps at MAX_BOOSTS, and a
+    drop is refused outright by Clear Body and friends. A zero result means the item
+    has nothing left to do -- which is also the one condition under which a
+    consumable on-hit item is NOT spent (Cell Battery is held onto at +6 Attack, and
+    under Contrary at -6).
+    """
+    current = active.get_boost_from_boost_string(stat)
+    if stages > 0:
+        return min(current + stages, constants.MAX_BOOSTS) - current
+    if (
+        active.ability in constants.IMMUNE_TO_STAT_LOWERING_ABILITIES
+        or active.item in constants.IMMUNE_TO_STAT_LOWERING_ITEMS
+    ):
+        return 0
+    return max(current + stages, -1 * constants.MAX_BOOSTS) - current
+
+
+def _on_hit_item_triggers(mutator, instruction_set, defender, boosts, first_added):
     """Whether an on-hit held item should fire for this one outcome.
 
-    The engine's ``frozen`` flag already covers a miss and an immune hit, but two
+    The engine's ``frozen`` flag already covers a miss and an immune hit, but three
     conditions it does not express are checked here:
 
-      * the defender actually lost HP. A hit absorbed by a Substitute leaves no
-        damage instruction against the defender, and the item's holder was not
-        itself struck.
+      * this hit actually took HP off the defender. Only the instructions from
+        ``first_added`` on are inspected: an instruction set is cumulative over the
+        whole turn, so a holder that made a Substitute earlier in the turn has its
+        own 25% HP cost sitting in the list, and reading the whole list would take
+        that for a hit on the holder and boost a Pokemon that was never struck.
+        Within this hit, a blow absorbed by a Substitute adds no damage instruction
+        against the defender either, which is the same non-trigger for the same
+        reason.
       * the defender is still standing afterwards. The engine's own faint check in
         ``get_instructions_from_damage`` reads HP from before the killing blow is
         added to the instruction set, so a Pokemon that is about to faint is never
         frozen and would otherwise collect a boost on its way out.
+      * the boost has somewhere to go. At the stat cap the engine emits a
+        zero-magnitude no-op, and a consumable must not be spent on one.
     """
     if not any(
         instr[0] == constants.MUTATOR_DAMAGE and instr[1] == defender and instr[2] > 0
-        for instr in instruction_set.instructions
+        for instr in instruction_set.instructions[first_added:]
     ):
         return False
     # Balanced apply/reverse, exactly as get_instructions_from_boosts does a moment
     # later, so the state this wrapper was handed is left as it was found.
     mutator.apply(instruction_set.instructions)
     try:
-        side = instruction_generator.get_side_from_state(mutator.state, defender)
-        return side.active.hp > 0
+        active = instruction_generator.get_side_from_state(
+            mutator.state, defender
+        ).active
+        if active.hp <= 0:
+            return False
+        return any(
+            _effective_boost(active, stat, stages) for stat, stages in boosts.items()
+        )
     finally:
         mutator.reverse(instruction_set.instructions)
 
@@ -63,26 +98,74 @@ def _on_hit_item_triggers(mutator, instruction_set, defender):
 # ``instruction_generator.get_instructions_from_damage`` via module attribute, so
 # wrapping that attribute scales opponent-directed damage by the reviewer
 # multiplier during instruction generation (and flags it so the post-hoc pass in
-# ``simulate_battle_with_poke_engine`` does not double-apply). Guarded against
-# double-wrapping on module reload (reload-safe singletons): capture the pristine
-# original and install the wrapper only once.
+# ``simulate_battle_with_poke_engine`` does not double-apply).
 #
 # The same wrapper also fans out the on-hit held-item boosts described above. They
-# belong in this one wrapper rather than a second layer over it: the reload guard is
-# a flag on the installed function, so a wrapper wrapping the wrapper would not carry
-# the flag and the next import would wrap again and scale damage twice.
-if not getattr(
-    instruction_generator.get_instructions_from_damage,
-    "_ankimon_review_wrapped",
-    False,
+# belong in this one wrapper rather than a second layer over it: a wrapper wrapping
+# the wrapper would delegate to a function that already scales damage, and the next
+# import would have no way to tell the two layers apart.
+#
+# Installation is versioned rather than merely guarded (reload-safe singletons). A
+# bare "already wrapped?" guard is only correct while the wrapper never gains a
+# feature: an in-process reload on top of an older generation would find the flag
+# set, skip the definition, and leave that older wrapper running -- which is exactly
+# how a Cell Battery holder would sit through a whole session doing nothing after an
+# update, since the item registration below would still stash a payload that the
+# older wrapper does not know how to read.
+_DAMAGE_WRAPPER_VERSION = 2
+
+
+def _damage_wrapper_version(fn):
+    """Which generation of the Ankimon damage wrapper ``fn`` is; 0 for none."""
+    version = getattr(fn, "_ankimon_damage_wrapper_version", None)
+    if version is not None:
+        return version
+    # Version 1 predates the version attribute and marked itself with a boolean.
+    return 1 if getattr(fn, "_ankimon_review_wrapped", False) else 0
+
+
+def _pristine_damage_fn(fn, version):
+    """The untouched engine function underneath ``fn``, or None if unrecoverable.
+
+    Replacing an older wrapper means calling what IT was calling; delegating to the
+    old wrapper itself would scale review damage twice.
+    """
+    if version == 0:
+        return fn
+    original = getattr(fn, "_ankimon_wrapped_function", None)
+    if original is None:
+        # Version 1 kept the original in a module global instead of an attribute --
+        # this very dict on an in-place reload, and the superseded module's dict
+        # when the add-on is reloaded into a fresh module object.
+        original = getattr(fn, "__globals__", {}).get(
+            "_original_get_instructions_from_damage"
+        )
+    if original is None or _damage_wrapper_version(original):
+        return None
+    return original
+
+
+_installed_damage_fn = instruction_generator.get_instructions_from_damage
+_installed_damage_wrapper_version = _damage_wrapper_version(_installed_damage_fn)
+_original_get_instructions_from_damage = _pristine_damage_fn(
+    _installed_damage_fn, _installed_damage_wrapper_version
+)
+
+if (
+    _original_get_instructions_from_damage is not None
+    and _installed_damage_wrapper_version < _DAMAGE_WRAPPER_VERSION
 ):
-    _original_get_instructions_from_damage = (
-        instruction_generator.get_instructions_from_damage
-    )
 
     def _wrapped_get_instructions_from_damage(
         mutator, defender, damage, accuracy, attacking_move, instruction
     ):
+        # Everything this call appends starts here. The instruction set arrives
+        # carrying the whole turn so far, and an on-hit item must only read the
+        # blow it is reacting to. Read before delegating, and only for a move that
+        # actually carries a payload -- callers that do not (the F37 unit tests
+        # among them) hand this wrapper an opaque instruction stand-in.
+        on_hit_boosts = attacking_move.get(_ON_HIT_BOOSTS_KEY)
+        first_added = len(instruction.instructions) if on_hit_boosts else 0
         if (
             defender == constants.OPPONENT
             and hasattr(mutator, "review_based_damage_multiplier")
@@ -102,23 +185,40 @@ if not getattr(
         # Reaching this call already establishes what an on-hit item needs: the move
         # survived every ability and item hook as a damaging move, so the Electric
         # absorbers (Volt Absorb / Lightning Rod / Motor Drive) are out. The engine
-        # then freezes the instruction on a miss, on an immune hit (damage == 0) and
-        # on a faint, and ``get_instructions_from_boosts`` hands a frozen instruction
-        # back untouched -- so none of those need a branch here.
-        on_hit_boosts = attacking_move.get(_ON_HIT_BOOSTS_KEY)
+        # then freezes the instruction on a miss and on an immune hit (damage == 0),
+        # and ``_on_hit_item_triggers`` covers the rest.
         if on_hit_boosts:
+            spent_item = attacking_move.get(_ON_HIT_ITEM_KEY)
             boosted = []
             for instruction_set in results:
-                if _on_hit_item_triggers(mutator, instruction_set, defender):
-                    boosted += instruction_generator.get_instructions_from_boosts(
-                        mutator, defender, on_hit_boosts, True, instruction_set
-                    )
-                else:
+                if not _on_hit_item_triggers(
+                    mutator, instruction_set, defender, on_hit_boosts, first_added
+                ):
                     boosted.append(instruction_set)
+                    continue
+                for fired in instruction_generator.get_instructions_from_boosts(
+                    mutator, defender, on_hit_boosts, True, instruction_set
+                ):
+                    if spent_item is not None:
+                        fired.add_instruction(
+                            (
+                                constants.MUTATOR_CHANGE_ITEM,
+                                defender,
+                                None,
+                                spent_item,
+                            )
+                        )
+                    boosted.append(fired)
             results = boosted
         return results
 
     _wrapped_get_instructions_from_damage._ankimon_review_wrapped = True
+    _wrapped_get_instructions_from_damage._ankimon_damage_wrapper_version = (
+        _DAMAGE_WRAPPER_VERSION
+    )
+    _wrapped_get_instructions_from_damage._ankimon_wrapped_function = (
+        _original_get_instructions_from_damage
+    )
     instruction_generator.get_instructions_from_damage = (
         _wrapped_get_instructions_from_damage
     )
@@ -287,6 +387,18 @@ def _install_stancechange_compat():
     before_move.stancechange = patched_stancechange
 
 
+# Abilities that do nothing to an incoming boost payload but transform it, and so
+# may be replayed over an on-hit item's boost. The allowlist is load-bearing rather
+# than cautious: most of the engine's defender-ability hooks REPLACE a move's BOOSTS
+# (stamina sets {defense: 1}), which would swallow the item's payload and hand back
+# the ability's own.
+_STAT_STAGE_ABILITIES = frozenset({"contrary"})
+
+# Bumped when the shape of what an on-hit effect stashes on a move changes, so an
+# in-process reload replaces an older shim instead of leaving it registered.
+_ON_HIT_ITEM_VERSION = 1
+
+
 def _install_on_hit_boost_items():
     """Give Cell Battery its battle effect: +1 Attack when hit by an Electric move.
 
@@ -309,14 +421,48 @@ def _install_on_hit_boost_items():
     out by the damage wrapper at the top of this module, which also means the
     ability's own ``BOOSTS`` is never touched.
 
-    Like weaknesspolicy (and whiteherb, and airballoon) the item is NOT consumed.
-    ``modify_attack_against`` returns a move dict and has no way to emit a
-    change_item instruction, so single use is not expressible in this hook. Repeat
-    triggers are bounded by MAX_BOOSTS, which is how the engine already models its
-    other one-shot items.
+    Cell Battery is consumed, as the real item is: the wrapper emits a reversible
+    change_item instruction alongside the boost, and only when the boost has a stage
+    left to move. That is a deliberate difference from the engine's own one-shot
+    items (weaknesspolicy, whiteherb, airballoon), which it models as reusable
+    because ``modify_attack_against`` returns a move dict and cannot emit an
+    instruction -- a limit of that hook, not of the engine. This effect does its work
+    in the instruction wrapper, where the instruction is expressible. Consumption is
+    scoped to the encounter: the item lives on the engine State, which
+    ``simulate_battle_with_poke_engine`` never writes back to the Pokemon object and
+    rebuilds from it on every reset.
     """
     from ..poke_engine.damage_calculator import type_effectiveness_modifier
+    from ..poke_engine.special_effects.abilities.modify_attack_against import (
+        ability_modify_attack_against,
+    )
     from ..poke_engine.special_effects.items import modify_attack_against
+
+    def _through_stat_stage_ability(boosts, attacking_pokemon, defending_pokemon):
+        """Replay the holder's stat-stage ability over the boost the item adds.
+
+        poke-engine runs a defender's ability hook BEFORE its item hook, so a boost
+        an item adds afterwards never meets Contrary: the holder would gain +1 Attack
+        where the mechanic says it loses one. The payload is handed back to the
+        engine's own ability hook on a synthetic opponent-targeting move carrying
+        nothing but these boosts, so the suppression rules (neutralizinggas,
+        mold-breaker-style bypass) stay the engine's rather than a second copy of
+        them, and only the abilities on ``_STAT_STAGE_ABILITIES`` are routed through
+        it.
+        """
+        if defending_pokemon.ability not in _STAT_STAGE_ABILITIES:
+            return boosts
+        probe = ability_modify_attack_against(
+            defending_pokemon.ability,
+            {
+                constants.TARGET: constants.NORMAL,
+                constants.BOOSTS: dict(boosts),
+                constants.SECONDARY: None,
+            },
+            attacking_pokemon,
+            defending_pokemon,
+        )
+        return probe.get(constants.BOOSTS) or boosts
 
     def _on_hit_boost(move_type, stat, stages):
         def effect(attacking_move, attacking_pokemon, defending_pokemon):
@@ -337,7 +483,10 @@ def _install_on_hit_boost_items():
                 return attacking_move
 
             attacking_move = attacking_move.copy()
-            attacking_move[_ON_HIT_BOOSTS_KEY] = {stat: stages}
+            attacking_move[_ON_HIT_BOOSTS_KEY] = _through_stat_stage_ability(
+                {stat: stages}, attacking_pokemon, defending_pokemon
+            )
+            attacking_move[_ON_HIT_ITEM_KEY] = defending_pokemon.item
             return attacking_move
 
         return effect
@@ -350,12 +499,22 @@ def _install_on_hit_boost_items():
         "cellbattery": ("electric", constants.ATTACK, 1),
     }
     for item_name, (move_type, stat, stages) in on_hit_boosts.items():
+        installed = modify_attack_against.item_lookup.get(item_name)
+        if installed is not None and (
+            getattr(installed, "__module__", None) == modify_attack_against.__name__
+            or getattr(installed, "_ankimon_on_hit_item_version", 0)
+            >= _ON_HIT_ITEM_VERSION
+        ):
+            # An entry defined in the engine's own module means a submodule bump
+            # implements the item natively now, and that must win over this shim;
+            # the same shim version means a reload is a no-op. Anything older is
+            # replaced -- leaving an earlier shim installed would pair a stale
+            # payload with the current wrapper.
+            continue
         effect = _on_hit_boost(move_type, stat, stages)
         effect.__name__ = item_name
-        # setdefault keeps this idempotent across the reload-safe-singletons module
-        # reload, and lets a future submodule bump that implements the item natively
-        # win over this shim.
-        modify_attack_against.item_lookup.setdefault(item_name, effect)
+        effect._ankimon_on_hit_item_version = _ON_HIT_ITEM_VERSION
+        modify_attack_against.item_lookup[item_name] = effect
 
 
 def _apply_engine_patch(patch):

--- a/src/Ankimon/functions/battle_functions.py
+++ b/src/Ankimon/functions/battle_functions.py
@@ -112,6 +112,24 @@ def update_pokemon_battle_status(battle_info: dict, enemy_pokemon, main_pokemon)
         return False, False
 
 
+def _display_item_name(engine_item: str, holder=None) -> str:
+    """The item's own spelling where it is available, not the engine's id.
+
+    ``to_engine_format`` normalises "cell-battery" to "cellbattery", and no rule
+    turns that back into "Cell Battery". The holder still carries the stored
+    name -- consumption happens on the engine state, which is rebuilt from the
+    Pokemon object on every reset -- so read it off there when the two describe
+    the same item, and fall back to the id otherwise.
+    """
+    engine_item = str(engine_item)
+    stored = getattr(holder, "held_item", None)
+    if isinstance(stored, str) and stored:
+        squashed = stored.replace("-", "").replace("_", "").replace(" ", "").lower()
+        if squashed == engine_item.replace("-", "").replace("_", "").lower():
+            return stored.replace("-", " ").replace("_", " ").title()
+    return engine_item.replace("-", " ").replace("_", " ").title()
+
+
 def _process_battle_effects(
     instructions: list,  # Keep for compatibility but won't use
     translator,
@@ -155,6 +173,8 @@ def _process_battle_effects(
         except (KeyError, AttributeError, Exception) as e:
             print(f"Translation error for key '{key}': {e}")
 
+        if "pokemon_name" in kwargs and "item" in kwargs:
+            return f"{kwargs['pokemon_name']} used up its {kwargs['item']}!"
         if "pokemon_name" in kwargs and "status_name" in kwargs:
             if "apply" in key or "still" in key:
                 return (
@@ -408,6 +428,20 @@ def _process_battle_effects(
                         "effect_health_restored",
                         pokemon_name=pokemon_name,
                         heal_amount=heal_amount,
+                    )
+                    effect_messages.append(message)
+
+            # Handle a held item being spent
+            elif key.endswith(".item"):
+                # Only consumption. An item ARRIVING (Thief, Trick, a switch-in)
+                # is a different event and reads wrong in this wording.
+                if before and after is None:
+                    target = "user" if key.startswith("user.") else "opponent"
+                    holder = main_pokemon if target == "user" else enemy_pokemon
+                    message = safe_translate(
+                        "effect_item_consumed",
+                        pokemon_name=get_pokemon_name(target),
+                        item=_display_item_name(before, holder),
                     )
                     effect_messages.append(message)
 

--- a/src/Ankimon/lang/en_text.json
+++ b/src/Ankimon/lang/en_text.json
@@ -108,6 +108,7 @@
   "pokemon_special_condition": "{pokemon_name} is affected by {condition}!",
   "effect_damage_dealt": "{pokemon_name} took {damage} damage!",
   "effect_health_restored": "{pokemon_name} restored {heal_amount} HP!",
+  "effect_item_consumed": "{pokemon_name} used up its {item}!",
   "effect_status_applied": "{pokemon_name} was afflicted with {status}!",
   "effect_stat_change": "{pokemon_name}'s {stat} {direction} by {amount} stage(s)!",
   "effect_volatile_status": "{pokemon_name} was affected by {status}!",

--- a/tests/test_battle_functions.py
+++ b/tests/test_battle_functions.py
@@ -63,3 +63,57 @@ def test_validate_pokemon_status_without_the_attribute():
         hp = 50
 
     assert validate_pokemon_status(Bare()) == "fighting"
+
+
+class _Holder:
+    """Enough of a PokemonObject for the effect messages to name it."""
+
+    def __init__(self, name, held_item=None):
+        self.display_name = name
+        self.name = name
+        self.held_item = held_item
+
+
+def _effects(changes, main=None, enemy=None):
+    from Ankimon.functions.battle_functions import _process_battle_effects
+
+    return _process_battle_effects(
+        [], None, main_pokemon=main, enemy_pokemon=enemy, changes=changes,
+    )
+
+
+def test_a_spent_held_item_is_announced_with_the_name_the_player_knows():
+    """The engine id has the hyphen stripped; the holder still has the real one.
+
+    Without this the only thing a Cell Battery holder sees is an unattributed
+    stat change, and every screen that shows the held item still shows it.
+    """
+    messages = _effects(
+        [
+            {"key": "user.active.attack_boost", "before": 0, "after": 1},
+            {"key": "user.active.item", "before": "cellbattery", "after": None},
+        ],
+        main=_Holder("Snorlax", held_item="cell-battery"),
+    )
+
+    assert any("Cell Battery" in message and "Snorlax" in message
+               for message in messages), messages
+
+
+def test_an_item_arriving_is_not_reported_as_one_being_used_up():
+    """Thief, Trick and a switch-in all change this key the other way."""
+    messages = _effects(
+        [{"key": "opponent.active.item", "before": None, "after": "leftovers"}],
+        enemy=_Holder("Rattata"),
+    )
+
+    assert not any("used up" in message for message in messages), messages
+
+
+def test_a_spent_item_is_named_from_the_engine_id_when_the_holder_has_moved_on():
+    messages = _effects(
+        [{"key": "opponent.active.item", "before": "absorbbulb", "after": None}],
+        enemy=_Holder("Rattata", held_item="oran-berry"),
+    )
+
+    assert any("Absorbbulb" in message for message in messages), messages

--- a/tests/test_cell_battery_item_effect.py
+++ b/tests/test_cell_battery_item_effect.py
@@ -22,6 +22,13 @@ a second Electric hit after the first spent the battery. Contrary is covered bec
 the engine runs a defender's ability before its item, which would otherwise hand a
 Contrary holder the +1 it is supposed to lose.
 
+Simple and Klutz are covered for a different reason: the engine implements neither,
+so neither can be had by replaying the payload through its ability hook the way
+Contrary is. Simple doubles the boost to +2 and Klutz stops the item firing and being
+spent at all, and both are checked against the engine's suppression rules -- a
+mold-breaker attacker turns Simple's doubling off, Neutralizing Gas hands a Klutz
+holder its battery back, and Mold Breaker does NOT turn Klutz off.
+
 Both the registration and the wrapper run inside ``_apply_engine_patch``, which
 swallows the exception and merely logs, so a regression here would be silent in
 production. These checks are what make it loud.
@@ -204,6 +211,7 @@ def _state(
     volatile=None,
     attack_boost=0,
     holder_speed=None,
+    attacker_ability=None,
 ):
     """Singles state whose USER side holds the item and receives the attack."""
     state = State(
@@ -217,6 +225,8 @@ def _state(
     state.user.active.attack_boost = attack_boost
     if ability is not None:
         state.user.active.ability = ability
+    if attacker_ability is not None:
+        state.opponent.active.ability = attacker_ability
     if volatile is not None:
         state.user.active.volatile_status.add(volatile)
     if holder_speed is not None:
@@ -256,6 +266,7 @@ def _opponent_damage(multiplier):
 
 _ATTACK_UP = (constants.MUTATOR_BOOST, constants.USER, constants.ATTACK, 1)
 _ATTACK_DOWN = (constants.MUTATOR_BOOST, constants.USER, constants.ATTACK, -1)
+_ATTACK_UP_DOUBLED = (constants.MUTATOR_BOOST, constants.USER, constants.ATTACK, 2)
 _SPENT = (constants.MUTATOR_CHANGE_ITEM, constants.USER, None, "cellbattery")
 
 
@@ -429,6 +440,79 @@ def test_contrary_holder_at_the_bottom_of_the_range_keeps_its_item():
     outcomes = _outcomes(
         "shockwave", ability="contrary", attack_boost=-1 * constants.MAX_BOOSTS
     )
+    assert _of_type(outcomes, constants.MUTATOR_BOOST) == []
+    assert _of_type(outcomes, constants.MUTATOR_CHANGE_ITEM) == []
+
+
+def test_simple_doubles_the_items_boost():
+    """Simple doubles a stage change, so Cell Battery is worth +2 Attack to a holder.
+
+    Unlike Contrary this cannot be had by replaying the payload through the engine's
+    ability hook: the engine implements no Simple at all, it appears only in
+    BYPASSABLE_ABILITIES, so the replay would hand back the +1 and the battery would
+    be spent on it.
+    """
+    outcomes = _outcomes("shockwave", ability="simple")
+    assert _of_type(outcomes, constants.MUTATOR_BOOST) == [_ATTACK_UP_DOUBLED]
+    assert _of_type(outcomes, constants.MUTATOR_CHANGE_ITEM) == [_SPENT]
+
+
+def test_simple_holder_takes_the_one_stage_it_has_left():
+    # A doubled boost at +5 asks for +7. The stage the holder actually has left is
+    # worth the item, so the engine clamps the instruction and the battery is spent.
+    outcomes = _outcomes(
+        "shockwave", ability="simple", attack_boost=constants.MAX_BOOSTS - 1
+    )
+    assert _of_type(outcomes, constants.MUTATOR_BOOST) == [_ATTACK_UP]
+    assert _of_type(outcomes, constants.MUTATOR_CHANGE_ITEM) == [_SPENT]
+
+
+def test_simple_holder_at_the_cap_keeps_its_item():
+    # Doubling must not talk the holder past the cap into spending the battery on a
+    # no-op: +6 is still +6 whether the item offers one stage or two.
+    outcomes = _outcomes(
+        "shockwave", ability="simple", attack_boost=constants.MAX_BOOSTS
+    )
+    assert _of_type(outcomes, constants.MUTATOR_BOOST) == []
+    assert _of_type(outcomes, constants.MUTATOR_CHANGE_ITEM) == []
+
+
+def test_mold_breaker_attacker_suppresses_simple():
+    """Simple is bypassable, so a mold-breaker hit leaves the boost at +1.
+
+    This is what the suppression check buys over a bare ``ability == "simple"``.
+    """
+    assert _boosts("shockwave", ability="simple", attacker_ability="moldbreaker") == [
+        _ATTACK_UP
+    ]
+
+
+def test_klutz_prevents_the_item_from_activating():
+    """Klutz switches the item off: the hit lands, the battery does nothing.
+
+    Nothing else on the path would stop it -- ``to_engine_format`` passes ability and
+    item through side by side and the engine's item dispatcher calls the registered
+    callback with no check of its own -- so neither a boost nor a spent battery may
+    come out of this.
+    """
+    outcomes = _outcomes("shockwave", ability="klutz")
+    assert _of_type(outcomes, constants.MUTATOR_BOOST) == []
+    assert _of_type(outcomes, constants.MUTATOR_CHANGE_ITEM) == []
+
+
+def test_neutralizing_gas_turns_klutz_off_and_the_item_back_on():
+    """The trap in checking Klutz unconditionally: Neutralizing Gas suppresses it."""
+    outcomes = _outcomes(
+        "shockwave", ability="klutz", attacker_ability="neutralizinggas"
+    )
+    assert _of_type(outcomes, constants.MUTATOR_BOOST) == [_ATTACK_UP]
+    assert _of_type(outcomes, constants.MUTATOR_CHANGE_ITEM) == [_SPENT]
+
+
+def test_mold_breaker_does_not_turn_klutz_off():
+    # Klutz is not in the engine's BYPASSABLE_ABILITIES, so a mold-breaker attacker
+    # leaves it alone. A blanket "any suppressor" check would hand the battery back.
+    outcomes = _outcomes("shockwave", ability="klutz", attacker_ability="moldbreaker")
     assert _of_type(outcomes, constants.MUTATOR_BOOST) == []
     assert _of_type(outcomes, constants.MUTATOR_CHANGE_ITEM) == []
 

--- a/tests/test_cell_battery_item_effect.py
+++ b/tests/test_cell_battery_item_effect.py
@@ -15,12 +15,20 @@ damaging Electric moves, Thunderbolt included. A test that only ever fired Shock
 would pass against that broken shape, so ``test_thunderbolt_...`` below is the point
 of this file.
 
+The item is consumed by the boost, as the real one is, so several tests here are
+about what must NOT happen twice or on an outcome that never earned it: a hit taken
+by a Substitute made earlier in the same turn, a holder already at the stat cap, and
+a second Electric hit after the first spent the battery. Contrary is covered because
+the engine runs a defender's ability before its item, which would otherwise hand a
+Contrary holder the +1 it is supposed to lose.
+
 Both the registration and the wrapper run inside ``_apply_engine_patch``, which
 swallows the exception and merely logs, so a regression here would be silent in
 production. These checks are what make it loud.
 """
 
 import importlib.util
+import math
 import sys
 import types
 from collections import defaultdict
@@ -108,15 +116,69 @@ def _installed():
     test_review_based_damage_multiplier installs the same wrapper at collection time
     and asserts it is still in place when its own tests run.
 
-    The ``cellbattery`` entry is left in the engine's item lookup, as harmless as the
-    MOVE_TARGET_SELF append that test_allies_move_target leaves behind -- it changes
-    nothing unless a battler is actually holding the item.
+    Everything else this module reaches into is engine-wide singleton state, so it is
+    all put back on the way out: the ``cellbattery`` entry in the item lookup, and
+    ShowdownConfig's damage calculation mode. These assertions want one averaged
+    damage roll rather than the engine default of every roll, and leaving that set
+    would quietly change what every test module collected after this one computes.
     """
     global hook
     previous_damage_fn = instruction_generator.get_instructions_from_damage
+    previous_calc_type = ShowdownConfig.damage_calc_type
+    lookup = modify_attack_against.item_lookup
+    had_cellbattery = "cellbattery" in lookup
+    previous_cellbattery = lookup.get("cellbattery")
+    ShowdownConfig.damage_calc_type = "average"
     hook = _load_hook()
     yield hook
     instruction_generator.get_instructions_from_damage = previous_damage_fn
+    ShowdownConfig.damage_calc_type = previous_calc_type
+    if had_cellbattery:
+        lookup["cellbattery"] = previous_cellbattery
+    else:
+        lookup.pop("cellbattery", None)
+
+
+def _legacy_v1_wrapper(original):
+    """A stand-in for the damage wrapper that shipped before on-hit items existed.
+
+    It scales review-based damage and nothing else, marks itself with the bare
+    boolean that generation used, and reaches its pristine original through a module
+    global rather than an attribute -- which is the shape the upgrade path has to
+    recognise and unwind. Built through FunctionType because a function's
+    ``__globals__`` cannot be reassigned afterwards.
+    """
+
+    def template(mutator, defender, damage, accuracy, attacking_move, instruction):
+        if (
+            defender == constants.OPPONENT
+            and hasattr(mutator, "review_based_damage_multiplier")
+            and damage is not None
+        ):
+            if damage > 0:
+                damage = max(
+                    1, math.floor(damage * mutator.review_based_damage_multiplier)
+                )
+            else:
+                damage = math.floor(damage * mutator.review_based_damage_multiplier)
+            mutator.review_based_damage_multiplier_applied = True
+        # Resolved out of the namespace handed to FunctionType below, not this
+        # module -- which is the whole point of building the stand-in that way.
+        return _original_get_instructions_from_damage(  # noqa: F821
+            mutator, defender, damage, accuracy, attacking_move, instruction
+        )
+
+    legacy = types.FunctionType(
+        template.__code__,
+        {
+            "constants": constants,
+            "math": math,
+            "_original_get_instructions_from_damage": original,
+        },
+        "legacy_v1_get_instructions_from_damage",
+    )
+    legacy._ankimon_review_wrapped = True
+    return legacy
 
 
 def _side(species, level=50):
@@ -141,9 +203,9 @@ def _state(
     attacker_level=50,
     volatile=None,
     attack_boost=0,
+    holder_speed=None,
 ):
     """Singles state whose USER side holds the item and receives the attack."""
-    ShowdownConfig.damage_calc_type = "average"
     state = State(
         _side(holder, holder_level),
         _side(attacker, attacker_level),
@@ -157,25 +219,44 @@ def _state(
         state.user.active.ability = ability
     if volatile is not None:
         state.user.active.volatile_status.add(volatile)
+    if holder_speed is not None:
+        state.user.active.speed = holder_speed
     return state
 
 
-def _outcomes(incoming_move, **kwargs):
-    """Every outcome of the opponent using ``incoming_move`` while the user Splashes."""
+def _outcomes(incoming_move, user_move="splash", **kwargs):
+    """Every outcome of the opponent using ``incoming_move`` against the holder."""
     mutator = StateMutator(_state(**kwargs))
-    return get_all_state_instructions(mutator, "splash", incoming_move)
+    return get_all_state_instructions(mutator, user_move, incoming_move)
 
 
-def _boosts(incoming_move, side=constants.USER, **kwargs):
+def _of_type(outcomes, mutator_type, side=constants.USER):
     return [
         instr
-        for outcome in _outcomes(incoming_move, **kwargs)
+        for outcome in outcomes
         for instr in outcome.instructions
-        if instr[0] == constants.MUTATOR_BOOST and instr[1] == side
+        if instr[0] == mutator_type and instr[1] == side
     ]
 
 
+def _boosts(incoming_move, side=constants.USER, **kwargs):
+    return _of_type(_outcomes(incoming_move, **kwargs), constants.MUTATOR_BOOST, side)
+
+
+def _opponent_damage(multiplier):
+    """Damage dealt TO the opponent with the review multiplier set to ``multiplier``."""
+    mutator = StateMutator(_state())
+    mutator.review_based_damage_multiplier = multiplier
+    return _of_type(
+        get_all_state_instructions(mutator, "tackle", "splash"),
+        constants.MUTATOR_DAMAGE,
+        constants.OPPONENT,
+    )
+
+
 _ATTACK_UP = (constants.MUTATOR_BOOST, constants.USER, constants.ATTACK, 1)
+_ATTACK_DOWN = (constants.MUTATOR_BOOST, constants.USER, constants.ATTACK, -1)
+_SPENT = (constants.MUTATOR_CHANGE_ITEM, constants.USER, None, "cellbattery")
 
 
 def test_cellbattery_is_registered_by_importing_the_hooks():
@@ -313,18 +394,100 @@ def test_weaknesspolicy_is_left_alone():
     ]
 
 
-def test_boost_is_capped_at_max_boosts():
-    # At +6 the engine's boost generator yields a zero-magnitude no-op, never a +7.
-    assert _boosts("shockwave", attack_boost=constants.MAX_BOOSTS) == [
-        (constants.MUTATOR_BOOST, constants.USER, constants.ATTACK, 0)
-    ]
+def test_a_holder_at_the_stat_cap_keeps_its_item():
+    """At +6 Attack there is no stage to gain, so Cell Battery is not spent.
+
+    The engine's boost generator would happily emit a zero-magnitude no-op here;
+    consuming an item to pay for one is what the mechanic explicitly does not do.
+    """
+    outcomes = _outcomes("shockwave", attack_boost=constants.MAX_BOOSTS)
+    assert _of_type(outcomes, constants.MUTATOR_BOOST) == []
+    assert _of_type(outcomes, constants.MUTATOR_CHANGE_ITEM) == []
+
+
+def test_contrary_holder_loses_attack_instead():
+    """Contrary reverses the item's boost, so the holder drops to -1 Attack.
+
+    The engine runs a defender's ability hook before its item hook, so a boost the
+    item adds afterwards never meets Contrary on its own; the effect replays it
+    through the engine's own ability hook to get this. (Shock Wave rather than
+    Thunderbolt only to keep this to one outcome -- a paralysis chance would branch
+    it and say nothing about Contrary.)
+    """
+    assert _boosts("shockwave", ability="contrary") == [_ATTACK_DOWN]
+
+
+def test_contrary_holder_is_consumed_at_the_top_of_the_range():
+    # +6 is the cap that stops a normal holder, and no obstacle at all to a drop.
+    assert _boosts(
+        "shockwave", ability="contrary", attack_boost=constants.MAX_BOOSTS
+    ) == [_ATTACK_DOWN]
+
+
+def test_contrary_holder_at_the_bottom_of_the_range_keeps_its_item():
+    # Under Contrary the cap that matters is -6, not +6.
+    outcomes = _outcomes(
+        "shockwave", ability="contrary", attack_boost=-1 * constants.MAX_BOOSTS
+    )
+    assert _of_type(outcomes, constants.MUTATOR_BOOST) == []
+    assert _of_type(outcomes, constants.MUTATOR_CHANGE_ITEM) == []
+
+
+def test_substitute_made_earlier_in_the_turn_does_not_trigger():
+    """A holder that Substitutes first must not read its own HP cost as a hit.
+
+    An instruction set is cumulative over the whole turn: the 25% self-damage that
+    paid for the Substitute is still in the list when the Electric move resolves
+    against the Substitute. Only the instructions this hit added may be inspected.
+    """
+    outcomes = _outcomes("thunderbolt", user_move="substitute", holder_speed=999)
+    hp_costs = _of_type(outcomes, constants.MUTATOR_DAMAGE)
+    assert hp_costs, "expected the Substitute's own HP cost in the instruction set"
+    assert _of_type(outcomes, constants.MUTATOR_BOOST) == []
+    assert _of_type(outcomes, constants.MUTATOR_CHANGE_ITEM) == []
+
+
+def test_the_item_is_consumed_by_the_boost():
+    """Cell Battery is a consumable: the boost comes with a change_item instruction.
+
+    ``modify_attack_against`` returns a move dict and cannot emit an instruction,
+    which is why the engine models its own one-shot items as reusable -- but this
+    effect does its work in the damage wrapper, where the instruction is expressible
+    and reversible.
+    """
+    outcomes = _outcomes("shockwave")
+    for outcome in outcomes:
+        assert _ATTACK_UP in outcome.instructions
+        assert _SPENT in outcome.instructions
+        # Spent after the boost it paid for, so reversing the set restores both.
+        assert outcome.instructions.index(_SPENT) > outcome.instructions.index(
+            _ATTACK_UP
+        )
+
+
+def test_a_spent_cell_battery_does_not_fire_again():
+    """The direct refutation of "repeat triggers are bounded by MAX_BOOSTS".
+
+    One outcome is applied to the state, exactly as simulate_battle_with_poke_engine
+    does, and the holder is hit a second time.
+    """
+    mutator = StateMutator(_state())
+    first = get_all_state_instructions(mutator, "splash", "shockwave")[0]
+    assert _ATTACK_UP in first.instructions
+    mutator.apply(first.instructions)
+    assert mutator.state.user.active.item is None
+    assert mutator.state.user.active.hp > 0, "expected the holder to survive the hit"
+
+    second = get_all_state_instructions(mutator, "splash", "shockwave")
+    assert _of_type(second, constants.MUTATOR_BOOST) == []
+    assert _of_type(second, constants.MUTATOR_CHANGE_ITEM) == []
 
 
 def test_reload_installs_one_wrapper_and_one_effect():
-    """A module reload must not stack a second damage wrapper or re-register.
+    """Reloading the current generation must not stack a second damage wrapper.
 
-    A second layer would also lose the ``_ankimon_review_wrapped`` flag, and the next
-    import would wrap again -- scaling review-based damage twice.
+    A second layer would delegate to a function that already scales review-based
+    damage, scaling it twice.
     """
     damage_fn = instruction_generator.get_instructions_from_damage
     effect = modify_attack_against.item_lookup["cellbattery"]
@@ -334,17 +497,76 @@ def test_reload_installs_one_wrapper_and_one_effect():
     assert _boosts("shockwave") == [_ATTACK_UP]
 
 
+def test_upgrade_over_the_previous_wrapper_generation():
+    """Loading over the wrapper that shipped before on-hit items must replace it.
+
+    That generation marked itself with a bare boolean, so a guard that only asks
+    "already wrapped?" skips the new definition on an in-process reload and leaves a
+    wrapper that has never heard of on-hit items installed for the rest of the
+    session -- Cell Battery inert until Anki is restarted. The replacement has to
+    take over the ORIGINAL that wrapper was calling, not the wrapper itself, or
+    review-based damage would be scaled once per layer.
+    """
+    installed = instruction_generator.get_instructions_from_damage
+    pristine = hook._original_get_instructions_from_damage
+    legacy = _legacy_v1_wrapper(pristine)
+    instruction_generator.get_instructions_from_damage = legacy
+    try:
+        upgraded = _load_hook()
+        assert instruction_generator.get_instructions_from_damage is not legacy
+        assert upgraded._original_get_instructions_from_damage is pristine
+        assert _boosts("shockwave") == [_ATTACK_UP]
+        assert _opponent_damage(0.5)[0][2] == _opponent_damage(1.0)[0][2] // 2
+    finally:
+        instruction_generator.get_instructions_from_damage = installed
+
+
+def test_a_stale_item_shim_is_replaced_on_reload():
+    """A shim from an older generation is upgraded, not left registered.
+
+    Its payload shape is whatever that generation stashed on the move, which the
+    current wrapper has no contract with.
+    """
+    lookup = modify_attack_against.item_lookup
+    current = lookup["cellbattery"]
+
+    def stale(attacking_move, attacking_pokemon, defending_pokemon):
+        return attacking_move
+
+    stale._ankimon_on_hit_item_version = 0
+    lookup["cellbattery"] = stale
+    try:
+        _load_hook()
+        assert lookup["cellbattery"] is not stale
+        assert _boosts("shockwave") == [_ATTACK_UP]
+    finally:
+        lookup["cellbattery"] = current
+
+
+def test_a_native_engine_implementation_wins_over_the_shim():
+    """A submodule bump that implements the item for real must not be displaced.
+
+    The engine's own entries are recognised by the module they are defined in,
+    which is how test_weaknesspolicy_is_left_alone identifies them too.
+    """
+    lookup = modify_attack_against.item_lookup
+    current = lookup["cellbattery"]
+
+    def native(attacking_move, attacking_pokemon, defending_pokemon):
+        return attacking_move
+
+    native.__module__ = modify_attack_against.__name__
+    lookup["cellbattery"] = native
+    try:
+        _load_hook()
+        assert lookup["cellbattery"] is native
+    finally:
+        lookup["cellbattery"] = current
+
+
 def test_review_based_damage_multiplier_still_scales():
     """The boost fan-out was added inside the F37 wrapper; F37 must still work."""
-    unscaled, scaled = [], []
-    for multiplier, sink in ((1.0, unscaled), (0.5, scaled)):
-        mutator = StateMutator(_state())
-        mutator.review_based_damage_multiplier = multiplier
-        sink += [
-            instr[2]
-            for outcome in get_all_state_instructions(mutator, "tackle", "splash")
-            for instr in outcome.instructions
-            if instr[0] == constants.MUTATOR_DAMAGE and instr[1] == constants.OPPONENT
-        ]
+    unscaled = _opponent_damage(1.0)
+    scaled = _opponent_damage(0.5)
     assert unscaled and scaled
-    assert scaled[0] == unscaled[0] // 2
+    assert scaled[0][2] == unscaled[0][2] // 2

--- a/tests/test_cell_battery_item_effect.py
+++ b/tests/test_cell_battery_item_effect.py
@@ -1,0 +1,350 @@
+"""Regression tests for the Cell Battery held-item effect.
+
+Ankimon sells Cell Battery and lets a Pokemon hold it, and the held item does reach
+the engine ("cell-battery" -> ``normalize_name`` -> "cellbattery" -> ``Pokemon.item``),
+but poke-engine has no entry for it, so the item did nothing at all in battle.
+``_install_on_hit_boost_items`` in ``ankimon_hooks_to_poke_engine`` registers the
+effect (+1 Attack when the holder is hit by a damaging Electric move) and the damage
+wrapper in the same module turns it into boost instructions.
+
+The boost deliberately does NOT ride on the move's ``BOOSTS``, the way the engine's
+own ``weaknesspolicy`` does. find_state_instructions resolves one boost payload
+through an elif chain in which a SECONDARY always wins, so a top-level BOOSTS is read
+only for a move with no secondary effect -- which drops it for 17 of the engine's 37
+damaging Electric moves, Thunderbolt included. A test that only ever fired Shock Wave
+would pass against that broken shape, so ``test_thunderbolt_...`` below is the point
+of this file.
+
+Both the registration and the wrapper run inside ``_apply_engine_patch``, which
+swallows the exception and merely logs, so a regression here would be silent in
+production. These checks are what make it loud.
+"""
+
+import importlib.util
+import sys
+import types
+from collections import defaultdict
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+_src = Path(__file__).parent.parent / "src"
+
+
+def _ensure_pkg(name):
+    """(Re)establish ``name`` as a real package rooted at src/.
+
+    Sibling test modules pollute ``sys.modules`` (e.g. test_database_manager
+    replaces ``sys.modules["Ankimon"]`` with a path-less ModuleType), which breaks
+    ``from Ankimon.*`` imports for whichever test runs next.
+    """
+    mod = sys.modules.get(name)
+    if not isinstance(mod, types.ModuleType) or not getattr(mod, "__path__", None):
+        stub = types.ModuleType(name)
+        stub.__path__ = [str(_src / name.replace(".", "/"))]
+        stub.__package__ = name
+        sys.modules[name] = stub
+
+
+for _pkg in ("Ankimon", "Ankimon.functions", "Ankimon.pyobj"):
+    _ensure_pkg(_pkg)
+
+# The real poke_engine IS needed (these assert on genuine engine output); drop any
+# non-real stand-ins so the actual modules load under Ankimon.__path__.
+for _name in [n for n in list(sys.modules) if n.startswith("Ankimon.poke_engine")]:
+    _m = sys.modules[_name]
+    if not isinstance(_m, types.ModuleType) or getattr(_m, "__file__", None) is None:
+        del sys.modules[_name]
+
+from Ankimon.poke_engine import constants, instruction_generator
+from Ankimon.poke_engine.battle import Pokemon as StatePokemon
+from Ankimon.poke_engine.config import ShowdownConfig
+from Ankimon.poke_engine.find_state_instructions import get_all_state_instructions
+from Ankimon.poke_engine.objects import Pokemon, Side, State, StateMutator
+from Ankimon.poke_engine.special_effects.items import modify_attack_against
+
+_HOOK_PATH = _src / "Ankimon" / "functions" / "ankimon_hooks_to_poke_engine.py"
+
+# The module under test imports the services registry and the error dialog at module
+# scope but does not use them in these paths, so they get stubbed for the import and
+# undone afterwards -- leaving MagicMocks under "Ankimon.*" changes what later test
+# modules see at COLLECTION time, before conftest's autouse restore fixture can run.
+_STUBBED = ("Ankimon.services", "Ankimon.pyobj.error_handler")
+
+hook = None
+
+
+def _load_hook():
+    """Import the hooks module fresh from its file; importing installs the patches."""
+    saved = {k: sys.modules.get(k) for k in _STUBBED}
+    for name in _STUBBED:
+        sys.modules[name] = MagicMock()
+    spec = importlib.util.spec_from_file_location(
+        "Ankimon.functions.ankimon_hooks_to_poke_engine", _HOOK_PATH
+    )
+    mod = importlib.util.module_from_spec(spec)
+    saved[spec.name] = sys.modules.get(spec.name)
+    sys.modules[spec.name] = mod
+    try:
+        spec.loader.exec_module(mod)
+    finally:
+        for name, previous in saved.items():
+            if previous is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = previous
+    return mod
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _installed():
+    """Install the patches for this module only, then put the engine back.
+
+    Unlike the sibling patches, the feature under test lives IN the damage wrapper,
+    so the wrapper cannot be unwound before the assertions run -- which is why this
+    is a fixture rather than a module-scope import. Whatever was installed on arrival
+    is captured and restored, instead of forcing the pristine engine function back:
+    test_review_based_damage_multiplier installs the same wrapper at collection time
+    and asserts it is still in place when its own tests run.
+
+    The ``cellbattery`` entry is left in the engine's item lookup, as harmless as the
+    MOVE_TARGET_SELF append that test_allies_move_target leaves behind -- it changes
+    nothing unless a battler is actually holding the item.
+    """
+    global hook
+    previous_damage_fn = instruction_generator.get_instructions_from_damage
+    hook = _load_hook()
+    yield hook
+    instruction_generator.get_instructions_from_damage = previous_damage_fn
+
+
+def _side(species, level=50):
+    side = Side(
+        Pokemon.from_state_pokemon_dict(StatePokemon(species, level).to_dict()),
+        {},
+        (0, 0),
+        defaultdict(lambda: 0),
+        (0, "some_pkmn"),
+    )
+    # to_dict() yields capitalised types; the damage tables are lowercase.
+    side.active.types = [t.lower() for t in side.active.types]
+    return side
+
+
+def _state(
+    holder="snorlax",
+    item="cellbattery",
+    ability=None,
+    holder_level=50,
+    attacker="rockruff",
+    attacker_level=50,
+    volatile=None,
+    attack_boost=0,
+):
+    """Singles state whose USER side holds the item and receives the attack."""
+    ShowdownConfig.damage_calc_type = "average"
+    state = State(
+        _side(holder, holder_level),
+        _side(attacker, attacker_level),
+        None,
+        None,
+        False,
+    )
+    state.user.active.item = item
+    state.user.active.attack_boost = attack_boost
+    if ability is not None:
+        state.user.active.ability = ability
+    if volatile is not None:
+        state.user.active.volatile_status.add(volatile)
+    return state
+
+
+def _outcomes(incoming_move, **kwargs):
+    """Every outcome of the opponent using ``incoming_move`` while the user Splashes."""
+    mutator = StateMutator(_state(**kwargs))
+    return get_all_state_instructions(mutator, "splash", incoming_move)
+
+
+def _boosts(incoming_move, side=constants.USER, **kwargs):
+    return [
+        instr
+        for outcome in _outcomes(incoming_move, **kwargs)
+        for instr in outcome.instructions
+        if instr[0] == constants.MUTATOR_BOOST and instr[1] == side
+    ]
+
+
+_ATTACK_UP = (constants.MUTATOR_BOOST, constants.USER, constants.ATTACK, 1)
+
+
+def test_cellbattery_is_registered_by_importing_the_hooks():
+    assert callable(hook._install_on_hit_boost_items)
+    assert "cellbattery" in modify_attack_against.item_lookup
+
+
+def test_thunderbolt_boosts_the_holders_attack():
+    """The whole point: Thunderbolt carries a SECONDARY, which shadows move BOOSTS.
+
+    Every outcome of Thunderbolt damages the holder (paralysis only branches the
+    status), so every outcome must carry the boost.
+    """
+    outcomes = _outcomes("thunderbolt")
+    assert len(outcomes) > 1, "expected Thunderbolt to branch on its paralysis chance"
+    for outcome in outcomes:
+        assert _ATTACK_UP in outcome.instructions
+
+
+def test_secondary_less_electric_move_boosts_exactly_once():
+    # Shock Wave has no secondary, so it is the move a BOOSTS-based implementation
+    # would have handled. Guards against the boost being applied twice.
+    assert _boosts("shockwave") == [_ATTACK_UP]
+
+
+def test_no_boost_without_the_item():
+    assert _boosts("thunderbolt", item=None) == []
+    # 'unknown_item' is what the engine itself puts on a Pokemon with no item.
+    assert _boosts("thunderbolt", item="unknown_item") == []
+
+
+def test_non_electric_damaging_move_does_not_trigger():
+    assert _boosts("tackle") == []
+
+
+def test_electric_status_move_does_not_trigger():
+    # Thunder Wave is Electric but deals no damage, so Cell Battery must stay put.
+    assert _boosts("thunderwave") == []
+
+
+def test_electric_immune_holder_is_not_boosted():
+    # Sandshrew is Ground; Cell Battery does not fire on an immune hit.
+    assert "ground" in _state(holder="sandshrew").user.active.types
+    assert _boosts("thunderbolt", holder="sandshrew") == []
+
+
+@pytest.mark.parametrize(
+    "ability,expected",
+    [
+        ("voltabsorb", []),
+        (
+            "lightningrod",
+            [(constants.MUTATOR_BOOST, constants.USER, constants.SPECIAL_ATTACK, 1)],
+        ),
+        ("motordrive", [(constants.MUTATOR_BOOST, constants.USER, constants.SPEED, 1)]),
+    ],
+)
+def test_electric_absorbing_abilities_keep_their_own_effect(ability, expected):
+    """These abilities turn the move into a STATUS move before the item hook runs.
+
+    The holder is not struck, so Cell Battery must not add its Attack boost -- and
+    must not displace the ability's own boost either.
+    """
+    assert _boosts("thunderbolt", ability=ability) == expected
+
+
+def test_a_miss_does_not_trigger():
+    # Thunder is 70% accurate, so the outcome set includes a miss.
+    outcomes = _outcomes("thunder")
+    hit, missed = [], []
+    for outcome in outcomes:
+        damaged = any(
+            instr[0] == constants.MUTATOR_DAMAGE and instr[1] == constants.USER
+            for instr in outcome.instructions
+        )
+        (hit if damaged else missed).append(outcome)
+    assert hit and missed, f"expected both a hit and a miss branch, got {outcomes}"
+    for outcome in hit:
+        assert _ATTACK_UP in outcome.instructions
+    for outcome in missed:
+        assert _ATTACK_UP not in outcome.instructions
+
+
+def test_fainting_holder_is_not_boosted():
+    """A Pokemon knocked out by the hit does not get the item's boost.
+
+    The engine's own faint check in ``get_instructions_from_damage`` reads HP from
+    before the killing blow joins the instruction set, so it never freezes here --
+    the wrapper has to notice this itself.
+    """
+    kwargs = {
+        "holder": "magikarp",
+        "holder_level": 5,
+        "attacker": "zapdos",
+        "attacker_level": 100,
+    }
+    lethal = [
+        instr
+        for outcome in _outcomes("thunderbolt", **kwargs)
+        for instr in outcome.instructions
+        if instr[0] == constants.MUTATOR_DAMAGE and instr[1] == constants.USER
+    ]
+    assert lethal, "expected the holder to be hit"
+    assert lethal[0][2] >= _state(**kwargs).user.active.maxhp, "expected a KO"
+    assert _boosts("thunderbolt", **kwargs) == []
+
+
+def test_hit_absorbed_by_a_substitute_does_not_trigger():
+    # The Substitute takes the hit, so its holder was never struck.
+    assert _boosts("thunderbolt", volatile=constants.SUBSTITUTE) == []
+
+
+def test_an_abilitys_own_boost_is_not_clobbered():
+    """Stamina sets the move's BOOSTS and leaves it damaging; both must survive.
+
+    Shock Wave rather than Thunderbolt, because a SECONDARY would shadow Stamina's
+    boost for reasons that have nothing to do with this change.
+    """
+    defense_up = (constants.MUTATOR_BOOST, constants.USER, constants.DEFENSE, 1)
+    assert _boosts("shockwave", ability="stamina", item=None) == [defense_up]
+    with_item = _boosts("shockwave", ability="stamina")
+    assert sorted(with_item) == sorted([defense_up, _ATTACK_UP])
+
+
+def test_weaknesspolicy_is_left_alone():
+    # setdefault must not have displaced an item the engine already implements.
+    assert (
+        modify_attack_against.item_lookup["weaknesspolicy"].__module__
+        == modify_attack_against.__name__
+    )
+    # Magikarp is Water, so Shock Wave is super effective and the policy fires.
+    assert sorted(_boosts("shockwave", holder="magikarp", item="weaknesspolicy")) == [
+        (constants.MUTATOR_BOOST, constants.USER, constants.ATTACK, 2),
+        (constants.MUTATOR_BOOST, constants.USER, constants.SPECIAL_ATTACK, 2),
+    ]
+
+
+def test_boost_is_capped_at_max_boosts():
+    # At +6 the engine's boost generator yields a zero-magnitude no-op, never a +7.
+    assert _boosts("shockwave", attack_boost=constants.MAX_BOOSTS) == [
+        (constants.MUTATOR_BOOST, constants.USER, constants.ATTACK, 0)
+    ]
+
+
+def test_reload_installs_one_wrapper_and_one_effect():
+    """A module reload must not stack a second damage wrapper or re-register.
+
+    A second layer would also lose the ``_ankimon_review_wrapped`` flag, and the next
+    import would wrap again -- scaling review-based damage twice.
+    """
+    damage_fn = instruction_generator.get_instructions_from_damage
+    effect = modify_attack_against.item_lookup["cellbattery"]
+    _load_hook()
+    assert instruction_generator.get_instructions_from_damage is damage_fn
+    assert modify_attack_against.item_lookup["cellbattery"] is effect
+    assert _boosts("shockwave") == [_ATTACK_UP]
+
+
+def test_review_based_damage_multiplier_still_scales():
+    """The boost fan-out was added inside the F37 wrapper; F37 must still work."""
+    unscaled, scaled = [], []
+    for multiplier, sink in ((1.0, unscaled), (0.5, scaled)):
+        mutator = StateMutator(_state())
+        mutator.review_based_damage_multiplier = multiplier
+        sink += [
+            instr[2]
+            for outcome in get_all_state_instructions(mutator, "tackle", "splash")
+            for instr in outcome.instructions
+            if instr[0] == constants.MUTATOR_DAMAGE and instr[1] == constants.OPPONENT
+        ]
+    assert unscaled and scaled
+    assert scaled[0] == unscaled[0] // 2


### PR DESCRIPTION
Supersedes #844.

## What was wrong with #844

#844's sole commit, `f5e3c0d`, is an empty commit: 0 files changed, 0 additions, 0 deletions. Nothing was ever written to the branch, so there was nothing to merge. The PR description claimed a monkeypatch of `poke_engine` inside `ankimon_hooks_to_poke_engine.py`; no such patch exists in that commit. CodeRabbit approved the empty diff.

## The real problem

Cell Battery genuinely has no battle effect, and the gap is entirely in the engine's item table.

The plumbing already works end to end. `PokemonObject.to_engine_format` normalizes the stored `held_item` `"cell-battery"` through `normalize_name` into `"cellbattery"` and hands it to the engine's `Pokemon.item`, which `item_modify_attack_against` reads on every incoming move. The engine's `item_lookup` simply has no `cellbattery` entry, so the item sat on its holder doing nothing.

This is live, not theoretical: Cell Battery is `items.csv` id 589 at 4000 currency, purchasable in the shop and giveable as a held item.

## The fix

Cell Battery now grants **+1 Attack when its holder is hit by a damaging Electric move**.

The engine is a git submodule, so the effect is registered from the add-on side in `ankimon_hooks_to_poke_engine`, next to the three engine-compat patches already living there and installed through the same `_apply_engine_patch` helper.

## An engine bug worth knowing about

The obvious implementation — mirror the engine's own `weaknesspolicy` and set the incoming move's `BOOSTS` — does not work, and it took a test against Thunderbolt to find out.

`find_state_instructions` resolves a single boost payload through one `elif` chain in which a `SECONDARY` always wins. A top-level `BOOSTS` is read only for a move that has no secondary effect. That silently drops it for **17 of the engine's 37 damaging Electric moves**, including Thunderbolt, Thunder, Thunder Shock, Spark, Thunder Punch, Discharge, Zap Cannon and Volt Tackle. An implementation tested only against Shock Wave would look correct and be inert against the moves players actually meet.

The same shadowing already affects the engine's own effects: `weaknesspolicy`, and the on-hit abilities Stamina, Justified, Weak Armor, Steam Engine and Thermal Exchange, are all inert against Thunderbolt-class moves today.

**This PR routes around that rather than repairing the chain.** Fixing the chain properly means carrying two boost payloads through move resolution, which changes established battle outcomes for roughly ten abilities. That deserves its own PR and its own golden-value review. Here, the item's boost is stashed on the move under a private key and fanned out through the engine's own `get_instructions_from_boosts` by the damage wrapper. A side benefit: the ability-supplied `BOOSTS` is never touched, so Stamina's Defence boost and Cell Battery's Attack boost both land when the move has no secondary.

## Deliberate behaviour

**The item is consumed**, as the real one is. The damage wrapper emits a reversible `change_item` alongside the boost, and only when the boost has a stage left to move, so a holder already at the cap keeps its battery rather than spending it on a no-op. This is a deliberate departure from the engine's own one-shot items (`weaknesspolicy`, `whiteherb`, `airballoon`), which it models as reusable only because `modify_attack_against` returns a move dict and cannot emit an instruction -- a limit of that hook, not of the engine. This effect does its work in the instruction wrapper, where the instruction is expressible. Consumption is scoped to the encounter: the item lives on the engine State, which `simulate_battle_with_poke_engine` never writes back to the Pokemon object and rebuilds from it on every reset.

**Spending the item is announced.** The `change_item` instruction reaches `diff_states` as `user.active.item: 'cellbattery' -> None`, and the change loop in `_process_battle_effects` had no branch for a key ending in `.item` and no trailing `else`, so it was dropped without a word: the player saw an unattributed "Attack increased by 1" and nothing about the battery, while every screen that shows the held item went on showing it. It now reports consumption only -- an item ARRIVING changes the same key the other way -- and names it the way the player knows it, since `to_engine_format` strips the hyphen and no rule turns `cellbattery` back into `Cell Battery`. Only `en_text.json` gains the string; the translator falls back to English per key.

**Three holder abilities are applied on this side**, because the engine applies none of them on this path: Contrary inverts the boost, Simple doubles it to +2, and Klutz stops the item firing or being spent at all. Each honours the engine's own suppression rules rather than comparing ability names, so Neutralizing Gas hands a Klutz holder its battery back and a mold-breaker attacker turns Simple's doubling off. Simple and Klutz cannot be had by replaying the payload through the engine's ability hook the way Contrary is, because the engine implements neither.

**Not boosted**, each covered by a test:

| Situation | Why |
|---|---|
| The move misses | Engine freezes the instruction |
| Electric-immune holder, e.g. a Ground type | Explicit type-effectiveness gate, and damage 0 freezes anyway |
| Volt Absorb / Lightning Rod / Motor Drive | They run first and turn the move into a status move; their own effects are preserved intact |
| Electric status move, e.g. Thunder Wave | Not a damaging move |
| Non-Electric move | Wrong type |
| Hit absorbed by a Substitute | No damage instruction against the holder, so it was never struck |
| Holder knocked out by the hit | The engine's own faint check reads HP from before the killing blow, so the wrapper checks this itself |

## Follow-up

Absorb Bulb (588), Snowball (689) and Luminous Moss (688) are the same shape and are already in Ankimon's item list. The patch is a `{item: (move type, stat, stages)}` table, so each is a one-line addition. Left out here so this change stays reviewable against one item's documented behaviour.

## Verification

- 34 tests in `tests/test_cell_battery_item_effect.py`, including the Thunderbolt regression that the `BOOSTS` approach fails, plus 3 in `tests/test_battle_functions.py` for the consumption message.
- Full test suite: **1,525 passed, 40 skipped, 9 subtests passed**; `python3 harness/check.py`: all 13 Tier-1 checks green.
- The combined release candidate (`main` + #850 + this PR) built and tested together: **1,647 passed, 40 skipped**, all 13 Tier-1 checks, and all five Tier-2 real-Anki probes.
- An adversarial re-review of this branch tried and failed to find a release blocker. It checked the engine contract for `change_item` reversibility, re-ran every one of the engine's 45 Electric moves under production's 16-roll damage setting, and confirmed the submodule pointer and engine files are untouched. Two of its four observations were refuted on the source; consumption being invisible was real and is fixed above.
- `ruff check` and `ruff format --check` under `ci_ruff_check.toml`: clean on both changed files. The hooks file gains no new lint findings over its baseline.
- The `poke_engine` submodule pointer is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019wsu6YpVYFPofYD5f8gSLq


