### PR TITLE
fix: ignore 'fainted' as a status effect application in battle messages

### DIFF
--- a/src/Ankimon/functions/battle_functions.py
+++ b/src/Ankimon/functions/battle_functions.py
@@ -179,8 +179,8 @@ def _process_battle_effects(
         # Track status applications
         if (
             key.endswith(".status")
-            and before in ("fighting", None)
-            and after not in ("fighting", None)
+            and before in ("fighting", "fainted", None)
+            and after not in ("fighting", "fainted", None)
         ):
             target = "user" if key.startswith("user.") else "opponent"
             newly_applied_statuses.add((target, normalize_status_name(after)))
@@ -305,7 +305,7 @@ def _process_battle_effects(
                 pokemon_name = get_pokemon_name(target)
 
                 # Status applied
-                if before in ("fighting", None) and after not in ("fighting", None):
+                if before in ("fighting", "fainted", None) and after not in ("fighting", "fainted", None):
                     normalized_status = normalize_status_name(after)
                     translation_key = f"status_{normalized_status}_apply"
 
@@ -325,7 +325,7 @@ def _process_battle_effects(
                     effect_messages.append(message)
 
                 # Status removed
-                elif before not in ("fighting", None) and after in ("fighting", None):
+                elif before not in ("fighting", "fainted", None) and after in ("fighting", "fainted", None):
                     normalized_status = normalize_status_name(before)
                     translation_key = f"status_{normalized_status}_remove"
 


### PR DESCRIPTION
Fixes an issue where Pokémon fainting would trigger an incorrect "is affected by Fainted" battle log message.

### Cause
In Ankimon's battle engine integration, the "fainted" condition is applied to the same `battle_status` property that handles normal status conditions like burn or poison. When the UI parses the state diffs to announce status changes, it looks for transitions away from `"fighting"` or `None`. Because `"fainted"` wasn't explicitly excluded, the UI would read it as a new, unknown status condition being applied and output `[Pokemon] is affected by Fainted!`.

### Fix
Added `"fainted"` to the tuple of ignored starting and ending states in `_process_battle_effects` in `battle_functions.py`. This ensures it is skipped during status parsing, leaving the actual faint handling to the main battle loop.

---
*PR created automatically by Jules for task [10218842628239654181](https://jules.google.com/task/10218842628239654181) started by @h0tp-ftw*